### PR TITLE
feat: Add cache audit metrics to perfscale config

### DIFF
--- a/tests/performance/scale/config/metrics-acs-central.yml
+++ b/tests/performance/scale/config/metrics-acs-central.yml
@@ -474,3 +474,24 @@
 
 - query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="central"}
   metricName: central_tar_matched_file_count_per_layer_sum
+
+- query: rox_central_cache_entries{namespace="stackrox",container="central"}
+  metricName: central_cache_entries
+
+- query: rox_central_cache_population_duration_seconds_bucket{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_bucket
+
+- query: rox_central_cache_population_duration_seconds_count{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_count
+
+- query: rox_central_cache_population_duration_seconds_sum{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_sum
+
+- query: rox_central_cache_bypass_total{namespace="stackrox",container="central"}
+  metricName: central_cache_bypass_total
+
+- query: rox_central_cache_hit_total{namespace="stackrox",container="central"}
+  metricName: central_cache_hit_total
+
+- query: rox_central_cache_miss_total{namespace="stackrox",container="central"}
+  metricName: central_cache_miss_total

--- a/tests/performance/scale/config/metrics-acs-central.yml
+++ b/tests/performance/scale/config/metrics-acs-central.yml
@@ -476,22 +476,22 @@
   metricName: central_tar_matched_file_count_per_layer_sum
 
 - query: rox_central_cache_entries{namespace="stackrox",container="central"}
-  metricName: central_cache_entries
+  metricName: central_rox_central_cache_entries
 
 - query: rox_central_cache_population_duration_seconds_bucket{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_bucket
+  metricName: central_rox_central_cache_population_duration_seconds_bucket
 
 - query: rox_central_cache_population_duration_seconds_count{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_count
+  metricName: central_rox_central_cache_population_duration_seconds_count
 
 - query: rox_central_cache_population_duration_seconds_sum{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_sum
+  metricName: central_rox_central_cache_population_duration_seconds_sum
 
 - query: rox_central_cache_bypass_total{namespace="stackrox",container="central"}
-  metricName: central_cache_bypass_total
+  metricName: central_rox_central_cache_bypass_total
 
 - query: rox_central_cache_hit_total{namespace="stackrox",container="central"}
-  metricName: central_cache_hit_total
+  metricName: central_rox_central_cache_hit_total
 
 - query: rox_central_cache_miss_total{namespace="stackrox",container="central"}
-  metricName: central_cache_miss_total
+  metricName: central_rox_central_cache_miss_total

--- a/tests/performance/scale/config/metrics-acs.yml
+++ b/tests/performance/scale/config/metrics-acs.yml
@@ -495,6 +495,27 @@
 - query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="central"}
   metricName: central_tar_matched_file_count_per_layer_sum
 
+- query: rox_central_cache_entries{namespace="stackrox",container="central"}
+  metricName: central_cache_entries
+
+- query: rox_central_cache_population_duration_seconds_bucket{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_bucket
+
+- query: rox_central_cache_population_duration_seconds_count{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_count
+
+- query: rox_central_cache_population_duration_seconds_sum{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_sum
+
+- query: rox_central_cache_bypass_total{namespace="stackrox",container="central"}
+  metricName: central_cache_bypass_total
+
+- query: rox_central_cache_hit_total{namespace="stackrox",container="central"}
+  metricName: central_cache_hit_total
+
+- query: rox_central_cache_miss_total{namespace="stackrox",container="central"}
+  metricName: central_cache_miss_total
+
 # File: metrics-acs-sensor.yml
 
 - query: go_gc_duration_seconds{namespace="stackrox",container="sensor"}

--- a/tests/performance/scale/config/metrics-acs.yml
+++ b/tests/performance/scale/config/metrics-acs.yml
@@ -496,25 +496,25 @@
   metricName: central_tar_matched_file_count_per_layer_sum
 
 - query: rox_central_cache_entries{namespace="stackrox",container="central"}
-  metricName: central_cache_entries
+  metricName: central_rox_central_cache_entries
 
 - query: rox_central_cache_population_duration_seconds_bucket{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_bucket
+  metricName: central_rox_central_cache_population_duration_seconds_bucket
 
 - query: rox_central_cache_population_duration_seconds_count{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_count
+  metricName: central_rox_central_cache_population_duration_seconds_count
 
 - query: rox_central_cache_population_duration_seconds_sum{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_sum
+  metricName: central_rox_central_cache_population_duration_seconds_sum
 
 - query: rox_central_cache_bypass_total{namespace="stackrox",container="central"}
-  metricName: central_cache_bypass_total
+  metricName: central_rox_central_cache_bypass_total
 
 - query: rox_central_cache_hit_total{namespace="stackrox",container="central"}
-  metricName: central_cache_hit_total
+  metricName: central_rox_central_cache_hit_total
 
 - query: rox_central_cache_miss_total{namespace="stackrox",container="central"}
-  metricName: central_cache_miss_total
+  metricName: central_rox_central_cache_miss_total
 
 # File: metrics-acs-sensor.yml
 

--- a/tests/performance/scale/config/metrics-full.yml
+++ b/tests/performance/scale/config/metrics-full.yml
@@ -670,6 +670,27 @@
 - query: tar_matched_file_count_per_layer_sum{namespace="stackrox",container="central"}
   metricName: central_tar_matched_file_count_per_layer_sum
 
+- query: rox_central_cache_entries{namespace="stackrox",container="central"}
+  metricName: central_cache_entries
+
+- query: rox_central_cache_population_duration_seconds_bucket{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_bucket
+
+- query: rox_central_cache_population_duration_seconds_count{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_count
+
+- query: rox_central_cache_population_duration_seconds_sum{namespace="stackrox",container="central"}
+  metricName: central_cache_population_duration_seconds_sum
+
+- query: rox_central_cache_bypass_total{namespace="stackrox",container="central"}
+  metricName: central_cache_bypass_total
+
+- query: rox_central_cache_hit_total{namespace="stackrox",container="central"}
+  metricName: central_cache_hit_total
+
+- query: rox_central_cache_miss_total{namespace="stackrox",container="central"}
+  metricName: central_cache_miss_total
+
 # File: metrics-acs-sensor.yml
 
 - query: go_gc_duration_seconds{namespace="stackrox",container="sensor"}

--- a/tests/performance/scale/config/metrics-full.yml
+++ b/tests/performance/scale/config/metrics-full.yml
@@ -671,25 +671,25 @@
   metricName: central_tar_matched_file_count_per_layer_sum
 
 - query: rox_central_cache_entries{namespace="stackrox",container="central"}
-  metricName: central_cache_entries
+  metricName: central_rox_central_cache_entries
 
 - query: rox_central_cache_population_duration_seconds_bucket{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_bucket
+  metricName: central_rox_central_cache_population_duration_seconds_bucket
 
 - query: rox_central_cache_population_duration_seconds_count{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_count
+  metricName: central_rox_central_cache_population_duration_seconds_count
 
 - query: rox_central_cache_population_duration_seconds_sum{namespace="stackrox",container="central"}
-  metricName: central_cache_population_duration_seconds_sum
+  metricName: central_rox_central_cache_population_duration_seconds_sum
 
 - query: rox_central_cache_bypass_total{namespace="stackrox",container="central"}
-  metricName: central_cache_bypass_total
+  metricName: central_rox_central_cache_bypass_total
 
 - query: rox_central_cache_hit_total{namespace="stackrox",container="central"}
-  metricName: central_cache_hit_total
+  metricName: central_rox_central_cache_hit_total
 
 - query: rox_central_cache_miss_total{namespace="stackrox",container="central"}
-  metricName: central_cache_miss_total
+  metricName: central_rox_central_cache_miss_total
 
 # File: metrics-acs-sensor.yml
 

--- a/tests/performance/scale/utilities/metrics-merge-yaml.sh
+++ b/tests/performance/scale/utilities/metrics-merge-yaml.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Use:
+# ./metrics-merge-yaml.sh <list of YAML files> <output file>
+
+# Example:
+# ./metrics-merge-yaml.sh metrics-base.yaml metrics-central.yaml metrics-sensor.yaml metrics-collector.yaml metrics.yaml
+
+main() {
+    local args=( "$@" )
+    local args_last_index=$(("${#args[@]}"-1))
+    local output_file_name="${args[args_last_index]}"
+
+    echo "Merge all files into: ${output_file_name}"
+
+    truncate -s 0 "${output_file_name}"
+    for ((i=0; i < args_last_index; i++))
+    do
+        { echo -e ""; echo -e "# File: ${args[$i]}"; echo -e ""; cat "${args[$i]}"; } >> "${output_file_name}"
+    done
+
+    echo "Done!"
+}
+
+main "$@"

--- a/tests/performance/scale/utilities/metrics-merge-yaml.sh
+++ b/tests/performance/scale/utilities/metrics-merge-yaml.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Use:
 # ./metrics-merge-yaml.sh <list of YAML files> <output file>
@@ -7,9 +8,18 @@
 # ./metrics-merge-yaml.sh metrics-base.yaml metrics-central.yaml metrics-sensor.yaml metrics-collector.yaml metrics.yaml
 
 main() {
+    if (( "$#" < 2 )); then
+        echo "Usage: ./metrics-merge-yaml.sh <list of YAML files> <output file>" >&2
+        exit 1
+    fi
+
     local args=( "$@" )
     local args_last_index=$(("${#args[@]}"-1))
     local output_file_name="${args[args_last_index]}"
+
+    for ((i=0; i < args_last_index; i++)); do
+        [[ -f "${args[$i]}" ]] || { echo "Input file not found: ${args[$i]}" >&2; exit 1; }
+    done
 
     echo "Merge all files into: ${output_file_name}"
 


### PR DESCRIPTION
## Description

Adds the cache audit metrics from #21267 to the perfscale metrics configuration so they are captured in nightly scale test runs. Also adds Mladen's metrics merge script to utilities/ for regenerating the merged config files.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Verified cache metrics appear in both `metrics-acs.yml` and `metrics-full.yml` after regeneration via the merge script.
