### PR TITLE
fix(tests): remove testBegin task with no matching tests

### DIFF
--- a/qa-tests-backend/Makefile
+++ b/qa-tests-backend/Makefile
@@ -52,12 +52,12 @@ clean-generated-srcs:
 .PHONY: test
 test: compile
 	@echo "+ $@"
-	$(GRADLE) testBegin testParallel testRest $(GRADLE_TEST_ARGS)
+	$(GRADLE) testParallel testRest $(GRADLE_TEST_ARGS)
 
 .PHONY: bat-test
 bat-test: compile
 	@echo "+ $@"
-	$(GRADLE) testBegin testParallelBAT testBAT $(GRADLE_TEST_ARGS)
+	$(GRADLE) testParallelBAT testBAT $(GRADLE_TEST_ARGS)
 
 .PHONY: smoke-test
 smoke-test: compile

--- a/qa-tests-backend/build.gradle.kts
+++ b/qa-tests-backend/build.gradle.kts
@@ -137,12 +137,6 @@ tasks.withType<Test>().configureEach {
     })
 }
 
-tasks.register<Test>("testBegin") {
-    useJUnitPlatform {
-        includeTags("Begin")
-    }
-}
-
 tasks.register<Test>("testParallel") {
     systemProperty("spock.configuration", rootProject.file("src/test/resources/ParallelSpockConfig.groovy"))
     useJUnitPlatform {
@@ -152,7 +146,7 @@ tasks.register<Test>("testParallel") {
 
 tasks.register<Test>("testRest") {
     useJUnitPlatform {
-        excludeTags("Begin", "Parallel", "Upgrade", "SensorBounce", "SensorBounceNext")
+        excludeTags("Parallel", "Upgrade", "SensorBounce", "SensorBounceNext")
     }
 }
 


### PR DESCRIPTION
## Description

#21286 moved `VulnMgmtSACTest` from `@Tag("Begin")` to `@Tag("BAT")`, leaving zero tests tagged `Begin`. The `testBegin` Gradle task then matches nothing, and the zero-test listener from #21078 correctly fails the build. This breaks all `bat-test` and `test` runs across ocp-4-21, ocp-4-22, and gke e2e jobs.

Remove the `testBegin` task, its Makefile references, and the stale `Begin` excludeTag from `testRest`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Verified no tests in the codebase use `@Tag("Begin")` after #21286
- Confirmed the `testBegin FAILED` error reproduced on ocp-4-21, ocp-4-22, and gke e2e jobs across multiple unrelated PRs (#21301, #21300)
- The fix is a pure removal with no behavioral change to test execution — previously-`Begin`-tagged tests now run under `BAT`/`testBAT`