### PR TITLE
ROX-34097: PoC roxctl version skew warning

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -207,7 +207,24 @@ func (s *serviceImpl) GetMetadata(ctx context.Context, _ *v1.Empty) (*v1.Metadat
 	if authn.IdentityFromContextOrNil(ctx) != nil {
 		metadata.Version = version.GetMainVersion()
 	}
+	metadata.KnownMajorBumps = knownMajorBumpsProto()
 	return metadata, nil
+}
+
+func knownMajorBumpsProto() []*v1.MajorVersionBump {
+	bumps, err := version.EmbeddedMajorBumps()
+	if err != nil {
+		log.Warnf("Failed to load embedded major version bumps: %v", err)
+		return nil
+	}
+	out := make([]*v1.MajorVersionBump, 0, len(bumps))
+	for _, b := range bumps {
+		out = append(out, &v1.MajorVersionBump{
+			FromVersion: b.From.String(),
+			ToVersion:   b.To.String(),
+		})
+	}
+	return out
 }
 
 // TLSChallenge implements a secure certificate discovery mechanism via an unauthenticated endpoint

--- a/generated/api/v1/metadata_service.pb.go
+++ b/generated/api/v1/metadata_service.pb.go
@@ -79,7 +79,7 @@ func (x Metadata_LicenseStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Metadata_LicenseStatus.Descriptor instead.
 func (Metadata_LicenseStatus) EnumDescriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{0, 0}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{1, 0}
 }
 
 type DatabaseStatus_DatabaseType int32
@@ -128,7 +128,7 @@ func (x DatabaseStatus_DatabaseType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DatabaseStatus_DatabaseType.Descriptor instead.
 func (DatabaseStatus_DatabaseType) EnumDescriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{4, 0}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{5, 0}
 }
 
 type CentralServicesCapabilities_CapabilityStatus int32
@@ -180,7 +180,61 @@ func (x CentralServicesCapabilities_CapabilityStatus) Number() protoreflect.Enum
 
 // Deprecated: Use CentralServicesCapabilities_CapabilityStatus.Descriptor instead.
 func (CentralServicesCapabilities_CapabilityStatus) EnumDescriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{6, 0}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{7, 0}
+}
+
+type MajorVersionBump struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Last minor release before the bump (e.g., "3.74").
+	FromVersion string `protobuf:"bytes,1,opt,name=from_version,json=fromVersion,proto3" json:"from_version,omitempty"`
+	// First release of the new major version (e.g., "4.0").
+	ToVersion     string `protobuf:"bytes,2,opt,name=to_version,json=toVersion,proto3" json:"to_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MajorVersionBump) Reset() {
+	*x = MajorVersionBump{}
+	mi := &file_api_v1_metadata_service_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MajorVersionBump) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MajorVersionBump) ProtoMessage() {}
+
+func (x *MajorVersionBump) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_metadata_service_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MajorVersionBump.ProtoReflect.Descriptor instead.
+func (*MajorVersionBump) Descriptor() ([]byte, []int) {
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *MajorVersionBump) GetFromVersion() string {
+	if x != nil {
+		return x.FromVersion
+	}
+	return ""
+}
+
+func (x *MajorVersionBump) GetToVersion() string {
+	if x != nil {
+		return x.ToVersion
+	}
+	return ""
 }
 
 type Metadata struct {
@@ -192,13 +246,17 @@ type Metadata struct {
 	//
 	// Deprecated: Marked as deprecated in api/v1/metadata_service.proto.
 	LicenseStatus Metadata_LicenseStatus `protobuf:"varint,4,opt,name=license_status,json=licenseStatus,proto3,enum=v1.Metadata_LicenseStatus" json:"license_status,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Known major version bumps in the product's release history.
