### PR TITLE
ROX-35306: allowlist PR actions to avoid spurious reruns

### DIFF
--- a/.tekton/checks.yaml
+++ b/.tekton/checks.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest checks"
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
-      (event == "pull_request" && body.action != "ready_for_review")
+      (event == "pull_request" && (body.action == "opened" || body.action == "synchronize" || body.action == "reopened"))
   labels:
     appstudio.openshift.io/application: acs
   name: checks

--- a/.tekton/checks.yaml
+++ b/.tekton/checks.yaml
@@ -7,12 +7,11 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.redhat.com/webhook_action: '{{body.action}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest checks"
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
-      (event == "pull_request" && (body.action == "opened" || body.action == "synchronize" || body.action == "reopened"))
+      (event == "pull_request" && body.action in ["opened", "synchronize", "reopened", "created"])
   labels:
     appstudio.openshift.io/application: acs
   name: checks

--- a/.tekton/checks.yaml
+++ b/.tekton/checks.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/webhook_action: '{{body.action}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest checks"
     pipelinesascode.tekton.dev/on-cel-expression: |

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -14,8 +14,8 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
-      (event == "pull_request" && body.action != "ready_for_review") ||
-      (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
+      (event == "pull_request" && (body.action == "opened" || body.action == "synchronize" || body.action == "reopened")) ||
+      (event == "pull_request" && body.action == "labeled" && has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
     # The empty `on-label` annotation is a workaround to make sure the pipeline gets triggered when the label gets first
     # added to the PR. See the Slack tread linked from ROX-30580.
     pipelinesascode.tekton.dev/on-label: "[]"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -15,7 +15,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
       (event == "pull_request" && (body.action == "opened" || body.action == "synchronize" || body.action == "reopened")) ||
-      (event == "pull_request" && body.action == "labeled" && has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
+      (event == "pull_request" && body.action == "labeled" && has(body.label) && body.label.name == "konflux-build")
     # The empty `on-label` annotation is a workaround to make sure the pipeline gets triggered when the label gets first
     # added to the PR. See the Slack tread linked from ROX-30580.
     pipelinesascode.tekton.dev/on-label: "[]"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -7,19 +7,13 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.redhat.com/webhook_action: '{{body.action}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest create-custom-snapshot"
     # Unlike other pipelines, this one is enabled for all PRs. See the description of determine-actual-build task.
-    # The condition for a label is to make sure the konflux-build label addition activates this pipeline, same as others.
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
-      (event == "pull_request" && (body.action == "opened" || body.action == "synchronize" || body.action == "reopened")) ||
-      (event == "pull_request" && body.action == "labeled" && has(body.label) && body.label.name == "konflux-build")
-    # The empty `on-label` annotation is a workaround to make sure the pipeline gets triggered when the label gets first
-    # added to the PR. See the Slack tread linked from ROX-30580.
-    pipelinesascode.tekton.dev/on-label: "[]"
+      (event == "pull_request" && body.action in ["opened", "synchronize", "reopened", "created"])
   labels:
     appstudio.openshift.io/application: acs
   name: create-custom-snapshot

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/webhook_action: '{{body.action}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest create-custom-snapshot"
     # Unlike other pipelines, this one is enabled for all PRs. See the description of determine-actual-build task.

--- a/.tekton/retag-scanner.yaml
+++ b/.tekton/retag-scanner.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/webhook_action: '{{body.action}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest retag-scanner"
     # TODO(ROX-21073): re-enable for all PR branches

--- a/.tekton/retag-scanner.yaml
+++ b/.tekton/retag-scanner.yaml
@@ -7,7 +7,6 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    build.appstudio.redhat.com/webhook_action: '{{body.action}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest retag-scanner"
     # TODO(ROX-21073): re-enable for all PR branches


### PR DESCRIPTION
## Description

Previously the CEL expression used `body.action != "ready_for_review"` which only excluded one action. While [Pipelines-as-Code only forwards a limited set  of PR actions](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/provider/github/detect.go#L15-L18)  (`opened`, `synchronize`, `synchronized`, `reopened`, `ready_for_review`, `labeled`),  the `labeled` action still passed through the old denylist, causing pipelines
  to rerun when adding any label to a PR.

  Switch to an explicit allowlist of `opened`, `synchronize`, `reopened`.  For create-custom-snapshot, also allow `labeled` only for the `konflux-build` label.

  Partially AI generated.

## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked
  above **OR** is not needed

## Testing and quality

  - [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
  functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

  n/a

### How I validated my change

- Adding `auto-retest` label on [#21219](https://github.com/stackrox/stackrox/pull/21219) triggered a rerun with the old CEL — [example  run](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/create-custom-snapshot-v7tgn/)
- Adding a label on this PR with the new CEL did **not** trigger a rerun
- Pushing an empty commit on this PR correctly triggered the run (verifying `synchronize` works)
- Closing and reopening this PR triggered the run (verifying `reopened` works)