### PR TITLE
ROX-35192: Add pull-mode VM scraper to Sensor

### DIFF
--- a/generated/internalapi/virtualmachine/v1/index_report.pb.go
+++ b/generated/internalapi/virtualmachine/v1/index_report.pb.go
@@ -299,9 +299,12 @@ func (x *DiscoveredData) GetDnfMetadataStatus() DnfMetadataStatus {
 // The index report is collected from the virtual machine agent and contains
 // the package information.
 type IndexReport struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	VsockCid      string                 `protobuf:"bytes,1,opt,name=vsock_cid,json=vsockCid,proto3" json:"vsock_cid,omitempty"`
-	IndexV4       *v4.IndexReport        `protobuf:"bytes,2,opt,name=index_v4,json=indexV4,proto3" json:"index_v4,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	VsockCid string                 `protobuf:"bytes,1,opt,name=vsock_cid,json=vsockCid,proto3" json:"vsock_cid,omitempty"`
+	IndexV4  *v4.IndexReport        `protobuf:"bytes,2,opt,name=index_v4,json=indexV4,proto3" json:"index_v4,omitempty"`
+	// Kubernetes VirtualMachine resource UID. Set by Sensor when the UID is
+	// already known.
+	VmId          string `protobuf:"bytes,3,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -348,6 +351,13 @@ func (x *IndexReport) GetIndexV4() *v4.IndexReport {
 		return x.IndexV4
 	}
 	return nil
+}
+
+func (x *IndexReport) GetVmId() string {
+	if x != nil {
+		return x.VmId
+	}
+	return ""
 }
 
 // The index report event is sent to Central and contains additional information
@@ -420,10 +430,11 @@ const file_internalapi_virtualmachine_v1_index_report_proto_rawDesc = "" +
 	"\n" +
 	"os_version\x18\x02 \x01(\tR\tosVersion\x12P\n" +
 	"\x11activation_status\x18\x03 \x01(\x0e2#.virtualmachine.v1.ActivationStatusR\x10activationStatus\x12T\n" +
-	"\x13dnf_metadata_status\x18\x04 \x01(\x0e2$.virtualmachine.v1.DnfMetadataStatusR\x11dnfMetadataStatus\"^\n" +
+	"\x13dnf_metadata_status\x18\x04 \x01(\x0e2$.virtualmachine.v1.DnfMetadataStatusR\x11dnfMetadataStatus\"s\n" +
 	"\vIndexReport\x12\x1b\n" +
 	"\tvsock_cid\x18\x01 \x01(\tR\bvsockCid\x122\n" +
-	"\bindex_v4\x18\x02 \x01(\v2\x17.scanner.v4.IndexReportR\aindexV4\"X\n" +
+	"\bindex_v4\x18\x02 \x01(\v2\x17.scanner.v4.IndexReportR\aindexV4\x12\x13\n" +
+	"\x05vm_id\x18\x03 \x01(\tR\x04vmId\"X\n" +
 	"\x10IndexReportEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x124\n" +
 	"\x05index\x18\x02 \x01(\v2\x1e.virtualmachine.v1.IndexReportR\x05index*#\n" +

--- a/generated/internalapi/virtualmachine/v1/index_report_vtproto.pb.go
+++ b/generated/internalapi/virtualmachine/v1/index_report_vtproto.pb.go
@@ -65,6 +65,7 @@ func (m *IndexReport) CloneVT() *IndexReport {
 	}
 	r := new(IndexReport)
 	r.VsockCid = m.VsockCid
+	r.VmId = m.VmId
 	if rhs := m.IndexV4; rhs != nil {
 		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v4.IndexReport }); ok {
 			r.IndexV4 = vtpb.CloneVT()
@@ -165,6 +166,9 @@ func (this *IndexReport) EqualVT(that *IndexReport) bool {
 			return false
 		}
 	} else if !proto.Equal(this.IndexV4, that.IndexV4) {
+		return false
+	}
+	if this.VmId != that.VmId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -337,6 +341,13 @@ func (m *IndexReport) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.VmId) > 0 {
+		i -= len(m.VmId)
+		copy(dAtA[i:], m.VmId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.VmId)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.IndexV4 != nil {
 		if vtmsg, ok := interface{}(m.IndexV4).(interface {
 			MarshalToSizedBufferVT([]byte) (int, error)
@@ -478,6 +489,10 @@ func (m *IndexReport) SizeVT() (n int) {
 		} else {
 			l = proto.Size(m.IndexV4)
 		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.VmId)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -869,6 +884,38 @@ func (m *IndexReport) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VmId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.VmId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1386,6 +1433,42 @@ func (m *IndexReport) UnmarshalVTUnsafe(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VmId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.VmId = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.23.0
 	github.com/gorilla/schema v1.4.1
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grafana/pyroscope-go v1.4.1
 	github.com/graph-gophers/graphql-go v1.10.3-0.20260702060009-60399cce0c05
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
@@ -315,7 +316,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.19 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.11 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -210,6 +210,8 @@ network:
   enableNetworkPolicies: null # bool
 system:
   enablePodSecurityPolicies: null # bool
+virtualMachines:
+  enabled: null # bool
 crs:
   file: null # string
 consolePlugin:

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -117,6 +117,9 @@ autoLockProcessBaselines:
 network:
   enableNetworkPolicies: true
 
+virtualMachines:
+  enabled: false
+
 enableOpenShiftMonitoring: false
 
 processIndicators:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
@@ -310,3 +310,35 @@ roleRef:
   kind: ClusterRole
   name: {{ include "srox.globalResourceName" (list . "stackrox:review-access") }}
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "srox.globalResourceName" (list . "stackrox:vsock-access") }}
+  labels:
+    {{- include "srox.labels" (list . "clusterrole" "stackrox:vsock-access") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "clusterrole" "stackrox:vsock-access") | nindent 4 }}
+rules:
+- resources:
+  - virtualmachineinstances/vsock
+  apiGroups: ["subresources.kubevirt.io"]
+  verbs:
+  - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "srox.globalResourceName" (list . "stackrox:vsock-access-binding") }}
+  labels:
+    {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:vsock-access-binding") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:vsock-access-binding") | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: sensor
+  namespace: {{ ._rox._namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "srox.globalResourceName" (list . "stackrox:vsock-access") }}
+  apiGroup: rbac.authorization.k8s.io

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
@@ -311,6 +311,7 @@ roleRef:
   name: {{ include "srox.globalResourceName" (list . "stackrox:review-access") }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if ._rox.virtualMachines.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -342,3 +343,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "srox.globalResourceName" (list . "stackrox:vsock-access") }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -222,6 +222,10 @@ spec:
         - name: ROX_OPENSHIFT_API
           value: "true"
         {{- end }}
+        {{- if ._rox.virtualMachines.enabled }}
+        - name: ROX_VIRTUAL_MACHINES
+          value: "true"
+        {{- end }}
         [<- if (not .KubectlOutput) >]
         {{- if ._rox.sensor.localImageScanning.enabled }}
         - name: ROX_SCANNER_GRPC_ENDPOINT

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -83,4 +83,12 @@ var (
 	// limit (ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB).
 	VirtualMachinesPullMaxResponseSizeKB = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_PULL_MAX_RESPONSE_SIZE_KB", 16384).
 						WithMinimum(1)
+
+	// VirtualMachinesScraperPollInterval defines how often the pull-mode scraper
+	// polls VMs for new reports.
+	VirtualMachinesScraperPollInterval = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL", 15*time.Second)
+
+	// VirtualMachinesScraperPerVMTimeout defines the per-VM deadline for dialing
+	// and pulling a report in a single scrape cycle.
+	VirtualMachinesScraperPerVMTimeout = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_PER_VM_TIMEOUT", 30*time.Second)
 )

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -71,4 +71,16 @@ var (
 	// VMIndexReportRelayCacheTTL is how long a cached VM index report payload may be kept before it is evicted
 	// from the relay's retransmission cache.
 	VMIndexReportRelayCacheTTL = registerDurationSetting("ROX_VM_INDEX_REPORT_RELAY_CACHE_TTL", 4*time.Hour)
+
+	// VirtualMachinesScraperConcurrency defines the maximum number of VMs scraped
+	// concurrently in a single poll cycle. Higher values reduce cycle wall-clock
+	// time but increase network fan-out.
+	VirtualMachinesScraperConcurrency = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_SCRAPER_CONCURRENCY", 20).
+						WithMinimum(1)
+
+	// VirtualMachinesPullMaxResponseSizeKB defines the maximum response size (in KB) that the
+	// pull-mode scraper accepts from a VM agent. Default 16384 KB (16 MiB) matches the push-mode
+	// limit (ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB).
+	VirtualMachinesPullMaxResponseSizeKB = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_PULL_MAX_RESPONSE_SIZE_KB", 16384).
+						WithMinimum(1)
 )

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -86,7 +86,7 @@ var (
 
 	// VirtualMachinesScraperPollInterval defines how often the pull-mode scraper
 	// polls VMs for new reports.
-	VirtualMachinesScraperPollInterval = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL", 15*time.Second)
+	VirtualMachinesScraperPollInterval = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL", 5*time.Minute)
 
 	// VirtualMachinesScraperPerVMTimeout defines the per-VM deadline for dialing
 	// and pulling a report in a single scrape cycle.

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -1,6 +1,15 @@
 package env
 
-import "time"
+import (
+	"math"
+	"time"
+)
+
+// maxPullResponseSizeKB is the largest KB value that doesn't overflow
+// uint32 once converted to bytes. VirtualMachinesPullMaxResponseSizeKB
+// feeds vsockclient.NewClient, which narrows the byte count to uint32 for
+// the wire protocol's frame-length field.
+const maxPullResponseSizeKB = math.MaxUint32 / 1024
 
 var (
 	// VirtualMachinesMaxConcurrentVsockConnections defines the maximum number of vsock connections handled in parallel.
@@ -80,9 +89,11 @@ var (
 
 	// VirtualMachinesPullMaxResponseSizeKB defines the maximum response size (in KB) that the
 	// pull-mode scraper accepts from a VM agent. Default 16384 KB (16 MiB) matches the push-mode
-	// limit (ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB).
+	// limit (ROX_VIRTUAL_MACHINES_VSOCK_CONN_MAX_SIZE_KB). Capped at maxPullResponseSizeKB so an
+	// operator-configured value can never overflow the uint32 byte count vsockclient.NewClient
+	// expects; a value above the cap falls back to the default instead.
 	VirtualMachinesPullMaxResponseSizeKB = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_PULL_MAX_RESPONSE_SIZE_KB", 16384).
-						WithMinimum(1)
+						WithMinimum(1).WithMaximum(maxPullResponseSizeKB)
 
 	// VirtualMachinesScraperPollInterval defines how often the pull-mode scraper
 	// polls VMs for new reports.

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -102,4 +102,11 @@ var (
 	// VirtualMachinesScraperPerVMTimeout defines the per-VM deadline for dialing
 	// and pulling a report in a single scrape cycle.
 	VirtualMachinesScraperPerVMTimeout = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_PER_VM_TIMEOUT", 30*time.Second)
+
+	// VirtualMachinesScraperMandatoryRefreshInterval defines the maximum age of a VM's last forwarded
+	// report before the scraper requests a full report regardless of whether roxagent reports it as
+	// unchanged. This bounds how long a report can go unevaluated against newly published Scanner V4
+	// vulnerability definitions, mirroring ROX_REPROCESSING_INTERVAL and ROX_NODE_SCANNING_INTERVAL's
+	// role for image and node scanning.
+	VirtualMachinesScraperMandatoryRefreshInterval = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_MANDATORY_REFRESH_INTERVAL", 4*time.Hour)
 )

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/virtual-machines.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/virtual-machines.test.yaml
@@ -1,0 +1,26 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+
+tests:
+- name: "virtual machine VSOCK RBAC and env var are absent by default"
+  expect: |
+    .clusterroles["stackrox:vsock-access"] | assertThat(. == null)
+    .clusterrolebindings["stackrox:vsock-access-binding"] | assertThat(. == null)
+    envVars(.deployments.sensor; "sensor")["ROX_VIRTUAL_MACHINES"] | assertThat(. == null)
+
+- name: "virtual machine VSOCK RBAC and env var are created when enabled"
+  set:
+    virtualMachines.enabled: true
+  expect: |
+    .clusterroles["stackrox:vsock-access"] | assertThat(. != null)
+    .clusterrolebindings["stackrox:vsock-access-binding"] | assertThat(. != null)
+    envVars(.deployments.sensor; "sensor")["ROX_VIRTUAL_MACHINES"] | assertThat(. == "true")
+
+- name: "virtual machine VSOCK RBAC and env var are absent when explicitly disabled"
+  set:
+    virtualMachines.enabled: false
+  expect: |
+    .clusterroles["stackrox:vsock-access"] | assertThat(. == null)
+    .clusterrolebindings["stackrox:vsock-access-binding"] | assertThat(. == null)
+    envVars(.deployments.sensor; "sensor")["ROX_VIRTUAL_MACHINES"] | assertThat(. == null)

--- a/proto/internalapi/virtualmachine/v1/index_report.proto
+++ b/proto/internalapi/virtualmachine/v1/index_report.proto
@@ -51,6 +51,9 @@ enum DnfMetadataStatus {
 message IndexReport {
   string vsock_cid = 1;
   scanner.v4.IndexReport index_v4 = 2;
+  // Kubernetes VirtualMachine resource UID. Set by Sensor when the UID is
+  // already known.
+  string vm_id = 3;
 }
 
 // The index report event is sent to Central and contains additional information

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -312,12 +312,14 @@ func (h *handlerImpl) handleIndexReport(
 		log.Warn("Received nil virtual machine index report: not sending to Central")
 		return
 	}
-	log.Debugf("Handling virtual machine index report with vsock_cid=%q...", indexReport.GetVsockCid())
+	log.Debugf("Handling virtual machine index report (vm_id=%q vsock_cid=%q)...",
+		indexReport.GetVmId(), indexReport.GetVsockCid())
 
 	msg, outcome, err := h.newMessageToCentral(indexReport)
 	if err != nil {
 		// TODO: send a message the sensor relay to retry later if the VM was not found
-		log.Warnf("unable to send index report message for the virtual machine with vsock cid %q to central: %v", indexReport.GetVsockCid(), err)
+		log.Warnf("unable to send index report message for virtual machine (vm_id=%q vsock_cid=%q) to central: %v",
+			indexReport.GetVmId(), indexReport.GetVsockCid(), err)
 		return
 	}
 	h.sendIndexReportEvent(toCentral, msg)
@@ -325,15 +327,9 @@ func (h *handlerImpl) handleIndexReport(
 }
 
 func (h *handlerImpl) newMessageToCentral(indexReport *v1.IndexReport) (*message.ExpiringMessage, string, error) {
-	cid, err := strconv.ParseUint(indexReport.GetVsockCid(), 10, 32)
+	vmInfo, outcome, err := h.resolveVM(indexReport)
 	if err != nil {
-		return nil, metrics.IndexReportHandlingMessageToCentralInvalidCID, errors.Wrapf(err, "Received an invalid Vsock CID: %q", indexReport.GetVsockCid())
-	}
-
-	vmInfo := h.store.GetFromCID(uint32(cid))
-	if vmInfo == nil {
-		// Return retryable error if the virtual machine is not yet known to Sensor.
-		return nil, metrics.IndexReportHandlingMessageToCentralVMUnknown, errors.Wrapf(errVirtualMachineNotFound, "VirtualMachine with Vsock CID %q not found", indexReport.GetVsockCid())
+		return nil, outcome, err
 	}
 
 	return message.New(&central.MsgFromSensor{
@@ -350,6 +346,33 @@ func (h *handlerImpl) newMessageToCentral(indexReport *v1.IndexReport) (*message
 			},
 		},
 	}), metrics.IndexReportHandlingMessageToCentralSuccess, nil
+}
+
+// resolveVM finds the VirtualMachine for an index report. Prefer vm_id when
+// Sensor already knows the Kubernetes UID (pull path). Otherwise resolve via
+// vsock_cid (push path from agent/relay).
+func (h *handlerImpl) resolveVM(indexReport *v1.IndexReport) (*virtualmachine.Info, string, error) {
+	if vmID := indexReport.GetVmId(); vmID != "" {
+		vmInfo := h.store.Get(virtualmachine.VMID(vmID))
+		if vmInfo == nil {
+			return nil, metrics.IndexReportHandlingMessageToCentralVMUnknown,
+				errors.Wrapf(errVirtualMachineNotFound, "VirtualMachine %q not found", vmID)
+		}
+		return vmInfo, "", nil
+	}
+
+	cid, err := strconv.ParseUint(indexReport.GetVsockCid(), 10, 32)
+	if err != nil {
+		return nil, metrics.IndexReportHandlingMessageToCentralInvalidCID,
+			errors.Wrapf(err, "Received an invalid Vsock CID: %q", indexReport.GetVsockCid())
+	}
+
+	vmInfo := h.store.GetFromCID(uint32(cid))
+	if vmInfo == nil {
+		return nil, metrics.IndexReportHandlingMessageToCentralVMUnknown,
+			errors.Wrapf(errVirtualMachineNotFound, "VirtualMachine with Vsock CID %q not found", indexReport.GetVsockCid())
+	}
+	return vmInfo, "", nil
 }
 
 func (h *handlerImpl) sendIndexReportEvent(

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -211,11 +212,6 @@ func (s *virtualMachineHandlerSuite) TestInvalidCID() {
 }
 
 func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
-	err := s.handler.Start()
-	s.Require().NoError(err)
-	s.handler.Notify(common.SensorComponentEventCentralReachable)
-	defer s.handler.Stop()
-
 	vmID := virtualmachine.VMID("test-vm")
 	cases := map[string]struct {
 		vsockCID string
@@ -231,28 +227,43 @@ func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			go func() {
-				err := s.handler.Send(context.Background(), &v1.IndexReport{
-					VmId:     string(vmID),
-					VsockCid: tc.vsockCID,
-				})
+			synctest.Test(s.T(), func(t *testing.T) {
+				handler := &handlerImpl{
+					centralReady: concurrency.NewSignal(),
+					lock:         &sync.RWMutex{},
+					stopper:      concurrency.NewStopper(),
+					store:        s.store,
+				}
+				err := handler.Start()
 				s.Require().NoError(err)
-			}()
+				handler.Notify(common.SensorComponentEventCentralReachable)
+				defer handler.Stop()
 
-			select {
-			case msg := <-s.handler.ResponsesC():
-				s.Require().NotNil(msg)
-				sensorEvent := msg.GetEvent()
-				s.Require().NotNil(sensorEvent)
-				s.Assert().Equal(string(vmID), sensorEvent.GetId())
-				indexEvent := sensorEvent.GetVirtualMachineIndexReport()
-				s.Require().NotNil(indexEvent)
-				s.Assert().Equal(string(vmID), indexEvent.GetId())
-				s.Assert().Equal(string(vmID), indexEvent.GetIndex().GetVmId())
-				s.Assert().Equal(tc.vsockCID, indexEvent.GetIndex().GetVsockCid())
-			case <-time.After(time.Second):
-				s.Fail("Expected message to be sent to central")
-			}
+				go func() {
+					err := handler.Send(context.Background(), &v1.IndexReport{
+						VmId:     string(vmID),
+						VsockCid: tc.vsockCID,
+					})
+					s.Require().NoError(err)
+				}()
+
+				synctest.Wait()
+
+				select {
+				case msg := <-handler.ResponsesC():
+					s.Require().NotNil(msg)
+					sensorEvent := msg.GetEvent()
+					s.Require().NotNil(sensorEvent)
+					s.Assert().Equal(string(vmID), sensorEvent.GetId())
+					indexEvent := sensorEvent.GetVirtualMachineIndexReport()
+					s.Require().NotNil(indexEvent)
+					s.Assert().Equal(string(vmID), indexEvent.GetId())
+					s.Assert().Equal(string(vmID), indexEvent.GetIndex().GetVmId())
+					s.Assert().Equal(tc.vsockCID, indexEvent.GetIndex().GetVsockCid())
+				default:
+					s.Fail("Expected message to be sent to central")
+				}
+			})
 		})
 	}
 }

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -249,20 +249,16 @@ func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
 
 				synctest.Wait()
 
-				select {
-				case msg := <-handler.ResponsesC():
-					s.Require().NotNil(msg)
-					sensorEvent := msg.GetEvent()
-					s.Require().NotNil(sensorEvent)
-					s.Assert().Equal(string(vmID), sensorEvent.GetId())
-					indexEvent := sensorEvent.GetVirtualMachineIndexReport()
-					s.Require().NotNil(indexEvent)
-					s.Assert().Equal(string(vmID), indexEvent.GetId())
-					s.Assert().Equal(string(vmID), indexEvent.GetIndex().GetVmId())
-					s.Assert().Equal(tc.vsockCID, indexEvent.GetIndex().GetVsockCid())
-				default:
-					s.Fail("Expected message to be sent to central")
-				}
+				msg := <-handler.ResponsesC()
+				s.Require().NotNil(msg)
+				sensorEvent := msg.GetEvent()
+				s.Require().NotNil(sensorEvent)
+				s.Assert().Equal(string(vmID), sensorEvent.GetId())
+				indexEvent := sensorEvent.GetVirtualMachineIndexReport()
+				s.Require().NotNil(indexEvent)
+				s.Assert().Equal(string(vmID), indexEvent.GetId())
+				s.Assert().Equal(string(vmID), indexEvent.GetIndex().GetVmId())
+				s.Assert().Equal(tc.vsockCID, indexEvent.GetIndex().GetVsockCid())
 			})
 		})
 	}

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -210,6 +210,53 @@ func (s *virtualMachineHandlerSuite) TestInvalidCID() {
 	}
 }
 
