### PR TITLE
ROX-34855: Filter empty scope (#21163)

### DIFF
--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -181,6 +181,11 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	filteredQ := common.WithoutV1ReportConfigs(parsedQuery)
+	// This filter removes report configs with empty collection.
+	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
+	filteredQ = search.ConjunctionQuery(
+		filteredQ,
+		search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 
 	// Fill in pagination.
 	paginated.FillPaginationV2(filteredQ, query.GetPagination(), maxPaginationLimit)
@@ -229,6 +234,11 @@ func (s *serviceImpl) CountReportConfigurations(ctx context.Context, request *ap
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	filteredQ := common.WithoutV1ReportConfigs(parsedQuery)
+	// This filter removes report configs with empty collection.
+	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
+	filteredQ = search.ConjunctionQuery(
+		filteredQ,
+		search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 
 	numReportConfigs, err := s.reportConfigStore.Count(ctx, filteredQ)
 	if err != nil {

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	withoutV1ConfigsQuery = search.NewQueryBuilder().AddExactMatches(search.EmbeddedCollectionID, "").ProtoQuery()
+	withoutEmptyScope = search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery()
 )
 
 type upsertTestCase struct {
@@ -240,12 +240,12 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 		expectedQ *v1.Query
 	}{
 		{
-			desc:  "Empty query",
+			desc:  "Query with empty query",
 			query: &apiV2.RawQuery{Query: ""},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
-					search.EmptyQuery(),
-					withoutV1ConfigsQuery)
+					common.WithoutV1ReportConfigs(search.EmptyQuery()),
+					withoutEmptyScope)
 				query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
 				return query
 			}(),
@@ -255,8 +255,8 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			query: &apiV2.RawQuery{Query: "Report Name:name"},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
-					search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
-					withoutV1ConfigsQuery)
+					common.WithoutV1ReportConfigs(search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery()),
+					withoutEmptyScope)
 				query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
 				return query
 			}(),
@@ -269,8 +269,8 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
-					search.EmptyQuery(),
-					withoutV1ConfigsQuery)
+					common.WithoutV1ReportConfigs(search.EmptyQuery()),
+					withoutEmptyScope)
 				query.Pagination = &v1.QueryPagination{Limit: 25}
 				return query
 			}(),
@@ -365,15 +365,19 @@ func (s *ReportServiceTestSuite) TestCountReportConfigurations() {
 			desc:  "Empty query",
 			query: &apiV2.RawQuery{Query: ""},
 			expectedQ: search.ConjunctionQuery(
-				search.NewQueryBuilder().ProtoQuery(),
-				withoutV1ConfigsQuery),
+				common.WithoutV1ReportConfigs(search.EmptyQuery()), // or parsed query variant
+				withoutEmptyScope,
+			),
 		},
 		{
 			desc:  "Query with search field",
 			query: &apiV2.RawQuery{Query: "Report Name:name"},
 			expectedQ: search.ConjunctionQuery(
-				search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
-				withoutV1ConfigsQuery),
+				common.WithoutV1ReportConfigs(
+					search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
+				),
+				withoutEmptyScope,
+			),
 		},
 	}
 


### PR DESCRIPTION
This PR backports https://github.com/stackrox/stackrox/pull/21163 to 4.9

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
