### PR TITLE
feat: add version skew detection POC

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -55,9 +55,9 @@ type DataStore interface {
 	AddCluster(ctx context.Context, cluster *storage.Cluster) (string, error)
 	UpdateCluster(ctx context.Context, cluster *storage.Cluster) error
 	RemoveCluster(ctx context.Context, id string, done *concurrency.Signal) error
-	// UpdateClusterStatus updates the cluster status. Note that any cluster-upgrade or cluster-cert-expiry status
-	// passed to this endpoint will be ignored. To insert that, callers MUST separately call
-	// UpdateClusterUpgradeStatus or UpdateClusterCertExpiry status.
+	// UpdateClusterStatus updates the cluster status. Note that any cluster-upgrade, cluster-cert-expiry,
+	// or version-skew status passed to this endpoint will be ignored. To insert those, callers MUST separately call
+	// UpdateClusterUpgradeStatus, UpdateClusterCertExpiryStatus, or UpdateClusterVersionSkew.
 	UpdateClusterStatus(ctx context.Context, id string, status *storage.ClusterStatus) error
 	UpdateClusterUpgradeStatus(ctx context.Context, id string, clusterUpgradeStatus *storage.ClusterUpgradeStatus) error
 	UpdateClusterCertExpiryStatus(ctx context.Context, id string, clusterCertExpiryStatus *storage.ClusterCertExpiryStatus) error

--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -61,6 +61,7 @@ type DataStore interface {
 	UpdateClusterStatus(ctx context.Context, id string, status *storage.ClusterStatus) error
 	UpdateClusterUpgradeStatus(ctx context.Context, id string, clusterUpgradeStatus *storage.ClusterUpgradeStatus) error
 	UpdateClusterCertExpiryStatus(ctx context.Context, id string, clusterCertExpiryStatus *storage.ClusterCertExpiryStatus) error
+	UpdateClusterVersionSkew(ctx context.Context, id string, versionSkew *storage.VersionSkew) error
 	UpdateClusterHealth(ctx context.Context, id string, clusterHealthStatus *storage.ClusterHealthStatus) error
 	UpdateSensorDeploymentIdentification(ctx context.Context, id string, identification *storage.SensorDeploymentIdentification) error
 	// UpdateAuditLogFileStates updates for each node in the cluster where the audit log was last at

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -144,6 +144,27 @@ func (ds *datastoreImpl) UpdateClusterCertExpiryStatus(ctx context.Context, id s
 	return ds.clusterStorage.Upsert(ctx, cluster)
 }
 
+func (ds *datastoreImpl) UpdateClusterVersionSkew(ctx context.Context, id string, versionSkew *storage.VersionSkew) error {
+	if err := checkWriteSac(ctx, id); err != nil {
+		return err
+	}
+
+	ds.lock.Lock()
+	defer ds.lock.Unlock()
+
+	cluster, err := ds.getClusterOnly(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if cluster.GetStatus() == nil {
+		cluster.Status = &storage.ClusterStatus{}
+	}
+
+	cluster.Status.VersionSkew = versionSkew
+	return ds.clusterStorage.Upsert(ctx, cluster)
+}
+
 func (ds *datastoreImpl) UpdateClusterStatus(ctx context.Context, id string, status *storage.ClusterStatus) error {
 	if err := checkWriteSac(ctx, id); err != nil {
 		return err
@@ -156,6 +177,7 @@ func (ds *datastoreImpl) UpdateClusterStatus(ctx context.Context, id string, sta
 
 	status.UpgradeStatus = cluster.GetStatus().GetUpgradeStatus()
 	status.CertExpiryStatus = cluster.GetStatus().GetCertExpiryStatus()
+	status.VersionSkew = cluster.GetStatus().GetVersionSkew()
 	cluster.Status = status
 
 	return ds.clusterStorage.Upsert(ctx, cluster)

--- a/central/cluster/datastore/mocks/datastore.go
+++ b/central/cluster/datastore/mocks/datastore.go
@@ -356,6 +356,20 @@ func (mr *MockDataStoreMockRecorder) UpdateClusterUpgradeStatus(ctx, id, cluster
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterUpgradeStatus", reflect.TypeOf((*MockDataStore)(nil).UpdateClusterUpgradeStatus), ctx, id, clusterUpgradeStatus)
 }
 
+// UpdateClusterVersionSkew mocks base method.
+func (m *MockDataStore) UpdateClusterVersionSkew(ctx context.Context, id string, versionSkew *storage.VersionSkew) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterVersionSkew", ctx, id, versionSkew)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterVersionSkew indicates an expected call of UpdateClusterVersionSkew.
+func (mr *MockDataStoreMockRecorder) UpdateClusterVersionSkew(ctx, id, versionSkew any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterVersionSkew", reflect.TypeOf((*MockDataStore)(nil).UpdateClusterVersionSkew), ctx, id, versionSkew)
+}
+
 // UpdateSensorDeploymentIdentification mocks base method.
 func (m *MockDataStore) UpdateSensorDeploymentIdentification(ctx context.Context, id string, identification *storage.SensorDeploymentIdentification) error {
 	m.ctrl.T.Helper()

--- a/central/graphql/resolvers/cluster_health.go
+++ b/central/graphql/resolvers/cluster_health.go
@@ -22,17 +22,19 @@ func init() {
 			"healthy: Int!",
 			"degraded: Int!",
 			"unhealthy: Int!",
+			"incompatibleVersionSkew: Int!",
 		}),
 	)
 }
 
 // ClusterHealthCounterResolver counts the clusters by their health status.
 type ClusterHealthCounterResolver struct {
-	total         int32
-	uninitialized int32
-	healthy       int32
-	degraded      int32
-	unhealthy     int32
+	total                   int32
+	uninitialized           int32
+	healthy                 int32
+	degraded                int32
+	unhealthy               int32
+	incompatibleVersionSkew int32
 }
 
 // ClusterHealthCounter returns counts of clusters in various health buckets.
@@ -68,11 +70,23 @@ func newClusterHealthCounterResolver(ctx context.Context, root *Resolver, q *v1.
 		return nil, err
 	}
 
+	clusters, err := root.ClusterDataStore.GetClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var incompatibleSkew int32
+	for _, c := range clusters {
+		if c.GetStatus().GetVersionSkew().GetStatus() == storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE {
+			incompatibleSkew++
+		}
+	}
+
 	resolver := &ClusterHealthCounterResolver{
-		total:     int32(len(total)),
-		healthy:   int32(len(healthy)),
-		degraded:  int32(len(degraded)),
-		unhealthy: int32(len(unhealthy)),
+		total:                   int32(len(total)),
+		healthy:                 int32(len(healthy)),
+		degraded:                int32(len(degraded)),
+		unhealthy:               int32(len(unhealthy)),
+		incompatibleVersionSkew: incompatibleSkew,
 	}
 	resolver.uninitialized = resolver.total - resolver.healthy - resolver.degraded - resolver.unhealthy
 	return resolver, nil
@@ -101,4 +115,9 @@ func (cr *ClusterHealthCounterResolver) Degraded(_ context.Context) int32 {
 // Unhealthy returns the number of clusters that are in unhealthy state.
 func (cr *ClusterHealthCounterResolver) Unhealthy(_ context.Context) int32 {
 	return cr.unhealthy
+}
+
+// IncompatibleVersionSkew returns the number of clusters with incompatible version skew.
+func (cr *ClusterHealthCounterResolver) IncompatibleVersionSkew(_ context.Context) int32 {
+	return cr.incompatibleVersionSkew
 }

--- a/central/graphql/resolvers/cluster_health.go
+++ b/central/graphql/resolvers/cluster_health.go
@@ -70,7 +70,7 @@ func newClusterHealthCounterResolver(ctx context.Context, root *Resolver, q *v1.
 		return nil, err
 	}
 
-	clusters, err := root.ClusterDataStore.GetClusters(ctx)
+	clusters, err := root.ClusterDataStore.SearchRawClusters(ctx, q)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -886,6 +886,8 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	utils.Must(builder.AddType("Metadata", []string{
 		"buildFlavor: String!",
 		"licenseStatus: Metadata_LicenseStatus!",
+		"maxCompatibleSensorVersion: String!",
+		"minCompatibleSensorVersion: String!",
 		"releaseBuild: Boolean!",
 		"version: String!",
 	}))
@@ -1535,12 +1537,12 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"digest: String!",
 	}))
 	utils.Must(builder.AddType("VersionSkew", []string{
+		"incompatibilityReason: VersionSkewIncompatibilityReason!",
 		"maxCompatibleSensorVersion: String!",
 		"minCompatibleSensorVersion: String!",
-		"reason: VersionSkewReason!",
 		"status: VersionSkewStatus!",
 	}))
-	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.VersionSkewReason(0)))
+	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.VersionSkewIncompatibilityReason(0)))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.VersionSkewStatus(0)))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ViolationState(0)))
 	utils.Must(builder.AddType("Volume", []string{
@@ -10349,6 +10351,16 @@ func (resolver *metadataResolver) LicenseStatus(ctx context.Context) string {
 	return value.String()
 }
 
+func (resolver *metadataResolver) MaxCompatibleSensorVersion(ctx context.Context) string {
+	value := resolver.data.GetMaxCompatibleSensorVersion()
+	return value
+}
+
+func (resolver *metadataResolver) MinCompatibleSensorVersion(ctx context.Context) string {
+	value := resolver.data.GetMinCompatibleSensorVersion()
+	return value
+}
+
 func (resolver *metadataResolver) ReleaseBuild(ctx context.Context) bool {
 	value := resolver.data.GetReleaseBuild()
 	return value
@@ -16584,6 +16596,11 @@ func (resolver *Resolver) wrapVersionSkewsWithContext(ctx context.Context, value
 	return output, nil
 }
 
+func (resolver *versionSkewResolver) IncompatibilityReason(ctx context.Context) string {
+	value := resolver.data.GetIncompatibilityReason()
+	return value.String()
+}
+
 func (resolver *versionSkewResolver) MaxCompatibleSensorVersion(ctx context.Context) string {
 	value := resolver.data.GetMaxCompatibleSensorVersion()
 	return value
@@ -16594,30 +16611,25 @@ func (resolver *versionSkewResolver) MinCompatibleSensorVersion(ctx context.Cont
 	return value
 }
 
-func (resolver *versionSkewResolver) Reason(ctx context.Context) string {
-	value := resolver.data.GetReason()
-	return value.String()
-}
-
 func (resolver *versionSkewResolver) Status(ctx context.Context) string {
 	value := resolver.data.GetStatus()
 	return value.String()
 }
 
-func toVersionSkewReason(value *string) storage.VersionSkewReason {
+func toVersionSkewIncompatibilityReason(value *string) storage.VersionSkewIncompatibilityReason {
 	if value != nil {
-		return storage.VersionSkewReason(storage.VersionSkewReason_value[*value])
+		return storage.VersionSkewIncompatibilityReason(storage.VersionSkewIncompatibilityReason_value[*value])
 	}
-	return storage.VersionSkewReason(0)
+	return storage.VersionSkewIncompatibilityReason(0)
 }
 
-func toVersionSkewReasons(values *[]string) []storage.VersionSkewReason {
+func toVersionSkewIncompatibilityReasons(values *[]string) []storage.VersionSkewIncompatibilityReason {
 	if values == nil {
 		return nil
 	}
-	output := make([]storage.VersionSkewReason, len(*values))
+	output := make([]storage.VersionSkewIncompatibilityReason, len(*values))
 	for i, v := range *values {
-		output[i] = toVersionSkewReason(&v)
+		output[i] = toVersionSkewIncompatibilityReason(&v)
 	}
 	return output
 }

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -344,6 +344,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"providerMetadata: ProviderMetadata",
 		"sensorVersion: String!",
 		"upgradeStatus: ClusterUpgradeStatus",
+		"versionSkew: VersionSkew",
 	}))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ClusterType(0)))
 	utils.Must(builder.AddType("ClusterUpgradeStatus", []string{
@@ -1533,6 +1534,14 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	utils.Must(builder.AddType("V2Metadata", []string{
 		"digest: String!",
 	}))
+	utils.Must(builder.AddType("VersionSkew", []string{
+		"maxCompatibleSensorVersion: String!",
+		"minCompatibleSensorVersion: String!",
+		"reason: VersionSkewReason!",
+		"status: VersionSkewStatus!",
+	}))
+	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.VersionSkewReason(0)))
+	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.VersionSkewStatus(0)))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ViolationState(0)))
 	utils.Must(builder.AddType("Volume", []string{
 		"destination: String!",
@@ -4712,6 +4721,11 @@ func (resolver *clusterStatusResolver) SensorVersion(ctx context.Context) string
 func (resolver *clusterStatusResolver) UpgradeStatus(ctx context.Context) (*clusterUpgradeStatusResolver, error) {
 	value := resolver.data.GetUpgradeStatus()
 	return resolver.root.wrapClusterUpgradeStatus(value, true, nil)
+}
+
+func (resolver *clusterStatusResolver) VersionSkew(ctx context.Context) (*versionSkewResolver, error) {
+	value := resolver.data.GetVersionSkew()
+	return resolver.root.wrapVersionSkew(value, true, nil)
 }
 
 func toClusterType(value *string) storage.ClusterType {
@@ -16526,6 +16540,104 @@ func (resolver *Resolver) wrapV2MetadatasWithContext(ctx context.Context, values
 func (resolver *v2MetadataResolver) Digest(ctx context.Context) string {
 	value := resolver.data.GetDigest()
 	return value
+}
+
+type versionSkewResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data *storage.VersionSkew
+}
+
+func (resolver *Resolver) wrapVersionSkew(value *storage.VersionSkew, ok bool, err error) (*versionSkewResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &versionSkewResolver{root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapVersionSkews(values []*storage.VersionSkew, err error) ([]*versionSkewResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*versionSkewResolver, len(values))
+	for i, v := range values {
+		output[i] = &versionSkewResolver{root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *Resolver) wrapVersionSkewWithContext(ctx context.Context, value *storage.VersionSkew, ok bool, err error) (*versionSkewResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &versionSkewResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapVersionSkewsWithContext(ctx context.Context, values []*storage.VersionSkew, err error) ([]*versionSkewResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*versionSkewResolver, len(values))
+	for i, v := range values {
+		output[i] = &versionSkewResolver{ctx: ctx, root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *versionSkewResolver) MaxCompatibleSensorVersion(ctx context.Context) string {
+	value := resolver.data.GetMaxCompatibleSensorVersion()
+	return value
+}
+
+func (resolver *versionSkewResolver) MinCompatibleSensorVersion(ctx context.Context) string {
+	value := resolver.data.GetMinCompatibleSensorVersion()
+	return value
+}
+
+func (resolver *versionSkewResolver) Reason(ctx context.Context) string {
+	value := resolver.data.GetReason()
+	return value.String()
+}
+
+func (resolver *versionSkewResolver) Status(ctx context.Context) string {
+	value := resolver.data.GetStatus()
+	return value.String()
+}
+
+func toVersionSkewReason(value *string) storage.VersionSkewReason {
+	if value != nil {
+		return storage.VersionSkewReason(storage.VersionSkewReason_value[*value])
+	}
+	return storage.VersionSkewReason(0)
+}
+
+func toVersionSkewReasons(values *[]string) []storage.VersionSkewReason {
+	if values == nil {
+		return nil
+	}
+	output := make([]storage.VersionSkewReason, len(*values))
+	for i, v := range *values {
+		output[i] = toVersionSkewReason(&v)
+	}
+	return output
+}
+
+func toVersionSkewStatus(value *string) storage.VersionSkewStatus {
+	if value != nil {
+		return storage.VersionSkewStatus(storage.VersionSkewStatus_value[*value])
+	}
+	return storage.VersionSkewStatus(0)
+}
+
+func toVersionSkewStatuses(values *[]string) []storage.VersionSkewStatus {
+	if values == nil {
+		return nil
+	}
+	output := make([]storage.VersionSkewStatus, len(*values))
+	for i, v := range *values {
+		output[i] = toVersionSkewStatus(&v)
+	}
+	return output
 }
 
 func toViolationState(value *string) storage.ViolationState {

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -206,6 +206,8 @@ func (s *serviceImpl) GetMetadata(ctx context.Context, _ *v1.Empty) (*v1.Metadat
 	// Only return the version to logged in users, not anonymous users.
 	if authn.IdentityFromContextOrNil(ctx) != nil {
 		metadata.Version = version.GetMainVersion()
+		metadata.MinCompatibleSensorVersion = version.MinCompatibleSensorVersion()
+		metadata.MaxCompatibleSensorVersion = version.MaxCompatibleSensorVersion()
 	}
 	return metadata, nil
 }

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -231,6 +232,11 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		if err := s.clusters.UpdateClusterCertExpiryStatus(clusterDSSAC, cluster.GetId(), expiryStatus); err != nil {
 			log.Warnf("Failed to update cluster expiry status for cluster %s: %v.", cluster.GetId(), err)
 		}
+	}
+
+	versionSkew := version.ComputeVersionSkew(version.GetMainVersion(), sensorHello.GetSensorVersion())
+	if err := s.clusters.UpdateClusterVersionSkew(clusterDSSAC, cluster.GetId(), versionSkew); err != nil {
+		log.Warnf("Failed to update version skew for cluster %s: %v.", cluster.GetId(), err)
 	}
 
 	log.Infof("Cluster %s (%s) has successfully connected to Central.", cluster.GetName(), cluster.GetId())

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -723,6 +723,9 @@
         },
         "certExpiryStatus": {
           "$ref": "#/definitions/storageClusterCertExpiryStatus"
+        },
+        "versionSkew": {
+          "$ref": "#/definitions/storageVersionSkew"
         }
       }
     },
@@ -1016,6 +1019,42 @@
           "format": "date-time"
         }
       }
+    },
+    "storageVersionSkew": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/storageVersionSkewStatus"
+        },
+        "reason": {
+          "$ref": "#/definitions/storageVersionSkewReason"
+        },
+        "minCompatibleSensorVersion": {
+          "type": "string"
+        },
+        "maxCompatibleSensorVersion": {
+          "type": "string"
+        }
+      }
+    },
+    "storageVersionSkewReason": {
+      "type": "string",
+      "enum": [
+        "VERSION_SKEW_REASON_UNSPECIFIED",
+        "VERSION_SKEW_REASON_SENSOR_TOO_OLD",
+        "VERSION_SKEW_REASON_SENSOR_AHEAD"
+      ],
+      "default": "VERSION_SKEW_REASON_UNSPECIFIED"
+    },
+    "storageVersionSkewStatus": {
+      "type": "string",
+      "enum": [
+        "VERSION_SKEW_STATUS_UNSPECIFIED",
+        "VERSION_SKEW_STATUS_MATCHING",
+        "VERSION_SKEW_STATUS_COMPATIBLE",
+        "VERSION_SKEW_STATUS_INCOMPATIBLE"
+      ],
+      "default": "VERSION_SKEW_STATUS_UNSPECIFIED"
     },
     "v1ClusterDefaultsResponse": {
       "type": "object",

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -1026,25 +1026,28 @@
         "status": {
           "$ref": "#/definitions/storageVersionSkewStatus"
         },
-        "reason": {
-          "$ref": "#/definitions/storageVersionSkewReason"
+        "incompatibilityReason": {
+          "$ref": "#/definitions/storageVersionSkewIncompatibilityReason",
+          "description": "Only set when status is VERSION_SKEW_STATUS_INCOMPATIBLE."
         },
         "minCompatibleSensorVersion": {
-          "type": "string"
+          "type": "string",
+          "description": "Oldest compatible Sensor version, in X.Y format (patch version not included)."
         },
         "maxCompatibleSensorVersion": {
-          "type": "string"
+          "type": "string",
+          "description": "Newest compatible Sensor version, in X.Y format (patch version not included)."
         }
       }
     },