+func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	s.handler.Notify(common.SensorComponentEventCentralReachable)
+	defer s.handler.Stop()
+
+	vmID := virtualmachine.VMID("test-vm")
+	cases := map[string]struct {
+		vsockCID string
+	}{
+		"should forward when only vm_id is set": {
+			vsockCID: "",
+		},
+		"should prefer vm_id over vsock_cid": {
+			vsockCID: "42",
+		},
+	}
+	s.store.EXPECT().Get(gomock.Eq(vmID)).Times(len(cases)).Return(&virtualmachine.Info{ID: vmID})
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			go func() {
+				err := s.handler.Send(context.Background(), &v1.IndexReport{
+					VmId:     string(vmID),
+					VsockCid: tc.vsockCID,
+				})
+				s.Require().NoError(err)
+			}()
+
+			select {
+			case msg := <-s.handler.ResponsesC():
+				s.Require().NotNil(msg)
+				sensorEvent := msg.GetEvent()
+				s.Require().NotNil(sensorEvent)
+				s.Assert().Equal(string(vmID), sensorEvent.GetId())
+				indexEvent := sensorEvent.GetVirtualMachineIndexReport()
+				s.Require().NotNil(indexEvent)
+				s.Assert().Equal(string(vmID), indexEvent.GetId())
+				s.Assert().Equal(string(vmID), indexEvent.GetIndex().GetVmId())
+				s.Assert().Equal(tc.vsockCID, indexEvent.GetIndex().GetVsockCid())
+			case <-time.After(time.Second):
+				s.Fail("Expected message to be sent to central")
+			}
+		})
+	}
+}
+
 func (s *virtualMachineHandlerSuite) TestStop() {
 	err := s.handler.Start()
 	s.Require().NoError(err)

--- a/sensor/common/virtualmachine/index/service.go
+++ b/sensor/common/virtualmachine/index/service.go
@@ -14,7 +14,14 @@ type Service interface {
 	AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error)
 }
 
+// PullActiveChecker reports whether a VM is actively scraped via pull mode.
+// When set, push-mode reports for actively-scraped VMs are dropped to avoid
+// duplicates during the push→pull transition.
+type PullActiveChecker interface {
+	IsActivelyScraped(key string) bool
+}
+
 // NewService returns the VirtualMachineIndexReportServiceServer API for Sensor to use.
-func NewService(handler Handler) Service {
-	return &serviceImpl{handler: handler}
+func NewService(handler Handler, pullChecker PullActiveChecker) Service {
+	return &serviceImpl{handler: handler, pullChecker: pullChecker}
 }

--- a/sensor/common/virtualmachine/index/service_impl.go
+++ b/sensor/common/virtualmachine/index/service_impl.go
@@ -21,7 +21,8 @@ const indexReportSendTimeout = 10 * time.Second
 
 type serviceImpl struct {
 	sensor.UnimplementedVirtualMachineIndexReportServiceServer
-	handler Handler
+	handler     Handler
+	pullChecker PullActiveChecker
 }
 
 var _ Service = (*serviceImpl)(nil)
@@ -57,6 +58,11 @@ func (s *serviceImpl) UpsertVirtualMachineIndexReport(ctx context.Context, req *
 		return &sensor.UpsertVirtualMachineIndexReportResponse{
 			Success: false,
 		}, errox.InvalidArgs.CausedBy("index report in request cannot be nil")
+	}
+
+	if s.pullChecker != nil && s.pullChecker.IsActivelyScraped(ir.GetVsockCid()) {
+		log.Debugf("Dropping push-mode report for vsock_cid=%q (VM is actively scraped via pull)", ir.GetVsockCid())
+		return &sensor.UpsertVirtualMachineIndexReportResponse{Success: true}, nil
 	}
 
 	log.Debugf("Upserting virtual machine index report with vsock_cid=%q", ir.GetVsockCid())

--- a/sensor/common/virtualmachine/index/service_impl.go
+++ b/sensor/common/virtualmachine/index/service_impl.go
@@ -62,6 +62,7 @@ func (s *serviceImpl) UpsertVirtualMachineIndexReport(ctx context.Context, req *
 
 	if s.pullChecker != nil && s.pullChecker.IsActivelyScraped(ir.GetVsockCid()) {
 		log.Debugf("Dropping push-mode report for vsock_cid=%q (VM is actively scraped via pull)", ir.GetVsockCid())
+		metrics.IndexReportsSuppressed.Inc()
 		return &sensor.UpsertVirtualMachineIndexReportResponse{Success: true}, nil
 	}
 

--- a/sensor/common/virtualmachine/index/service_impl_test.go
+++ b/sensor/common/virtualmachine/index/service_impl_test.go
@@ -134,3 +134,50 @@ func (s *virtualMachineServiceSuite) TestUpsertVirtualMachine_ShouldNotPanicWhen
 		s.Require().Error(err)
 	})
 }
+
+func (s *virtualMachineServiceSuite) TestUpsertVirtualMachine_PushSuppressedForActivelyScrapedVM() {
+	ctx := context.Background()
+
+	var sendCalled bool
+	mockHandler := mocks.NewMockHandler(s.ctrl)
+	mockHandler.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *v1.IndexReport) error {
+			sendCalled = true
+			return nil
+		},
+	)
+
+	svc := &serviceImpl{
+		handler: mockHandler,
+		// Mark VM with CID 100 as actively scraped via pull mode.
+		pullChecker: &fakePullChecker{scraped: map[string]bool{"100": true}},
+	}
+
+	// CID 100 has both push and pull active simultaneously. When both modes
+	// coexist, pull takes precedence and the push report must be suppressed
+	// to avoid sending duplicate data to Central.
+	// (The pull path forwarding is tested separately in scraper_test.go.)
+	resp, err := svc.UpsertVirtualMachineIndexReport(ctx, &sensor.UpsertVirtualMachineIndexReportRequest{
+		IndexReport: &v1.IndexReport{VsockCid: "100"},
+	})
+	s.Require().NoError(err)
+	s.Assert().True(resp.GetSuccess())
+	s.Assert().False(sendCalled, "Send must NOT be called when pull is active for this VM")
+
+	// CID 200 uses push only (not being pulled). Its push report must be
+	// forwarded to Central as usual.
+	resp, err = svc.UpsertVirtualMachineIndexReport(ctx, &sensor.UpsertVirtualMachineIndexReportRequest{
+		IndexReport: &v1.IndexReport{VsockCid: "200"},
+	})
+	s.Require().NoError(err)
+	s.Assert().True(resp.GetSuccess())
+	s.Assert().True(sendCalled, "Send MUST be called when push is the only mode for this VM")
+}
+
+type fakePullChecker struct {
+	scraped map[string]bool
+}
+
+func (f *fakePullChecker) IsActivelyScraped(key string) bool {
+	return f.scraped[key]
+}

--- a/sensor/common/virtualmachine/index/service_impl_test.go
+++ b/sensor/common/virtualmachine/index/service_impl_test.go
@@ -36,7 +36,7 @@ func (s *virtualMachineServiceSuite) SetupTest() {
 }
 
 func (s *virtualMachineServiceSuite) TestNewService() {
-	svc := NewService(NewHandler(s.store))
+	svc := NewService(NewHandler(s.store), nil)
 	s.Require().NotNil(svc)
 	s.Require().IsType(&serviceImpl{}, svc)
 

--- a/sensor/common/virtualmachine/index/service_impl_test.go
+++ b/sensor/common/virtualmachine/index/service_impl_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/centralsensor"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/index/mocks"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
@@ -153,6 +155,8 @@ func (s *virtualMachineServiceSuite) TestUpsertVirtualMachine_PushSuppressedForA
 		pullChecker: &fakePullChecker{scraped: map[string]bool{"100": true}},
 	}
 
+	suppressedBefore := testutil.ToFloat64(metrics.IndexReportsSuppressed)
+
 	// CID 100 has both push and pull active simultaneously. When both modes
 	// coexist, pull takes precedence and the push report must be suppressed
 	// to avoid sending duplicate data to Central.
@@ -163,6 +167,8 @@ func (s *virtualMachineServiceSuite) TestUpsertVirtualMachine_PushSuppressedForA
 	s.Require().NoError(err)
 	s.Assert().True(resp.GetSuccess())
 	s.Assert().False(sendCalled, "Send must NOT be called when pull is active for this VM")
+	s.Assert().Equal(suppressedBefore+1, testutil.ToFloat64(metrics.IndexReportsSuppressed),
+		"suppressing a push report must increment IndexReportsSuppressed")
 
 	// CID 200 uses push only (not being pulled). Its push report must be
 	// forwarded to Central as usual.
@@ -172,6 +178,8 @@ func (s *virtualMachineServiceSuite) TestUpsertVirtualMachine_PushSuppressedForA
 	s.Require().NoError(err)
 	s.Assert().True(resp.GetSuccess())
 	s.Assert().True(sendCalled, "Send MUST be called when push is the only mode for this VM")
+	s.Assert().Equal(suppressedBefore+1, testutil.ToFloat64(metrics.IndexReportsSuppressed),
+		"a forwarded (non-suppressed) push report must NOT increment IndexReportsSuppressed")
 }
 
 type fakePullChecker struct {

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -130,8 +130,119 @@ var IndexReportAcksReceived = prometheus.NewCounterVec(
 	[]string{"action"}, // "ACK" or "NACK"
 )
 
+// Pull-mode request status label values for PullRequestsTotal.
+const (
+	PullStatusSuccess       = "success"
+	PullStatusUnchanged     = "unchanged"
+	PullStatusDialError     = "dial_error"
+	PullStatusReadError     = "read_error"
+	PullStatusInvalidReport = "invalid_report"
+	PullStatusSendError     = "send_error"
+	PullStatusNotReady      = "not_ready"
+	PullStatusUnknownMethod = "unknown_method"
+	PullStatusTimeout       = "timeout"
+)
+
+// PullDialDurationSeconds measures time to establish a websocket connection per VM.
+var PullDialDurationSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_dial_duration_seconds",
+		Help:      "Time to establish websocket connection to a VM agent",
+		Buckets:   prometheus.ExponentialBuckets(0.01, 2, 12), // 10ms to ~20s
+	},
+)
+
+// PullReadDurationSeconds measures time to receive the full response from a VM agent.
+var PullReadDurationSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_read_duration_seconds",
+		Help:      "Time to receive full response from a VM agent",
+		Buckets:   prometheus.ExponentialBuckets(0.05, 2, 11), // 50ms to ~51s
+	},
+)
+
+// PullTotalDurationSeconds measures end-to-end time per VM (dial + read + send to Central).
+var PullTotalDurationSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_total_duration_seconds",
+		Help:      "End-to-end duration per VM: dial + read + send to Central",
+		Buckets:   prometheus.ExponentialBuckets(0.1, 2, 11), // 100ms to ~102s
+	},
+)
+
+// PullCycleDurationSeconds measures the full poll cycle across all VMs.
+var PullCycleDurationSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_cycle_duration_seconds",
+		Help:      "Duration of a full poll cycle across all VMs",
+		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1s to ~512s
+	},
+)
+
+// PullReportBytes measures response payload size in bytes.
+var PullReportBytes = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_report_bytes",
+		Help:      "Response payload size in bytes from VM agent",
+		Buckets:   prometheus.ExponentialBuckets(1024, 2, 14), // 1KB to ~8MB
+	},
+)
+
+// PullReportPackages measures package count per report.
+var PullReportPackages = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_report_packages",
+		Help:      "Number of packages per VM index report",
+		Buckets:   prometheus.ExponentialBuckets(10, 2, 10), // 10 to ~5120
+	},
+)
+
+// PullRequestsTotal counts per-VM pull attempts by status.
+var PullRequestsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_requests_total",
+		Help:      "Per-VM pull attempts by outcome status",
+	},
+	[]string{"status"},
+)
+
+// PullCyclesTotal counts poll cycles executed.
+var PullCyclesTotal = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_cycles_total",
+		Help:      "Total number of pull poll cycles executed",
+	},
+)
+
+// PullVMsInCycle tracks the number of running VMs in the last poll set.
+var PullVMsInCycle = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_vms_in_cycle",
+		Help:      "Number of running VMs in the last poll set",
+	},
+)
+
 func init() {
 	prometheus.MustRegister(
+		// Push-mode metrics.
 		IndexReportsReceived,
 		IndexReportsSent,
 		VirtualMachineIndexReportHandlingDurationMilliseconds,
@@ -140,5 +251,15 @@ func init() {
 		IndexReportEnqueueBlockedTotal,
 		VMDiscoveredData,
 		IndexReportAcksReceived,
+		// Pull-mode metrics.
+		PullDialDurationSeconds,
+		PullReadDurationSeconds,
+		PullTotalDurationSeconds,
+		PullCycleDurationSeconds,
+		PullReportBytes,
+		PullReportPackages,
+		PullRequestsTotal,
+		PullCyclesTotal,
+		PullVMsInCycle,
 	)
 }

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -205,7 +205,11 @@ var PullReportBytes = prometheus.NewHistogram(
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "vsock_pull_report_bytes",
 		Help:      "Response payload size in bytes from VM agent",
-		Buckets:   prometheus.ExponentialBuckets(1024, 2, 14), // 1KB to ~8MB
+		// 1KB to ~32MB brackets the 16MB default response-size ceiling
+		// (env.VirtualMachinesPullMaxResponseSizeKB) with a bucket to spare,
+		// giving the >8MB range that reportcheck.IsViable flags as
+		// "unusually large" its own resolution up to that ceiling.
+		Buckets: prometheus.ExponentialBuckets(1024, 2, 16),
 	},
 )
 

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -30,6 +30,17 @@ var IndexReportsReceived = prometheus.NewCounter(
 	},
 )
 
