### PR TITLE
ROX-35239: fix roxctl static   linking in Konflux main image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -351,7 +351,7 @@ jobs:
           sudo ln -sf /usr/include/asm /usr/include/x86_64-linux-musl/asm
 
       - name: Build Go Binaries
-        run: GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 make build-prep main-build-nodeps roxctl_linux-${{ matrix.arch }}
+        run: GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 make build-prep main-build-nodeps
 
       - name: Bundle the build to preserve permissions
         run: tar -cvf go-binaries-build.tar bin/linux_${{ matrix.arch }}

--- a/Makefile
+++ b/Makefile
@@ -675,10 +675,21 @@ docker-build-roxctl-image:
 		--label quay.expires-after=$(QUAY_TAG_EXPIRATION) \
 		image/roxctl
 
-.PHONY: copy-go-binaries-to-image-dir
-copy-go-binaries-to-image-dir:
+.PHONY: copy-server-binaries-to-image-dir
+copy-server-binaries-to-image-dir:
 	cp bin/linux_$(GOARCH)/central image/rhel/bin/central
 	cp bin/linux_$(GOARCH)/config-controller image/rhel/bin/config-controller
+	cp bin/linux_$(GOARCH)/migrator image/rhel/bin/migrator
+	cp bin/linux_$(GOARCH)/kubernetes        image/rhel/bin/kubernetes-sensor
+	cp bin/linux_$(GOARCH)/upgrader          image/rhel/bin/sensor-upgrader
+	cp bin/linux_$(GOARCH)/admission-control image/rhel/bin/admission-control
+	cp bin/linux_$(GOARCH)/compliance        image/rhel/bin/compliance
+	cp bin/linux_$(GOARCH)/roxagent          image/rhel/bin/roxagent
+	# Workaround to bug in lima: https://github.com/lima-vm/lima/issues/602
+	find image/rhel/bin -not -path "*/.*" -type f -exec chmod +x {} \;
+
+.PHONY: copy-cli-binaries-to-image-dir
+copy-cli-binaries-to-image-dir:
 ifdef CI
 	cp bin/linux_amd64/roxctl image/rhel/bin/roxctl-linux-amd64
 	cp bin/linux_arm64/roxctl image/rhel/bin/roxctl-linux-arm64
@@ -693,14 +704,11 @@ ifneq ($(HOST_OS),linux)
 endif
 	cp bin/$(HOST_OS)_amd64/roxctl image/rhel/bin/roxctl-$(HOST_OS)-amd64
 endif
-	cp bin/linux_$(GOARCH)/migrator image/rhel/bin/migrator
-	cp bin/linux_$(GOARCH)/kubernetes        image/rhel/bin/kubernetes-sensor
-	cp bin/linux_$(GOARCH)/upgrader          image/rhel/bin/sensor-upgrader
-	cp bin/linux_$(GOARCH)/admission-control image/rhel/bin/admission-control
-	cp bin/linux_$(GOARCH)/compliance        image/rhel/bin/compliance
-	cp bin/linux_$(GOARCH)/roxagent          image/rhel/bin/roxagent
 	# Workaround to bug in lima: https://github.com/lima-vm/lima/issues/602
 	find image/rhel/bin -not -path "*/.*" -type f -exec chmod +x {} \;
+
+.PHONY: copy-go-binaries-to-image-dir
+copy-go-binaries-to-image-dir: copy-server-binaries-to-image-dir copy-cli-binaries-to-image-dir
 
 
 .PHONY: copy-binaries-to-image-dir

--- a/Makefile
+++ b/Makefile
@@ -505,15 +505,13 @@ main-build-nodeps:
 		config-controller \
 		migrator \
 		operator/cmd \
+		roxctl \
 		scanner/cmd/scanner \
 		sensor/admission-control \
 		sensor/kubernetes \
 		sensor/upgrader \
 		compliance/virtualmachines/roxagent
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
-ifndef CI
-	CGO_ENABLED=0 $(GOBUILD) roxctl
-endif
 
 .PHONY: scale-build
 scale-build: build-prep

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -1,7 +1,7 @@
 ARG PG_VERSION=15
 
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26@sha256:8bca01ace56d684c43f59d9c60c8e9516ee30c46e7d7357c2f9b526369d3fddf AS go-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26@sha256:8bca01ace56d684c43f59d9c60c8e9516ee30c46e7d7357c2f9b526369d3fddf AS go-base
 
 RUN dnf -y install --allowerasing jq
 
@@ -15,12 +15,16 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
 ENV CI=1
 
+
+FROM go-base AS cli-builder
+
 # TODO(ROX-13200): make sure roxctl cli is built without running go mod tidy.
-# CLI builds are without strictfipsruntime (and CGO_ENABLED is set to 0) because these binaries are for user download and use outside the cluster.
-RUN make roxctl-build
+RUN GOTAGS="release" make roxctl-build copy-cli-binaries-to-image-dir
+
+
+FROM go-base AS go-builder
 
 ENV CGO_ENABLED=1
 # TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
@@ -34,7 +38,8 @@ RUN mkdir -p image/rhel/docs/api/v1 && \
     mkdir -p image/rhel/docs/api/v2 && \
     ./scripts/mergeswag.sh 2 generated/api/v2 >image/rhel/docs/api/v2/swagger.json
 
-RUN make copy-go-binaries-to-image-dir
+RUN make copy-server-binaries-to-image-dir && \
+    cp bin/linux_$(go env GOARCH)/roxctl image/rhel/bin/roxctl
 
 
 FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:6a3eed5bfd580871fde7329421ce0b2ae533e28792f6db1accbd77602e271ad7 as ui-builder