+	// Clients (roxctl, Sensor) embed their own copy of this data;
+	// the union of both sets gives the most accurate version-range computation.
+	KnownMajorBumps []*MajorVersionBump `protobuf:"bytes,5,rep,name=known_major_bumps,json=knownMajorBumps,proto3" json:"known_major_bumps,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *Metadata) Reset() {
 	*x = Metadata{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[0]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -210,7 +268,7 @@ func (x *Metadata) String() string {
 func (*Metadata) ProtoMessage() {}
 
 func (x *Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[0]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -223,7 +281,7 @@ func (x *Metadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metadata.ProtoReflect.Descriptor instead.
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{0}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *Metadata) GetVersion() string {
@@ -255,6 +313,13 @@ func (x *Metadata) GetLicenseStatus() Metadata_LicenseStatus {
 	return Metadata_NONE
 }
 
+func (x *Metadata) GetKnownMajorBumps() []*MajorVersionBump {
+	if x != nil {
+		return x.KnownMajorBumps
+	}
+	return nil
+}
+
 type TrustInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// holds the certificate chain held by Central
@@ -273,7 +338,7 @@ type TrustInfo struct {
 
 func (x *TrustInfo) Reset() {
 	*x = TrustInfo{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[1]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -285,7 +350,7 @@ func (x *TrustInfo) String() string {
 func (*TrustInfo) ProtoMessage() {}
 
 func (x *TrustInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[1]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -298,7 +363,7 @@ func (x *TrustInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TrustInfo.ProtoReflect.Descriptor instead.
 func (*TrustInfo) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{1}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *TrustInfo) GetCertChain() [][]byte {
@@ -350,7 +415,7 @@ type TLSChallengeResponse struct {
 
 func (x *TLSChallengeResponse) Reset() {
 	*x = TLSChallengeResponse{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[2]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -362,7 +427,7 @@ func (x *TLSChallengeResponse) String() string {
 func (*TLSChallengeResponse) ProtoMessage() {}
 
 func (x *TLSChallengeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[2]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -375,7 +440,7 @@ func (x *TLSChallengeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TLSChallengeResponse.ProtoReflect.Descriptor instead.
 func (*TLSChallengeResponse) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{2}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *TLSChallengeResponse) GetTrustInfoSerialized() []byte {
@@ -409,7 +474,7 @@ type TLSChallengeRequest struct {
 
 func (x *TLSChallengeRequest) Reset() {
 	*x = TLSChallengeRequest{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[3]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -421,7 +486,7 @@ func (x *TLSChallengeRequest) String() string {
 func (*TLSChallengeRequest) ProtoMessage() {}
 
 func (x *TLSChallengeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[3]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,7 +499,7 @@ func (x *TLSChallengeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TLSChallengeRequest.ProtoReflect.Descriptor instead.
 func (*TLSChallengeRequest) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{3}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *TLSChallengeRequest) GetChallengeToken() string {
@@ -459,7 +524,7 @@ type DatabaseStatus struct {
 
 func (x *DatabaseStatus) Reset() {
 	*x = DatabaseStatus{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[4]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -471,7 +536,7 @@ func (x *DatabaseStatus) String() string {
 func (*DatabaseStatus) ProtoMessage() {}
 
 func (x *DatabaseStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[4]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -484,7 +549,7 @@ func (x *DatabaseStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatabaseStatus.ProtoReflect.Descriptor instead.
 func (*DatabaseStatus) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{4}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DatabaseStatus) GetDatabaseAvailable() bool {
@@ -524,7 +589,7 @@ type DatabaseBackupStatus struct {
 
 func (x *DatabaseBackupStatus) Reset() {
 	*x = DatabaseBackupStatus{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[5]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -536,7 +601,7 @@ func (x *DatabaseBackupStatus) String() string {
 func (*DatabaseBackupStatus) ProtoMessage() {}
 
 func (x *DatabaseBackupStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[5]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -549,7 +614,7 @@ func (x *DatabaseBackupStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatabaseBackupStatus.ProtoReflect.Descriptor instead.
 func (*DatabaseBackupStatus) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{5}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *DatabaseBackupStatus) GetBackupInfo() *storage.BackupInfo {
@@ -585,7 +650,7 @@ type CentralServicesCapabilities struct {
 
 func (x *CentralServicesCapabilities) Reset() {
 	*x = CentralServicesCapabilities{}
-	mi := &file_api_v1_metadata_service_proto_msgTypes[6]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -597,7 +662,7 @@ func (x *CentralServicesCapabilities) String() string {
 func (*CentralServicesCapabilities) ProtoMessage() {}
 
 func (x *CentralServicesCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_metadata_service_proto_msgTypes[6]
+	mi := &file_api_v1_metadata_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -610,7 +675,7 @@ func (x *CentralServicesCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CentralServicesCapabilities.ProtoReflect.Descriptor instead.
 func (*CentralServicesCapabilities) Descriptor() ([]byte, []int) {
-	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{6}
+	return file_api_v1_metadata_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CentralServicesCapabilities) GetCentralScanningCanUseContainerIamRoleForEcr() CentralServicesCapabilities_CapabilityStatus {
@@ -652,12 +717,17 @@ var File_api_v1_metadata_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_metadata_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dapi/v1/metadata_service.proto\x12\x02v1\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19storage/system_info.proto\"\x93\x02\n" +
+	"\x1dapi/v1/metadata_service.proto\x12\x02v1\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x19storage/system_info.proto\"T\n" +
+	"\x10MajorVersionBump\x12!\n" +
+	"\ffrom_version\x18\x01 \x01(\tR\vfromVersion\x12\x1d\n" +
+	"\n" +
+	"to_version\x18\x02 \x01(\tR\ttoVersion\"\xd5\x02\n" +
 	"\bMetadata\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12!\n" +
 	"\fbuild_flavor\x18\x02 \x01(\tR\vbuildFlavor\x12#\n" +
 	"\rrelease_build\x18\x03 \x01(\bR\freleaseBuild\x12E\n" +
-	"\x0elicense_status\x18\x04 \x01(\x0e2\x1a.v1.Metadata.LicenseStatusB\x02\x18\x01R\rlicenseStatus\"^\n" +
+	"\x0elicense_status\x18\x04 \x01(\x0e2\x1a.v1.Metadata.LicenseStatusB\x02\x18\x01R\rlicenseStatus\x12@\n" +
+	"\x11known_major_bumps\x18\x05 \x03(\v2\x14.v1.MajorVersionBumpR\x0fknownMajorBumps\"^\n" +
 	"\rLicenseStatus\x12\f\n" +
 	"\x04NONE\x10\x00\x1a\x02\b\x01\x12\x0f\n" +
 	"\aINVALID\x10\x01\x1a\x02\b\x01\x12\x0f\n" +
@@ -722,45 +792,47 @@ func file_api_v1_metadata_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v1_metadata_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_v1_metadata_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_api_v1_metadata_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_api_v1_metadata_service_proto_goTypes = []any{
 	(Metadata_LicenseStatus)(0),                       // 0: v1.Metadata.LicenseStatus
 	(DatabaseStatus_DatabaseType)(0),                  // 1: v1.DatabaseStatus.DatabaseType
 	(CentralServicesCapabilities_CapabilityStatus)(0), // 2: v1.CentralServicesCapabilities.CapabilityStatus
-	(*Metadata)(nil),                                  // 3: v1.Metadata
-	(*TrustInfo)(nil),                                 // 4: v1.TrustInfo
-	(*TLSChallengeResponse)(nil),                      // 5: v1.TLSChallengeResponse
-	(*TLSChallengeRequest)(nil),                       // 6: v1.TLSChallengeRequest
-	(*DatabaseStatus)(nil),                            // 7: v1.DatabaseStatus
-	(*DatabaseBackupStatus)(nil),                      // 8: v1.DatabaseBackupStatus
-	(*CentralServicesCapabilities)(nil),               // 9: v1.CentralServicesCapabilities
-	(*storage.BackupInfo)(nil),                        // 10: storage.BackupInfo
-	(*Empty)(nil),                                     // 11: v1.Empty
+	(*MajorVersionBump)(nil),                          // 3: v1.MajorVersionBump
+	(*Metadata)(nil),                                  // 4: v1.Metadata
+	(*TrustInfo)(nil),                                 // 5: v1.TrustInfo
+	(*TLSChallengeResponse)(nil),                      // 6: v1.TLSChallengeResponse
+	(*TLSChallengeRequest)(nil),                       // 7: v1.TLSChallengeRequest
+	(*DatabaseStatus)(nil),                            // 8: v1.DatabaseStatus
+	(*DatabaseBackupStatus)(nil),                      // 9: v1.DatabaseBackupStatus
+	(*CentralServicesCapabilities)(nil),               // 10: v1.CentralServicesCapabilities
+	(*storage.BackupInfo)(nil),                        // 11: storage.BackupInfo
+	(*Empty)(nil),                                     // 12: v1.Empty
 }
 var file_api_v1_metadata_service_proto_depIdxs = []int32{
 	0,  // 0: v1.Metadata.license_status:type_name -> v1.Metadata.LicenseStatus
-	1,  // 1: v1.DatabaseStatus.database_type:type_name -> v1.DatabaseStatus.DatabaseType
-	10, // 2: v1.DatabaseBackupStatus.backup_info:type_name -> storage.BackupInfo
-	2,  // 3: v1.CentralServicesCapabilities.central_scanning_can_use_container_iam_role_for_ecr:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
-	2,  // 4: v1.CentralServicesCapabilities.central_can_use_cloud_backup_integrations:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
-	2,  // 5: v1.CentralServicesCapabilities.central_can_display_declarative_config_health:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
-	2,  // 6: v1.CentralServicesCapabilities.central_can_update_cert:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
-	2,  // 7: v1.CentralServicesCapabilities.central_can_use_acscs_email_integration:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
-	11, // 8: v1.MetadataService.GetMetadata:input_type -> v1.Empty
-	6,  // 9: v1.MetadataService.TLSChallenge:input_type -> v1.TLSChallengeRequest
-	11, // 10: v1.MetadataService.GetDatabaseStatus:input_type -> v1.Empty
-	11, // 11: v1.MetadataService.GetDatabaseBackupStatus:input_type -> v1.Empty
-	11, // 12: v1.MetadataService.GetCentralCapabilities:input_type -> v1.Empty
-	3,  // 13: v1.MetadataService.GetMetadata:output_type -> v1.Metadata
-	5,  // 14: v1.MetadataService.TLSChallenge:output_type -> v1.TLSChallengeResponse
-	7,  // 15: v1.MetadataService.GetDatabaseStatus:output_type -> v1.DatabaseStatus
-	8,  // 16: v1.MetadataService.GetDatabaseBackupStatus:output_type -> v1.DatabaseBackupStatus
-	9,  // 17: v1.MetadataService.GetCentralCapabilities:output_type -> v1.CentralServicesCapabilities
-	13, // [13:18] is the sub-list for method output_type
-	8,  // [8:13] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	3,  // 1: v1.Metadata.known_major_bumps:type_name -> v1.MajorVersionBump
+	1,  // 2: v1.DatabaseStatus.database_type:type_name -> v1.DatabaseStatus.DatabaseType
+	11, // 3: v1.DatabaseBackupStatus.backup_info:type_name -> storage.BackupInfo
+	2,  // 4: v1.CentralServicesCapabilities.central_scanning_can_use_container_iam_role_for_ecr:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
+	2,  // 5: v1.CentralServicesCapabilities.central_can_use_cloud_backup_integrations:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
+	2,  // 6: v1.CentralServicesCapabilities.central_can_display_declarative_config_health:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
+	2,  // 7: v1.CentralServicesCapabilities.central_can_update_cert:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
+	2,  // 8: v1.CentralServicesCapabilities.central_can_use_acscs_email_integration:type_name -> v1.CentralServicesCapabilities.CapabilityStatus
+	12, // 9: v1.MetadataService.GetMetadata:input_type -> v1.Empty
+	7,  // 10: v1.MetadataService.TLSChallenge:input_type -> v1.TLSChallengeRequest
+	12, // 11: v1.MetadataService.GetDatabaseStatus:input_type -> v1.Empty
+	12, // 12: v1.MetadataService.GetDatabaseBackupStatus:input_type -> v1.Empty
+	12, // 13: v1.MetadataService.GetCentralCapabilities:input_type -> v1.Empty
+	4,  // 14: v1.MetadataService.GetMetadata:output_type -> v1.Metadata
+	6,  // 15: v1.MetadataService.TLSChallenge:output_type -> v1.TLSChallengeResponse
+	8,  // 16: v1.MetadataService.GetDatabaseStatus:output_type -> v1.DatabaseStatus
+	9,  // 17: v1.MetadataService.GetDatabaseBackupStatus:output_type -> v1.DatabaseBackupStatus
+	10, // 18: v1.MetadataService.GetCentralCapabilities:output_type -> v1.CentralServicesCapabilities
+	14, // [14:19] is the sub-list for method output_type
+	9,  // [9:14] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_metadata_service_proto_init() }
@@ -775,7 +847,7 @@ func file_api_v1_metadata_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v1_metadata_service_proto_rawDesc), len(file_api_v1_metadata_service_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/api/v1/metadata_service.swagger.json
+++ b/generated/api/v1/metadata_service.swagger.json
@@ -286,6 +286,19 @@
         }
       }
     },
+    "v1MajorVersionBump": {
+      "type": "object",
+      "properties": {
+        "fromVersion": {
+          "type": "string",
+          "description": "Last minor release before the bump (e.g., \"3.74\")."
+        },
+        "toVersion": {
+          "type": "string",
+          "description": "First release of the new major version (e.g., \"4.0\")."
+        }
+      }
+    },
     "v1Metadata": {
       "type": "object",
       "properties": {
@@ -301,6 +314,14 @@
         "licenseStatus": {
           "$ref": "#/definitions/MetadataLicenseStatus",
           "title": "Do not use this field. It will always contain \"VALID\""
+        },
+        "knownMajorBumps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MajorVersionBump"
+          },
+          "description": "Known major version bumps in the product's release history.\nClients (roxctl, Sensor) embed their own copy of this data;\nthe union of both sets gives the most accurate version-range computation."
         }
       }
     },

--- a/generated/api/v1/metadata_service_vtproto.pb.go
+++ b/generated/api/v1/metadata_service_vtproto.pb.go
@@ -21,6 +21,24 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *MajorVersionBump) CloneVT() *MajorVersionBump {
+	if m == nil {
+		return (*MajorVersionBump)(nil)
+	}
+	r := new(MajorVersionBump)
+	r.FromVersion = m.FromVersion
+	r.ToVersion = m.ToVersion
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *MajorVersionBump) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *Metadata) CloneVT() *Metadata {
 	if m == nil {
 		return (*Metadata)(nil)
@@ -30,6 +48,13 @@ func (m *Metadata) CloneVT() *Metadata {
 	r.BuildFlavor = m.BuildFlavor
 	r.ReleaseBuild = m.ReleaseBuild
 	r.LicenseStatus = m.LicenseStatus
+	if rhs := m.KnownMajorBumps; rhs != nil {
+		tmpContainer := make([]*MajorVersionBump, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.KnownMajorBumps = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -198,6 +223,28 @@ func (m *CentralServicesCapabilities) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (this *MajorVersionBump) EqualVT(that *MajorVersionBump) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.FromVersion != that.FromVersion {
+		return false
+	}
+	if this.ToVersion != that.ToVersion {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MajorVersionBump) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MajorVersionBump)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Metadata) EqualVT(that *Metadata) bool {
 	if this == that {
 		return true
@@ -215,6 +262,23 @@ func (this *Metadata) EqualVT(that *Metadata) bool {
 	}
 	if this.LicenseStatus != that.LicenseStatus {
 		return false
+	}
+	if len(this.KnownMajorBumps) != len(that.KnownMajorBumps) {
+		return false
+	}
+	for i, vx := range this.KnownMajorBumps {
+		vy := that.KnownMajorBumps[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &MajorVersionBump{}
+			}
+			if q == nil {
+				q = &MajorVersionBump{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -403,6 +467,53 @@ func (this *CentralServicesCapabilities) EqualMessageVT(thatMsg proto.Message) b
 	}
 	return this.EqualVT(that)
 }
+func (m *MajorVersionBump) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MajorVersionBump) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *MajorVersionBump) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ToVersion) > 0 {
+		i -= len(m.ToVersion)
+		copy(dAtA[i:], m.ToVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ToVersion)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.FromVersion) > 0 {
+		i -= len(m.FromVersion)
+		copy(dAtA[i:], m.FromVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.FromVersion)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Metadata) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -432,6 +543,18 @@ func (m *Metadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.KnownMajorBumps) > 0 {
+		for iNdEx := len(m.KnownMajorBumps) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.KnownMajorBumps[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2a
+		}
 	}
 	if m.LicenseStatus != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.LicenseStatus))
@@ -811,6 +934,24 @@ func (m *CentralServicesCapabilities) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	return len(dAtA) - i, nil
 }
 
+func (m *MajorVersionBump) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.FromVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ToVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *Metadata) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -830,6 +971,12 @@ func (m *Metadata) SizeVT() (n int) {
 	}
 	if m.LicenseStatus != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.LicenseStatus))
+	}
+	if len(m.KnownMajorBumps) > 0 {
+		for _, e := range m.KnownMajorBumps {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -975,6 +1122,121 @@ func (m *CentralServicesCapabilities) SizeVT() (n int) {
 	return n
 }
 
+func (m *MajorVersionBump) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MajorVersionBump: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MajorVersionBump: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FromVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.FromVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ToVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ToVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *Metadata) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1107,6 +1369,40 @@ func (m *Metadata) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownMajorBumps", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KnownMajorBumps = append(m.KnownMajorBumps, &MajorVersionBump{})
+			if err := m.KnownMajorBumps[len(m.KnownMajorBumps)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1959,6 +2255,129 @@ func (m *CentralServicesCapabilities) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *MajorVersionBump) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MajorVersionBump: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MajorVersionBump: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FromVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.FromVersion = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ToVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ToVersion = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *Metadata) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2099,6 +2518,40 @@ func (m *Metadata) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownMajorBumps", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KnownMajorBumps = append(m.KnownMajorBumps, &MajorVersionBump{})
+			if err := m.KnownMajorBumps[len(m.KnownMajorBumps)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/version/major_bumps.yaml
+++ b/pkg/version/major_bumps.yaml
@@ -1,0 +1,9 @@
+# Major version transitions in the product's release history.
+# Maintained on master; embedded in Central, Sensor, and roxctl at build time.
+# Each entry records the last minor release before a major version bump
+# and the first release of the new major version.
+bumps:
+  - from: "3.74"
+    to: "4.0"
+  - from: "4.11"
+    to: "5.0"

--- a/pkg/version/skew.go
+++ b/pkg/version/skew.go
@@ -1,0 +1,200 @@
+package version
+
+import (
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed major_bumps.yaml
+var majorBumpsYAML []byte
+
+// MajorBump records a major version transition: the last minor release
+// before the bump and the first release of the new major.
+type MajorBump struct {
+	From XY `yaml:"from"`
+	To   XY `yaml:"to"`
+}
+
+// XY is a major.minor version pair (e.g. 4.11).
+type XY struct {
+	Major int
+	Minor int
+}
+
+func (v XY) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+func (v XY) less(other XY) bool {
+	if v.Major != other.Major {
+		return v.Major < other.Major
+	}
+	return v.Minor < other.Minor
+}
+
+func (v *XY) UnmarshalYAML(node *yaml.Node) error {
+	var s string
+	if err := node.Decode(&s); err != nil {
+		return err
+	}
+	parsed, err := ParseXY(s)
+	if err != nil {
+		return err
+	}
+	*v = parsed
+	return nil
+}
+
+// ParseXY extracts major.minor from a version string.
+// Accepts formats like "4.11", "4.11.2", "4.11.0-rc.1", "4.11.x-123-gabcdef1234".
+func ParseXY(version string) (XY, error) {
+	parsed, err := parseVersion(version)
+	if err != nil {
+		return XY{}, fmt.Errorf("parsing version %q: %w", version, err)
+	}
+	return XY{Major: parsed.MarketingMajor, Minor: parsed.EngRelease}, nil
+}
+
+type bumpsFile struct {
+	Bumps []MajorBump `yaml:"bumps"`
+}
+
+// EmbeddedMajorBumps returns the major version bumps compiled into this binary.
+func EmbeddedMajorBumps() ([]MajorBump, error) {
+	return parseMajorBumps(majorBumpsYAML)
+}
+
+func parseMajorBumps(data []byte) ([]MajorBump, error) {
+	var f bumpsFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parsing major bumps YAML: %w", err)
+	}
+	return f.Bumps, nil
+}
+
+// MergeBumps returns the deduplicated union of two bump lists.
+func MergeBumps(a, b []MajorBump) []MajorBump {
+	seen := make(map[XY]bool, len(a)+len(b))
+	var merged []MajorBump
+	for _, bump := range append(a, b...) {
+		if !seen[bump.From] {
+			seen[bump.From] = true
+			merged = append(merged, bump)
+		}
+	}
+	return merged
+}
+
+// SkewStatus describes the result of a version skew check.
+type SkewStatus int
+
+const (
+	SkewOK            SkewStatus = iota // within allowed range
+	SkewWarning                         // outside allowed range
+	SkewIndeterminate                   // couldn't compare (dev builds, etc.)
+)
+
+// SkewResult holds the outcome of a version skew check.
+type SkewResult struct {
+	Status   SkewStatus
+	Distance int
+	Message  string
+}
+
+// CheckSkew checks whether roxctlVersion is within maxSkew minor releases
+// of centralVersion, accounting for major version bumps.
+func CheckSkew(roxctlVersion, centralVersion string, maxSkew int, bumps []MajorBump) SkewResult {
+	if roxctlVersion == centralVersion {
+		return SkewResult{Status: SkewOK, Distance: 0, Message: "versions match"}
+	}
+
+	roxXY, err := ParseXY(roxctlVersion)
+	if err != nil {
+		return SkewResult{
+			Status:  SkewIndeterminate,
+			Message: fmt.Sprintf("cannot parse roxctl version %q: %v", roxctlVersion, err),
+		}
+	}
+
+	cenXY, err := ParseXY(centralVersion)
+	if err != nil {
+		return SkewResult{
+			Status:  SkewIndeterminate,
+			Message: fmt.Sprintf("cannot parse Central version %q: %v", centralVersion, err),
+		}
+	}
+
+	if roxXY == cenXY {
+		return SkewResult{Status: SkewOK, Distance: 0, Message: "versions match (same X.Y)"}
+	}
+
+	dist, err := MinorDistance(roxXY, cenXY, bumps)
+	if err != nil {
+		return SkewResult{
+			Status:  SkewIndeterminate,
+			Message: fmt.Sprintf("cannot compute version distance: %v", err),
+		}
+	}
+
+	if dist <= maxSkew {
+		return SkewResult{
+			Status:   SkewOK,
+			Distance: dist,
+			Message:  fmt.Sprintf("roxctl %s and Central %s are %d minor version(s) apart (limit: %d)", roxXY, cenXY, dist, maxSkew),
+		}
+	}
+
+	direction := "newer"
+	if roxXY.less(cenXY) {
+		direction = "older"
+	}
+	return SkewResult{
+		Status:   SkewWarning,
+		Distance: dist,
+		Message: fmt.Sprintf(
+			"roxctl %s is %d minor version(s) %s than Central %s (supported range: %d)",
+			roxXY, dist, direction, cenXY, maxSkew,
+		),
+	}
+}
+
+// MinorDistance computes the absolute distance in minor releases between
+// two versions, correctly walking through major version bumps.
+//
+// For example, with bump 4.11→5.0:
+//
+//	MinorDistance(4.10, 5.1) = 3   (4.10 → 4.11 → 5.0 → 5.1)
+func MinorDistance(a, b XY, bumps []MajorBump) (int, error) {
+	if a == b {
+		return 0, nil
+	}
+	lo, hi := a, b
+	if b.less(a) {
+		lo, hi = b, a
+	}
+
+	bumpFrom := make(map[int]MajorBump, len(bumps))
+	for _, bump := range bumps {
+		bumpFrom[bump.From.Major] = bump
+	}
+
+	dist := 0
+	cur := lo
+	for cur != hi {
+		if cur.Major == hi.Major {
+			dist += hi.Minor - cur.Minor
+			cur = hi
+			continue
+		}
+
+		bump, ok := bumpFrom[cur.Major]
+		if !ok {
+			return 0, fmt.Errorf("cannot traverse from %s to %s: no known major bump from major version %d", lo, hi, cur.Major)
+		}
+		dist += bump.From.Minor - cur.Minor + 1
+		cur = bump.To
+	}
+	return dist, nil
+}

--- a/pkg/version/skew.go
+++ b/pkg/version/skew.go
@@ -180,6 +180,13 @@ func MinorDistance(a, b XY, bumps []MajorBump) (int, error) {
 		bumpFrom[bump.From.Major] = bump
 	}
 
+	for _, v := range []XY{lo, hi} {
+		if bump, ok := bumpFrom[v.Major]; ok && v.Minor > bump.From.Minor {
+			return 0, fmt.Errorf("version %s is inconsistent with bump data: major %d bumps at %s but version has minor %d",
+				v, v.Major, bump.From, v.Minor)
+		}
+	}
+
 	dist := 0
 	cur := lo
 	for cur != hi {

--- a/pkg/version/skew_test.go
+++ b/pkg/version/skew_test.go
@@ -117,6 +117,21 @@ func TestMinorDistance(t *testing.T) {
 			bumps:   testBumps,
 			wantErr: true,
 		},
+		"lo version exceeds bump point": {
+			a: XY{4, 12}, b: XY{5, 1},
+			bumps:   testBumps,
+			wantErr: true,
+		},
+		"hi version exceeds bump point": {
+			a: XY{3, 70}, b: XY{3, 75},
+			bumps:   testBumps,
+			wantErr: true,
+		},
+		"version at bump point is valid": {
+			a: XY{4, 11}, b: XY{5, 2},
+			bumps: testBumps,
+			want:  3,
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -189,6 +204,10 @@ func TestCheckSkew(t *testing.T) {
 		"RC central": {
 			roxctl: "4.11.0", central: "5.0.0-rc.1",
 			maxSkew: 3, status: SkewOK,
+		},
+		"version inconsistent with bumps": {
+			roxctl: "4.12.0", central: "5.1.0",
+			maxSkew: 3, status: SkewIndeterminate,
 		},
 	}
 	for name, tt := range tests {

--- a/pkg/version/skew_test.go
+++ b/pkg/version/skew_test.go
@@ -1,0 +1,218 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testBumps = []MajorBump{
+	{From: XY{3, 74}, To: XY{4, 0}},
+	{From: XY{4, 11}, To: XY{5, 0}},
+}
+
+func TestParseXY(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		want    XY
+		wantErr bool
+	}{
+		"simple X.Y": {
+			input: "4.11",
+			want:  XY{4, 11},
+		},
+		"release X.Y.Z": {
+			input: "4.11.2",
+			want:  XY{4, 11},
+		},
+		"RC version": {
+			input: "4.11.0-rc.1",
+			want:  XY{4, 11},
+		},
+		"dev build": {
+			input: "4.11.x-123-gabcdef1234",
+			want:  XY{4, 11},
+		},
+		"major version 5": {
+			input: "5.1.0",
+			want:  XY{5, 1},
+		},
+		"old 3-component": {
+			input: "3.74.1",
+			want:  XY{3, 74},
+		},
+		"invalid": {
+			input:   "not-a-version",
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseXY(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMinorDistance(t *testing.T) {
+	tests := map[string]struct {
+		a, b    XY
+		bumps   []MajorBump
+		want    int
+		wantErr bool
+	}{
+		"same version": {
+			a: XY{4, 5}, b: XY{4, 5},
+			bumps: testBumps,
+			want:  0,
+		},
+		"same major, 1 apart": {
+			a: XY{4, 5}, b: XY{4, 6},
+			bumps: testBumps,
+			want:  1,
+		},
+		"same major, 3 apart": {
+			a: XY{4, 5}, b: XY{4, 8},
+			bumps: testBumps,
+			want:  3,
+		},
+		"across 4->5 bump, adjacent": {
+			a: XY{4, 11}, b: XY{5, 0},
+			bumps: testBumps,
+			want:  1,
+		},
+		"across 4->5 bump, distance 3": {
+			a: XY{4, 10}, b: XY{5, 1},
+			bumps: testBumps,
+			want:  3,
+		},
+		"across 4->5 bump, distance 5": {
+			a: XY{4, 9}, b: XY{5, 2},
+			bumps: testBumps,
+			want:  5,
+		},
+		"reversed order": {
+			a: XY{5, 1}, b: XY{4, 10},
+			bumps: testBumps,
+			want:  3,
+		},
+		"across 3->4 bump": {
+			a: XY{3, 74}, b: XY{4, 0},
+			bumps: testBumps,
+			want:  1,
+		},
+		"across 3->4 bump, distance 4": {
+			a: XY{3, 73}, b: XY{4, 2},
+			bumps: testBumps,
+			want:  4,
+		},
+		"missing bump data": {
+			a: XY{4, 5}, b: XY{6, 0},
+			bumps:   testBumps,
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := MinorDistance(tt.a, tt.b, tt.bumps)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckSkew(t *testing.T) {
+	tests := map[string]struct {
+		roxctl  string
+		central string
+		maxSkew int
+		status  SkewStatus
+	}{
+		"identical versions": {
+			roxctl: "4.11.2", central: "4.11.2",
+			maxSkew: 3, status: SkewOK,
+		},
+		"same X.Y, different patch": {
+			roxctl: "4.11.1", central: "4.11.3",
+			maxSkew: 3, status: SkewOK,
+		},
+		"within range, 2 apart": {
+			roxctl: "4.9.0", central: "4.11.0",
+			maxSkew: 3, status: SkewOK,
+		},
+		"at boundary, 3 apart": {
+			roxctl: "4.8.0", central: "4.11.0",
+			maxSkew: 3, status: SkewOK,
+		},
+		"outside range, 4 apart": {
+			roxctl: "4.7.0", central: "4.11.0",
+			maxSkew: 3, status: SkewWarning,
+		},
+		"roxctl newer, within range": {
+			roxctl: "5.1.0", central: "4.11.0",
+			maxSkew: 3, status: SkewOK,
+		},
+		"roxctl newer, outside range": {
+			roxctl: "5.3.0", central: "4.11.0",
+			maxSkew: 3, status: SkewWarning,
+		},
+		"cross-major within range": {
+			roxctl: "4.10.0", central: "5.1.0",
+			maxSkew: 3, status: SkewOK,
+		},
+		"cross-major outside range": {
+			roxctl: "4.8.0", central: "5.1.0",
+			maxSkew: 3, status: SkewWarning,
+		},
+		"unparseable roxctl version": {
+			roxctl: "garbage", central: "4.11.0",
+			maxSkew: 3, status: SkewIndeterminate,
+		},
+		"unparseable central version": {
+			roxctl: "4.11.0", central: "garbage",
+			maxSkew: 3, status: SkewIndeterminate,
+		},
+		"dev build roxctl": {
+			roxctl: "4.11.x-123-gabcdef1234", central: "4.11.0",
+			maxSkew: 3, status: SkewOK,
+		},
+		"RC central": {
+			roxctl: "4.11.0", central: "5.0.0-rc.1",
+			maxSkew: 3, status: SkewOK,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := CheckSkew(tt.roxctl, tt.central, tt.maxSkew, testBumps)
+			assert.Equal(t, tt.status, result.Status, "message: %s", result.Message)
+		})
+	}
+}
+
+func TestMergeBumps(t *testing.T) {
+	a := []MajorBump{{From: XY{3, 74}, To: XY{4, 0}}}
+	b := []MajorBump{
+		{From: XY{3, 74}, To: XY{4, 0}},
+		{From: XY{4, 11}, To: XY{5, 0}},
+	}
+	merged := MergeBumps(a, b)
+	assert.Len(t, merged, 2)
+}
+
+func TestEmbeddedMajorBumps(t *testing.T) {
+	bumps, err := EmbeddedMajorBumps()
+	require.NoError(t, err)
+	assert.NotEmpty(t, bumps)
+	assert.Equal(t, XY{3, 74}, bumps[0].From)
+	assert.Equal(t, XY{4, 0}, bumps[0].To)
+}

--- a/proto/api/v1/metadata_service.proto
+++ b/proto/api/v1/metadata_service.proto
@@ -9,6 +9,13 @@ import "storage/system_info.proto";
 option go_package = "./api/v1;v1";
 option java_package = "io.stackrox.proto.api.v1";
 
+message MajorVersionBump {
+  // Last minor release before the bump (e.g., "3.74").
+  string from_version = 1;
+  // First release of the new major version (e.g., "4.0").
+  string to_version = 2;
+}
+
 message Metadata {
   enum LicenseStatus {
     NONE = 0 [deprecated = true];
@@ -24,6 +31,11 @@ message Metadata {
 
   // Do not use this field. It will always contain "VALID"
   LicenseStatus license_status = 4 [deprecated = true];
+
+  // Known major version bumps in the product's release history.
+  // Clients (roxctl, Sensor) embed their own copy of this data;
+  // the union of both sets gives the most accurate version-range computation.
+  repeated MajorVersionBump known_major_bumps = 5;
 }
 
 message TrustInfo {

--- a/roxctl/central/whoami/whoami.go
+++ b/roxctl/central/whoami/whoami.go
@@ -10,10 +10,12 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/util"
+	"google.golang.org/grpc"
 )
 
 type centralWhoAmICommand struct {
@@ -92,7 +94,57 @@ User name:
 		cmd.env.Logger().PrintfLn("\t%s %s", accessString(access), resource)
 	}
 
+	cmd.checkVersionSkew(ctx, conn)
+
 	return nil
+}
+
+const maxVersionSkew = 3
+
+func (cmd *centralWhoAmICommand) checkVersionSkew(ctx context.Context, conn *grpc.ClientConn) {
+	metadata, err := v1.NewMetadataServiceClient(conn).GetMetadata(ctx, &v1.Empty{})
+	if err != nil {
+		cmd.env.Logger().WarnfLn("Could not fetch Central metadata for version skew check: %v", err)
+		return
+	}
+
+	centralVersion := metadata.GetVersion()
+	if centralVersion == "" {
+		return
+	}
+
+	localBumps, err := version.EmbeddedMajorBumps()
+	if err != nil {
+		cmd.env.Logger().WarnfLn("Could not load embedded version bump data: %v", err)
+		return
+	}
+
+	remoteBumps := bumpsFromProto(metadata.GetKnownMajorBumps())
+	merged := version.MergeBumps(localBumps, remoteBumps)
+
+	result := version.CheckSkew(version.GetMainVersion(), centralVersion, maxVersionSkew, merged)
+	switch result.Status {
+	case version.SkewWarning:
+		cmd.env.Logger().WarnfLn("WARNING: %s", result.Message)
+	case version.SkewOK:
+		cmd.env.Logger().InfofLn("Version check: %s", result.Message)
+	}
+}
+
+func bumpsFromProto(pb []*v1.MajorVersionBump) []version.MajorBump {
+	out := make([]version.MajorBump, 0, len(pb))
+	for _, b := range pb {
+		from, err := version.ParseXY(b.GetFromVersion())
+		if err != nil {
+			continue
+		}
+		to, err := version.ParseXY(b.GetToVersion())
+		if err != nil {
+			continue
+		}
+		out = append(out, version.MajorBump{From: from, To: to})
+	}
+	return out
 }
 
 func accessString(access storage.Access) string {


### PR DESCRIPTION
## Description

PoC for version skew detection between roxctl and Central (companion to #21359 which covers the UI/Sensor side).

When running `roxctl central whoami`, roxctl now:
1. Fetches Central's metadata (version + known major version bumps)
2. Merges bump data from both sides (roxctl embedded copy + Central) for maximum accuracy
3. Computes the minor release distance, correctly walking across major version transitions
4. Warns on stderr if distance exceeds 3 minor releases

### Key design decisions (from ROX-34097 grooming)
- roxctl does the check locally, not Central -- works with old Centrals that don't have the new proto field
- Major bumps stored in YAML (pkg/version/major_bumps.yaml), embedded via go:embed -- reusable by non-Go tooling (operator scripts, CI)
- Both sides contribute bump data: Central sends its known bumps via Metadata.known_major_bumps, roxctl merges with its own embedded copy. Newer side fills gaps for the older side.
- Backward compatible: new roxctl + old Central gracefully degrades (uses only local bumps); old roxctl + new Central works unchanged

### Proto changes
- New MajorVersionBump message in metadata_service.proto
- New repeated MajorVersionBump known_major_bumps field on Metadata (field 5 -- will need reconciliation with #21359 which also uses field 5 for min_compatible_sensor_version)

### Files
| File | Change |
|------|--------|
| pkg/version/major_bumps.yaml | New -- version transitions data (3.74->4.0, 4.11->5.0) |
| pkg/version/skew.go | New -- ParseXY, MinorDistance, CheckSkew, MergeBumps, YAML embedding |
| pkg/version/skew_test.go | New -- 33 table-driven tests |
| proto/api/v1/metadata_service.proto | MajorVersionBump message + field on Metadata |
| central/metadata/service/service_impl.go | GetMetadata returns embedded bumps |
| roxctl/central/whoami/whoami.go | Skew check after auth info |

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

- 33 unit tests covering: same version, within/outside N+-3 range, cross-major transitions, dev/RC builds, unparseable versions, bump merging, embedded YAML parsing
- go build ./roxctl/... and go build ./central/metadata/... compile cleanly
- go vet passes on all changed packages