+// IndexReportsSuppressed counts push-mode index reports dropped because the
+// VM is actively scraped via pull mode.
+var IndexReportsSuppressed = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "virtual_machine_index_reports_suppressed_total",
+		Help:      "Total number of push-mode virtual machine index reports suppressed because the VM is actively scraped via pull mode",
+	},
+)
+
 // IndexReportsSent is a counter for the number of virtual machine index reports sent.
 // Asserted in VM E2E tests (tests/vm_scanning_metrics_test.go). Update tests when renaming or removing.
 var IndexReportsSent = prometheus.NewCounterVec(
@@ -244,6 +255,7 @@ func init() {
 	prometheus.MustRegister(
 		// Push-mode metrics.
 		IndexReportsReceived,
+		IndexReportsSuppressed,
 		IndexReportsSent,
 		VirtualMachineIndexReportHandlingDurationMilliseconds,
 		IndexReportProcessingDurationMilliseconds,

--- a/sensor/common/virtualmachine/reportcheck/check.go
+++ b/sensor/common/virtualmachine/reportcheck/check.go
@@ -1,0 +1,39 @@
+package reportcheck
+
+import (
+	"fmt"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// Observed on RHEL 9/10 VMs (2026-06): ~524 packages, ~449 KiB per report.
+	warnMinPackages = 5
+	warnMaxBytes    = 2 << 20 // 2 MiB (~3× observed max of ~512 KiB)
+)
+
+// IsViable returns whether the report is safe to forward, plus a
+// human-readable warning (empty if clean). The caller is responsible
+// for logging and adding VM context.
+func IsViable(report *v4.IndexReport) (bool, string) {
+	if report == nil {
+		return false, "nil report"
+	}
+
+	pkgs := len(report.GetContents().GetPackages())
+	size := proto.Size(report)
+
+	if pkgs == 0 {
+		return true, fmt.Sprintf("zero packages (state=%s, size=%d bytes) — VM may have no package manager or scan failed silently",
+			report.GetState(), size)
+	}
+	if pkgs < warnMinPackages {
+		return true, fmt.Sprintf("only %d packages — unexpectedly low for a production VM", pkgs)
+	}
+	if size > warnMaxBytes {
+		return true, fmt.Sprintf("report is %d bytes (%d packages) — unusually large", size, pkgs)
+	}
+
+	return true, ""
+}

--- a/sensor/common/virtualmachine/reportcheck/check.go
+++ b/sensor/common/virtualmachine/reportcheck/check.go
@@ -7,16 +7,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const (
-	// Observed on RHEL 9/10 VMs (2026-06): ~524 packages, ~449 KiB per report.
-	warnMinPackages = 5
-	warnMaxBytes    = 2 << 20 // 2 MiB (~3× observed max of ~512 KiB)
-)
-
 // IsViable returns whether the report is safe to forward, plus a
 // human-readable warning (empty if clean). The caller is responsible
 // for logging and adding VM context.
-func IsViable(report *v4.IndexReport) (bool, string) {
+//
+// warnMaxBytes is the size, in bytes, above which a report is flagged as
+// unusually large. Callers derive it from the configured pull-mode
+// response-size ceiling (see env.VirtualMachinesPullMaxResponseSizeKB)
+// rather than a value hardcoded here, so the warning stays in sync with
+// that ceiling instead of drifting from it.
+func IsViable(report *v4.IndexReport, warnMaxBytes int) (bool, string) {
 	if report == nil {
 		return false, "nil report"
 	}
@@ -28,11 +28,11 @@ func IsViable(report *v4.IndexReport) (bool, string) {
 		return true, fmt.Sprintf("zero packages (state=%s, size=%d bytes) — VM may have no package manager or scan failed silently",
 			report.GetState(), size)
 	}
-	if pkgs < warnMinPackages {
-		return true, fmt.Sprintf("only %d packages — unexpectedly low for a production VM", pkgs)
-	}
+	// Debuggability: the protocol between Sensor and roxagent has a limit (currently 16MB).
+	// If the report is larger than the limit, the transmission will fail.
+	// We want to have a trace in the logs to help debug the issue in case it happens.
 	if size > warnMaxBytes {
-		return true, fmt.Sprintf("report is %d bytes (%d packages) — unusually large", size, pkgs)
+		return true, fmt.Sprintf("report is %d bytes (%d packages)", size, pkgs)
 	}
 
 	return true, ""

--- a/sensor/common/virtualmachine/reportcheck/check_test.go
+++ b/sensor/common/virtualmachine/reportcheck/check_test.go
@@ -1,0 +1,85 @@
+package reportcheck
+
+import (
+	"strings"
+	"testing"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func packageMap(n int) map[string]*v4.Package {
+	pkgs := make(map[string]*v4.Package, n)
+	for i := range n {
+		pkgs[string(rune('a'+i))] = &v4.Package{Name: string(rune('a' + i)), Version: "1.0.0"}
+	}
+	return pkgs
+}
+
+func TestIsViable(t *testing.T) {
+	cases := map[string]struct {
+		report      *v4.IndexReport
+		wantViable  bool
+		wantWarning string // substring; "" means the warning must be empty
+	}{
+		"should reject a nil report": {
+			report:      nil,
+			wantViable:  false,
+			wantWarning: "nil report",
+		},
+		"should warn but accept a report with zero packages": {
+			report: &v4.IndexReport{
+				State:    "IndexFinished",
+				Contents: &v4.Contents{},
+			},
+			wantViable:  true,
+			wantWarning: "zero packages",
+		},
+		"should warn but accept a report with fewer packages than the minimum": {
+			report: &v4.IndexReport{
+				State:    "IndexFinished",
+				Contents: &v4.Contents{Packages: packageMap(warnMinPackages - 1)},
+			},
+			wantViable:  true,
+			wantWarning: "unexpectedly low",
+		},
+		"should accept a normal report with no warning": {
+			report: &v4.IndexReport{
+				State:    "IndexFinished",
+				Contents: &v4.Contents{Packages: packageMap(warnMinPackages + 5)},
+			},
+			wantViable:  true,
+			wantWarning: "",
+		},
+		"should warn but accept an unusually large report": {
+			report: &v4.IndexReport{
+				State: "IndexFinished",
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						// A handful of normal packages plus one with an
+						// oversized field pushes the encoded report past
+						// warnMaxBytes without needing thousands of entries.
+						"a": {Name: "a", Version: "1.0.0"},
+						"b": {Name: "b", Version: "1.0.0"},
+						"c": {Name: "c", Version: "1.0.0"},
+						"d": {Name: "d", Version: "1.0.0"},
+						"e": {Name: "e", Version: strings.Repeat("x", warnMaxBytes+1024)},
+					},
+				},
+			},
+			wantViable:  true,
+			wantWarning: "unusually large",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			viable, warning := IsViable(tc.report)
+			assert.Equal(t, tc.wantViable, viable)
+			if tc.wantWarning == "" {
+				assert.Empty(t, warning)
+			} else {
+				assert.Contains(t, warning, tc.wantWarning)
+			}
+		})
+	}
+}

--- a/sensor/common/virtualmachine/reportcheck/check_test.go
+++ b/sensor/common/virtualmachine/reportcheck/check_test.go
@@ -16,6 +16,10 @@ func packageMap(n int) map[string]*v4.Package {
 	return pkgs
 }
 
+// testWarnMaxBytes stands in for the caller-supplied threshold that, in
+// production, is derived from env.VirtualMachinesPullMaxResponseSizeKB.
+const testWarnMaxBytes = 2 << 20 // 2 MiB
+
 func TestIsViable(t *testing.T) {
 	cases := map[string]struct {
 		report      *v4.IndexReport
@@ -35,18 +39,10 @@ func TestIsViable(t *testing.T) {
 			wantViable:  true,
 			wantWarning: "zero packages",
 		},
-		"should warn but accept a report with fewer packages than the minimum": {
-			report: &v4.IndexReport{
-				State:    "IndexFinished",
-				Contents: &v4.Contents{Packages: packageMap(warnMinPackages - 1)},
-			},
-			wantViable:  true,
-			wantWarning: "unexpectedly low",
-		},
 		"should accept a normal report with no warning": {
 			report: &v4.IndexReport{
 				State:    "IndexFinished",
-				Contents: &v4.Contents{Packages: packageMap(warnMinPackages + 5)},
+				Contents: &v4.Contents{Packages: packageMap(5)},
 			},
 			wantViable:  true,
 			wantWarning: "",
@@ -58,22 +54,22 @@ func TestIsViable(t *testing.T) {
 					Packages: map[string]*v4.Package{
 						// A handful of normal packages plus one with an
 						// oversized field pushes the encoded report past
-						// warnMaxBytes without needing thousands of entries.
+						// testWarnMaxBytes without needing thousands of entries.
 						"a": {Name: "a", Version: "1.0.0"},
 						"b": {Name: "b", Version: "1.0.0"},
 						"c": {Name: "c", Version: "1.0.0"},
 						"d": {Name: "d", Version: "1.0.0"},
-						"e": {Name: "e", Version: strings.Repeat("x", warnMaxBytes+1024)},
+						"e": {Name: "e", Version: strings.Repeat("x", testWarnMaxBytes+1024)},
 					},
 				},
 			},
 			wantViable:  true,
-			wantWarning: "unusually large",
+			wantWarning: "report is",
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			viable, warning := IsViable(tc.report)
+			viable, warning := IsViable(tc.report, testWarnMaxBytes)
 			assert.Equal(t, tc.wantViable, viable)
 			if tc.wantWarning == "" {
 				assert.Empty(t, warning)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -224,6 +224,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 
 	if result.Unchanged {
 		if s.now().Sub(state.lastForwardedAt) <= mandatoryRefreshAfter {
+			s.registerScrapedVM(scrapedVMs, vm)
 			log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, state.lastGeneration)
 			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
 			return true
@@ -264,14 +265,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 
 	state.lastGeneration = result.Meta.GetReportGeneration()
 	state.lastForwardedAt = s.now()
-	// Register both identifiers so IsActivelyScraped works whether the
-	// caller uses "namespace/name" (pull path) or a CID string (push path).
-	concurrency.WithLock(&s.mu, func() {
-		scrapedVMs.Add(key)
-		if vm.VSOCKCID != nil {
-			scrapedVMs.Add(strconv.FormatUint(uint64(*vm.VSOCKCID), 10))
-		}
-	})
+	s.registerScrapedVM(scrapedVMs, vm)
 
 	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, dial=%s, read=%s, total=%s",
 		key, state.lastGeneration, len(result.IndexReport.GetContents().GetPackages()), reportSize,
@@ -298,6 +292,18 @@ func (s *VMScraper) handleGetReportError(key string, err error) {
 		log.Warnf("VMScraper: protocol error for %q (possible version mismatch): %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
 	}
+}
+
+func (s *VMScraper) registerScrapedVM(scrapedVMs set.StringSet, vm *virtualmachine.Info) {
+	key := vm.Namespace + "/" + vm.Name
+	// Register both identifiers so IsActivelyScraped works whether the
+	// caller uses "namespace/name" (pull path) or a CID string (push path).
+	concurrency.WithLock(&s.mu, func() {
+		scrapedVMs.Add(key)
+		if vm.VSOCKCID != nil {
+			scrapedVMs.Add(strconv.FormatUint(uint64(*vm.VSOCKCID), 10))
+		}
+	})
 }
 
 // getOrCreateState returns the vmState for key, creating it if absent.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -1,0 +1,326 @@
+package vmscraper
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/reportcheck"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+)
+
+var log = logging.LoggerForModule()
+
+const (
+	defaultPollInterval   = 15 * time.Second
+	mandatoryRefreshAfter = 4 * time.Hour
+	perVMTimeout          = 30 * time.Second
+)
+
+func getVsockPort() uint32 {
+	return uint32(env.VirtualMachinesVsockPort.IntegerSetting())
+}
+
+// RunningVMStore provides the list of running VMs.
+type RunningVMStore interface {
+	ListRunning() []*virtualmachine.Info
+}
+
+// VMDialer connects to a VM's VSOCK port.
+type VMDialer interface {
+	Dial(ctx context.Context, namespace, name string, port uint32, useTLS bool) (io.ReadWriteCloser, error)
+}
+
+// IndexReportSender sends index reports toward Central.
+type IndexReportSender interface {
+	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error
+}
+
+// ProtocolClient performs the request/response protocol over a stream.
+type ProtocolClient interface {
+	GetReport(stream io.ReadWriteCloser, ifNewerThan uint32) (*vsockclient.GetReportResult, error)
+}
+
+// VMScraper polls running VMs and pulls their scan reports via VSOCK.
+type VMScraper struct {
+	store       RunningVMStore
+	sender      IndexReportSender
+	dialer      VMDialer
+	client      ProtocolClient
+	interval    time.Duration
+	concurrency int
+	stopper     concurrency.Stopper
+	now         func() time.Time
+
+	mu        sync.Mutex
+	vmState   map[string]*vmState
+	activeVMs set.StringSet
+}
+
+type vmState struct {
+	lastGeneration  uint32
+	lastForwardedAt time.Time
+}
+
+var _ common.SensorComponent = (*VMScraper)(nil)
+
+// New creates a VMScraper with production defaults.
+func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
+	return &VMScraper{
+		store:       store,
+		sender:      sender,
+		dialer:      dialer,
+		client:      client,
+		interval:    defaultPollInterval,
+		concurrency: env.VirtualMachinesScraperConcurrency.IntegerSetting(),
+		vmState:     make(map[string]*vmState),
+		activeVMs:   set.NewStringSet(),
+		now:         time.Now,
+	}
+}
+
+// IsActivelyScraped reports whether the given VM is actively scraped via pull
+// mode. Accepts either a "namespace/name" key or a vsock CID string.
+// Used to suppress duplicate push-mode reports during the push→pull transition.
+func (s *VMScraper) IsActivelyScraped(key string) bool {
+	return concurrency.WithLock1(&s.mu, func() bool {
+		return s.activeVMs.Contains(key)
+	})
+}
+
+func (s *VMScraper) Name() string { return "virtualmachine.vmscraper" }
+
+func (s *VMScraper) Start() error {
+	s.stopper = concurrency.NewStopper()
+	go s.run()
+	return nil
+}
+
+func (s *VMScraper) Stop() {
+	s.stopper.Client().Stop()
+}
+
+func (s *VMScraper) Capabilities() []centralsensor.SensorCapability { return nil }
+func (s *VMScraper) Notify(_ common.SensorComponentEvent)           {}
+func (s *VMScraper) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
+	return nil
+}
+func (s *VMScraper) Accepts(_ *central.MsgToSensor) bool         { return false }
+func (s *VMScraper) ResponsesC() <-chan *message.ExpiringMessage { return nil }
+
+func (s *VMScraper) run() {
+	defer s.stopper.Flow().ReportStopped()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-s.stopper.Flow().StopRequested()
+		cancel()
+	}()
+
+	// Poll immediately on start so VMs don't wait a full interval before first scrape.
+	s.pollOnce(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.pollOnce(ctx)
+		}
+	}
+}
+
+func (s *VMScraper) pollOnce(ctx context.Context) {
+	cycleStart := s.now()
+	vms := s.store.ListRunning()
+	log.Infof("VMScraper: about to poll %d running VMs (concurrency=%d)", len(vms), s.concurrency)
+	metrics.PullCyclesTotal.Inc()
+	metrics.PullVMsInCycle.Set(float64(len(vms)))
+
+	// Build a new activeVMs set during the cycle. The old set remains in
+	// effect for IsActivelyScraped callers, preventing a suppression gap
+	// while scraping is in progress.
+	scrapedVMs := set.NewStringSet()
+	var successCount atomic.Int32
+
+	liveKeys := set.NewStringSet()
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(s.concurrency)
+
+	for _, vm := range vms {
+		liveKeys.Add(vm.Namespace + "/" + vm.Name)
+		g.Go(func() error {
+			if s.scrapeVM(gCtx, vm, scrapedVMs) {
+				successCount.Add(1)
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	concurrency.WithLock(&s.mu, func() {
+		s.activeVMs = scrapedVMs
+	})
+
+	s.pruneStaleVMState(liveKeys)
+	elapsed := time.Since(cycleStart)
+	log.Infof("VMScraper: cycle done: %d/%d VMs scraped successfully in %s", successCount.Load(), len(vms), elapsed.Truncate(time.Millisecond))
+	metrics.PullCycleDurationSeconds.Observe(elapsed.Seconds())
+}
+
+func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrapedVMs set.StringSet) bool {
+	key := vm.Namespace + "/" + vm.Name
+	state := s.getOrCreateState(key)
+
+	vmCtx, cancel := context.WithTimeout(ctx, perVMTimeout)
+	defer cancel()
+
+	totalStart := s.now()
+
+	log.Debugf("VMScraper: dialing roxagent on %q with TLS", key)
+	dialStart := s.now()
+	port := getVsockPort()
+	stream, err := s.dialer.Dial(vmCtx, vm.Namespace, vm.Name, port, true)
+	metrics.PullDialDurationSeconds.Observe(time.Since(dialStart).Seconds())
+	if err != nil {
+		if vmCtx.Err() != nil {
+			log.Warnf("VMScraper: dialing roxagent on %q timed out: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()
+		} else {
+			log.Warnf("VMScraper: dialing roxagent on %q failed: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusDialError).Inc()
+		}
+		return false
+	}
+	defer func() { _ = stream.Close() }()
+
+	readStart := s.now()
+	result, err := s.client.GetReport(stream, state.lastGeneration)
+	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
+	if err != nil {
+		s.handleGetReportError(key, err)
+		return false
+	}
+
+	if result.Unchanged {
+		if s.now().Sub(state.lastForwardedAt) <= mandatoryRefreshAfter {
+			log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, state.lastGeneration)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
+			return true
+		}
+		stream2, err := s.dialer.Dial(vmCtx, vm.Namespace, vm.Name, port, true)
+		if err != nil {
+			log.Warnf("VMScraper: re-dialing roxagent on %q for mandatory refresh failed: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusDialError).Inc()
+			return false
+		}
+		defer func() { _ = stream2.Close() }()
+
+		result, err = s.client.GetReport(stream2, 0)
+		if err != nil {
+			s.handleGetReportError(key, err)
+			return false
+		}
+	}
+
+	viable, warning := reportcheck.IsViable(result.IndexReport)
+	if warning != "" {
+		log.Warnf("VM report from %q: %s", key, warning)
+	}
+	if !viable {
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusInvalidReport).Inc()
+		return false
+	}
+
+	reportSize := proto.Size(result.IndexReport)
+	metrics.PullReportBytes.Observe(float64(reportSize))
+	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
+
+	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
+		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
+		return false
+	}
+
+	state.lastGeneration = result.Meta.GetReportGeneration()
+	state.lastForwardedAt = s.now()
+	// Register both identifiers so IsActivelyScraped works whether the
+	// caller uses "namespace/name" (pull path) or a CID string (push path).
+	concurrency.WithLock(&s.mu, func() {
+		scrapedVMs.Add(key)
+		if vm.VSOCKCID != nil {
+			scrapedVMs.Add(strconv.FormatUint(uint64(*vm.VSOCKCID), 10))
+		}
+	})
+
+	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, dial=%s, read=%s, total=%s",
+		key, state.lastGeneration, len(result.IndexReport.GetContents().GetPackages()), reportSize,
+		time.Since(dialStart).Truncate(time.Millisecond),
+		time.Since(readStart).Truncate(time.Millisecond),
+		time.Since(totalStart).Truncate(time.Millisecond))
+	metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSuccess).Inc()
+	metrics.PullTotalDurationSeconds.Observe(time.Since(totalStart).Seconds())
+	return true
+}
+
+func (s *VMScraper) handleGetReportError(key string, err error) {
+	switch {
+	case errors.Is(err, vsockclient.ErrNotReady):
+		log.Debugf("VMScraper: roxagent on %q has not yet generated a report", key)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusNotReady).Inc()
+	case errors.Is(err, vsockclient.ErrUnknownMethod):
+		log.Warnf("VMScraper: roxagent on %q does not support the GetReport method", key)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnknownMethod).Inc()
+	case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
+		log.Debugf("VMScraper: roxagent on %q connection closed (agent may be down or restarting): %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
+	default:
+		log.Warnf("VMScraper: protocol error for %q (possible version mismatch): %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
+	}
+}
+
+// getOrCreateState returns the vmState for key, creating it if absent.
+// The returned pointer is mutated outside the lock — this is safe because
+// each VM key is processed by exactly one goroutine per poll cycle
+// (the VM list contains unique entries, and errgroup assigns one goroutine each).
+func (s *VMScraper) getOrCreateState(key string) *vmState {
+	return concurrency.WithLock1(&s.mu, func() *vmState {
+		st, ok := s.vmState[key]
+		if !ok {
+			st = &vmState{}
+			s.vmState[key] = st
+		}
+		return st
+	})
+}
+
+func (s *VMScraper) pruneStaleVMState(liveKeys set.StringSet) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key := range s.vmState {
+		if !liveKeys.Contains(key) {
+			delete(s.vmState, key)
+		}
+	}
+}

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -30,9 +30,7 @@ import (
 var log = logging.LoggerForModule()
 
 const (
-	defaultPollInterval   = 15 * time.Second
 	mandatoryRefreshAfter = 4 * time.Hour
-	perVMTimeout          = 30 * time.Second
 )
 
 func getVsockPort() uint32 {
@@ -61,14 +59,15 @@ type ProtocolClient interface {
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
 type VMScraper struct {
-	store       RunningVMStore
-	sender      IndexReportSender
-	dialer      VMDialer
-	client      ProtocolClient
-	interval    time.Duration
-	concurrency int
-	stopper     concurrency.Stopper
-	now         func() time.Time
+	store        RunningVMStore
+	sender       IndexReportSender
+	dialer       VMDialer
+	client       ProtocolClient
+	interval     time.Duration
+	perVMTimeout time.Duration
+	concurrency  int
+	stopper      concurrency.Stopper
+	now          func() time.Time
 
 	mu        sync.Mutex
 	vmState   map[string]*vmState
@@ -85,15 +84,16 @@ var _ common.SensorComponent = (*VMScraper)(nil)
 // New creates a VMScraper with production defaults.
 func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
 	return &VMScraper{
-		store:       store,
-		sender:      sender,
-		dialer:      dialer,
-		client:      client,
-		interval:    defaultPollInterval,
-		concurrency: env.VirtualMachinesScraperConcurrency.IntegerSetting(),
-		vmState:     make(map[string]*vmState),
-		activeVMs:   set.NewStringSet(),
-		now:         time.Now,
+		store:        store,
+		sender:       sender,
+		dialer:       dialer,
+		client:       client,
+		interval:     env.VirtualMachinesScraperPollInterval.DurationSetting(),
+		perVMTimeout: env.VirtualMachinesScraperPerVMTimeout.DurationSetting(),
+		concurrency:  env.VirtualMachinesScraperConcurrency.IntegerSetting(),
+		vmState:      make(map[string]*vmState),
+		activeVMs:    set.NewStringSet(),
+		now:          time.Now,
 	}
 }
 
@@ -192,7 +192,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	key := vm.Namespace + "/" + vm.Name
 	state := s.getOrCreateState(key)
 
-	vmCtx, cancel := context.WithTimeout(ctx, perVMTimeout)
+	vmCtx, cancel := context.WithTimeout(ctx, s.perVMTimeout)
 	defer cancel()
 
 	totalStart := s.now()

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -199,12 +199,22 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	totalStart := s.now()
 	port := getVsockPort()
 
+	// The mandatory refresh is a deterministic, time-based decision Sensor
+	// can make before dialing at all, so request the full report on this
+	// first (and only) round trip instead of asking "anything newer?" and
+	// re-dialing once told no.
+	ifNewerThan, knownEpoch := state.lastGeneration, state.lastEpoch
+	mandatoryRefreshDue := s.now().Sub(state.lastForwardedAt) > mandatoryRefreshAfter
+	if mandatoryRefreshDue {
+		ifNewerThan, knownEpoch = 0, 0
+	}
+
 	log.Debugf("VMScraper: dialing roxagent on %q with TLS", key)
 	// knownEpoch lets a current roxagent make the complete "changed or not"
 	// decision server-side and serve the full report in this same round trip
 	// on a restart-coincidence false match, instead of relying solely on the
 	// client-side fallback below.
-	result, ok := s.dialAndGetReport(vmCtx, vm, key, port, state.lastGeneration, state.lastEpoch)
+	result, ok := s.dialAndGetReport(vmCtx, vm, key, port, ifNewerThan, knownEpoch)
 	if !ok {
 		return false
 	}
@@ -218,18 +228,21 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 		// generation-only comparison can produce a false "unchanged" right
 		// after a restart (report_generation resets to 1 and coincidentally
 		// re-matches Sensor's cached value).
+		//
+		// mandatoryRefreshDue is deliberately not re-checked here: when
+		// true, the call above already requested ifNewerThan=0, so a
+		// current roxagent can only report Unchanged for a reason other
+		// than the mandatory refresh — i.e. an epoch mismatch below.
 		epoch := result.Meta.GetEpoch()
 		epochMismatch := epoch != 0 && epoch != state.lastEpoch
-		if !epochMismatch && s.now().Sub(state.lastForwardedAt) <= mandatoryRefreshAfter {
+		if !epochMismatch {
 			s.registerScrapedVM(scrapedVMs, vm)
 			log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, state.lastGeneration)
 			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
 			return true
 		}
-		if epochMismatch {
-			log.Infof("VMScraper: roxagent on %q restarted (epoch changed from %d to %d, generation coincidentally matched cached value %d) — forcing full report",
-				key, state.lastEpoch, epoch, state.lastGeneration)
-		}
+		log.Infof("VMScraper: roxagent on %q restarted (epoch changed from %d to %d, generation coincidentally matched cached value %d) — forcing full report",
+			key, state.lastEpoch, epoch, state.lastGeneration)
 		result, ok = s.dialAndGetReport(vmCtx, vm, key, port, 0, 0)
 		if !ok {
 			return false
@@ -270,10 +283,10 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 
 // dialAndGetReport dials the VM and issues a single GetReport request,
 // recording dial/read latency metrics and classifying dial failures
-// (timeout vs. other) consistently. scrapeVM calls this twice on the
-// mandatory-refresh/epoch-mismatch path (see the Unchanged branch above),
-// and previously duplicated this logic inline for each call — which had
-// let the second call's dial silently skip the latency metrics.
+// (timeout vs. other) consistently regardless of which call site invokes
+// it. scrapeVM calls this twice on the epoch-mismatch fallback path (see
+// the Unchanged branch above), so keeping the timing and error-handling
+// logic in one place ensures both calls are measured the same way.
 func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Info, key string, port, ifNewerThan, knownEpoch uint32) (*vsockclient.GetReportResult, bool) {
 	dialStart := s.now()
 	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -169,7 +169,7 @@ func (s *VMScraper) pollOnce(ctx context.Context) {
 	g.SetLimit(s.concurrency)
 
 	for _, vm := range vms {
-		liveKeys.Add(vm.Namespace + "/" + vm.Name)
+		liveKeys.Add(vmKey(vm))
 		g.Go(func() error {
 			if s.scrapeVM(gCtx, vm, scrapedVMs) {
 				successCount.Add(1)
@@ -190,40 +190,22 @@ func (s *VMScraper) pollOnce(ctx context.Context) {
 }
 
 func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrapedVMs set.StringSet) bool {
-	key := vm.Namespace + "/" + vm.Name
+	key := vmKey(vm)
 	state := s.getOrCreateState(key)
 
 	vmCtx, cancel := context.WithTimeout(ctx, s.perVMTimeout)
 	defer cancel()
 
 	totalStart := s.now()
+	port := getVsockPort()
 
 	log.Debugf("VMScraper: dialing roxagent on %q with TLS", key)
-	dialStart := s.now()
-	port := getVsockPort()
-	stream, err := s.dialer.Dial(vmCtx, vm.Namespace, vm.Name, port, true)
-	metrics.PullDialDurationSeconds.Observe(time.Since(dialStart).Seconds())
-	if err != nil {
-		if vmCtx.Err() != nil {
-			log.Warnf("VMScraper: dialing roxagent on %q timed out: %v", key, err)
-			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()
-		} else {
-			log.Warnf("VMScraper: dialing roxagent on %q failed: %v", key, err)
-			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusDialError).Inc()
-		}
-		return false
-	}
-	defer func() { _ = stream.Close() }()
-
-	readStart := s.now()
 	// knownEpoch lets a current roxagent make the complete "changed or not"
 	// decision server-side and serve the full report in this same round trip
 	// on a restart-coincidence false match, instead of relying solely on the
 	// client-side fallback below.
-	result, err := s.client.GetReport(stream, state.lastGeneration, state.lastEpoch)
-	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
-	if err != nil {
-		s.handleGetReportError(key, err)
+	result, ok := s.dialAndGetReport(vmCtx, vm, key, port, state.lastGeneration, state.lastEpoch)
+	if !ok {
 		return false
 	}
 
@@ -248,17 +230,8 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 			log.Infof("VMScraper: roxagent on %q restarted (epoch changed from %d to %d, generation coincidentally matched cached value %d) — forcing full report",
 				key, state.lastEpoch, epoch, state.lastGeneration)
 		}
-		stream2, err := s.dialer.Dial(vmCtx, vm.Namespace, vm.Name, port, true)
-		if err != nil {
-			log.Warnf("VMScraper: re-dialing roxagent on %q for mandatory refresh failed: %v", key, err)
-			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusDialError).Inc()
-			return false
-		}
-		defer func() { _ = stream2.Close() }()
-
-		result, err = s.client.GetReport(stream2, 0, 0)
-		if err != nil {
-			s.handleGetReportError(key, err)
+		result, ok = s.dialAndGetReport(vmCtx, vm, key, port, 0, 0)
+		if !ok {
 			return false
 		}
 	}
@@ -287,14 +260,44 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	state.lastForwardedAt = s.now()
 	s.registerScrapedVM(scrapedVMs, vm)
 
-	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, dial=%s, read=%s, total=%s",
+	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, total=%s",
 		key, state.lastGeneration, len(result.IndexReport.GetContents().GetPackages()), reportSize,
-		time.Since(dialStart).Truncate(time.Millisecond),
-		time.Since(readStart).Truncate(time.Millisecond),
 		time.Since(totalStart).Truncate(time.Millisecond))
 	metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSuccess).Inc()
 	metrics.PullTotalDurationSeconds.Observe(time.Since(totalStart).Seconds())
 	return true
+}
+
+// dialAndGetReport dials the VM and issues a single GetReport request,
+// recording dial/read latency metrics and classifying dial failures
+// (timeout vs. other) consistently. scrapeVM calls this twice on the
+// mandatory-refresh/epoch-mismatch path (see the Unchanged branch above),
+// and previously duplicated this logic inline for each call — which had
+// let the second call's dial silently skip the latency metrics.
+func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Info, key string, port, ifNewerThan, knownEpoch uint32) (*vsockclient.GetReportResult, bool) {
+	dialStart := s.now()
+	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
+	metrics.PullDialDurationSeconds.Observe(time.Since(dialStart).Seconds())
+	if err != nil {
+		if ctx.Err() != nil {
+			log.Warnf("VMScraper: dialing roxagent on %q timed out: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()
+		} else {
+			log.Warnf("VMScraper: dialing roxagent on %q failed: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusDialError).Inc()
+		}
+		return nil, false
+	}
+	defer func() { _ = stream.Close() }()
+
+	readStart := s.now()
+	result, err := s.client.GetReport(stream, ifNewerThan, knownEpoch)
+	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
+	if err != nil {
+		s.handleGetReportError(key, err)
+		return nil, false
+	}
+	return result, true
 }
 
 func (s *VMScraper) handleGetReportError(key string, err error) {
@@ -314,8 +317,13 @@ func (s *VMScraper) handleGetReportError(key string, err error) {
 	}
 }
 
+// vmKey returns the identifier used for vmState and activeVMs lookups.
+func vmKey(vm *virtualmachine.Info) string {
+	return vm.Namespace + "/" + vm.Name
+}
+
 func (s *VMScraper) registerScrapedVM(scrapedVMs set.StringSet, vm *virtualmachine.Info) {
-	key := vm.Namespace + "/" + vm.Name
+	key := vmKey(vm)
 	// Register both identifiers so IsActivelyScraped works whether the
 	// caller uses "namespace/name" (pull path) or a CID string (push path).
 	concurrency.WithLock(&s.mu, func() {

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -31,10 +31,6 @@ var (
 	errStartMoreThanOnce = errors.New("unable to start the VM scraper more than once")
 )
 
-const (
-	mandatoryRefreshAfter = 4 * time.Hour
-)
-
 func getVsockPort() uint32 {
 	return uint32(env.VirtualMachinesVsockPort.IntegerSetting())
 }
@@ -61,17 +57,18 @@ type ProtocolClient interface {
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
 type VMScraper struct {
-	store        RunningVMStore
-	sender       IndexReportSender
-	dialer       VMDialer
-	client       ProtocolClient
-	interval     time.Duration
-	perVMTimeout time.Duration
-	concurrency  int
-	warnMaxBytes int
-	stopper      concurrency.Stopper
-	started      atomic.Bool
-	now          func() time.Time
+	store                 RunningVMStore
+	sender                IndexReportSender
+	dialer                VMDialer
+	client                ProtocolClient
+	interval              time.Duration
+	perVMTimeout          time.Duration
+	mandatoryRefreshAfter time.Duration
+	concurrency           int
+	warnMaxBytes          int
+	stopper               concurrency.Stopper
+	started               atomic.Bool
+	now                   func() time.Time
 
 	mu        sync.Mutex
 	vmState   map[string]*vmState
@@ -89,13 +86,14 @@ var _ common.SensorComponent = (*VMScraper)(nil)
 // New creates a VMScraper with production defaults.
 func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
 	return &VMScraper{
-		store:        store,
-		sender:       sender,
-		dialer:       dialer,
-		client:       client,
-		interval:     env.VirtualMachinesScraperPollInterval.DurationSetting(),
-		perVMTimeout: env.VirtualMachinesScraperPerVMTimeout.DurationSetting(),
-		concurrency:  env.VirtualMachinesScraperConcurrency.IntegerSetting(),
+		store:                 store,
+		sender:                sender,
+		dialer:                dialer,
+		client:                client,
+		interval:              env.VirtualMachinesScraperPollInterval.DurationSetting(),
+		perVMTimeout:          env.VirtualMachinesScraperPerVMTimeout.DurationSetting(),
+		mandatoryRefreshAfter: env.VirtualMachinesScraperMandatoryRefreshInterval.DurationSetting(),
+		concurrency:           env.VirtualMachinesScraperConcurrency.IntegerSetting(),
 		// Warn once a report is halfway to the hard response-size ceiling,
 		// so operators get advance notice before reports start actually
 		// being rejected at that limit.
@@ -211,7 +209,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	// first (and only) round trip instead of asking "anything newer?" and
 	// re-dialing once told no.
 	ifNewerThan, knownEpoch := state.lastGeneration, state.lastEpoch
-	mandatoryRefreshDue := s.now().Sub(state.lastForwardedAt) > mandatoryRefreshAfter
+	mandatoryRefreshDue := s.now().Sub(state.lastForwardedAt) > s.mandatoryRefreshAfter
 	if mandatoryRefreshDue {
 		ifNewerThan, knownEpoch = 0, 0
 	}

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -31,8 +31,21 @@ var (
 	errStartMoreThanOnce = errors.New("unable to start the VM scraper more than once")
 )
 
+// minPollInterval clamps ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL to avoid
+// accidental high-churn vsock polling.
+const minPollInterval = time.Minute
+
 func getVsockPort() uint32 {
 	return uint32(env.VirtualMachinesVsockPort.IntegerSetting())
+}
+
+func clampPollInterval(interval time.Duration) time.Duration {
+	if interval < minPollInterval {
+		log.Warnf("ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL=%v is below the minimum of %v; using %v",
+			interval, minPollInterval, minPollInterval)
+		return minPollInterval
+	}
+	return interval
 }
 
 // RunningVMStore provides the list of running VMs.
@@ -90,7 +103,7 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		sender:                sender,
 		dialer:                dialer,
 		client:                client,
-		interval:              env.VirtualMachinesScraperPollInterval.DurationSetting(),
+		interval:              clampPollInterval(env.VirtualMachinesScraperPollInterval.DurationSetting()),
 		perVMTimeout:          env.VirtualMachinesScraperPerVMTimeout.DurationSetting(),
 		mandatoryRefreshAfter: env.VirtualMachinesScraperMandatoryRefreshInterval.DurationSetting(),
 		concurrency:           env.VirtualMachinesScraperConcurrency.IntegerSetting(),

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -321,13 +321,22 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	result, err := s.client.GetReport(stream, ifNewerThan, knownEpoch)
 	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
 	if err != nil {
-		s.handleGetReportError(key, err)
+		s.handleGetReportError(ctx, key, err)
 		return nil, false
 	}
 	return result, true
 }
 
-func (s *VMScraper) handleGetReportError(key string, err error) {
+func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err error) {
+	// Dial already applies ctx's deadline to the socket's read/write
+	// deadlines, so a timed-out read surfaces here as a plain I/O error.
+	// Prefer ctx.Err() so those land as timeout (matching the dial path)
+	// rather than as a protocol/read error.
+	if ctx.Err() != nil {
+		log.Warnf("VMScraper: reading report from %q timed out: %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()
+		return
+	}
 	switch {
 	case errors.Is(err, vsockclient.ErrNotReady):
 		log.Debugf("VMScraper: roxagent on %q has not yet generated a report", key)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -66,6 +66,7 @@ type VMScraper struct {
 	interval     time.Duration
 	perVMTimeout time.Duration
 	concurrency  int
+	warnMaxBytes int
 	stopper      concurrency.Stopper
 	now          func() time.Time
 
@@ -92,6 +93,10 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		interval:     env.VirtualMachinesScraperPollInterval.DurationSetting(),
 		perVMTimeout: env.VirtualMachinesScraperPerVMTimeout.DurationSetting(),
 		concurrency:  env.VirtualMachinesScraperConcurrency.IntegerSetting(),
+		// Warn once a report is halfway to the hard response-size ceiling,
+		// so operators get advance notice before reports start actually
+		// being rejected at that limit.
+		warnMaxBytes: env.VirtualMachinesPullMaxResponseSizeKB.IntegerSetting() * 1024 / 2,
 		vmState:      make(map[string]*vmState),
 		activeVMs:    set.NewStringSet(),
 		now:          time.Now,
@@ -249,7 +254,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 		}
 	}
 
-	viable, warning := reportcheck.IsViable(result.IndexReport)
+	viable, warning := reportcheck.IsViable(result.IndexReport, s.warnMaxBytes)
 	if warning != "" {
 		log.Warnf("VM report from %q: %s", key, warning)
 	}

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -23,8 +24,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/stackrox/rox/generated/internalapi/central"
 )
 
 var log = logging.LoggerForModule()
@@ -292,6 +291,15 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 // it. scrapeVM calls this twice on the epoch-mismatch fallback path (see
 // the Unchanged branch above), so keeping the timing and error-handling
 // logic in one place ensures both calls are measured the same way.
+//
+// Because each call observes PullDialDurationSeconds and
+// PullReadDurationSeconds, that fallback path produces two histogram
+// samples for one logical VM scrape. PullRequestsTotal is still
+// incremented once (on the final outcome). Dashboard authors should not
+// equate sum(rate(..._count)) of those histograms with PullRequestsTotal.
+// The second dial (and thus the double observation) goes away once
+// ROX-35756 replaces the generation+epoch pair with a single per-scan
+// token, which removes the restart-coincidence fallback entirely.
 func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Info, key string, port, ifNewerThan, knownEpoch uint32) (*vsockclient.GetReportResult, bool) {
 	dialStart := s.now()
 	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -140,11 +140,7 @@ func (s *VMScraper) ResponsesC() <-chan *message.ExpiringMessage { return nil }
 
 func (s *VMScraper) run() {
 	defer s.stopper.Flow().ReportStopped()
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-s.stopper.Flow().StopRequested()
-		cancel()
-	}()
+	ctx := concurrency.AsContext(s.stopper.LowLevel().GetStopRequestSignal())
 
 	// Poll immediately on start so VMs don't wait a full interval before first scrape.
 	s.pollOnce(ctx)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -52,7 +52,7 @@ type IndexReportSender interface {
 
 // ProtocolClient performs the request/response protocol over a stream.
 type ProtocolClient interface {
-	GetReport(stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error)
+	GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error)
 }
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
@@ -318,7 +318,7 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	defer func() { _ = stream.Close() }()
 
 	readStart := s.now()
-	result, err := s.client.GetReport(stream, ifNewerThan, knownEpoch)
+	result, err := s.client.GetReport(ctx, stream, ifNewerThan, knownEpoch)
 	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
 	if err != nil {
 		s.handleGetReportError(ctx, key, err)
@@ -328,10 +328,9 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 }
 
 func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err error) {
-	// Dial already applies ctx's deadline to the socket's read/write
-	// deadlines, so a timed-out read surfaces here as a plain I/O error.
-	// Prefer ctx.Err() so those land as timeout (matching the dial path)
-	// rather than as a protocol/read error.
+	// Timed-out or cancelled reads surface here after Dial's deadline
+	// and/or GetReport's close-on-cancel. Prefer ctx.Err() so those land
+	// as timeout (matching the dial path) rather than as a protocol/read error.
 	if ctx.Err() != nil {
 		log.Warnf("VMScraper: reading report from %q timed out: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -26,7 +26,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var log = logging.LoggerForModule()
+var (
+	log                  = logging.LoggerForModule()
+	errStartMoreThanOnce = errors.New("unable to start the VM scraper more than once")
+)
 
 const (
 	mandatoryRefreshAfter = 4 * time.Hour
@@ -67,6 +70,7 @@ type VMScraper struct {
 	concurrency  int
 	warnMaxBytes int
 	stopper      concurrency.Stopper
+	started      atomic.Bool
 	now          func() time.Time
 
 	mu        sync.Mutex
@@ -114,6 +118,9 @@ func (s *VMScraper) IsActivelyScraped(key string) bool {
 func (s *VMScraper) Name() string { return "virtualmachine.vmscraper" }
 
 func (s *VMScraper) Start() error {
+	if s.started.Swap(true) {
+		return errStartMoreThanOnce
+	}
 	s.stopper = concurrency.NewStopper()
 	go s.run()
 	return nil

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -54,7 +54,7 @@ type IndexReportSender interface {
 
 // ProtocolClient performs the request/response protocol over a stream.
 type ProtocolClient interface {
-	GetReport(stream io.ReadWriteCloser, ifNewerThan uint32) (*vsockclient.GetReportResult, error)
+	GetReport(stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error)
 }
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
@@ -76,6 +76,7 @@ type VMScraper struct {
 
 type vmState struct {
 	lastGeneration  uint32
+	lastEpoch       uint32
 	lastForwardedAt time.Time
 }
 
@@ -215,7 +216,11 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	defer func() { _ = stream.Close() }()
 
 	readStart := s.now()
-	result, err := s.client.GetReport(stream, state.lastGeneration)
+	// knownEpoch lets a current roxagent make the complete "changed or not"
+	// decision server-side and serve the full report in this same round trip
+	// on a restart-coincidence false match, instead of relying solely on the
+	// client-side fallback below.
+	result, err := s.client.GetReport(stream, state.lastGeneration, state.lastEpoch)
 	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
 	if err != nil {
 		s.handleGetReportError(key, err)
@@ -223,11 +228,25 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	}
 
 	if result.Unchanged {
-		if s.now().Sub(state.lastForwardedAt) <= mandatoryRefreshAfter {
+		// Backward-compat fallback: against a current roxagent that honors
+		// knownEpoch, an epoch mismatch is already resolved in the response
+		// above (Unchanged would be false), so this branch is effectively
+		// dead code. It only matters against an agent that predates the
+		// knownEpoch request field and ignores it, where roxagent's
+		// generation-only comparison can produce a false "unchanged" right
+		// after a restart (report_generation resets to 1 and coincidentally
+		// re-matches Sensor's cached value).
+		epoch := result.Meta.GetEpoch()
+		epochMismatch := epoch != 0 && epoch != state.lastEpoch
+		if !epochMismatch && s.now().Sub(state.lastForwardedAt) <= mandatoryRefreshAfter {
 			s.registerScrapedVM(scrapedVMs, vm)
 			log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, state.lastGeneration)
 			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
 			return true
+		}
+		if epochMismatch {
+			log.Infof("VMScraper: roxagent on %q restarted (epoch changed from %d to %d, generation coincidentally matched cached value %d) — forcing full report",
+				key, state.lastEpoch, epoch, state.lastGeneration)
 		}
 		stream2, err := s.dialer.Dial(vmCtx, vm.Namespace, vm.Name, port, true)
 		if err != nil {
@@ -237,7 +256,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 		}
 		defer func() { _ = stream2.Close() }()
 
-		result, err = s.client.GetReport(stream2, 0)
+		result, err = s.client.GetReport(stream2, 0, 0)
 		if err != nil {
 			s.handleGetReportError(key, err)
 			return false
@@ -264,6 +283,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	}
 
 	state.lastGeneration = result.Meta.GetReportGeneration()
+	state.lastEpoch = result.Meta.GetEpoch()
 	state.lastForwardedAt = s.now()
 	s.registerScrapedVM(scrapedVMs, vm)
 

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -1,0 +1,342 @@
+package vmscraper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mocks ---
+
+type mockStore struct {
+	vms []*virtualmachine.Info
+}
+
+func (m *mockStore) ListRunning() []*virtualmachine.Info { return m.vms }
+
+type mockDialer struct {
+	err error
+}
+
+func (m *mockDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return nopCloser{}, nil
+}
+
+type nopCloser struct{}
+
+func (nopCloser) Read([]byte) (int, error)  { return 0, io.EOF }
+func (nopCloser) Write([]byte) (int, error) { return 0, nil }
+func (nopCloser) Close() error              { return nil }
+
+type mockProtocolClient struct {
+	resultQueue []*vsockclient.GetReportResult
+	errQueue    []error
+	calls       []protocolCall
+	callIdx     int
+}
+
+type protocolCall struct {
+	ifNewerThan uint32
+}
+
+func (m *mockProtocolClient) GetReport(_ io.ReadWriteCloser, ifNewerThan uint32) (*vsockclient.GetReportResult, error) {
+	m.calls = append(m.calls, protocolCall{ifNewerThan: ifNewerThan})
+	idx := m.callIdx
+	m.callIdx++
+	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
+		return nil, m.errQueue[idx]
+	}
+	if idx < len(m.resultQueue) {
+		return m.resultQueue[idx], nil
+	}
+	return nil, errors.New("unexpected call: no more queued results")
+}
+
+func (m *mockProtocolClient) reset() {
+	m.calls = nil
+	m.callIdx = 0
+}
+
+type mockSender struct {
+	sent []*v4.IndexReport
+}
+
+func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+	m.sent = append(m.sent, report)
+	return nil
+}
+
+// --- Helpers ---
+
+func ptr32(v uint32) *uint32 { return &v }
+
+func makeVM(ns, name string, cid uint32) *virtualmachine.Info {
+	return &virtualmachine.Info{
+		Namespace: ns,
+		Name:      name,
+		VSOCKCID:  ptr32(cid),
+		Running:   true,
+	}
+}
+
+func makeReport(gen uint32) *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		IndexReport: &v4.IndexReport{
+			State: "IndexFinished",
+		},
+		Meta: &pb.ResponseMeta{
+			ReportGeneration: gen,
+		},
+	}
+}
+
+func unchangedResult() *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		Unchanged: true,
+		Meta:      &pb.ResponseMeta{ReportGeneration: 1},
+	}
+}
+
+// --- Tests ---
+
+func TestVMScraper_PollsRunningVMs(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+		makeVM("ns2", "vm-b", 200),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1), makeReport(1)},
+		errQueue:    []error{nil, nil},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	assert.Len(t, sender.sent, 2)
+	assert.Len(t, client.calls, 2)
+}
+
+func TestVMScraper_SkipsUnchangedGeneration(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+
+	s.pollOnce(context.Background())
+	require.Len(t, sender.sent, 1)
+
+	// Second poll returns unchanged
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResult()}
+	s.pollOnce(context.Background())
+	assert.Len(t, sender.sent, 1, "should not forward unchanged report")
+}
+
+func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.now = func() time.Time { return time.Now() }
+
+	s.pollOnce(context.Background())
+	require.Len(t, sender.sent, 1)
+
+	// Simulate 4h+1s elapsed
+	s.now = func() time.Time { return time.Now().Add(mandatoryRefreshAfter + time.Second) }
+
+	// First call returns unchanged, second call (forced refresh gen=0) returns full report
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResult(), makeReport(1)}
+	s.pollOnce(context.Background())
+
+	require.Len(t, client.calls, 2)
+	assert.Equal(t, uint32(1), client.calls[0].ifNewerThan, "first call uses last generation")
+	assert.Equal(t, uint32(0), client.calls[1].ifNewerThan, "second call forces full report")
+	assert.Len(t, sender.sent, 2, "should forward after 4h even if unchanged")
+}
+
+func TestVMScraper_ForwardsOnGenerationChange(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+	require.Len(t, sender.sent, 1)
+
+	// New generation
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
+	s.pollOnce(context.Background())
+	assert.Len(t, sender.sent, 2, "should forward on generation change")
+}
+
+func TestVMScraper_HandlesDialError(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+		makeVM("ns2", "vm-b", 200),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{nil, makeReport(1)},
+		errQueue:    []error{errors.New("connection refused"), nil},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	assert.Len(t, sender.sent, 1, "should still send for vm-b despite vm-a protocol error")
+}
+
+func TestVMScraper_PrunesStaleState(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+		makeVM("ns2", "vm-b", 200),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1), makeReport(1)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+	assert.Len(t, s.vmState, 2)
+	assert.True(t, s.activeVMs.Contains("ns1/vm-a"))
+
+	// Remove vm-a from running set
+	store.vms = []*virtualmachine.Info{makeVM("ns2", "vm-b", 200)}
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
+	s.pollOnce(context.Background())
+
+	assert.Len(t, s.vmState, 1, "stale vm-a state should be pruned")
+	assert.False(t, s.activeVMs.Contains("ns1/vm-a"), "vm-a should no longer be active")
+	assert.True(t, s.activeVMs.Contains("ns2/vm-b"))
+}
+
+func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
+	return &VMScraper{
+		store:       store,
+		sender:      sender,
+		dialer:      dialer,
+		client:      client,
+		interval:    5 * time.Minute,
+		concurrency: 1,
+		vmState:     make(map[string]*vmState),
+		activeVMs:   set.NewStringSet(),
+		now:         time.Now,
+	}
+}
+
+// --- Thread-safe mocks for concurrent tests ---
+
+type delayDialer struct {
+	delay time.Duration
+}
+
+func (d *delayDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	time.Sleep(d.delay)
+	return nopCloser{}, nil
+}
+
+type safeProtocolClient struct {
+	mu    sync.Mutex
+	gen   uint32
+	calls int
+}
+
+func (c *safeProtocolClient) GetReport(_ io.ReadWriteCloser, _ uint32) (*vsockclient.GetReportResult, error) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	return makeReport(c.gen), nil
+}
+
+type safeSender struct {
+	mu   sync.Mutex
+	sent int
+}
+
+func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.IndexReport) error {
+	s.mu.Lock()
+	s.sent++
+	s.mu.Unlock()
+	return nil
+}
+
+func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
+	const (
+		numVMs      = 10
+		dialDelay   = 50 * time.Millisecond
+		concurrency = 10
+	)
+
+	vms := make([]*virtualmachine.Info, numVMs)
+	for i := range vms {
+		vms[i] = makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i))
+	}
+
+	store := &mockStore{vms: vms}
+	sender := &safeSender{}
+	dialer := &delayDialer{delay: dialDelay}
+	client := &safeProtocolClient{gen: 1}
+
+	s := &VMScraper{
+		store:       store,
+		sender:      sender,
+		dialer:      dialer,
+		client:      client,
+		interval:    5 * time.Minute,
+		concurrency: concurrency,
+		vmState:     make(map[string]*vmState),
+		activeVMs:   set.NewStringSet(),
+		now:         time.Now,
+	}
+
+	start := time.Now()
+	s.pollOnce(context.Background())
+	elapsed := time.Since(start)
+
+	sequentialMin := dialDelay * numVMs
+	require.Less(t, elapsed, sequentialMin,
+		"concurrent scraping (%v) should be faster than sequential minimum (%v)", elapsed, sequentialMin)
+	assert.Equal(t, numVMs, sender.sent)
+	assert.Equal(t, numVMs, client.calls)
+}

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -155,6 +155,31 @@ func TestVMScraper_SkipsUnchangedGeneration(t *testing.T) {
 	assert.Len(t, sender.sent, 1, "should not forward unchanged report")
 }
 
+func TestVMScraper_RemainsActiveAcrossUnchangedPolls(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+
+	s.pollOnce(context.Background())
+	require.True(t, s.IsActivelyScraped("ns1/vm-a"))
+	require.True(t, s.IsActivelyScraped("100"))
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResult()}
+	s.pollOnce(context.Background())
+
+	assert.Len(t, sender.sent, 1, "should not forward unchanged report")
+	assert.True(t, s.IsActivelyScraped("ns1/vm-a"))
+	assert.True(t, s.IsActivelyScraped("100"))
+}
+
 func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -592,3 +592,28 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 	require.Greater(t, maxObserved, int32(1),
 		"expected multiple VMs to be dialed concurrently, observed max concurrency of %d", maxObserved)
 }
+
+func TestClampPollInterval(t *testing.T) {
+	cases := map[string]struct {
+		in   time.Duration
+		want time.Duration
+	}{
+		"should leave values at the minimum unchanged": {
+			in:   time.Minute,
+			want: time.Minute,
+		},
+		"should leave values above the minimum unchanged": {
+			in:   5 * time.Minute,
+			want: 5 * time.Minute,
+		},
+		"should clamp values below the minimum up to one minute": {
+			in:   30 * time.Second,
+			want: time.Minute,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, clampPollInterval(tc.in))
+		})
+	}
+}

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -406,11 +407,25 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 
 // --- Thread-safe mocks for concurrent tests ---
 
+// delayDialer sleeps for delay on every Dial and tracks the highest number
+// of Dial calls observed in flight at once, so tests can assert on actual
+// concurrency instead of inferring it from wall-clock elapsed time (which is
+// prone to flaking under CI load/GC pauses).
 type delayDialer struct {
-	delay time.Duration
+	delay       time.Duration
+	inFlight    atomic.Int32
+	maxObserved atomic.Int32
 }
 
 func (d *delayDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	cur := d.inFlight.Add(1)
+	defer d.inFlight.Add(-1)
+	for {
+		prevMax := d.maxObserved.Load()
+		if cur <= prevMax || d.maxObserved.CompareAndSwap(prevMax, cur) {
+			break
+		}
+	}
 	time.Sleep(d.delay)
 	return nopCloser{}, nil
 }
@@ -469,13 +484,16 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 		now:         time.Now,
 	}
 
