### PR TITLE
ROX-35298: remove empty testBegin phase

### DIFF
--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -52,12 +52,12 @@ clean-generated-srcs:
 .PHONY: test
 test: compile
 	@echo "+ $@"
-	$(GRADLE) testBegin testParallel testRest $(GRADLE_TEST_ARGS)
+	$(GRADLE) testParallel testRest $(GRADLE_TEST_ARGS)
 
 .PHONY: bat-test
 bat-test: compile
 	@echo "+ $@"
-	$(GRADLE) testBegin testParallelBAT testBAT $(GRADLE_TEST_ARGS)
+	$(GRADLE) testParallelBAT testBAT $(GRADLE_TEST_ARGS)
 
 .PHONY: smoke-test
 smoke-test: compile

--- a/qa-tests-backend/build.gradle.kts
+++ b/qa-tests-backend/build.gradle.kts
@@ -137,12 +137,6 @@ tasks.withType<Test>().configureEach {
     })
 }
 
-tasks.register<Test>("testBegin") {
-    useJUnitPlatform {
-        includeTags("Begin")
-    }
-}
-
 tasks.register<Test>("testParallel") {
     systemProperty("spock.configuration", rootProject.file("src/test/resources/ParallelSpockConfig.groovy"))
     useJUnitPlatform {
@@ -152,7 +146,7 @@ tasks.register<Test>("testParallel") {
 
 tasks.register<Test>("testRest") {
     useJUnitPlatform {
-        excludeTags("Begin", "Parallel", "Upgrade", "SensorBounce", "SensorBounceNext")
+        excludeTags("Parallel", "Upgrade", "SensorBounce", "SensorBounceNext")
     }
 }
 


### PR DESCRIPTION
## Description

The testBegin Gradle task fails because no tests are tagged "Begin" anymore — the only such test (`VulnMgmtSACTest`) was re-tagged to "BAT" in #21286, while #21078 added a safety net that fails builds with zero matching tests. The combination broke all qa-e2e jobs (nightly + PR).

Remove the `testBegin` task, its Makefile invocations, and the stale `"Begin"` entry from testRest's excludeTags list.

Partially generated by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI