### PR TITLE
ROX-34959: enable ROX_INIT_CONTAINER_SUPPORT by default

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -135,7 +135,7 @@ var (
 	VirtualMachinesEnhancedDataModel = registerFeature("Enables virtual machine enhanced data model", "ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL")
 
 	// InitContainerSupport enables extraction, scanning, and evaluation of init containers in deployments.
-	InitContainerSupport = registerFeature("Enable init container support", "ROX_INIT_CONTAINER_SUPPORT")
+	InitContainerSupport = registerFeature("Enable init container support", "ROX_INIT_CONTAINER_SUPPORT", enabled)
 
 	// BackgroundMigration enables long-running background migrations in Central
 	BackgroundMigration = registerFeature("Enable long-running background migrations in Central", "ROX_BACKGROUND_MIGRATION", enabled)

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -10,7 +10,6 @@ import services.ImageService
 import services.PolicyService
 import util.Timer
 
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -392,7 +391,6 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    @IgnoreIf({ System.getenv("ROX_INIT_CONTAINER_SUPPORT") != "true" })
     def "Verify AC enforcement on init containers: #desc"() {
         when:
         "Create a deployment with init containers"

--- a/tests/init_container_test.go
+++ b/tests/init_container_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e && !release
+//go:build test_e2e
 
 package tests
 
@@ -41,10 +41,6 @@ func TestInitContainers(t *testing.T) {
 }
 
 func (s *InitContainerSuite) SetupSuite() {
-	if os.Getenv("ROX_INIT_CONTAINER_SUPPORT") != "true" {
-		s.T().Skip("ROX_INIT_CONTAINER_SUPPORT not enabled")
-	}
-
 	conn := centralgrpc.GRPCConnectionToCentral(s.T())
 	s.deploymentService = v1.NewDeploymentServiceClient(conn)
 	s.policyService = v1.NewPolicyServiceClient(conn)


### PR DESCRIPTION
## Description

ROX-34959. Enables `ROX_INIT_CONTAINER_SUPPORT` feature flag by default. Init container extraction, scanning, and policy evaluation are now on for all builds including release/nightly.

Also removes test skip guards that were gating on the feature flag:
- Go e2e tests: removed `//go:build !release` constraint and `os.Getenv` skip check
- Groovy admission controller test: removed `@IgnoreIf` annotation and unused import

Fixes ROX-35211 (nightly AC test failures due to flag being off on release builds).

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: feature flag now enabled by default
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

- Relying on CI for validation
