### PR TITLE
ci: Pass image tag from wait-for-images to test jobs

### DIFF
--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -24,6 +24,8 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
       )
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.build-tag.outputs.tag }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -33,7 +35,9 @@ jobs:
     - uses: ./.github/actions/handle-tagged-build
     - name: Compute build tag
       id: build-tag
-      run: echo "tag=${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}" | tee -a "$GITHUB_ENV"
+      run: |
+        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
+        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
     - name: Wait for images
       uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
       with:
@@ -49,6 +53,7 @@ jobs:
     needs: [ wait-for-images ]
     runs-on: ubuntu-latest
     env:
+      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       CI_JOB_NAME: gke-byodb-test

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -26,6 +26,8 @@ jobs:
     if: >-
       github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.build-tag.outputs.tag }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
@@ -35,7 +37,9 @@ jobs:
     - uses: ./.github/actions/handle-tagged-build
     - name: Compute build tag
       id: build-tag
-      run: echo "tag=${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}" | tee -a "$GITHUB_ENV"
+      run: |
+        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
+        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
     - name: Wait for images
       uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
       with:
@@ -51,6 +55,7 @@ jobs:
     needs: [ wait-for-images ]
     runs-on: ubuntu-latest
     env:
+      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
       CI_JOB_NAME: gke-db-backup-restore-test
       ARTIFACT_DIR: ./junit-reports/
       LOAD_BALANCER: lb

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -22,6 +22,8 @@ jobs:
     if: >-
       github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.build-tag.outputs.tag }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
@@ -31,7 +33,9 @@ jobs:
     - uses: ./.github/actions/handle-tagged-build
     - name: Compute build tag
       id: build-tag
-      run: echo "tag=${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}" | tee -a "$GITHUB_ENV"
+      run: |
+        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
+        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
     - name: Wait for images
       uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
       with:
@@ -47,6 +51,7 @@ jobs:
     needs: [ wait-for-images ]
     runs-on: ubuntu-latest
     env:
+      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       CI_JOB_NAME: gke-nongroovy-e2e-tests


### PR DESCRIPTION
## Description

On nightly tag pushes, the `wait-for-images` job computes the correct image tag via `handle-tagged-build`, but this tag is lost when crossing the job boundary to the test job. GHA environment variables don't persist across jobs, so the test job recomputes the tag with `make tag`, which doesn't account for nightly tags, causing a tag mismatch.

This fix writes the computed tag to `GITHUB_OUTPUT` in `wait-for-images` and exposes it as a job output. The downstream test job then receives it via `needs.wait-for-images.outputs.tag` and sets `MAIN_IMAGE_TAG` accordingly.

Applied to all three affected workflows: `e2e-byodb-test`, `e2e-db-backup-restore-test`, and `e2e-nongroovy-tests`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI will validate on the next nightly run. The change is mechanical: adding `GITHUB_OUTPUT` alongside the existing `GITHUB_ENV`, declaring job outputs, and forwarding the tag to the downstream job's env.
