### PR TITLE
ROX-35227: fix Artifactory test always returning success

### DIFF
--- a/pkg/registries/artifactory/artifactory.go
+++ b/pkg/registries/artifactory/artifactory.go
@@ -1,17 +1,26 @@
 package artifactory
 
 import (
+	"github.com/heroku/docker-registry-client/registry"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registries/docker"
 	"github.com/stackrox/rox/pkg/registries/types"
 )
+
+var log = logging.LoggerForModule()
 
 // Creator provides the type and registries.Creator to add to the registry of image registries.
 func Creator() (string, types.Creator) {
 	return types.ArtifactoryType,
 		func(integration *storage.ImageIntegration, options ...types.CreatorOption) (types.Registry, error) {
 			cfg := types.ApplyCreatorOptions(options...)
-			return docker.NewDockerRegistry(integration, false, cfg.GetMetricsHandler())
+			reg, err := docker.NewDockerRegistry(integration, false, cfg.GetMetricsHandler())
+			if err != nil {
+				return nil, err
+			}
+			return &artifactoryRegistry{Registry: reg}, nil
 		}
 }
 
@@ -21,6 +30,31 @@ func CreatorWithoutRepoList() (string, types.Creator) {
 	return types.ArtifactoryType,
 		func(integration *storage.ImageIntegration, options ...types.CreatorOption) (types.Registry, error) {
 			cfg := types.ApplyCreatorOptions(options...)
-			return docker.NewDockerRegistry(integration, true, cfg.GetMetricsHandler())
+			reg, err := docker.NewDockerRegistry(integration, true, cfg.GetMetricsHandler())
+			if err != nil {
+				return nil, err
+			}
+			return &artifactoryRegistry{Registry: reg}, nil
 		}
+}
+
+var _ types.Registry = (*artifactoryRegistry)(nil)
+
+type artifactoryRegistry struct {
+	*docker.Registry
+}
+
+// Test overrides the default docker Test because Artifactory's /v2 ping
+// endpoint does not require authentication, so Ping always succeeds even
+// with invalid credentials.
+func (a *artifactoryRegistry) Test() error {
+	_, err := a.Client.Repositories()
+	if err != nil {
+		log.Errorf("error testing Artifactory integration: %v", err)
+		if e, _ := err.(*registry.ClientError); e != nil {
+			return errors.Errorf("error testing Artifactory integration (code: %d). Please check Central logs for full error", e.Code())
+		}
+		return err
+	}
+	return nil
 }

--- a/pkg/registries/artifactory/artifactory.go
+++ b/pkg/registries/artifactory/artifactory.go
@@ -45,8 +45,8 @@ type artifactoryRegistry struct {
 }
 
 // Test overrides the default docker Test because Artifactory's /v2 ping
-// endpoint does not require authentication, so Ping always succeeds even
-// with invalid credentials.
+// endpoint may not require authentication (e.g. when anonymous access is
+// enabled), causing Ping to succeed even with invalid credentials.
 func (a *artifactoryRegistry) Test() error {
 	_, err := a.Client.Repositories()
 	if err != nil {


### PR DESCRIPTION
## Description

[ROX-35227](https://redhat.atlassian.net/browse/ROX-35227)

Artifactory's Docker V2 registry `/v2/` ping endpoint does not require authentication, which means the default `docker.Registry.Test()` method (which calls `Ping()`) always returns success regardless of whether the configured credentials are valid. This causes Artifactory image integrations to appear healthy even when they are misconfigured.

This PR introduces an `artifactoryRegistry` wrapper type that embeds `*docker.Registry` and overrides the `Test()` method to call `Repositories()` instead of `Ping()`. The `Repositories()` endpoint requires authentication, so invalid credentials will correctly result in a test failure. This follows the exact same pattern established by the ECR integration in `pkg/registries/ecr/ecr.go`.

Both `Creator()` and `CreatorWithoutRepoList()` now return an `*artifactoryRegistry` instead of a bare `*docker.Registry`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### How I validated my change

- Deployed a JFrog Container Registry instance in-cluster via the official Helm chart (`jfrog/artifactory-jcr`)
- Created a JFrog Artifactory integration in the Central UI pointing at the JCR instance
- Verified that invalid credentials correctly return a 401 "Bad Credentials" error
- Verified that valid credentials return success

[ROX-35227]: https://redhat.atlassian.net/browse/ROX-35227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