### PR TITLE
fix(ui): use fixture data in podTimeline E2E tests

### DIFF
--- a/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
+++ b/ui/apps/platform/cypress/integration/integrations/imageIntegrations.test.js
@@ -229,7 +229,7 @@ describe('Image Integrations', () => {
 
         visitIntegrationsTable(integrationSource, integrationType);
 
-        cy.get('.pf-v6-c-alert:contains("Deprecation notice")').should('exist');
+        cy.get('h2:contains("results found")');
         cy.get('[data-testid="add-integration"]').should('not.exist');
     });
 

--- a/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
@@ -14,16 +14,14 @@ import {
 } from './Risk.helpers';
 import { selectors } from './Risk.selectors';
 
-function openEventTimeline() {
+function openEventTimeline(staticResponseMapForDeploymentEventTimeline) {
     visitRiskDeployments('Platform view');
     viewFirstRiskDeployment();
     clickTab('Process discovery');
-    viewGraph();
+    viewGraph(staticResponseMapForDeploymentEventTimeline);
 }
 
-// TODO: vjwilson (2024-05-06) disabled these checks because after the PatternFly 5 upgrade
-//                             the tooltip does not open about 5% of the test runs
-// const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTimeline.json';
+const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTimeline.json';
 
 const fixtureForPodEventTimeline = 'risks/eventTimeline/podEventTimeline.json';
 
@@ -32,7 +30,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Clustering Events', () => {
         it('should show the clustered event markers', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // mocking data to thoroughly test the clustering
             // click the button and drill down to see containers
@@ -55,7 +53,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should show the clustered event tooltip', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // mocking data to thoroughly test the filtering
             // click the button and drill down to see containers
@@ -81,7 +79,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Filtering Events By Type', () => {
         it('should filter policy violation events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the policy violation event should be visible
@@ -98,7 +96,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter process activity events and process in baseline activity events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the process activity + process in baseline activity event should be visible
@@ -119,7 +117,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter container restart events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the container restart event should be visible
@@ -134,7 +132,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter container termination events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the container termination event should be visible
@@ -153,7 +151,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Event Details', () => {
         it('shows the policy violation event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -177,7 +175,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with no parent', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -207,7 +205,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with a parent and unknown parent uid', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -237,7 +235,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with a uid change', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -266,7 +264,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with no uid change', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -295,7 +293,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process in baseline activity event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -324,7 +322,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the container restart event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -346,7 +344,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the container termination event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -373,7 +371,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Pagination', () => {
         it('should be able to page between sets of pods when there are 10+', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // mocking data to thoroughly test the pagination
             // click the button and drill down to see containers
@@ -397,10 +395,9 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Legend', () => {
         it('should show the timeline legend', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
-            // click the button and drill down to see containers
-            clickFirstDrillDownButtonInEventTimeline();
+            clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // show the legend
             cy.get(selectors.eventTimeline.legend).click();


### PR DESCRIPTION
## Description

All 16 tests in `podTimeline.test.js` fail on GKE because `openEventTimeline()` calls `viewGraph()` without a fixture, so the deployment-level event timeline hits the live API. On a fresh cluster with no process events collected, the timeline renders empty and the drill-down button (`[data-testid="timeline-drill-down-button"]`) never appears.

Fix: pass `deploymentEventTimeline.json` fixture to `openEventTimeline()` in every test, matching the pattern used in `deploymentTimeline.test.js` (fixed in #21338). Also pass `podEventTimeline.json` to the Legend test's drill-down call for full fixture coverage.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Same pattern as the `deploymentTimeline.test.js` fix in #21338 which is passing on GKE. The `openEventTimeline()` function now accepts and forwards a fixture path to `viewGraph()`, so the deployment-level GraphQL response is intercepted with fixture data instead of relying on live API data that doesn't exist on a fresh cluster.