### PR TITLE
chore(ui): Pass early on non-UI OSCI jobs for ui only changes

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -12,6 +12,12 @@ set -euo pipefail
 
 info "Start of CI handling"
 
+# Skip expensive setup for non-UI jobs when the PR only touches ui/ files.
+if [[ "${JOB_NAME:-}" =~ nongroovy|upgrade ]] && changes_limited_to "ui/"; then
+    info "Skipping begin: UI-only PR, non-UI job ${JOB_NAME}"
+    exit 0
+fi
+
 openshift_ci_mods
 openshift_ci_import_creds
 

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -12,6 +12,23 @@ source "$ROOT/tests/e2e/lib.sh"
 
 set -euo pipefail
 
+if [[ "$#" -lt 1 ]]; then
+    die "usage: dispatch <ci-job> [<...other parameters...>]"
+fi
+
+ci_job="$1"
+shift
+
+# Skip non-UI jobs early when the PR only touches files under ui/.
+case "$ci_job" in
+    *nongroovy*|*upgrade*)
+        if changes_limited_to "ui/"; then
+            info "Skipping $ci_job: all changes are under ui/"
+            exit 0
+        fi
+        ;;
+esac
+
 if [[ -f "${SHARED_DIR:-}/shared_env" ]]; then
     # shellcheck disable=SC1091
     source "${SHARED_DIR:-}/shared_env"
@@ -21,12 +38,6 @@ openshift_ci_mods
 openshift_ci_import_creds
 create_exit_trap
 
-if [[ "$#" -lt 1 ]]; then
-    die "usage: dispatch <ci-job> [<...other parameters...>]"
-fi
-
-ci_job="$1"
-shift
 ci_export CI_JOB_NAME "$ci_job"
 
 case "$ci_job" in

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1186,6 +1186,35 @@ is_in_PR_context() {
     return 1
 }
 
+# Returns 0 when the current PR only changes files under the given path prefix.
+# Returns 1 for non-PR contexts (postsubmit, periodic) so callers always run.
+changes_limited_to() {
+    local prefix="${1:?usage: changes_limited_to <path-prefix>}"
+
+    is_in_PR_context || return 1
+
+    local base_ref
+    if is_OPENSHIFT_CI; then
+        base_ref="${PULL_BASE_SHA:-}"
+    elif is_GITHUB_ACTIONS; then
+        if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+            git fetch --depth=1 origin "${GITHUB_BASE_REF}" 2>/dev/null || return 1
+            base_ref="origin/${GITHUB_BASE_REF}"
+        fi
+    fi
+    if [[ -z "${base_ref:-}" ]]; then
+        return 1
+    fi
+
+    local changed
+    changed="$(git diff --name-only "${base_ref}...HEAD" 2>/dev/null)" || return 1
+    if [[ -z "$changed" ]]; then
+        return 1
+    fi
+
+    ! grep -qv "^${prefix}" <<< "$changed"
+}
+
 get_PR_number() {
     if is_OPENSHIFT_CI && [[ -n "${PULL_NUMBER:-}" ]]; then
         echo "${PULL_NUMBER}"


### PR DESCRIPTION
## Description

Pass early on non-UI OSCI jobs for ui only changes. Greatly reduces the amount of time and compute needed to complete these required (but irrelevant) jobs, as well as reduce the likelihood of flakes requiring a `/retest`.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Run jobs using commit with `".*"` as placeholder for testing (always pass):
```
nongroovy - 17 min
gke-upgrade - 16 min
```
<img width="1057" height="275" alt="image" src="https://github.com/user-attachments/assets/d2b22025-7d3b-4492-b78a-822927c974a7" />
<img width="1057" height="275" alt="image" src="https://github.com/user-attachments/assets/f48c19c7-38ad-4978-b756-9b6af967bee7" />

Run jobs using commit with `"ui/` - runs full jobs since this PR contains changes outside of `ui/`:
```
nongroovy - 67 min
gke-upgrade - 137 min
```
<img width="1057" height="275" alt="image" src="https://github.com/user-attachments/assets/18bc6e7d-536e-4753-aeb2-ba7cf58e17a7" />
<img width="1057" height="275" alt="image" src="https://github.com/user-attachments/assets/7b7e730d-0d8f-4c4d-8645-edfe52da38bd" />



