### PR TITLE
feat: add counter metric support to tracker

### DIFF
--- a/central/metrics/custom/tracker/configuration.go
+++ b/central/metrics/custom/tracker/configuration.go
@@ -40,8 +40,24 @@ type Configuration struct {
 	toAdd          []MetricName
 	toDelete       []MetricName
 	period         time.Duration
+	enabled        bool
 }
 
+// GetMetrics returns the parsed metric descriptors.
+func (cfg *Configuration) GetMetrics() MetricDescriptors {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.metrics
+}
+
+// isEnabled checks if a counter (non-periodic) tracker is enabled.
 func (cfg *Configuration) isEnabled() bool {
+	return cfg != nil && cfg.enabled && len(cfg.metrics) > 0
+}
+
+// isGatheringEnabled checks if a gauge (periodic) tracker is enabled.
+// The enabled flag is ignored: having metrics and a period is sufficient.
+func (cfg *Configuration) isGatheringEnabled() bool {
 	return cfg != nil && len(cfg.metrics) > 0 && cfg.period > 0
 }

--- a/central/metrics/custom/tracker/tracker_base.go
+++ b/central/metrics/custom/tracker/tracker_base.go
@@ -141,11 +141,31 @@ type TrackerBase[F Finding] struct {
 	KnownLabels func(map[string]*storage.PrometheusMetrics_Group_Labels) []Label
 }
 
+// IsEnabled returns true if this tracker has an active configuration with
+// metrics defined. For counter trackers this also requires the enabled flag.
+func (tracker *TrackerBase[F]) IsEnabled() bool {
+	cfg, _ := tracker.getConfiguration()
+	if tracker.isCounter() {
+		return cfg.isEnabled()
+	}
+	return cfg.isGatheringEnabled()
+}
+
+// isCounter returns true if this is a counter tracker (real-time increments)
+// as opposed to a gauge tracker (periodic gathering).
+func (tracker *TrackerBase[F]) isCounter() bool {
+	return tracker.generator == nil
+}
+
 // MakeTrackerBase initializes a scoped tracker without any period or metrics
 // configuration. Call Reconfigure to configure the period and the metrics.
+// NOTE: Scoped counter trackers (generator == nil) are not supported and will panic.
 func MakeTrackerBase[F Finding](metricPrefix, description string,
 	getters LazyLabelGetters[F], generator FindingGenerator[F],
 ) *TrackerBase[F] {
+	if generator == nil {
+		panic("scoped counter trackers are not supported; use MakeGlobalTrackerBase for counters")
+	}
 	return makeTrackerBase(metricPrefix, description, true, getters, generator)
 }
 
