### PR TITLE
proto: add enabled field and api_requests group

### DIFF
--- a/generated/api/v1/config_service.swagger.json
+++ b/generated/api/v1/config_service.swagger.json
@@ -294,7 +294,7 @@
         "gatheringPeriodMinutes": {
           "type": "integer",
           "format": "int64",
-          "description": "The gathering period for periodically gathered metrics. If set to zero,\ngathering is disabled."
+          "description": "Period in minutes for periodic gatherers.\nIgnored for non-periodic gatherers."
         },
         "descriptors": {
           "type": "object",
@@ -302,6 +302,10 @@
             "$ref": "#/definitions/GroupLabels"
           },
           "description": "Metric descriptors is a map of metric names to the list of allowed\nlabels."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable gathering for non-periodic gatherers, such as counters."
         }
       },
       "description": "A group is a collection of metrics that are computed by the same\naggregator. Metrics in a group may use different subsets of a complete list\nof labels supported by the aggregator."
@@ -525,6 +529,9 @@
           "$ref": "#/definitions/PrometheusMetricsGroup"
         },
         "nodeVulnerabilities": {
+          "$ref": "#/definitions/PrometheusMetricsGroup"
+        },
+        "apiRequests": {
           "$ref": "#/definitions/PrometheusMetricsGroup"
         }
       },

--- a/generated/storage/config_vtproto.pb.go
+++ b/generated/storage/config_vtproto.pb.go
@@ -188,6 +188,7 @@ func (m *PrometheusMetrics_Group) CloneVT() *PrometheusMetrics_Group {
 	}
 	r := new(PrometheusMetrics_Group)
 	r.GatheringPeriodMinutes = m.GatheringPeriodMinutes
+	r.Enabled = m.Enabled
 	if rhs := m.Descriptors; rhs != nil {
 		tmpContainer := make(map[string]*PrometheusMetrics_Group_Labels, len(rhs))
 		for k, v := range rhs {
@@ -214,6 +215,7 @@ func (m *PrometheusMetrics) CloneVT() *PrometheusMetrics {
 	r.ImageVulnerabilities = m.ImageVulnerabilities.CloneVT()
 	r.PolicyViolations = m.PolicyViolations.CloneVT()
 	r.NodeVulnerabilities = m.NodeVulnerabilities.CloneVT()
+	r.ApiRequests = m.ApiRequests.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -697,6 +699,9 @@ func (this *PrometheusMetrics_Group) EqualVT(that *PrometheusMetrics_Group) bool
 			}
 		}
 	}
+	if this.Enabled != that.Enabled {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -720,6 +725,9 @@ func (this *PrometheusMetrics) EqualVT(that *PrometheusMetrics) bool {
 		return false
 	}
 	if !this.NodeVulnerabilities.EqualVT(that.NodeVulnerabilities) {
+		return false
+	}
+	if !this.ApiRequests.EqualVT(that.ApiRequests) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1534,6 +1542,16 @@ func (m *PrometheusMetrics_Group) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Enabled {
+		i--
+		if m.Enabled {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
 	if len(m.Descriptors) > 0 {
 		for k := range m.Descriptors {
 			v := m.Descriptors[k]
@@ -1593,6 +1611,16 @@ func (m *PrometheusMetrics) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ApiRequests != nil {
+		size, err := m.ApiRequests.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
 	}
 	if m.NodeVulnerabilities != nil {
 		size, err := m.NodeVulnerabilities.MarshalToSizedBufferVT(dAtA[:i])
@@ -2427,6 +2455,9 @@ func (m *PrometheusMetrics_Group) SizeVT() (n int) {
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
 	}
+	if m.Enabled {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2447,6 +2478,10 @@ func (m *PrometheusMetrics) SizeVT() (n int) {
 	}
 	if m.NodeVulnerabilities != nil {
 		l = m.NodeVulnerabilities.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ApiRequests != nil {
+		l = m.ApiRequests.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -4194,6 +4229,26 @@ func (m *PrometheusMetrics_Group) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Descriptors[mapkey] = mapvalue
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Enabled", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Enabled = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -4350,6 +4405,42 @@ func (m *PrometheusMetrics) UnmarshalVT(dAtA []byte) error {
 				m.NodeVulnerabilities = &PrometheusMetrics_Group{}
 			}
 			if err := m.NodeVulnerabilities.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApiRequests", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ApiRequests == nil {
+				m.ApiRequests = &PrometheusMetrics_Group{}
+			}
+			if err := m.ApiRequests.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -7239,6 +7330,26 @@ func (m *PrometheusMetrics_Group) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.Descriptors[mapkey] = mapvalue
 			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Enabled", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Enabled = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -7395,6 +7506,42 @@ func (m *PrometheusMetrics) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.NodeVulnerabilities = &PrometheusMetrics_Group{}
 			}
 			if err := m.NodeVulnerabilities.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ApiRequests", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ApiRequests == nil {
+				m.ApiRequests = &PrometheusMetrics_Group{}
+			}
+			if err := m.ApiRequests.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/proto/storage/config.proto
+++ b/proto/storage/config.proto
@@ -89,16 +89,19 @@ message PrometheusMetrics {
       // filters.
       map<string, string> exclude_filters = 3;
     }
-    // The gathering period for periodically gathered metrics. If set to zero,
-    // gathering is disabled.
+    // Period in minutes for periodic gatherers.
+    // Ignored for non-periodic gatherers.
     uint32 gathering_period_minutes = 1;
     // Metric descriptors is a map of metric names to the list of allowed
     // labels.
     map<string, Labels> descriptors = 2;
+    // Enable gathering for non-periodic gatherers, such as counters.
+    bool enabled = 3;
   }
   Group image_vulnerabilities = 1;
   Group policy_violations = 2;
   Group node_vulnerabilities = 3;
+  Group api_requests = 4;
 }
 
 // next available tag: 10

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -5640,6 +5640,11 @@
                 "id": 3,
                 "name": "node_vulnerabilities",
                 "type": "Group"
+              },
+              {
+                "id": 4,
+                "name": "api_requests",
+                "type": "Group"
               }
             ],
             "messages": [
@@ -5650,6 +5655,11 @@
                     "id": 1,
                     "name": "gathering_period_minutes",
                     "type": "uint32"
+                  },
+                  {
+                    "id": 3,
+                    "name": "enabled",
+                    "type": "bool"
                   }
                 ],
                 "maps": [


### PR DESCRIPTION
## Description

Add `bool enabled = 3` to `PrometheusMetrics.Group` for counter-style metrics
that don't require periodic gathering. Add `Group api_requests = 4` to
`PrometheusMetrics` for API request counting configuration.

Part of the custom metrics PR stack.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Proto schema change only — generated code passes CI compilation.
<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21131**
    * **PR #21132**
      * **PR #21133**
        * **PR #21134**
          * **PR #21360** 👈
            * **PR #21361**
              * **PR #18080**
<!-- GHIT dependencies end -->