### PR TITLE
ROX-35136: Add Scanner V4 and Config Controller to Central Services table

### DIFF
--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1622,6 +1622,10 @@ spec:
     | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
     | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
+    | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data and vulnerability matching results. |
+    | Config-As-Code                   | Deployment      | Config-As-Code component enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations. |
 
     ### Secured Cluster Services Explained
 

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1624,8 +1624,8 @@ spec:
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
     | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
     | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
-    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data and vulnerability matching results. |
-    | Config-As-Code                   | Deployment      | Config-As-Code component enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
+    | Config Controller                | Deployment      | Config Controller watches SecurityPolicy custom resources and reconciles them with Central to manage security policies declaratively. |
 
     ### Secured Cluster Services Explained
 

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1620,10 +1620,10 @@ spec:
     | :------------------------------- | :-------------- | :-------------- |
     | Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |
     | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
-    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
+    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses Horizontal Pod Autoscaler (HPA) to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
     | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
-    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content in vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
     | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
     | Config Controller                | Deployment      | Config Controller watches SecurityPolicy custom resources and reconciles them with Central to manage security policies declaratively. |
 

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -1634,6 +1634,10 @@ spec:
     | Sensor                           | Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters. |
     | Collector                        | DaemonSet       | Analyzes and monitors container activity on Kubernetes nodes.|
     | Admission Controller             | Deployment      | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle. |
+    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner uses Horizontal Pod Autoscaler (HPA) to scale the number of replicas based on workload. |
+    | Scanner DB                       | Deployment      | Scanner DB is a PostgreSQL-based persistent storage for indexed image data. |
+    | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
 
     ### Central Custom Resource
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -1626,6 +1626,10 @@ spec:
     | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
     | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
+    | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data and vulnerability matching results. |
+    | Config-As-Code                   | Deployment      | Config-As-Code component enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations. |
 
     ### Secured Cluster Services Explained
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -1638,6 +1638,10 @@ spec:
     | Sensor                           | Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters. |
     | Collector                        | DaemonSet       | Analyzes and monitors container activity on Kubernetes nodes.|
     | Admission Controller             | Deployment      | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle. |
+    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner uses Horizontal Pod Autoscaler (HPA) to scale the number of replicas based on workload. |
+    | Scanner DB                       | Deployment      | Scanner DB is a PostgreSQL-based persistent storage for indexed image data. |
+    | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
 
     ### Central Custom Resource
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -1624,10 +1624,10 @@ spec:
     | :------------------------------- | :-------------- | :-------------- |
     | Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |
     | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
-    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
+    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses Horizontal Pod Autoscaler (HPA) to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
     | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
-    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content in vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
     | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
     | Config Controller                | Deployment      | Config Controller watches SecurityPolicy custom resources and reconciles them with Central to manage security policies declaratively. |
 

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -1628,8 +1628,8 @@ spec:
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
     | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
     | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
-    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data and vulnerability matching results. |
-    | Config-As-Code                   | Deployment      | Config-As-Code component enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
+    | Config Controller                | Deployment      | Config Controller watches SecurityPolicy custom resources and reconciles them with Central to manage security policies declaratively. |
 
     ### Secured Cluster Services Explained
 

--- a/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
@@ -76,6 +76,10 @@ spec:
     | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
     | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
+    | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data and vulnerability matching results. |
+    | Config-As-Code                   | Deployment      | Config-As-Code component enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations. |
 
     ### Secured Cluster Services Explained
 

--- a/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
@@ -88,6 +88,10 @@ spec:
     | Sensor                           | Deployment      | Sensor analyzes and monitors Kubernetes in secured clusters. |
     | Collector                        | DaemonSet       | Analyzes and monitors container activity on Kubernetes nodes.|
     | Admission Controller             | Deployment      | ValidatingWebhookConfiguration for enforcing policies in the deploy lifecycle. |
