### PR TITLE
test: verify roxctl binary is statically linked

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -717,6 +717,10 @@ jobs:
         if: github.event_name != 'pull_request'
         run: make check-debugger
 
+      - name: Check roxctl CLI binaries are statically linked
+        if: github.event_name != 'pull_request'
+        run: make check-roxctl-static
+
       - name: Prepare roxctl build context
         run: |
           cp -r image/rhel/THIRD_PARTY_NOTICES image/roxctl/THIRD_PARTY_NOTICES

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -717,9 +717,6 @@ jobs:
         if: github.event_name != 'pull_request'
         run: make check-debugger
 
-      - name: Check roxctl CLI binaries are statically linked
-        run: make check-roxctl-static
-
       - name: Prepare roxctl build context
         run: |
           cp -r image/rhel/THIRD_PARTY_NOTICES image/roxctl/THIRD_PARTY_NOTICES
@@ -1280,6 +1277,64 @@ jobs:
         jira-token: ${{ secrets.JIRA_TOKEN }}
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
+
+  check-roxctl-static:
+    runs-on: ubuntu-latest
+    needs:
+    - pre-build-cli
+    - pre-build-go-binaries
+    if: ${{ !cancelled() }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 1
+        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+
+    - uses: ./.github/actions/download-artifact-with-retry
+      with:
+        name: cli-build
+
+    - name: Unpack cli build
+      run: tar xvf cli-build.tar
+
+    - uses: ./.github/actions/download-artifact-with-retry
+      with:
+        name: go-binaries-build-amd64-default
+
+    - name: Unpack Go binaries build
+      run: tar xvf go-binaries-build.tar
+
+    - name: Check roxctl binaries are statically linked
+      run: |
+        failed=0
+        checked=0
+        for bin in bin/linux_amd64/roxctl bin/darwin_amd64/roxctl bin/linux_arm64/roxctl; do
+          [[ -f "$bin" ]] || continue
+          out=$(file -b "$bin")
+          name=$(basename "$(dirname "$bin")")/roxctl
+          if echo "$out" | grep -q "ELF"; then
+            checked=$((checked + 1))
+            if echo "$out" | grep -q "dynamically linked"; then
+              echo "::error::$name is dynamically linked: $out"
+              failed=1
+            else
+              echo "OK: $name is statically linked"
+            fi
+          elif echo "$out" | grep -q "Mach-O\|PE32"; then
+            echo "OK: $name is non-Linux binary (skip linking check)"
+          else
+            echo "SKIP: $name is not a real binary ($(echo "$out" | head -c 40))"
+          fi
+        done
+
+        if [[ "$failed" -eq 1 ]]; then
+          echo "::error::roxctl CLI binaries must be statically linked for portability."
+          exit 1
+        fi
+        if [[ "$checked" -eq 0 ]]; then
+          echo "No ELF roxctl binaries found (CLI build was likely skipped)."
+        fi
 
   slack-on-build-failure:
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1281,9 +1281,11 @@ jobs:
   check-roxctl-static:
     runs-on: ubuntu-latest
     needs:
-    - pre-build-cli
-    - pre-build-go-binaries
+    - define-job-matrix
+    - build-and-push-main
     if: ${{ !cancelled() }}
+    env:
+      BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}
     steps:
     - name: Checkout
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
@@ -1291,50 +1293,21 @@ jobs:
         fetch-depth: 1
         ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
-    - uses: ./.github/actions/download-artifact-with-retry
+    - uses: ./.github/actions/job-preamble
       with:
-        name: cli-build
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Unpack cli build
-      run: tar xvf cli-build.tar
-
-    - uses: ./.github/actions/download-artifact-with-retry
+    - name: Login to quay.io/stackrox-io
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # ratchet:docker/login-action@v4
       with:
-        name: go-binaries-build-amd64-default
+        registry: quay.io
+        username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+        password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 
-    - name: Unpack Go binaries build
-      run: tar xvf go-binaries-build.tar
-
-    - name: Check roxctl binaries are statically linked
+    - name: Check roxctl binaries in main image are statically linked
       run: |