-	start := time.Now()
 	s.pollOnce(context.Background())
-	elapsed := time.Since(start)
 
-	sequentialMin := dialDelay * numVMs
-	require.Less(t, elapsed, sequentialMin,
-		"concurrent scraping (%v) should be faster than sequential minimum (%v)", elapsed, sequentialMin)
 	assert.Equal(t, numVMs, sender.sent)
 	assert.Equal(t, numVMs, client.calls)
+	// Direct concurrency signal instead of a wall-clock inference: with
+	// concurrency == numVMs, all dials should be in flight together at some
+	// point during the cycle. A threshold below numVMs still proves
+	// concurrent (rather than sequential) execution without being flaky
+	// about exactly how many overlap under scheduler/CI load.
+	maxObserved := dialer.maxObserved.Load()
+	require.Greater(t, maxObserved, int32(1),
+		"expected multiple VMs to be dialed concurrently, observed max concurrency of %d", maxObserved)
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -419,6 +419,14 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 	}
 }
 
+func TestVMScraper_StartRejectsSecondCall(t *testing.T) {
+	s := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	require.NoError(t, s.Start())
+	t.Cleanup(s.Stop)
+
+	assert.ErrorIs(t, s.Start(), errStartMoreThanOnce)
+}
+
 func TestVMScraper_PrunesStaleState(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -220,14 +220,15 @@ func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 	// Simulate 4h+1s elapsed
 	s.now = func() time.Time { return time.Now().Add(mandatoryRefreshAfter + time.Second) }
 
-	// First call returns unchanged, second call (forced refresh gen=0) returns full report
+	// The mandatory refresh is known before dialing, so a single call
+	// requesting the full report (ifNewerThan=0) is enough.
 	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{unchangedResult(), makeReport(1)}
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
 	s.pollOnce(context.Background())
 
-	require.Len(t, client.calls, 2)
-	assert.Equal(t, uint32(1), client.calls[0].ifNewerThan, "first call uses last generation")
-	assert.Equal(t, uint32(0), client.calls[1].ifNewerThan, "second call forces full report")
+	require.Len(t, client.calls, 1, "mandatory refresh should resolve in a single round trip")
+	assert.Equal(t, uint32(0), client.calls[0].ifNewerThan, "mandatory refresh forces the full report on the only call")
+	assert.Equal(t, uint32(0), client.calls[0].knownEpoch, "mandatory refresh forces the full report on the only call")
 	assert.Len(t, sender.sent, 2, "should forward after 4h even if unchanged")
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -233,8 +233,8 @@ func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 	s.pollOnce(context.Background())
 	require.Len(t, sender.sent, 1)
 
-	// Simulate 4h+1s elapsed
-	s.now = func() time.Time { return time.Now().Add(mandatoryRefreshAfter + time.Second) }
+	// Simulate mandatoryRefreshAfter+1s elapsed
+	s.now = func() time.Time { return time.Now().Add(s.mandatoryRefreshAfter + time.Second) }
 
 	// The mandatory refresh is known before dialing, so a single call
 	// requesting the full report (ifNewerThan=0) is enough.
@@ -456,13 +456,14 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
 	return &VMScraper{
-		store:        store,
-		sender:       sender,
-		dialer:       dialer,
-		client:       client,
-		interval:     5 * time.Minute,
-		perVMTimeout: 10 * time.Second,
-		concurrency:  1,
+		store:                 store,
+		sender:                sender,
+		dialer:                dialer,
+		client:                client,
+		interval:              5 * time.Minute,
+		perVMTimeout:          10 * time.Second,
+		mandatoryRefreshAfter: 4 * time.Hour,
+		concurrency:           1,
 		// Half of the 16MiB default pull response-size ceiling — same
 		// derivation New() uses from env.VirtualMachinesPullMaxResponseSizeKB.
 		warnMaxBytes: 8 << 20,

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -394,15 +394,19 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
 	return &VMScraper{
-		store:       store,
-		sender:      sender,
-		dialer:      dialer,
-		client:      client,
-		interval:    5 * time.Minute,
-		concurrency: 1,
-		vmState:     make(map[string]*vmState),
-		activeVMs:   set.NewStringSet(),
-		now:         time.Now,
+		store:        store,
+		sender:       sender,
+		dialer:       dialer,
+		client:       client,
+		interval:     5 * time.Minute,
+		perVMTimeout: 10 * time.Second,
+		concurrency:  1,
+		// Half of the 16MiB default pull response-size ceiling — same
+		// derivation New() uses from env.VirtualMachinesPullMaxResponseSizeKB.
+		warnMaxBytes: 8 << 20,
+		vmState:      make(map[string]*vmState),
+		activeVMs:    set.NewStringSet(),
+		now:          time.Now,
 	}
 }
 
@@ -474,15 +478,17 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 	client := &safeProtocolClient{gen: 1}
 
 	s := &VMScraper{
-		store:       store,
-		sender:      sender,
-		dialer:      dialer,
-		client:      client,
-		interval:    5 * time.Minute,
-		concurrency: concurrency,
-		vmState:     make(map[string]*vmState),
-		activeVMs:   set.NewStringSet(),
-		now:         time.Now,
+		store:        store,
+		sender:       sender,
+		dialer:       dialer,
+		client:       client,
+		interval:     5 * time.Minute,
+		perVMTimeout: 10 * time.Second,
+		concurrency:  concurrency,
+		warnMaxBytes: 8 << 20,
+		vmState:      make(map[string]*vmState),
+		activeVMs:    set.NewStringSet(),
+		now:          time.Now,
 	}
 
 	s.pollOnce(context.Background())

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -28,14 +28,30 @@ type mockStore struct {
 func (m *mockStore) ListRunning() []*virtualmachine.Info { return m.vms }
 
 type mockDialer struct {
-	err error
+	err      error
+	errQueue []error
+	callIdx  int
 }
 
 func (m *mockDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	idx := m.callIdx
+	m.callIdx++
+	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
+		return nil, m.errQueue[idx]
+	}
 	if m.err != nil {
 		return nil, m.err
 	}
 	return nopCloser{}, nil
+}
+
+// blockingDialer waits until ctx is done, then returns ctx.Err(). Used to
+// exercise the per-VM timeout classification in dialAndGetReport.
+type blockingDialer struct{}
+
+func (blockingDialer) Dial(ctx context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 type nopCloser struct{}
@@ -347,22 +363,60 @@ func TestVMScraper_ForwardsOnGenerationChange(t *testing.T) {
 	assert.Len(t, sender.sent, 2, "should forward on generation change")
 }
 
-func TestVMScraper_HandlesDialError(t *testing.T) {
-	store := &mockStore{vms: []*virtualmachine.Info{
+func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
+	vms := []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),
 		makeVM("ns2", "vm-b", 200),
-	}}
-	sender := &mockSender{}
-	dialer := &mockDialer{}
-	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{nil, makeReport(1)},
-		errQueue:    []error{errors.New("connection refused"), nil},
 	}
 
-	s := newTestScraper(store, sender, dialer, client)
-	s.pollOnce(context.Background())
+	cases := map[string]struct {
+		dialer       VMDialer
+		perVMTimeout time.Duration
+		resultQueue  []*vsockclient.GetReportResult
+		errQueue     []error
+		wantCalls    int
+		wantSent     int
+	}{
+		"should still send for vm-b when vm-a hits a protocol error": {
+			dialer:      &mockDialer{},
+			resultQueue: []*vsockclient.GetReportResult{nil, makeReport(1)},
+			errQueue:    []error{errors.New("connection refused"), nil},
+			wantCalls:   2,
+			wantSent:    1,
+		},
+		"should still send for vm-b when vm-a dial fails": {
+			dialer: &mockDialer{
+				errQueue: []error{errors.New("dial failed"), nil},
+			},
+			resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+			wantCalls:   1,
+			wantSent:    1,
+		},
+		"should forward nothing when every dial times out": {
+			dialer:       blockingDialer{},
+			perVMTimeout: 20 * time.Millisecond,
+			wantCalls:    0,
+			wantSent:     0,
+		},
+	}
 
-	assert.Len(t, sender.sent, 1, "should still send for vm-b despite vm-a protocol error")
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sender := &mockSender{}
+			client := &mockProtocolClient{
+				resultQueue: tc.resultQueue,
+				errQueue:    tc.errQueue,
+			}
+			s := newTestScraper(&mockStore{vms: vms}, sender, tc.dialer, client)
+			if tc.perVMTimeout > 0 {
+				s.perVMTimeout = tc.perVMTimeout
+			}
+			s.pollOnce(context.Background())
+
+			assert.Len(t, client.calls, tc.wantCalls)
+			assert.Len(t, sender.sent, tc.wantSent)
+		})
+	}
 }
 
 func TestVMScraper_PrunesStaleState(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -425,6 +427,29 @@ func TestVMScraper_StartRejectsSecondCall(t *testing.T) {
 	t.Cleanup(s.Stop)
 
 	assert.ErrorIs(t, s.Start(), errStartMoreThanOnce)
+}
+
+// GetReport does not take a context; Dial stamps ctx's deadline onto the
+// socket, so a timed-out read returns a plain I/O error after ctx is already
+// done. Classification must follow ctx.Err(), same as the dial-failure path.
+func TestVMScraper_GetReportTimeoutClassified(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	client := &mockProtocolClient{
+		errQueue: []error{errors.New("i/o timeout")},
+	}
+	s := newTestScraper(&mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
+
+	timeoutBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout))
+	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, ok := s.dialAndGetReport(ctx, vm, "ns1/vm-a", 1, 0, 0)
+
+	assert.False(t, ok)
+	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout)))
+	assert.Equal(t, readErrBefore, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError)),
+		"timed-out read must not be counted as a protocol/read error")
 }
 
 func TestVMScraper_PrunesStaleState(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -74,7 +74,7 @@ type protocolCall struct {
 	knownEpoch  uint32
 }
 
-func (m *mockProtocolClient) GetReport(_ io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error) {
+func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error) {
 	m.calls = append(m.calls, protocolCall{ifNewerThan: ifNewerThan, knownEpoch: knownEpoch})
 	idx := m.callIdx
 	m.callIdx++
@@ -529,7 +529,7 @@ type safeProtocolClient struct {
 	calls int
 }
 
-func (c *safeProtocolClient) GetReport(_ io.ReadWriteCloser, _ uint32, _ uint32) (*vsockclient.GetReportResult, error) {
+func (c *safeProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, _ uint32, _ uint32) (*vsockclient.GetReportResult, error) {
 	c.mu.Lock()
 	c.calls++
 	c.mu.Unlock()

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -52,10 +52,11 @@ type mockProtocolClient struct {
 
 type protocolCall struct {
 	ifNewerThan uint32
+	knownEpoch  uint32
 }
 
-func (m *mockProtocolClient) GetReport(_ io.ReadWriteCloser, ifNewerThan uint32) (*vsockclient.GetReportResult, error) {
-	m.calls = append(m.calls, protocolCall{ifNewerThan: ifNewerThan})
+func (m *mockProtocolClient) GetReport(_ io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error) {
+	m.calls = append(m.calls, protocolCall{ifNewerThan: ifNewerThan, knownEpoch: knownEpoch})
 	idx := m.callIdx
 	m.callIdx++
 	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
@@ -109,6 +110,25 @@ func unchangedResult() *vsockclient.GetReportResult {
 	return &vsockclient.GetReportResult{
 		Unchanged: true,
 		Meta:      &pb.ResponseMeta{ReportGeneration: 1},
+	}
+}
+
+func makeReportWithEpoch(gen, epoch uint32) *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		IndexReport: &v4.IndexReport{
+			State: "IndexFinished",
+		},
+		Meta: &pb.ResponseMeta{
+			ReportGeneration: gen,
+			Epoch:            epoch,
+		},
+	}
+}
+
+func unchangedResultWithEpoch(gen, epoch uint32) *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		Unchanged: true,
+		Meta:      &pb.ResponseMeta{ReportGeneration: gen, Epoch: epoch},
 	}
 }
 
@@ -210,6 +230,100 @@ func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 	assert.Len(t, sender.sent, 2, "should forward after 4h even if unchanged")
 }
 
+// TestVMScraper_ForwardsOnEpochMismatch reproduces the restart-collision
+// scenario: roxagent restarts and its report_generation counter (which resets
+// to 1 on every restart) coincidentally climbs back to the exact value Sensor
+// already has cached for this VM. This test exercises the client-side
+// fallback path (mockProtocolClient returns Unchanged with a mismatched
+// epoch, as an older roxagent that ignores knownEpoch would); a current
+// roxagent instead resolves this in the first round trip (see
+// vsockserver.protocol_test.go on the roxagent-serve branch).
+func TestVMScraper_ForwardsOnEpochMismatch(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReportWithEpoch(5, 100)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+	require.Len(t, sender.sent, 1)
+
+	// Agent restarts and, before Sensor's next poll, coincidentally climbs back
+	// to generation=5 with a new epoch. roxagent's own generation-only check
+	// reports "unchanged"; Sensor must not trust that because the epoch moved.
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{
+		unchangedResultWithEpoch(5, 200),
+		makeReportWithEpoch(5, 200),
+	}
+	s.pollOnce(context.Background())
+
+	require.Len(t, client.calls, 2, "epoch mismatch should force a second call for the full report")
+	assert.Equal(t, uint32(5), client.calls[0].ifNewerThan, "first call uses last generation")
+	assert.Equal(t, uint32(100), client.calls[0].knownEpoch, "first call sends the previously cached epoch")
+	assert.Equal(t, uint32(0), client.calls[1].ifNewerThan, "second call forces full report")
+	assert.Equal(t, uint32(0), client.calls[1].knownEpoch, "second (forced) call doesn't need to send an epoch")
+	assert.Len(t, sender.sent, 2, "should forward despite matching generation, because epoch changed")
+}
+
+// TestVMScraper_TrustsUnchangedWhenEpochZero ensures backward compatibility
+// with roxagent builds that predate the epoch field (always reporting epoch
+// 0): Sensor must keep trusting the generation-only Unchanged flag as before,
+// not treat every poll as a restart.
+func TestVMScraper_TrustsUnchangedWhenEpochZero(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReportWithEpoch(1, 0)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+	require.Len(t, sender.sent, 1)
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithEpoch(1, 0)}
+	s.pollOnce(context.Background())
+
+	require.Len(t, client.calls, 1, "epoch 0 means the agent predates the field; no forced second call")
+	assert.Len(t, sender.sent, 1, "should not forward unchanged report from a pre-epoch agent")
+}
+
+// TestVMScraper_SendsKnownEpochOnRequest verifies Sensor sends its
+// last-cached epoch on every request, letting a current roxagent resolve a
+// restart-coincidence false match in a single round trip instead of relying
+// on the client-side fallback.
+func TestVMScraper_SendsKnownEpochOnRequest(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReportWithEpoch(1, 100)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	require.Len(t, client.calls, 1)
+	assert.Equal(t, uint32(0), client.calls[0].knownEpoch, "first-ever request for a VM has no cached epoch")
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithEpoch(1, 100)}
+	s.pollOnce(context.Background())
+
+	require.Len(t, client.calls, 1, "matching epoch and generation should resolve in a single round trip")
+	assert.Equal(t, uint32(100), client.calls[0].knownEpoch, "subsequent requests send the cached epoch")
+}
+
 func TestVMScraper_ForwardsOnGenerationChange(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),
