### PR TITLE
ROX-35285: switch Konflux builds to Go native FIPS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -351,7 +351,7 @@ jobs:
           sudo ln -sf /usr/include/asm /usr/include/x86_64-linux-musl/asm
 
       - name: Build Go Binaries
-        run: GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 make build-prep main-build-nodeps roxctl_linux-${{ matrix.arch }}
+        run: GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=0 make build-prep main-build-nodeps
 
       - name: Bundle the build to preserve permissions
         run: tar -cvf go-binaries-build.tar bin/linux_${{ matrix.arch }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,6 +22,9 @@ env:
   # prevent per-commit cache misses.
   BUILD_TAG: 0.0.0
   SHORTCOMMIT: "0000000"
+  GOFIPS140: certified
+  GODEBUG: "fips140=only"
+  CGO_ENABLED: 0
 
 jobs:
   detect-changes:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,9 +22,7 @@ env:
   # prevent per-commit cache misses.
   BUILD_TAG: 0.0.0
   SHORTCOMMIT: "0000000"
-  GOFIPS140: certified
   GODEBUG: "fips140=only"
-  CGO_ENABLED: 0
 
 jobs:
   detect-changes:

--- a/Makefile
+++ b/Makefile
@@ -509,8 +509,7 @@ main-build-nodeps:
 		sensor/admission-control \
 		sensor/kubernetes \
 		sensor/upgrader \
-		compliance/virtualmachines/roxagent \
-		roxctl
+		compliance/virtualmachines/roxagent
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
 
 .PHONY: scale-build

--- a/Makefile
+++ b/Makefile
@@ -511,9 +511,7 @@ main-build-nodeps:
 		sensor/upgrader \
 		compliance/virtualmachines/roxagent
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
-ifndef CI
 	CGO_ENABLED=0 $(GOBUILD) roxctl
-endif
 
 .PHONY: scale-build
 scale-build: build-prep

--- a/Makefile
+++ b/Makefile
@@ -509,9 +509,9 @@ main-build-nodeps:
 		sensor/admission-control \
 		sensor/kubernetes \
 		sensor/upgrader \
-		compliance/virtualmachines/roxagent
+		compliance/virtualmachines/roxagent \
+		roxctl
 	mv bin/linux_$(GOARCH)/cmd bin/linux_$(GOARCH)/stackrox-operator
-	CGO_ENABLED=0 $(GOBUILD) roxctl
 
 .PHONY: scale-build
 scale-build: build-prep

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -17,15 +17,9 @@ ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
 ENV GOTAGS="release"
 ENV CI=1
-
-# TODO(ROX-13200): make sure roxctl cli is built without running go mod tidy.
-# CLI builds are without strictfipsruntime (and CGO_ENABLED is set to 0) because these binaries are for user download and use outside the cluster.
-RUN make roxctl-build
-
-ENV CGO_ENABLED=1
-# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
-ENV GOTAGS="release,strictfipsruntime"
-ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=0
+ENV GOFIPS140=certified
+ENV GOLANG_FIPS=0
 
 RUN make main-build-nodeps
 
@@ -82,7 +76,6 @@ RUN dnf module enable -y \
         findutils \
         gzip \
         less \
-        openssl \
         postgresql \
         tar && \
     dnf clean all --installroot=/out/ && \
@@ -135,6 +128,7 @@ LABEL \
 EXPOSE 8443
 
 ENV PATH="/stackrox:$PATH" \
+    GODEBUG="fips140=on" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
     ROX_IMAGE_FLAVOR="rhacs" \
     ROX_PRODUCT_BRANDING="RHACS_BRANDING"

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -15,7 +15,7 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+ENV GOTAGS="release,no_openssl"
 # TODO(ROX-13200): make sure roxctl cli is built without running go mod tidy.
 ENV CI=1
 ENV CGO_ENABLED=0

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -16,6 +16,7 @@ ENV BUILD_TAG="$BUILD_TAG"
 ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
 ENV GOTAGS="release"
+# TODO(ROX-13200): make sure roxctl cli is built without running go mod tidy.
 ENV CI=1
 ENV CGO_ENABLED=0
 ENV GOFIPS140=certified

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -131,7 +131,7 @@ LABEL \
 EXPOSE 8443
 
 ENV PATH="/stackrox:$PATH" \
-    GODEBUG="fips140=only" \
+    GODEBUG="fips140=on" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
     ROX_IMAGE_FLAVOR="rhacs" \
     ROX_PRODUCT_BRANDING="RHACS_BRANDING"

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -22,6 +22,8 @@ ENV CGO_ENABLED=0
 ENV GOFIPS140=certified
 ENV GOLANG_FIPS=0
 
+RUN make roxctl-build
+
 RUN make main-build-nodeps
 
 RUN mkdir -p image/rhel/docs/api/v1 && \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -129,7 +129,7 @@ LABEL \
 EXPOSE 8443
 
 ENV PATH="/stackrox:$PATH" \
-    GODEBUG="fips140=on" \
+    GODEBUG="fips140=only" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \
     ROX_IMAGE_FLAVOR="rhacs" \
     ROX_PRODUCT_BRANDING="RHACS_BRANDING"

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -16,9 +16,10 @@ ARG BUILD_TAG
 RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is unset"; exit 6; fi
 ENV BUILD_TAG="$BUILD_TAG"
 
-ENV CI=1 GOFLAGS=""
+ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
 ENV GOTAGS="release,no_openssl"
+ENV CI=1
 ENV CGO_ENABLED=0
 ENV GOFIPS140=certified
 ENV GOLANG_FIPS=0

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -18,7 +18,7 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV CI=1 GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+ENV GOTAGS="release,no_openssl"
 ENV CGO_ENABLED=0
 ENV GOFIPS140=certified
 ENV GOLANG_FIPS=0

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -78,7 +78,7 @@ LABEL \
     release="1"
 
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true" \
-    GODEBUG="fips140=on"
+    GODEBUG="fips140=only"
 
 USER 65534:65534
 

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -79,7 +79,7 @@ LABEL \
     release="1"
 
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true" \
-    GODEBUG="fips140=only"
+    GODEBUG="fips140=on"
 
 USER 65534:65534
 

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -18,11 +18,12 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV CI=1 GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
-ENV GOTAGS="release,strictfipsruntime"
-ENV GOEXPERIMENT=strictfipsruntime
+ENV GOTAGS="release"
+ENV CGO_ENABLED=0
+ENV GOFIPS140=certified
+ENV GOLANG_FIPS=0
 
-RUN RACE=0 CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build.sh ./roxctl && \
+RUN RACE=0 GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build.sh ./roxctl && \
     cp bin/linux_$(go env GOARCH)/roxctl image/bin/roxctl
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa AS ubi-micro-base
@@ -44,7 +45,6 @@ RUN dnf install -y \
     ca-certificates \
     gzip \
     less \
-    openssl \
     tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/*
@@ -77,7 +77,8 @@ LABEL \
     # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
     release="1"
 
-ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
+ENV ROX_ROXCTL_IN_MAIN_IMAGE="true" \
+    GODEBUG="fips140=on"
 
 USER 65534:65534
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -74,7 +74,7 @@ COPY --from=builder /go/src/github.com/stackrox/rox/app/image/bin/operator /usr/
 COPY LICENSE /licenses/LICENSE
 
 ENV ROX_IMAGE_FLAVOR="rhacs" \
-    GODEBUG="fips140=only"
+    GODEBUG="fips140=on"
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -72,7 +72,7 @@ COPY --from=builder /go/src/github.com/stackrox/rox/app/image/bin/operator /usr/
 COPY LICENSE /licenses/LICENSE
 
 ENV ROX_IMAGE_FLAVOR="rhacs" \
-    GODEBUG="fips140=on"
+    GODEBUG="fips140=only"
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -9,10 +9,10 @@ RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is
 ENV BUILD_TAG="$BUILD_TAG"
 
 # TODO(ROX-20240): enable non-release development builds.
-# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
-ENV GOTAGS="release,strictfipsruntime"
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CI=1 GOFLAGS="" CGO_ENABLED=1
+ENV GOTAGS="release"
+ENV CI=1 GOFLAGS="" CGO_ENABLED=0
+ENV GOFIPS140=certified
+ENV GOLANG_FIPS=0
 
 RUN GOOS=linux GOARCH=$(go env GOARCH) scripts/go-build-file.sh operator/cmd/main.go image/bin/operator
 
@@ -37,7 +37,6 @@ RUN dnf install -y \
     ca-certificates \
     gzip \
     less \
-    openssl \
     tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/*
@@ -72,7 +71,8 @@ COPY --from=builder /go/src/github.com/stackrox/rox/app/image/bin/operator /usr/
 
 COPY LICENSE /licenses/LICENSE
 
-ENV ROX_IMAGE_FLAVOR="rhacs"
+ENV ROX_IMAGE_FLAVOR="rhacs" \
+    GODEBUG="fips140=on"
 
 # The following are numeric uid and gid of `nobody` user in UBI.
 # We can't use symbolic names because otherwise k8s will fail to start the pod with an error like this:

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -9,7 +9,7 @@ RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is
 ENV BUILD_TAG="$BUILD_TAG"
 
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+ENV GOTAGS="release,no_openssl"
 ENV CI=1 GOFLAGS="" CGO_ENABLED=0
 ENV GOFIPS140=certified
 ENV GOLANG_FIPS=0

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -8,9 +8,11 @@ ARG BUILD_TAG
 RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is unset"; exit 6; fi
 ENV BUILD_TAG="$BUILD_TAG"
 
+ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
 ENV GOTAGS="release,no_openssl"
-ENV CI=1 GOFLAGS="" CGO_ENABLED=0
+ENV CI=1
+ENV CGO_ENABLED=0
 ENV GOFIPS140=certified
 ENV GOLANG_FIPS=0
 

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -14,7 +14,6 @@ packages:
 - ca-certificates
 - gzip
 - less
-- openssl
 - tar
 moduleEnable:
 # final stage in image/rhel/konflux.Dockerfile

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -6,15 +6,16 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-# TODO(ROX-27054): Remove the redundant strictfipsruntime option if one is found to be so.
-ENV GOTAGS="release,strictfipsruntime"
-ENV GOEXPERIMENT=strictfipsruntime
+ENV GOTAGS="release"
 ENV CI=1
+ENV CGO_ENABLED=0
+ENV GOFIPS140=certified
+ENV GOLANG_FIPS=0
 
 COPY . /src
 WORKDIR /src
 
-RUN make -C scanner NODEPS=1 CGO_ENABLED=1 image/scanner/bin/scanner copy-scripts
+RUN make -C scanner NODEPS=1 image/scanner/bin/scanner copy-scripts
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa AS ubi-micro-base
 
@@ -31,7 +32,6 @@ RUN dnf install -y \
     ca-certificates \
     gzip \
     less \
-    openssl \
     tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
@@ -85,6 +85,8 @@ RUN \
     chown -R 65534:65534 /etc/pki/ca-trust && save-dir-contents /etc/pki/ca-trust/source
 
 COPY LICENSE /licenses/LICENSE
+
+ENV GODEBUG="fips140=on"
 
 # This is equivalent to nobody:nobody.
 USER 65534:65534

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -86,7 +86,7 @@ RUN \
 
 COPY LICENSE /licenses/LICENSE
 
-ENV GODEBUG="fips140=only"
+ENV GODEBUG="fips140=on"
 
 # This is equivalent to nobody:nobody.
 USER 65534:65534

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -86,7 +86,7 @@ RUN \
 
 COPY LICENSE /licenses/LICENSE
 
-ENV GODEBUG="fips140=on"
+ENV GODEBUG="fips140=only"
 
 # This is equivalent to nobody:nobody.
 USER 65534:65534

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -6,7 +6,7 @@ ENV BUILD_TAG="$BUILD_TAG"
 
 ENV GOFLAGS=""
 # TODO(ROX-20240): enable non-release development builds.
-ENV GOTAGS="release"
+ENV GOTAGS="release,no_openssl"
 ENV CI=1
 ENV CGO_ENABLED=0
 ENV GOFIPS140=certified


### PR DESCRIPTION
## Description

Switch all Konflux builds from `strictfipsruntime` + `CGO_ENABLED=1` + OpenSSL to Go 1.26 native FIPS 140-3 module (`GOFIPS140=certified`, CMVP #5247).

**Problem:** In-container roxctl was never FIPS-compliant — it's a symlink to the static non-FIPS CLI download binary. PR #21324 tried to fix CLI downloads but broke the main image build. PR #21356 proposed a split-build workaround.

**Solution:** Native FIPS produces statically linked FIPS binaries without OpenSSL or CGO. All binaries (central, sensor, roxctl, scanner, operator) now use the same build flags. No separate build stages needed.

**Key changes:**
- `GOFIPS140=certified` + `CGO_ENABLED=0` + `GOLANG_FIPS=0` in all Konflux Dockerfiles
- `-tags no_openssl` to compile out Red Hat's OpenSSL FIPS backend
- `GODEBUG=fips140=only` in runtime images for strict FIPS enforcement
- Removed `openssl` from runtime images and `rpms.in.yaml` (no longer needed)
- Restored `roxctl-build` for multi-arch CLI downloads in main image
- Removed redundant `roxctl_linux` target from GHA build

**Why `GOLANG_FIPS=0` + `no_openssl`?** Red Hat downstream Go 1.26 patches add OpenSSL-based FIPS support ([source](https://github.com/golang-fips/go/blob/go1.26-fips-release/patches/000-fips.patch)). `GOLANG_FIPS=0` disables it at runtime, `no_openssl` compiles it out at build time. Both are needed — without them, the OpenSSL backend and native FIPS module conflict.

**Why `fips140=only`?** Stricter than `fips140=on` — panics on any non-FIPS-approved crypto algorithm. Confirmed by FIPS team (cllang, dbenoit, jreznik) that Go 1.26 native FIPS is validated on Amazon Linux as Operational Environment (CMVP #5247), making this the correct path for ROSA HCP/EKS FIPS compliance.

**`rpms.lock.yaml`** still contains openssl entries as transitive deps. The Konflux bot will regenerate it — extra prefetched RPMs are harmless.

Supersedes:
- #21356

Refs:
- #17868
- #21324

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validated on image `quay.io/rhacs-eng/release-main:4.12.0-296-ga7579f734a-fast`.

**Static linking:**
```bash
$ docker run --rm --entrypoint ldd $IMG /stackrox/central
        not a dynamic executable
$ docker run --rm --entrypoint ldd $IMG /assets/downloads/cli/roxctl-linux-amd64
        not a dynamic executable
```

**All 7 roxctl CLI download variants present:**
```bash
$ docker run --rm --entrypoint ls $IMG /assets/downloads/cli/
roxctl-darwin-amd64  roxctl-darwin-arm64  roxctl-linux  roxctl-linux-amd64
roxctl-linux-arm64  roxctl-linux-ppc64le  roxctl-linux-s390x  roxctl-windows-amd64.exe
```

**GODEBUG=fips140=only baked into image:**
```bash
$ docker inspect $IMG --format '{{range .Config.Env}}{{println .}}{{end}}' | grep GODEBUG
GODEBUG=fips140=only
```

**FIPS module embedded (1230 references in central binary):**
```bash
$ docker run --rm --entrypoint sh $IMG -c "grep -c fips140 /stackrox/central"
1230
```

**FIPS cipher enforcement — negative test with openssl s_server:**

Set up two TLS 1.2 test servers:
- FIPS server (port 14443): `ECDHE-RSA-AES128-GCM-SHA256` (GCM, FIPS-approved)

	```
	  openssl s_server -accept 14443 -cert cert.pem -key key.pem \
	    -cipher 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384' \
	    -no_tls1_3 -www -quiet
	```
- Non-FIPS server (port 14444): `ECDHE-RSA-AES128-SHA` (CBC, not FIPS-approved)
	```
	  openssl s_server -accept 14444 -cert cert.pem -key key.pem \
	    -cipher 'ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA' \
	    -no_tls1_3 -www -quiet
	```

gRPC (roxctl central whoami):
```bash
# FIPS server — TLS succeeds (fails on ALPN, expected — not a real gRPC server)
$ docker run --rm --network=host --entrypoint roxctl $IMG \
    central whoami --insecure-skip-tls-verify -e https://localhost:14443
ERROR: ... missing selected ALPN property

# Non-FIPS server — TLS handshake rejected
$ docker run --rm --network=host --entrypoint roxctl $IMG \
    central whoami --insecure-skip-tls-verify -e https://localhost:14444
ERROR: ... remote error: tls: handshake failure
```

Plain HTTPS (roxctl central debug dump):
```bash
# FIPS server — HTTPS succeeds, downloads response
$ docker run --rm --network=host --entrypoint roxctl $IMG \
    central debug dump --insecure-skip-tls-verify -e https://localhost:14443
INFO: Successfully wrote debug zip file

# Non-FIPS server — TLS handshake rejected
$ docker run --rm --network=host --entrypoint roxctl $IMG \
    central debug dump --insecure-skip-tls-verify -e https://localhost:14444
ERROR: ... remote error: tls: handshake failure
```

**Runtime override test:** Even with `GODEBUG=fips140=off`, CBC ciphers are still rejected — `GOFIPS140=certified` restricts available cipher suites at the binary level.

**OpenSSL not used by Go binaries** (present only as postgresql transitive dependency):
```bash
$ docker run --rm --entrypoint sh $IMG -c "ls /usr/lib64/libpq*"
/usr/lib64/libpq.so.private15-5
```