@@ -167,7 +187,7 @@ func makeTrackerBase[F Finding](metricPrefix, description string, scoped bool,
 	if scoped {
 		registryFactory = metrics.GetCustomRegistry
 	}
-	return &TrackerBase[F]{
+	tb := &TrackerBase[F]{
 		metricPrefix:    metricPrefix,
 		description:     description,
 		getters:         getters,
@@ -178,11 +198,25 @@ func makeTrackerBase[F Finding](metricPrefix, description string, scoped bool,
 			return getters.Labels()
 		},
 	}
+	tb.KnownLabels = func(map[string]*storage.PrometheusMetrics_Group_Labels) []Label {
+		tb.metricsConfigMux.RLock()
+		defer tb.metricsConfigMux.RUnlock()
+		return tb.getters.Labels()
+	}
+	return tb
+}
+
+// ResetGetters replaces all label getters with the provided set.
+// Synchronized with IncrementCounter via metricsConfigMux.
+func (tracker *TrackerBase[F]) ResetGetters(getters LazyLabelGetters[F]) {
+	tracker.metricsConfigMux.Lock()
+	defer tracker.metricsConfigMux.Unlock()
+	tracker.getters = getters
 }
 
 // NewConfiguration does not apply the configuration.
 func (tracker *TrackerBase[F]) NewConfiguration(cfg *storage.PrometheusMetrics_Group) (*Configuration, error) {
-	current := tracker.getConfiguration()
+	current, _ := tracker.getConfiguration()
 	if current == nil {
 		current = &Configuration{}
 	}
@@ -204,6 +238,7 @@ func (tracker *TrackerBase[F]) NewConfiguration(cfg *storage.PrometheusMetrics_G
 		toAdd:          toAdd,
 		toDelete:       toDelete,
 		period:         time.Minute * time.Duration(cfg.GetGatheringPeriodMinutes()),
+		enabled:        cfg.GetEnabled(),
 	}, nil
 }
 
@@ -215,12 +250,15 @@ func (tracker *TrackerBase[F]) Reconfigure(cfg *Configuration) {
 	}
 	previous := tracker.setConfiguration(cfg)
 	if previous != nil {
-		if !cfg.isEnabled() {
-			log.Debugf("Metrics collection has been disabled for %s", tracker.description)
+		if (!cfg.isEnabled() && tracker.isCounter()) || (!cfg.isGatheringEnabled() && !tracker.isCounter()) {
+			log.Infof("Metrics collection has been disabled for %s", tracker.description)
 			tracker.unregisterMetrics(slices.Collect(maps.Keys(previous.metrics)))
 			return
 		}
 		tracker.unregisterMetrics(cfg.toDelete)
+	}
+	if len(cfg.toAdd) > 0 {
+		log.Infof("Configuring %s metrics: %v", tracker.description, cfg.toAdd)
 	}
 	tracker.registerMetrics(cfg, cfg.toAdd)
 	// Note: aggregators are recreated lazily in getGatherer() when config
@@ -255,12 +293,26 @@ func (tracker *TrackerBase[F]) registerMetrics(cfg *Configuration, metrics []Met
 
 func (tracker *TrackerBase[F]) registerMetric(gatherer *gatherer[F], cfg *Configuration, metric MetricName) {
 	help := formatMetricHelp(tracker.description, cfg, metric)
+	labels := labelsAsStrings(cfg.metrics[metric])
 
-	if err := gatherer.registry.RegisterMetric(
-		string(metric),
-		help,
-		labelsAsStrings(cfg.metrics[metric]),
-	); err != nil {
+	var err error
+	if tracker.isCounter() {
+		// Counter tracker: real-time increments.
+		err = gatherer.registry.RegisterCounter(
+			string(metric),
+			help,
+			labels,
+		)
+	} else {
+		// Gauge tracker: periodic gathering.
+		err = gatherer.registry.RegisterMetric(
+			string(metric),
+			help,
+			labels,
+		)
+	}
+
+	if err != nil {
 		log.Errorf("Failed to register %s metric %q: %v", tracker.description, metric, err)
 		return
 	}
@@ -305,10 +357,10 @@ func formatMetricHelp(description string, cfg *Configuration, metric MetricName)
 	return help.String()
 }
 
-func (tracker *TrackerBase[F]) getConfiguration() *Configuration {
+func (tracker *TrackerBase[F]) getConfiguration() (*Configuration, LazyLabelGetters[F]) {
 	tracker.metricsConfigMux.RLock()
 	defer tracker.metricsConfigMux.RUnlock()
-	return tracker.config
+	return tracker.config, tracker.getters
 }
 
 // setConfiguration updates the tracker configuration and returns the previous
@@ -323,8 +375,8 @@ func (tracker *TrackerBase[F]) setConfiguration(config *Configuration) *Configur
 
 // Gather the data not more often then maxAge.
 func (tracker *TrackerBase[F]) Gather(ctx context.Context) {
-	cfg := tracker.getConfiguration()
-	if !cfg.isEnabled() {
+	cfg, _ := tracker.getConfiguration()
+	if !cfg.isGatheringEnabled() {
 		return
 	}
 	id := globalScopeID
@@ -365,6 +417,45 @@ func (tracker *TrackerBase[F]) Gather(ctx context.Context) {
 		// Central traits:
 		telemeter.WithTraits(tracker.makeProps(descriptionTitle)),
 		telemeter.WithNoDuplicates(tracker.metricPrefix))
+}
+
+// IncrementCounter increments a counter metric with label values extracted from the finding.
+// This should only be called on counter trackers (created with nil generator).
+// If no configuration exists, the increment is a no-op.
+func (tracker *TrackerBase[F]) IncrementCounter(finding F) {
+	if !tracker.isCounter() {
+		// This is a gauge tracker, not a counter tracker
+		return
+	}
+
+	cfg, getters := tracker.getConfiguration()
+	if !cfg.isEnabled() {
+		return
+	}
+
+	aggregator := makeAggregator(cfg.metrics, cfg.includeFilters, cfg.excludeFilters, getters)
+	aggregator.count(finding)
+	if len(aggregator.result) == 0 {
+		return
+	}
+
+	// Ensure the global gatherer exists (counter trackers are always global).
+	if _, exists := tracker.gatherers.Load(globalScopeID); !exists {
+		// Lazy-create the global gatherer and keep it marked as running
+		// to prevent cleanup (counter trackers are always active).
+		tracker.getGatherer(globalScopeID, cfg)
+	}
+
+	// Increment counters in the global gatherer.
+	tracker.gatherers.Range(func(_, g any) bool {
+		for metric, records := range aggregator.result {
+			gatherer := g.(*gatherer[F])
+			for _, rec := range records {
+				gatherer.registry.IncrementCounter(string(metric), rec.labels)
+			}
+		}
+		return true
+	})
 }
 
 func (tracker *TrackerBase[F]) makeProps(descriptionTitle string) map[string]any {

--- a/central/metrics/custom/tracker/tracker_base_test.go
+++ b/central/metrics/custom/tracker/tracker_base_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/metrics/mocks"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/errox"
@@ -46,15 +47,57 @@ func makeTestGatherFunc(data []map[Label]string) FindingGenerator[testFinding] {
 func TestMakeTrackerBase(t *testing.T) {
 	tracker := MakeTrackerBase("test", "Test", testLabelGetters, nilGatherFunc)
 	assert.NotNil(t, tracker)
-	assert.Nil(t, tracker.getConfiguration())
+	cfg, _ := tracker.getConfiguration()
+	assert.Nil(t, cfg)
 	assert.True(t, tracker.scoped)
 }
 
+func TestMakeTrackerBase_PanicsOnScopedCounter(t *testing.T) {
+	assert.Panics(t, func() {
+		MakeTrackerBase("test", "Test", testLabelGetters, nil)
+	}, "should panic when creating scoped counter tracker")
+}
+
 func Test_makeTrackerBase(t *testing.T) {
-	tracker := makeTrackerBase("test", "Test", false, testLabelGetters, nilGatherFunc)
+	metrics.DeleteGlobalRegistry()
+	// Test global counter tracker.
+	tracker := makeTrackerBase("test", "Test", false, testLabelGetters, nil)
 	assert.NotNil(t, tracker)
-	assert.Nil(t, tracker.getConfiguration())
+	cfg, _ := tracker.getConfiguration()
+	assert.Nil(t, cfg)
 	assert.False(t, tracker.scoped)
+
+	tracker.Reconfigure(&Configuration{
+		metrics: makeTestMetricDescriptors(t),
+		enabled: true,
+	})
+
+	// After Reconfigure, no gatherer should exist yet (lazy creation).
+	i := 0
+	tracker.gatherers.Range(func(key, value any) bool {
+		i++
+		return true
+	})
+	assert.Equal(t, 0, i, "no gatherers should exist after Reconfigure")
+
+	// Simulate first increment to trigger lazy creation.
+	tracker.IncrementCounter(testFinding(0))
+
+	// Now the global gatherer should exist with running=true.
+	i = 0
+	var id string
+	var g *gatherer[testFinding]
+	tracker.gatherers.Range(func(key, value any) bool {
+		i++
+		id = key.(string)
+		g = value.(*gatherer[testFinding])
+		return true
+	})
+	assert.Equal(t, 1, i)
+	assert.Equal(t, globalScopeID, id)
+	if assert.NotNil(t, g) {
+		assert.True(t, g.running.Load(), "gatherer should be marked as running to prevent cleanup")
+	}
 }
 
 func TestTrackerBase_Reconfigure(t *testing.T) {
@@ -63,7 +106,7 @@ func TestTrackerBase_Reconfigure(t *testing.T) {
 		tracker := MakeTrackerBase("test", "Test", testLabelGetters, nilGatherFunc)
 
 		tracker.Reconfigure(nil)
-		config := tracker.getConfiguration()
+		config, _ := tracker.getConfiguration()
 		if assert.NotNil(t, config) {
 			assert.Nil(t, config.metrics)
 			assert.Zero(t, config.period)
@@ -75,11 +118,13 @@ func TestTrackerBase_Reconfigure(t *testing.T) {
 		cfg0 := &Configuration{}
 
 		tracker.Reconfigure(cfg0)
-		assert.Same(t, cfg0, tracker.getConfiguration())
+		got0, _ := tracker.getConfiguration()
+		assert.Same(t, cfg0, got0)
 
 		cfg1 := &Configuration{}
 		tracker.Reconfigure(cfg1)
-		assert.Same(t, cfg1, tracker.getConfiguration())
+		got1, _ := tracker.getConfiguration()
+		assert.Same(t, cfg1, got1)
 	})
 
 	t.Run("test add -> delete -> stop", func(t *testing.T) {
@@ -116,7 +161,7 @@ func TestTrackerBase_Reconfigure(t *testing.T) {
 		}
 		// Initial configuration.
 		tracker.Reconfigure(cfg0)
-		config := tracker.getConfiguration()
+		config, _ := tracker.getConfiguration()
 		assert.Same(t, cfg0, config)
 		assert.Empty(t, trackedMetricNames)
 
@@ -144,7 +189,8 @@ func TestTrackerBase_Reconfigure(t *testing.T) {
 			period:   2 * time.Hour,
 		}
 		tracker.Reconfigure(cfg1)
-		assert.Same(t, cfg1, tracker.getConfiguration())
+		got1, _ := tracker.getConfiguration()
+		assert.Same(t, cfg1, got1)
 		assert.Empty(t, registered)
 		assert.ElementsMatch(t, cfg1.toDelete, unregistered)
 
@@ -456,7 +502,7 @@ func TestTrackerBase_getGatherer(t *testing.T) {
 		period:  time.Hour,
 	})
 
-	cfg := tracker.getConfiguration()
+	cfg, _ := tracker.getConfiguration()
 	rf.EXPECT().RegisterMetric(gomock.Any(), gomock.Any(), gomock.Any()).
 		// each new gatherer, created by getGatherer, calls RegisterMetric
 		// for every metric.
@@ -713,6 +759,7 @@ rox_central_test_Test_scope_scoped_access_metric2{Namespace="ns 3"} 1
 	})
 
 	t.Run("global access", func(t *testing.T) {
+		metrics.DeleteGlobalRegistry()
 		tracker := MakeGlobalTrackerBase("test", "Test",
 			testLabelGetters,
 			makeTestGatherFunc(testData))
@@ -768,4 +815,232 @@ func readMetrics(registry metrics.CustomRegistry) string {
 	rec := httptest.NewRecorder()
 	registry.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 	return rec.Body.String()
+}
+
+func TestTrackerBase_NewConfiguration_exposesGaugeMetrics(t *testing.T) {
+	metrics.DeleteGlobalRegistry()
+
+	tracker := MakeGlobalTrackerBase("test", "Test",
+		testLabelGetters,
+		makeTestGatherFunc(testData))
+
+	cfg, err := tracker.NewConfiguration(&storage.PrometheusMetrics_Group{
+		Enabled:                true,
+		GatheringPeriodMinutes: 60,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"by_cluster": {Labels: []string{"Cluster"}},
+		},
+	})
+	require.NoError(t, err)
+	tracker.Reconfigure(cfg)
+
+	ctx := makeAdminContext(t)
+	tracker.Gather(ctx)
+	tracker.cleanupWG.Wait()
+
+	globalRegistry, err := metrics.GetGlobalRegistry()
+	require.NoError(t, err)
+
+	scraped := readMetrics(globalRegistry)
+	assert.Contains(t, scraped, "rox_central_test_by_cluster")
+	assert.Contains(t, scraped, `Cluster="cluster 1"`)
+}
+
+func TestTrackerBase_NewConfiguration_exposesCounterMetrics(t *testing.T) {
+	metrics.DeleteGlobalRegistry()
+
+	tracker := MakeGlobalTrackerBase("test", "test counter", testLabelGetters, nil)
+
+	cfg, err := tracker.NewConfiguration(&storage.PrometheusMetrics_Group{
+		Enabled: true,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"by_severity": {Labels: []string{"Cluster", "Severity"}},
+		},
+	})
+	require.NoError(t, err)
+	tracker.Reconfigure(cfg)
+
+	tracker.IncrementCounter(testFinding(0))
+
+	globalRegistry, err := metrics.GetGlobalRegistry()
+	require.NoError(t, err)
+
+	scraped := readMetrics(globalRegistry)
+	assert.Contains(t, scraped, "rox_central_test_by_severity")
+	assert.Contains(t, scraped, `Cluster="cluster 1"`)
+	assert.Contains(t, scraped, `Severity="CRITICAL"`)
+}
+
+func TestTrackerBase_IncrementCounter_exposesMetrics(t *testing.T) {
+	metrics.DeleteGlobalRegistry()
+
+	tracker := MakeGlobalTrackerBase("test", "test counter", testLabelGetters, nil)
+
+	md := MetricDescriptors{
+		"test_counter": {"Cluster", "Severity"},
+	}
+	tracker.Reconfigure(&Configuration{
+		metrics: md,
+		toAdd:   slices.Collect(maps.Keys(md)),
+		enabled: true,
+	})
+
+	tracker.IncrementCounter(testFinding(0))
+	tracker.IncrementCounter(testFinding(0))
+	tracker.IncrementCounter(testFinding(1))
+
+	globalRegistry, err := metrics.GetGlobalRegistry()
+	require.NoError(t, err)
+
+	const expectedMetrics = `# HELP rox_central_test_counter The total number of test counter aggregated by Cluster, Severity
+# TYPE rox_central_test_counter counter
+rox_central_test_counter{Cluster="cluster 1",Severity="CRITICAL"} 2
+rox_central_test_counter{Cluster="cluster 2",Severity="HIGH"} 1
+`
+
+	assert.Equal(t, expectedMetrics, readMetrics(globalRegistry))
+}
+
+func TestTrackerBase_IncrementCounter(t *testing.T) {
+	t.Run("increments counter in global registry", func(t *testing.T) {
+		metrics.DeleteGlobalRegistry()
+
+		ctrl := gomock.NewController(t)
+		mockRegistry := mocks.NewMockCustomRegistry(ctrl)
+
+		tracker := MakeGlobalTrackerBase("test", "test counter", testLabelGetters, nil)
+
+		tracker.registryFactory = func(userID string) (metrics.CustomRegistry, error) {
+			if userID == globalScopeID {
+				return mockRegistry, nil
+			}
+			return nil, errox.InvariantViolation.Newf("unexpected userID: %s", userID)
+		}
+
+		md := MetricDescriptors{
+			"test_counter": {"Cluster", "Severity"},
+		}
+		cfg := &Configuration{
+			metrics: md,
+			toAdd:   slices.Collect(maps.Keys(md)),
+			period:  0, // Counter trackers don't use period.
+			enabled: true,
+		}
+
+		mockRegistry.EXPECT().RegisterCounter("test_counter", gomock.Any(), []string{"Cluster", "Severity"}).Return(nil)
+
+		tracker.Reconfigure(cfg)
+
+		// Expect IncrementCounter to be called on the global registry
+		expectedLabels := prometheus.Labels{
+			"Cluster":  "cluster 1",
+			"Severity": "CRITICAL",
+		}
+		mockRegistry.EXPECT().IncrementCounter("test_counter", expectedLabels)
+
+		// Increment the counter - this should lazy-create the global gatherer.
+		tracker.IncrementCounter(testFinding(0))
+
+		// Verify the global gatherer exists and is marked as running.
+		gr, exists := tracker.gatherers.Load(globalScopeID)
+		require.True(t, exists, "global gatherer should exist after first increment")
+		require.True(t, gr.(*gatherer[testFinding]).running.Load(), "global gatherer should be marked as running")
+	})
+
+	t.Run("no-op when no gatherers exist", func(t *testing.T) {
+		metrics.DeleteGlobalRegistry()
+		tracker := MakeGlobalTrackerBase("test", "test counter", testLabelGetters, nil)
+
+		md := MetricDescriptors{
+			"test_counter": {"Cluster"},
+		}
+		cfg := &Configuration{
+			metrics: md,
+			toAdd:   slices.Collect(maps.Keys(md)),
+		}
+		tracker.Reconfigure(cfg)
+
+		// Increment should be a no-op (no panic, no error).
+		tracker.IncrementCounter(testFinding(0))
+	})
+
+	t.Run("does nothing on gauge tracker", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRegistry := mocks.NewMockCustomRegistry(ctrl)
+
+		tracker := MakeTrackerBase("test", "test gauge", testLabelGetters, nilGatherFunc)
+		tracker.registryFactory = func(string) (metrics.CustomRegistry, error) {
+			return mockRegistry, nil
+		}
+
+		md := MetricDescriptors{
+			"test_metric": {"Cluster"},
+		}
+		cfg := &Configuration{
+			metrics: md,
+			toAdd:   slices.Collect(maps.Keys(md)),
+			period:  time.Hour,
+		}
+		tracker.Reconfigure(cfg)
+
+		// Expect RegisterMetric (not RegisterCounter) to be called.
+		mockRegistry.EXPECT().RegisterMetric("test_metric", gomock.Any(), []string{"Cluster"}).Return(nil)
+
+		tracker.getGatherer("user1", cfg)
+
+		// IncrementCounter should be a no-op for gauge trackers.
+		// No IncrementCounter expectation - it should not be called.
+		tracker.IncrementCounter(testFinding(0))
+	})
+
+	t.Run("returns early when configuration is nil", func(t *testing.T) {
+		metrics.DeleteGlobalRegistry()
+		tracker := MakeGlobalTrackerBase("test", "test counter", testLabelGetters, nil)
+		tracker.IncrementCounter(testFinding(0))
+	})
+
+	t.Run("extracts correct label values from finding", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockRegistry := mocks.NewMockCustomRegistry(ctrl)
+
+		tracker := MakeGlobalTrackerBase("test", "test counter", testLabelGetters, nil)
+		tracker.registryFactory = func(userID string) (metrics.CustomRegistry, error) {
+			if userID == globalScopeID {
+				return mockRegistry, nil
+			}
+			return nil, errox.InvariantViolation.Newf("unexpected userID: %s", userID)
+		}
+
+		md := MetricDescriptors{
+			"test_counter": {"Cluster", "Namespace", "CVE", "Severity"},
+		}
+		cfg := &Configuration{
+			metrics: md,
+			toAdd:   slices.Collect(maps.Keys(md)),
+			enabled: true,
+		}
+
+		// Expect RegisterCounter to be called when the global gatherer is lazy-created.
+		mockRegistry.EXPECT().RegisterCounter("test_counter", gomock.Any(),
+			[]string{"Cluster", "Namespace", "CVE", "Severity"}).Return(nil)
+
+		tracker.getGatherer("user1", cfg)
+		tracker.gatherers.Range(func(_, v any) bool {
+			v.(*gatherer[testFinding]).running.Store(false)
+			return true
+		})
+		tracker.Reconfigure(cfg)
+
+		// Expect correct labels extracted from testFinding(1).
+		expectedLabels := prometheus.Labels{
+			"Cluster":   testData[1]["Cluster"],
+			"Namespace": testData[1]["Namespace"],
+			"CVE":       testData[1]["CVE"],
+			"Severity":  testData[1]["Severity"],
+		}
+		mockRegistry.EXPECT().IncrementCounter("test_counter", expectedLabels)
+
+		// This should lazy-create the global gatherer and increment the counter.
+		tracker.IncrementCounter(testFinding(1))
+	})
 }

--- a/central/metrics/custom_registry.go
+++ b/central/metrics/custom_registry.go
@@ -31,8 +31,10 @@ type CustomRegistry interface {
 	Lock()
 	Unlock()
 	RegisterMetric(metricName string, description string, labels []string) error
+	RegisterCounter(metricName string, description string, labels []string) error
 	UnregisterMetric(metricName string) bool
 	SetTotal(metricName string, labels prometheus.Labels, total int)
+	IncrementCounter(metricName string, labels prometheus.Labels)
 	Reset(metricName string)
 }
 
@@ -40,7 +42,8 @@ type customRegistry struct {
 	*prometheus.Registry
 	sync.Mutex
 	http.Handler
-	gauges sync.Map // map[metricName string]*prometheus.GaugeVec
+	gauges   sync.Map // map[metricName string]*prometheus.GaugeVec
+	counters sync.Map // map[metricName string]*prometheus.CounterVec
 }
 
 var (
@@ -97,8 +100,24 @@ func DeleteCustomRegistry(userID string) {
 		_ = registry.UnregisterMetric(metric.(string))
 		return true
 	})
+	registry.counters.Range(func(metric, vec any) bool {
+		_ = registry.UnregisterMetric(metric.(string))
+		return true
+	})
 	registry.gauges.Clear()
+	registry.counters.Clear()
 	delete(userRegistries, userID)
+}
+
+func DeleteGlobalRegistry() {
+	registriesMux.Lock()
+	defer registriesMux.Unlock()
+	if globalRegistry == nil {
+		return
+	}
+	globalRegistry.gauges.Clear()
+	globalRegistry.counters.Clear()
+	globalRegistry = nil
 }
 
 var _ CustomRegistry = (*customRegistry)(nil)
@@ -107,6 +126,9 @@ var _ CustomRegistry = (*customRegistry)(nil)
 func (cr *customRegistry) UnregisterMetric(metricName string) bool {
 	if gauge, loaded := cr.gauges.LoadAndDelete(metricName); loaded {
 		return cr.Unregister(gauge.(*prometheus.GaugeVec))
+	}
+	if counter, loaded := cr.counters.LoadAndDelete(metricName); loaded {
+		return cr.Unregister(counter.(*prometheus.CounterVec))
 	}
 	return false
 }
@@ -125,6 +147,20 @@ func (cr *customRegistry) RegisterMetric(metricName string, description string, 
 	return nil
 }
 
+// RegisterCounter registers a counter metric with configurable labels.
+func (cr *customRegistry) RegisterCounter(metricName string, description string, labels []string) error {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      metricName,
+		Help:      description,
+	}, labels)
+	if _, loaded := cr.counters.LoadOrStore(metricName, counter); !loaded {
+		return cr.Register(counter)
+	}
+	return nil
+}
+
 // SetTotal sets the value to the gauge of a metric.
 func (cr *customRegistry) SetTotal(metricName string, labels prometheus.Labels, total int) {
 	if gauge, ok := cr.gauges.Load(metricName); ok {
@@ -132,10 +168,20 @@ func (cr *customRegistry) SetTotal(metricName string, labels prometheus.Labels, 
 	}
 }
 
+// IncrementCounter increments the counter metric with the given labels.
+func (cr *customRegistry) IncrementCounter(metricName string, labels prometheus.Labels) {
+	if counter, ok := cr.counters.Load(metricName); ok {
+		counter.(*prometheus.CounterVec).With(labels).Inc()
+	}
+}
+
 // Reset the metric to drop potentially stale labels.
 func (cr *customRegistry) Reset(metricName string) {
 	if gauge, ok := cr.gauges.Load(metricName); ok {
 		gauge.(*prometheus.GaugeVec).Reset()
+	}
+	if counter, ok := cr.counters.Load(metricName); ok {
+		counter.(*prometheus.CounterVec).Reset()
 	}
 }
 

--- a/central/metrics/mocks/custom_registry.go
+++ b/central/metrics/mocks/custom_registry.go
@@ -57,6 +57,18 @@ func (mr *MockCustomRegistryMockRecorder) Gather() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gather", reflect.TypeOf((*MockCustomRegistry)(nil).Gather))
 }
 
+// IncrementCounter mocks base method.
+func (m *MockCustomRegistry) IncrementCounter(metricName string, labels prometheus.Labels) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IncrementCounter", metricName, labels)
+}
+
+// IncrementCounter indicates an expected call of IncrementCounter.
+func (mr *MockCustomRegistryMockRecorder) IncrementCounter(metricName, labels any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementCounter", reflect.TypeOf((*MockCustomRegistry)(nil).IncrementCounter), metricName, labels)
+}
+
 // Lock mocks base method.
 func (m *MockCustomRegistry) Lock() {
 	m.ctrl.T.Helper()
@@ -67,6 +79,20 @@ func (m *MockCustomRegistry) Lock() {
 func (mr *MockCustomRegistryMockRecorder) Lock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lock", reflect.TypeOf((*MockCustomRegistry)(nil).Lock))
+}
+
+// RegisterCounter mocks base method.
+func (m *MockCustomRegistry) RegisterCounter(metricName, description string, labels []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterCounter", metricName, description, labels)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterCounter indicates an expected call of RegisterCounter.
+func (mr *MockCustomRegistryMockRecorder) RegisterCounter(metricName, description, labels any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCounter", reflect.TypeOf((*MockCustomRegistry)(nil).RegisterCounter), metricName, description, labels)
 }
 
 // RegisterMetric mocks base method.


### PR DESCRIPTION
## Description

Extend `TrackerBase` with `IncrementCounter` for real-time event counting
(vs gauge-style periodic gathering). Counters use the `enabled` proto field
and register via `RegisterCounter` on the global `CustomRegistry`.

Add `IncrementCounter`/`RegisterCounter` to `CustomRegistry` with a separate
`counters sync.Map`. Add `DeleteGlobalRegistry` for test cleanup.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Comprehensive tests for counter lifecycle, concurrent access, and configuration changes included.
<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21131**
    * **PR #21132**
      * **PR #21133**
        * **PR #21134**
          * **PR #21360**
            * **PR #21361** 👈
              * **PR #18080**
<!-- GHIT dependencies end -->