@@ -307,7 +421,7 @@ type safeProtocolClient struct {
 	calls int
 }
 
-func (c *safeProtocolClient) GetReport(_ io.ReadWriteCloser, _ uint32) (*vsockclient.GetReportResult, error) {
+func (c *safeProtocolClient) GetReport(_ io.ReadWriteCloser, _ uint32, _ uint32) (*vsockclient.GetReportResult, error) {
 	c.mu.Lock()
 	c.calls++
 	c.mu.Unlock()

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -20,6 +20,8 @@ var (
 	ErrNotReady = errors.New("agent has not yet generated a report")
 	// ErrUnknownMethod indicates the agent does not support the requested method.
 	ErrUnknownMethod = errors.New("agent does not support the requested method")
+	// ErrInternal indicates the agent encountered an internal error.
+	ErrInternal = errors.New("agent internal error")
 )
 
 // GetReportResult holds the parsed response from a GetReport call.
@@ -97,6 +99,8 @@ func errorFromResponse(e *pb.ErrorResponse) error {
 		return fmt.Errorf("%w: %s", ErrNotReady, e.GetMessage())
 	case pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD:
 		return fmt.Errorf("%w: %s", ErrUnknownMethod, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_INTERNAL:
+		return fmt.Errorf("%w: %s", ErrInternal, e.GetMessage())
 	default:
 		return fmt.Errorf("agent error (%s): %s", e.GetCode(), e.GetMessage())
 	}

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -1,0 +1,103 @@
+package vsockclient
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/pkg/vsockframing"
+	"google.golang.org/protobuf/proto"
+)
+
+// CapabilityReportV1 is the protocol capability for the v1 report exchange.
+const CapabilityReportV1 = "report_v1"
+
+var (
+	// ErrNotReady indicates the agent has not yet generated a report.
+	ErrNotReady = errors.New("agent has not yet generated a report")
+	// ErrUnknownMethod indicates the agent does not support the requested method.
+	ErrUnknownMethod = errors.New("agent does not support the requested method")
+)
+
+// GetReportResult holds the parsed response from a GetReport call.
+type GetReportResult struct {
+	IndexReport *v4.IndexReport
+	Unchanged   bool
+	Meta        *pb.ResponseMeta
+}
+
+// Client sends VMServiceRequests and reads VMServiceResponses over a framed stream.
+type Client struct {
+	capabilities    []string
+	maxResponseSize int
+}
+
+// NewClient creates a protocol client with the given Sensor capabilities
+// and maximum response size in bytes.
+func NewClient(capabilities []string, maxResponseSize int) *Client {
+	return &Client{capabilities: capabilities, maxResponseSize: maxResponseSize}
+}
+
+// GetReport sends a GetReportRequest and returns the response.
+// The stream must be an io.ReadWriteCloser (from MultiDialer.Dial).
+func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32) (*GetReportResult, error) {
+	req := &pb.VMServiceRequest{
+		Meta: &pb.RequestMeta{
+			RequestId:    uuid.NewV4().String(),
+			Capabilities: c.capabilities,
+		},
+		Method: &pb.VMServiceRequest_GetReport{
+			GetReport: &pb.GetReportRequest{
+				IfNewerThanGeneration: ifNewerThan,
+			},
+		},
+	}
+
+	reqData, err := proto.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	if err := vsockframing.WriteFrame(stream, reqData); err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+
+	respData, err := vsockframing.ReadFrame(stream, uint32(c.maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	var resp pb.VMServiceResponse
+	if err := proto.Unmarshal(respData, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	switch r := resp.GetResult().(type) {
+	case *pb.VMServiceResponse_GetReport:
+		if r.GetReport.GetIndexReport() == nil && !r.GetReport.GetUnchanged() {
+			return nil, errors.New("agent returned a new report response but IndexReport is nil")
+		}
+		return &GetReportResult{
+			IndexReport: r.GetReport.GetIndexReport(),
+			Unchanged:   r.GetReport.GetUnchanged(),
+			Meta:        resp.GetMeta(),
+		}, nil
+	case *pb.VMServiceResponse_Error:
+		return nil, errorFromResponse(r.Error)
+	default:
+		return nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
+	}
+}
+
+func errorFromResponse(e *pb.ErrorResponse) error {
+	switch e.GetCode() {
+	case pb.ErrorCode_ERROR_CODE_NOT_READY:
+		return fmt.Errorf("%w: %s", ErrNotReady, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD:
+		return fmt.Errorf("%w: %s", ErrUnknownMethod, e.GetMessage())
+	default:
+		return fmt.Errorf("agent error (%s): %s", e.GetCode(), e.GetMessage())
+	}
+}

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -32,6 +32,13 @@ type GetReportResult struct {
 	Meta        *pb.ResponseMeta
 }
 
+// defaultMaxResponseSize is the fallback used by NewClient for an
+// out-of-range maxResponseSize. It matches the documented default of
+// env.VirtualMachinesPullMaxResponseSizeKB (16 MiB): a misconfigured limit
+// should fail toward a safe, bounded default, not toward "unlimited" —
+// the data source is a VM agent, not a fully trusted peer.
+const defaultMaxResponseSize = 16 << 20
+
 // Client sends VMServiceRequests and reads VMServiceResponses over a framed stream.
 type Client struct {
 	capabilities    []string
@@ -39,13 +46,13 @@ type Client struct {
 }
 
 // NewClient creates a protocol client with the given Sensor capabilities
-// and maximum response size in bytes. maxResponseSize is clamped to
-// [1, math.MaxUint32] since it's narrowed to uint32 when passed to
-// vsockframing.ReadFrame; an out-of-range value (e.g. from a misconfigured
-// size setting) would otherwise wrap into a bogus, silently-wrong limit.
+// and maximum response size in bytes. maxResponseSize must fit in
+// [1, math.MaxUint32], since it's narrowed to uint32 when passed to
+// vsockframing.ReadFrame; out-of-range values (e.g. from a misconfigured
+// size setting) fall back to defaultMaxResponseSize.
 func NewClient(capabilities []string, maxResponseSize int) *Client {
 	if maxResponseSize <= 0 || int64(maxResponseSize) > math.MaxUint32 {
-		maxResponseSize = math.MaxUint32
+		maxResponseSize = defaultMaxResponseSize
 	}
 	return &Client{capabilities: capabilities, maxResponseSize: maxResponseSize}
 }

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -8,10 +8,13 @@ import (
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"google.golang.org/protobuf/proto"
 )
+
+var log = logging.LoggerForModule()
 
 // CapabilityReportV1 is the protocol capability for the v1 report exchange.
 const CapabilityReportV1 = "report_v1"
@@ -52,6 +55,8 @@ type Client struct {
 // size setting) fall back to defaultMaxResponseSize.
 func NewClient(capabilities []string, maxResponseSize int) *Client {
 	if maxResponseSize <= 0 || int64(maxResponseSize) > math.MaxUint32 {
+		log.Warnf("VMScraper: configured max response size %d is out of range (0, %d], falling back to default of %d bytes",
+			maxResponseSize, uint32(math.MaxUint32), defaultMaxResponseSize)
 		maxResponseSize = defaultMaxResponseSize
 	}
 	return &Client{capabilities: capabilities, maxResponseSize: maxResponseSize}

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -43,9 +43,13 @@ func NewClient(capabilities []string, maxResponseSize int) *Client {
 	return &Client{capabilities: capabilities, maxResponseSize: maxResponseSize}
 }
 
-// GetReport sends a GetReportRequest and returns the response.
+// GetReport sends a GetReportRequest and returns the response. knownEpoch is
+// the last epoch Sensor observed for this VM (see ResponseMeta.epoch); pass 0
+// when unknown. Sending it lets the agent detect a restart-coincidence false
+// match and serve the full report in this same round trip, instead of the
+// caller needing a second, forced request.
 // The stream must be an io.ReadWriteCloser (from MultiDialer.Dial).
-func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32) (*GetReportResult, error) {
+func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*GetReportResult, error) {
 	req := &pb.VMServiceRequest{
 		Meta: &pb.RequestMeta{
 			RequestId:    uuid.NewV4().String(),
@@ -53,7 +57,8 @@ func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32) (*GetR
 		},
 		Method: &pb.VMServiceRequest_GetReport{
 			GetReport: &pb.GetReportRequest{
-				IfNewerThanGeneration: ifNewerThan,
+				LastKnownGeneration: ifNewerThan,
+				KnownEpoch:          knownEpoch,
 			},
 		},
 	}

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -38,8 +39,14 @@ type Client struct {
 }
 
 // NewClient creates a protocol client with the given Sensor capabilities
-// and maximum response size in bytes.
+// and maximum response size in bytes. maxResponseSize is clamped to
+// [1, math.MaxUint32] since it's narrowed to uint32 when passed to
+// vsockframing.ReadFrame; an out-of-range value (e.g. from a misconfigured
+// size setting) would otherwise wrap into a bogus, silently-wrong limit.
 func NewClient(capabilities []string, maxResponseSize int) *Client {
+	if maxResponseSize <= 0 || int64(maxResponseSize) > math.MaxUint32 {
+		maxResponseSize = math.MaxUint32
+	}
 	return &Client{capabilities: capabilities, maxResponseSize: maxResponseSize}
 }
 

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -1,6 +1,7 @@
 package vsockclient
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -67,8 +68,17 @@ func NewClient(capabilities []string, maxResponseSize int) *Client {
 // when unknown. Sending it lets the agent detect a restart-coincidence false
 // match and serve the full report in this same round trip, instead of the
 // caller needing a second, forced request.
-// The stream must be an io.ReadWriteCloser (from MultiDialer.Dial).
-func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*GetReportResult, error) {
+//
+// The stream must be an io.ReadWriteCloser (from MultiDialer.Dial). If ctx is
+// cancelled while a write or read is in progress, the stream is closed so the
+// blocked I/O unblocks promptly — needed on Sensor shutdown, where parent
+// cancel does not rewrite the dial-time socket deadline.
+func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*GetReportResult, error) {
+	stop := context.AfterFunc(ctx, func() {
+		_ = stream.Close()
+	})
+	defer stop()
+
 	req := &pb.VMServiceRequest{
 		Meta: &pb.RequestMeta{
 			RequestId:    uuid.NewV4().String(),
@@ -87,12 +97,12 @@ func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32, knownE
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 	if err := vsockframing.WriteFrame(stream, reqData); err != nil {
-		return nil, fmt.Errorf("sending request: %w", err)
+		return nil, wrapStreamErr(ctx, "sending request", err)
 	}
 
 	respData, err := vsockframing.ReadFrame(stream, uint32(c.maxResponseSize))
 	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
+		return nil, wrapStreamErr(ctx, "reading response", err)
 	}
 
 	var resp pb.VMServiceResponse
@@ -115,6 +125,13 @@ func (c *Client) GetReport(stream io.ReadWriteCloser, ifNewerThan uint32, knownE
 	default:
 		return nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
 	}
+}
+
+func wrapStreamErr(ctx context.Context, op string, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("%s: %w", op, ctxErr)
+	}
+	return fmt.Errorf("%s: %w", op, err)
 }
 
 func errorFromResponse(e *pb.ErrorResponse) error {

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -6,6 +6,7 @@ import (
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,10 +16,10 @@ import (
 func TestSendGetReport_Success(t *testing.T) {
 	client := NewClient([]string{CapabilityReportV1}, 10<<20)
 	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
+	defer utils.IgnoreError(clientConn.Close)
 
 	go func() {
-		defer func() { _ = agentConn.Close() }()
+		defer utils.IgnoreError(agentConn.Close)
 		reqData, err := vsockframing.ReadFrame(agentConn, 10<<20)
 		require.NoError(t, err)
 
@@ -51,10 +52,10 @@ func TestSendGetReport_Success(t *testing.T) {
 func TestSendGetReport_Unchanged(t *testing.T) {
 	client := NewClient(nil, 10<<20)
 	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
+	defer utils.IgnoreError(clientConn.Close)
 
 	go func() {
-		defer func() { _ = agentConn.Close() }()
+		defer utils.IgnoreError(agentConn.Close)
 		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
 		require.NoError(t, err)
 
@@ -79,10 +80,10 @@ func TestSendGetReport_Unchanged(t *testing.T) {
 func TestSendGetReport_NilReportRejected(t *testing.T) {
 	client := NewClient(nil, 10<<20)
 	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
+	defer utils.IgnoreError(clientConn.Close)
 
 	go func() {
-		defer func() { _ = agentConn.Close() }()
+		defer utils.IgnoreError(agentConn.Close)
 		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
 		require.NoError(t, err)
 
@@ -102,60 +103,58 @@ func TestSendGetReport_NilReportRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "IndexReport is nil")
 }
 
-func TestSendGetReport_NotReady(t *testing.T) {
-	client := NewClient(nil, 10<<20)
-	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
+func TestSendGetReport_ErrorCodes(t *testing.T) {
+	cases := map[string]struct {
+		code      pb.ErrorCode
+		message   string
+		wantErr   error
+		wantInMsg string
+	}{
+		"should wrap ErrNotReady for NOT_READY": {
+			code:    pb.ErrorCode_ERROR_CODE_NOT_READY,
+			message: "report not yet generated",
+			wantErr: ErrNotReady,
+		},
+		"should wrap ErrUnknownMethod for UNKNOWN_METHOD": {
+			code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
+			message: "get_report not supported",
+			wantErr: ErrUnknownMethod,
+		},
+		"should wrap ErrInternal for INTERNAL": {
+			code:      pb.ErrorCode_ERROR_CODE_INTERNAL,
+			message:   "scan crashed",
+			wantErr:   ErrInternal,
+			wantInMsg: "scan crashed",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := NewClient(nil, 10<<20)
+			clientConn, agentConn := net.Pipe()
+			defer utils.IgnoreError(clientConn.Close)
 
-	go func() {
-		defer func() { _ = agentConn.Close() }()
-		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
-		require.NoError(t, err)
+			go func() {
+				defer utils.IgnoreError(agentConn.Close)
+				_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+				require.NoError(t, err)
 
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
-			Result: &pb.VMServiceResponse_Error{
-				Error: &pb.ErrorResponse{
-					Code:    pb.ErrorCode_ERROR_CODE_NOT_READY,
-					Message: "report not yet generated",
-				},
-			},
-		}
-		respData, err := proto.Marshal(resp)
-		require.NoError(t, err)
-		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
-	}()
+				resp := &pb.VMServiceResponse{
+					Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+					Result: &pb.VMServiceResponse_Error{
+						Error: &pb.ErrorResponse{Code: tc.code, Message: tc.message},
+					},
+				}
+				respData, err := proto.Marshal(resp)
+				require.NoError(t, err)
+				require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+			}()
 
-	_, err := client.GetReport(clientConn, 0)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrNotReady)
-}
-
-func TestSendGetReport_UnknownMethod(t *testing.T) {
-	client := NewClient(nil, 10<<20)
-	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
-
-	go func() {
-		defer func() { _ = agentConn.Close() }()
-		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
-		require.NoError(t, err)
-
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
-			Result: &pb.VMServiceResponse_Error{
-				Error: &pb.ErrorResponse{
-					Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
-					Message: "get_report not supported",
-				},
-			},
-		}
-		respData, err := proto.Marshal(resp)
-		require.NoError(t, err)
-		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
-	}()
-
-	_, err := client.GetReport(clientConn, 0)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrUnknownMethod)
+			_, err := client.GetReport(clientConn, 0)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.wantErr)
+			if tc.wantInMsg != "" {
+				assert.Contains(t, err.Error(), tc.wantInMsg)
+			}
+		})
+	}
 }

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -1,0 +1,161 @@
+package vsockclient
+
+import (
+	"net"
+	"testing"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/vsockframing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSendGetReport_Success(t *testing.T) {
+	client := NewClient([]string{CapabilityReportV1}, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	go func() {
+		defer func() { _ = agentConn.Close() }()
+		reqData, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		require.NoError(t, err)
+
+		var req pb.VMServiceRequest
+		require.NoError(t, proto.Unmarshal(reqData, &req))
+		assert.NotEmpty(t, req.GetMeta().GetRequestId())
+		assert.Equal(t, []string{CapabilityReportV1}, req.GetMeta().GetCapabilities())
+		assert.Equal(t, uint32(0), req.GetGetReport().GetIfNewerThanGeneration())
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
+			Result: &pb.VMServiceResponse_GetReport{
+				GetReport: &pb.GetReportResponse{
+					IndexReport: &v4.IndexReport{HashId: "test-hash"},
+				},
+			},
+		}
+		respData, err := proto.Marshal(resp)
+		require.NoError(t, err)
+		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+	}()
+
+	result, err := client.GetReport(clientConn, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "test-hash", result.IndexReport.GetHashId())
+	assert.False(t, result.Unchanged)
+	assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+}
+
+func TestSendGetReport_Unchanged(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	go func() {
+		defer func() { _ = agentConn.Close() }()
+		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		require.NoError(t, err)
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 5},
+			Result: &pb.VMServiceResponse_GetReport{
+				GetReport: &pb.GetReportResponse{Unchanged: true},
+			},
+		}
+		respData, err := proto.Marshal(resp)
+		require.NoError(t, err)
+		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+	}()
+
+	result, err := client.GetReport(clientConn, 5)
+	require.NoError(t, err)
+	assert.Nil(t, result.IndexReport)
+	assert.True(t, result.Unchanged)
+	assert.Equal(t, uint32(5), result.Meta.GetReportGeneration())
+}
+
+func TestSendGetReport_NilReportRejected(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	go func() {
+		defer func() { _ = agentConn.Close() }()
+		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		require.NoError(t, err)
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
+			Result: &pb.VMServiceResponse_GetReport{
+				GetReport: &pb.GetReportResponse{},
+			},
+		}
+		respData, err := proto.Marshal(resp)
+		require.NoError(t, err)
+		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+	}()
+
+	_, err := client.GetReport(clientConn, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IndexReport is nil")
+}
+
+func TestSendGetReport_NotReady(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	go func() {
+		defer func() { _ = agentConn.Close() }()
+		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		require.NoError(t, err)
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+			Result: &pb.VMServiceResponse_Error{
+				Error: &pb.ErrorResponse{
+					Code:    pb.ErrorCode_ERROR_CODE_NOT_READY,
+					Message: "report not yet generated",
+				},
+			},
+		}
+		respData, err := proto.Marshal(resp)
+		require.NoError(t, err)
+		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+	}()
+
+	_, err := client.GetReport(clientConn, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotReady)
+}
+
+func TestSendGetReport_UnknownMethod(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	go func() {
+		defer func() { _ = agentConn.Close() }()
+		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		require.NoError(t, err)
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+			Result: &pb.VMServiceResponse_Error{
+				Error: &pb.ErrorResponse{
+					Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
+					Message: "get_report not supported",
+				},
+			},
+		}
+		respData, err := proto.Marshal(resp)
+		require.NoError(t, err)
+		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+	}()
+
+	_, err := client.GetReport(clientConn, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownMethod)
+}

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -1,8 +1,10 @@
 package vsockclient
 
 import (
+	"context"
 	"net"
 	"testing"
+	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -50,7 +52,7 @@ func TestSendGetReport_Success(t *testing.T) {
 		assert.Equal(t, uint32(0), req.GetGetReport().GetLastKnownGeneration())
 	})
 
-	result, err := client.GetReport(clientConn, 0, 0)
+	result, err := client.GetReport(context.Background(), clientConn, 0, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "test-hash", result.IndexReport.GetHashId())
 	assert.False(t, result.Unchanged)
@@ -72,7 +74,7 @@ func TestSendGetReport_Unchanged(t *testing.T) {
 		assert.Equal(t, uint32(42), req.GetGetReport().GetKnownEpoch())
 	})
 
-	result, err := client.GetReport(clientConn, 5, 42)
+	result, err := client.GetReport(context.Background(), clientConn, 5, 42)
 	require.NoError(t, err)
 	assert.Nil(t, result.IndexReport)
 	assert.True(t, result.Unchanged)
@@ -91,7 +93,7 @@ func TestSendGetReport_NilReportRejected(t *testing.T) {
 		},
 	}, nil)
 
-	_, err := client.GetReport(clientConn, 0, 0)
+	_, err := client.GetReport(context.Background(), clientConn, 0, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "IndexReport is nil")
 }
@@ -133,12 +135,53 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 				},
 			}, nil)
 
-			_, err := client.GetReport(clientConn, 0, 0)
+			_, err := client.GetReport(context.Background(), clientConn, 0, 0)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, tc.wantErr)
 			if tc.wantInMsg != "" {
 				assert.Contains(t, err.Error(), tc.wantInMsg)
 			}
 		})
