### PR TITLE
ROX-35030: Add retry to report download HTTP request

### DIFF
--- a/tests/report_entity_scope_test.go
+++ b/tests/report_entity_scope_test.go
@@ -398,8 +398,8 @@ func (s *ReportEntityScopeSuite) downloadReport(reportID string) {
 	password := centralgrpc.RoxPassword(s.T())
 	username := centralgrpc.RoxUsername(s.T())
 
-	url := fmt.Sprintf("https://%s/api/reports/jobs/download?id=%s", endpoint, reportID)
-	s.T().Logf("Downloading report from %s", url)
+	downloadURL := fmt.Sprintf("https://%s/api/reports/jobs/download?id=%s", endpoint, reportID)
+	s.T().Logf("Downloading report from %s", downloadURL)
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -408,12 +408,19 @@ func (s *ReportEntityScopeSuite) downloadReport(reportID string) {
 		Timeout: 60 * time.Second,
 	}
 
-	req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, url, nil)
-	s.Require().NoError(err)
-	req.SetBasicAuth(username, password)
+	var resp *http.Response
+	s.Require().Eventually(func() bool {
+		req, err := http.NewRequestWithContext(s.ctx, http.MethodGet, downloadURL, nil)
+		s.Require().NoError(err)
+		req.SetBasicAuth(username, password)
 
-	resp, err := client.Do(req)
-	s.Require().NoError(err)
+		resp, err = client.Do(req)
+		if err != nil {
+			s.T().Logf("Download attempt failed: %v", err)
+			return false
+		}
+		return true
+	}, 2*time.Minute, 5*time.Second, "failed to download report after retries")
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Description

Follow-up to #21268 which fixed the Central readiness flake in `TestReportEntityScope`.

After that fix, `TestRunAndDownloadReport` is still failing consistently: the report generates successfully via gRPC, but the subsequent HTTP GET to download it gets "connection refused". The `downloadReport` method uses a raw `http.Client` with no retry logic, unlike the gRPC calls which have retry interceptors.

Wraps the HTTP download request in `s.Require().Eventually()` with a 2-minute timeout and 5-second polling interval to handle transient connection failures.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Code compiles cleanly with `go vet -tags test_e2e ./tests/`
- Post-merge CI logs from ROX-35030 show `TestRunAndDownloadReport` consistently failing at the HTTP download step with "connection refused" while all gRPC calls succeed. This retry wraps the same transient failure pattern.