### PR TITLE
fix(test): use fixture data for timeline drill-down test

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
@@ -229,6 +229,7 @@ describe('Image Integrations', () => {
 
         visitIntegrationsTable(integrationSource, integrationType);
 
+        cy.get('.pf-v6-c-alert:contains("Deprecation notice")').should('exist');
         cy.get('[data-testid="add-integration"]').should('not.exist');
     });
 

--- a/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
@@ -142,21 +142,23 @@ describe('Risk Event Timeline for Deployment', () => {
 
     describe('Drilling Down To Container Events', () => {
         it("should drill down on a pod to see that pod's containers", () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
-            cy.get(selectors.eventTimeline.timeline.namesList.firstListedName, {
-                timeout: 30000,
-            }).then((firstListedName) => {
-                const firstPodName = firstListedName.text();
+            cy.get(selectors.eventTimeline.timeline.namesList.firstListedName).then(
+                (firstListedName) => {
+                    const firstPodName = firstListedName.text();
 
-                // click the button and drill down to see containers
-                clickFirstDrillDownButtonInEventTimeline();
+                    clickFirstDrillDownButtonInEventTimeline(
+                        'risks/eventTimeline/podEventTimeline.json'
+                    );
 
-                // the back button should be visible
-                cy.get(selectors.eventTimeline.backButton);
-                // the pod name should be shown in the panel header
-                cy.get(selectors.eventTimeline.panelHeader.header).should('contain', firstPodName);
-            });
+                    cy.get(selectors.eventTimeline.backButton);
+                    cy.get(selectors.eventTimeline.panelHeader.header).should(
+                        'contain',
+                        firstPodName
+                    );
+                }
+            );
         });
     });
 


### PR DESCRIPTION
## Description

The deployment timeline drill-down test (`deploymentTimeline.test.js`) was the only test in the file using real API data. When the `getDeploymentEventTimeline` query returned empty pods (no process events collected), the timeline rendered without list items. No timeout increase helps because the component renders from a single fetch with no polling.

Switched to fixture data (`deploymentEventTimeline.json` + `podEventTimeline.json`), consistent with every other test in this file. The test validates UI navigation behavior (drill down shows pod name + back button), not data availability.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Code review only. The fix applies the same fixture-based pattern used by all other tests in the file. The existing fixtures (`deploymentEventTimeline.json`, `podEventTimeline.json`) contain valid pod/container data that exercises the drill-down navigation path.