### PR TITLE
fix: ensure roxctl and roxagent are always statically linked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -508,10 +508,11 @@ main-build-nodeps:
 		scanner/cmd/scanner \
 		sensor/admission-control \
 		sensor/kubernetes \
-		sensor/upgrader
+		sensor/upgrader \
+		compliance/virtualmachines/roxagent
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
 ifndef SKIP_CLI_BUILD
-	CGO_ENABLED=0 $(GOBUILD) roxctl compliance/virtualmachines/roxagent
+	CGO_ENABLED=0 $(GOBUILD) roxctl
 endif
 
 .PHONY: scale-build

--- a/Makefile
+++ b/Makefile
@@ -505,13 +505,14 @@ main-build-nodeps:
 		config-controller \
 		migrator \
 		operator/cmd \
-		roxctl \
 		scanner/cmd/scanner \
 		sensor/admission-control \
 		sensor/kubernetes \
-		sensor/upgrader \
-		compliance/virtualmachines/roxagent
+		sensor/upgrader
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
+ifndef SKIP_CLI_BUILD
+	CGO_ENABLED=0 $(GOBUILD) roxctl compliance/virtualmachines/roxagent
+endif
 
 .PHONY: scale-build
 scale-build: build-prep

--- a/scripts/go-tool.sh
+++ b/scripts/go-tool.sh
@@ -71,7 +71,9 @@ function invoke_go() {
     echo >&2 "RACE==true, forcing CGO_ENABLED=1"
     cgo_enabled=1
     args+=("-race")
+  fi
 
+  if [[ "$cgo_enabled" != 0 ]]; then
     if command -v musl-gcc &> /dev/null; then
       echo >&2 "Using musl-gcc for static linking to avoid GLIBC dependencies"
       cc_compiler="musl-gcc"
@@ -79,13 +81,6 @@ function invoke_go() {
     else
       echo >&2 "musl-gcc not found, using default cc and linker (auto)"
     fi
-  fi
-
-  # -linkmode=external must be set for all CGO builds so the external linker
-  # (gcc or musl-gcc) is used. This check is inside invoke_go rather than at
-  # the top level because race builds override cgo_enabled to 1 after the
-  # environment is read.
-  if [[ "$cgo_enabled" != 0 ]]; then
     echo >&2 "CGO_ENABLED=$cgo_enabled, adding -linkmode=external"
     cgo_ldflags+=('-linkmode=external')
   fi

--- a/scripts/go-tool.sh
+++ b/scripts/go-tool.sh
@@ -71,9 +71,7 @@ function invoke_go() {
     echo >&2 "RACE==true, forcing CGO_ENABLED=1"
     cgo_enabled=1
     args+=("-race")
-  fi
 
-  if [[ "$cgo_enabled" != 0 ]]; then
     if command -v musl-gcc &> /dev/null; then
       echo >&2 "Using musl-gcc for static linking to avoid GLIBC dependencies"
       cc_compiler="musl-gcc"
@@ -81,6 +79,13 @@ function invoke_go() {
     else
       echo >&2 "musl-gcc not found, using default cc and linker (auto)"
     fi
+  fi
+
+  # -linkmode=external must be set for all CGO builds so the external linker
+  # (gcc or musl-gcc) is used. This check is inside invoke_go rather than at
+  # the top level because race builds override cgo_enabled to 1 after the
+  # environment is read.
+  if [[ "$cgo_enabled" != 0 ]]; then
     echo >&2 "CGO_ENABLED=$cgo_enabled, adding -linkmode=external"
     cgo_ldflags+=('-linkmode=external')
   fi


### PR DESCRIPTION
## Summary

**Option A** of three parallel PRs for comparison.

Since `a268b764fd` ("skip CLI build on pull requests"), `roxctl` was included in the `main-build-nodeps` target without explicit `CGO_ENABLED=0`. In the Konflux Dockerfile, `main-build-nodeps` runs after `ENV CGO_ENABLED=1` is set for FIPS/strictfipsruntime, so roxctl gets silently rebuilt as dynamically linked against GLIBC 2.32+. This broke downstream consumers (e.g. automation-flavors) that extract `roxctl` from the `main` image and run it on Alpine.

All `4.10.x` releases ship a statically linked `roxctl-linux-amd64`; `4.11.0` ships a dynamically linked one — confirmed across `quay.io/stackrox-io/main`, `quay.io/rhacs-eng/main`, and `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9`.

- **Makefile**: remove `roxctl` from the main `$(GOBUILD)` call in `main-build-nodeps`; build it separately with explicit `CGO_ENABLED=0`, guarded by `SKIP_CLI_BUILD`.

### Comparison PRs

- **A** (this PR): removes roxctl from main build, guards with `SKIP_CLI_BUILD`
- **B** (full revert): #21323 — reverts both Makefile and build.yaml from #19817
- **C** (partial revert): #21324 — reverts only Makefile from #19817, guards with `ifndef CI`

### A vs C

The only difference: A uses `ifndef SKIP_CLI_BUILD` (the flag the build.yaml optimization sets), C uses `ifndef CI` (the original guard). Both produce the same result in Konflux (where `CI=1` is set and `SKIP_CLI_BUILD` is not).

## Test plan

- [ ] Verify `make main-build-nodeps` still builds all server components (including roxagent) with `CGO_ENABLED=1`
- [ ] Verify `roxctl` is built with `CGO_ENABLED=0` (`file bin/linux_amd64/roxctl` → "statically linked")
- [ ] Verify `SKIP_CLI_BUILD=1 make main-build-nodeps` skips roxctl
- [ ] Verify Konflux build produces a statically linked `roxctl-linux-amd64` in the final image

🤖 Generated with [Claude Code](https://claude.com/claude-code)