+	}
+}
+
+// Cancelling ctx must unblock a GetReport that is stuck waiting for a
+// response — shutdown cancel does not rewrite the dial-time deadline, so
+// GetReport closes the stream itself.
+func TestSendGetReport_ContextCancelUnblocks(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer utils.IgnoreError(agentConn.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Consume the request so GetReport is blocked in ReadFrame, then cancel.
+	reqRead := make(chan struct{})
+	go func() {
+		defer close(reqRead)
+		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		require.NoError(t, err)
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.GetReport(ctx, clientConn, 0, 0)
+		errCh <- err
+	}()
+
+	select {
+	case <-reqRead:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for GetReport to send request")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetReport did not unblock on context cancel")
 	}
 }

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -13,34 +13,42 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// serveOnce plays the agent side of a request/response exchange over
+// agentConn. Run in its own goroutine, since GetReport blocks on the
+// response for the duration of the net.Pipe round trip.
+func serveOnce(t *testing.T, agentConn net.Conn, resp *pb.VMServiceResponse, validateReq func(*pb.VMServiceRequest)) {
+	defer utils.IgnoreError(agentConn.Close)
+	reqData, err := vsockframing.ReadFrame(agentConn, 10<<20)
+	require.NoError(t, err)
+
+	if validateReq != nil {
+		var req pb.VMServiceRequest
+		require.NoError(t, proto.Unmarshal(reqData, &req))
+		validateReq(&req)
+	}
+
+	respData, err := proto.Marshal(resp)
+	require.NoError(t, err)
+	require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
+}
+
 func TestSendGetReport_Success(t *testing.T) {
 	client := NewClient([]string{CapabilityReportV1}, 10<<20)
 	clientConn, agentConn := net.Pipe()
 	defer utils.IgnoreError(clientConn.Close)
 
-	go func() {
-		defer utils.IgnoreError(agentConn.Close)
-		reqData, err := vsockframing.ReadFrame(agentConn, 10<<20)
-		require.NoError(t, err)
-
-		var req pb.VMServiceRequest
-		require.NoError(t, proto.Unmarshal(reqData, &req))
+	go serveOnce(t, agentConn, &pb.VMServiceResponse{
+		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
+		Result: &pb.VMServiceResponse_GetReport{
+			GetReport: &pb.GetReportResponse{
+				IndexReport: &v4.IndexReport{HashId: "test-hash"},
+			},
+		},
+	}, func(req *pb.VMServiceRequest) {
 		assert.NotEmpty(t, req.GetMeta().GetRequestId())
 		assert.Equal(t, []string{CapabilityReportV1}, req.GetMeta().GetCapabilities())
 		assert.Equal(t, uint32(0), req.GetGetReport().GetLastKnownGeneration())
-
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
-			Result: &pb.VMServiceResponse_GetReport{
-				GetReport: &pb.GetReportResponse{
-					IndexReport: &v4.IndexReport{HashId: "test-hash"},
-				},
-			},
-		}
-		respData, err := proto.Marshal(resp)
-		require.NoError(t, err)
-		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
-	}()
+	})
 
 	result, err := client.GetReport(clientConn, 0, 0)
 	require.NoError(t, err)