@@ -97,16 +102,16 @@ COPY --from=ui-builder /go/src/github.com/stackrox/rox/app/ui/build /ui/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/migrator /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/central /stackrox/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/compliance /stackrox/bin/
-COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/roxctl* /assets/downloads/cli/
+COPY --from=cli-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/roxctl* /assets/downloads/cli/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/kubernetes-sensor /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/sensor-upgrader /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/admission-control /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/config-controller /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/roxagent /stackrox/bin/
 COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/static-bin/* /stackrox/
+COPY --from=go-builder /go/src/github.com/stackrox/rox/app/image/rhel/bin/roxctl /stackrox/roxctl
 RUN GOARCH=$(uname -m) ; \
     case $GOARCH in x86_64) GOARCH=amd64 ;; aarch64) GOARCH=arm64 ;; esac ; \
-    ln -s /assets/downloads/cli/roxctl-linux-$GOARCH /stackrox/roxctl ; \
     ln -s /assets/downloads/cli/roxctl-linux-$GOARCH /assets/downloads/cli/roxctl-linux
 
 ARG BUILD_TAG


### PR DESCRIPTION
## Description

Fixes roxctl CLI downloads being built as **dynamically linked FIPS binaries** in the Konflux-built main image since 4.11.0.

### Problem
- #19817 moved roxctl into `main-build-nodeps` to reduce CI build time. In Konflux, `main-build-nodeps` runs with `CGO_ENABLED=1` and `GOEXPERIMENT=strictfipsruntime`, so roxctl CLI downloads became dynamically linked FIPS binaries instead of static ones. Users downloading roxctl from the RHACS image get a binary that crashes outside the container due to missing glibc/FIPS libraries.

- #21324 attempted to fix this with an `ifndef CI` guard that excluded roxctl from server builds in CI. This fixed the CLI downloads but broke the in-container `/stackrox/roxctl` — it was never built in Konflux at all.

### Evidence

Binary inspection of released images confirms the regression:

| Image | `/stackrox/roxctl` | Linking | Size |
|-------|-------------------|---------|------|
| `main:4.9.0` | symlink → cli download | **static** | 97 MB |
| `main:4.10.0` | symlink → cli download | **static** | 95 MB |
| `main:4.11.0` | symlink → cli download | **dynamic** (libresolv, libc) | 127 MB |

### Solution

Split the Konflux Dockerfile into three Docker stages that build roxctl with different link modes:

- **`go-base`**: common source and build setup
- **`cli-builder`** (from go-base): builds roxctl with `CGO_ENABLED=0`, no FIPS — static binaries for `/assets/downloads/cli/`
- **`go-builder`** (from go-base): builds server binaries with `CGO_ENABLED=1` + `strictfipsruntime` — FIPS binary for `/stackrox/roxctl`

BuildKit runs `cli-builder` and `go-builder` in parallel since they share the same base.

The Makefile `copy-go-binaries-to-image-dir` target is split into `copy-server-binaries-to-image-dir` and `copy-cli-binaries-to-image-dir` so the Dockerfile stages can call exactly the target they need.

### Alternatives considered

- **Keep `ifndef CI` guard and add a separate `go build` for FIPS roxctl**: simpler but mixes two build concerns in a single Docker stage, harder to reason about which flags apply to which binary.
- **Build roxctl separately in the Makefile with explicit `CGO_ENABLED=0`**: would require overriding the environment variables set in the Dockerfile, fragile.

### Commits

1. **Revert PR #21324** — removes the broken `ifndef CI` guard
2. **Fix**: split Konflux Dockerfile into three stages, split Makefile copy target, produce two distinct roxctl binaries (static for downloads, FIPS for in-container)
3. **GHA cleanup**: remove redundant `roxctl_linux` target from GHA build (CGO_ENABLED=0 `main-build-nodeps` already produces static roxctl)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

Build-system-only change. No automated tests — validated by inspecting binaries in the built image.

### How I validated my change

Confirmed the regression by inspecting released images:

```
$ file /stackrox/roxctl  # extracted from quay.io/rhacs-eng/main:4.10.0
ELF 64-bit LSB executable, x86-64, statically linked, stripped

$ file /stackrox/roxctl  # extracted from quay.io/rhacs-eng/main:4.11.0
ELF 64-bit LSB executable, x86-64, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped
```

Validated the fix on GHA-built image (`quay.io/rhacs-eng/main:4.12.x-287-ge9e3646e93`):
- `/assets/downloads/cli/roxctl-linux-amd64`: **statically linked** (98 MB)
- `/stackrox/roxctl`: symlink → cli download (expected for GHA)

Validated the fix on Konflux-built image (`quay.io/rhacs-eng/release-main:4.12.0-287-ge9e3646e93-fast`):
- `/assets/downloads/cli/roxctl-linux-amd64`: **statically linked** (98 MB) — all 7 platform binaries present and static
- `/stackrox/roxctl`: **dynamically linked FIPS** (130 MB, links libresolv, libc) — separate binary from `go-builder` stage

Two distinct roxctl binaries in the Konflux image, each with the correct link mode.

Additional checks:
- `image/rhel/Dockerfile` (GHA) does not use `copy-go-binaries-to-image-dir`, so the Makefile split is safe
- `image/roxctl/konflux.Dockerfile` (separate roxctl container) is unaffected — it builds with its own `CGO_ENABLED=1` intentionally