### PR TITLE
ROX-34782: add retry to operator-sdk go install

### DIFF
--- a/make/gotools.mk
+++ b/make/gotools.mk
@@ -8,7 +8,7 @@
 #   GOTOOLS_BIN: the directory in which binaries are stored; defaults to $(GOTOOLS_ROOT)/bin.
 #
 # This file defines a single (user-facing) macro, `go-tool`, which can be invoked via
-#   $(call go-tool VARNAME, go-pkg [, module-root])
+#   $(call go-tool VARNAME, go-pkg [, module-root [, extra-flags]])
 # where go-pkg can be:
 # - an absolute Go import path with an explicit version, e.g.,
 #     github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0. In this case, the tool is installed via `go install`,
@@ -81,7 +81,6 @@ _gotools_mod_root := $(GOTOOLS_PROJECT_ROOT)
 else
 _gotools_mod_root := $(strip $(3))
 endif
-
 # We need to strip a `/v2` (etc.) suffix to derive the tool binary's basename.
 _gotools_bin_name := $$(notdir $$(shell echo "$$(_gotools_pkg)" | sed -E 's@/v[[:digit:]]+$$$$@@g'))
 _gotools_canonical_bin_path := $(GOTOOLS_BIN)/$$(_gotools_bin_name)
@@ -98,7 +97,7 @@ ifneq ($(filter ./%,$(2)),)
 .PHONY: $$(_gotools_canonical_bin_path)
 $$(_gotools_canonical_bin_path):
 	@echo "+ $$(notdir $$@)"
-	$$(SILENT)$(RUN_WITH_RETRY_FN); run_with_retry env GOBIN="$$(dir $$@)" go install "$(strip $(2))"
+	$$(SILENT)$(RUN_WITH_RETRY_FN); run_with_retry env GOBIN="$$(dir $$@)" go install $(strip $(4)) "$(strip $(2))"
 else
 # Tool is specified with version, so we don't take any info from the go.mod file.
 # We install the tool into a location that is version-dependent, and build it via this target. Since the name of
@@ -108,7 +107,7 @@ ifneq ($$(_gotools_version),)
 _gotools_versioned_bin_path := $(GOTOOLS_ROOT)/versioned/$$(_gotools_pkg)/$$(_gotools_version)/$$(_gotools_bin_name)
 $$(_gotools_versioned_bin_path):
 	@echo "+ $$(notdir $$@)"
-	$$(SILENT)$(RUN_WITH_RETRY_FN); run_with_retry env GOBIN="$$(dir $$@)" go install "$(strip $(2))"
+	$$(SILENT)$(RUN_WITH_RETRY_FN); run_with_retry env GOBIN="$$(dir $$@)" go install $(strip $(4)) "$(strip $(2))"
 
 # To make the tool accessible in the canonical location, we create a symlink. This only depends on the versioned path,
 # i.e., only needs to be recreated when the version is bumped.
@@ -121,7 +120,7 @@ else
 # Tool is specified with an absolute path without a version. Take info from go.mod file in the respective directory.
 $$(_gotools_canonical_bin_path): $$(_gotools_mod_root)/go.mod $$(_gotools_mod_root)/go.sum
 	@echo "+ $$(notdir $$@)"
-	$$(SILENT)cd "$$(dir $$<)" && $(RUN_WITH_RETRY_FN); run_with_retry env GOBIN="$$(dir $$@)" go install "$(strip $(2))"
+	$$(SILENT)cd "$$(dir $$<)" && $(RUN_WITH_RETRY_FN); run_with_retry env GOBIN="$$(dir $$@)" go install $(strip $(4)) "$(strip $(2))"
 
 endif
 endif
@@ -130,7 +129,7 @@ _GOTOOLS_ALL_GOTOOLS += $$(_gotools_canonical_bin_path)
 
 endef
 