@@ -54,26 +62,15 @@ func TestSendGetReport_Unchanged(t *testing.T) {
 	clientConn, agentConn := net.Pipe()
 	defer utils.IgnoreError(clientConn.Close)
 
-	go func() {
-		defer utils.IgnoreError(agentConn.Close)
-		reqData, err := vsockframing.ReadFrame(agentConn, 10<<20)
-		require.NoError(t, err)
-
-		var req pb.VMServiceRequest
-		require.NoError(t, proto.Unmarshal(reqData, &req))
+	go serveOnce(t, agentConn, &pb.VMServiceResponse{
+		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 5},
+		Result: &pb.VMServiceResponse_GetReport{
+			GetReport: &pb.GetReportResponse{Unchanged: true},
+		},
+	}, func(req *pb.VMServiceRequest) {
 		assert.Equal(t, uint32(5), req.GetGetReport().GetLastKnownGeneration())
 		assert.Equal(t, uint32(42), req.GetGetReport().GetKnownEpoch())
-
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 5},
-			Result: &pb.VMServiceResponse_GetReport{
-				GetReport: &pb.GetReportResponse{Unchanged: true},
-			},
-		}
-		respData, err := proto.Marshal(resp)
-		require.NoError(t, err)
-		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
-	}()
+	})
 
 	result, err := client.GetReport(clientConn, 5, 42)
 	require.NoError(t, err)
@@ -87,21 +84,12 @@ func TestSendGetReport_NilReportRejected(t *testing.T) {
 	clientConn, agentConn := net.Pipe()
 	defer utils.IgnoreError(clientConn.Close)
 
-	go func() {
-		defer utils.IgnoreError(agentConn.Close)
-		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
-		require.NoError(t, err)
-
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
-			Result: &pb.VMServiceResponse_GetReport{
-				GetReport: &pb.GetReportResponse{},
-			},
-		}
-		respData, err := proto.Marshal(resp)
-		require.NoError(t, err)
-		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
-	}()
+	go serveOnce(t, agentConn, &pb.VMServiceResponse{
+		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
+		Result: &pb.VMServiceResponse_GetReport{
+			GetReport: &pb.GetReportResponse{},
+		},
+	}, nil)
 
 	_, err := client.GetReport(clientConn, 0, 0)
 	require.Error(t, err)
@@ -138,21 +126,12 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			clientConn, agentConn := net.Pipe()
 			defer utils.IgnoreError(clientConn.Close)
 
