### PR TITLE
fix: build roxctl in GHA pre-build-go-binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -351,7 +351,7 @@ jobs:
           sudo ln -sf /usr/include/asm /usr/include/x86_64-linux-musl/asm
 
       - name: Build Go Binaries
-        run: GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 make build-prep main-build-nodeps
+        run: GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 make build-prep main-build-nodeps roxctl_linux-${{ matrix.arch }}
 
       - name: Bundle the build to preserve permissions
         run: tar -cvf go-binaries-build.tar bin/linux_${{ matrix.arch }}


### PR DESCRIPTION
## Summary

Follow-up to #21324. Since the `ifndef CI` guard was restored in `main-build-nodeps`, roxctl is skipped in CI. On PR builds without the `ci-build-cli` label, `pre-build-cli` creates text stubs. With nothing else building roxctl, the stub ends up in the image and Central crashes on startup (`start-central.sh` calls `/stackrox/roxctl log-convert`).

Append `roxctl_linux-${{ matrix.arch }}` to the existing make command in `pre-build-go-binaries` so a real statically linked roxctl is always in `go-binaries-build`, overwriting any stubs.

### Evidence

- PR #21340 (MintMaker, includes #21324 fix, no `ci-build-cli` label): Central CrashLoopBackOff — roxctl is a text stub
- PR #21331 (MintMaker, same): 4 Prow failures
- Master merge commit CI: all pass (push builds use real CLI binaries, not stubs)

### Backport

Same fix applied to release-4.11 in #21333.

### Related

Remove the no-op roxctl call in the central entrypoint: https://github.com/stackrox/stackrox/pull/21301

## Test plan

- [ ] Verify PR builds without `ci-build-cli` label produce a real roxctl in the image
- [ ] Verify Central starts successfully in Prow e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)