### PR TITLE
fix: invalidate stale namespace filter cache on errors

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -191,6 +191,7 @@ func (ds *datastoreImpl) buildCache(ctx context.Context) error {
 				ds.idToNamespaceFilterCache.Add(c.GetId(), compiledFilter)
 			} else {
 				log.Errorf("Could not compile filter regexp: %v", err)
+				ds.idToNamespaceFilterCache.Remove(c.GetId())
 			}
 		} else {
 			// We got empty filter building the cluster. There should be no
@@ -939,6 +940,7 @@ func (ds *datastoreImpl) updateClusterNoLock(ctx context.Context, cluster *stora
 			ds.idToNamespaceFilterCache.Add(cluster.GetId(), compiledFilter)
 		} else {
 			log.Errorf("Could not compile filter regexp: %v", err)
+			ds.idToNamespaceFilterCache.Remove(cluster.GetId())
 		}
 	} else {
 		// We got empty filter updating the cluster. Make sure the cache is

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -214,6 +214,7 @@ func (ds *datastoreImpl) buildCache(ctx context.Context) error {
 				ds.idToNamespaceFilterCache.Add(c.GetId(), compiledFilter)
 			} else {
 				log.Errorf("Could not compile filter regexp: %v", err)
+				ds.idToNamespaceFilterCache.Remove(c.GetId())
 			}
 		} else {
 			// We got empty filter building the cluster. There should be no
@@ -1054,6 +1055,7 @@ func (ds *datastoreImpl) updateClusterNoLock(ctx context.Context, cluster *stora
 			ds.idToNamespaceFilterCache.Add(cluster.GetId(), compiledFilter)
 		} else {
 			log.Errorf("Could not compile filter regexp: %v", err)
+			ds.idToNamespaceFilterCache.Remove(cluster.GetId())
 		}
 	} else {
 		// We got empty filter updating the cluster. Make sure the cache is

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -935,6 +935,38 @@ func (s *clusterDataStoreTestSuite) TestUpdateCluster() {
 	assert.Equal(s.T(), filter.(*regexp.Regexp).String(), "test-.*")
 }
 
+func (s *clusterDataStoreTestSuite) TestUpdateClusterIncorrectFilterInvalidatesCache() {
+	clusterID := fixtureconsts.Cluster1
+	s.datastore.idToNamespaceFilterCache.Add(clusterID, regexp.MustCompile("previously-valid-.*"))
+
+	testCluster := &storage.Cluster{
+		Id:        clusterID,
+		Name:      "test",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		MainImage: "docker.io/stackrox/rox:latest",
+		HelmConfig: &storage.CompleteClusterConfig{
+			DynamicConfig: &storage.DynamicClusterConfig{
+				ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+					ExcludeNamespaceFilter: "[",
+					NoPersistence:          false,
+				},
+			},
+		},
+	}
+
+	ctx := sac.WithAllAccess(s.T().Context())
+
+	s.clusterStore.EXPECT().
+		Upsert(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	err := s.datastore.updateClusterNoLock(ctx, testCluster)
+	s.NoError(err)
+
+	_, ok := s.datastore.idToNamespaceFilterCache.Get(clusterID)
+	assert.False(s.T(), ok)
+}
+
 func (s *clusterDataStoreTestSuite) TestUpdateClusterIncorrectFilter() {
 	clusterID := fixtureconsts.Cluster1
 	testCluster := &storage.Cluster{

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -987,6 +987,38 @@ func (s *clusterDataStoreTestSuite) TestUpdateCluster() {
 	assert.Equal(s.T(), filter.(*regexp.Regexp).String(), "test-.*")
 }
 
+func (s *clusterDataStoreTestSuite) TestUpdateClusterIncorrectFilterInvalidatesCache() {
+	clusterID := fixtureconsts.Cluster1
+	s.datastore.idToNamespaceFilterCache.Add(clusterID, regexp.MustCompile("previously-valid-.*"))
+
+	testCluster := &storage.Cluster{
+		Id:        clusterID,
+		Name:      "test",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		MainImage: "docker.io/stackrox/rox:latest",
+		HelmConfig: &storage.CompleteClusterConfig{
+			DynamicConfig: &storage.DynamicClusterConfig{
+				ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+					ExcludeNamespaceFilter: "[",
+					NoPersistence:          false,
+				},
+			},
+		},
+	}
+
+	ctx := sac.WithAllAccess(s.T().Context())
+
+	s.clusterStore.EXPECT().
+		Upsert(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	err := s.datastore.updateClusterNoLock(ctx, testCluster)
+	s.NoError(err)
+
+	_, ok := s.datastore.idToNamespaceFilterCache.Get(clusterID)
+	assert.False(s.T(), ok)
+}
+
 func (s *clusterDataStoreTestSuite) TestUpdateClusterIncorrectFilter() {
 	clusterID := fixtureconsts.Cluster1
 	testCluster := &storage.Cluster{


### PR DESCRIPTION
## Description

When a namespace filter regex failed to compile (e.g. malformed user-provided `ExcludeNamespaceFilter`), the error was logged but any previously cached compiled regex stayed in `idToNamespaceFilterCache`. `MatchProcessIndicator` then silently matched against the stale filter.

Now the cache entry is removed on compile errors, so the system fails closed (no indicators match) until a valid filter is configured.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

The existing `TestUpdateClusterIncorrectFilter` only verifies that an invalid regex doesn't get **added** to an empty cache — it starts with a fresh cache, so it passes with or without the fix.

Added `TestUpdateClusterIncorrectFilterInvalidatesCache` which covers the actual stale cache scenario: seeds the cache with a valid filter, updates with an invalid regex, and asserts the old entry is removed.

```
=== RUN   TestClusterDataStore/TestUpdateClusterIncorrectFilterInvalidatesCache
--- PASS: TestClusterDataStore/TestUpdateClusterIncorrectFilterInvalidatesCache (0.00s)
```

AI-assisted.