### PR TITLE
ROX-34488: discover cosign signatures via OCI 1.1 Referrers API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
     would leak to all images sharing the same digest.
   - Policies now evaluate correctly per the deployed/checked image name and respect its
     vulnerability exceptions, rather than being affected by shared-digest exception leakage.
+- ROX-34488: Added support for cosign signature discovery via OCI 1.1 referrers, including
+  DSSE envelope verification for sigstore bundle-format signatures.
 
 ### Removed Features
 

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -522,6 +522,16 @@
       ],
       "default": "UI_NONE"
     },
+    "CosignSignatureSignatureFormat": {
+      "type": "string",
+      "enum": [
+        "UNSPECIFIED",
+        "SIMPLE_SIGNING",
+        "DEAD_SIMPLE_SIGNING_ENVELOPE"
+      ],
+      "default": "UNSPECIFIED",
+      "description": "Signature format used in this message.\n\n - SIMPLE_SIGNING: SimpleSigning: signature is stored across raw_signature, signature_payload,\ncert_pem, cert_chain_pem, and rekor_bundle.\n - DEAD_SIMPLE_SIGNING_ENVELOPE: DSSE (Dead Simple Signing Envelope): signature is a complete sigstore bundle\nstored in sigstore_bundle. The decomposed simple signing fields are not used."
+    },
     "EmbeddedVulnerabilityScoreVersion": {
       "type": "string",
       "enum": [
@@ -812,6 +822,14 @@
         "rekorBundle": {
           "type": "string",
           "format": "byte"
+        },
+        "signatureFormat": {
+          "$ref": "#/definitions/CosignSignatureSignatureFormat"
+        },
+        "sigstoreBundle": {
+          "type": "string",
+          "format": "byte",
+          "description": "Complete sigstore bundle as raw JSON. When populated, it supersedes the\ndecomposed simple signing fields."
         }
       }
     },

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -125,6 +125,16 @@
         }
       }
     },
+    "CosignSignatureSignatureFormat": {
+      "type": "string",
+      "enum": [
+        "UNSPECIFIED",
+        "SIMPLE_SIGNING",
+        "DEAD_SIMPLE_SIGNING_ENVELOPE"
+      ],
+      "default": "UNSPECIFIED",
+      "description": "Signature format used in this message.\n\n - SIMPLE_SIGNING: SimpleSigning: signature is stored across raw_signature, signature_payload,\ncert_pem, cert_chain_pem, and rekor_bundle.\n - DEAD_SIMPLE_SIGNING_ENVELOPE: DSSE (Dead Simple Signing Envelope): signature is a complete sigstore bundle\nstored in sigstore_bundle. The decomposed simple signing fields are not used."
+    },
     "EmbeddedImageScanComponentExecutable": {
       "type": "object",
       "properties": {
@@ -670,6 +680,14 @@
         "rekorBundle": {
           "type": "string",
           "format": "byte"
+        },
+        "signatureFormat": {
+          "$ref": "#/definitions/CosignSignatureSignatureFormat"
+        },
+        "sigstoreBundle": {
+          "type": "string",
+          "format": "byte",
+          "description": "Complete sigstore bundle as raw JSON. When populated, it supersedes the\ndecomposed simple signing fields."
         }
       }
     },

--- a/generated/storage/image.pb.go
+++ b/generated/storage/image.pb.go
@@ -264,6 +264,60 @@ func (ImageSignatureVerificationResult_Status) EnumDescriptor() ([]byte, []int) 
 	return file_storage_image_proto_rawDescGZIP(), []int{4, 0}
 }
 
+// Signature format used in this message.
+type CosignSignature_SignatureFormat int32
+
+const (
+	CosignSignature_UNSPECIFIED CosignSignature_SignatureFormat = 0
+	// SimpleSigning: signature is stored across raw_signature, signature_payload,
+	// cert_pem, cert_chain_pem, and rekor_bundle.
+	CosignSignature_SIMPLE_SIGNING CosignSignature_SignatureFormat = 1
+	// DSSE (Dead Simple Signing Envelope): signature is a complete sigstore bundle
+	// stored in sigstore_bundle. The decomposed simple signing fields are not used.
+	CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE CosignSignature_SignatureFormat = 2
+)
+
+// Enum value maps for CosignSignature_SignatureFormat.
+var (
+	CosignSignature_SignatureFormat_name = map[int32]string{
+		0: "UNSPECIFIED",
+		1: "SIMPLE_SIGNING",
+		2: "DEAD_SIMPLE_SIGNING_ENVELOPE",
+	}
+	CosignSignature_SignatureFormat_value = map[string]int32{
+		"UNSPECIFIED":                  0,
+		"SIMPLE_SIGNING":               1,
+		"DEAD_SIMPLE_SIGNING_ENVELOPE": 2,
+	}
+)
+
+func (x CosignSignature_SignatureFormat) Enum() *CosignSignature_SignatureFormat {
+	p := new(CosignSignature_SignatureFormat)
+	*p = x
+	return p
+}
+
+func (x CosignSignature_SignatureFormat) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CosignSignature_SignatureFormat) Descriptor() protoreflect.EnumDescriptor {
+	return file_storage_image_proto_enumTypes[4].Descriptor()
+}
+
+func (CosignSignature_SignatureFormat) Type() protoreflect.EnumType {
+	return &file_storage_image_proto_enumTypes[4]
+}
+
+func (x CosignSignature_SignatureFormat) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CosignSignature_SignatureFormat.Descriptor instead.
+func (CosignSignature_SignatureFormat) EnumDescriptor() ([]byte, []int) {
+	return file_storage_image_proto_rawDescGZIP(), []int{10, 0}
+}
+
 // This proto is deprecated and replaced by ImageV2.
 // Next Tag: 19
 //