-			go func() {
-				defer utils.IgnoreError(agentConn.Close)
-				_, err := vsockframing.ReadFrame(agentConn, 10<<20)
-				require.NoError(t, err)
-
-				resp := &pb.VMServiceResponse{
-					Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
-					Result: &pb.VMServiceResponse_Error{
-						Error: &pb.ErrorResponse{Code: tc.code, Message: tc.message},
-					},
-				}
-				respData, err := proto.Marshal(resp)
-				require.NoError(t, err)
-				require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
-			}()
+			go serveOnce(t, agentConn, &pb.VMServiceResponse{
+				Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_Error{
+					Error: &pb.ErrorResponse{Code: tc.code, Message: tc.message},
+				},
+			}, nil)
 
 			_, err := client.GetReport(clientConn, 0, 0)
 			require.Error(t, err)

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -27,7 +27,7 @@ func TestSendGetReport_Success(t *testing.T) {
 		require.NoError(t, proto.Unmarshal(reqData, &req))
 		assert.NotEmpty(t, req.GetMeta().GetRequestId())
 		assert.Equal(t, []string{CapabilityReportV1}, req.GetMeta().GetCapabilities())
-		assert.Equal(t, uint32(0), req.GetGetReport().GetIfNewerThanGeneration())
+		assert.Equal(t, uint32(0), req.GetGetReport().GetLastKnownGeneration())
 
 		resp := &pb.VMServiceResponse{
 			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
@@ -42,7 +42,7 @@ func TestSendGetReport_Success(t *testing.T) {
 		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
 	}()
 
-	result, err := client.GetReport(clientConn, 0)
+	result, err := client.GetReport(clientConn, 0, 0)
 	require.NoError(t, err)
 	assert.Equal(t, "test-hash", result.IndexReport.GetHashId())
 	assert.False(t, result.Unchanged)
@@ -56,8 +56,13 @@ func TestSendGetReport_Unchanged(t *testing.T) {
 
 	go func() {
 		defer utils.IgnoreError(agentConn.Close)
-		_, err := vsockframing.ReadFrame(agentConn, 10<<20)
+		reqData, err := vsockframing.ReadFrame(agentConn, 10<<20)
 		require.NoError(t, err)
+
+		var req pb.VMServiceRequest
+		require.NoError(t, proto.Unmarshal(reqData, &req))
+		assert.Equal(t, uint32(5), req.GetGetReport().GetLastKnownGeneration())
+		assert.Equal(t, uint32(42), req.GetGetReport().GetKnownEpoch())
 
 		resp := &pb.VMServiceResponse{
 			Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 5},
@@ -70,7 +75,7 @@ func TestSendGetReport_Unchanged(t *testing.T) {
 		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
 	}()
 
-	result, err := client.GetReport(clientConn, 5)
+	result, err := client.GetReport(clientConn, 5, 42)
 	require.NoError(t, err)
 	assert.Nil(t, result.IndexReport)
 	assert.True(t, result.Unchanged)
@@ -98,7 +103,7 @@ func TestSendGetReport_NilReportRejected(t *testing.T) {
 		require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
 	}()
 
-	_, err := client.GetReport(clientConn, 0)
+	_, err := client.GetReport(clientConn, 0, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "IndexReport is nil")
 }
@@ -149,7 +154,7 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 				require.NoError(t, vsockframing.WriteFrame(agentConn, respData))
 			}()
 
-			_, err := client.GetReport(clientConn, 0)
+			_, err := client.GetReport(clientConn, 0, 0)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, tc.wantErr)
 			if tc.wantInMsg != "" {

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
@@ -118,6 +118,19 @@ func (s *VirtualMachineStore) Size() int {
 	return len(s.virtualMachines)
 }
 
+// ListRunning returns copies of all VMs currently in running state.
+func (s *VirtualMachineStore) ListRunning() []*virtualmachine.Info {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	var out []*virtualmachine.Info
+	for _, vm := range s.virtualMachines {
+		if vm.Running {
+			out = append(out, vm.Copy())
+		}
+	}
+	return out
+}
+
 // GetFromCID returns the VirtualMachineInfo associated with a given VSOCK CID
 func (s *VirtualMachineStore) GetFromCID(cid uint32) *virtualmachine.Info {
 	s.lock.RLock()

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -2,11 +2,15 @@ package sensor
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	sensorInternal "github.com/stackrox/rox/generated/internalapi/sensor"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -47,7 +51,10 @@ import (
 	"github.com/stackrox/rox/sensor/common/sensor"
 	signalService "github.com/stackrox/rox/sensor/common/signal"
 	"github.com/stackrox/rox/sensor/common/store"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	vmIndex "github.com/stackrox/rox/sensor/common/virtualmachine/index"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vmscraper"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh"
 	"github.com/stackrox/rox/sensor/kubernetes/clusterhealth"
 	"github.com/stackrox/rox/sensor/kubernetes/clustermetrics"
@@ -61,6 +68,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/orchestrator"
 	"github.com/stackrox/rox/sensor/kubernetes/telemetry"
 	"github.com/stackrox/rox/sensor/kubernetes/upgrade"
+	"github.com/stackrox/rox/sensor/kubernetes/virtualmachine/vsockdialer"
 )
 
 var log = logging.LoggerForModule()
@@ -197,10 +205,25 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	var virtualMachineHandler vmIndex.Handler
+	var vmService vmIndex.Service
 	if features.VirtualMachines.Enabled() {
 		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines())
 		components = append(components, virtualMachineHandler)
 		complianceMultiplexer.AddComponentWithComplianceC(virtualMachineHandler)
+
+		var pullChecker vmIndex.PullActiveChecker
+		if kvConfig := cfg.k8sClient.RESTConfig(); kvConfig != nil {
+			pullMaxBytes := int64(env.VirtualMachinesPullMaxResponseSizeKB.IntegerSetting()) * 1024
+			vmDial := vsockdialer.NewMultiDialer(kvConfig, pullMaxBytes)
+			vmProtoClient := vsockclient.NewClient([]string{vsockclient.CapabilityReportV1}, int(pullMaxBytes))
+			vmSender := &vmScraperSenderAdapter{handler: virtualMachineHandler}
+			scraper := vmscraper.New(storeProvider.VirtualMachines(), vmSender, vmDial, vmProtoClient)
+			pullChecker = scraper
+			components = append(components, scraper)
+		} else {
+			log.Warn("VSOCK pull mode disabled (no REST config available)")
+		}
+		vmService = vmIndex.NewService(virtualMachineHandler, pullChecker)
 	}
 
 	matcher := compliance.NewNodeIDMatcher(storeProvider.Nodes())
@@ -300,8 +323,8 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		apiServices = append(apiServices, fileSystemService)
 	}
 
-	if features.VirtualMachines.Enabled() {
-		apiServices = append(apiServices, vmIndex.NewService(virtualMachineHandler))
+	if vmService != nil {
+		apiServices = append(apiServices, vmService)
 	}
 
 	if admCtrlSettingsMgr != nil {
@@ -310,4 +333,24 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	s.AddAPIServices(apiServices...)
 	return s, nil
+}
+
+// vmScraperSenderAdapter adapts vmIndex.Handler to vmscraper.IndexReportSender.
+// It constructs the v1.IndexReport envelope that the handler expects.
+type vmScraperSenderAdapter struct {
+	handler vmIndex.Handler
+}
+
+func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error {
+	var cidStr string
+	if vm.VSOCKCID != nil {
+		cidStr = strconv.FormatUint(uint64(*vm.VSOCKCID), 10)
+	}
+	if err := a.handler.Send(ctx, &v1.IndexReport{
+		VsockCid: cidStr,
+		IndexV4:  report,
+	}); err != nil {
+		return fmt.Errorf("sending index report: %w", err)
+	}
+	return nil
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -336,17 +336,24 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 // vmScraperSenderAdapter adapts vmIndex.Handler to vmscraper.IndexReportSender.
 // It constructs the v1.IndexReport envelope that the handler expects.
+// Pull mode sets vm_id from the Kubernetes UID so the handler can forward
+// without requiring vsock_cid. vsock_cid is still included when known for
+// ACK correlation and push-suppression.
 type vmScraperSenderAdapter struct {
 	handler vmIndex.Handler
 }
 
 func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error {
+	if vm == nil {
+		return errors.New("virtual machine info is nil")
+	}
 	var cidStr string
 	if vm.VSOCKCID != nil {
 		cidStr = strconv.FormatUint(uint64(*vm.VSOCKCID), 10)
 	}
 	if err := a.handler.Send(ctx, &v1.IndexReport{
 		VsockCid: cidStr,
+		VmId:     string(vm.ID),
 		IndexV4:  report,
 	}); err != nil {
 		return errors.Wrap(err, "sending index report")

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -2,7 +2,6 @@ package sensor
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -350,7 +349,7 @@ func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.In
 		VsockCid: cidStr,
 		IndexV4:  report,
 	}); err != nil {
-		return fmt.Errorf("sending index report: %w", err)
+		return errors.Wrap(err, "sending index report")
 	}
 	return nil
 }

--- a/sensor/kubernetes/sensor/vm_scraper_sender_adapter_test.go
+++ b/sensor/kubernetes/sensor/vm_scraper_sender_adapter_test.go
@@ -1,0 +1,72 @@
+package sensor
+
+import (
+	"context"
+	"testing"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/index/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestVMScraperSenderAdapter_Send(t *testing.T) {
+	cid := uint32(100)
+
+	cases := map[string]struct {
+		vm           *virtualmachine.Info
+		wantErr      bool
+		wantVmID     string
+		wantVsockCid string
+	}{
+		"should set vm_id when CID is nil": {
+			vm: &virtualmachine.Info{
+				ID:       "vm-1",
+				VSOCKCID: nil,
+			},
+			wantVmID:     "vm-1",
+			wantVsockCid: "",
+		},
+		"should include CID when known": {
+			vm: &virtualmachine.Info{
+				ID:       "vm-1",
+				VSOCKCID: &cid,
+			},
+			wantVmID:     "vm-1",
+			wantVsockCid: "100",
+		},
+		"should return error when VM is nil": {
+			vm:      nil,
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			handler := mocks.NewMockHandler(ctrl)
+			adapter := &vmScraperSenderAdapter{handler: handler}
+
+			if !tc.wantErr {
+				handler.EXPECT().
+					Send(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, report *v1.IndexReport) error {
+						assert.Equal(t, tc.wantVmID, report.GetVmId())
+						assert.Equal(t, tc.wantVsockCid, report.GetVsockCid())
+						assert.Equal(t, "IndexFinished", report.GetIndexV4().GetState())
+						return nil
+					})
+			}
+
+			err := adapter.Send(t.Context(), tc.vm, &v4.IndexReport{State: "IndexFinished"})
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -1,0 +1,217 @@
+// Package vsockdialer dials KubeVirt VM VSOCK ports via the Kubernetes API.
+//
+// This replaces kubevirt.io/client-go's AsyncSubresourceHelper with a
+// self-contained websocket dialer using only k8s.io/client-go/rest and
+// gorilla/websocket. We cannot import kubevirt.io/client-go because its
+// log package unconditionally registers a -v flag in init(), which panics
+// when glog (already in the sensor dep tree) also registers -v.
+// Upstream code: https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/log/log.go#L88
+// Upstream bug:  https://github.com/kubevirt/kubevirt/issues/16951
+package vsockdialer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/gorilla/websocket"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	subresourceAPIGroup = "subresources.kubevirt.io"
+	apiVersion          = "v1"
+	wsSubprotocol       = "plain.kubevirt.io"
+	wsBufferSize        = 1 << 20 // 1 MiB I/O buffer; not a message size limit (larger messages are chunked internally)
+)
+
+// MultiDialer dials VMs across namespaces via the KubeVirt subresource API.
+type MultiDialer struct {
+	config      *rest.Config
+	wsReadLimit int64
+}
+
+// NewMultiDialer creates a dialer from in-cluster (or kubeconfig) REST config.
+// wsReadLimit sets the maximum WebSocket message size in bytes.
+func NewMultiDialer(config *rest.Config, wsReadLimit int64) *MultiDialer {
+	return &MultiDialer{config: config, wsReadLimit: wsReadLimit}
+}
+
+// Dial connects to the named VMI's VSOCK port in the given namespace.
+// The context controls dial timeout and, if it carries a deadline, that
+// deadline is propagated to the connection's read/write deadlines so
+// the entire operation (dial + request + response) is bounded.
+//
+// An alternative would be threading context.Context through GetReport
+// with goroutine+select cancellation — we chose deadline propagation
+// for simplicity since the scraper's per-VM context already expresses
+// the right timeout budget for the whole exchange.
+func (d *MultiDialer) Dial(ctx context.Context, namespace, name string, port uint32, useTLS bool) (io.ReadWriteCloser, error) {
+	params := url.Values{}
+	params.Set("port", strconv.FormatUint(uint64(port), 10))
+	params.Set("tls", strconv.FormatBool(useTLS))
+
+	conn, err := dialSubresource(ctx, d.config, "virtualmachineinstances", namespace, name, "vsock", params)
+	if err != nil {
+		return nil, fmt.Errorf("VSOCK dial %s/%s:%d: %w", namespace, name, port, err)
+	}
+	conn.SetReadLimit(d.wsReadLimit)
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetReadDeadline(deadline)
+		_ = conn.SetWriteDeadline(deadline)
+	}
+	return &wsStream{conn: conn}, nil
+}
+
+func dialSubresource(ctx context.Context, config *rest.Config, resource, namespace, name, subresource string, queryParams url.Values) (*websocket.Conn, error) {
+	wsURL, err := buildWSURL(config, resource, namespace, name, subresource, queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	headers, err := authHeaders(config)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := rest.TLSConfigFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("TLS config: %w", err)
+	}
+
+	proxy := http.ProxyFromEnvironment
+	if config.Proxy != nil {
+		proxy = config.Proxy
+	}
+
+	dialer := &websocket.Dialer{
+		Proxy:           proxy,
+		TLSClientConfig: tlsConfig,
+		WriteBufferSize: wsBufferSize,
+		ReadBufferSize:  wsBufferSize,
+		Subprotocols:    []string{wsSubprotocol},
+		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}
+
+	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	if err != nil {
+		code := 0
+		if resp != nil {
+			code = resp.StatusCode
+		}
+		return nil, fmt.Errorf("websocket dial (status %d): %w", code, err)
+	}
+	return conn, nil
+}
+
+func buildWSURL(config *rest.Config, resource, namespace, name, subresource string, queryParams url.Values) (string, error) {
+	u, err := url.Parse(config.Host)
+	if err != nil {
+		return "", fmt.Errorf("parsing host: %w", err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	default:
+		return "", fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+
+	u.Path = path.Join(u.Path,
+		fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s/%s",
+			subresourceAPIGroup, apiVersion, namespace, resource, name, subresource))
+	if len(queryParams) > 0 {
+		u.RawQuery = queryParams.Encode()
+	}
+	return u.String(), nil
+}
+
+// authHeaders extracts auth headers (bearer token, client certs, impersonation)
+// that rest.HTTPWrappersForConfig injects into requests.
+func authHeaders(config *rest.Config) (http.Header, error) {
+	capture := &headerCapture{}
+	rt, err := rest.HTTPWrappersForConfig(config, capture)
+	if err != nil {
+		return nil, fmt.Errorf("wrapping transport: %w", err)
+	}
+	probe, err := http.NewRequest(http.MethodGet, config.Host, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building probe request: %w", err)
+	}
+	_, _ = rt.RoundTrip(probe)
+	return capture.headers, nil
+}
+
+type headerCapture struct{ headers http.Header }
+
+func (h *headerCapture) RoundTrip(req *http.Request) (*http.Response, error) {
+	h.headers = req.Header.Clone()
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+// wsStream adapts a websocket.Conn into an io.ReadWriteCloser that reads
+// across websocket binary message boundaries and writes binary messages.
+type wsStream struct {
+	conn   *websocket.Conn
+	reader io.Reader
+}
+
+func (s *wsStream) Read(p []byte) (int, error) {
+	for {
+		if s.reader == nil {
+			msgType, rd, err := s.conn.NextReader()
+			if err != nil {
+				if isWSClose(err) {
+					return 0, io.EOF
+				}
+				return 0, err //nolint:wrapcheck // implements io.Reader
+			}
+			if msgType == websocket.CloseMessage {
+				return 0, io.EOF
+			}
+			s.reader = rd
+		}
+
+		n, err := s.reader.Read(p)
+		if err == io.EOF {
+			s.reader = nil
+			if n > 0 {
+				return n, nil
+			}
+			continue
+		}
+		return n, err //nolint:wrapcheck // implements io.Reader
+	}
+}
+
+func (s *wsStream) Write(p []byte) (int, error) {
+	if err := s.conn.WriteMessage(websocket.BinaryMessage, p); err != nil {
+		return 0, fmt.Errorf("writing websocket message: %w", err)
+	}
+	return len(p), nil
+}
+
+func (s *wsStream) Close() error {
+	if err := s.conn.Close(); err != nil {
+		return fmt.Errorf("closing websocket: %w", err)
+	}
+	return nil
+}
+
+func isWSClose(err error) bool {
+	var ce *websocket.CloseError
+	if errors.As(err, &ce) {
+		return true
+	}
+	return errors.Is(err, io.EOF)
+}

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 
 	"github.com/gorilla/websocket"
@@ -119,9 +118,7 @@ func buildWSURL(config *rest.Config, resource, namespace, name, subresource stri
 		return "", fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}
 
-	u.Path = path.Join(u.Path,
-		fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s/%s",
-			subresourceAPIGroup, apiVersion, namespace, resource, name, subresource))
+	u = u.JoinPath("apis", subresourceAPIGroup, apiVersion, "namespaces", namespace, resource, name, subresource)
 	if len(queryParams) > 0 {
 		u.RawQuery = queryParams.Encode()
 	}

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -179,8 +179,7 @@ func (s *wsStream) Close() error {
 }
 
 func isWSClose(err error) bool {
-	var ce *websocket.CloseError
-	if errors.As(err, &ce) {
+	if _, ok := errors.AsType[*websocket.CloseError](err); ok {
 		return true
 	}
 	return errors.Is(err, io.EOF)

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -46,13 +46,12 @@ func NewMultiDialer(config *rest.Config, wsReadLimit int64) *MultiDialer {
 
 // Dial connects to the named VMI's VSOCK port in the given namespace.
 // The context controls dial timeout and, if it carries a deadline, that
-// deadline is propagated to the connection's read/write deadlines so
-// the entire operation (dial + request + response) is bounded.
+// deadline is propagated to the connection's read/write deadlines so the
+// per-VM timeout budget covers dial + request + response.
 //
-// An alternative would be threading context.Context through GetReport
-// with goroutine+select cancellation — we chose deadline propagation
-// for simplicity since the scraper's per-VM context already expresses
-// the right timeout budget for the whole exchange.
+// Deadline propagation alone does not abort an in-flight read when the
+// parent context is cancelled without a nearer deadline (e.g. Sensor
+// shutdown). GetReport closes the stream on ctx cancel for that case.
 func (d *MultiDialer) Dial(ctx context.Context, namespace, name string, port uint32, useTLS bool) (io.ReadWriteCloser, error) {
 	params := url.Values{}
 	params.Set("port", strconv.FormatUint(uint64(port), 10))

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -1,12 +1,14 @@
 // Package vsockdialer dials KubeVirt VM VSOCK ports via the Kubernetes API.
 //
 // This replaces kubevirt.io/client-go's AsyncSubresourceHelper with a
-// self-contained websocket dialer using only k8s.io/client-go/rest and
-// gorilla/websocket. We cannot import kubevirt.io/client-go because its
-// log package unconditionally registers a -v flag in init(), which panics
-// when glog (already in the sensor dep tree) also registers -v.
-// Upstream code: https://github.com/kubevirt/kubevirt/blob/main/staging/src/kubevirt.io/client-go/log/log.go#L88
-// Upstream bug:  https://github.com/kubevirt/kubevirt/issues/16951
+// self-contained websocket dialer built on k8s.io/client-go/transport/websocket
+// (the same building block client-go itself uses for `kubectl exec`/
+// `port-forward` over WebSocket) plus gorilla/websocket for the connection
+// type. We cannot import kubevirt.io/client-go directly yet — kubevirt#16951
+// is no longer a blocker, but kubevirt#18382 and kubevirt#18408 still are.
+// See https://github.com/stackrox/stackrox/pull/21587 for tracking; re-evaluate
+// once both land in a tagged release. Do not switch to a personal fork for
+// production use.
 package vsockdialer
 
 import (
@@ -14,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -22,13 +23,13 @@ import (
 
 	"github.com/gorilla/websocket"
 	"k8s.io/client-go/rest"
+	wstransport "k8s.io/client-go/transport/websocket"
 )
 
 const (
 	subresourceAPIGroup = "subresources.kubevirt.io"
 	apiVersion          = "v1"
 	wsSubprotocol       = "plain.kubevirt.io"
-	wsBufferSize        = 1 << 20 // 1 MiB I/O buffer; not a message size limit (larger messages are chunked internally)
 )
 
 // MultiDialer dials VMs across namespaces via the KubeVirt subresource API.
@@ -57,7 +58,12 @@ func (d *MultiDialer) Dial(ctx context.Context, namespace, name string, port uin
 	params.Set("port", strconv.FormatUint(uint64(port), 10))
 	params.Set("tls", strconv.FormatBool(useTLS))
 
-	conn, err := dialSubresource(ctx, d.config, "virtualmachineinstances", namespace, name, "vsock", params)
+	wsURL, err := buildWSURL(d.config, "virtualmachineinstances", namespace, name, "vsock", params)
+	if err != nil {
+		return nil, fmt.Errorf("VSOCK dial %s/%s:%d: %w", namespace, name, port, err)
+	}
+
+	conn, err := dialSubresource(ctx, d.config, wsURL)
 	if err != nil {
 		return nil, fmt.Errorf("VSOCK dial %s/%s:%d: %w", namespace, name, port, err)
 	}
@@ -69,45 +75,32 @@ func (d *MultiDialer) Dial(ctx context.Context, namespace, name string, port uin
 	return &wsStream{conn: conn}, nil
 }
 
-func dialSubresource(ctx context.Context, config *rest.Config, resource, namespace, name, subresource string, queryParams url.Values) (*websocket.Conn, error) {
-	wsURL, err := buildWSURL(config, resource, namespace, name, subresource, queryParams)
+// dialSubresource negotiates a WebSocket connection to wsURL using
+// k8s.io/client-go/transport/websocket. That package builds the
+// RoundTripper straight from the REST config — TLS, proxying, and auth
+// (bearer token, client certs, impersonation, exec/OIDC credential
+// plugins) — the same way a real apiserver request would, so we don't
+// have to reimplement auth-header extraction here.
+//
+// Trade-off: the negotiated connection's I/O buffers are fixed at ~33KiB by
+// client-go's RoundTripper, smaller than a hand-rolled dialer could use.
+// This only affects how many read/write syscalls a large message takes —
+// messages are chunked across frames regardless of buffer size — so it
+// doesn't affect correctness.
+func dialSubresource(ctx context.Context, config *rest.Config, wsURL string) (*websocket.Conn, error) {
+	rt, holder, err := wstransport.RoundTripperFor(config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building websocket round tripper: %w", err)
 	}
 
-	headers, err := authHeaders(config)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wsURL, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("building request: %w", err)
 	}
 
-	tlsConfig, err := rest.TLSConfigFor(config)
+	conn, err := wstransport.Negotiate(rt, holder, req, wsSubprotocol)
 	if err != nil {
-		return nil, fmt.Errorf("TLS config: %w", err)
-	}
-
-	proxy := http.ProxyFromEnvironment
-	if config.Proxy != nil {
-		proxy = config.Proxy
-	}
-
-	dialer := &websocket.Dialer{
-		Proxy:           proxy,
-		TLSClientConfig: tlsConfig,
-		WriteBufferSize: wsBufferSize,
-		ReadBufferSize:  wsBufferSize,
-		Subprotocols:    []string{wsSubprotocol},
-		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, network, addr)
-		},
-	}
-
-	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
-	if err != nil {
-		code := 0
-		if resp != nil {
-			code = resp.StatusCode
-		}
-		return nil, fmt.Errorf("websocket dial (status %d): %w", code, err)
+		return nil, fmt.Errorf("websocket dial: %w", err)
 	}
 	return conn, nil
 }
@@ -134,29 +127,6 @@ func buildWSURL(config *rest.Config, resource, namespace, name, subresource stri
 		u.RawQuery = queryParams.Encode()
 	}
 	return u.String(), nil
-}
-
-// authHeaders extracts auth headers (bearer token, client certs, impersonation)
-// that rest.HTTPWrappersForConfig injects into requests.
-func authHeaders(config *rest.Config) (http.Header, error) {
-	capture := &headerCapture{}
-	rt, err := rest.HTTPWrappersForConfig(config, capture)
-	if err != nil {
-		return nil, fmt.Errorf("wrapping transport: %w", err)
-	}
-	probe, err := http.NewRequest(http.MethodGet, config.Host, nil)
-	if err != nil {
-		return nil, fmt.Errorf("building probe request: %w", err)
-	}
-	_, _ = rt.RoundTrip(probe)
-	return capture.headers, nil
-}
-
-type headerCapture struct{ headers http.Header }
-
-func (h *headerCapture) RoundTrip(req *http.Request) (*http.Response, error) {
-	h.headers = req.Header.Clone()
-	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
 }
 
 // wsStream adapts a websocket.Conn into an io.ReadWriteCloser that reads

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer_test.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer_test.go
@@ -1,0 +1,50 @@
+package vsockdialer
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestBuildWSURL(t *testing.T) {
+	params := url.Values{}
+	params.Set("port", "1024")
+	params.Set("tls", "true")
+
+	cases := map[string]struct {
+		host    string
+		wantURL string
+		wantErr string // substring to match against the error; empty means no error expected
+	}{
+		"should rewrite https to wss": {
+			host:    "https://api.example.com:6443",
+			wantURL: "wss://api.example.com:6443/apis/subresources.kubevirt.io/v1/namespaces/ns1/virtualmachineinstances/vm-a/vsock?port=1024&tls=true",
+		},
+		"should rewrite http to ws": {
+			host:    "http://localhost:8080",
+			wantURL: "ws://localhost:8080/apis/subresources.kubevirt.io/v1/namespaces/ns1/virtualmachineinstances/vm-a/vsock?port=1024&tls=true",
+		},
+		"should reject unsupported scheme": {
+			host:    "ftp://api.example.com",
+			wantErr: "unsupported scheme",
+		},
+		"should reject unparseable host": {
+			host:    "https://api.example.com:abc",
+			wantErr: "parsing host",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := buildWSURL(&rest.Config{Host: tc.host}, "virtualmachineinstances", "ns1", "vm-a", "vsock", params)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantURL, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description

> 📖 **Design documentation:** This PR is part of the VSOCK pull-mode feature. Before reviewing, please familiarize yourself with the architecture and protocol design in [ADR-0006: VM Scanning VSOCK Pull Mode](https://github.com/stackrox/architecture-decision-records/blob/piotr/ADR-0006-vsock-pull-mode/stackrox/ADR-0006-vm-scanning-vsock-pull-mode.md) — especially the architecture overview and TLS sections. It will make the scraper and dialer code much easier to follow.

Sensor-side implementation of pull-mode VM scanning. Sensor dials into VMs over VSOCK (via KubeVirt WebSocket subresource), pulls cached index reports using the VMService protocol, deduplicates by generation counter, and forwards to Central.

Key components:
- `vsockdialer/` — WebSocket-over-VSOCK via KubeVirt subresource API
- `vsockclient/` — protocol client (send request, parse response)
- `vmscraper/` — poll loop with generation-based dedup, bounded concurrency
- `metrics/` — Prometheus metrics for pull-mode operations
- `reportcheck/` — pulled report validation

Also includes:
- Push-suppression logic (drops push-mode reports for actively scraped VMs)
- Helm RBAC for `virtualmachineinstances/vsock` subresource
- Promotes `gorilla/websocket` to direct dependency

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Added tests in CI
Deployed the entire stack (using the piotr/ROX-35195-v2-vsock-pull-poc branch), so that the https://github.com/stackrox/stackrox/pull/21435 are included and observed it on a cluster (confirming that feature works in UI, metrics and logs are clean).
