### PR TITLE
ROX-32912: Bump ClairCore to fix alias table int4 overflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
-	github.com/quay/claircore v1.5.53-0.20260623202659-e6cd4c8e9962
+	github.com/quay/claircore v1.5.53-0.20260625185455-a2178084cc0c
 	github.com/quay/claircore/toolkit v1.6.1
 	github.com/quay/zlog/v2 v2.1.1
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
-github.com/quay/claircore v1.5.53-0.20260623202659-e6cd4c8e9962 h1:boYeLNO7qfRfmIJ6RGrIw5zIDFhR1781iMGqUQfNqUs=
-github.com/quay/claircore v1.5.53-0.20260623202659-e6cd4c8e9962/go.mod h1:Tru7zL45XO2Q/j5vPmIM6750/X332bAhum7i3OlUpHI=
+github.com/quay/claircore v1.5.53-0.20260625185455-a2178084cc0c h1:3pUgLLib201iCuShnFZ4ggOZW1mEgFGYT+HGnXdHXg4=
+github.com/quay/claircore v1.5.53-0.20260625185455-a2178084cc0c/go.mod h1:Tru7zL45XO2Q/j5vPmIM6750/X332bAhum7i3OlUpHI=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.6.1 h1:a3X1v28n5bo05T94cBlaoPU8xYCErRGPM3l6AlmYWj4=
 github.com/quay/claircore/toolkit v1.6.1/go.mod h1:dTzlp1pgNchc+CN73HJiG9+e0ygU54QPt397eXnGGo4=


### PR DESCRIPTION
## Description

Backport of #21425 from master to release-4.11.

Bumps ClairCore to [`a2178084`](https://github.com/quay/claircore/commit/a2178084cc0cfde7e72f4bf0c736dbdc94187983), which widens the `vulnerability` foreign key columns in the `vulnerability_alias` and `vulnerability_self` tables from `INTEGER` (int4) to `BIGINT` (int8), and adds explicit `::bigint[]` casts in the alias queries.

Without this fix, long-running systems where `vuln.id` exceeds 2^31-1 fail during scans with: `unable to encode []int64{...} into binary format for _int4`.

See #21425 for full details and validation.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready

### How I validated my change

Cherry-pick of the already-validated master PR. See #21425 for validation details.