### PR TITLE
Revert "skip CLI build on pull requests" (#19817)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -220,50 +220,10 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Create CLI stub files
-        if: |
-          !(needs.define-job-matrix.outputs.gotags == 'release'
-            || github.ref_name == 'master'
-            || github.event_name == 'workflow_call'
-            || contains(github.event.pull_request.labels.*.name, 'ci-build-cli'))
-        run: |
-          cat > stub.txt << 'EOF'
-          This is a placeholder file. CLI binaries were not built for this PR build.
-
-          To build CLI binaries in PR builds:
-          - Add the "ci-build-cli" label to your pull request
-          - Re-push to trigger a new build
-
-          To download the latest roxctl binary:
-          - Visit https://mirror.openshift.com/pub/rhacs/assets/latest/bin/
-
-          EOF
-
-          mkdir -p bin/{linux_{amd64,arm64,ppc64le,s390x},darwin_{amd64,arm64},windows_amd64}
-
-          for arch in linux_amd64 linux_arm64 linux_ppc64le linux_s390x darwin_amd64 darwin_arm64; do
-            cp stub.txt bin/${arch}/roxctl
-            cp stub.txt bin/${arch}/roxagent
-          done
-          cp stub.txt bin/windows_amd64/roxctl.exe
-
-      - name: PR labels
-        uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
-
       - name: Cache Go dependencies
-        if: |
-          needs.define-job-matrix.outputs.gotags == 'release'
-            || github.ref_name == 'master'
-            || github.event_name == 'workflow_call'
-            || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
         uses: ./.github/actions/cache-go-dependencies
 
       - name: Build CLI
-        if: |
-          needs.define-job-matrix.outputs.gotags == 'release'
-            || github.ref_name == 'master'
-            || github.event_name == 'workflow_call'
-            || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
         run: make cli
 
       - name: Bundle build to preserve permissions

--- a/Makefile
+++ b/Makefile
@@ -505,13 +505,15 @@ main-build-nodeps:
 		config-controller \
 		migrator \
 		operator/cmd \
-		roxctl \
 		scanner/cmd/scanner \
 		sensor/admission-control \
 		sensor/kubernetes \
 		sensor/upgrader \
 		compliance/virtualmachines/roxagent
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
+ifndef CI
+	CGO_ENABLED=0 $(GOBUILD) roxctl
+endif
 
 .PHONY: scale-build
 scale-build: build-prep


### PR DESCRIPTION
## Summary

Full revert of `a268b764fd`. **Option B** of three parallel PRs for comparison.

- **Makefile**: removes `roxctl` from the `main-build-nodeps` `$(GOBUILD)` call, restores the `ifndef CI / CGO_ENABLED=0` guard
- **build.yaml**: removes the label-gated CLI build optimization and stub file generation — CLI builds run on every PR again

### Context

That commit moved roxctl into the `main-build-nodeps` target list without explicit `CGO_ENABLED=0`. In the Konflux Dockerfile, `ENV CGO_ENABLED=1` is set before `main-build-nodeps` runs (for FIPS), so roxctl gets silently rebuilt as a dynamically linked binary (GLIBC_2.32+). All 4.10.x releases have static roxctl; 4.11.0 has dynamic.

### Comparison PRs

- **A** (new fix): #21322 — keeps CLI skip optimization, adds `go-tool.sh` defense-in-depth
- **B** (this PR): full revert of #19817
- **C**: #TBD — partial revert, Makefile only, keeps build.yaml optimization

## Test plan

- [ ] Verify `make main-build-nodeps` with `CGO_ENABLED=1` does not rebuild roxctl
- [ ] Verify `file bin/linux_amd64/roxctl` shows "statically linked" after `make roxctl-build && make main-build-nodeps`
- [ ] Verify CI builds CLI on every PR (no label gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)