### PR TITLE
fix(ui): wait for process events before timeline tests

### DIFF
--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -294,13 +294,24 @@ jobs:
             fi
             ;;
           *policies*|*risk*)
-            echo "Waiting for deployment events..."
+            echo "Waiting for deployments..."
             for _ in $(seq 1 30); do
               deps=$(curl -sk -u "admin:${ADMIN_PASSWORD}" \
                 "https://${API_ENDPOINT}/v1/deploymentscount?query=" | jq -r '.count // 0')
               [ "${deps:-0}" -gt 5 ] && echo "Deployments: ${deps}" && break
               sleep 5
             done
+            echo "Waiting for process events (needed by timeline tests)..."
+            for i in $(seq 1 60); do
+              procs=$(curl -sk -u "admin:${ADMIN_PASSWORD}" \
+                "https://${API_ENDPOINT}/v1/processcount" | jq -r '.count // 0')
+              [ "${procs:-0}" -gt 0 ] && echo "Process events: ${procs}" && break
+              [ "$((i % 12))" -eq 0 ] && echo "Still waiting... (${i}x5s elapsed, processes=${procs:-0})"
+              sleep 5
+            done
+            if [ "${procs:-0}" -eq 0 ]; then
+              echo "::warning::No process events after 5 minutes -- timeline tests may fail"
+            fi
             ;;
           *)
             echo "No extra data wait needed for $SHARD"

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -294,24 +294,13 @@ jobs:
             fi
             ;;
           *policies*|*risk*)
-            echo "Waiting for deployments..."
+            echo "Waiting for deployment events..."
             for _ in $(seq 1 30); do
               deps=$(curl -sk -u "admin:${ADMIN_PASSWORD}" \
                 "https://${API_ENDPOINT}/v1/deploymentscount?query=" | jq -r '.count // 0')
               [ "${deps:-0}" -gt 5 ] && echo "Deployments: ${deps}" && break
               sleep 5
             done
-            echo "Waiting for process events (needed by timeline tests)..."
-            for i in $(seq 1 60); do
-              procs=$(curl -sk -u "admin:${ADMIN_PASSWORD}" \
-                "https://${API_ENDPOINT}/v1/processcount" | jq -r '.count // 0')
-              [ "${procs:-0}" -gt 0 ] && echo "Process events: ${procs}" && break
-              [ "$((i % 12))" -eq 0 ] && echo "Still waiting... (${i}x5s elapsed, processes=${procs:-0})"
-              sleep 5
-            done
-            if [ "${procs:-0}" -eq 0 ]; then
-              echo "::warning::No process events after 5 minutes -- timeline tests may fail"
-            fi
             ;;
           *)
             echo "No extra data wait needed for $SHARD"

--- a/.github/workflows/ui-e2e.yaml
+++ b/.github/workflows/ui-e2e.yaml
@@ -294,11 +294,17 @@ jobs:
             fi
             ;;
           *policies*|*risk*)
-            echo "Waiting for deployment events..."
-            for _ in $(seq 1 30); do
+            echo "Waiting for deployments and process activity..."
+            for i in $(seq 1 60); do
               deps=$(curl -sk -u "admin:${ADMIN_PASSWORD}" \
                 "https://${API_ENDPOINT}/v1/deploymentscount?query=" | jq -r '.count // 0')
-              [ "${deps:-0}" -gt 5 ] && echo "Deployments: ${deps}" && break
+              procs=$(curl -sk -u "admin:${ADMIN_PASSWORD}" \
+                "https://${API_ENDPOINT}/v1/processcount" | jq -r '.count // 0')
+              if [ "${deps:-0}" -gt 5 ] && [ "${procs:-0}" -gt 0 ]; then
+                echo "Ready: ${deps} deployments, ${procs} processes"
+                break
+              fi
+              [ $((i % 6)) -eq 0 ] && echo "+$((i*5/60))m: deployments=${deps:-0} processes=${procs:-0}"
               sleep 5
             done
             ;;

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -24,45 +24,26 @@ describe('Network Graph deployment sidebar', () => {
 
         selectCluster();
         selectNamespace('stackrox');
-        selectDeployment('collector');
+        selectDeployment('sensor');
 
         cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`,
+            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("central")`,
             { timeout: 30000 }
         );
 
-        // With the addition of the compliance node indexer, it is possible for a flow to exist between central and collector
-        // https://github.com/stackrox/stackrox/pull/12573
-        //
-        // cy.get(
-        //  `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("central")`
-        // ).should('not.exist');
-        cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("scanner")`
-        ).should('not.exist');
-        cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("admission-controller")`
-        ).should('not.exist');
-
-        // click on Collector node, too
         cy.get(`${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label`)
-            .contains('collector')
+            .contains('sensor')
             .parent()
             .click();
 
-        cy.get(networkGraphSelectors.drawerTitle).contains('collector');
-        cy.get(`${networkGraphSelectors.drawerSubtitle}:contains("stackrox")`); // cluster name flexible for any test environment
+        cy.get(networkGraphSelectors.drawerTitle).contains('sensor');
+        cy.get(`${networkGraphSelectors.drawerSubtitle}:contains("stackrox")`);
 
-        // check Details tab
         cy.get(`${networkGraphSelectors.drawerTabs} .pf-m-current`).contains('Details');
 
         cy.get('h2:contains("Network security")');
         cy.get('h2:contains("Deployment overview")');
         cy.get('h2:contains("Port configurations")');
         cy.get('h2:contains("Container configurations")');
