### PR TITLE
chore(upgrade): bump upgrade test versions to 4.9.8 and 4.10.4

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -10,7 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.6.2"
 EARLIER_SHA="ecff2a443c8b9a2dc7bf606162da89da81dd8e9e"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
-PREVIOUS_RELEASES=("4.6.10" "4.7.9" "4.8.11" "4.9.7" "4.10.3" "4.11.0")
+PREVIOUS_RELEASES=("4.6.10" "4.7.9" "4.8.11" "4.9.8" "4.10.4" "4.11.0")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"


### PR DESCRIPTION
## Description

Bump PREVIOUS_RELEASES in postgres upgrade test to latest patch versions (4.9.7 → 4.9.8, 4.10.3 → 4.10.4).

Ref: https://spaces.redhat.com/display/StackRox/Upstream+Release+Automation#UpstreamReleaseAutomation-update-upgrade-testUpdateUpgradeTest

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

CI upgrade test will exercise the new version list.