-    "storageVersionSkewReason": {
+    "storageVersionSkewIncompatibilityReason": {
       "type": "string",
       "enum": [
-        "VERSION_SKEW_REASON_UNSPECIFIED",
-        "VERSION_SKEW_REASON_SENSOR_TOO_OLD",
-        "VERSION_SKEW_REASON_SENSOR_AHEAD"
+        "VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED",
+        "VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD",
+        "VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW"
       ],
-      "default": "VERSION_SKEW_REASON_UNSPECIFIED"
+      "default": "VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED"
     },
     "storageVersionSkewStatus": {
       "type": "string",

--- a/generated/api/v1/metadata_service.pb.go
+++ b/generated/api/v1/metadata_service.pb.go
@@ -191,9 +191,11 @@ type Metadata struct {
 	// Do not use this field. It will always contain "VALID"
 	//
 	// Deprecated: Marked as deprecated in api/v1/metadata_service.proto.
-	LicenseStatus Metadata_LicenseStatus `protobuf:"varint,4,opt,name=license_status,json=licenseStatus,proto3,enum=v1.Metadata_LicenseStatus" json:"license_status,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	LicenseStatus              Metadata_LicenseStatus `protobuf:"varint,4,opt,name=license_status,json=licenseStatus,proto3,enum=v1.Metadata_LicenseStatus" json:"license_status,omitempty"`
+	MinCompatibleSensorVersion string                 `protobuf:"bytes,5,opt,name=min_compatible_sensor_version,json=minCompatibleSensorVersion,proto3" json:"min_compatible_sensor_version,omitempty"`
+	MaxCompatibleSensorVersion string                 `protobuf:"bytes,6,opt,name=max_compatible_sensor_version,json=maxCompatibleSensorVersion,proto3" json:"max_compatible_sensor_version,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *Metadata) Reset() {
@@ -253,6 +255,20 @@ func (x *Metadata) GetLicenseStatus() Metadata_LicenseStatus {
 		return x.LicenseStatus
 	}
 	return Metadata_NONE
+}
+
+func (x *Metadata) GetMinCompatibleSensorVersion() string {
+	if x != nil {
+		return x.MinCompatibleSensorVersion
+	}
+	return ""
+}
+
+func (x *Metadata) GetMaxCompatibleSensorVersion() string {
+	if x != nil {
+		return x.MaxCompatibleSensorVersion
+	}
+	return ""
 }
 
 type TrustInfo struct {
@@ -652,12 +668,14 @@ var File_api_v1_metadata_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_metadata_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dapi/v1/metadata_service.proto\x12\x02v1\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19storage/system_info.proto\"\x93\x02\n" +
+	"\x1dapi/v1/metadata_service.proto\x12\x02v1\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19storage/system_info.proto\"\x99\x03\n" +
 	"\bMetadata\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12!\n" +
 	"\fbuild_flavor\x18\x02 \x01(\tR\vbuildFlavor\x12#\n" +
 	"\rrelease_build\x18\x03 \x01(\bR\freleaseBuild\x12E\n" +
-	"\x0elicense_status\x18\x04 \x01(\x0e2\x1a.v1.Metadata.LicenseStatusB\x02\x18\x01R\rlicenseStatus\"^\n" +
+	"\x0elicense_status\x18\x04 \x01(\x0e2\x1a.v1.Metadata.LicenseStatusB\x02\x18\x01R\rlicenseStatus\x12A\n" +
+	"\x1dmin_compatible_sensor_version\x18\x05 \x01(\tR\x1aminCompatibleSensorVersion\x12A\n" +
+	"\x1dmax_compatible_sensor_version\x18\x06 \x01(\tR\x1amaxCompatibleSensorVersion\"^\n" +
 	"\rLicenseStatus\x12\f\n" +
 	"\x04NONE\x10\x00\x1a\x02\b\x01\x12\x0f\n" +
 	"\aINVALID\x10\x01\x1a\x02\b\x01\x12\x0f\n" +

--- a/generated/api/v1/metadata_service.swagger.json
+++ b/generated/api/v1/metadata_service.swagger.json
@@ -301,6 +301,12 @@
         "licenseStatus": {
           "$ref": "#/definitions/MetadataLicenseStatus",
           "title": "Do not use this field. It will always contain \"VALID\""
+        },
+        "minCompatibleSensorVersion": {
+          "type": "string"
+        },
+        "maxCompatibleSensorVersion": {
+          "type": "string"
         }
       }
     },

--- a/generated/api/v1/metadata_service_vtproto.pb.go
+++ b/generated/api/v1/metadata_service_vtproto.pb.go
@@ -30,6 +30,8 @@ func (m *Metadata) CloneVT() *Metadata {
 	r.BuildFlavor = m.BuildFlavor
 	r.ReleaseBuild = m.ReleaseBuild
 	r.LicenseStatus = m.LicenseStatus
+	r.MinCompatibleSensorVersion = m.MinCompatibleSensorVersion
+	r.MaxCompatibleSensorVersion = m.MaxCompatibleSensorVersion
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -214,6 +216,12 @@ func (this *Metadata) EqualVT(that *Metadata) bool {
 		return false
 	}
 	if this.LicenseStatus != that.LicenseStatus {
+		return false
+	}
+	if this.MinCompatibleSensorVersion != that.MinCompatibleSensorVersion {
+		return false
+	}
+	if this.MaxCompatibleSensorVersion != that.MaxCompatibleSensorVersion {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -432,6 +440,20 @@ func (m *Metadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MaxCompatibleSensorVersion) > 0 {
+		i -= len(m.MaxCompatibleSensorVersion)
+		copy(dAtA[i:], m.MaxCompatibleSensorVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MaxCompatibleSensorVersion)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.MinCompatibleSensorVersion) > 0 {
+		i -= len(m.MinCompatibleSensorVersion)
+		copy(dAtA[i:], m.MinCompatibleSensorVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MinCompatibleSensorVersion)))
+		i--
+		dAtA[i] = 0x2a
 	}
 	if m.LicenseStatus != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.LicenseStatus))
