### PR TITLE
ROX-32912: Enable VEX not-affected filtering by default

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -193,7 +193,7 @@ var (
 	SensorInformerWatchdog = registerFeature("Sensor informer watchdog logging", "ROX_SENSOR_INFORMER_WATCHDOG", enabled)
 
 	// ScannerV4RedHatVEXNotAffected enables filtering image vulnerabilities using Red Hat VEX known_not_affected assertions.
-	ScannerV4RedHatVEXNotAffected = registerFeature("Scanner V4 will filter image vulnerabilities using Red Hat VEX known_not_affected assertions", "ROX_SCANNER_V4_RED_HAT_VEX_NOT_AFFECTED")
+	ScannerV4RedHatVEXNotAffected = registerFeature("Scanner V4 will filter image vulnerabilities using Red Hat VEX known_not_affected assertions", "ROX_SCANNER_V4_RED_HAT_VEX_NOT_AFFECTED", enabled)
 
 	// ScannerV4Dedupe de-duplicates packages and vulnerabilities from appearing in scan results.
 	ScannerV4Dedupe = registerFeature("Deduplicate packages and vulnerabilities found in Scanner V4 results.", "ROX_SCANNER_V4_DEDUPE")


### PR DESCRIPTION
## Description

ROX-32912: Enables `ROX_SCANNER_V4_RED_HAT_VEX_NOT_AFFECTED` by default.

This flag controls VEX `known_not_affected` filtering in Central's `imageScan()`. When enabled, Central cross-references VEX assertions (from `package_not_vulnerable` in the Scanner V4 VulnerabilityReport) with vulnerability findings via aliases, and suppresses CVEs that Red Hat has marked as not affected for the scanned container.

Enabling this flag without the corresponding vulnerability bundle update is safe: `filterNotAffectedVulnerabilities` returns early when `package_not_vulnerable` is empty or alias data is absent, so scan results remain identical to flag OFF until the bundle and matcher actually provide the alias data.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

The filter function (`filterNotAffectedVulnerabilities` in `pkg/scanners/scannerv4/convert.go`) is a no-op when the VulnerabilityReport has no `package_not_vulnerable` entries (line 530-532) or when alias data is empty (boundary list stays empty, line 575-577). The current v2 vulnerability bundle does not include alias data, so enabling this flag has no observable effect on scan results until the bundle is updated. Full end-to-end validation of the filtering behavior was performed in #20807.