-go-tool = $(eval $(call go-tool-impl,$(1),$(2),$(3)))
+go-tool = $(eval $(call go-tool-impl,$(1),$(2),$(3),$(4)))
 
 
 .PHONY: gotools-clean

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -203,10 +203,7 @@ $(call go-tool, YQ, github.com/mikefarah/yq/v4, tools/yq)
 
 # Build operator-sdk with containers_image_openpgp tag to avoid gpgme dependency
 # See: https://github.com/containers/image/blob/df7e80d2d19872b61f352a8a182ec934dc0c2346/README.md#buildtag-containers_image_openpgp
-OPERATOR_SDK := $(GOTOOLS_BIN)/operator-sdk
-$(OPERATOR_SDK): tools/operator-sdk/go.mod tools/operator-sdk/go.sum
-	@echo "+ $(notdir $@)"
-	$(SILENT)cd tools/operator-sdk && GOBIN="$(dir $@)" go install -tags=containers_image_openpgp github.com/operator-framework/operator-sdk/cmd/operator-sdk
+$(call go-tool, OPERATOR_SDK, github.com/operator-framework/operator-sdk/cmd/operator-sdk, tools/operator-sdk, -tags=containers_image_openpgp)
 
 OPERATOR_SDK_VERSION = $(shell cd tools/operator-sdk; go list -m -f '{{ .Version }}' github.com/operator-framework/operator-sdk)
 


### PR DESCRIPTION
## Description

The `operator-sdk` build target in `operator/Makefile` was hand-rolled with a bare `go install` because it needs `-tags=containers_image_openpgp`. Unlike all tools registered via the `go-tool` macro in `gotools.mk`, it lacked the `run_with_retry` wrapper (8 attempts, exponential backoff). This caused CI flakes when the Go module proxy returned transient errors.

Instead of just adding the retry wrapper to the hand-rolled target, the `go-tool` macro now accepts an optional 4th parameter for extra `go install` flags. The operator-sdk target is converted to use the macro, getting retry logic for free.

Authored by Claude.

See https://redhat-internal.slack.com/archives/CELUQKESC/p1782292205843359 for current qa-e2e-test failures.

## User-facing documentation

Not needed.

## Testing and quality

No production code, just building.

- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Well, it is used in CI.

### How I validated my change

Starting on master branch:

```bash
$ rm -f operator/.gotools/bin/operator-sdk; GOMODCACHE=/tmp/empty-mod-cache GOPROXY=https://localhost make -C operator "$(pwd)/operator/.gotools/bin/operator-sdk"

+ operator-sdk
go: downloading go1.26.3 (darwin/arm64)
go: download go1.26.3: golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64: Get "https://localhost/golang.org/toolchain/@v/v0.0.1-go1.26.3.darwin-arm64.zip": dial tcp [::1]:443: connect: connection refused
make: *** [/Users/mclasmeier/go/src/github.com/stackrox/stackrox/operator/.gotools/bin/operator-sdk] Error 1

$ sb
Switched to branch 'mc/gotools-tags-retry'
Your branch is up to date with 'origin/mc/gotools-tags-retry'.

$ rm -f operator/.gotools/bin/operator-sdk; GOMODCACHE=/tmp/empty-mod-cache GOPROXY=https://localhost make -C operator "$(pwd)/operator/.gotools/bin/operator-sdk"

+ operator-sdk
go: downloading go1.26.3 (darwin/arm64)
go: download go1.26.3: golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64: Get "https://localhost/golang.org/toolchain/@v/v0.0.1-go1.26.3.darwin-arm64.zip": dial tcp [::1]:443: connect: connection refused
Retry 1/8 failed. Retrying after 1 seconds...
go: downloading go1.26.3 (darwin/arm64)
go: download go1.26.3: golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64: Get "https://localhost/golang.org/toolchain/@v/v0.0.1-go1.26.3.darwin-arm64.zip": dial tcp [::1]:443: connect: connection refused
Retry 2/8 failed. Retrying after 4 seconds...
^Cmake: *** [/Users/mclasmeier/go/src/github.com/stackrox/stackrox/operator/.gotools/bin/operator-sdk] Interrupt: 2

```