@@ -831,6 +853,14 @@ func (m *Metadata) SizeVT() (n int) {
 	if m.LicenseStatus != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.LicenseStatus))
 	}
+	l = len(m.MinCompatibleSensorVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.MaxCompatibleSensorVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1107,6 +1137,70 @@ func (m *Metadata) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MinCompatibleSensorVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MaxCompatibleSensorVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2099,6 +2193,78 @@ func (m *Metadata) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.MinCompatibleSensorVersion = stringValue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.MaxCompatibleSensorVersion = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -235,52 +235,52 @@ func (VersionSkewStatus) EnumDescriptor() ([]byte, []int) {
 	return file_storage_cluster_proto_rawDescGZIP(), []int{3}
 }
 
-type VersionSkewReason int32
+type VersionSkewIncompatibilityReason int32
 
 const (
-	VersionSkewReason_VERSION_SKEW_REASON_UNSPECIFIED    VersionSkewReason = 0
-	VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD VersionSkewReason = 1
-	VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD   VersionSkewReason = 2
+	VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED    VersionSkewIncompatibilityReason = 0
+	VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD VersionSkewIncompatibilityReason = 1
+	VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW VersionSkewIncompatibilityReason = 2
 )
 
-// Enum value maps for VersionSkewReason.
+// Enum value maps for VersionSkewIncompatibilityReason.
 var (
-	VersionSkewReason_name = map[int32]string{
-		0: "VERSION_SKEW_REASON_UNSPECIFIED",
-		1: "VERSION_SKEW_REASON_SENSOR_TOO_OLD",
-		2: "VERSION_SKEW_REASON_SENSOR_AHEAD",
+	VersionSkewIncompatibilityReason_name = map[int32]string{
+		0: "VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED",
+		1: "VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD",
+		2: "VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW",
 	}
-	VersionSkewReason_value = map[string]int32{
-		"VERSION_SKEW_REASON_UNSPECIFIED":    0,
-		"VERSION_SKEW_REASON_SENSOR_TOO_OLD": 1,
-		"VERSION_SKEW_REASON_SENSOR_AHEAD":   2,
+	VersionSkewIncompatibilityReason_value = map[string]int32{
+		"VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED":    0,
+		"VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD": 1,
+		"VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW": 2,
 	}
 )
 
-func (x VersionSkewReason) Enum() *VersionSkewReason {
-	p := new(VersionSkewReason)
+func (x VersionSkewIncompatibilityReason) Enum() *VersionSkewIncompatibilityReason {
+	p := new(VersionSkewIncompatibilityReason)
 	*p = x
 	return p
 }
 
-func (x VersionSkewReason) String() string {
+func (x VersionSkewIncompatibilityReason) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (VersionSkewReason) Descriptor() protoreflect.EnumDescriptor {
+func (VersionSkewIncompatibilityReason) Descriptor() protoreflect.EnumDescriptor {
 	return file_storage_cluster_proto_enumTypes[4].Descriptor()
 }
 
-func (VersionSkewReason) Type() protoreflect.EnumType {
+func (VersionSkewIncompatibilityReason) Type() protoreflect.EnumType {
 	return &file_storage_cluster_proto_enumTypes[4]
 }
 
-func (x VersionSkewReason) Number() protoreflect.EnumNumber {
+func (x VersionSkewIncompatibilityReason) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use VersionSkewReason.Descriptor instead.
-func (VersionSkewReason) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use VersionSkewIncompatibilityReason.Descriptor instead.
+func (VersionSkewIncompatibilityReason) EnumDescriptor() ([]byte, []int) {
 	return file_storage_cluster_proto_rawDescGZIP(), []int{4}
 }
 
@@ -1851,11 +1851,14 @@ func (x *ClusterCertExpiryStatus) GetSensorCertNotBefore() *timestamppb.Timestam
 }
 
 type VersionSkew struct {
-	state                      protoimpl.MessageState `protogen:"open.v1"`
-	Status                     VersionSkewStatus      `protobuf:"varint,1,opt,name=status,proto3,enum=storage.VersionSkewStatus" json:"status,omitempty"`
-	Reason                     VersionSkewReason      `protobuf:"varint,2,opt,name=reason,proto3,enum=storage.VersionSkewReason" json:"reason,omitempty"`
-	MinCompatibleSensorVersion string                 `protobuf:"bytes,3,opt,name=min_compatible_sensor_version,json=minCompatibleSensorVersion,proto3" json:"min_compatible_sensor_version,omitempty"`
-	MaxCompatibleSensorVersion string                 `protobuf:"bytes,4,opt,name=max_compatible_sensor_version,json=maxCompatibleSensorVersion,proto3" json:"max_compatible_sensor_version,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Status VersionSkewStatus      `protobuf:"varint,1,opt,name=status,proto3,enum=storage.VersionSkewStatus" json:"status,omitempty"`
+	// Only set when status is VERSION_SKEW_STATUS_INCOMPATIBLE.
+	IncompatibilityReason VersionSkewIncompatibilityReason `protobuf:"varint,2,opt,name=incompatibility_reason,json=incompatibilityReason,proto3,enum=storage.VersionSkewIncompatibilityReason" json:"incompatibility_reason,omitempty"`
+	// Oldest compatible Sensor version, in X.Y format (patch version not included).
+	MinCompatibleSensorVersion string `protobuf:"bytes,3,opt,name=min_compatible_sensor_version,json=minCompatibleSensorVersion,proto3" json:"min_compatible_sensor_version,omitempty"`
+	// Newest compatible Sensor version, in X.Y format (patch version not included).
+	MaxCompatibleSensorVersion string `protobuf:"bytes,4,opt,name=max_compatible_sensor_version,json=maxCompatibleSensorVersion,proto3" json:"max_compatible_sensor_version,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
@@ -1897,11 +1900,11 @@ func (x *VersionSkew) GetStatus() VersionSkewStatus {
 	return VersionSkewStatus_VERSION_SKEW_STATUS_UNSPECIFIED
 }
 
-func (x *VersionSkew) GetReason() VersionSkewReason {
+func (x *VersionSkew) GetIncompatibilityReason() VersionSkewIncompatibilityReason {
 	if x != nil {
-		return x.Reason
+		return x.IncompatibilityReason
 	}
-	return VersionSkewReason_VERSION_SKEW_REASON_UNSPECIFIED
+	return VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED
 }
 
 func (x *VersionSkew) GetMinCompatibleSensorVersion() string {
@@ -3050,10 +3053,10 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0f\"\xb4\x01\n" +
 	"\x17ClusterCertExpiryStatus\x12H\n" +
 	"\x12sensor_cert_expiry\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x10sensorCertExpiry\x12O\n" +
-	"\x16sensor_cert_not_before\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x13sensorCertNotBefore\"\xfb\x01\n" +
+	"\x16sensor_cert_not_before\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x13sensorCertNotBefore\"\xa9\x02\n" +
 	"\vVersionSkew\x122\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x1a.storage.VersionSkewStatusR\x06status\x122\n" +
-	"\x06reason\x18\x02 \x01(\x0e2\x1a.storage.VersionSkewReasonR\x06reason\x12A\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x1a.storage.VersionSkewStatusR\x06status\x12`\n" +
+	"\x16incompatibility_reason\x18\x02 \x01(\x0e2).storage.VersionSkewIncompatibilityReasonR\x15incompatibilityReason\x12A\n" +
 	"\x1dmin_compatible_sensor_version\x18\x03 \x01(\tR\x1aminCompatibleSensorVersion\x12A\n" +
 	"\x1dmax_compatible_sensor_version\x18\x04 \x01(\tR\x1amaxCompatibleSensorVersion\"\xf5\x03\n" +
 	"\rClusterStatus\x12%\n" +
@@ -3172,11 +3175,11 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x1fVERSION_SKEW_STATUS_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cVERSION_SKEW_STATUS_MATCHING\x10\x01\x12\"\n" +
 	"\x1eVERSION_SKEW_STATUS_COMPATIBLE\x10\x02\x12$\n" +
-	" VERSION_SKEW_STATUS_INCOMPATIBLE\x10\x03*\x86\x01\n" +
-	"\x11VersionSkewReason\x12#\n" +
-	"\x1fVERSION_SKEW_REASON_UNSPECIFIED\x10\x00\x12&\n" +
-	"\"VERSION_SKEW_REASON_SENSOR_TOO_OLD\x10\x01\x12$\n" +
-	" VERSION_SKEW_REASON_SENSOR_AHEAD\x10\x02B.\n" +
+	" VERSION_SKEW_STATUS_INCOMPATIBLE\x10\x03*\xc7\x01\n" +
+	" VersionSkewIncompatibilityReason\x123\n" +
+	"/VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED\x10\x00\x126\n" +
+	"2VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD\x10\x01\x126\n" +
+	"2VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW\x10\x02B.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (
@@ -3198,7 +3201,7 @@ var file_storage_cluster_proto_goTypes = []any{
 	(CollectionMethod)(0),                   // 1: storage.CollectionMethod
 	(ManagerType)(0),                        // 2: storage.ManagerType
 	(VersionSkewStatus)(0),                  // 3: storage.VersionSkewStatus
-	(VersionSkewReason)(0),                  // 4: storage.VersionSkewReason
+	(VersionSkewIncompatibilityReason)(0),   // 4: storage.VersionSkewIncompatibilityReason
 	(ClusterMetadata_Type)(0),               // 5: storage.ClusterMetadata.Type
 	(ClusterUpgradeStatus_Upgradability)(0), // 6: storage.ClusterUpgradeStatus.Upgradability
 	(ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType)(0), // 7: storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
@@ -3265,7 +3268,7 @@ var file_storage_cluster_proto_depIdxs = []int32{
 	39, // 26: storage.ClusterCertExpiryStatus.sensor_cert_expiry:type_name -> google.protobuf.Timestamp
 	39, // 27: storage.ClusterCertExpiryStatus.sensor_cert_not_before:type_name -> google.protobuf.Timestamp
 	3,  // 28: storage.VersionSkew.status:type_name -> storage.VersionSkewStatus
-	4,  // 29: storage.VersionSkew.reason:type_name -> storage.VersionSkewReason
+	4,  // 29: storage.VersionSkew.incompatibility_reason:type_name -> storage.VersionSkewIncompatibilityReason
 	39, // 30: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
 	14, // 31: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
 	15, // 32: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -183,6 +183,107 @@ func (ManagerType) EnumDescriptor() ([]byte, []int) {
 	return file_storage_cluster_proto_rawDescGZIP(), []int{2}
 }
 
+type VersionSkewStatus int32
+
+const (
+	VersionSkewStatus_VERSION_SKEW_STATUS_UNSPECIFIED  VersionSkewStatus = 0
+	VersionSkewStatus_VERSION_SKEW_STATUS_MATCHING     VersionSkewStatus = 1
+	VersionSkewStatus_VERSION_SKEW_STATUS_COMPATIBLE   VersionSkewStatus = 2
+	VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE VersionSkewStatus = 3
+)
+
+// Enum value maps for VersionSkewStatus.
+var (
+	VersionSkewStatus_name = map[int32]string{
+		0: "VERSION_SKEW_STATUS_UNSPECIFIED",
+		1: "VERSION_SKEW_STATUS_MATCHING",
+		2: "VERSION_SKEW_STATUS_COMPATIBLE",
+		3: "VERSION_SKEW_STATUS_INCOMPATIBLE",
+	}
+	VersionSkewStatus_value = map[string]int32{
+		"VERSION_SKEW_STATUS_UNSPECIFIED":  0,
+		"VERSION_SKEW_STATUS_MATCHING":     1,
+		"VERSION_SKEW_STATUS_COMPATIBLE":   2,
+		"VERSION_SKEW_STATUS_INCOMPATIBLE": 3,
+	}
+)
+
+func (x VersionSkewStatus) Enum() *VersionSkewStatus {
+	p := new(VersionSkewStatus)
+	*p = x
+	return p
+}
+
+func (x VersionSkewStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (VersionSkewStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_storage_cluster_proto_enumTypes[3].Descriptor()
+}
+
+func (VersionSkewStatus) Type() protoreflect.EnumType {
+	return &file_storage_cluster_proto_enumTypes[3]
+}
+
+func (x VersionSkewStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use VersionSkewStatus.Descriptor instead.
+func (VersionSkewStatus) EnumDescriptor() ([]byte, []int) {
+	return file_storage_cluster_proto_rawDescGZIP(), []int{3}
+}
+
+type VersionSkewReason int32
+
+const (
+	VersionSkewReason_VERSION_SKEW_REASON_UNSPECIFIED    VersionSkewReason = 0
+	VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD VersionSkewReason = 1
+	VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD   VersionSkewReason = 2
+)
+
+// Enum value maps for VersionSkewReason.
+var (
+	VersionSkewReason_name = map[int32]string{
+		0: "VERSION_SKEW_REASON_UNSPECIFIED",
+		1: "VERSION_SKEW_REASON_SENSOR_TOO_OLD",
+		2: "VERSION_SKEW_REASON_SENSOR_AHEAD",
+	}
+	VersionSkewReason_value = map[string]int32{
+		"VERSION_SKEW_REASON_UNSPECIFIED":    0,
+		"VERSION_SKEW_REASON_SENSOR_TOO_OLD": 1,
+		"VERSION_SKEW_REASON_SENSOR_AHEAD":   2,
+	}
+)
+
+func (x VersionSkewReason) Enum() *VersionSkewReason {
+	p := new(VersionSkewReason)
+	*p = x
+	return p
+}
+
+func (x VersionSkewReason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (VersionSkewReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_storage_cluster_proto_enumTypes[4].Descriptor()
+}
+
+func (VersionSkewReason) Type() protoreflect.EnumType {
+	return &file_storage_cluster_proto_enumTypes[4]
+}
+
+func (x VersionSkewReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use VersionSkewReason.Descriptor instead.
+func (VersionSkewReason) EnumDescriptor() ([]byte, []int) {
+	return file_storage_cluster_proto_rawDescGZIP(), []int{4}
+}
+
 type ClusterMetadata_Type int32
 
 const (
@@ -231,11 +332,11 @@ func (x ClusterMetadata_Type) String() string {
 }
 
 func (ClusterMetadata_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cluster_proto_enumTypes[3].Descriptor()
+	return file_storage_cluster_proto_enumTypes[5].Descriptor()
 }
 
 func (ClusterMetadata_Type) Type() protoreflect.EnumType {
-	return &file_storage_cluster_proto_enumTypes[3]
+	return &file_storage_cluster_proto_enumTypes[5]
 }
 
 func (x ClusterMetadata_Type) Number() protoreflect.EnumNumber {
@@ -294,11 +395,11 @@ func (x ClusterUpgradeStatus_Upgradability) String() string {
 }
 
 func (ClusterUpgradeStatus_Upgradability) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cluster_proto_enumTypes[4].Descriptor()
+	return file_storage_cluster_proto_enumTypes[6].Descriptor()
 }
 
 func (ClusterUpgradeStatus_Upgradability) Type() protoreflect.EnumType {
-	return &file_storage_cluster_proto_enumTypes[4]
+	return &file_storage_cluster_proto_enumTypes[6]
 }
 
 func (x ClusterUpgradeStatus_Upgradability) Number() protoreflect.EnumNumber {
@@ -307,7 +408,7 @@ func (x ClusterUpgradeStatus_Upgradability) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ClusterUpgradeStatus_Upgradability.Descriptor instead.
 func (ClusterUpgradeStatus_Upgradability) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{16, 0}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{17, 0}
 }
 
 type ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType int32
@@ -343,11 +444,11 @@ func (x ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType) String() s
 }
 
 func (ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cluster_proto_enumTypes[5].Descriptor()
+	return file_storage_cluster_proto_enumTypes[7].Descriptor()
 }
 
 func (ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType) Type() protoreflect.EnumType {
-	return &file_storage_cluster_proto_enumTypes[5]
+	return &file_storage_cluster_proto_enumTypes[7]
 }
 
 func (x ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType) Number() protoreflect.EnumNumber {
@@ -356,7 +457,7 @@ func (x ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType) Number() p
 
 // Deprecated: Use ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType.Descriptor instead.
 func (ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{16, 0, 0}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{17, 0, 0}
 }
 
 type UpgradeProgress_UpgradeState int32
@@ -427,11 +528,11 @@ func (x UpgradeProgress_UpgradeState) String() string {
 }
 
 func (UpgradeProgress_UpgradeState) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cluster_proto_enumTypes[6].Descriptor()
+	return file_storage_cluster_proto_enumTypes[8].Descriptor()
 }
 
 func (UpgradeProgress_UpgradeState) Type() protoreflect.EnumType {
-	return &file_storage_cluster_proto_enumTypes[6]
+	return &file_storage_cluster_proto_enumTypes[8]
 }
 
 func (x UpgradeProgress_UpgradeState) Number() protoreflect.EnumNumber {
@@ -440,7 +541,7 @@ func (x UpgradeProgress_UpgradeState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use UpgradeProgress_UpgradeState.Descriptor instead.
 func (UpgradeProgress_UpgradeState) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{17, 0}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{18, 0}
 }
 
 type ClusterHealthStatus_HealthStatusLabel int32
@@ -483,11 +584,11 @@ func (x ClusterHealthStatus_HealthStatusLabel) String() string {
 }
 
 func (ClusterHealthStatus_HealthStatusLabel) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cluster_proto_enumTypes[7].Descriptor()
+	return file_storage_cluster_proto_enumTypes[9].Descriptor()
 }
 
 func (ClusterHealthStatus_HealthStatusLabel) Type() protoreflect.EnumType {
-	return &file_storage_cluster_proto_enumTypes[7]
+	return &file_storage_cluster_proto_enumTypes[9]
 }
 
 func (x ClusterHealthStatus_HealthStatusLabel) Number() protoreflect.EnumNumber {
@@ -496,7 +597,7 @@ func (x ClusterHealthStatus_HealthStatusLabel) Number() protoreflect.EnumNumber 
 
 // Deprecated: Use ClusterHealthStatus_HealthStatusLabel.Descriptor instead.
 func (ClusterHealthStatus_HealthStatusLabel) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{19, 0}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{20, 0}
 }
 
 // ClusterMetadata contains metadata information about the cluster infrastructure.
@@ -1749,6 +1850,74 @@ func (x *ClusterCertExpiryStatus) GetSensorCertNotBefore() *timestamppb.Timestam
 	return nil
 }
 
+type VersionSkew struct {
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	Status                     VersionSkewStatus      `protobuf:"varint,1,opt,name=status,proto3,enum=storage.VersionSkewStatus" json:"status,omitempty"`
+	Reason                     VersionSkewReason      `protobuf:"varint,2,opt,name=reason,proto3,enum=storage.VersionSkewReason" json:"reason,omitempty"`
+	MinCompatibleSensorVersion string                 `protobuf:"bytes,3,opt,name=min_compatible_sensor_version,json=minCompatibleSensorVersion,proto3" json:"min_compatible_sensor_version,omitempty"`
+	MaxCompatibleSensorVersion string                 `protobuf:"bytes,4,opt,name=max_compatible_sensor_version,json=maxCompatibleSensorVersion,proto3" json:"max_compatible_sensor_version,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *VersionSkew) Reset() {
+	*x = VersionSkew{}
+	mi := &file_storage_cluster_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VersionSkew) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VersionSkew) ProtoMessage() {}
+
+func (x *VersionSkew) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_cluster_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VersionSkew.ProtoReflect.Descriptor instead.
+func (*VersionSkew) Descriptor() ([]byte, []int) {
+	return file_storage_cluster_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *VersionSkew) GetStatus() VersionSkewStatus {
+	if x != nil {
+		return x.Status
+	}
+	return VersionSkewStatus_VERSION_SKEW_STATUS_UNSPECIFIED
+}
+
+func (x *VersionSkew) GetReason() VersionSkewReason {
+	if x != nil {
+		return x.Reason
+	}
+	return VersionSkewReason_VERSION_SKEW_REASON_UNSPECIFIED
+}
+
+func (x *VersionSkew) GetMinCompatibleSensorVersion() string {
+	if x != nil {
+		return x.MinCompatibleSensorVersion
+	}
+	return ""
+}
+
+func (x *VersionSkew) GetMaxCompatibleSensorVersion() string {
+	if x != nil {
+		return x.MaxCompatibleSensorVersion
+	}
+	return ""
+}
+
 type ClusterStatus struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SensorVersion string                 `protobuf:"bytes,1,opt,name=sensor_version,json=sensorVersion,proto3" json:"sensor_version,omitempty"`
@@ -1758,13 +1927,14 @@ type ClusterStatus struct {
 	OrchestratorMetadata  *OrchestratorMetadata    `protobuf:"bytes,4,opt,name=orchestrator_metadata,json=orchestratorMetadata,proto3" json:"orchestrator_metadata,omitempty"`
 	UpgradeStatus         *ClusterUpgradeStatus    `protobuf:"bytes,5,opt,name=upgrade_status,json=upgradeStatus,proto3" json:"upgrade_status,omitempty"`
 	CertExpiryStatus      *ClusterCertExpiryStatus `protobuf:"bytes,6,opt,name=cert_expiry_status,json=certExpiryStatus,proto3" json:"cert_expiry_status,omitempty"`
+	VersionSkew           *VersionSkew             `protobuf:"bytes,7,opt,name=version_skew,json=versionSkew,proto3" json:"version_skew,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ClusterStatus) Reset() {
 	*x = ClusterStatus{}
-	mi := &file_storage_cluster_proto_msgTypes[15]
+	mi := &file_storage_cluster_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1776,7 +1946,7 @@ func (x *ClusterStatus) String() string {
 func (*ClusterStatus) ProtoMessage() {}
 
 func (x *ClusterStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[15]
+	mi := &file_storage_cluster_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1789,7 +1959,7 @@ func (x *ClusterStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterStatus.ProtoReflect.Descriptor instead.
 func (*ClusterStatus) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{15}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ClusterStatus) GetSensorVersion() string {
@@ -1834,6 +2004,13 @@ func (x *ClusterStatus) GetCertExpiryStatus() *ClusterCertExpiryStatus {
 	return nil
 }
 
+func (x *ClusterStatus) GetVersionSkew() *VersionSkew {
+	if x != nil {
+		return x.VersionSkew
+	}
+	return nil
+}
+
 type ClusterUpgradeStatus struct {
 	state                     protoimpl.MessageState             `protogen:"open.v1"`
 	Upgradability             ClusterUpgradeStatus_Upgradability `protobuf:"varint,1,opt,name=upgradability,proto3,enum=storage.ClusterUpgradeStatus_Upgradability" json:"upgradability,omitempty"`
@@ -1849,7 +2026,7 @@ type ClusterUpgradeStatus struct {
 
 func (x *ClusterUpgradeStatus) Reset() {
 	*x = ClusterUpgradeStatus{}
-	mi := &file_storage_cluster_proto_msgTypes[16]
+	mi := &file_storage_cluster_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1861,7 +2038,7 @@ func (x *ClusterUpgradeStatus) String() string {
 func (*ClusterUpgradeStatus) ProtoMessage() {}
 
 func (x *ClusterUpgradeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[16]
+	mi := &file_storage_cluster_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1874,7 +2051,7 @@ func (x *ClusterUpgradeStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterUpgradeStatus.ProtoReflect.Descriptor instead.
 func (*ClusterUpgradeStatus) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{16}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ClusterUpgradeStatus) GetUpgradability() ClusterUpgradeStatus_Upgradability {
@@ -1909,7 +2086,7 @@ type UpgradeProgress struct {
 
 func (x *UpgradeProgress) Reset() {
 	*x = UpgradeProgress{}
-	mi := &file_storage_cluster_proto_msgTypes[17]
+	mi := &file_storage_cluster_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1921,7 +2098,7 @@ func (x *UpgradeProgress) String() string {
 func (*UpgradeProgress) ProtoMessage() {}
 
 func (x *UpgradeProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[17]
+	mi := &file_storage_cluster_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1934,7 +2111,7 @@ func (x *UpgradeProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpgradeProgress.ProtoReflect.Descriptor instead.
 func (*UpgradeProgress) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{17}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UpgradeProgress) GetUpgradeState() UpgradeProgress_UpgradeState {
@@ -1970,7 +2147,7 @@ type AuditLogFileState struct {
 
 func (x *AuditLogFileState) Reset() {
 	*x = AuditLogFileState{}
-	mi := &file_storage_cluster_proto_msgTypes[18]
+	mi := &file_storage_cluster_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1982,7 +2159,7 @@ func (x *AuditLogFileState) String() string {
 func (*AuditLogFileState) ProtoMessage() {}
 
 func (x *AuditLogFileState) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[18]
+	mi := &file_storage_cluster_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1995,7 +2172,7 @@ func (x *AuditLogFileState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuditLogFileState.ProtoReflect.Descriptor instead.
 func (*AuditLogFileState) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{18}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *AuditLogFileState) GetCollectLogsSince() *timestamppb.Timestamp {
@@ -2043,7 +2220,7 @@ type ClusterHealthStatus struct {
 
 func (x *ClusterHealthStatus) Reset() {
 	*x = ClusterHealthStatus{}
-	mi := &file_storage_cluster_proto_msgTypes[19]
+	mi := &file_storage_cluster_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2055,7 +2232,7 @@ func (x *ClusterHealthStatus) String() string {
 func (*ClusterHealthStatus) ProtoMessage() {}
 
 func (x *ClusterHealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[19]
+	mi := &file_storage_cluster_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2068,7 +2245,7 @@ func (x *ClusterHealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterHealthStatus.ProtoReflect.Descriptor instead.
 func (*ClusterHealthStatus) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{19}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ClusterHealthStatus) GetId() string {
@@ -2175,7 +2352,7 @@ type CollectorHealthInfo struct {
 
 func (x *CollectorHealthInfo) Reset() {
 	*x = CollectorHealthInfo{}
-	mi := &file_storage_cluster_proto_msgTypes[20]
+	mi := &file_storage_cluster_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2187,7 +2364,7 @@ func (x *CollectorHealthInfo) String() string {
 func (*CollectorHealthInfo) ProtoMessage() {}
 
 func (x *CollectorHealthInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[20]
+	mi := &file_storage_cluster_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2200,7 +2377,7 @@ func (x *CollectorHealthInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CollectorHealthInfo.ProtoReflect.Descriptor instead.
 func (*CollectorHealthInfo) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{20}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CollectorHealthInfo) GetVersion() string {
@@ -2317,7 +2494,7 @@ type AdmissionControlHealthInfo struct {
 
 func (x *AdmissionControlHealthInfo) Reset() {
 	*x = AdmissionControlHealthInfo{}
-	mi := &file_storage_cluster_proto_msgTypes[21]
+	mi := &file_storage_cluster_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2329,7 +2506,7 @@ func (x *AdmissionControlHealthInfo) String() string {
 func (*AdmissionControlHealthInfo) ProtoMessage() {}
 
 func (x *AdmissionControlHealthInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[21]
+	mi := &file_storage_cluster_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2342,7 +2519,7 @@ func (x *AdmissionControlHealthInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdmissionControlHealthInfo.ProtoReflect.Descriptor instead.
 func (*AdmissionControlHealthInfo) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{21}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *AdmissionControlHealthInfo) GetTotalDesiredPodsOpt() isAdmissionControlHealthInfo_TotalDesiredPodsOpt {
@@ -2437,7 +2614,7 @@ type ScannerHealthInfo struct {
 
 func (x *ScannerHealthInfo) Reset() {
 	*x = ScannerHealthInfo{}
-	mi := &file_storage_cluster_proto_msgTypes[22]
+	mi := &file_storage_cluster_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2449,7 +2626,7 @@ func (x *ScannerHealthInfo) String() string {
 func (*ScannerHealthInfo) ProtoMessage() {}
 
 func (x *ScannerHealthInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[22]
+	mi := &file_storage_cluster_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2462,7 +2639,7 @@ func (x *ScannerHealthInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScannerHealthInfo.ProtoReflect.Descriptor instead.
 func (*ScannerHealthInfo) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{22}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ScannerHealthInfo) GetTotalDesiredAnalyzerPodsOpt() isScannerHealthInfo_TotalDesiredAnalyzerPodsOpt {
@@ -2600,7 +2777,7 @@ type DynamicClusterConfig_ProcessIndicatorsConfig struct {
 
 func (x *DynamicClusterConfig_ProcessIndicatorsConfig) Reset() {
 	*x = DynamicClusterConfig_ProcessIndicatorsConfig{}
-	mi := &file_storage_cluster_proto_msgTypes[23]
+	mi := &file_storage_cluster_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2612,7 +2789,7 @@ func (x *DynamicClusterConfig_ProcessIndicatorsConfig) String() string {
 func (*DynamicClusterConfig_ProcessIndicatorsConfig) ProtoMessage() {}
 
 func (x *DynamicClusterConfig_ProcessIndicatorsConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[23]
+	mi := &file_storage_cluster_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2664,7 +2841,7 @@ type ClusterUpgradeStatus_UpgradeProcessStatus struct {
 
 func (x *ClusterUpgradeStatus_UpgradeProcessStatus) Reset() {
 	*x = ClusterUpgradeStatus_UpgradeProcessStatus{}
-	mi := &file_storage_cluster_proto_msgTypes[27]
+	mi := &file_storage_cluster_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2676,7 +2853,7 @@ func (x *ClusterUpgradeStatus_UpgradeProcessStatus) String() string {
 func (*ClusterUpgradeStatus_UpgradeProcessStatus) ProtoMessage() {}
 
 func (x *ClusterUpgradeStatus_UpgradeProcessStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[27]
+	mi := &file_storage_cluster_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2689,7 +2866,7 @@ func (x *ClusterUpgradeStatus_UpgradeProcessStatus) ProtoReflect() protoreflect.
 
 // Deprecated: Use ClusterUpgradeStatus_UpgradeProcessStatus.ProtoReflect.Descriptor instead.
 func (*ClusterUpgradeStatus_UpgradeProcessStatus) Descriptor() ([]byte, []int) {
-	return file_storage_cluster_proto_rawDescGZIP(), []int{16, 0}
+	return file_storage_cluster_proto_rawDescGZIP(), []int{17, 0}
 }
 
 func (x *ClusterUpgradeStatus_UpgradeProcessStatus) GetActive() bool {
@@ -2873,14 +3050,20 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0f\"\xb4\x01\n" +
 	"\x17ClusterCertExpiryStatus\x12H\n" +
 	"\x12sensor_cert_expiry\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x10sensorCertExpiry\x12O\n" +
-	"\x16sensor_cert_not_before\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x13sensorCertNotBefore\"\xbc\x03\n" +
+	"\x16sensor_cert_not_before\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x13sensorCertNotBefore\"\xfb\x01\n" +
+	"\vVersionSkew\x122\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x1a.storage.VersionSkewStatusR\x06status\x122\n" +
+	"\x06reason\x18\x02 \x01(\x0e2\x1a.storage.VersionSkewReasonR\x06reason\x12A\n" +
+	"\x1dmin_compatible_sensor_version\x18\x03 \x01(\tR\x1aminCompatibleSensorVersion\x12A\n" +
+	"\x1dmax_compatible_sensor_version\x18\x04 \x01(\tR\x1amaxCompatibleSensorVersion\"\xf5\x03\n" +
 	"\rClusterStatus\x12%\n" +
 	"\x0esensor_version\x18\x01 \x01(\tR\rsensorVersion\x12R\n" +
 	"\x17DEPRECATED_last_contact\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x15DEPRECATEDLastContact\x12F\n" +
 	"\x11provider_metadata\x18\x03 \x01(\v2\x19.storage.ProviderMetadataR\x10providerMetadata\x12R\n" +
 	"\x15orchestrator_metadata\x18\x04 \x01(\v2\x1d.storage.OrchestratorMetadataR\x14orchestratorMetadata\x12D\n" +
 	"\x0eupgrade_status\x18\x05 \x01(\v2\x1d.storage.ClusterUpgradeStatusR\rupgradeStatus\x12N\n" +
-	"\x12cert_expiry_status\x18\x06 \x01(\v2 .storage.ClusterCertExpiryStatusR\x10certExpiryStatus\"\xa1\x06\n" +
+	"\x12cert_expiry_status\x18\x06 \x01(\v2 .storage.ClusterCertExpiryStatusR\x10certExpiryStatus\x127\n" +
+	"\fversion_skew\x18\a \x01(\v2\x14.storage.VersionSkewR\vversionSkew\"\xa1\x06\n" +
 	"\x14ClusterUpgradeStatus\x12Q\n" +
 	"\rupgradability\x18\x01 \x01(\x0e2+.storage.ClusterUpgradeStatus.UpgradabilityR\rupgradability\x12>\n" +
 	"\x1bupgradability_status_reason\x18\x02 \x01(\tR\x19upgradabilityStatusReason\x12b\n" +
@@ -2984,7 +3167,16 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x14MANAGER_TYPE_UNKNOWN\x10\x00\x12\x17\n" +
 	"\x13MANAGER_TYPE_MANUAL\x10\x01\x12\x1b\n" +
 	"\x17MANAGER_TYPE_HELM_CHART\x10\x02\x12$\n" +
-	" MANAGER_TYPE_KUBERNETES_OPERATOR\x10\x03B.\n" +
+	" MANAGER_TYPE_KUBERNETES_OPERATOR\x10\x03*\xa4\x01\n" +
+	"\x11VersionSkewStatus\x12#\n" +
+	"\x1fVERSION_SKEW_STATUS_UNSPECIFIED\x10\x00\x12 \n" +
+	"\x1cVERSION_SKEW_STATUS_MATCHING\x10\x01\x12\"\n" +
+	"\x1eVERSION_SKEW_STATUS_COMPATIBLE\x10\x02\x12$\n" +
+	" VERSION_SKEW_STATUS_INCOMPATIBLE\x10\x03*\x86\x01\n" +
+	"\x11VersionSkewReason\x12#\n" +
+	"\x1fVERSION_SKEW_REASON_UNSPECIFIED\x10\x00\x12&\n" +
+	"\"VERSION_SKEW_REASON_SENSOR_TOO_OLD\x10\x01\x12$\n" +
+	" VERSION_SKEW_REASON_SENSOR_AHEAD\x10\x02B.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (
@@ -2999,104 +3191,110 @@ func file_storage_cluster_proto_rawDescGZIP() []byte {
 	return file_storage_cluster_proto_rawDescData
 }
 
-var file_storage_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_storage_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_storage_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_storage_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_storage_cluster_proto_goTypes = []any{
 	(ClusterType)(0),                        // 0: storage.ClusterType
 	(CollectionMethod)(0),                   // 1: storage.CollectionMethod
 	(ManagerType)(0),                        // 2: storage.ManagerType
-	(ClusterMetadata_Type)(0),               // 3: storage.ClusterMetadata.Type
-	(ClusterUpgradeStatus_Upgradability)(0), // 4: storage.ClusterUpgradeStatus.Upgradability
-	(ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType)(0), // 5: storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
-	(UpgradeProgress_UpgradeState)(0),                                 // 6: storage.UpgradeProgress.UpgradeState
-	(ClusterHealthStatus_HealthStatusLabel)(0),                        // 7: storage.ClusterHealthStatus.HealthStatusLabel
-	(*ClusterMetadata)(nil),                                           // 8: storage.ClusterMetadata
-	(*GoogleProviderMetadata)(nil),                                    // 9: storage.GoogleProviderMetadata
-	(*AWSProviderMetadata)(nil),                                       // 10: storage.AWSProviderMetadata
-	(*AzureProviderMetadata)(nil),                                     // 11: storage.AzureProviderMetadata
-	(*ProviderMetadata)(nil),                                          // 12: storage.ProviderMetadata
-	(*OrchestratorMetadata)(nil),                                      // 13: storage.OrchestratorMetadata
-	(*AdmissionControllerConfig)(nil),                                 // 14: storage.AdmissionControllerConfig
-	(*TolerationsConfig)(nil),                                         // 15: storage.TolerationsConfig
-	(*StaticClusterConfig)(nil),                                       // 16: storage.StaticClusterConfig
-	(*AutoLockProcessBaselinesConfig)(nil),                            // 17: storage.AutoLockProcessBaselinesConfig
-	(*DynamicClusterConfig)(nil),                                      // 18: storage.DynamicClusterConfig
-	(*CompleteClusterConfig)(nil),                                     // 19: storage.CompleteClusterConfig
-	(*SensorDeploymentIdentification)(nil),                            // 20: storage.SensorDeploymentIdentification
-	(*Cluster)(nil),                                                   // 21: storage.Cluster
-	(*ClusterCertExpiryStatus)(nil),                                   // 22: storage.ClusterCertExpiryStatus
-	(*ClusterStatus)(nil),                                             // 23: storage.ClusterStatus
-	(*ClusterUpgradeStatus)(nil),                                      // 24: storage.ClusterUpgradeStatus
-	(*UpgradeProgress)(nil),                                           // 25: storage.UpgradeProgress
-	(*AuditLogFileState)(nil),                                         // 26: storage.AuditLogFileState
-	(*ClusterHealthStatus)(nil),                                       // 27: storage.ClusterHealthStatus
-	(*CollectorHealthInfo)(nil),                                       // 28: storage.CollectorHealthInfo
-	(*AdmissionControlHealthInfo)(nil),                                // 29: storage.AdmissionControlHealthInfo
-	(*ScannerHealthInfo)(nil),                                         // 30: storage.ScannerHealthInfo
-	(*DynamicClusterConfig_ProcessIndicatorsConfig)(nil),              // 31: storage.DynamicClusterConfig.ProcessIndicatorsConfig
-	nil, // 32: storage.CompleteClusterConfig.ClusterLabelsEntry
-	nil, // 33: storage.Cluster.LabelsEntry
-	nil, // 34: storage.Cluster.AuditLogStateEntry
-	(*ClusterUpgradeStatus_UpgradeProcessStatus)(nil), // 35: storage.ClusterUpgradeStatus.UpgradeProcessStatus
-	(*timestamppb.Timestamp)(nil),                     // 36: google.protobuf.Timestamp
+	(VersionSkewStatus)(0),                  // 3: storage.VersionSkewStatus
+	(VersionSkewReason)(0),                  // 4: storage.VersionSkewReason
+	(ClusterMetadata_Type)(0),               // 5: storage.ClusterMetadata.Type
+	(ClusterUpgradeStatus_Upgradability)(0), // 6: storage.ClusterUpgradeStatus.Upgradability
+	(ClusterUpgradeStatus_UpgradeProcessStatus_UpgradeProcessType)(0), // 7: storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
+	(UpgradeProgress_UpgradeState)(0),                                 // 8: storage.UpgradeProgress.UpgradeState
+	(ClusterHealthStatus_HealthStatusLabel)(0),                        // 9: storage.ClusterHealthStatus.HealthStatusLabel
+	(*ClusterMetadata)(nil),                                           // 10: storage.ClusterMetadata
+	(*GoogleProviderMetadata)(nil),                                    // 11: storage.GoogleProviderMetadata
+	(*AWSProviderMetadata)(nil),                                       // 12: storage.AWSProviderMetadata
+	(*AzureProviderMetadata)(nil),                                     // 13: storage.AzureProviderMetadata
+	(*ProviderMetadata)(nil),                                          // 14: storage.ProviderMetadata
+	(*OrchestratorMetadata)(nil),                                      // 15: storage.OrchestratorMetadata
+	(*AdmissionControllerConfig)(nil),                                 // 16: storage.AdmissionControllerConfig
+	(*TolerationsConfig)(nil),                                         // 17: storage.TolerationsConfig
+	(*StaticClusterConfig)(nil),                                       // 18: storage.StaticClusterConfig
+	(*AutoLockProcessBaselinesConfig)(nil),                            // 19: storage.AutoLockProcessBaselinesConfig
+	(*DynamicClusterConfig)(nil),                                      // 20: storage.DynamicClusterConfig
+	(*CompleteClusterConfig)(nil),                                     // 21: storage.CompleteClusterConfig
+	(*SensorDeploymentIdentification)(nil),                            // 22: storage.SensorDeploymentIdentification
+	(*Cluster)(nil),                                                   // 23: storage.Cluster
+	(*ClusterCertExpiryStatus)(nil),                                   // 24: storage.ClusterCertExpiryStatus
+	(*VersionSkew)(nil),                                               // 25: storage.VersionSkew
+	(*ClusterStatus)(nil),                                             // 26: storage.ClusterStatus
+	(*ClusterUpgradeStatus)(nil),                                      // 27: storage.ClusterUpgradeStatus
+	(*UpgradeProgress)(nil),                                           // 28: storage.UpgradeProgress
+	(*AuditLogFileState)(nil),                                         // 29: storage.AuditLogFileState
+	(*ClusterHealthStatus)(nil),                                       // 30: storage.ClusterHealthStatus
+	(*CollectorHealthInfo)(nil),                                       // 31: storage.CollectorHealthInfo
+	(*AdmissionControlHealthInfo)(nil),                                // 32: storage.AdmissionControlHealthInfo
+	(*ScannerHealthInfo)(nil),                                         // 33: storage.ScannerHealthInfo
+	(*DynamicClusterConfig_ProcessIndicatorsConfig)(nil),              // 34: storage.DynamicClusterConfig.ProcessIndicatorsConfig
+	nil, // 35: storage.CompleteClusterConfig.ClusterLabelsEntry
+	nil, // 36: storage.Cluster.LabelsEntry
+	nil, // 37: storage.Cluster.AuditLogStateEntry
+	(*ClusterUpgradeStatus_UpgradeProcessStatus)(nil), // 38: storage.ClusterUpgradeStatus.UpgradeProcessStatus
+	(*timestamppb.Timestamp)(nil),                     // 39: google.protobuf.Timestamp
 }
 var file_storage_cluster_proto_depIdxs = []int32{
-	3,  // 0: storage.ClusterMetadata.type:type_name -> storage.ClusterMetadata.Type
-	9,  // 1: storage.ProviderMetadata.google:type_name -> storage.GoogleProviderMetadata
-	10, // 2: storage.ProviderMetadata.aws:type_name -> storage.AWSProviderMetadata
-	11, // 3: storage.ProviderMetadata.azure:type_name -> storage.AzureProviderMetadata
-	8,  // 4: storage.ProviderMetadata.cluster:type_name -> storage.ClusterMetadata
-	36, // 5: storage.OrchestratorMetadata.build_date:type_name -> google.protobuf.Timestamp
+	5,  // 0: storage.ClusterMetadata.type:type_name -> storage.ClusterMetadata.Type
+	11, // 1: storage.ProviderMetadata.google:type_name -> storage.GoogleProviderMetadata
+	12, // 2: storage.ProviderMetadata.aws:type_name -> storage.AWSProviderMetadata
+	13, // 3: storage.ProviderMetadata.azure:type_name -> storage.AzureProviderMetadata
+	10, // 4: storage.ProviderMetadata.cluster:type_name -> storage.ClusterMetadata
+	39, // 5: storage.OrchestratorMetadata.build_date:type_name -> google.protobuf.Timestamp
 	0,  // 6: storage.StaticClusterConfig.type:type_name -> storage.ClusterType
 	1,  // 7: storage.StaticClusterConfig.collection_method:type_name -> storage.CollectionMethod
-	15, // 8: storage.StaticClusterConfig.tolerations_config:type_name -> storage.TolerationsConfig
-	14, // 9: storage.DynamicClusterConfig.admission_controller_config:type_name -> storage.AdmissionControllerConfig
-	17, // 10: storage.DynamicClusterConfig.auto_lock_process_baselines_config:type_name -> storage.AutoLockProcessBaselinesConfig
-	31, // 11: storage.DynamicClusterConfig.process_indicators:type_name -> storage.DynamicClusterConfig.ProcessIndicatorsConfig
-	18, // 12: storage.CompleteClusterConfig.dynamic_config:type_name -> storage.DynamicClusterConfig
-	16, // 13: storage.CompleteClusterConfig.static_config:type_name -> storage.StaticClusterConfig
-	32, // 14: storage.CompleteClusterConfig.cluster_labels:type_name -> storage.CompleteClusterConfig.ClusterLabelsEntry
+	17, // 8: storage.StaticClusterConfig.tolerations_config:type_name -> storage.TolerationsConfig
+	16, // 9: storage.DynamicClusterConfig.admission_controller_config:type_name -> storage.AdmissionControllerConfig
+	19, // 10: storage.DynamicClusterConfig.auto_lock_process_baselines_config:type_name -> storage.AutoLockProcessBaselinesConfig
+	34, // 11: storage.DynamicClusterConfig.process_indicators:type_name -> storage.DynamicClusterConfig.ProcessIndicatorsConfig
+	20, // 12: storage.CompleteClusterConfig.dynamic_config:type_name -> storage.DynamicClusterConfig
+	18, // 13: storage.CompleteClusterConfig.static_config:type_name -> storage.StaticClusterConfig
+	35, // 14: storage.CompleteClusterConfig.cluster_labels:type_name -> storage.CompleteClusterConfig.ClusterLabelsEntry
 	0,  // 15: storage.Cluster.type:type_name -> storage.ClusterType
-	33, // 16: storage.Cluster.labels:type_name -> storage.Cluster.LabelsEntry
+	36, // 16: storage.Cluster.labels:type_name -> storage.Cluster.LabelsEntry
 	1,  // 17: storage.Cluster.collection_method:type_name -> storage.CollectionMethod
-	23, // 18: storage.Cluster.status:type_name -> storage.ClusterStatus
-	18, // 19: storage.Cluster.dynamic_config:type_name -> storage.DynamicClusterConfig
-	15, // 20: storage.Cluster.tolerations_config:type_name -> storage.TolerationsConfig
-	27, // 21: storage.Cluster.health_status:type_name -> storage.ClusterHealthStatus
-	19, // 22: storage.Cluster.helm_config:type_name -> storage.CompleteClusterConfig
-	20, // 23: storage.Cluster.most_recent_sensor_id:type_name -> storage.SensorDeploymentIdentification
-	34, // 24: storage.Cluster.audit_log_state:type_name -> storage.Cluster.AuditLogStateEntry
+	26, // 18: storage.Cluster.status:type_name -> storage.ClusterStatus
+	20, // 19: storage.Cluster.dynamic_config:type_name -> storage.DynamicClusterConfig
+	17, // 20: storage.Cluster.tolerations_config:type_name -> storage.TolerationsConfig
+	30, // 21: storage.Cluster.health_status:type_name -> storage.ClusterHealthStatus
+	21, // 22: storage.Cluster.helm_config:type_name -> storage.CompleteClusterConfig
+	22, // 23: storage.Cluster.most_recent_sensor_id:type_name -> storage.SensorDeploymentIdentification
+	37, // 24: storage.Cluster.audit_log_state:type_name -> storage.Cluster.AuditLogStateEntry
 	2,  // 25: storage.Cluster.managed_by:type_name -> storage.ManagerType
-	36, // 26: storage.ClusterCertExpiryStatus.sensor_cert_expiry:type_name -> google.protobuf.Timestamp
-	36, // 27: storage.ClusterCertExpiryStatus.sensor_cert_not_before:type_name -> google.protobuf.Timestamp
-	36, // 28: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
-	12, // 29: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
-	13, // 30: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata
-	24, // 31: storage.ClusterStatus.upgrade_status:type_name -> storage.ClusterUpgradeStatus
-	22, // 32: storage.ClusterStatus.cert_expiry_status:type_name -> storage.ClusterCertExpiryStatus
-	4,  // 33: storage.ClusterUpgradeStatus.upgradability:type_name -> storage.ClusterUpgradeStatus.Upgradability
-	35, // 34: storage.ClusterUpgradeStatus.most_recent_process:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus
-	6,  // 35: storage.UpgradeProgress.upgrade_state:type_name -> storage.UpgradeProgress.UpgradeState
-	36, // 36: storage.UpgradeProgress.since:type_name -> google.protobuf.Timestamp
-	36, // 37: storage.AuditLogFileState.collect_logs_since:type_name -> google.protobuf.Timestamp
-	28, // 38: storage.ClusterHealthStatus.collector_health_info:type_name -> storage.CollectorHealthInfo
-	29, // 39: storage.ClusterHealthStatus.admission_control_health_info:type_name -> storage.AdmissionControlHealthInfo
-	30, // 40: storage.ClusterHealthStatus.scanner_health_info:type_name -> storage.ScannerHealthInfo
-	7,  // 41: storage.ClusterHealthStatus.sensor_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 42: storage.ClusterHealthStatus.collector_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 43: storage.ClusterHealthStatus.overall_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 44: storage.ClusterHealthStatus.admission_control_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 45: storage.ClusterHealthStatus.scanner_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	36, // 46: storage.ClusterHealthStatus.last_contact:type_name -> google.protobuf.Timestamp
-	26, // 47: storage.Cluster.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
-	36, // 48: storage.ClusterUpgradeStatus.UpgradeProcessStatus.initiated_at:type_name -> google.protobuf.Timestamp
-	25, // 49: storage.ClusterUpgradeStatus.UpgradeProcessStatus.progress:type_name -> storage.UpgradeProgress
-	5,  // 50: storage.ClusterUpgradeStatus.UpgradeProcessStatus.type:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
-	51, // [51:51] is the sub-list for method output_type
-	51, // [51:51] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	39, // 26: storage.ClusterCertExpiryStatus.sensor_cert_expiry:type_name -> google.protobuf.Timestamp
+	39, // 27: storage.ClusterCertExpiryStatus.sensor_cert_not_before:type_name -> google.protobuf.Timestamp
+	3,  // 28: storage.VersionSkew.status:type_name -> storage.VersionSkewStatus
+	4,  // 29: storage.VersionSkew.reason:type_name -> storage.VersionSkewReason
+	39, // 30: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
+	14, // 31: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
+	15, // 32: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata
+	27, // 33: storage.ClusterStatus.upgrade_status:type_name -> storage.ClusterUpgradeStatus
+	24, // 34: storage.ClusterStatus.cert_expiry_status:type_name -> storage.ClusterCertExpiryStatus
+	25, // 35: storage.ClusterStatus.version_skew:type_name -> storage.VersionSkew
+	6,  // 36: storage.ClusterUpgradeStatus.upgradability:type_name -> storage.ClusterUpgradeStatus.Upgradability
+	38, // 37: storage.ClusterUpgradeStatus.most_recent_process:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus
+	8,  // 38: storage.UpgradeProgress.upgrade_state:type_name -> storage.UpgradeProgress.UpgradeState
+	39, // 39: storage.UpgradeProgress.since:type_name -> google.protobuf.Timestamp
+	39, // 40: storage.AuditLogFileState.collect_logs_since:type_name -> google.protobuf.Timestamp
+	31, // 41: storage.ClusterHealthStatus.collector_health_info:type_name -> storage.CollectorHealthInfo
+	32, // 42: storage.ClusterHealthStatus.admission_control_health_info:type_name -> storage.AdmissionControlHealthInfo
+	33, // 43: storage.ClusterHealthStatus.scanner_health_info:type_name -> storage.ScannerHealthInfo
+	9,  // 44: storage.ClusterHealthStatus.sensor_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	9,  // 45: storage.ClusterHealthStatus.collector_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	9,  // 46: storage.ClusterHealthStatus.overall_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	9,  // 47: storage.ClusterHealthStatus.admission_control_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	9,  // 48: storage.ClusterHealthStatus.scanner_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	39, // 49: storage.ClusterHealthStatus.last_contact:type_name -> google.protobuf.Timestamp
+	29, // 50: storage.Cluster.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
+	39, // 51: storage.ClusterUpgradeStatus.UpgradeProcessStatus.initiated_at:type_name -> google.protobuf.Timestamp
+	28, // 52: storage.ClusterUpgradeStatus.UpgradeProcessStatus.progress:type_name -> storage.UpgradeProgress
+	7,  // 53: storage.ClusterUpgradeStatus.UpgradeProcessStatus.type:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
+	54, // [54:54] is the sub-list for method output_type
+	54, // [54:54] is the sub-list for method input_type
+	54, // [54:54] is the sub-list for extension type_name
+	54, // [54:54] is the sub-list for extension extendee
+	0,  // [0:54] is the sub-list for field type_name
 }
 
 func init() { file_storage_cluster_proto_init() }
@@ -3112,16 +3310,16 @@ func file_storage_cluster_proto_init() {
 	file_storage_cluster_proto_msgTypes[5].OneofWrappers = []any{
 		(*OrchestratorMetadata_OpenshiftVersion)(nil),
 	}
-	file_storage_cluster_proto_msgTypes[20].OneofWrappers = []any{
+	file_storage_cluster_proto_msgTypes[21].OneofWrappers = []any{
 		(*CollectorHealthInfo_TotalDesiredPods)(nil),
 		(*CollectorHealthInfo_TotalReadyPods)(nil),
 		(*CollectorHealthInfo_TotalRegisteredNodes)(nil),
 	}
-	file_storage_cluster_proto_msgTypes[21].OneofWrappers = []any{
+	file_storage_cluster_proto_msgTypes[22].OneofWrappers = []any{
 		(*AdmissionControlHealthInfo_TotalDesiredPods)(nil),
 		(*AdmissionControlHealthInfo_TotalReadyPods)(nil),
 	}
-	file_storage_cluster_proto_msgTypes[22].OneofWrappers = []any{
+	file_storage_cluster_proto_msgTypes[23].OneofWrappers = []any{
 		(*ScannerHealthInfo_TotalDesiredAnalyzerPods)(nil),
 		(*ScannerHealthInfo_TotalReadyAnalyzerPods)(nil),
 		(*ScannerHealthInfo_TotalDesiredDbPods)(nil),
@@ -3132,8 +3330,8 @@ func file_storage_cluster_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_cluster_proto_rawDesc), len(file_storage_cluster_proto_rawDesc)),
-			NumEnums:      8,
-			NumMessages:   28,
+			NumEnums:      10,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/storage/cluster_vtproto.pb.go
+++ b/generated/storage/cluster_vtproto.pb.go
@@ -433,7 +433,7 @@ func (m *VersionSkew) CloneVT() *VersionSkew {
 	}
 	r := new(VersionSkew)
 	r.Status = m.Status
-	r.Reason = m.Reason
+	r.IncompatibilityReason = m.IncompatibilityReason
 	r.MinCompatibleSensorVersion = m.MinCompatibleSensorVersion
 	r.MaxCompatibleSensorVersion = m.MaxCompatibleSensorVersion
 	if len(m.unknownFields) > 0 {
@@ -1425,7 +1425,7 @@ func (this *VersionSkew) EqualVT(that *VersionSkew) bool {
 	if this.Status != that.Status {
 		return false
 	}
-	if this.Reason != that.Reason {
+	if this.IncompatibilityReason != that.IncompatibilityReason {
 		return false
 	}
 	if this.MinCompatibleSensorVersion != that.MinCompatibleSensorVersion {
@@ -3364,8 +3364,8 @@ func (m *VersionSkew) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x1a
 	}
-	if m.Reason != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Reason))
+	if m.IncompatibilityReason != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.IncompatibilityReason))
 		i--
 		dAtA[i] = 0x10
 	}
@@ -4690,8 +4690,8 @@ func (m *VersionSkew) SizeVT() (n int) {
 	if m.Status != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Status))
 	}
-	if m.Reason != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.Reason))
+	if m.IncompatibilityReason != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.IncompatibilityReason))
 	}
 	l = len(m.MinCompatibleSensorVersion)
 	if l > 0 {
@@ -8527,9 +8527,9 @@ func (m *VersionSkew) UnmarshalVT(dAtA []byte) error {
 			}
 		case 2:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Reason", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field IncompatibilityReason", wireType)
 			}
-			m.Reason = 0
+			m.IncompatibilityReason = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -8539,7 +8539,7 @@ func (m *VersionSkew) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Reason |= VersionSkewReason(b&0x7F) << shift
+				m.IncompatibilityReason |= VersionSkewIncompatibilityReason(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -14005,9 +14005,9 @@ func (m *VersionSkew) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 		case 2:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Reason", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field IncompatibilityReason", wireType)
 			}
-			m.Reason = 0
+			m.IncompatibilityReason = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -14017,7 +14017,7 @@ func (m *VersionSkew) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Reason |= VersionSkewReason(b&0x7F) << shift
+				m.IncompatibilityReason |= VersionSkewIncompatibilityReason(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/generated/storage/cluster_vtproto.pb.go
+++ b/generated/storage/cluster_vtproto.pb.go
@@ -427,6 +427,26 @@ func (m *ClusterCertExpiryStatus) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *VersionSkew) CloneVT() *VersionSkew {
+	if m == nil {
+		return (*VersionSkew)(nil)
+	}
+	r := new(VersionSkew)
+	r.Status = m.Status
+	r.Reason = m.Reason
+	r.MinCompatibleSensorVersion = m.MinCompatibleSensorVersion
+	r.MaxCompatibleSensorVersion = m.MaxCompatibleSensorVersion
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *VersionSkew) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ClusterStatus) CloneVT() *ClusterStatus {
 	if m == nil {
 		return (*ClusterStatus)(nil)
@@ -438,6 +458,7 @@ func (m *ClusterStatus) CloneVT() *ClusterStatus {
 	r.OrchestratorMetadata = m.OrchestratorMetadata.CloneVT()
 	r.UpgradeStatus = m.UpgradeStatus.CloneVT()
 	r.CertExpiryStatus = m.CertExpiryStatus.CloneVT()
+	r.VersionSkew = m.VersionSkew.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1395,6 +1416,34 @@ func (this *ClusterCertExpiryStatus) EqualMessageVT(thatMsg proto.Message) bool 
 	}
 	return this.EqualVT(that)
 }
+func (this *VersionSkew) EqualVT(that *VersionSkew) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Status != that.Status {
+		return false
+	}
+	if this.Reason != that.Reason {
+		return false
+	}
+	if this.MinCompatibleSensorVersion != that.MinCompatibleSensorVersion {
+		return false
+	}
+	if this.MaxCompatibleSensorVersion != that.MaxCompatibleSensorVersion {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *VersionSkew) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*VersionSkew)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *ClusterStatus) EqualVT(that *ClusterStatus) bool {
 	if this == that {
 		return true
@@ -1417,6 +1466,9 @@ func (this *ClusterStatus) EqualVT(that *ClusterStatus) bool {
 		return false
 	}
 	if !this.CertExpiryStatus.EqualVT(that.CertExpiryStatus) {
+		return false
+	}
+	if !this.VersionSkew.EqualVT(that.VersionSkew) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3268,6 +3320,63 @@ func (m *ClusterCertExpiryStatus) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *VersionSkew) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VersionSkew) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VersionSkew) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MaxCompatibleSensorVersion) > 0 {
+		i -= len(m.MaxCompatibleSensorVersion)
+		copy(dAtA[i:], m.MaxCompatibleSensorVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MaxCompatibleSensorVersion)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.MinCompatibleSensorVersion) > 0 {
+		i -= len(m.MinCompatibleSensorVersion)
+		copy(dAtA[i:], m.MinCompatibleSensorVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MinCompatibleSensorVersion)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Reason != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Reason))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Status != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Status))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ClusterStatus) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -3297,6 +3406,16 @@ func (m *ClusterStatus) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.VersionSkew != nil {
+		size, err := m.VersionSkew.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x3a
 	}
 	if m.CertExpiryStatus != nil {
 		size, err := m.CertExpiryStatus.MarshalToSizedBufferVT(dAtA[:i])
@@ -4562,6 +4681,30 @@ func (m *ClusterCertExpiryStatus) SizeVT() (n int) {
 	return n
 }
 
+func (m *VersionSkew) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Status != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Status))
+	}
+	if m.Reason != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Reason))
+	}
+	l = len(m.MinCompatibleSensorVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.MaxCompatibleSensorVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *ClusterStatus) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4590,6 +4733,10 @@ func (m *ClusterStatus) SizeVT() (n int) {
 	}
 	if m.CertExpiryStatus != nil {
 		l = m.CertExpiryStatus.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.VersionSkew != nil {
+		l = m.VersionSkew.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -8330,6 +8477,159 @@ func (m *ClusterCertExpiryStatus) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *VersionSkew) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VersionSkew: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VersionSkew: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			m.Status = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Status |= VersionSkewStatus(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reason", wireType)
+			}
+			m.Reason = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Reason |= VersionSkewReason(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MinCompatibleSensorVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MaxCompatibleSensorVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *ClusterStatus) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8568,6 +8868,42 @@ func (m *ClusterStatus) UnmarshalVT(dAtA []byte) error {
 				m.CertExpiryStatus = &ClusterCertExpiryStatus{}
 			}
 			if err := m.CertExpiryStatus.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VersionSkew", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VersionSkew == nil {
+				m.VersionSkew = &VersionSkew{}
+			}
+			if err := m.VersionSkew.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -13619,6 +13955,167 @@ func (m *ClusterCertExpiryStatus) UnmarshalVTUnsafe(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *VersionSkew) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VersionSkew: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VersionSkew: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			m.Status = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Status |= VersionSkewStatus(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reason", wireType)
+			}
+			m.Reason = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Reason |= VersionSkewReason(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.MinCompatibleSensorVersion = stringValue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxCompatibleSensorVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.MaxCompatibleSensorVersion = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *ClusterStatus) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -13861,6 +14358,42 @@ func (m *ClusterStatus) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.CertExpiryStatus = &ClusterCertExpiryStatus{}
 			}
 			if err := m.CertExpiryStatus.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VersionSkew", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VersionSkew == nil {
+				m.VersionSkew = &VersionSkew{}
+			}
+			if err := m.VersionSkew.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/version/skew.go
+++ b/pkg/version/skew.go
@@ -74,7 +74,7 @@ func ComputeVersionSkew(centralVersion, sensorVersion string) *storage.VersionSk
 		(sensorParsed.MarketingMajor == centralParsed.MarketingMajor &&
 			sensorParsed.EngRelease > centralParsed.EngRelease) {
 		result.Status = storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE
-		result.Reason = storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD
+		result.IncompatibilityReason = storage.VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW
 		return result
 	}
 
@@ -85,6 +85,6 @@ func ComputeVersionSkew(centralVersion, sensorVersion string) *storage.VersionSk
 	}
 
 	result.Status = storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE
-	result.Reason = storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD
+	result.IncompatibilityReason = storage.VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD
 	return result
 }

--- a/pkg/version/skew.go
+++ b/pkg/version/skew.go
@@ -10,6 +10,33 @@ const (
 	supportedMinorVersionSkew = 3
 )
 
+func compatibleRange(ver string) (min, max string) {
+	parsed, err := parseVersion(ver)
+	if err != nil {
+		return "", ""
+	}
+	minMinor := parsed.EngRelease - supportedMinorVersionSkew + 1
+	if minMinor < 0 {
+		minMinor = 0
+	}
+	return fmt.Sprintf("%d.%d", parsed.MarketingMajor, minMinor),
+		fmt.Sprintf("%d.%d", parsed.MarketingMajor, parsed.EngRelease)
+}
+
+// MinCompatibleSensorVersion returns the oldest sensor version that
+// the current Central build is compatible with.
+func MinCompatibleSensorVersion() string {
+	min, _ := compatibleRange(GetMainVersion())
+	return min
+}
+
+// MaxCompatibleSensorVersion returns the newest sensor version that
+// the current Central build knows about.
+func MaxCompatibleSensorVersion() string {
+	_, max := compatibleRange(GetMainVersion())
+	return max
+}
+
 // ComputeVersionSkew determines the version skew status between Central and a Sensor.
 // It compares only the X.Y (major.minor) components, ignoring patch versions.
 func ComputeVersionSkew(centralVersion, sensorVersion string) *storage.VersionSkew {

--- a/pkg/version/skew.go
+++ b/pkg/version/skew.go
@@ -1,0 +1,63 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/stackrox/rox/generated/storage"
+)
+
+const (
+	supportedMinorVersionSkew = 3
+)
+
+// ComputeVersionSkew determines the version skew status between Central and a Sensor.
+// It compares only the X.Y (major.minor) components, ignoring patch versions.
+func ComputeVersionSkew(centralVersion, sensorVersion string) *storage.VersionSkew {
+	result := &storage.VersionSkew{}
+
+	if sensorVersion == "" || centralVersion == "" {
+		return result
+	}
+
+	centralParsed, err := parseVersion(centralVersion)
+	if err != nil {
+		return result
+	}
+
+	sensorParsed, err := parseVersion(sensorVersion)
+	if err != nil {
+		return result
+	}
+
+	minMinor := centralParsed.EngRelease - supportedMinorVersionSkew + 1
+	if minMinor < 0 {
+		minMinor = 0
+	}
+
+	result.MinCompatibleSensorVersion = fmt.Sprintf("%d.%d", centralParsed.MarketingMajor, minMinor)
+	result.MaxCompatibleSensorVersion = fmt.Sprintf("%d.%d", centralParsed.MarketingMajor, centralParsed.EngRelease)
+
+	if centralParsed.MarketingMajor == sensorParsed.MarketingMajor &&
+		centralParsed.EngRelease == sensorParsed.EngRelease {
+		result.Status = storage.VersionSkewStatus_VERSION_SKEW_STATUS_MATCHING
+		return result
+	}
+
+	if sensorParsed.MarketingMajor > centralParsed.MarketingMajor ||
+		(sensorParsed.MarketingMajor == centralParsed.MarketingMajor &&
+			sensorParsed.EngRelease > centralParsed.EngRelease) {
+		result.Status = storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE
+		result.Reason = storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD
+		return result
+	}
+
+	if sensorParsed.MarketingMajor == centralParsed.MarketingMajor &&
+		sensorParsed.EngRelease >= minMinor {
+		result.Status = storage.VersionSkewStatus_VERSION_SKEW_STATUS_COMPATIBLE
+		return result
+	}
+
+	result.Status = storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE
+	result.Reason = storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD
+	return result
+}

--- a/pkg/version/skew_test.go
+++ b/pkg/version/skew_test.go
@@ -12,7 +12,7 @@ func TestComputeVersionSkew(t *testing.T) {
 		centralVersion string
 		sensorVersion  string
 		expectedStatus storage.VersionSkewStatus
-		expectedReason storage.VersionSkewReason
+		expectedReason storage.VersionSkewIncompatibilityReason
 		expectedMin    string
 		expectedMax    string
 	}{
@@ -48,7 +48,7 @@ func TestComputeVersionSkew(t *testing.T) {
 			centralVersion: "4.7.0",
 			sensorVersion:  "4.4.0",
 			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
-			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD,
+			expectedReason: storage.VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD,
 			expectedMin:    "4.5",
 			expectedMax:    "4.7",
 		},
@@ -56,7 +56,7 @@ func TestComputeVersionSkew(t *testing.T) {
 			centralVersion: "4.7.0",
 			sensorVersion:  "4.8.0",
 			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
-			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD,
+			expectedReason: storage.VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW,
 			expectedMin:    "4.5",
 			expectedMax:    "4.7",
 		},
@@ -64,7 +64,7 @@ func TestComputeVersionSkew(t *testing.T) {
 			centralVersion: "4.7.0",
 			sensorVersion:  "5.1.0",
 			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
-			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD,
+			expectedReason: storage.VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW,
 			expectedMin:    "4.5",
 			expectedMax:    "4.7",
 		},
@@ -72,7 +72,7 @@ func TestComputeVersionSkew(t *testing.T) {
 			centralVersion: "5.1.0",
 			sensorVersion:  "4.10.0",
 			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
-			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD,
+			expectedReason: storage.VersionSkewIncompatibilityReason_VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD,
 			expectedMin:    "5.0",
 			expectedMax:    "5.1",
 		},
@@ -106,7 +106,7 @@ func TestComputeVersionSkew(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			result := ComputeVersionSkew(tc.centralVersion, tc.sensorVersion)
 			assert.Equal(t, tc.expectedStatus, result.GetStatus())
-			assert.Equal(t, tc.expectedReason, result.GetReason())
+			assert.Equal(t, tc.expectedReason, result.GetIncompatibilityReason())
 			if tc.expectedMin != "" {
 				assert.Equal(t, tc.expectedMin, result.GetMinCompatibleSensorVersion())
 			}

--- a/pkg/version/skew_test.go
+++ b/pkg/version/skew_test.go
@@ -1,0 +1,118 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeVersionSkew(t *testing.T) {
+	cases := map[string]struct {
+		centralVersion string
+		sensorVersion  string
+		expectedStatus storage.VersionSkewStatus
+		expectedReason storage.VersionSkewReason
+		expectedMin    string
+		expectedMax    string
+	}{
+		"matching versions": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "4.7.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_MATCHING,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"matching X.Y different patch": {
+			centralVersion: "4.7.1",
+			sensorVersion:  "4.7.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_MATCHING,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"compatible one minor behind": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "4.6.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_COMPATIBLE,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"compatible two minor behind": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "4.5.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_COMPATIBLE,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"incompatible three minor behind": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "4.4.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
+			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"sensor one minor ahead": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "4.8.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
+			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"sensor higher major version": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "5.1.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
+			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_AHEAD,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"sensor lower major version": {
+			centralVersion: "5.1.0",
+			sensorVersion:  "4.10.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_INCOMPATIBLE,
+			expectedReason: storage.VersionSkewReason_VERSION_SKEW_REASON_SENSOR_TOO_OLD,
+			expectedMin:    "5.0",
+			expectedMax:    "5.1",
+		},
+		"empty sensor version": {
+			centralVersion: "4.7.0",
+			sensorVersion:  "",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_UNSPECIFIED,
+		},
+		"empty central version": {
+			centralVersion: "",
+			sensorVersion:  "4.7.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_UNSPECIFIED,
+		},
+		"dev build versions matching": {
+			centralVersion: "4.7.x-19-gabcdef1234",
+			sensorVersion:  "4.7.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_MATCHING,
+			expectedMin:    "4.5",
+			expectedMax:    "4.7",
+		},
+		"low minor version clamps to zero": {
+			centralVersion: "4.1.0",
+			sensorVersion:  "4.0.0",
+			expectedStatus: storage.VersionSkewStatus_VERSION_SKEW_STATUS_COMPATIBLE,
+			expectedMin:    "4.0",
+			expectedMax:    "4.1",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := ComputeVersionSkew(tc.centralVersion, tc.sensorVersion)
+			assert.Equal(t, tc.expectedStatus, result.GetStatus())
+			assert.Equal(t, tc.expectedReason, result.GetReason())
+			if tc.expectedMin != "" {
+				assert.Equal(t, tc.expectedMin, result.GetMinCompatibleSensorVersion())
+			}
+			if tc.expectedMax != "" {
+				assert.Equal(t, tc.expectedMax, result.GetMaxCompatibleSensorVersion())
+			}
+		})
+	}
+}

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -24,6 +24,9 @@ message Metadata {
 
   // Do not use this field. It will always contain "VALID"
   LicenseStatus license_status = 4 [deprecated = true];
+
+  string min_compatible_sensor_version = 5;
+  string max_compatible_sensor_version = 6;
 }
 
 message TrustInfo {

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -223,6 +223,26 @@ message ClusterCertExpiryStatus {
   google.protobuf.Timestamp sensor_cert_not_before = 2;
 }
 
+enum VersionSkewStatus {
+  VERSION_SKEW_STATUS_UNSPECIFIED = 0;
+  VERSION_SKEW_STATUS_MATCHING = 1;
+  VERSION_SKEW_STATUS_COMPATIBLE = 2;
+  VERSION_SKEW_STATUS_INCOMPATIBLE = 3;
+}
+
+enum VersionSkewReason {
+  VERSION_SKEW_REASON_UNSPECIFIED = 0;
+  VERSION_SKEW_REASON_SENSOR_TOO_OLD = 1;
+  VERSION_SKEW_REASON_SENSOR_AHEAD = 2;
+}
+
+message VersionSkew {
+  VersionSkewStatus status = 1;
+  VersionSkewReason reason = 2;
+  string min_compatible_sensor_version = 3;
+  string max_compatible_sensor_version = 4;
+}
+
 message ClusterStatus {
   string sensor_version = 1;
   // This field has been deprecated starting release 49.0. Use healthStatus.lastContact instead.
@@ -231,6 +251,7 @@ message ClusterStatus {
   OrchestratorMetadata orchestrator_metadata = 4;
   ClusterUpgradeStatus upgrade_status = 5;
   ClusterCertExpiryStatus cert_expiry_status = 6;
+  VersionSkew version_skew = 7;
 }
 
 message ClusterUpgradeStatus {

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -230,16 +230,19 @@ enum VersionSkewStatus {
   VERSION_SKEW_STATUS_INCOMPATIBLE = 3;
 }
 
-enum VersionSkewReason {
-  VERSION_SKEW_REASON_UNSPECIFIED = 0;
-  VERSION_SKEW_REASON_SENSOR_TOO_OLD = 1;
-  VERSION_SKEW_REASON_SENSOR_AHEAD = 2;
+enum VersionSkewIncompatibilityReason {
+  VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED = 0;
+  VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD = 1;
+  VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW = 2;
 }
 
 message VersionSkew {
   VersionSkewStatus status = 1;
-  VersionSkewReason reason = 2;
+  // Only set when status is VERSION_SKEW_STATUS_INCOMPATIBLE.
+  VersionSkewIncompatibilityReason incompatibility_reason = 2;
+  // Oldest compatible Sensor version, in X.Y format (patch version not included).
   string min_compatible_sensor_version = 3;
+  // Newest compatible Sensor version, in X.Y format (patch version not included).
   string max_compatible_sensor_version = 4;
 }
 

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -157,6 +157,24 @@ export type ClusterCertExpiryStatus = {
     sensorCertExpiry: string; // ISO 8601 date string
 };
 
+export type VersionSkewStatus =
+    | 'VERSION_SKEW_STATUS_UNSPECIFIED'
+    | 'VERSION_SKEW_STATUS_MATCHING'
+    | 'VERSION_SKEW_STATUS_COMPATIBLE'
+    | 'VERSION_SKEW_STATUS_INCOMPATIBLE';
+
+export type VersionSkewReason =
+    | 'VERSION_SKEW_REASON_UNSPECIFIED'
+    | 'VERSION_SKEW_REASON_SENSOR_TOO_OLD'
+    | 'VERSION_SKEW_REASON_SENSOR_AHEAD';
+
+export type VersionSkew = {
+    status: VersionSkewStatus;
+    reason: VersionSkewReason;
+    minCompatibleSensorVersion: string;
+    maxCompatibleSensorVersion: string;
+};
+
 export type ClusterStatus = {
     sensorVersion: string;
     // DEPRECATED_last_contact
@@ -164,6 +182,7 @@ export type ClusterStatus = {
     orchestratorMetadata: ClusterOrchestratorMetadata;
     upgradeStatus: ClusterUpgradeStatus;
     certExpiryStatus: ClusterCertExpiryStatus;
+    versionSkew?: VersionSkew;
 };
 
 export type ClusterUpgradability =

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -163,15 +163,17 @@ export type VersionSkewStatus =
     | 'VERSION_SKEW_STATUS_COMPATIBLE'
     | 'VERSION_SKEW_STATUS_INCOMPATIBLE';
 
-export type VersionSkewReason =
-    | 'VERSION_SKEW_REASON_UNSPECIFIED'
-    | 'VERSION_SKEW_REASON_SENSOR_TOO_OLD'
-    | 'VERSION_SKEW_REASON_SENSOR_AHEAD';
+export type VersionSkewIncompatibilityReason =
+    | 'VERSION_SKEW_INCOMPATIBILITY_REASON_UNSPECIFIED'
+    | 'VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_OLD'
+    | 'VERSION_SKEW_INCOMPATIBILITY_REASON_SENSOR_TOO_NEW';
 
 export type VersionSkew = {
     status: VersionSkewStatus;
-    reason: VersionSkewReason;
+    incompatibilityReason: VersionSkewIncompatibilityReason;
+    // X.Y format (patch version not included).
     minCompatibleSensorVersion: string;
+    // X.Y format (patch version not included).
     maxCompatibleSensorVersion: string;
 };
 

--- a/ui/apps/platform/src/types/metadataService.proto.ts
+++ b/ui/apps/platform/src/types/metadataService.proto.ts
@@ -3,4 +3,6 @@ export type Metadata = {
     buildFlavor: string;
     releaseBuild: boolean;
     licenseStatus: string;
+    minCompatibleSensorVersion?: string;
+    maxCompatibleSensorVersion?: string;
 };


### PR DESCRIPTION
## Description

POC for version skew detection between Central and Sensor. Adds a `VersionSkew` field to `ClusterStatus` that reports whether the version skew is matching, compatible, or incompatible. Central computes this on sensor connect using a hardcoded 3-minor-version range and persists it. Data flows through `/v1/clusters` API — visible in browser console, no UI component changes.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit tests for `ComputeVersionSkew` covering: matching versions, compatible skew (1-2 minor behind), incompatible skew (3+ minor behind, sensor ahead, cross-major), edge cases (empty versions, dev builds, low minor clamping). Compilation verified for affected packages.