-        failed=0
-        checked=0
-        for bin in bin/linux_amd64/roxctl bin/darwin_amd64/roxctl bin/linux_arm64/roxctl; do
-          [[ -f "$bin" ]] || continue
-          out=$(file -b "$bin")
-          name=$(basename "$(dirname "$bin")")/roxctl
-          if echo "$out" | grep -q "ELF"; then
-            checked=$((checked + 1))
-            if echo "$out" | grep -q "dynamically linked"; then
-              echo "::error::$name is dynamically linked: $out"
-              failed=1
-            else
-              echo "OK: $name is statically linked"
-            fi
-          elif echo "$out" | grep -q "Mach-O\|PE32"; then
-            echo "OK: $name is non-Linux binary (skip linking check)"
-          else
-            echo "SKIP: $name is not a real binary ($(echo "$out" | head -c 40))"
-          fi
-        done
-
-        if [[ "$failed" -eq 1 ]]; then
-          echo "::error::roxctl CLI binaries must be statically linked for portability."
-          exit 1
-        fi
-        if [[ "$checked" -eq 0 ]]; then
-          echo "No ELF roxctl binaries found (CLI build was likely skipped)."
-        fi
+        TAG=$(make --quiet --no-print-directory tag)
+        IMAGE="quay.io/stackrox-io/main:${TAG}" ./scripts/check-roxctl-static.sh
 
   slack-on-build-failure:
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -718,7 +718,6 @@ jobs:
         run: make check-debugger
 
       - name: Check roxctl CLI binaries are statically linked
-        if: github.event_name != 'pull_request'
         run: make check-roxctl-static
 
       - name: Prepare roxctl build context

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -397,6 +397,80 @@ spec:
       operator: in
       values: ["false"]
 
