### PR TITLE
ROX-35191: expose RESTConfig on Sensor k8s client interface

### DIFF
--- a/sensor/debugger/certs/cert_fetcher_test.go
+++ b/sensor/debugger/certs/cert_fetcher_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
 
 func createTestSecret(name, namespace string, data map[string][]byte) *v1.Secret {
@@ -32,6 +33,10 @@ func createTestSecret(name, namespace string, data map[string][]byte) *v1.Secret
 
 type testClient struct {
 	k8s kubernetes.Interface
+}
+
+func (t *testClient) RESTConfig() *rest.Config {
+	return nil
 }
 
 func (t *testClient) Kubernetes() kubernetes.Interface {

--- a/sensor/debugger/k8s/k8sclient.go
+++ b/sensor/debugger/k8s/k8sclient.go
@@ -40,12 +40,14 @@ func MakeFakeClientFromRest(restConfig *rest.Config) *ClientSet {
 	}
 
 	return &ClientSet{
-		k8s: client,
+		restConfig: restConfig,
+		k8s:        client,
 	}
 }
 
 // ClientSet is a test version of kubernetes.ClientSet
 type ClientSet struct {
+	restConfig        *rest.Config
 	dynamic           dynamic.Interface
 	k8s               kubernetes.Interface
 	openshiftApps     appVersioned.Interface
@@ -68,6 +70,7 @@ func MakeOutOfClusterClient() (*ClientSet, error) {
 	}
 
 	return &ClientSet{
+		restConfig:        config,
 		k8s:               k8sClient,
 		dynamic:           mustCreateDynamicClient(config),
 		openshiftApps:     mustCreateOpenshiftAppsClient(config),
@@ -127,6 +130,11 @@ func mustCreateDynamicClient(config *rest.Config) dynamic.Interface {
 		log.Panicf("Creating dynamic client: %v", err)
 	}
 	return client
+}
+
+// RESTConfig returns the REST config used to create this client
+func (c *ClientSet) RESTConfig() *rest.Config {
+	return c.restConfig
 }
 
 // Kubernetes returns the kubernetes interface

--- a/sensor/kubernetes/client/client.go
+++ b/sensor/kubernetes/client/client.go
@@ -19,6 +19,7 @@ var (
 
 // Interface implements an interface that bridges Kubernetes and Openshift
 type Interface interface {
+	RESTConfig() *rest.Config
 	Kubernetes() kubernetes.Interface
 	Dynamic() dynamic.Interface
 	OpenshiftApps() appVersioned.Interface
@@ -28,6 +29,7 @@ type Interface interface {
 }
 
 type clientSet struct {
+	restConfig        *rest.Config
 	dynamic           dynamic.Interface
 	k8s               kubernetes.Interface
 	openshiftApps     appVersioned.Interface
@@ -91,6 +93,7 @@ func mustCreateDynamicClient(config *rest.Config) dynamic.Interface {
 // MustCreateInterfaceFromRest creates a client interface using a rest config as a parameter
 func MustCreateInterfaceFromRest(config *rest.Config) Interface {
 	return &clientSet{
+		restConfig:        config,
 		dynamic:           mustCreateDynamicClient(config),
 		k8s:               k8sutil.MustCreateK8sClient(config),
 		openshiftApps:     mustCreateOpenshiftAppsClient(config),
@@ -107,6 +110,10 @@ func MustCreateInterface() Interface {
 		log.Panicf("Obtaining in-cluster Kubernetes config: %v", err)
 	}
 	return MustCreateInterfaceFromRest(config)
+}
+
+func (c *clientSet) RESTConfig() *rest.Config {
+	return c.restConfig
 }
 
 func (c *clientSet) Kubernetes() kubernetes.Interface {

--- a/sensor/kubernetes/client/client.go
+++ b/sensor/kubernetes/client/client.go
@@ -19,6 +19,8 @@ var (
 
 // Interface implements an interface that bridges Kubernetes and Openshift
 type Interface interface {
+	// RESTConfig returns the underlying REST configuration.
+	// Callers must not modify the returned value; use rest.CopyConfig first if mutation is needed.
 	RESTConfig() *rest.Config
 	Kubernetes() kubernetes.Interface
 	Dynamic() dynamic.Interface

--- a/sensor/kubernetes/clusterstatus/updater_test.go
+++ b/sensor/kubernetes/clusterstatus/updater_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
 
 type updaterSuite struct {
@@ -36,6 +37,10 @@ func TestClusterStatusUpdater(t *testing.T) {
 type fakeClientSet struct {
 	k8s    kubernetes.Interface
 	config configVersioned.Interface
+}
+
+func (c *fakeClientSet) RESTConfig() *rest.Config {
+	return nil
 }
 
 func (c *fakeClientSet) Kubernetes() kubernetes.Interface {

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -102,6 +102,7 @@ func init() {
 
 // clientSetImpl implements our client.Interface
 type clientSetImpl struct {
+	restConfig        *rest.Config
 	kubernetes        kubernetes.Interface
 	dynamic           dynamic.Interface
 	openshiftApps     appVersioned.Interface
@@ -112,7 +113,7 @@ type clientSetImpl struct {
 
 // RESTConfig returns nil for the fake client (no real cluster)
 func (c *clientSetImpl) RESTConfig() *rest.Config {
-	return nil
+	return c.restConfig
 }
 
 // Kubernetes returns the fake Kubernetes clientset
@@ -151,6 +152,7 @@ type WorkloadManager struct {
 	fakeClient                *fake.Clientset
 	dynamicClient             *fakeDynamic.FakeDynamicClient
 	client                    client.Interface
+	restConfig                *rest.Config
 	processPool               *ProcessPool
 	labelsPool                *labelsPoolPerNamespace
 	endpointPool              *EndpointPool
@@ -188,6 +190,7 @@ type WorkloadManagerConfig struct {
 	externalIpPool *pool
 	containerPool  *pool
 	storagePath    string
+	restConfig     *rest.Config
 }
 
 // ConfigDefaults default configuration
@@ -252,6 +255,12 @@ func (c *WorkloadManagerConfig) WithStoragePath(path string) *WorkloadManagerCon
 	return c
 }
 
+// WithRESTConfig configures the WorkloadManagerConfig's REST config.
+func (c *WorkloadManagerConfig) WithRESTConfig(restConfig *rest.Config) *WorkloadManagerConfig {
+	c.restConfig = restConfig
+	return c
+}
+
 // Client returns the mock client
 func (w *WorkloadManager) Client() client.Interface {
 	return w.client
@@ -289,6 +298,7 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 		db:                   db,
 		workload:             &workload,
 		originatorCache:      NewOriginatorCache(),
+		restConfig:           config.restConfig,
 		labelsPool:           config.labelsPool,
 		endpointPool:         config.endpointPool,
 		ipPool:               config.ipPool,
@@ -493,6 +503,7 @@ func (w *WorkloadManager) initializePreexistingResources() {
 	dynClient := fakeDynamic.NewSimpleDynamicClientWithCustomListKinds(scheme, customListKinds)
 
 	clientSet := &clientSetImpl{
+		restConfig: w.restConfig,
 		kubernetes: w.fakeClient,
 		dynamic:    dynClient,
 	}

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -111,7 +111,7 @@ type clientSetImpl struct {
 	openshiftOperator operatorVersioned.Interface
 }
 
-// RESTConfig returns nil for the fake client (no real cluster)
+// RESTConfig returns the REST configuration injected via WithRESTConfig, or nil if none was set.
 func (c *clientSetImpl) RESTConfig() *rest.Config {
 	return c.restConfig
 }

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -36,6 +36,7 @@ import (
 	fakeDynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -107,6 +108,11 @@ type clientSetImpl struct {
 	openshiftConfig   configVersioned.Interface
 	openshiftRoute    routeVersioned.Interface
 	openshiftOperator operatorVersioned.Interface
+}
+
+// RESTConfig returns nil for the fake client (no real cluster)
+func (c *clientSetImpl) RESTConfig() *rest.Config {
+	return nil
 }
 
 // Kubernetes returns the fake Kubernetes clientset

--- a/sensor/kubernetes/fake/rest_config_test.go
+++ b/sensor/kubernetes/fake/rest_config_test.go
@@ -14,11 +14,11 @@ func TestWorkloadManagerClientRESTConfigReturnsConfiguredValue(t *testing.T) {
 	workloadFile := filepath.Join(t.TempDir(), "workload.yaml")
 	require.NoError(t, os.WriteFile(workloadFile, []byte("{}\n"), 0o600))
 
+	wantConfig := &rest.Config{Host: "https://example.stackrox.invalid"}
 	config := ConfigDefaults().
 		WithWorkloadFile(workloadFile).
-		WithStoragePath("")
-	wantConfig := &rest.Config{Host: "https://example.stackrox.invalid"}
-	config.WithRESTConfig(wantConfig)
+		WithStoragePath("").
+		WithRESTConfig(wantConfig)
 
 	manager := NewWorkloadManager(config)
 	require.NotNil(t, manager)

--- a/sensor/kubernetes/fake/rest_config_test.go
+++ b/sensor/kubernetes/fake/rest_config_test.go
@@ -1,0 +1,28 @@
+package fake
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestWorkloadManagerClientRESTConfigReturnsConfiguredValue(t *testing.T) {
+	workloadFile := filepath.Join(t.TempDir(), "workload.yaml")
+	require.NoError(t, os.WriteFile(workloadFile, []byte("{}\n"), 0o600))
+
+	config := ConfigDefaults().
+		WithWorkloadFile(workloadFile).
+		WithStoragePath("")
+	wantConfig := &rest.Config{Host: "https://example.stackrox.invalid"}
+	config.WithRESTConfig(wantConfig)
+
+	manager := NewWorkloadManager(config)
+	require.NotNil(t, manager)
+	t.Cleanup(manager.Stop)
+
+	assert.Same(t, wantConfig, manager.Client().RESTConfig())
+}


### PR DESCRIPTION
## Description

> 📖 **Design documentation:** This PR is part of the VSOCK pull-mode feature. Before reviewing, please familiarize yourself with the architecture and protocol design in [ADR-0006: VM Scanning VSOCK Pull Mode](https://github.com/stackrox/architecture-decision-records/blob/piotr/ADR-0006-vsock-pull-mode/stackrox/ADR-0006-vm-scanning-vsock-pull-mode.md) — especially the architecture overview and protocol sections. It will make the code changes much easier to follow.

Add `RESTConfig() *rest.Config` to the Sensor Kubernetes client interface and all its implementations (real, fake, debugger).

### Why

The VSOCK dialer (ROX-35192) needs to open WebSocket tunnels through the KubeVirt `virtualmachineinstances/vsock` subresource API. The natural approach would be to use `kubevirt.io/client-go`'s `AsyncSubresourceHelper`, but we cannot import that library: its `log` package unconditionally registers a `-v` flag in `init()`, which panics at startup because `glog` (already in the Sensor dependency tree) also registers `-v`.

Upstream bug: https://github.com/kubevirt/kubevirt/issues/16951
Upstream code: https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/log/log.go#L88

Instead, we implement a self-contained WebSocket dialer using `k8s.io/client-go/rest` + `gorilla/websocket`. This requires direct access to the `*rest.Config` from Sensor's Kubernetes client, hence this interface extension.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI should be fully sufficient
