### PR TITLE
ROX-34955: reject container type filters on irrelevant policies

### DIFF
--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -513,5 +513,11 @@ func (s *policyValidator) validateEvaluationFilter(policy *storage.Policy) error
 	if policies.AppliesAtBuildTime(policy) && !policies.AppliesAtDeployTime(policy) && !policies.AppliesAtRunTime(policy) {
 		return errors.New("container type filters in the evaluation filter are not applicable to build-only policies")
 	}
+	if s.isAuditEventPolicy(policy) {
+		return errors.New("container type filters in the evaluation filter are not applicable to audit log event policies")
+	}
+	if s.isNodeEventPolicy(policy) {
+		return errors.New("container type filters in the evaluation filter are not applicable to node event policies")
+	}
 	return nil
 }

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -1378,6 +1378,7 @@ func (s *PolicyValidatorTestSuite) TestValidateScope() {
 func (s *PolicyValidatorTestSuite) TestValidateEvaluationFilter() {
 	tests := map[string]struct {
 		lifecycleStages    []storage.LifecycleStage
+		eventSource        storage.EventSource
 		skipContainerTypes []storage.ContainerType
 		expectError        bool
 	}{
@@ -1404,12 +1405,30 @@ func (s *PolicyValidatorTestSuite) TestValidateEvaluationFilter() {
 		"no lifecycle stages with skip init is allowed": {
 			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
 		},
+		"audit log event with skip init is rejected": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+			eventSource:        storage.EventSource_AUDIT_LOG_EVENT,
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+			expectError:        true,
+		},
+		"node event with skip init is rejected": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+			eventSource:        storage.EventSource_NODE_EVENT,
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+			expectError:        true,
+		},
+		"deployment event with skip init is allowed": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+			eventSource:        storage.EventSource_DEPLOYMENT_EVENT,
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+		},
 	}
 
 	for name, tc := range tests {
 		s.Run(name, func() {
 			policy := &storage.Policy{
 				LifecycleStages: tc.lifecycleStages,
+				EventSource:     tc.eventSource,
 			}
 			if tc.skipContainerTypes != nil {
 				policy.EvaluationFilter = &storage.EvaluationFilter{


### PR DESCRIPTION
## Description

Extends the evaluation filter validation to also reject container type filters on audit log event and node event policies. These policy types don't evaluate containers, so container type filtering is not applicable.

Previously we only rejected container type filters on build-only policies.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

Unit tests covering: audit log event with skip init rejected, node event with skip init rejected, deployment event with skip init allowed.

Deployed build to a GKE cluster and verified via API:
- Creating a runtime/audit log event policy with `skipContainerTypes: ["INIT"]` → rejected with "not applicable to audit log event policies"
- Creating a runtime/node event policy with `skipContainerTypes: ["INIT"]` → rejected with "not applicable to node event policies"
- Creating a runtime/deployment event policy with `skipContainerTypes: ["INIT"]` → created successfully
