### PR TITLE
ROX-35238: Remove enhanced data model warning

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
@@ -1,12 +1,9 @@
 import { Route, Routes } from 'react-router-dom-v5-compat';
-import { Bullseye, PageSection } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { PageSection } from '@patternfly/react-core';
 
-import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import VirtualMachineCvesOverviewPage from './Overview/VirtualMachineCvesOverviewPage';
 import VirtualMachinePage from './VirtualMachine/VirtualMachinePage';
@@ -14,32 +11,6 @@ import VirtualMachinePage from './VirtualMachine/VirtualMachinePage';
 function VirtualMachineCvesPage() {
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
-
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isEnhancedDataModelEnabled = isFeatureFlagEnabled(
-        'ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL'
-    );
-
-    if (isEnhancedDataModelEnabled) {
-        return (
-            <PageSection>
-                <PageTitle title="Virtual Machine CVEs" />
-                <Bullseye>
-                    <EmptyStateTemplate
-                        title="Enhanced data model preview is active"
-                        headingLevel="h1"
-                        icon={ExclamationTriangleIcon}
-                        status="warning"
-                    >
-                        The enhanced virtual machine data model is currently enabled. This preview
-                        feature only supports API access. The UI for virtual machine CVEs is not
-                        available while the ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL feature flag is
-                        enabled.
-                    </EmptyStateTemplate>
-                </Bullseye>
-            </PageSection>
-        );
-    }
 
     return (
         <>


### PR DESCRIPTION
## Description

The Virtual Machines UI is being updated to use the enhanced data model, so the warning banner blocking the UI is no longer needed.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Enabled `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL` and verified the warning banner no longer appears.