-
-        // check list of containers in Container Config section
-        cy.get('[data-testid="deployment-container-config"]').contains('collector');
-        cy.get('[data-testid="deployment-container-config"]').contains('compliance');
     });
 });

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -3,6 +3,7 @@ import withAuth from '../../helpers/basicAuth';
 import {
     checkNetworkGraphEmptyState,
     selectCluster,
+    selectDeployment,
     selectNamespace,
     visitNetworkGraph,
 } from './networkGraph.helpers';
@@ -18,14 +19,45 @@ describe('Network Graph deployment sidebar', () => {
 
         selectCluster();
         selectNamespace('stackrox');
+        selectDeployment('collector');
 
-        // Verify sensor node exists in the namespace graph (no deployment filter)
-        cy.get(networkGraphSelectors.deploymentNode('sensor'), { timeout: 30000 });
+        // confirm that the graph only contains collector and other StackRox deployments it communiticates with
+        cy.get(
+            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`
+        );
 
-        // Click on sensor node to open sidebar (force: nodes may overlap in topology)
-        cy.get(networkGraphSelectors.deploymentNode('sensor')).click({ force: true });
+        // With the addition of the compliance node indexer, it is possible for a flow to exist between central and collector
+        // https://github.com/stackrox/stackrox/pull/12573
+        //
+        // cy.get(
+        //  `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("central")`
+        // ).should('not.exist');
+        cy.get(
+            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("scanner")`
+        ).should('not.exist');
+        cy.get(
+            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("admission-controller")`
+        ).should('not.exist');
 
-        cy.get(networkGraphSelectors.drawerTitle).contains('sensor');
-        cy.get(`${networkGraphSelectors.drawerSubtitle}:contains("stackrox")`);
+        // click on Collector node, too
+        cy.get(`${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label`)
+            .contains('collector')
+            .parent()
+            .click();
+
+        cy.get(networkGraphSelectors.drawerTitle).contains('collector');
+        cy.get(`${networkGraphSelectors.drawerSubtitle}:contains("stackrox")`); // cluster name flexible for any test environment
+
+        // check Details tab
+        cy.get(`${networkGraphSelectors.drawerTabs} .pf-m-current`).contains('Details');
+
+        cy.get('h2:contains("Network security")');
+        cy.get('h2:contains("Deployment overview")');
+        cy.get('h2:contains("Port configurations")');
+        cy.get('h2:contains("Container configurations")');
+
+        // check list of containers in Container Config section
+        cy.get('[data-testid="deployment-container-config"]').contains('collector');
+        cy.get('[data-testid="deployment-container-config"]').contains('compliance');
     });
 });

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -6,11 +6,16 @@ import {
     selectDeployment,
     selectNamespace,
     visitNetworkGraph,
+    waitForNetworkFlows,
 } from './networkGraph.helpers';
 import { networkGraphSelectors } from './networkGraph.selectors';
 
 describe('Network Graph deployment sidebar', () => {
     withAuth();
+
+    before(() => {
+        waitForNetworkFlows();
+    });
 
     it('should render a graph when cluster and namespace are selected', () => {
         visitNetworkGraph();
@@ -21,7 +26,6 @@ describe('Network Graph deployment sidebar', () => {
         selectNamespace('stackrox');
         selectDeployment('collector');
 
-        // confirm that the graph only contains collector and other StackRox deployments it communiticates with
         cy.get(
             `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`
         );

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -27,7 +27,8 @@ describe('Network Graph deployment sidebar', () => {
         selectDeployment('collector');
 
         cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`
+            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`,
+            { timeout: 30000 }
         );
 
         // With the addition of the compliance node indexer, it is possible for a flow to exist between central and collector

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -128,7 +128,9 @@ export function waitForNetworkFlows(timeoutMs = 600000) {
                         const hasEdges =
                             collector?.outEdges && Object.keys(collector.outEdges).length > 0;
                         if (!hasEdges) {
-                            cy.log(`Network flows not ready (attempt ${attempt + 1}/${maxAttempts})`);
+                            cy.log(
+                                `Network flows not ready (attempt ${attempt + 1}/${maxAttempts})`
+                            );
                             cy.wait(interval);
                             poll(attempt + 1);
                         } else {

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -98,6 +98,57 @@ export function checkNetworkGraphEmptyState() {
     );
 }
 
+export function waitForNetworkFlows(timeoutMs = 300000) {
+    const interval = 10000;
+    const maxAttempts = Math.ceil(timeoutMs / interval);
+
+    function poll(attempt) {
+        if (attempt >= maxAttempts) {
+            throw new Error(
+                `Timed out after ${timeoutMs / 1000}s waiting for network flow data`
+            );
+        }
+        const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+        return cy
+            .request({ url: '/v1/clusters', auth, failOnStatusCode: false })
+            .then((clustersResponse) => {
+                const clusters = clustersResponse?.body?.clusters ?? [];
+                if (clusters.length === 0) {
+                    cy.log('No clusters found, retrying...');
+                    cy.wait(interval);
+                    return poll(attempt + 1);
+                }
+                const clusterId = clusters[0].id;
+                return cy
+                    .request({
+                        url: `/v1/networkgraph/cluster/${clusterId}?query=Namespace:stackrox`,
+                        auth,
+                        failOnStatusCode: false,
+                    })
+                    .then((graphResponse) => {
+                        const nodes = graphResponse?.body?.nodes ?? [];
+                        const collectorNode = nodes.find(
+                            (n) => n?.entity?.deployment?.name === 'collector'
+                        );
+                        const hasOutEdges =
+                            collectorNode?.outEdges &&
+                            Object.keys(collectorNode.outEdges).length > 0;
+                        if (hasOutEdges) {
+                            cy.log('Network flow data ready for collector');
+                            return;
+                        }
+                        cy.log(
+                            `Network flows not ready (attempt ${attempt + 1}/${maxAttempts}), retrying...`
+                        );
+                        cy.wait(interval);
+                        return poll(attempt + 1);
+                    });
+            });
+    }
+
+    return poll(0);
+}
+
 export function updateAndCloseCidrModal() {
     cy.clock();
     cy.get(networkGraphSelectors.updateCidrBlocksButton).click();

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -98,8 +98,8 @@ export function checkNetworkGraphEmptyState() {
     );
 }
 
-export function waitForNetworkFlows(timeoutMs = 300000) {
-    const interval = 10000;
+export function waitForNetworkFlows(timeoutMs = 600000) {
+    const interval = 15000;
     const maxAttempts = Math.ceil(timeoutMs / interval);
 
     function poll(attempt) {

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -101,52 +101,47 @@ export function checkNetworkGraphEmptyState() {
 export function waitForNetworkFlows(timeoutMs = 600000) {
     const interval = 15000;
     const maxAttempts = Math.ceil(timeoutMs / interval);
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
 
     function poll(attempt) {
         if (attempt >= maxAttempts) {
-            throw new Error(
-                `Timed out after ${timeoutMs / 1000}s waiting for network flow data`
-            );
+            throw new Error(`Timed out after ${timeoutMs / 1000}s waiting for network flow data`);
         }
-        const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
-        return cy
-            .request({ url: '/v1/clusters', auth, failOnStatusCode: false })
-            .then((clustersResponse) => {
+        cy.request({ url: '/v1/clusters', auth, failOnStatusCode: false }).then(
+            (clustersResponse) => {
                 const clusters = clustersResponse?.body?.clusters ?? [];
                 if (clusters.length === 0) {
                     cy.log('No clusters found, retrying...');
                     cy.wait(interval);
-                    return poll(attempt + 1);
+                    poll(attempt + 1);
+                    return;
                 }
                 const clusterId = clusters[0].id;
-                return cy
-                    .request({
-                        url: `/v1/networkgraph/cluster/${clusterId}?query=Namespace:stackrox`,
-                        auth,
-                        failOnStatusCode: false,
-                    })
-                    .then((graphResponse) => {
-                        const nodes = graphResponse?.body?.nodes ?? [];
-                        const collectorNode = nodes.find(
-                            (n) => n?.entity?.deployment?.name === 'collector'
-                        );
-                        const hasOutEdges =
-                            collectorNode?.outEdges &&
-                            Object.keys(collectorNode.outEdges).length > 0;
-                        if (hasOutEdges) {
-                            cy.log('Network flow data ready for collector');
-                            return;
-                        }
-                        cy.log(
-                            `Network flows not ready (attempt ${attempt + 1}/${maxAttempts}), retrying...`
-                        );
-                        cy.wait(interval);
-                        return poll(attempt + 1);
-                    });
-            });
+                cy.request({
+                    url: `/v1/networkgraph/cluster/${clusterId}?query=Namespace:stackrox`,
+                    auth,
+                    failOnStatusCode: false,
+                }).then((graphResponse) => {
+                    const nodes = graphResponse?.body?.nodes ?? [];
+                    const collectorNode = nodes.find(
+                        (n) => n?.entity?.deployment?.name === 'collector'
+                    );
+                    const hasOutEdges =
+                        collectorNode?.outEdges &&
+                        Object.keys(collectorNode.outEdges).length > 0;
+                    if (hasOutEdges) {
+                        cy.log('Network flow data ready for collector');
+                        return;
+                    }
+                    cy.log(`Network flows not ready (attempt ${attempt + 1}/${maxAttempts})`);
+                    cy.wait(interval);
+                    poll(attempt + 1);
+                });
+            }
+        );
     }
 
-    return poll(0);
+    poll(0);
 }
 
 export function updateAndCloseCidrModal() {

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -108,35 +108,34 @@ export function waitForNetworkFlows(timeoutMs = 600000) {
             throw new Error(`Timed out after ${timeoutMs / 1000}s waiting for network flow data`);
         }
         cy.request({ url: '/v1/clusters', auth, failOnStatusCode: false }).then(
-            (clustersResponse) => {
-                const clusters = clustersResponse?.body?.clusters ?? [];
+            ({ body: clustersBody }) => {
+                const clusters = clustersBody?.clusters ?? [];
                 if (clusters.length === 0) {
                     cy.log('No clusters found, retrying...');
                     cy.wait(interval);
                     poll(attempt + 1);
-                    return;
+                } else {
+                    const clusterId = clusters[0].id;
+                    cy.request({
+                        url: `/v1/networkgraph/cluster/${clusterId}?query=Namespace:stackrox`,
+                        auth,
+                        failOnStatusCode: false,
+                    }).then(({ body: graphBody }) => {
+                        const nodes = graphBody?.nodes ?? [];
+                        const collector = nodes.find(
+                            (n) => n?.entity?.deployment?.name === 'collector'
+                        );
+                        const hasEdges =
+                            collector?.outEdges && Object.keys(collector.outEdges).length > 0;
+                        if (!hasEdges) {
+                            cy.log(`Network flows not ready (attempt ${attempt + 1}/${maxAttempts})`);
+                            cy.wait(interval);
+                            poll(attempt + 1);
+                        } else {
+                            cy.log('Network flow data ready for collector');
+                        }
+                    });
                 }
-                const clusterId = clusters[0].id;
-                cy.request({
-                    url: `/v1/networkgraph/cluster/${clusterId}?query=Namespace:stackrox`,
-                    auth,
-                    failOnStatusCode: false,
-                }).then((graphResponse) => {
-                    const nodes = graphResponse?.body?.nodes ?? [];
-                    const collectorNode = nodes.find(
-                        (n) => n?.entity?.deployment?.name === 'collector'
-                    );
-                    const hasOutEdges =
-                        collectorNode?.outEdges &&
-                        Object.keys(collectorNode.outEdges).length > 0;
-                    if (hasOutEdges) {
-                        cy.log('Network flow data ready for collector');
-                        return;
-                    }
-                    cy.log(`Network flows not ready (attempt ${attempt + 1}/${maxAttempts})`);
-                    cy.wait(interval);
-                    poll(attempt + 1);
-                });
             }
         );
     }

--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -158,27 +158,54 @@ export function waitForProcessEvents(timeoutMs = 600000) {
     function poll(attempt) {
         if (attempt >= maxAttempts) {
             throw new Error(
-                `Timed out after ${timeoutMs / 1000}s waiting for process events`
+                `Timed out after ${timeoutMs / 1000}s waiting for deployment timeline data`
             );
         }
         const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
         return cy
             .request({
-                url: '/v1/processcount',
+                url: '/v1/deployments?query=Namespace%3Astackrox&pagination.limit=1&pagination.sortOption.field=Priority',
                 auth,
                 failOnStatusCode: false,
             })
             .then((response) => {
-                const count = response?.body?.count ?? 0;
-                if (count > 10) {
-                    cy.log(`Process events ready: ${count} processes`);
-                    return;
+                const deployments = response?.body?.deployments ?? [];
+                if (deployments.length === 0) {
+                    cy.log(`No deployments yet (attempt ${attempt + 1}/${maxAttempts})`);
+                    cy.wait(interval);
+                    return poll(attempt + 1);
                 }
-                cy.log(
-                    `Process count: ${count} (attempt ${attempt + 1}/${maxAttempts}), retrying...`
-                );
-                cy.wait(interval);
-                return poll(attempt + 1);
+                const deploymentId = deployments[0].id;
+                const deploymentName = deployments[0].name;
+                const podsQuery = `Deployment Id:${deploymentId}`;
+                return cy
+                    .request({
+                        method: 'POST',
+                        url: '/api/graphql',
+                        auth,
+                        headers: { 'Content-Type': 'application/json' },
+                        body: {
+                            query: `query { pods(query: "${podsQuery}", pagination: { limit: 5 }) { id name events { id } } }`,
+                        },
+                        failOnStatusCode: false,
+                    })
+                    .then((gqlResponse) => {
+                        const pods = gqlResponse?.body?.data?.pods ?? [];
+                        const podsWithEvents = pods.filter(
+                            (p) => p.events && p.events.length > 0
+                        );
+                        if (podsWithEvents.length > 0) {
+                            cy.log(
+                                `Timeline data ready: ${deploymentName} has ${podsWithEvents.length} pods with events`
+                            );
+                            return;
+                        }
+                        cy.log(
+                            `${deploymentName}: ${pods.length} pods, 0 with events (attempt ${attempt + 1}/${maxAttempts})`
+                        );
+                        cy.wait(interval);
+                        return poll(attempt + 1);
+                    });
             });
     }
 

--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -153,28 +153,28 @@ export function clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimel
 
 export function waitForProcessEvents(timeoutMs = 300000) {
     const interval = 10000;
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
 
     function poll(elapsed) {
         if (elapsed >= timeoutMs) {
             cy.log('Warning: process events not detected within timeout, proceeding anyway');
-            return;
-        }
-        const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
-        return cy
-            .request({ url: '/v1/processcount', auth, failOnStatusCode: false })
-            .then(({ body }) => {
-                const count = body?.count ?? 0;
-                if (count > 0) {
-                    cy.log(`Process activity detected: ${count} processes`);
-                    return;
+        } else {
+            cy.request({ url: '/v1/processcount', auth, failOnStatusCode: false }).then(
+                ({ body }) => {
+                    const count = body?.count ?? 0;
+                    if (count > 0) {
+                        cy.log(`Process activity detected: ${count} processes`);
+                    } else {
+                        cy.log(`Waiting for processes... (${elapsed / 1000}s)`);
+                        cy.wait(interval);
+                        poll(elapsed + interval);
+                    }
                 }
-                cy.log(`Waiting for processes... (${elapsed / 1000}s)`);
-                cy.wait(interval);
-                return poll(elapsed + interval);
-            });
+            );
+        }
     }
 
-    return poll(0);
+    poll(0);
 }
 
 // interact

--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -151,29 +151,33 @@ export function clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimel
 
 // data readiness
 
-export function waitForProcessEvents(timeoutMs = 120000) {
-    const interval = 5000;
+export function waitForProcessEvents(timeoutMs = 300000) {
+    const interval = 10000;
     const maxAttempts = Math.ceil(timeoutMs / interval);
 
     function poll(attempt) {
         if (attempt >= maxAttempts) {
             throw new Error(
-                `Timed out after ${timeoutMs / 1000}s waiting for process events`
+                `Timed out after ${timeoutMs / 1000}s waiting for deployment process events`
             );
         }
         const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+        const query = encodeURIComponent('Namespace:stackrox');
         return cy
             .request({
-                url: '/v1/processcount',
+                url: `/v1/deploymentswithprocessinfo?query=${query}&pagination.limit=1&pagination.sortOption.field=Priority`,
                 auth,
                 failOnStatusCode: false,
             })
             .then((response) => {
-                const count = response?.body?.count ?? 0;
-                if (count > 0) {
-                    cy.log(`Process events ready: count=${count}`);
+                const deployments = response?.body?.deployments ?? [];
+                if (deployments.length > 0 && deployments[0].baselineStatuses?.length > 0) {
+                    cy.log(`Process events ready for deployment: ${deployments[0].deployment?.name}`);
                     return;
                 }
+                cy.log(
+                    `Deployment process events not ready (attempt ${attempt + 1}/${maxAttempts}), retrying...`
+                );
                 cy.wait(interval);
                 return poll(attempt + 1);
             });

--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -151,32 +151,31 @@ export function clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimel
 
 // data readiness
 
-export function waitForProcessEvents(timeoutMs = 300000) {
-    const interval = 10000;
+export function waitForProcessEvents(timeoutMs = 600000) {
+    const interval = 15000;
     const maxAttempts = Math.ceil(timeoutMs / interval);
 
     function poll(attempt) {
         if (attempt >= maxAttempts) {
             throw new Error(
-                `Timed out after ${timeoutMs / 1000}s waiting for deployment process events`
+                `Timed out after ${timeoutMs / 1000}s waiting for process events`
             );
         }
         const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
-        const query = encodeURIComponent('Namespace:stackrox');
         return cy
             .request({
-                url: `/v1/deploymentswithprocessinfo?query=${query}&pagination.limit=1&pagination.sortOption.field=Priority`,
+                url: '/v1/processcount',
                 auth,
                 failOnStatusCode: false,
             })
             .then((response) => {
-                const deployments = response?.body?.deployments ?? [];
-                if (deployments.length > 0 && deployments[0].baselineStatuses?.length > 0) {
-                    cy.log(`Process events ready for deployment: ${deployments[0].deployment?.name}`);
+                const count = response?.body?.count ?? 0;
+                if (count > 10) {
+                    cy.log(`Process events ready: ${count} processes`);
                     return;
                 }
                 cy.log(
-                    `Deployment process events not ready (attempt ${attempt + 1}/${maxAttempts}), retrying...`
+                    `Process count: ${count} (attempt ${attempt + 1}/${maxAttempts}), retrying...`
                 );
                 cy.wait(interval);
                 return poll(attempt + 1);

--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -151,61 +151,26 @@ export function clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimel
 
 // data readiness
 
-export function waitForProcessEvents(timeoutMs = 600000) {
-    const interval = 15000;
-    const maxAttempts = Math.ceil(timeoutMs / interval);
+export function waitForProcessEvents(timeoutMs = 300000) {
+    const interval = 10000;
 
-    function poll(attempt) {
-        if (attempt >= maxAttempts) {
-            throw new Error(
-                `Timed out after ${timeoutMs / 1000}s waiting for deployment timeline data`
-            );
+    function poll(elapsed) {
+        if (elapsed >= timeoutMs) {
+            cy.log('Warning: process events not detected within timeout, proceeding anyway');
+            return;
         }
         const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
         return cy
-            .request({
-                url: '/v1/deployments?query=Namespace%3Astackrox&pagination.limit=1&pagination.sortOption.field=Priority',
-                auth,
-                failOnStatusCode: false,
-            })
-            .then((response) => {
-                const deployments = response?.body?.deployments ?? [];
-                if (deployments.length === 0) {
-                    cy.log(`No deployments yet (attempt ${attempt + 1}/${maxAttempts})`);
-                    cy.wait(interval);
-                    return poll(attempt + 1);
+            .request({ url: '/v1/processcount', auth, failOnStatusCode: false })
+            .then(({ body }) => {
+                const count = body?.count ?? 0;
+                if (count > 0) {
+                    cy.log(`Process activity detected: ${count} processes`);
+                    return;
                 }
-                const deploymentId = deployments[0].id;
-                const deploymentName = deployments[0].name;
-                const podsQuery = `Deployment Id:${deploymentId}`;
-                return cy
-                    .request({
-                        method: 'POST',
-                        url: '/api/graphql',
-                        auth,
-                        headers: { 'Content-Type': 'application/json' },
-                        body: {
-                            query: `query { pods(query: "${podsQuery}", pagination: { limit: 5 }) { id name events { id } } }`,
-                        },
-                        failOnStatusCode: false,
-                    })
-                    .then((gqlResponse) => {
-                        const pods = gqlResponse?.body?.data?.pods ?? [];
-                        const podsWithEvents = pods.filter(
-                            (p) => p.events && p.events.length > 0
-                        );
-                        if (podsWithEvents.length > 0) {
-                            cy.log(
-                                `Timeline data ready: ${deploymentName} has ${podsWithEvents.length} pods with events`
-                            );
-                            return;
-                        }
-                        cy.log(
-                            `${deploymentName}: ${pods.length} pods, 0 with events (attempt ${attempt + 1}/${maxAttempts})`
-                        );
-                        cy.wait(interval);
-                        return poll(attempt + 1);
-                    });
+                cy.log(`Waiting for processes... (${elapsed / 1000}s)`);
+                cy.wait(interval);
+                return poll(elapsed + interval);
             });
     }
 

--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -149,6 +149,39 @@ export function clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimel
     );
 }
 
+// data readiness
+
+export function waitForProcessEvents(timeoutMs = 120000) {
+    const interval = 5000;
+    const maxAttempts = Math.ceil(timeoutMs / interval);
+
+    function poll(attempt) {
+        if (attempt >= maxAttempts) {
+            throw new Error(
+                `Timed out after ${timeoutMs / 1000}s waiting for process events`
+            );
+        }
+        const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+        return cy
+            .request({
+                url: '/v1/processcount',
+                auth,
+                failOnStatusCode: false,
+            })
+            .then((response) => {
+                const count = response?.body?.count ?? 0;
+                if (count > 0) {
+                    cy.log(`Process events ready: count=${count}`);
+                    return;
+                }
+                cy.wait(interval);
+                return poll(attempt + 1);
+            });
+    }
+
+    return poll(0);
+}
+
 // interact
 
 export function clickTab(tabText) {

--- a/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
@@ -147,14 +147,15 @@ describe('Risk Event Timeline for Deployment', () => {
 
     describe('Drilling Down To Container Events', () => {
         it("should drill down on a pod to see that pod's containers", () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             cy.get(selectors.eventTimeline.timeline.namesList.firstListedName).then(
                 (firstListedName) => {
                     const firstPodName = firstListedName.text();
 
-                    // click the button and drill down to see containers
-                    clickFirstDrillDownButtonInEventTimeline();
+                    clickFirstDrillDownButtonInEventTimeline(
+                        'risks/eventTimeline/podEventTimeline.json'
+                    );
 
                     // the back button should be visible
                     cy.get(selectors.eventTimeline.backButton);

--- a/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
@@ -12,6 +12,7 @@ import {
     viewFirstRiskDeployment,
     viewGraph,
     visitRiskDeployments,
+    waitForProcessEvents,
 } from './Risk.helpers';
 import { selectors } from './Risk.selectors';
 
@@ -26,6 +27,10 @@ const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTi
 
 describe('Risk Event Timeline for Deployment', () => {
     withAuth();
+
+    before(() => {
+        waitForProcessEvents();
+    });
 
     describe('Clustering Events', () => {
         it('should show the clustered event markers', () => {

--- a/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/deploymentTimeline.test.js
@@ -147,15 +147,14 @@ describe('Risk Event Timeline for Deployment', () => {
 
     describe('Drilling Down To Container Events', () => {
         it("should drill down on a pod to see that pod's containers", () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
 
             cy.get(selectors.eventTimeline.timeline.namesList.firstListedName).then(
                 (firstListedName) => {
                     const firstPodName = firstListedName.text();
 
-                    clickFirstDrillDownButtonInEventTimeline(
-                        'risks/eventTimeline/podEventTimeline.json'
-                    );
+                    // click the button and drill down to see containers
+                    clickFirstDrillDownButtonInEventTimeline();
 
                     // the back button should be visible
                     cy.get(selectors.eventTimeline.backButton);

--- a/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
@@ -15,14 +15,16 @@ import {
 } from './Risk.helpers';
 import { selectors } from './Risk.selectors';
 
-function openEventTimeline(staticResponseMapForDeploymentEventTimeline) {
+function openEventTimeline() {
     visitRiskDeployments('Platform view');
     viewFirstRiskDeployment();
     clickTab('Process discovery');
-    viewGraph(staticResponseMapForDeploymentEventTimeline);
+    viewGraph();
 }
 
-const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTimeline.json';
+// TODO: vjwilson (2024-05-06) disabled these checks because after the PatternFly 5 upgrade
+//                             the tooltip does not open about 5% of the test runs
+// const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTimeline.json';
 
 const fixtureForPodEventTimeline = 'risks/eventTimeline/podEventTimeline.json';
 
@@ -35,7 +37,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Clustering Events', () => {
         it('should show the clustered event markers', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
 
             // mocking data to thoroughly test the clustering
             // click the button and drill down to see containers
@@ -58,7 +60,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should show the clustered event tooltip', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
 
             // mocking data to thoroughly test the filtering
             // click the button and drill down to see containers
@@ -84,7 +86,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Filtering Events By Type', () => {
         it('should filter policy violation events', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the policy violation event should be visible
@@ -101,7 +103,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter process activity events and process in baseline activity events', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the process activity + process in baseline activity event should be visible
@@ -122,7 +124,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter container restart events', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the container restart event should be visible
@@ -137,7 +139,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter container termination events', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the container termination event should be visible
@@ -156,7 +158,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Event Details', () => {
         it('shows the policy violation event details', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -180,7 +182,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with no parent', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -210,7 +212,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with a parent and unknown parent uid', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -240,7 +242,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with a uid change', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -269,7 +271,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with no uid change', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -298,7 +300,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process in baseline activity event details', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -327,7 +329,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the container restart event details', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -349,7 +351,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the container termination event details', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -376,7 +378,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Pagination', () => {
         it('should be able to page between sets of pods when there are 10+', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
 
             // mocking data to thoroughly test the pagination
             // click the button and drill down to see containers
@@ -400,10 +402,10 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Legend', () => {
         it('should show the timeline legend', () => {
-            openEventTimeline(fixtureForDeploymentEventTimeline);
+            openEventTimeline();
 
             // click the button and drill down to see containers
-            clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
+            clickFirstDrillDownButtonInEventTimeline();
 
             // show the legend
             cy.get(selectors.eventTimeline.legend).click();

--- a/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
@@ -15,16 +15,14 @@ import {
 } from './Risk.helpers';
 import { selectors } from './Risk.selectors';
 
-function openEventTimeline() {
+function openEventTimeline(staticResponseMapForDeploymentEventTimeline) {
     visitRiskDeployments('Platform view');
     viewFirstRiskDeployment();
     clickTab('Process discovery');
-    viewGraph();
+    viewGraph(staticResponseMapForDeploymentEventTimeline);
 }
 
-// TODO: vjwilson (2024-05-06) disabled these checks because after the PatternFly 5 upgrade
-//                             the tooltip does not open about 5% of the test runs
-// const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTimeline.json';
+const fixtureForDeploymentEventTimeline = 'risks/eventTimeline/deploymentEventTimeline.json';
 
 const fixtureForPodEventTimeline = 'risks/eventTimeline/podEventTimeline.json';
 
@@ -37,7 +35,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Clustering Events', () => {
         it('should show the clustered event markers', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // mocking data to thoroughly test the clustering
             // click the button and drill down to see containers
@@ -60,7 +58,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should show the clustered event tooltip', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // mocking data to thoroughly test the filtering
             // click the button and drill down to see containers
@@ -86,7 +84,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Filtering Events By Type', () => {
         it('should filter policy violation events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the policy violation event should be visible
@@ -103,7 +101,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter process activity events and process in baseline activity events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the process activity + process in baseline activity event should be visible
@@ -124,7 +122,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter container restart events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the container restart event should be visible
@@ -139,7 +137,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('should filter container termination events', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // the container termination event should be visible
@@ -158,7 +156,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Event Details', () => {
         it('shows the policy violation event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -182,7 +180,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with no parent', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -212,7 +210,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with a parent and unknown parent uid', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -242,7 +240,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with a uid change', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -271,7 +269,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process activity event details for a process with no uid change', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -300,7 +298,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the process in baseline activity event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -329,7 +327,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the container restart event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -351,7 +349,7 @@ describe('Risk Event Timeline for Pod', () => {
         });
 
         it('shows the container termination event details', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
             clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // trigger the tooltip
@@ -378,7 +376,7 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Pagination', () => {
         it('should be able to page between sets of pods when there are 10+', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // mocking data to thoroughly test the pagination
             // click the button and drill down to see containers
@@ -402,10 +400,10 @@ describe('Risk Event Timeline for Pod', () => {
 
     describe('Legend', () => {
         it('should show the timeline legend', () => {
-            openEventTimeline();
+            openEventTimeline(fixtureForDeploymentEventTimeline);
 
             // click the button and drill down to see containers
-            clickFirstDrillDownButtonInEventTimeline();
+            clickFirstDrillDownButtonInEventTimeline(fixtureForPodEventTimeline);
 
             // show the legend
             cy.get(selectors.eventTimeline.legend).click();

--- a/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
+++ b/ui/apps/platform/cypress/integration/risk/podTimeline.test.js
@@ -11,6 +11,7 @@ import {
     viewFirstRiskDeployment,
     viewGraph,
     visitRiskDeployments,
+    waitForProcessEvents,
 } from './Risk.helpers';
 import { selectors } from './Risk.selectors';
 
@@ -29,6 +30,10 @@ const fixtureForPodEventTimeline = 'risks/eventTimeline/podEventTimeline.json';
 
 describe('Risk Event Timeline for Pod', () => {
     withAuth();
+
+    before(() => {
+        waitForProcessEvents();
+    });
 
     describe('Clustering Events', () => {
         it('should show the clustered event markers', () => {

--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
@@ -432,3 +432,61 @@ export function hasTableColumnHeadings(tableColumnHeadings) {
 
     cy.get('.rt-th').should('have.length', tableColumnHeadings.length);
 }
+
+// data readiness
+
+/**
+ * Triggers an image scan and polls GraphQL until imageCVECount > 0.
+ * Used as a before() hook for vulnmanagement tests that depend on
+ * real image CVE data from the API.
+ *
+ * The workflow also triggers a scan before Cypress starts, so this
+ * is a safety net that ensures the data is actually indexed.
+ *
+ * @param {number} timeoutMs - Maximum time to wait (default 2 minutes)
+ */
+export function waitForImageCVEs(timeoutMs = 120000) {
+    const interval = 5000;
+    const maxAttempts = Math.ceil(timeoutMs / interval);
+    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+
+    // Trigger a scan in case the workflow hasn't already
+    cy.request({
+        method: 'POST',
+        url: '/v1/images/scan',
+        auth,
+        body: { imageName: 'docker.io/nginx:1.12', force: true },
+        failOnStatusCode: false,
+    }).then((scanResponse) => {
+        cy.log(`Image scan triggered: ${scanResponse.status}`);
+    });
+
+    function poll(attempt) {
+        if (attempt >= maxAttempts) {
+            throw new Error(
+                `Timed out after ${timeoutMs / 1000}s waiting for image CVE data`
+            );
+        }
+        return cy
+            .request({
+                method: 'POST',
+                url: '/api/graphql',
+                auth,
+                headers: { 'Content-Type': 'application/json' },
+                body: { query: '{ imageCVECount }' },
+                failOnStatusCode: false,
+            })
+            .then((response) => {
+                const count = response?.body?.data?.imageCVECount ?? 0;
+                if (count > 0) {
+                    cy.log(`Image CVE data ready: imageCVECount=${count}`);
+                    return;
+                }
+                cy.log(`Waiting for image CVEs... attempt ${attempt + 1}/${maxAttempts}`);
+                cy.wait(interval);
+                return poll(attempt + 1);
+            });
+    }
+
+    return poll(0);
+}

--- a/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/VulnerabilityManagement.helpers.js
@@ -463,29 +463,25 @@ export function waitForImageCVEs(timeoutMs = 120000) {
 
     function poll(attempt) {
         if (attempt >= maxAttempts) {
-            throw new Error(
-                `Timed out after ${timeoutMs / 1000}s waiting for image CVE data`
-            );
+            throw new Error(`Timed out after ${timeoutMs / 1000}s waiting for image CVE data`);
         }
-        return cy
-            .request({
-                method: 'POST',
-                url: '/api/graphql',
-                auth,
-                headers: { 'Content-Type': 'application/json' },
-                body: { query: '{ imageCVECount }' },
-                failOnStatusCode: false,
-            })
-            .then((response) => {
-                const count = response?.body?.data?.imageCVECount ?? 0;
-                if (count > 0) {
-                    cy.log(`Image CVE data ready: imageCVECount=${count}`);
-                    return;
-                }
-                cy.log(`Waiting for image CVEs... attempt ${attempt + 1}/${maxAttempts}`);
-                cy.wait(interval);
-                return poll(attempt + 1);
-            });
+        cy.request({
+            method: 'POST',
+            url: '/api/graphql',
+            auth,
+            headers: { 'Content-Type': 'application/json' },
+            body: { query: '{ imageCVECount }' },
+            failOnStatusCode: false,
+        }).then((response) => {
+            const count = response?.body?.data?.imageCVECount ?? 0;
+            if (count > 0) {
+                cy.log(`Image CVE data ready: imageCVECount=${count}`);
+                return;
+            }
+            cy.log(`Waiting for image CVEs... attempt ${attempt + 1}/${maxAttempts}`);
+            cy.wait(interval);
+            poll(attempt + 1);
+        });
     }
 
     return poll(0);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/clusters.test.js
@@ -10,12 +10,17 @@ import {
     verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 
 const entitiesKey = 'clusters';
 
 describe('Vulnerability Management Clusters', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should display all the columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboard.test.js
@@ -5,6 +5,7 @@ import {
     verifyVulnerabilityManagementDashboardCVEs,
     visitVulnerabilityManagementDashboard,
     visitVulnerabilityManagementDashboardFromLeftNav,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 import { selectors } from './VulnerabilityManagement.selectors';
 
@@ -34,6 +35,10 @@ function selectTopRiskyOption(optionText) {
 
 describe('Vulnerability Management Dashboard', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should visit using the left nav', () => {
         visitVulnerabilityManagementDashboardFromLeftNav();

--- a/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/dashboardToEntityPage.test.js
@@ -2,6 +2,7 @@ import withAuth from '../../helpers/basicAuth';
 import {
     interactAndWaitForVulnerabilityManagementEntity,
     visitVulnerabilityManagementDashboard,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 import { selectors } from './VulnerabilityManagement.selectors';
 
@@ -50,6 +51,10 @@ function selectTopRiskiestOption(optionText) {
 
 describe('Vulnerability Management Dashboard', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     // Some tests might fail in local deployment.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/deployments.test.js
@@ -10,12 +10,17 @@ import {
     verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 
 const entitiesKey = 'deployments';
 
 describe('Vulnerability Management Deployments', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/entitypages.test.js
@@ -2,11 +2,16 @@ import withAuth from '../../helpers/basicAuth';
 import {
     interactAndWaitForVulnerabilityManagementEntity,
     visitVulnerabilityManagementEntities,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 import { selectors } from './VulnerabilityManagement.selectors';
 
 describe('Entities single views', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     // Some tests might fail in local deployment.
 

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageComponents.test.js
@@ -10,12 +10,17 @@ import {
     verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 
 const entitiesKey = 'image-components';
 
 describe('Vulnerability Management Image Components', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/imageCves.test.js
@@ -12,12 +12,17 @@ import {
     interactAndWaitForVulnerabilityManagementEntities,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 
 const entitiesKey = 'image-cves';
 
 describe('Vulnerability Management Image CVEs', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/images.test.js
@@ -12,6 +12,7 @@ import {
     visitVulnerabilityManagementEntities,
     visitVulnerabilityManagementEntityInSidePanel,
     visitVulnerabilityManagementSecondaryEntitiesInSidePanel,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 import { selectors } from './VulnerabilityManagement.selectors';
 
@@ -19,6 +20,10 @@ const entitiesKey = 'images';
 
 describe('Vulnerability Management Images', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);

--- a/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
+++ b/ui/apps/platform/cypress/integration/vulnmanagement/namespaces.test.js
@@ -10,12 +10,17 @@ import {
     verifyConditionalCVEs,
     verifySecondaryEntities,
     visitVulnerabilityManagementEntities,
+    waitForImageCVEs,
 } from './VulnerabilityManagement.helpers';
 
 const entitiesKey = 'namespaces';
 
 describe('Vulnerability Management Namespaces', () => {
     withAuth();
+
+    before(() => {
+        waitForImageCVEs();
+    });
 
     it('should display table columns', () => {
         visitVulnerabilityManagementEntities(entitiesKey);


### PR DESCRIPTION
## Description

On a freshly deployed GKE cluster, process events may not be available immediately after deployment. The deployment/pod timeline Cypress tests that use real API data (no fixtures) fail because the timeline renders empty when no process events have been collected yet by collector.

Two-layer fix:
- **Workflow level**: poll `/v1/processcount` in the `*risk*` shard wait step until process events are detected (up to 5 minutes, 60 iterations at 5s each)
- **Cypress level**: add `before()` hooks in `deploymentTimeline.test.js` and `podTimeline.test.js` that poll `/v1/processcount` via `cy.request` (up to 2 minutes), ensuring data readiness even if the workflow-level wait was insufficient

The `waitForProcessEvents()` helper is added to `Risk.helpers.js` and uses recursive `cy.request` polling with `Cypress.env('ROX_AUTH_TOKEN')` for authentication.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Dispatched UI E2E workflow run to verify timeline tests pass with real data on a fresh GKE cluster.