+  - name: check-roxctl-static
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    taskSpec:
+      params:
+      - name: IMAGE_URL
+        type: string
+      - name: IMAGE_DIGEST
+        type: string
+      steps:
+      - name: check
+        image: registry.access.redhat.com/ubi9/ubi:latest
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          dnf install -y -q skopeo file
+
+          tmpdir=$(mktemp -d)
+          image="$(params.IMAGE_URL)@$(params.IMAGE_DIGEST)"
+          echo "Pulling amd64 image: $image"
+
+          skopeo copy --override-arch amd64 --override-os linux \
+            "docker://${image}" "dir:${tmpdir}/image"
+
+          echo "Extracting roxctl binaries from layers..."
+          mkdir -p "${tmpdir}/extracted"
+          for layer in "${tmpdir}"/image/*; do
+            [[ -f "$layer" ]] || continue
+            # Skip the manifest and version files
+            file -b "$layer" | grep -qi "gzip\|tar\|zstandard" || continue
+            if tar tf "$layer" 2>/dev/null | grep -q "assets/downloads/cli/roxctl-linux-"; then
+              tar xf "$layer" -C "${tmpdir}/extracted" --wildcards 'assets/downloads/cli/roxctl-linux-*' 2>/dev/null || true
+            fi
+          done
+
+          failed=0
+          checked=0
+          for bin in "${tmpdir}"/extracted/assets/downloads/cli/roxctl-linux-*; do
+            [[ -f "$bin" ]] || continue
+            name=$(basename "$bin")
+            [[ "$name" == "roxctl-linux" ]] && continue
+            out=$(file -b "$bin")
+            if echo "$out" | grep -q "ELF"; then
+              checked=$((checked + 1))
+              if echo "$out" | grep -q "dynamically linked"; then
+                echo "FAIL: /assets/downloads/cli/$name is dynamically linked"
+                echo "  $out"
+                failed=1
+              else
+                echo "OK: /assets/downloads/cli/$name is statically linked"
+              fi
+            fi
+          done
+
+          rm -rf "$tmpdir"
+
+          if [[ "$checked" -eq 0 ]]; then
+            echo "ERROR: no ELF roxctl binaries found in the image"
+            exit 1
+          fi
+          if [[ "$failed" -eq 1 ]]; then
+            echo "FAIL: roxctl CLI binaries must be statically linked for portability."
+            exit 1
+          fi
+          echo "All $checked roxctl binaries verified as statically linked."
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values: ["false"]
+
   - name: clair-scan
     matrix:
       params:

--- a/.tekton/main-pipeline.yaml
+++ b/.tekton/main-pipeline.yaml
@@ -404,6 +404,9 @@ spec:
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     taskSpec:
+      description: |
+        Verify that roxctl CLI binaries in the main image are statically linked.
+        Dynamically linked roxctl breaks downstream consumers on Alpine or older glibc distros.
       params:
       - name: IMAGE_URL
         type: string
@@ -411,12 +414,12 @@ spec:
         type: string
       steps:
       - name: check
-        image: registry.access.redhat.com/ubi9/ubi:latest
+        image: registry.access.redhat.com/ubi9-minimal:latest@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
+        imagePullPolicy: IfNotPresent
         script: |
-          #!/usr/bin/env bash
           set -euo pipefail
 
-          dnf install -y -q skopeo file
+          microdnf install -y -q skopeo file tar
 
           tmpdir=$(mktemp -d)
           image="$(params.IMAGE_URL)@$(params.IMAGE_DIGEST)"
@@ -429,10 +432,10 @@ spec:
           mkdir -p "${tmpdir}/extracted"
           for layer in "${tmpdir}"/image/*; do
             [[ -f "$layer" ]] || continue
-            # Skip the manifest and version files
             file -b "$layer" | grep -qi "gzip\|tar\|zstandard" || continue
             if tar tf "$layer" 2>/dev/null | grep -q "assets/downloads/cli/roxctl-linux-"; then
-              tar xf "$layer" -C "${tmpdir}/extracted" --wildcards 'assets/downloads/cli/roxctl-linux-*' 2>/dev/null || true
+              tar xf "$layer" -C "${tmpdir}/extracted" --wildcards \
+                'assets/downloads/cli/roxctl-linux-*' 2>/dev/null || true
             fi
           done
 

--- a/Makefile
+++ b/Makefile
@@ -848,6 +848,10 @@ offline-bundle: clean-offline-bundle
 .PHONY: check-debugger
 check-debugger:
 	/usr/bin/env DEBUG_BUILD="$(DEBUG_BUILD)" BUILD_TAG="$(BUILD_TAG)" TAG="$(TAG)" ./scripts/check-debugger.sh
+
+.PHONY: check-roxctl-static
+check-roxctl-static:
+	/usr/bin/env TAG="$(TAG)" ./scripts/check-roxctl-static.sh
 ifeq ($(DEBUG_BUILD),yes)
 	$(warning Warning: DEBUG_BUILD is enabled. Don not use this for production builds)
 endif

--- a/scripts/check-roxctl-static.sh
+++ b/scripts/check-roxctl-static.sh
@@ -3,11 +3,19 @@
 # Verify that roxctl CLI binaries in the main image are statically linked.
 # Dynamically linked roxctl binaries break downstream consumers that run
 # them on Alpine or older glibc distros.
-# This script must be called from the Makefile which sets TAG.
+#
+# Usage: TAG=<image-tag> ./scripts/check-roxctl-static.sh
+#        IMAGE=<full-image-ref> ./scripts/check-roxctl-static.sh
+#
+# When IMAGE is set, it is used directly. Otherwise stackrox/main:${TAG}
+# is used (for local builds via `make check-roxctl-static`).
 
 set -euo pipefail
 
-image="stackrox/main:${TAG}"
+image="${IMAGE:-stackrox/main:${TAG}}"
+echo "Checking image: $image"
+
+docker pull "$image" 2>/dev/null || true
 container=$(docker create "$image")
 
 tmpdir=$(mktemp -d)

--- a/scripts/check-roxctl-static.sh
+++ b/scripts/check-roxctl-static.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Verify that roxctl CLI binaries in the main image are statically linked.
+# Dynamically linked roxctl binaries break downstream consumers that run
+# them on Alpine or older glibc distros.
+# This script must be called from the Makefile which sets TAG.
+
+set -euo pipefail
+
+image="stackrox/main:${TAG}"
+container=$(docker create "$image")
+trap 'docker rm "$container" &>/dev/null' EXIT
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"; docker rm "$container" &>/dev/null' EXIT
+
+docker cp "$container":/assets/downloads/cli "$tmpdir/cli"
+
+failed=0
+for bin in "$tmpdir"/cli/roxctl-linux-*; do
+  name=$(basename "$bin")
+  [[ "$name" == "roxctl-linux" ]] && continue
+  out=$(file -b "$bin")
+  if echo "$out" | grep -q "dynamically linked"; then
+    echo >&2 "FAIL: /assets/downloads/cli/$name is dynamically linked"
+    echo >&2 "  $out"
+    failed=1
+  elif echo "$out" | grep -q "statically linked"; then
+    echo "OK: /assets/downloads/cli/$name is statically linked"
+  elif echo "$out" | grep -q "ELF"; then
+    echo >&2 "WARN: /assets/downloads/cli/$name has unknown linking: $out"
+  fi
+done
+
+if [[ "$failed" -eq 1 ]]; then
+  echo >&2 "roxctl CLI binaries must be statically linked for portability."
+  exit 1
+fi

--- a/scripts/check-roxctl-static.sh
+++ b/scripts/check-roxctl-static.sh
@@ -9,7 +9,6 @@ set -euo pipefail
 
 image="stackrox/main:${TAG}"
 container=$(docker create "$image")
-trap 'docker rm "$container" &>/dev/null' EXIT
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"; docker rm "$container" &>/dev/null' EXIT
@@ -17,22 +16,30 @@ trap 'rm -rf "$tmpdir"; docker rm "$container" &>/dev/null' EXIT
 docker cp "$container":/assets/downloads/cli "$tmpdir/cli"
 
 failed=0
+checked=0
 for bin in "$tmpdir"/cli/roxctl-linux-*; do
   name=$(basename "$bin")
   [[ "$name" == "roxctl-linux" ]] && continue
   out=$(file -b "$bin")
-  if echo "$out" | grep -q "dynamically linked"; then
-    echo >&2 "FAIL: /assets/downloads/cli/$name is dynamically linked"
-    echo >&2 "  $out"
-    failed=1
-  elif echo "$out" | grep -q "statically linked"; then
-    echo "OK: /assets/downloads/cli/$name is statically linked"
-  elif echo "$out" | grep -q "ELF"; then
-    echo >&2 "WARN: /assets/downloads/cli/$name has unknown linking: $out"
+  if echo "$out" | grep -q "ELF"; then
+    checked=$((checked + 1))
+    if echo "$out" | grep -q "dynamically linked"; then
+      echo >&2 "FAIL: /assets/downloads/cli/$name is dynamically linked"
+      echo >&2 "  $out"
+      failed=1
+    else
+      echo "OK: /assets/downloads/cli/$name is statically linked"
+    fi
+  else
+    echo "SKIP: /assets/downloads/cli/$name is not an ELF binary (stub)"
   fi
 done
 
 if [[ "$failed" -eq 1 ]]; then
   echo >&2 "roxctl CLI binaries must be statically linked for portability."
   exit 1
+fi
+
+if [[ "$checked" -eq 0 ]]; then
+  echo "No ELF roxctl binaries found (CLI build was likely skipped). Skipping check."
 fi

--- a/tests/roxctl/bats-tests/local/roxctl-static-linking.bats
+++ b/tests/roxctl/bats-tests/local/roxctl-static-linking.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+setup_file() {
+  delete-outdated-binaries "$(roxctl-release version)"
+  echo "Testing roxctl version: '$(roxctl-release version)'" >&3
+}
+
+@test "roxctl-release linux binary is statically linked" {
+  [[ "$(luname)" == "linux" ]] || skip "static linking check only runs on linux"
+  local roxctl_bin
+  roxctl_bin="$(roxctl-release-cmd)"
+  run file -b "$roxctl_bin"
+  assert_success
+  assert_output --partial "statically linked"
+}
+
+@test "roxctl-release linux binary has no dynamic library dependencies" {
+  [[ "$(luname)" == "linux" ]] || skip "ldd check only runs on linux"
+  local roxctl_bin
+  roxctl_bin="$(roxctl-release-cmd)"
+  run ldd "$roxctl_bin"
+  assert_output --partial "not a dynamic executable"
+}


### PR DESCRIPTION
## Summary

Two layers of defense against roxctl static linking regressions (like 4.11.0 / #19817):

1. **BATS test** (`tests/roxctl/bats-tests/local/roxctl-static-linking.bats`): verifies the standalone `make roxctl` build produces a statically linked binary. Runs as part of `local-roxctl-tests` on every PR.

2. **Post-build image check** (`scripts/check-roxctl-static.sh`): extracts `/assets/downloads/cli/roxctl-linux-*` from the built main image and verifies they are statically linked. Runs on master/push builds alongside `check-debugger` (not on PRs, following the same pattern as #20203).

The BATS test guards the build target; the image check guards the final artifact. The 4.11.0 regression would only have been caught by the image check (the build target was correct, but `main-build-nodeps` clobbered it afterward).

### Related PRs

- Fix (master): #21324
- Fix (4.11 backport): #21333

## Test plan

- [x] Verify `local-roxctl-tests` CI job passes with the BATS test
- [ ] Verify `check-roxctl-static` runs successfully on master push builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)