@@ -1301,14 +1355,18 @@ type Signature_Cosign struct {
 func (*Signature_Cosign) isSignature_Signature() {}
 
 type CosignSignature struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	RawSignature     []byte                 `protobuf:"bytes,1,opt,name=raw_signature,json=rawSignature,proto3" json:"raw_signature,omitempty"`
-	SignaturePayload []byte                 `protobuf:"bytes,2,opt,name=signature_payload,json=signaturePayload,proto3" json:"signature_payload,omitempty"`
-	CertPem          []byte                 `protobuf:"bytes,3,opt,name=cert_pem,json=certPem,proto3" json:"cert_pem,omitempty"`
-	CertChainPem     []byte                 `protobuf:"bytes,4,opt,name=cert_chain_pem,json=certChainPem,proto3" json:"cert_chain_pem,omitempty"`
-	RekorBundle      []byte                 `protobuf:"bytes,5,opt,name=rekor_bundle,json=rekorBundle,proto3" json:"rekor_bundle,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state            protoimpl.MessageState          `protogen:"open.v1"`
+	RawSignature     []byte                          `protobuf:"bytes,1,opt,name=raw_signature,json=rawSignature,proto3" json:"raw_signature,omitempty"`
+	SignaturePayload []byte                          `protobuf:"bytes,2,opt,name=signature_payload,json=signaturePayload,proto3" json:"signature_payload,omitempty"`
+	CertPem          []byte                          `protobuf:"bytes,3,opt,name=cert_pem,json=certPem,proto3" json:"cert_pem,omitempty"`
+	CertChainPem     []byte                          `protobuf:"bytes,4,opt,name=cert_chain_pem,json=certChainPem,proto3" json:"cert_chain_pem,omitempty"`
+	RekorBundle      []byte                          `protobuf:"bytes,5,opt,name=rekor_bundle,json=rekorBundle,proto3" json:"rekor_bundle,omitempty"`
+	SignatureFormat  CosignSignature_SignatureFormat `protobuf:"varint,6,opt,name=signature_format,json=signatureFormat,proto3,enum=storage.CosignSignature_SignatureFormat" json:"signature_format,omitempty"`
+	// Complete sigstore bundle as raw JSON. When populated, it supersedes the
+	// decomposed simple signing fields.
+	SigstoreBundle []byte `protobuf:"bytes,7,opt,name=sigstore_bundle,json=sigstoreBundle,proto3" json:"sigstore_bundle,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CosignSignature) Reset() {
@@ -1372,6 +1430,20 @@ func (x *CosignSignature) GetCertChainPem() []byte {
 func (x *CosignSignature) GetRekorBundle() []byte {
 	if x != nil {
 		return x.RekorBundle
+	}
+	return nil
+}
+
+func (x *CosignSignature) GetSignatureFormat() CosignSignature_SignatureFormat {
+	if x != nil {
+		return x.SignatureFormat
+	}
+	return CosignSignature_UNSPECIFIED
+}
+
+func (x *CosignSignature) GetSigstoreBundle() []byte {
+	if x != nil {
+		return x.SigstoreBundle
 	}
 	return nil
 }
@@ -2134,13 +2206,19 @@ const file_storage_image_proto_rawDesc = "" +
 	"\afetched\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\afetched\"L\n" +
 	"\tSignature\x122\n" +
 	"\x06cosign\x18\x01 \x01(\v2\x18.storage.CosignSignatureH\x00R\x06cosignB\v\n" +
-	"\tSignature\"\xc7\x01\n" +
+	"\tSignature\"\x9f\x03\n" +
 	"\x0fCosignSignature\x12#\n" +
 	"\rraw_signature\x18\x01 \x01(\fR\frawSignature\x12+\n" +
 	"\x11signature_payload\x18\x02 \x01(\fR\x10signaturePayload\x12\x19\n" +
 	"\bcert_pem\x18\x03 \x01(\fR\acertPem\x12$\n" +
 	"\x0ecert_chain_pem\x18\x04 \x01(\fR\fcertChainPem\x12!\n" +
-	"\frekor_bundle\x18\x05 \x01(\fR\vrekorBundle\"$\n" +
+	"\frekor_bundle\x18\x05 \x01(\fR\vrekorBundle\x12S\n" +
+	"\x10signature_format\x18\x06 \x01(\x0e2(.storage.CosignSignature.SignatureFormatR\x0fsignatureFormat\x12'\n" +
+	"\x0fsigstore_bundle\x18\a \x01(\fR\x0esigstoreBundle\"X\n" +
+	"\x0fSignatureFormat\x12\x0f\n" +
+	"\vUNSPECIFIED\x10\x00\x12\x12\n" +
+	"\x0eSIMPLE_SIGNING\x10\x01\x12 \n" +
+	"\x1cDEAD_SIMPLE_SIGNING_ENVELOPE\x10\x02\"$\n" +
 	"\n" +
 	"V2Metadata\x12\x16\n" +
 	"\x06digest\x18\x01 \x01(\tR\x06digest\"\xfb\x02\n" +
@@ -2223,75 +2301,77 @@ func file_storage_image_proto_rawDescGZIP() []byte {
 	return file_storage_image_proto_rawDescData
 }
 
-var file_storage_image_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_storage_image_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_storage_image_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_storage_image_proto_goTypes = []any{
 	(SourceType)(0),     // 0: storage.SourceType
 	(Image_Note)(0),     // 1: storage.Image.Note
 	(ImageScan_Note)(0), // 2: storage.ImageScan.Note
-	(ImageSignatureVerificationResult_Status)(0), // 3: storage.ImageSignatureVerificationResult.Status
-	(*Image)(nil),                                 // 4: storage.Image
-	(*DataSource)(nil),                            // 5: storage.DataSource
-	(*ImageScan)(nil),                             // 6: storage.ImageScan
-	(*ImageSignatureVerificationData)(nil),        // 7: storage.ImageSignatureVerificationData
-	(*ImageSignatureVerificationResult)(nil),      // 8: storage.ImageSignatureVerificationResult
-	(*EmbeddedImageScanComponent)(nil),            // 9: storage.EmbeddedImageScanComponent
-	(*License)(nil),                               // 10: storage.License
-	(*ImageMetadata)(nil),                         // 11: storage.ImageMetadata
-	(*ImageSignature)(nil),                        // 12: storage.ImageSignature
-	(*Signature)(nil),                             // 13: storage.Signature
-	(*CosignSignature)(nil),                       // 14: storage.CosignSignature
-	(*V2Metadata)(nil),                            // 15: storage.V2Metadata
-	(*V1Metadata)(nil),                            // 16: storage.V1Metadata
-	(*ImageLayer)(nil),                            // 17: storage.ImageLayer
-	(*ImageName)(nil),                             // 18: storage.ImageName
-	(*ListImage)(nil),                             // 19: storage.ListImage
-	(*WatchedImage)(nil),                          // 20: storage.WatchedImage
-	(*BaseImageInfo)(nil),                         // 21: storage.BaseImageInfo
-	(*EmbeddedImageScanComponent_Executable)(nil), // 22: storage.EmbeddedImageScanComponent.Executable
-	nil,                           // 23: storage.V1Metadata.LabelsEntry
-	(*timestamppb.Timestamp)(nil), // 24: google.protobuf.Timestamp
-	(*EmbeddedVulnerability)(nil), // 25: storage.EmbeddedVulnerability
+	(ImageSignatureVerificationResult_Status)(0),  // 3: storage.ImageSignatureVerificationResult.Status
+	(CosignSignature_SignatureFormat)(0),          // 4: storage.CosignSignature.SignatureFormat
+	(*Image)(nil),                                 // 5: storage.Image
+	(*DataSource)(nil),                            // 6: storage.DataSource
+	(*ImageScan)(nil),                             // 7: storage.ImageScan
+	(*ImageSignatureVerificationData)(nil),        // 8: storage.ImageSignatureVerificationData
+	(*ImageSignatureVerificationResult)(nil),      // 9: storage.ImageSignatureVerificationResult
+	(*EmbeddedImageScanComponent)(nil),            // 10: storage.EmbeddedImageScanComponent
+	(*License)(nil),                               // 11: storage.License
+	(*ImageMetadata)(nil),                         // 12: storage.ImageMetadata
+	(*ImageSignature)(nil),                        // 13: storage.ImageSignature
+	(*Signature)(nil),                             // 14: storage.Signature
+	(*CosignSignature)(nil),                       // 15: storage.CosignSignature
+	(*V2Metadata)(nil),                            // 16: storage.V2Metadata
+	(*V1Metadata)(nil),                            // 17: storage.V1Metadata
+	(*ImageLayer)(nil),                            // 18: storage.ImageLayer
+	(*ImageName)(nil),                             // 19: storage.ImageName
+	(*ListImage)(nil),                             // 20: storage.ListImage
+	(*WatchedImage)(nil),                          // 21: storage.WatchedImage
+	(*BaseImageInfo)(nil),                         // 22: storage.BaseImageInfo
+	(*EmbeddedImageScanComponent_Executable)(nil), // 23: storage.EmbeddedImageScanComponent.Executable
+	nil,                           // 24: storage.V1Metadata.LabelsEntry
+	(*timestamppb.Timestamp)(nil), // 25: google.protobuf.Timestamp
+	(*EmbeddedVulnerability)(nil), // 26: storage.EmbeddedVulnerability
 }
 var file_storage_image_proto_depIdxs = []int32{
-	18, // 0: storage.Image.name:type_name -> storage.ImageName
-	18, // 1: storage.Image.names:type_name -> storage.ImageName
-	11, // 2: storage.Image.metadata:type_name -> storage.ImageMetadata
-	6,  // 3: storage.Image.scan:type_name -> storage.ImageScan
-	7,  // 4: storage.Image.signature_verification_data:type_name -> storage.ImageSignatureVerificationData
-	12, // 5: storage.Image.signature:type_name -> storage.ImageSignature
-	24, // 6: storage.Image.last_updated:type_name -> google.protobuf.Timestamp
+	19, // 0: storage.Image.name:type_name -> storage.ImageName
+	19, // 1: storage.Image.names:type_name -> storage.ImageName
+	12, // 2: storage.Image.metadata:type_name -> storage.ImageMetadata
+	7,  // 3: storage.Image.scan:type_name -> storage.ImageScan
+	8,  // 4: storage.Image.signature_verification_data:type_name -> storage.ImageSignatureVerificationData
+	13, // 5: storage.Image.signature:type_name -> storage.ImageSignature
+	25, // 6: storage.Image.last_updated:type_name -> google.protobuf.Timestamp
 	1,  // 7: storage.Image.notes:type_name -> storage.Image.Note
-	21, // 8: storage.Image.base_image_info:type_name -> storage.BaseImageInfo
-	24, // 9: storage.ImageScan.scan_time:type_name -> google.protobuf.Timestamp
-	9,  // 10: storage.ImageScan.components:type_name -> storage.EmbeddedImageScanComponent
-	5,  // 11: storage.ImageScan.data_source:type_name -> storage.DataSource
+	22, // 8: storage.Image.base_image_info:type_name -> storage.BaseImageInfo
+	25, // 9: storage.ImageScan.scan_time:type_name -> google.protobuf.Timestamp
+	10, // 10: storage.ImageScan.components:type_name -> storage.EmbeddedImageScanComponent
+	6,  // 11: storage.ImageScan.data_source:type_name -> storage.DataSource
 	2,  // 12: storage.ImageScan.notes:type_name -> storage.ImageScan.Note
-	8,  // 13: storage.ImageSignatureVerificationData.results:type_name -> storage.ImageSignatureVerificationResult
-	24, // 14: storage.ImageSignatureVerificationResult.verification_time:type_name -> google.protobuf.Timestamp
+	9,  // 13: storage.ImageSignatureVerificationData.results:type_name -> storage.ImageSignatureVerificationResult
+	25, // 14: storage.ImageSignatureVerificationResult.verification_time:type_name -> google.protobuf.Timestamp
 	3,  // 15: storage.ImageSignatureVerificationResult.status:type_name -> storage.ImageSignatureVerificationResult.Status
-	10, // 16: storage.EmbeddedImageScanComponent.license:type_name -> storage.License
-	25, // 17: storage.EmbeddedImageScanComponent.vulns:type_name -> storage.EmbeddedVulnerability
+	11, // 16: storage.EmbeddedImageScanComponent.license:type_name -> storage.License
+	26, // 17: storage.EmbeddedImageScanComponent.vulns:type_name -> storage.EmbeddedVulnerability
 	0,  // 18: storage.EmbeddedImageScanComponent.source:type_name -> storage.SourceType
-	22, // 19: storage.EmbeddedImageScanComponent.executables:type_name -> storage.EmbeddedImageScanComponent.Executable
-	16, // 20: storage.ImageMetadata.v1:type_name -> storage.V1Metadata
-	15, // 21: storage.ImageMetadata.v2:type_name -> storage.V2Metadata
-	5,  // 22: storage.ImageMetadata.data_source:type_name -> storage.DataSource
-	13, // 23: storage.ImageSignature.signatures:type_name -> storage.Signature
-	24, // 24: storage.ImageSignature.fetched:type_name -> google.protobuf.Timestamp
-	14, // 25: storage.Signature.cosign:type_name -> storage.CosignSignature
-	24, // 26: storage.V1Metadata.created:type_name -> google.protobuf.Timestamp
-	17, // 27: storage.V1Metadata.layers:type_name -> storage.ImageLayer
-	23, // 28: storage.V1Metadata.labels:type_name -> storage.V1Metadata.LabelsEntry
-	24, // 29: storage.ImageLayer.created:type_name -> google.protobuf.Timestamp
-	24, // 30: storage.ListImage.created:type_name -> google.protobuf.Timestamp
-	24, // 31: storage.ListImage.last_updated:type_name -> google.protobuf.Timestamp
-	24, // 32: storage.BaseImageInfo.created:type_name -> google.protobuf.Timestamp
-	33, // [33:33] is the sub-list for method output_type
-	33, // [33:33] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	23, // 19: storage.EmbeddedImageScanComponent.executables:type_name -> storage.EmbeddedImageScanComponent.Executable
+	17, // 20: storage.ImageMetadata.v1:type_name -> storage.V1Metadata
+	16, // 21: storage.ImageMetadata.v2:type_name -> storage.V2Metadata
+	6,  // 22: storage.ImageMetadata.data_source:type_name -> storage.DataSource
+	14, // 23: storage.ImageSignature.signatures:type_name -> storage.Signature
+	25, // 24: storage.ImageSignature.fetched:type_name -> google.protobuf.Timestamp
+	15, // 25: storage.Signature.cosign:type_name -> storage.CosignSignature
+	4,  // 26: storage.CosignSignature.signature_format:type_name -> storage.CosignSignature.SignatureFormat
+	25, // 27: storage.V1Metadata.created:type_name -> google.protobuf.Timestamp
+	18, // 28: storage.V1Metadata.layers:type_name -> storage.ImageLayer
+	24, // 29: storage.V1Metadata.labels:type_name -> storage.V1Metadata.LabelsEntry
+	25, // 30: storage.ImageLayer.created:type_name -> google.protobuf.Timestamp
+	25, // 31: storage.ListImage.created:type_name -> google.protobuf.Timestamp
+	25, // 32: storage.ListImage.last_updated:type_name -> google.protobuf.Timestamp
+	25, // 33: storage.BaseImageInfo.created:type_name -> google.protobuf.Timestamp
+	34, // [34:34] is the sub-list for method output_type
+	34, // [34:34] is the sub-list for method input_type
+	34, // [34:34] is the sub-list for extension type_name
+	34, // [34:34] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_storage_image_proto_init() }
@@ -2326,7 +2406,7 @@ func file_storage_image_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_image_proto_rawDesc), len(file_storage_image_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      5,
 			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/generated/storage/image_vtproto.pb.go
+++ b/generated/storage/image_vtproto.pb.go
@@ -420,6 +420,7 @@ func (m *CosignSignature) CloneVT() *CosignSignature {
 		return (*CosignSignature)(nil)
 	}
 	r := new(CosignSignature)
+	r.SignatureFormat = m.SignatureFormat
 	if rhs := m.RawSignature; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -444,6 +445,11 @@ func (m *CosignSignature) CloneVT() *CosignSignature {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
 		r.RekorBundle = tmpBytes
+	}
+	if rhs := m.SigstoreBundle; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.SigstoreBundle = tmpBytes
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -1376,6 +1382,12 @@ func (this *CosignSignature) EqualVT(that *CosignSignature) bool {
 		return false
 	}
 	if string(this.RekorBundle) != string(that.RekorBundle) {
+		return false
+	}
+	if this.SignatureFormat != that.SignatureFormat {
+		return false
+	}
+	if string(this.SigstoreBundle) != string(that.SigstoreBundle) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2776,6 +2788,18 @@ func (m *CosignSignature) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.SigstoreBundle) > 0 {
+		i -= len(m.SigstoreBundle)
+		copy(dAtA[i:], m.SigstoreBundle)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SigstoreBundle)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if m.SignatureFormat != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.SignatureFormat))
+		i--
+		dAtA[i] = 0x30
+	}
 	if len(m.RekorBundle) > 0 {
 		i -= len(m.RekorBundle)
 		copy(dAtA[i:], m.RekorBundle)
@@ -3818,6 +3842,13 @@ func (m *CosignSignature) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.RekorBundle)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.SignatureFormat != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.SignatureFormat))
+	}
+	l = len(m.SigstoreBundle)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -6690,6 +6721,59 @@ func (m *CosignSignature) UnmarshalVT(dAtA []byte) error {
 			m.RekorBundle = append(m.RekorBundle[:0], dAtA[iNdEx:postIndex]...)
 			if m.RekorBundle == nil {
 				m.RekorBundle = []byte{}
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SignatureFormat", wireType)
+			}
+			m.SignatureFormat = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SignatureFormat |= CosignSignature_SignatureFormat(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SigstoreBundle", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SigstoreBundle = append(m.SigstoreBundle[:0], dAtA[iNdEx:postIndex]...)
+			if m.SigstoreBundle == nil {
+				m.SigstoreBundle = []byte{}
 			}
 			iNdEx = postIndex
 		default:
@@ -10870,6 +10954,56 @@ func (m *CosignSignature) UnmarshalVTUnsafe(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.RekorBundle = dAtA[iNdEx:postIndex]
+			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SignatureFormat", wireType)
+			}
+			m.SignatureFormat = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.SignatureFormat |= CosignSignature_SignatureFormat(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SigstoreBundle", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SigstoreBundle = dAtA[iNdEx:postIndex]
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/sigstore/cosign/v3 v3.1.2
 	github.com/sigstore/rekor v1.5.3
 	github.com/sigstore/sigstore v1.10.8
+	github.com/sigstore/sigstore-go v1.2.1
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -405,7 +406,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.3.0 // indirect
-	github.com/sigstore/sigstore-go v1.2.1 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.1.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/pkg/images/enricher/testing_test.go
+++ b/pkg/images/enricher/testing_test.go
@@ -56,7 +56,7 @@ type fakeSigFetcher struct {
 }
 
 func (f *fakeSigFetcher) FetchSignatures(_ context.Context, _ *storage.Image, _ string,
-	_ types.Registry) ([]*storage.Signature, error) {
+	_ types.Registry, _ ...retry.OptionsModifier) ([]*storage.Signature, error) {
 	if f.fail {
 		err := errors.New("some error")
 		if f.retryable {

--- a/pkg/signatures/cosign_payload_fetcher.go
+++ b/pkg/signatures/cosign_payload_fetcher.go
@@ -1,0 +1,161 @@
+package signatures
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	"github.com/stackrox/rox/generated/storage"
+	imgUtils "github.com/stackrox/rox/pkg/images/utils"
+)
+
+const (
+	bundleSigArtifactTypePrefix = "application/vnd.dev.sigstore.bundle"
+
+	// maxReferrerManifests limits the number of referrer signature manifests processed per image
+	// to bound latency and prevent pathological cases from consuming the caller's timeout budget.
+	maxReferrerManifests = 50
+)
+
+// signaturePayload is the internal representation of a fetched cosign signature before
+// it is persisted into the CosignSignature proto. Two formats are supported:
+//
+//   - SimpleSigning: the legacy cosign format. The signature, payload, certificate, and
+//     rekor bundle are stored as individual fields in cosign.SignedPayload.
+//   - Sigstore bundle: the OCI 1.1 bundle format. The raw bundle JSON is stored as-is
+//     in sigstoreBundle and verified directly via sigstore-go at verification time.
+//
+// The format is determined by sigstoreBundle: non-empty means sigstore bundle,
+// empty means SimpleSigning.
+type signaturePayload struct {
+	cosign.SignedPayload
+	sigstoreBundle []byte
+}
+
+var _ oci.SignedEntity = (*tagSignedEntity)(nil)
+
+// tagSignedEntity adapts an image reference for tag-based signature discovery.
+// Signatures() constructs the cosign tag reference (<algo>-<hex>.sig) and fetches
+// the signature manifest from the registry. Digest() returns the image digest so
+// cosign can build the tag. Only these two methods are called by cosign.FetchSignatures.
+// Attestations and Attachment return safe defaults to prevent panics if cosign evolves.
+type tagSignedEntity struct {
+	opts   []ociremote.Option
+	imgRef name.Reference
+	imgSHA string
+}
+
+func newTagSignedEntity(img *storage.Image, imgRef name.Reference, opts ...ociremote.Option) *tagSignedEntity {
+	return &tagSignedEntity{
+		opts:   opts,
+		imgRef: imgRef,
+		imgSHA: imgUtils.GetSHA(img),
+	}
+}
+
+func (s *tagSignedEntity) Digest() (v1.Hash, error) {
+	return v1.NewHash(s.imgSHA)
+}
+
+func (s *tagSignedEntity) Signatures() (oci.Signatures, error) {
+	h, err := s.Digest()
+	if err != nil {
+		return nil, err
+	}
+	// Cosign ref: https://github.com/sigstore/cosign/blob/main/pkg/oci/remote/remote.go
+	return ociremote.Signatures(s.imgRef.Context().Tag(fmt.Sprint(h.Algorithm, "-", h.Hex, ".sig")), s.opts...)
+}
+
+func (s *tagSignedEntity) Attestations() (oci.Signatures, error) { return nil, nil }
+
+func (s *tagSignedEntity) Attachment(_ string) (oci.File, error) {
+	return nil, fmt.Errorf("attachments not supported on tag-based signature entity")
+}
+
+// fetchSignaturesByTag discovers SimpleSigning signatures via the cosign tag-based method.
+// Discovery: looks up the tag <algo>-<hex>.sig in the same repository as the image.
+// Format: always SimpleSigning (signature and payload stored in OCI layer annotations).
+func fetchSignaturesByTag(image *storage.Image, imgRef name.Reference, opts []ociremote.Option) ([]signaturePayload, error) {
+	se := newTagSignedEntity(image, imgRef, opts...)
+	payloads, err := cosign.FetchSignatures(se)
+	if err != nil && (isMissingSignatureError(err) || isUnknownMimeTypeError(err)) {
+		return nil, nil
+	}
+	wrapped := make([]signaturePayload, len(payloads))
+	for i, p := range payloads {
+		wrapped[i] = signaturePayload{SignedPayload: p}
+	}
+	return wrapped, err
+}
+
+// fetchSignaturesByReferrer discovers sigstore bundle signatures via the OCI 1.1 Referrers API.
+// Discovery: queries the referrers index for the image digest and filters for sigstore
+// bundle artifact types. Only the sigstore bundle format is supported for referrer-based
+// discovery — cosign v3 exclusively produces bundles for this path.
+func fetchSignaturesByReferrer(ctx context.Context, digestRef name.Digest, repo name.Repository,
+	opts []ociremote.Option,
+) ([]signaturePayload, error) {
+	log.Infof("Fetching OCI referrer signatures for %s", digestRef.String())
+
+	index, err := ociremote.Referrers(digestRef, "", opts...)
+	if err != nil {
+		if checkIfErrorContainsCode(err, http.StatusNotFound) {
+			log.Infof("OCI referrers API not supported for %s (404)", digestRef.String())
+			return nil, nil
+		}
+		return nil, err
+	}
+	if index == nil {
+		return nil, nil
+	}
+
+	manifests := index.Manifests
+	if len(manifests) > maxReferrerManifests {
+		log.Warnf("Image %s has %d referrer manifests, processing only first %d",
+			digestRef.String(), len(manifests), maxReferrerManifests)
+		manifests = manifests[:maxReferrerManifests]
+	}
+
+	var payloads []signaturePayload
+	for _, desc := range manifests {
+		if ctx.Err() != nil {
+			break
+		}
+		if !strings.HasPrefix(desc.ArtifactType, bundleSigArtifactTypePrefix) {
+			continue
+		}
+		p, err := fetchSigstoreBundle(repo.Digest(desc.Digest.String()), opts)
+		if err != nil {
+			log.Warnf("Failed to fetch sigstore bundle from referrer %s: %v", desc.Digest, err)
+			continue
+		}
+		payloads = append(payloads, p...)
+	}
+	return payloads, nil
+}
+
+// fetchSigstoreBundle fetches a sigstore bundle referrer and stores the raw JSON.
+// Format: sigstore bundle (DSSE envelope + verification material + tlog entries in one blob).
+// Storage: the raw bundle JSON is stored in SigstoreBundle; no decomposition into individual
+// fields. Verification is deferred to verifySigstoreBundle which uses sigstore-go directly.
+func fetchSigstoreBundle(bundleRef name.Reference, opts []ociremote.Option) ([]signaturePayload, error) {
+	b, err := ociremote.Bundle(bundleRef, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	bundleJSON, err := b.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("marshalling sigstore bundle: %w", err)
+	}
+
+	return []signaturePayload{{
+		sigstoreBundle: bundleJSON,
+	}}, nil
+}

--- a/pkg/signatures/cosign_payload_fetcher_test.go
+++ b/pkg/signatures/cosign_payload_fetcher_test.go
@@ -1,0 +1,101 @@
+package signatures
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	"github.com/sigstore/cosign/v3/pkg/oci/static"
+	"github.com/stackrox/rox/pkg/images/types"
+	imgUtils "github.com/stackrox/rox/pkg/images/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// uploadSignatureAsReferrer stores a cosign signature as an OCI 1.1 referrer for the given image.
+func uploadSignatureAsReferrer(imgRef string, b64Sig string, sigPayload, certPEM, chainPEM []byte) error {
+	sigOpts := []static.Option{static.WithCertChain(certPEM, chainPEM)}
+
+	sig, err := static.NewSignature(sigPayload, b64Sig, sigOpts...)
+	if err != nil {
+		return err
+	}
+
+	ref, err := name.ParseReference(imgRef)
+	if err != nil {
+		return err
+	}
+	d, ok := ref.(name.Digest)
+	if !ok {
+		return fmt.Errorf("could not cast reference %q to name.Digest", ref.String())
+	}
+
+	se, err := ociremote.SignedEntity(ref)
+	if err != nil {
+		return err
+	}
+
+	newSE, err := mutate.AttachSignatureToEntity(se, sig)
+	if err != nil {
+		return err
+	}
+
+	return ociremote.WriteSignaturesExperimentalOCI(d, newSE)
+}
+
+func TestFetchTagPayloads_WithSignatures(t *testing.T) {
+	registryServer, imgRef, err := registryServerWithImage("nginx")
+	require.NoError(t, err, "setting up registry")
+	defer registryServer.Close()
+
+	sigPayload, err := base64.StdEncoding.DecodeString(payload1)
+	require.NoError(t, err)
+
+	require.NoError(t, uploadSignatureForImage(imgRef, sig1, sigPayload, nil, nil, nil),
+		"uploading tag-based signature")
+
+	ref, err := name.ParseReference(imgRef)
+	require.NoError(t, err)
+	img, err := imgUtils.GenerateImageFromString(imgRef)
+	require.NoError(t, err)
+
+	payloads, err := fetchSignaturesByTag(types.ToImage(img), ref, nil)
+	require.NoError(t, err)
+	assert.Len(t, payloads, 1)
+	assert.Equal(t, sigPayload, payloads[0].Payload)
+	assert.Equal(t, sig1, payloads[0].Base64Signature)
+}
+
+func TestFetchTagPayloads_NoSignatures(t *testing.T) {
+	registryServer, imgRef, err := registryServerWithImage("nginx")
+	require.NoError(t, err, "setting up registry")
+	defer registryServer.Close()
+
+	ref, err := name.ParseReference(imgRef)
+	require.NoError(t, err)
+	img, err := imgUtils.GenerateImageFromString(imgRef)
+	require.NoError(t, err)
+
+	payloads, err := fetchSignaturesByTag(types.ToImage(img), ref, nil)
+	require.NoError(t, err)
+	assert.Empty(t, payloads)
+}
+
+func TestFetchReferrerPayloads_NoSignatures(t *testing.T) {
+	registryServer, imgRef, err := registryServerWithImage("nginx")
+	require.NoError(t, err, "setting up registry")
+	defer registryServer.Close()
+
+	ref, err := name.ParseReference(imgRef)
+	require.NoError(t, err)
+	d, ok := ref.(name.Digest)
+	require.True(t, ok)
+
+	payloads, err := fetchSignaturesByReferrer(context.Background(), d, ref.Context(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, payloads)
+}

--- a/pkg/signatures/cosign_sig_fetcher.go
+++ b/pkg/signatures/cosign_sig_fetcher.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/stackrox/rox/pkg/sync"
 	"net/http"
 	"net/url"
 	"slices"
@@ -13,13 +15,10 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	gcrRemote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	dockerRegistry "github.com/heroku/docker-registry-client/registry"
-	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
-	"github.com/sigstore/cosign/v3/pkg/oci"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/stackrox/rox/generated/storage"
@@ -30,6 +29,8 @@ import (
 	"github.com/stackrox/rox/pkg/retry"
 	"golang.org/x/time/rate"
 )
+
+const fetchTimeout = 10 * time.Second
 
 type cosignSignatureFetcher struct {
 	// registryRateLimiter is a rate limiter for parallel calls to the registry. This will avoid reaching out to the
@@ -53,11 +54,15 @@ func init() {
 }
 
 // FetchSignatures implements the SignatureFetcher interface.
-// The signature associated with the image will be fetched from the given registry.
-// It will return the storage.ImageSignature and an error that indicated whether the fetching should be retried or not.
-// NOTE: No error will be returned when the image has no signature available. All occurring errors will be logged.
+// Signatures are discovered via two methods concurrently: the legacy cosign tag-based
+// path and the OCI 1.1 Referrers API. Results from both are merged and deduplicated.
+// When one path fails but the other returns signatures, the error is logged and the
+// successful results are returned. When both paths fail, the joined error is returned
+// to the caller so retry logic can act on it. Unauthorized errors are wrapped as
+// errox.NotAuthorized regardless of which path produced them.
+// NOTE: No error will be returned when the image has no signature available.
 func (c *cosignSignatureFetcher) FetchSignatures(ctx context.Context, image *storage.Image,
-	fullImageName string, registry registryTypes.Registry,
+	fullImageName string, registry registryTypes.Registry, retryOpts ...retry.OptionsModifier,
 ) ([]*storage.Signature, error) {
 	// Short-circuit for images that do not have V2 metadata associated with them. These would be older images manifest
 	// schemes that are not supported by cosign, like the docker v1 manifest.
@@ -75,85 +80,161 @@ func (c *cosignSignatureFetcher) FetchSignatures(ctx context.Context, image *sto
 	// Wait until the registry rate limiter allows entrance.
 	err = c.registryRateLimiter.Wait(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "waiting for rate limiter entrance for registry %q", registry.Name())
+		return nil, fmt.Errorf("waiting for rate limiter entrance for registry %q: %w", registry.Name(), err)
 	}
 
-	// Fetch the signatures by injecting the registry specific authentication options to the google/go-containerregistry
-	// client.
-	// Additionally, use a local signed entity to skip fetching the image manifest and only fetch the signature manifest.
-	se := newLocalSignedEntity(image, imgRef, ociremote.WithRemoteOptions(optionsFromRegistry(ctx, registry)...))
-	signedPayloads, err := cosign.FetchSignatures(se)
+	// Inject the registry specific authentication options to the google/go-containerregistry client.
+	remoteOpts := optionsFromRegistry(ctx, registry)
+	log.Debugf("FetchSignatures for %q: registry=%q hasAuth=%t",
+		fullImageName, registry.Name(), len(remoteOpts) > 0)
+	ociOpts := []ociremote.Option{ociremote.WithRemoteOptions(remoteOpts...)}
 
-	// Cosign will return an error in case no signature is associated, we don't want to return that error. Since no
-	// error types are exposed need to check for string comparison.
-	// Cosign ref:
-	//  https://github.com/sigstore/cosign/blob/44f3814667ba6a398aef62814cabc82aee4896e5/pkg/cosign/fetch.go#L84-L86
-	if err != nil && !isMissingSignatureError(err) && !isUnknownMimeTypeError(err) {
-		// Specifically mark an error as errox.NotAuthorized so we skip using the same credentials for fetching.
-		// We can safely skip the potential marking of retryable errors as unauthorized errors are not transient.
-		if isUnauthorizedError(err) {
-			return nil, errox.NotAuthorized.CausedBy(err)
+	// Fetch from both discovery methods concurrently. Each path retries independently
+	// so a transient failure in one does not block the other.
+	var (
+		tagPayloads      []signaturePayload
+		tagErr           error
+		referrerPayloads []signaturePayload
+		referrerErr      error
+		wg               sync.WaitGroup
+	)
+	wg.Go(func() {
+		tagPayloads, tagErr = fetchWithRetry(ctx, ociOpts, retryOpts, func(opts []ociremote.Option) ([]signaturePayload, error) {
+			return fetchSignaturesByTag(image, imgRef, opts)
+		})
+	})
+	wg.Go(func() {
+		imgSHA := imgUtils.GetSHA(image)
+		if imgSHA == "" {
+			referrerErr = fmt.Errorf("image %q has no SHA digest for referrer lookup", fullImageName)
+			return
 		}
-		// Ensure we mark transient errors as retryable.
-		return nil, makeTransientErrorRetryable(err)
+		digestRef := imgRef.Context().Digest(imgSHA)
+		referrerPayloads, referrerErr = fetchWithRetry(ctx, ociOpts, retryOpts, func(opts []ociremote.Option) ([]signaturePayload, error) {
+			return fetchSignaturesByReferrer(ctx, digestRef, imgRef.Context(), opts)
+		})
+	})
+	wg.Wait()
+
+	// Merge payloads from both discovery methods.
+	var allPayloads []signaturePayload
+	if tagErr == nil {
+		allPayloads = append(allPayloads, tagPayloads...)
+		log.Debugf("Tag-based discovery returned %d payload(s) for %q", len(tagPayloads), fullImageName)
+	} else {
+		log.Infof("Tag-based discovery failed for %q: %v", fullImageName, tagErr)
+	}
+	if referrerErr == nil {
+		allPayloads = append(allPayloads, referrerPayloads...)
+		log.Debugf("Referrer-based discovery returned %d payload(s) for %q", len(referrerPayloads), fullImageName)
+	} else {
+		log.Infof("Referrer-based discovery failed for %q: %v", fullImageName, referrerErr)
+	}
+	log.Debugf("Merged payload count for %q: %d", fullImageName, len(allPayloads))
+
+	fetchErr := errors.Join(tagErr, referrerErr)
+	if fetchErr != nil {
+		if len(allPayloads) > 0 {
+			log.Warnf("Partial signature discovery failure for %q: %v", fullImageName, fetchErr)
+		} else if isUnauthorizedError(tagErr) || isUnauthorizedError(referrerErr) {
+			return nil, errox.NotAuthorized.CausedBy(fetchErr)
+		} else {
+			return nil, fetchErr
+		}
 	}
 
-	// Short-circuit if no signatures are associated with the image.
-	if len(signedPayloads) == 0 {
+	if len(allPayloads) == 0 {
+		log.Debugf("No signatures found for %q via either discovery method", fullImageName)
 		return nil, nil
 	}
 
-	cosignSignatures := make([]*storage.Signature, 0, len(signedPayloads))
-
-	for _, signedPayload := range signedPayloads {
-		rawSig, err := base64.StdEncoding.DecodeString(signedPayload.Base64Signature)
-		// We skip the invalid base64 signature and log its occurrence.
-		if err != nil {
-			log.Errorf("Error during decoding of raw signature for image %q: %v",
-				fullImageName, err)
-			continue
-		}
-
-		certPEM, err := certificateFromSignedPayload(signedPayload)
-		if err != nil {
-			log.Errorf("Error during unmarshalling certificate to PEM for image %q: %v", fullImageName, err)
-		}
-
-		chainPEM, err := certificateChainFromSignedPayload(signedPayload)
-		if err != nil {
-			log.Errorf("Error during unmarshalling certificate chain to PEM for image %q: %v",
-				fullImageName, err)
-		}
-
-		var rekorBundle []byte
-		if signedPayload.Bundle != nil {
-			rekorBundle, err = json.Marshal(signedPayload.Bundle)
-			if err != nil {
-				log.Errorf("Error during marshalling rekor bundle for image %q: %v", fullImageName, err)
-			}
-		}
-
-		// Since we are only focusing on public keys and certificates, we are ignoring the rekor bundles associated with
-		// the signature.
-		cosignSignatures = append(cosignSignatures, &storage.Signature{
-			Signature: &storage.Signature_Cosign{
-				Cosign: &storage.CosignSignature{
-					RawSignature:     rawSig,
-					SignaturePayload: signedPayload.Payload,
-					CertPem:          certPEM,
-					CertChainPem:     chainPEM,
-					RekorBundle:      rekorBundle,
-				},
-			},
-		})
-	}
-
-	// Since we are skipping invalid base64 signatures, need to check the length of the result.
+	cosignSignatures := convertPayloadsToSignatures(allPayloads, fullImageName)
 	if len(cosignSignatures) == 0 {
 		return nil, nil
 	}
 
 	return protoutils.SliceUnique(cosignSignatures), nil
+}
+
+// fetchWithRetry calls fn, optionally wrapping it in retry logic with a per-attempt timeout.
+// The timeout context is injected into the OCI options so fn does not need to handle contexts.
+// When retryOpts is empty, fn is called directly without retry or timeout wrapping.
+func fetchWithRetry(ctx context.Context, ociOpts []ociremote.Option, retryOpts []retry.OptionsModifier,
+	fn func([]ociremote.Option) ([]signaturePayload, error),
+) ([]signaturePayload, error) {
+	if len(retryOpts) == 0 {
+		return fn(ociOpts)
+	}
+	var payloads []signaturePayload
+	err := retry.WithRetry(func() error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+		defer cancel()
+		opts := append(slices.Clone(ociOpts),
+			ociremote.WithMoreRemoteOptions(gcrRemote.WithContext(fetchCtx)))
+		var fetchErr error
+		payloads, fetchErr = fn(opts)
+		return makeTransientErrorRetryable(fetchErr)
+	}, retryOpts...)
+	return payloads, err
+}
+
+// convertPayloadsToSignatures converts fetched payloads into CosignSignature protos.
+// Storage: sigstore bundles are stored as raw JSON in SigstoreBundle. SimpleSigning
+// signatures are decomposed into individual proto fields (RawSignature, SignaturePayload,
+// CertPem, CertChainPem, RekorBundle). Old images without SigstoreBundle fall back to
+// the decomposed fields at verification time.
+func convertPayloadsToSignatures(payloads []signaturePayload, fullImageName string) []*storage.Signature {
+	signatures := make([]*storage.Signature, 0, len(payloads))
+
+	for _, signedPayload := range payloads {
+		cosignSig := &storage.CosignSignature{}
+
+		if len(signedPayload.sigstoreBundle) > 0 {
+			cosignSig.SigstoreBundle = signedPayload.sigstoreBundle
+			cosignSig.SignatureFormat = storage.CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE
+		} else {
+			cosignSig.SignatureFormat = storage.CosignSignature_SIMPLE_SIGNING
+			cosignSig.SignaturePayload = signedPayload.Payload
+			rawSig, err := base64.StdEncoding.DecodeString(signedPayload.Base64Signature)
+			if err != nil {
+				log.Errorf("Error during decoding of raw signature for image %q: %v",
+					fullImageName, err)
+				continue
+			}
+			cosignSig.RawSignature = rawSig
+
+			certPEM, err := certificateFromSignedPayload(signedPayload.SignedPayload)
+			if err != nil {
+				log.Errorf("Error during unmarshalling certificate to PEM for image %q: %v", fullImageName, err)
+			}
+			cosignSig.CertPem = certPEM
+
+			chainPEM, err := certificateChainFromSignedPayload(signedPayload.SignedPayload)
+			if err != nil {
+				log.Errorf("Error during unmarshalling certificate chain to PEM for image %q: %v",
+					fullImageName, err)
+			}
+			cosignSig.CertChainPem = chainPEM
+
+			if signedPayload.Bundle != nil {
+				rekorBundle, err := json.Marshal(signedPayload.Bundle)
+				if err != nil {
+					log.Errorf("Error during marshalling rekor bundle for image %q: %v", fullImageName, err)
+				} else {
+					cosignSig.RekorBundle = rekorBundle
+				}
+			}
+		}
+
+		signatures = append(signatures, &storage.Signature{
+			Signature: &storage.Signature_Cosign{Cosign: cosignSig},
+		})
+	}
+
+	return signatures
 }
 
 func certificateFromSignedPayload(sp cosign.SignedPayload) ([]byte, error) {
@@ -261,6 +342,9 @@ func isUnknownMimeTypeError(err error) bool {
 // isUnauthorizedError is checking whether the returned error indicates that there was a http.StatusUnauthorized was
 // returned during fetching of signatures.
 func isUnauthorizedError(err error) bool {
+	if err == nil {
+		return false
+	}
 	return checkIfErrorContainsCode(err, http.StatusUnauthorized, http.StatusForbidden)
 }
 
@@ -285,41 +369,4 @@ func checkIfErrorContainsCode(err error, codes ...int) bool {
 	}
 
 	return false
-}
-
-var _ oci.SignedEntity = (*localSignedEntity)(nil)
-
-// localSignedEntity is an implementation of oci.SignedEntity used for fetching signatures.
-// This implementation skips fetching the manifest of the signed image, since within the image enriching, we already
-// fetched the image manifest beforehand.
-type localSignedEntity struct {
-	oci.SignedEntity
-	opts   []ociremote.Option
-	imgRef name.Reference
-	imgSHA string
-}
-
-func newLocalSignedEntity(img *storage.Image, imgRef name.Reference, opts ...ociremote.Option) *localSignedEntity {
-	imgSHA := imgUtils.GetSHA(img)
-	return &localSignedEntity{
-		opts:   opts,
-		imgRef: imgRef,
-		imgSHA: imgSHA,
-	}
-}
-
-func (s *localSignedEntity) Digest() (v1.Hash, error) {
-	return v1.NewHash(s.imgSHA)
-}
-
-func (s *localSignedEntity) Signatures() (oci.Signatures, error) {
-	h, err := s.Digest()
-	if err != nil {
-		return nil, err
-	}
-	// The name reference of the signature to fetch is going to be:
-	// <registry>/<repository>@<digest>.sig
-	// This is being kept in line with:
-	// https://github.com/sigstore/cosign/blob/65eb28af970d133adeefdc6c48d6e9304dd8cc3a/pkg/oci/remote/remote.go#L87
-	return ociremote.Signatures(s.imgRef.Context().Tag(fmt.Sprint(h.Algorithm, "-", h.Hex, ".sig")), s.opts...)
 }

--- a/pkg/signatures/cosign_sig_fetcher_test.go
+++ b/pkg/signatures/cosign_sig_fetcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	dockerRegistry "github.com/heroku/docker-registry-client/registry"
 	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
@@ -287,6 +288,32 @@ func TestCosignSignatureFetcher_FetchSignature_NoSignature(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestCosignSignatureFetcher_FetchSignature_SimpleSigningReferrerIgnored(t *testing.T) {
+	registryServer, imgRef, err := registryServerWithImage("nginx")
+	require.NoError(t, err, "setting up registry")
+	defer registryServer.Close()
+
+	cimg, err := imgUtils.GenerateImageFromString(imgRef)
+	require.NoError(t, err, "creating test image")
+	img := types.ToImage(cimg)
+	img.Metadata = &storage.ImageMetadata{V2: &storage.V2Metadata{Digest: "something"}}
+
+	sigPayload1, err := base64.StdEncoding.DecodeString(payload1)
+	require.NoError(t, err, "decoding payload")
+
+	// Upload a SimpleSigning signature as OCI referrer. The referrer path only
+	// supports sigstore bundles, so this signature should be ignored.
+	require.NoError(t, uploadSignatureAsReferrer(imgRef, sig1, sigPayload1, nil, nil),
+		"uploading signature as referrer")
+
+	f := newCosignSignatureFetcher()
+	reg := &mockRegistry{cfg: &registryTypes.Config{}}
+
+	res, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), reg)
+	assert.NoError(t, err)
+	assert.Empty(t, res)
+}
+
 func TestIsMissingSignatureError(t *testing.T) {
 	notFoundErr := dockerRegistry.HttpStatusError{
 		Response: &http.Response{
@@ -495,4 +522,124 @@ func TestIsUnknownMimeTypeError(t *testing.T) {
 			assert.Equal(t, c.expectedRes, isUnknownMimeTypeError(c.err))
 		})
 	}
+}
+
+func TestConvertPayloadsToSignatures_SigstoreBundle(t *testing.T) {
+	bundleJSON := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+	payloads := []signaturePayload{{sigstoreBundle: bundleJSON}}
+
+	sigs := convertPayloadsToSignatures(payloads, "test:latest")
+	require.Len(t, sigs, 1)
+	cosignSig := sigs[0].GetCosign()
+	assert.Equal(t, bundleJSON, cosignSig.GetSigstoreBundle())
+	assert.Equal(t, storage.CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE, cosignSig.GetSignatureFormat())
+	assert.Empty(t, cosignSig.GetRawSignature())
+	assert.Empty(t, cosignSig.GetSignaturePayload())
+}
+
+func TestConvertPayloadsToSignatures_SimpleSigning(t *testing.T) {
+	sigPayload, err := base64.StdEncoding.DecodeString(payload1)
+	require.NoError(t, err)
+	payloads := []signaturePayload{
+		{SignedPayload: cosign.SignedPayload{Base64Signature: sig1, Payload: sigPayload}},
+	}
+
+	sigs := convertPayloadsToSignatures(payloads, "test:latest")
+	require.Len(t, sigs, 1)
+	cosignSig := sigs[0].GetCosign()
+	assert.Empty(t, cosignSig.GetSigstoreBundle())
+	assert.Equal(t, storage.CosignSignature_SIMPLE_SIGNING, cosignSig.GetSignatureFormat())
+	assert.Equal(t, sigPayload, cosignSig.GetSignaturePayload())
+	assert.NotEmpty(t, cosignSig.GetRawSignature())
+}
+
+func TestConvertPayloadsToSignatures_MixedFormats(t *testing.T) {
+	sigPayload, err := base64.StdEncoding.DecodeString(payload1)
+	require.NoError(t, err)
+	bundleJSON := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+	payloads := []signaturePayload{
+		{SignedPayload: cosign.SignedPayload{Base64Signature: sig1, Payload: sigPayload}},
+		{sigstoreBundle: bundleJSON},
+	}
+
+	sigs := convertPayloadsToSignatures(payloads, "test:latest")
+	require.Len(t, sigs, 2)
+	assert.Empty(t, sigs[0].GetCosign().GetSigstoreBundle())
+	assert.Equal(t, bundleJSON, sigs[1].GetCosign().GetSigstoreBundle())
+}
+
+func TestCosignSignatureFetcher_FetchSignature_NoV2MetadataSkipsBoth(t *testing.T) {
+	cimg, err := imgUtils.GenerateImageFromString("test.io/test:latest")
+	require.NoError(t, err)
+	img := types.ToImage(cimg)
+	// No V2 metadata set — should short-circuit before any registry call.
+
+	f := newCosignSignatureFetcher()
+	res, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), nil)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestCosignSignatureFetcher_FetchSignature_NoSignatureFromEither(t *testing.T) {
+	registryServer, imgRef, err := registryServerWithImage("nginx")
+	require.NoError(t, err, "setting up registry")
+	defer registryServer.Close()
+
+	cimg, err := imgUtils.GenerateImageFromString(imgRef)
+	require.NoError(t, err, "creating test image")
+	img := types.ToImage(cimg)
+	img.Metadata = &storage.ImageMetadata{V2: &storage.V2Metadata{Digest: "something"}}
+
+	f := newCosignSignatureFetcher()
+	reg := &mockRegistry{cfg: &registryTypes.Config{}}
+
+	result, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), reg)
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestCosignSignatureFetcher_FetchSignature_WithCredentials(t *testing.T) {
+	registryServer, imgRef, err := registryServerWithImage("nginx")
+	require.NoError(t, err, "setting up registry")
+	defer registryServer.Close()
+
+	cimg, err := imgUtils.GenerateImageFromString(imgRef)
+	require.NoError(t, err, "creating test image")
+	img := types.ToImage(cimg)
+	img.Metadata = &storage.ImageMetadata{V2: &storage.V2Metadata{Digest: "something"}}
+
+	rawSig1, err := base64.StdEncoding.DecodeString(sig1)
+	require.NoError(t, err, "decoding signature")
+	sigPayload1, err := base64.StdEncoding.DecodeString(payload1)
+	require.NoError(t, err, "decoding payload")
+
+	require.NoError(t, uploadSignatureForImage(imgRef, sig1, sigPayload1, nil, nil, nil),
+		"uploading tag-based signature")
+
+	expectedSignatures := []*storage.Signature{
+		{
+			Signature: &storage.Signature_Cosign{
+				Cosign: &storage.CosignSignature{
+					RawSignature:     rawSig1,
+					SignaturePayload: sigPayload1,
+				},
+			},
+		},
+	}
+
+	ref, err := name.ParseReference(imgRef)
+	require.NoError(t, err)
+
+	f := newCosignSignatureFetcher()
+	// Use a registry config with credentials to exercise the authenticated transport path.
+	// The URL is required for WrapTransport to perform the initial /v2/ probe.
+	reg := &mockRegistry{cfg: &registryTypes.Config{
+		Username: "testuser",
+		Password: "testpass",
+		URL:      "http://" + ref.Context().RegistryStr(),
+	}}
+
+	res, err := f.FetchSignatures(context.Background(), img, img.GetName().GetFullName(), reg)
+	assert.NoError(t, err)
+	protoassert.SlicesEqual(t, expectedSignatures, res)
 }

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -5,9 +5,12 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
@@ -19,6 +22,9 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	rekorClient "github.com/sigstore/rekor/pkg/client"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
@@ -47,6 +53,16 @@ var (
 	errNoVerifiedReferences = errors.New("no verified references")
 	errUnverifiedBundle     = errors.New("unverified transparency log bundle")
 )
+
+// verifiableSignature holds signature data ready for verification. Exactly one of
+// the two fields is populated:
+//   - sigstoreBundle: raw sigstore bundle JSON, verified via verifySigstoreBundle (sigstore-go).
+//   - sig: reconstructed oci.Signature from decomposed SimpleSigning fields, verified via
+//     cosign.VerifyImageSignature.
+type verifiableSignature struct {
+	sig            oci.Signature
+	sigstoreBundle []byte
+}
 
 var once sync.Once
 
@@ -173,7 +189,7 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 		return storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, nil, errNoVerificationData
 	}
 
-	sigs, hash, err := retrieveVerificationDataFromImage(image)
+	vsigs, hash, err := retrieveVerificationDataFromImage(image)
 	if err != nil {
 		return getVerificationResultStatusFromErr(err), nil, err
 	}
@@ -200,9 +216,9 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 	var mutex sync.Mutex
 	var wg sync.WaitGroup
 	for _, opts := range c.verifierOpts {
-		for cnt, sig := range sigs {
+		for cnt, vsig := range vsigs {
 			wg.Go(func() {
-				verifierRefs, err := verifyImageSignature(ctx, sig, hash, image, opts)
+				verifierRefs, err := verifySignature(ctx, vsig.sig, hash, image, opts, vsig.sigstoreBundle)
 				mutex.Lock()
 				defer mutex.Unlock()
 				if err != nil {
@@ -212,7 +228,6 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 					)
 					return
 				}
-				// Successful verification. Keep the image references.
 				verifiedImageReferences.AddAll(verifierRefs...)
 			})
 		}
@@ -234,10 +249,17 @@ func (c *cosignSignatureVerifier) createVerifierOpts(ctx context.Context) error 
 		return errors.Wrap(err, "creating default cosign check opts")
 	}
 
+	// Build TrustedMaterial once from the tlog keys for public key verifiers.
+	// Safe to set on pubkey opts: ValidateAndUnpackCert (which conflicts with
+	// TrustedMaterial) is only reached when SigVerifier is nil.
+	tlogTrustedMaterial, err := trustedMaterialFromTlogKeys(defaultOpts)
+	if err != nil {
+		return err
+	}
+
 	var verifierErrs error
 	// Public key verifiers.
 	for _, key := range c.parsedPublicKeys {
-		// For now, only supporting SHA256 as algorithm.
 		v, err := signature.LoadVerifier(key, crypto.SHA256)
 		if err != nil {
 			verifierErrs = multierror.Append(verifierErrs, errors.Wrap(err, "creating verifier"))
@@ -245,6 +267,7 @@ func (c *cosignSignatureVerifier) createVerifierOpts(ctx context.Context) error 
 		}
 		opts := defaultOpts
 		opts.SigVerifier = v
+		opts.TrustedMaterial = tlogTrustedMaterial
 		c.verifierOpts = append(c.verifierOpts, opts)
 	}
 
@@ -317,9 +340,10 @@ func (c *cosignSignatureVerifier) defaultCosignCheckOpts(ctx context.Context) (c
 }
 
 func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opts cosign.CheckOpts) (cosign.CheckOpts, error) {
-	// Skip verifying the identities when the wildcard matching logic being used. This fixes an issue
-	// with verifying the identity which will yield an error when using the wildcard expressions _and_ the certificate
-	// to verify has no identities associated with it (i.e. within the BYOPKI use-case).
+	// Only set non-wildcard identities. The legacy ValidateAndUnpackCert path calls
+	// CheckCertificatePolicy which fails on BYOPKI certs that lack OIDC extensions.
+	// For the sigstore-go bundle path, verifySigstoreBundle injects wildcard identities
+	// when Identities is empty and SigVerifier is nil.
 	if cert.oidcIssuerExpr != ".*" && cert.identityExpr != ".*" {
 		opts.Identities = []cosign.Identity{{
 			IssuerRegExp:  cert.oidcIssuerExpr,
@@ -347,6 +371,12 @@ func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opt
 			return opts, err
 		}
 		opts.SigVerifier = v
+		// Build TrustedMaterial from the custom chain for bundle verification.
+		tm, err := trustedMaterialFromChain(cert.chain, opts)
+		if err != nil {
+			return opts, err
+		}
+		opts.TrustedMaterial = tm
 		return opts, nil
 
 	case cert.cert != nil:
@@ -371,6 +401,12 @@ func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opt
 			pool.AddCert(caCert)
 		}
 		opts.RootCerts = pool
+		// Build TrustedMaterial from the custom chain for bundle verification.
+		tm, err := trustedMaterialFromChain(cert.chain, opts)
+		if err != nil {
+			return opts, err
+		}
+		opts.TrustedMaterial = tm
 		return opts, nil
 
 	default:
@@ -382,19 +418,50 @@ func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opt
 	}
 }
 
-func verifyImageSignature(ctx context.Context, signature oci.Signature,
+// trustedMaterialFromChain builds a root.TrustedMaterial from a certificate chain
+// and the rekor/ctlog keys already configured on opts. The last cert in the chain
+// is treated as the root; the rest are intermediates.
+func trustedMaterialFromChain(chain []*x509.Certificate, opts cosign.CheckOpts) (root.TrustedMaterial, error) {
+	ca := &root.FulcioCertificateAuthority{
+		Root:          chain[len(chain)-1],
+		Intermediates: chain[:len(chain)-1],
+	}
+
+	tr, err := root.NewTrustedRoot(
+		root.TrustedRootMediaType01,
+		[]root.CertificateAuthority{ca},
+		transparencyLogsFromKeys(opts.CTLogPubKeys),
+		nil,
+		transparencyLogsFromKeys(opts.RekorPubKeys),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("building trusted root from certificate chain: %w", err)
+	}
+	return tr, nil
+}
+
+// verifySignature dispatches signature verification based on format:
+//   - Sigstore bundle: delegates to verifySigstoreBundle which uses cosign.VerifyNewBundle
+//     (sigstore-go). The bundle carries its own verification material (cert, tlog entry).
+//   - SimpleSigning: delegates to cosign.VerifyImageSignature which verifies the signature
+//     and rekor bundle (transparency log proof) from the decomposed proto fields.
+func verifySignature(ctx context.Context, sig oci.Signature,
 	imageHash gcrv1.Hash, image *storage.Image, cosignOpts cosign.CheckOpts,
+	sigstoreBundle []byte,
 ) ([]string, error) {
-	// If there is no error during the verification, the signature was successfully verified
-	// as well as the claims.
-	bundleVerified, err := cosign.VerifyImageSignature(ctx, signature, imageHash, &cosignOpts)
+	if len(sigstoreBundle) > 0 {
+		return verifySigstoreBundle(ctx, imageHash, image, cosignOpts, sigstoreBundle)
+	}
+
+	rekorVerified, err := cosign.VerifyImageSignature(ctx, sig, imageHash, &cosignOpts)
 	if err != nil {
 		return nil, err
 	}
-	if !bundleVerified && !cosignOpts.IgnoreTlog {
+	if !rekorVerified && !cosignOpts.IgnoreTlog {
 		return nil, errUnverifiedBundle
 	}
-	refs, err := getVerifiedImageReference(signature, image)
+
+	refs, err := getVerifiedImageReference(sig, image)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting verified image references")
 	}
@@ -402,6 +469,95 @@ func verifyImageSignature(ctx context.Context, signature oci.Signature,
 		return nil, errNoVerifiedReferences
 	}
 	return refs, nil
+}
+
+// verifySigstoreBundle verifies a sigstore bundle directly via cosign.VerifyNewBundle.
+// TrustedMaterial is set lazily here because it is exclusive with the legacy
+// RootCerts/IntermediateCerts fields used by the non-bundle verification path.
+// Custom certificate chains set TrustedMaterial in cosignCheckOptsFromCert;
+// all other cases fall back to the public Sigstore trusted root from TUF.
+func verifySigstoreBundle(ctx context.Context,
+	imageHash gcrv1.Hash, image *storage.Image, cosignOpts cosign.CheckOpts,
+	sigstoreBundle []byte,
+) ([]string, error) {
+	if cosignOpts.TrustedMaterial == nil {
+		if tr, err := cosign.TrustedRoot(); err == nil {
+			cosignOpts.TrustedMaterial = tr
+		} else if cosignOpts.SigVerifier != nil {
+			// Public key verification without TUF (air-gapped). Provide an empty
+			// TrustedMaterial so sigstore-go's verifier doesn't nil-panic.
+			cosignOpts.TrustedMaterial = &root.BaseTrustedMaterial{}
+		} else {
+			return nil, fmt.Errorf("loading sigstore trusted root for bundle verification: %w", err)
+		}
+	}
+
+	// sigstore-go requires at least one identity for cert-based verification.
+	// cosignCheckOptsFromCert skips Identities for wildcard BYOPKI certs (they lack
+	// OIDC extensions that the legacy path would check), so inject them here.
+	if len(cosignOpts.Identities) == 0 && cosignOpts.SigVerifier == nil {
+		cosignOpts.Identities = []cosign.Identity{{SubjectRegExp: ".*", IssuerRegExp: ".*"}}
+	}
+
+	bundle := &sgbundle.Bundle{}
+	if err := bundle.UnmarshalJSON(sigstoreBundle); err != nil {
+		return nil, fmt.Errorf("unmarshalling sigstore bundle: %w", err)
+	}
+
+	digestBytes, err := hex.DecodeString(imageHash.Hex)
+	if err != nil {
+		return nil, fmt.Errorf("decoding image digest hex: %w", err)
+	}
+
+	artifactPolicy := verify.WithArtifactDigest(imageHash.Algorithm, digestBytes)
+	if _, err := cosign.VerifyNewBundle(ctx, &cosignOpts, artifactPolicy, bundle); err != nil {
+		return nil, err
+	}
+
+	// Sigstore bundles bind to the image digest, not a docker reference, so all
+	// names sharing the same digest are considered verified.
+	return getAllImageReferences(image), nil
+}
+
+// transparencyLogsFromKeys converts cosign's TrustedTransparencyLogPubKeys map into
+// sigstore-go TransparencyLog entries.
+func transparencyLogsFromKeys(keys *cosign.TrustedTransparencyLogPubKeys) map[string]*root.TransparencyLog {
+	if keys == nil || len(keys.Keys) == 0 {
+		return nil
+	}
+	logs := make(map[string]*root.TransparencyLog, len(keys.Keys))
+	for logID, key := range keys.Keys {
+		idBytes, err := hex.DecodeString(logID)
+		if err != nil {
+			continue
+		}
+		logs[logID] = &root.TransparencyLog{
+			ID:                idBytes,
+			PublicKey:         key.PubKey,
+			HashFunc:          crypto.SHA256,
+			SignatureHashFunc: crypto.SHA256,
+			// ponytail: sigstore-go VerifySET rejects zero-value ValidityPeriodStart
+			// as "not set". Unix epoch is a non-zero sentinel meaning "always valid".
+			ValidityPeriodStart: time.Unix(0, 0),
+		}
+	}
+	return logs
+}
+
+// trustedMaterialFromTlogKeys builds a root.TrustedMaterial from the Rekor and CTLog keys
+// on CheckOpts. Returns nil if no custom keys are configured (verifySigstoreBundle will
+// fall back to the public Sigstore TUF root).
+func trustedMaterialFromTlogKeys(opts cosign.CheckOpts) (root.TrustedMaterial, error) {
+	rekorLogs := transparencyLogsFromKeys(opts.RekorPubKeys)
+	ctLogs := transparencyLogsFromKeys(opts.CTLogPubKeys)
+	if len(rekorLogs) == 0 && len(ctLogs) == 0 {
+		return nil, nil
+	}
+	tr, err := root.NewTrustedRoot(root.TrustedRootMediaType01, nil, ctLogs, nil, rekorLogs)
+	if err != nil {
+		return nil, fmt.Errorf("building trusted root from transparency log keys: %w", err)
+	}
+	return tr, nil
 }
 
 // getVerificationResultStatusFromErr will map an error to a specific storage.ImageSignatureVerificationResult_Status.
@@ -433,7 +589,13 @@ func unmarshalRekorBundle(byteBundle []byte) (*bundle.RekorBundle, error) {
 	return rekorBundle, nil
 }
 
-func retrieveVerificationDataFromImage(image *storage.Image) ([]oci.Signature, gcrv1.Hash, error) {
+// retrieveVerificationDataFromImage reads stored signatures from the image proto and
+// prepares them for verification. Two storage formats are handled:
+//   - SigstoreBundle set: the raw bundle JSON is carried through for verifySigstoreBundle.
+//   - SigstoreBundle empty (legacy): the decomposed fields (RawSignature, SignaturePayload,
+//     CertPem, CertChainPem, RekorBundle) are reassembled into an oci.Signature for
+//     cosign.VerifyImageSignature.
+func retrieveVerificationDataFromImage(image *storage.Image) ([]verifiableSignature, gcrv1.Hash, error) {
 	imgSHA := imgUtils.GetSHA(image)
 	// If there is no digest associated with the image, we cannot safely do signature and claim verification.
 	if imgSHA == "" {
@@ -454,19 +616,29 @@ func retrieveVerificationDataFromImage(image *storage.Image) ([]oci.Signature, g
 			"invalid hashing algorithm %s used, only SHA256 is supported", hash.Algorithm)
 	}
 
-	// Each signature contains the base64 encoded version of it and the associated payload.
-	// In the future, this will also include potential rekor bundles for keyless verification.
-	signatures := make([]oci.Signature, 0, len(image.GetSignature().GetSignatures()))
+	vsigs := make([]verifiableSignature, 0, len(image.GetSignature().GetSignatures()))
 	for _, imgSig := range image.GetSignature().GetSignatures() {
 		if imgSig.GetCosign() == nil {
 			continue
 		}
-		b64Sig := base64.StdEncoding.EncodeToString(imgSig.GetCosign().GetRawSignature())
-		sigOpts := []static.Option{
-			static.WithCertChain(imgSig.GetCosign().GetCertPem(), imgSig.GetCosign().GetCertChainPem()),
+
+		cosignSig := imgSig.GetCosign()
+
+		// Sigstore bundle: carry the raw bundle for direct sigstore-go verification.
+		if len(cosignSig.GetSigstoreBundle()) > 0 {
+			vsigs = append(vsigs, verifiableSignature{
+				sigstoreBundle: cosignSig.GetSigstoreBundle(),
+			})
+			continue
 		}
 
-		rekorBundle, err := unmarshalRekorBundle(imgSig.GetCosign().GetRekorBundle())
+		// Legacy decomposed fields.
+		b64Sig := base64.StdEncoding.EncodeToString(cosignSig.GetRawSignature())
+		sigOpts := []static.Option{
+			static.WithCertChain(cosignSig.GetCertPem(), cosignSig.GetCertChainPem()),
+		}
+
+		rekorBundle, err := unmarshalRekorBundle(cosignSig.GetRekorBundle())
 		if err != nil {
 			log.Errorf("Failed to unmarshal rekor bundle for image %q: %s", image.GetName().GetFullName(), err)
 		}
@@ -474,54 +646,40 @@ func retrieveVerificationDataFromImage(image *storage.Image) ([]oci.Signature, g
 			sigOpts = append(sigOpts, static.WithBundle(rekorBundle))
 		}
 
-		sig, err := static.NewSignature(imgSig.GetCosign().GetSignaturePayload(), b64Sig, sigOpts...)
+		sig, err := static.NewSignature(cosignSig.GetSignaturePayload(), b64Sig, sigOpts...)
 		if err != nil {
 			return nil, gcrv1.Hash{}, errCorruptedSignature.CausedBy(err)
 		}
-		signatures = append(signatures, sig)
+		vsigs = append(vsigs, verifiableSignature{
+			sig: sig,
+		})
 	}
 
-	return signatures, hash, nil
+	return vsigs, hash, nil
 }
 
-// getVerifiedImageReferenceFromSignature retrieves the verified docker reference in the format of
-// <registry>/<repository> from the payload of the oci.Signature and filters out image names that are verified by
-// the docker reference using the image names associated with the storage.Image.
+// getVerifiedImageReference returns image names verified by a SimpleSigning signature.
+// The payload carries a docker reference; only names matching registry+repository are returned.
 func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([]string, error) {
 	payloadBytes, err := signature.Payload()
 	if err != nil {
 		return nil, err
 	}
-	// The payload of each signature will be the JSON representation of the simple signing format.
-	// This will include the docker manifest reference which was used for this specific signature, which will be our
-	// reference which is valid for this specific signature.
 	var simpleContainer payload.SimpleContainerImage
 	if err := json.Unmarshal(payloadBytes, &simpleContainer); err != nil {
 		return nil, err
 	}
 
-	// Match all image names that share the same registry and repository for the docker reference of the signature.
-	// This will ensure we mark each image name as verified as long as it is within:
-	// - the same registry
-	// - the same repository
-	// - and has the same digest
-	// This way we also cover the case where we e.g. reference an image with digest format (<registry>/<repository>@<digest>)
-	// as well as images using floating tags (<registry>/<repository>:<tag>).
 	signatureIdentity := simpleContainer.Critical.Identity.DockerReference
 	log.Debugf("Retrieving verified image references from the image names [%v] and signature identity %q",
 		image.GetNames(), signatureIdentity)
 	var verifiedImageReferences []string
-	// We must ensure here that `append` is not called directly on the result of
-	// `image.GetNames()`. Otherwise, we create a data race caused by concurrent
-	// writes to the underlying data array of the slice.
 	imageNames := protoutils.SliceUnique(
 		append([]*storage.ImageName{image.GetName()}, image.GetNames()...),
 	)
 	for _, name := range imageNames {
 		ok, err := equalRegistryRepository(signatureIdentity, name.GetFullName())
 		if err != nil {
-			// Theoretically, all references should be parsable.
-			// In case we somehow get an invalid entry, we will log the occurrence and skip this entry.
 			log.Errorf("Failed to compare image name %q and signature identity %q: %v", name.GetFullName(), signatureIdentity, err)
 			continue
 		}
@@ -530,6 +688,19 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 		}
 	}
 	return verifiedImageReferences, nil
+}
+
+func getAllImageReferences(image *storage.Image) []string {
+	imageNames := protoutils.SliceUnique(
+		append([]*storage.ImageName{image.GetName()}, image.GetNames()...),
+	)
+	refs := make([]string, 0, len(imageNames))
+	for _, n := range imageNames {
+		if fullName := n.GetFullName(); fullName != "" {
+			refs = append(refs, fullName)
+		}
+	}
+	return refs
 }
 
 func equalRegistryRepository(signatureIdentity, imageName string) (bool, error) {

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -710,20 +710,21 @@ func TestRetrieveVerificationDataFromImage_Success(t *testing.T) {
 		b64CosignSignature, b64CosignSignaturePayload, nil, nil, nil)
 	require.NoError(t, err, "error creating image")
 
-	sigs, hash, err := retrieveVerificationDataFromImage(img)
+	vsigs, hash, err := retrieveVerificationDataFromImage(img)
 	require.NoError(t, err, "should not fail")
 
-	assert.Len(t, sigs, 1, "expected one signature")
-	sig := sigs[0]
-	b64sig, err := sig.Base64Signature()
+	assert.Len(t, vsigs, 1, "expected one signature")
+	vsig := vsigs[0]
+	b64sig, err := vsig.sig.Base64Signature()
 	require.NoError(t, err)
 	assert.Equal(t, b64CosignSignature, b64sig, "expected the base64 values of the signatures to match")
-	payload, err := sig.Payload()
+	payload, err := vsig.sig.Payload()
 	require.NoError(t, err)
 	expectedPayload, err := base64.StdEncoding.DecodeString(b64CosignSignaturePayload)
 	require.NoError(t, err)
 	assert.Equal(t, expectedPayload, payload, "expected the payloads of the signature to match")
 	assert.Equal(t, imgHash, hash.String(), "expected the hash to match the image's hash")
+	assert.Empty(t, vsig.sigstoreBundle)
 }
 
 func TestRetrieveVerificationDataFromImage_Failure(t *testing.T) {
@@ -752,6 +753,66 @@ func TestRetrieveVerificationDataFromImage_Failure(t *testing.T) {
 			assert.ErrorIs(t, err, c.err)
 		})
 	}
+}
+
+func TestRetrieveVerificationDataFromImage_SigstoreBundle(t *testing.T) {
+	imgHash := "sha256:3a4d57227f02243dfc8a2849ec4a116646bed293b9e93cbf9d4a673a28ef6345"
+	bundleJSON := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+
+	cimg, err := imgUtils.GenerateImageFromString("docker.io/nginx@" + imgHash)
+	require.NoError(t, err)
+	img := types.ToImage(cimg)
+	img.Signature = &storage.ImageSignature{
+		Signatures: []*storage.Signature{
+			{
+				Signature: &storage.Signature_Cosign{
+					Cosign: &storage.CosignSignature{
+						SigstoreBundle:  bundleJSON,
+						SignatureFormat: storage.CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE,
+					},
+				},
+			},
+		},
+	}
+
+	vsigs, hash, err := retrieveVerificationDataFromImage(img)
+	require.NoError(t, err)
+	assert.Len(t, vsigs, 1)
+	assert.Equal(t, bundleJSON, vsigs[0].sigstoreBundle)
+	assert.Nil(t, vsigs[0].sig)
+	assert.Equal(t, imgHash, hash.String())
+}
+
+func TestRetrieveVerificationDataFromImage_MixedFormats(t *testing.T) {
+	imgHash := "sha256:3a4d57227f02243dfc8a2849ec4a116646bed293b9e93cbf9d4a673a28ef6345"
+	bundleJSON := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+
+	img, err := generateImageWithCosignSignature("docker.io/nginx@"+imgHash,
+		"MEUCIDGMmJyxVKGPxvPk/QlRzMSGzcI8pYCy+MB7RTTpegzTAiEArssqWntVN8oJOMV0Aey0zhsNqRmEVQAY"+
+			"ZNkn8hkAnXI=",
+		"eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2Q4ZDM4O"+
+			"TJkLTQ4YmQtNDY3MS1hNTQ2LTJlNzBhOTAwYjcwMiJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmVlODli"+
+			"MDA1MjhmZjRmMDJmMjQwNWU0ZWUyMjE3NDNlYmMzZjhlOGRkMGJmZDVjNGMyMGEyZmEyYWFhN2VkZTMifSwidHlwZSI6ImNvc2lnbiBjb25"+
+			"0YWluZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ==",
+		nil, nil, nil)
+	require.NoError(t, err)
+	// Add a second signature with a sigstore bundle.
+	img.GetSignature().Signatures = append(img.GetSignature().GetSignatures(), &storage.Signature{
+		Signature: &storage.Signature_Cosign{
+			Cosign: &storage.CosignSignature{
+				SigstoreBundle:  bundleJSON,
+				SignatureFormat: storage.CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE,
+			},
+		},
+	})
+
+	vsigs, _, err := retrieveVerificationDataFromImage(img)
+	require.NoError(t, err)
+	assert.Len(t, vsigs, 2)
+	assert.NotNil(t, vsigs[0].sig, "first signature should be SimpleSigning")
+	assert.Empty(t, vsigs[0].sigstoreBundle)
+	assert.Nil(t, vsigs[1].sig, "second signature should be bundle-only")
+	assert.Equal(t, bundleJSON, vsigs[1].sigstoreBundle)
 }
 
 func TestEqualRegistryRepository(t *testing.T) {

--- a/pkg/signatures/factory.go
+++ b/pkg/signatures/factory.go
@@ -27,7 +27,8 @@ type SignatureVerifier interface {
 
 // SignatureFetcher is responsible for fetching raw signatures supporting multiple specific signature formats.
 type SignatureFetcher interface {
-	FetchSignatures(ctx context.Context, image *storage.Image, fullImageName string, registry registryTypes.Registry) ([]*storage.Signature, error)
+	FetchSignatures(ctx context.Context, image *storage.Image, fullImageName string,
+		registry registryTypes.Registry, retryOpts ...retry.OptionsModifier) ([]*storage.Signature, error)
 }
 
 // NewSignatureVerifier creates a new signature verifier capable of verifying signatures against the provided config.
@@ -121,20 +122,14 @@ func FetchImageSignaturesWithRetries(ctx context.Context, fetcher SignatureFetch
 		return nil, nil
 	}
 
-	var fetchedSignatures []*storage.Signature
-	var err error
-	err = retry.WithRetry(func() error {
-		sigFetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-		fetchedSignatures, err = fetcher.FetchSignatures(sigFetchCtx, image, fullImageName, registry)
-		return err
-	},
+	retryOpts := []retry.OptionsModifier{
 		retry.WithContext(ctx),
 		retry.Tries(5),
 		retry.OnlyRetryableErrors(),
 		retry.BetweenAttempts(func(_ int) {
 			time.Sleep(500 * time.Millisecond)
-		}))
+		}),
+	}
 
-	return fetchedSignatures, err
+	return fetcher.FetchSignatures(ctx, image, fullImageName, registry, retryOpts...)
 }

--- a/proto/storage/image.proto
+++ b/proto/storage/image.proto
@@ -200,6 +200,22 @@ message CosignSignature {
   bytes cert_pem = 3;
   bytes cert_chain_pem = 4;
   bytes rekor_bundle = 5;
+
+  // Signature format used in this message.
+  enum SignatureFormat {
+    UNSPECIFIED = 0;
+    // SimpleSigning: signature is stored across raw_signature, signature_payload,
+    // cert_pem, cert_chain_pem, and rekor_bundle.
+    SIMPLE_SIGNING = 1;
+    // DSSE (Dead Simple Signing Envelope): signature is a complete sigstore bundle
+    // stored in sigstore_bundle. The decomposed simple signing fields are not used.
+    DEAD_SIMPLE_SIGNING_ENVELOPE = 2;
+  }
+  SignatureFormat signature_format = 6;
+
+  // Complete sigstore bundle as raw JSON. When populated, it supersedes the
+  // decomposed simple signing fields.
+  bytes sigstore_bundle = 7;
 }
 
 message V2Metadata {

--- a/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageSignatureVerificationTest.groovy
@@ -42,6 +42,8 @@ class ImageSignatureVerificationTest extends BaseSpecification {
     static final private String KEYLESS_SIGSTORE_UNVERIFIABLE = "Keyless-Sigstore-Unverifiable"
     static final private String KEYLESS_RHTAS_MATCHING = "Keyless-RHTAS-Matching"
     static final private String KEYLESS_RHTAS_UNVERIFIABLE = "Keyless-RHTAS-Unverifiable"
+    static final private String REFERRER_SIGSTORE_BUNDLE_PUBKEY = "Referrer-SigstoreBundle-PubKey"
+    static final private String REFERRER_SIGSTORE_BUNDLE_KEYLESS = "Referrer-SigstoreBundle-Keyless"
 
     // List of integration names used within tests.
     // NOTE: If you add a new name, make sure to add it here.
@@ -59,6 +61,8 @@ class ImageSignatureVerificationTest extends BaseSpecification {
             KEYLESS_SIGSTORE_UNVERIFIABLE,
             KEYLESS_RHTAS_MATCHING,
             KEYLESS_RHTAS_UNVERIFIABLE,
+            REFERRER_SIGSTORE_BUNDLE_PUBKEY,
+            REFERRER_SIGSTORE_BUNDLE_KEYLESS,
     ]
 
     // Public keys used within signature integrations.
@@ -139,6 +143,17 @@ nzTe7BpOmVwmqLkIefEJe5L4PSXtp2KFLZqGO/kY5A==
     static final private String BYOPKI_UNVERIFIABLE_ISSUER = "invalid"
     static final private String BYOPKI_UNVERIFIABLE_IDENTITY = "invalid"
 
+    // Public key used to sign the referrer-based test images (both SimpleSigning and sigstore bundle).
+    // Source: https://vault.bitwarden.com/#/vault?itemId=95313e19-de46-4533-b160-af620120452a.
+    static final private Map<String, String> REFERRER_COSIGN_PUBLIC_KEY = [
+            "Referrer": """\
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu8+OtJR+dVIDHk89zl8WnzcQskow
+bfbvZqSDudXtfGwpKu6tZ1CtH9utaLkglXynrLNecl0QvrhuCuKA/htSwA==
+-----END PUBLIC KEY-----
+""",
+    ]
+
     static final private String KEYLESS_SIGSTORE_ISSUER = "https://github.com/login/oauth"
     static final private String KEYLESS_SIGSTORE_IDENTITY = ".*@redhat.com"
     static final private String KEYLESS_SIGSTORE_REKOR_URL = "https://rekor.sigstore.dev"
@@ -191,6 +206,10 @@ YTuoC8lh1tt0nLkIQpdAJMuWndZJkRHcZriW1Qc2l3Mau0DtuYK17uz7pEwci+tK
             "sha256:37f7b378a29ceb4c551b1b5582e27747b855bbfaa73fa11914fe0df028dc581f"
     static final private String KEYLESS_RHTAS_IMAGE_DIGEST =
             "sha256:e246aa22ad2cbdfbd19e2a6ca2b275e26245a21920e2b2d0666324cee3f15549"
+    static final private String REFERRER_SIGSTORE_BUNDLE_PUBKEY_IMAGE_DIGEST =
+            "sha256:9e2bbca079387d7965c3a9cee6d0c53f4f4e63ff7637877a83c4c05f2a666112"
+    static final private String REFERRER_SIGSTORE_BUNDLE_KEYLESS_IMAGE_DIGEST =
+            "sha256:98ad9d1a2be345201bb0709b0d38655eb1b370145c7d94ca1fe9c421f76e245a"
 
     static final private List<String> IMAGE_DIGESTS = [
             DISTROLESS_IMAGE_DIGEST,
@@ -202,6 +221,8 @@ YTuoC8lh1tt0nLkIQpdAJMuWndZJkRHcZriW1Qc2l3Mau0DtuYK17uz7pEwci+tK
             BYOPKI_IMAGE_DIGEST,
             KEYLESS_SIGSTORE_IMAGE_DIGEST,
             KEYLESS_RHTAS_IMAGE_DIGEST,
+            REFERRER_SIGSTORE_BUNDLE_PUBKEY_IMAGE_DIGEST,
+            REFERRER_SIGSTORE_BUNDLE_KEYLESS_IMAGE_DIGEST,
     ]
 
     // Deployment holding an image which has a cosign signature that is verifiable with the DISTROLESS_PUBLIC_KEY.
@@ -291,6 +312,26 @@ YTuoC8lh1tt0nLkIQpdAJMuWndZJkRHcZriW1Qc2l3Mau0DtuYK17uz7pEwci+tK
             .setNamespace(SIGNATURE_TESTING_NAMESPACE)
             .setImagePrefetcherAffinity()
 
+    // Deployment holding an image signed with a public key using the sigstore bundle format.
+    static final private Deployment REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT = new Deployment()
+            .setName("referrer-sigstore-bundle-pubkey")
+            .setImage("quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-pubkey" +
+                    "@$REFERRER_SIGSTORE_BUNDLE_PUBKEY_IMAGE_DIGEST")
+            .addLabel("app", "image-with-referrer-sigstore-bundle-pubkey")
+            .setCommand(["sleep", "600"])
+            .setNamespace(SIGNATURE_TESTING_NAMESPACE)
+            .setImagePrefetcherAffinity()
+
+    // Deployment holding an image signed keyless using the sigstore bundle format.
+    static final private Deployment REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT = new Deployment()
+            .setName("referrer-sigstore-bundle-keyless")
+            .setImage("quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-keyless" +
+                    "@$REFERRER_SIGSTORE_BUNDLE_KEYLESS_IMAGE_DIGEST")
+            .addLabel("app", "image-with-referrer-sigstore-bundle-keyless")
+            .setCommand(["sleep", "600"])
+            .setNamespace(SIGNATURE_TESTING_NAMESPACE)
+            .setImagePrefetcherAffinity()
+
     // List of deployments used within the tests. This will be used during setup of the spec / teardown to create /
     // delete all deployments.
     // NOTE: If you add another deployment, make sure to add it here as well.
@@ -304,6 +345,8 @@ YTuoC8lh1tt0nLkIQpdAJMuWndZJkRHcZriW1Qc2l3Mau0DtuYK17uz7pEwci+tK
             BYOPKI_DEPLOYMENT,
             KEYLESS_SIGSTORE_DEPLOYMENT,
             KEYLESS_RHTAS_DEPLOYMENT,
+            REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT,
+            REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT,
     ]
 
     // Base policy which will be used for creating subsequent policies that have signature integration IDs as values.
@@ -486,6 +529,27 @@ YTuoC8lh1tt0nLkIQpdAJMuWndZJkRHcZriW1Qc2l3Mau0DtuYK17uz7pEwci+tK
         assert keylessRHTASUnverifiableSignatureIntegrationID
         CREATED_SIGNATURE_INTEGRATIONS.put(KEYLESS_RHTAS_UNVERIFIABLE,
             keylessRHTASUnverifiableSignatureIntegrationID)
+
+        // Signature integration for referrer sigstore bundle signed with a public key.
+        String referrerSigstoreBundlePubKeyID = createSignatureIntegration(
+            REFERRER_SIGSTORE_BUNDLE_PUBKEY, REFERRER_COSIGN_PUBLIC_KEY,
+        )
+        assert referrerSigstoreBundlePubKeyID
+        CREATED_SIGNATURE_INTEGRATIONS.put(REFERRER_SIGSTORE_BUNDLE_PUBKEY, referrerSigstoreBundlePubKeyID)
+
+        // Signature integration for referrer sigstore bundle signed keyless via public Sigstore.
+        String referrerSigstoreBundleKeylessID = createSignatureIntegration(
+            REFERRER_SIGSTORE_BUNDLE_KEYLESS, NO_PUBLIC_KEYS,
+            new CertificateVerificationArgs(
+                chain: "",
+                identity: KEYLESS_SIGSTORE_IDENTITY,
+                issuer: KEYLESS_SIGSTORE_ISSUER,
+                ctlogEnabled: true,
+            ),
+            new TransparencyLogVerificationArgs(enabled: true, url: KEYLESS_SIGSTORE_REKOR_URL),
+        )
+        assert referrerSigstoreBundleKeylessID
+        CREATED_SIGNATURE_INTEGRATIONS.put(REFERRER_SIGSTORE_BUNDLE_KEYLESS, referrerSigstoreBundleKeylessID)
 
         // Create all required deployments.
         orchestrator.batchCreateDeployments(DEPLOYMENTS)
@@ -704,7 +768,50 @@ YTuoC8lh1tt0nLkIQpdAJMuWndZJkRHcZriW1Qc2l3Mau0DtuYK17uz7pEwci+tK
         KEYLESS_RHTAS_UNVERIFIABLE                 | SAME_DIGEST_WITH_SIGNATURE   | true
         KEYLESS_RHTAS_UNVERIFIABLE                 | TEKTON_DEPLOYMENT            | true
         KEYLESS_RHTAS_UNVERIFIABLE                 | UNVERIFIABLE_DEPLOYMENT      | true
-        KEYLESS_RHTAS_UNVERIFIABLE                 | WITHOUT_SIGNATURE_DEPLOYMENT | true
+        KEYLESS_RHTAS_UNVERIFIABLE                 | WITHOUT_SIGNATURE_DEPLOYMENT                     | true
+        // Existing integrations should alert for all referrer-based deployments.
+        DISTROLESS                                 | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        DISTROLESS                                 | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        TEKTON                                     | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        TEKTON                                     | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        UNVERIFIABLE                               | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        UNVERIFIABLE                               | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        DISTROLESS_AND_TEKTON                      | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        DISTROLESS_AND_TEKTON                      | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        POLICY_WITH_DISTROLESS_TEKTON_UNVERIFIABLE | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        POLICY_WITH_DISTROLESS_TEKTON_UNVERIFIABLE | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        SAME_DIGEST                                | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        SAME_DIGEST                                | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        BYOPKI_WILDCARD                            | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        BYOPKI_WILDCARD                            | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        BYOPKI_MATCHING                            | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        BYOPKI_MATCHING                            | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        BYOPKI_UNVERIFIABLE                        | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        BYOPKI_UNVERIFIABLE                        | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        BYOPKI_WILDCARD_AND_TEKTON                 | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        BYOPKI_WILDCARD_AND_TEKTON                 | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        KEYLESS_SIGSTORE_MATCHING                  | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        KEYLESS_SIGSTORE_MATCHING                  | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        KEYLESS_SIGSTORE_UNVERIFIABLE              | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        KEYLESS_SIGSTORE_UNVERIFIABLE              | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        KEYLESS_RHTAS_MATCHING                     | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        KEYLESS_RHTAS_MATCHING                     | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        KEYLESS_RHTAS_UNVERIFIABLE                 | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        KEYLESS_RHTAS_UNVERIFIABLE                 | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        // Referrer SimpleSigning with public key: only the matching deployment passes.
+        // Referrer SimpleSigning with keyless: only the matching deployment passes.
+        // Referrer sigstore bundle with public key: only the matching deployment passes.
+        REFERRER_SIGSTORE_BUNDLE_PUBKEY            | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | false
+        REFERRER_SIGSTORE_BUNDLE_PUBKEY            | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | true
+        REFERRER_SIGSTORE_BUNDLE_PUBKEY            | DISTROLESS_DEPLOYMENT                             | true
+        REFERRER_SIGSTORE_BUNDLE_PUBKEY            | TEKTON_DEPLOYMENT                                 | true
+        REFERRER_SIGSTORE_BUNDLE_PUBKEY            | WITHOUT_SIGNATURE_DEPLOYMENT                      | true
+        // Referrer sigstore bundle with keyless: only the matching deployment passes.
+        REFERRER_SIGSTORE_BUNDLE_KEYLESS           | REFERRER_SIGSTORE_BUNDLE_PUBKEY_DEPLOYMENT        | true
+        REFERRER_SIGSTORE_BUNDLE_KEYLESS           | REFERRER_SIGSTORE_BUNDLE_KEYLESS_DEPLOYMENT       | false
+        REFERRER_SIGSTORE_BUNDLE_KEYLESS           | DISTROLESS_DEPLOYMENT                             | true
+        REFERRER_SIGSTORE_BUNDLE_KEYLESS           | TEKTON_DEPLOYMENT                                 | true
+        REFERRER_SIGSTORE_BUNDLE_KEYLESS           | WITHOUT_SIGNATURE_DEPLOYMENT                      | true
     }
 
     // Helper which creates a policy builder for a policy which uses the image signature policy criteria.

--- a/qa-tests-backend/src/test/groovy/testdata/referrer-test-images.md
+++ b/qa-tests-backend/src/test/groovy/testdata/referrer-test-images.md
@@ -1,0 +1,70 @@
+# Referrer-based Signature Test Images
+
+Instructions for creating test images with OCI 1.1 referrer-based sigstore
+bundle signatures for `ImageSignatureVerificationTest`.
+
+## Prerequisites
+
+```bash
+cosign version  # requires v3+ for --new-bundle-format
+crane version   # for copying base images
+```
+
+## Generate a key pair
+
+```bash
+cosign generate-key-pair
+# Produces cosign.key (private) and cosign.pub (public).
+# Store both in Bitwarden alongside existing signature test credentials.
+```
+
+## 1. referrer-sigstore-bundle-pubkey
+
+Sigstore bundle format, public key, attached as OCI referrer.
+
+```bash
+crane cp docker.io/library/alpine:latest \
+  quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-pubkey
+
+DIGEST=$(crane digest quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-pubkey)
+
+cosign sign \
+  --key cosign.key \
+  --new-bundle-format \
+  "quay.io/rhacs-eng/qa-signatures@$DIGEST"
+```
+
+## 2. referrer-sigstore-bundle-keyless
+
+Sigstore bundle format, keyless (public Sigstore), attached as OCI referrer.
+Sign with an `@redhat.com` GitHub identity to match the test's OIDC config.
+
+```bash
+crane cp docker.io/library/alpine:latest \
+  quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-keyless
+
+DIGEST=$(crane digest quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-keyless)
+
+cosign sign \
+  --new-bundle-format \
+  "quay.io/rhacs-eng/qa-signatures@$DIGEST"
+```
+
+## After signing
+
+Update `ImageSignatureVerificationTest.groovy` with:
+- `REFERRER_COSIGN_PUBLIC_KEY`: contents of `cosign.pub`
+- `REFERRER_SIGSTORE_BUNDLE_PUBKEY_IMAGE_DIGEST`: digest from step 1
+- `REFERRER_SIGSTORE_BUNDLE_KEYLESS_IMAGE_DIGEST`: digest from step 2
+
+## Verification
+
+```bash
+cosign verify --key cosign.pub --new-bundle-format \
+  quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-pubkey
+
+cosign verify --new-bundle-format \
+  --certificate-identity-regexp=".*@redhat.com" \
+  --certificate-oidc-issuer="https://github.com/login/oauth" \
+  quay.io/rhacs-eng/qa-signatures:referrer-sigstore-bundle-keyless
+```


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`FetchSignatures` now queries both the legacy tag-based path (sha256-<digest>.sig) and the OCI 1.1 Referrers API for cosign signature artifacts. Results from both methods are merged and deduplicated. No configuration toggle is needed — both discovery methods are always attempted, and referrer errors are gracefully swallowed so registries without OCI 1.1 support continue working.

This enables RHACS to verify images signed with cosign v3+ which defaults to storing signatures as OCI referrers rather than legacy tags.


### Walkthrough

```
┌───────────────────────────────────────────────┬──────────┬─────────────────────────────────────────────────────────────────────────────────────┐
│                     File                      │  Change  │                                       Summary                                       │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│                                               │          │ Refactors FetchSignatures to run tag-based and referrer-based discovery             │
│ pkg/signatures/cosign_sig_fetcher.go          │ Modified │ concurrently via sync.WaitGroup.Go, merging and deduplicating results. Moves retry  │
│                                               │          │ logic into fetchWithRetry helper.                                                   │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│                                               │          │ New file implementing fetchTagPayloads, fetchReferrerPayloads, and the              │
│ pkg/signatures/cosign_payload_fetcher.go      │ Added    │ tagSignedEntity/referrerSignedEntity adapters for cosign's oci.SignedEntity         │
│                                               │          │ interface.                                                                          │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ pkg/signatures/factory.go                     │ Modified │ Pushes retry options into SignatureFetcher.FetchSignatures via variadic retryOpts   │
│                                               │          │ parameter, removing the external retry wrapper.                                     │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ pkg/signatures/cosign_sig_fetcher_test.go     │ Modified │ Adds tests for referrer-only, both-paths, deduplication, no-signatures-from-either, │
│                                               │          │  no-V2-metadata, and authenticated transport scenarios.                             │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ pkg/signatures/cosign_payload_fetcher_test.go │ Added    │ Tests for fetchTagPayloads and fetchReferrerPayloads with and without signatures.   │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ pkg/images/enricher/testing_test.go           │ Modified │ Updates FetchSignatures mock signature to include new retryOpts parameter.          │
├───────────────────────────────────────────────┼──────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ CHANGELOG.md                                  │ Modified │ Documents new OCI 1.1 Referrers API support.                                        │
└───────────────────────────────────────────────┴──────────┴─────────────────────────────────────────────────────────────────────────────────────┘
```

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
