### PR TITLE
ROX-35312: add GHA workflow to publish signing key bundle

### DIFF
--- a/.github/workflows/scripts/validate-signing-key-bundle.sh
+++ b/.github/workflows/scripts/validate-signing-key-bundle.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Validates a Red Hat signing key bundle JSON file.
+#
+# Checks mirror the Go ParseKeyBundle logic in pkg/signatures/key_bundle.go:
+#   - valid JSON with non-empty "keys" array
+#   - each key has a non-empty "name" without path separators
+#   - no duplicate key names
+#   - each "pem" value is a valid PEM-encoded public key
+#
+# USAGE: validate-signing-key-bundle.sh <bundle.json>
+
+set -euo pipefail
+
+bundle="${1:?Usage: validate-signing-key-bundle.sh <bundle.json>}"
+
+if [[ ! -f "$bundle" ]]; then
+    echo "ERROR: file not found: $bundle" >&2
+    exit 1
+fi
+
+# 1. Valid JSON structure with non-empty keys array.
+key_count=$(jq -e '.keys | length' "$bundle") || {
+    echo "ERROR: invalid JSON or missing 'keys' array" >&2
+    exit 1
+}
+
+if [[ "$key_count" -eq 0 ]]; then
+    echo "ERROR: key bundle must contain at least one key" >&2
+    exit 1
+fi
+
+echo "Found $key_count key(s), validating..."
+
+# 2-4. Validate each key entry.
+seen_names=()
+for i in $(seq 0 $((key_count - 1))); do
+    name=$(jq -r ".keys[$i].name // empty" "$bundle")
+    pem_data=$(jq -r ".keys[$i].pem // empty" "$bundle")
+
+    if [[ -z "$name" ]]; then
+        echo "ERROR: key at index $i has empty name" >&2
+        exit 1
+    fi
+
+    if [[ "$name" == */* || "$name" == *\\* ]]; then
+        echo "ERROR: key name '$name' contains path separators" >&2
+        exit 1
+    fi
+
+    for seen in "${seen_names[@]+"${seen_names[@]}"}"; do
+        if [[ "$seen" == "$name" ]]; then
+            echo "ERROR: duplicate key name '$name'" >&2
+            exit 1
+        fi
+    done
+    seen_names+=("$name")
+
+    if [[ -z "$pem_data" ]]; then
+        echo "ERROR: key '$name' has empty PEM data" >&2
+        exit 1
+    fi
+
+    if ! echo "$pem_data" | openssl pkey -pubin -noout 2>/dev/null; then
+        echo "ERROR: key '$name' has invalid PEM public key" >&2
+        exit 1
+    fi
+
+    echo "  [$i] '$name' — valid"
+done
+
+echo "Bundle validation passed: $key_count key(s) OK"

--- a/.github/workflows/scripts/validate-signing-key-bundle.sh
+++ b/.github/workflows/scripts/validate-signing-key-bundle.sh
@@ -37,7 +37,7 @@ for i in $(seq 0 $((key_count - 1))); do
     name=$(jq -r ".keys[$i].name // empty" "$bundle")
     pem_data=$(jq -r ".keys[$i].pem // empty" "$bundle")
 
-    if [[ -z "$name" ]]; then
+    if [[ -z "${name//[[:space:]]/}" ]]; then
         echo "ERROR: key at index $i has empty name" >&2
         exit 1
     fi

--- a/.github/workflows/scripts/validate-signing-key-bundle.sh
+++ b/.github/workflows/scripts/validate-signing-key-bundle.sh
@@ -2,10 +2,10 @@
 # Validates a Red Hat signing key bundle JSON file.
 #
 # Checks mirror the Go ParseKeyBundle logic in pkg/signatures/key_bundle.go:
-#   - valid JSON with non-empty "keys" array
-#   - each key has a non-empty "name" without path separators
+#   - valid JSON with non-empty "cosignKeys" array
+#   - each key has a non-empty "name" (after trimming) without path separators
 #   - no duplicate key names
-#   - each "pem" value is a valid PEM-encoded public key
+#   - each "publicKey" value is a valid PEM-encoded public key
 #
 # USAGE: validate-signing-key-bundle.sh <bundle.json>
 
@@ -18,9 +18,9 @@ if [[ ! -f "$bundle" ]]; then
     exit 1
 fi
 
-# 1. Valid JSON structure with non-empty keys array.
-key_count=$(jq -e '.keys | length' "$bundle") || {
-    echo "ERROR: invalid JSON or missing 'keys' array" >&2
+# 1. Valid JSON structure with non-empty cosignKeys array.
+key_count=$(jq -e '.cosignKeys | length' "$bundle") || {
+    echo "ERROR: invalid JSON or missing 'cosignKeys' array" >&2
     exit 1
 }
 
@@ -34,10 +34,14 @@ echo "Found $key_count key(s), validating..."
 # 2-4. Validate each key entry.
 seen_names=()
 for i in $(seq 0 $((key_count - 1))); do
-    name=$(jq -r ".keys[$i].name // empty" "$bundle")
-    pem_data=$(jq -r ".keys[$i].pem // empty" "$bundle")
+    raw_name=$(jq -r ".cosignKeys[$i].name // empty" "$bundle")
+    pem_data=$(jq -r ".cosignKeys[$i].publicKey // empty" "$bundle")
 
-    if [[ -z "${name//[[:space:]]/}" ]]; then
+    # Trim whitespace to match Go's strings.TrimSpace before all checks.
+    name="${raw_name#"${raw_name%%[![:space:]]*}"}"
+    name="${name%"${name##*[![:space:]]}"}"
+
+    if [[ -z "$name" ]]; then
         echo "ERROR: key at index $i has empty name" >&2
         exit 1
     fi
@@ -56,7 +60,7 @@ for i in $(seq 0 $((key_count - 1))); do
     seen_names+=("$name")
 
     if [[ -z "$pem_data" ]]; then
-        echo "ERROR: key '$name' has empty PEM data" >&2
+        echo "ERROR: key '$name' has empty publicKey" >&2
         exit 1
     fi
 

--- a/.github/workflows/signing-key-bundle-update.yaml
+++ b/.github/workflows/signing-key-bundle-update.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/signing-key-bundle-update.yaml
+++ b/.github/workflows/signing-key-bundle-update.yaml
@@ -1,0 +1,55 @@
+name: Red Hat signing key bundle update
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - pkg/signatures/bundle.json
+  workflow_dispatch:
+
+jobs:
+  validate-and-upload:
+    if: ${{ github.repository_owner == 'stackrox' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+
+    - name: Validate key bundle
+      run: .github/workflows/scripts/validate-signing-key-bundle.sh pkg/signatures/bundle.json
+
+    # TODO(ROX-35312): Enable upload once the workflow is validated end-to-end.
+    # - name: Authenticate with Google Cloud
+    #   uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+    #   with:
+    #     credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+    #
+    # - name: Set up Cloud SDK
+    #   uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+    #
+    # - name: Upload key bundle to GCS
+    #   run: |
+    #     gsutil -h "Content-Type: application/json" \
+    #       cp pkg/signatures/bundle.json \
+    #       gs://definitions.stackrox.io/signing-keys/bundle.json
+
+    - name: Upload skipped (dry run)
+      run: |
+        echo "Dry run — upload is disabled."
+        echo "Would upload pkg/signatures/bundle.json to gs://definitions.stackrox.io/signing-keys/bundle.json"
+
+  send-notification:
+    needs:
+    - validate-and-upload
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+    # TODO(ROX-35312): Switch to a dedicated sensor-ecosystem webhook and
+    # mention <!subteam^SENSOR_ECOSYSTEM_GROUP_ID|acs-sensor-ecosystem-primary>
+    # once the Slack webhook secret is set up.
+    - name: Send Slack notification on failure
+      run: |
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed: Red Hat signing key bundle update\"}" \
+          ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}

--- a/.github/workflows/signing-key-bundle-update.yaml
+++ b/.github/workflows/signing-key-bundle-update.yaml
@@ -14,30 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
 
     - name: Validate key bundle
       run: .github/workflows/scripts/validate-signing-key-bundle.sh pkg/signatures/bundle.json
 
-    # TODO(ROX-35312): Enable upload once the workflow is validated end-to-end.
-    # - name: Authenticate with Google Cloud
-    #   uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
-    #   with:
-    #     credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
-    #
-    # - name: Set up Cloud SDK
-    #   uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
-    #
-    # - name: Upload key bundle to GCS
-    #   run: |
-    #     gsutil -h "Content-Type: application/json" \
-    #       cp pkg/signatures/bundle.json \
-    #       gs://definitions.stackrox.io/signing-keys/bundle.json
+    - name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
-    - name: Upload skipped (dry run)
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+
+    - name: Upload key bundle to GCS
       run: |
-        echo "Dry run — upload is disabled."
-        echo "Would upload pkg/signatures/bundle.json to gs://definitions.stackrox.io/signing-keys/bundle.json"
+        gsutil -h "Content-Type: application/json" \
+          cp pkg/signatures/bundle.json \
+          gs://definitions.stackrox.io/signing-keys/bundle.json
 
   send-notification:
     needs:
@@ -45,11 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     if: failure()
     steps:
-    # TODO(ROX-35312): Switch to a dedicated sensor-ecosystem webhook and
-    # mention <!subteam^SENSOR_ECOSYSTEM_GROUP_ID|acs-sensor-ecosystem-primary>
-    # once the Slack webhook secret is set up.
     - name: Send Slack notification on failure
       run: |
         curl -X POST -H 'Content-type: application/json' \
-          --data "{\"text\":\"<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed: Red Hat signing key bundle update\"}" \
-          ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
+          --data "{\"text\":\"<!subteam^S04S96AAVND|acs-scanner-primary> <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed: Red Hat signing key bundle update\"}" \
+          ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/signing-key-bundle-update.yaml
+++ b/.github/workflows/signing-key-bundle-update.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   validate-and-upload:
     if: ${{ github.repository_owner == 'stackrox' }}

--- a/.github/workflows/signing-key-bundle-update.yaml
+++ b/.github/workflows/signing-key-bundle-update.yaml
@@ -8,6 +8,9 @@ on:
       - pkg/signatures/bundle.json
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-and-upload:
     if: ${{ github.repository_owner == 'stackrox' }}
@@ -15,19 +18,24 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Validate key bundle
       run: .github/workflows/scripts/validate-signing-key-bundle.sh pkg/signatures/bundle.json
 
     - name: Authenticate with Google Cloud
+      if: github.ref == 'refs/heads/master'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
         credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Set up Cloud SDK
+      if: github.ref == 'refs/heads/master'
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
 
     - name: Upload key bundle to GCS
+      if: github.ref == 'refs/heads/master'
       run: |
         gsutil -h "Content-Type: application/json" \
           cp pkg/signatures/bundle.json \


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow (`signing-key-bundle-update.yaml`) that validates and uploads the Red Hat signing key bundle (`pkg/signatures/bundle.json`) to `gs://definitions.stackrox.io/signing-keys/bundle.json`.

Part of the signing key rotation work: ROX-35080.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Ran the validation script locally against the real bundle and several malformed inputs:

```
$ .github/workflows/scripts/validate-signing-key-bundle.sh pkg/signatures/bundle.json
Found 1 key(s), validating...
  [0] 'release-key-3' — valid
Bundle validation passed: 1 key(s) OK
```

Error cases tested: empty keys array, invalid JSON, empty key name, path separators in name, duplicate key names, invalid PEM — all correctly rejected.