+    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner uses Horizontal Pod Autoscaler (HPA) to scale the number of replicas based on workload. |
+    | Scanner DB                       | Deployment      | Scanner DB is a PostgreSQL-based persistent storage for indexed image data. |
+    | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
 
     ### Central Custom Resource
 

--- a/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
@@ -74,10 +74,10 @@ spec:
     | :------------------------------- | :-------------- | :-------------- |
     | Central                          | Deployment      | Users interact with Red Hat Advanced Cluster Security through the user interface or APIs on Central. Central also sends notifications for violations and interacts with integrations. |
     | Central DB                       | Deployment      | Central DB is a PostgreSQL-based persistent storage for the data collected and managed by Central. |
-    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses HPA to scale the number of replicas based on workload. |
+    | Scanner                          | Deployment      | Scanner is a Red Hat developed and certified image scanner. Scanner analyzes and reports vulnerabilities for images. Scanner uses Horizontal Pod Autoscaler (HPA) to scale the number of replicas based on workload. |
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
     | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
-    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
+    | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content in vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
     | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
     | Config Controller                | Deployment      | Config Controller watches SecurityPolicy custom resources and reconciles them with Central to manage security policies declaratively. |
 

--- a/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml
@@ -78,8 +78,8 @@ spec:
     | Scanner DB                       | Deployment      | Scanner DB is a cache for vulnerability definitions to serve vulnerability scanning use cases throughout the software development life cycle. |
     | Scanner V4 Indexer               | Deployment      | Scanner V4 Indexer analyzes container image layers and creates an index of packages and files. Scanner V4 Indexer uses HPA to scale the number of replicas based on workload. |
     | Scanner V4 Matcher               | Deployment      | Scanner V4 Matcher matches indexed image content against vulnerability databases to identify security issues. Scanner V4 Matcher uses HPA to scale the number of replicas based on workload. |
-    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data and vulnerability matching results. |
-    | Config-As-Code                   | Deployment      | Config-As-Code component enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations. |
+    | Scanner V4 DB                    | Deployment      | Scanner V4 DB is a PostgreSQL-based persistent storage for indexed image data. |
+    | Config Controller                | Deployment      | Config Controller watches SecurityPolicy custom resources and reconciles them with Central to manage security policies declaratively. |
 
     ### Secured Cluster Services Explained
 


### PR DESCRIPTION
## Description

This PR adds four new components to the "Central Services Explained" documentation table in the operator ClusterServiceVersion files:

- **Scanner V4 Indexer**: Analyzes container image layers and creates an index of packages and files. Uses HPA for replica scaling.
- **Scanner V4 Matcher**: Matches indexed image content against vulnerability databases to identify security issues. Uses HPA for replica scaling.
- **Scanner V4 DB**: PostgreSQL-based persistent storage for indexed image data and vulnerability matching results.
- **Config-As-Code**: Enables declarative configuration management by monitoring ConfigMaps and Secrets to automatically apply security policies and integrations.

This expands the Central Services documentation from 4 to 8 components, providing complete visibility into all Central Services deployments.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed _(documentation-only change)_
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed _(operator CSV documentation update)_

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md) _(documentation-only change)_
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests _(not applicable - documentation change)_
- [ ] added e2e tests _(not applicable - documentation change)_
- [ ] added regression tests _(not applicable - documentation change)_
- [ ] added compatibility tests _(not applicable - documentation change)_
- [ ] modified existing tests _(not applicable - documentation change)_

### How I validated my change

This is a documentation-only change to the operator ClusterServiceVersion YAML files:
1. Updated the source file: `operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml`
2. Regenerated derived files using `make -C operator generate manifests bundle`
3. Verified all three CSV files contain the new components:
   - `operator/config/ui-metadata/bases/rhacs-operator.clusterserviceversion.yaml`
   - `operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml`
   - `operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml`
4. Confirmed the table formatting is consistent with existing entries
5. Verified component descriptions are accurate and follow the existing style

The changes only affect the markdown documentation tables within the CSV files and do not modify any code or functionality.
