### PR TITLE
ROX-35419: Pre-register Scanner V4 bundles

### DIFF
--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -426,31 +426,27 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	// Filter to allowed bundles once; the slice is reused for pre-registration,
-	// processing, and GC.
-	allowedBundles := make([]*zip.File, 0, len(zipReader.File))
+	// Bundles to process in this update cycle, filtered by allowlist.
+	bundles := make([]*zip.File, 0, len(zipReader.File))
 	for _, f := range zipReader.File {
 		if !u.isBundleAllowed(f.Name) {
 			slog.InfoContext(ctx, "skipping bundle (not in allowlist)", "bundle", f.Name)
 			continue
 		}
-		allowedBundles = append(allowedBundles, f)
+		bundles = append(bundles, f)
 	}
 
-	// Pre-register all allowed bundles so that Initialized() correctly reports
-	// not-ready until every bundle has been processed at least once. Without
-	// this, the health-check probe can observe a window where only completed
-	// bundles have rows (all with valid timestamps) and prematurely latch
-	// initialized=true.
-	for _, f := range allowedBundles {
+	// Create update-time rows for new bundles since they don't have one yet, using the
+	// last known update time to preserve aggregate timestamp accuracy.
+	for _, f := range bundles {
 		if _, err := u.metadataStore.GetOrSetLastVulnerabilityUpdate(ctx, f.Name, prevTime); err != nil {
-			return false, fmt.Errorf("pre-registering bundle %s: %w", f.Name, err)
+			return false, fmt.Errorf("setting last update-time for bundle %s: %w", f.Name, err)
 		}
 	}
-	slog.InfoContext(ctx, "pre-registered vulnerability bundles", "count", len(allowedBundles))
+	slog.InfoContext(ctx, "pre-registered vulnerability bundles", "count", len(bundles))
 
 	// Process each vulnerability bundle in the .zip archive.
-	for _, bundleF := range allowedBundles {
+	for _, bundleF := range bundles {
 		bundleCtx := log.With(ctx, "bundle", bundleF.Name)
 		slog.InfoContext(bundleCtx, "starting bundle update")
 		if err := u.updateBundle(bundleCtx, bundleF, zipTime, prevTime); err != nil {
@@ -462,8 +458,8 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 
 	// Clean updaters that were deleted (not in the zip and older than this update).
 	// Safe to be run concurrently.
-	names := make([]string, 0, len(allowedBundles))
-	for _, f := range allowedBundles {
+	names := make([]string, 0, len(bundles))
+	for _, f := range bundles {
 		names = append(names, f.Name)
 	}
 	err = u.metadataStore.GCVulnerabilityUpdates(ctx, names, zipTime)

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -426,15 +426,31 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	// Iterate through each vulnerability bundle in the .zip archive
-	names := make([]string, 0, len(zipReader.File))
-	for i := range zipReader.File {
-		bundleF := zipReader.File[i]
-		if !u.isBundleAllowed(bundleF.Name) {
-			slog.InfoContext(ctx, "skipping bundle (not in allowlist)", "bundle", bundleF.Name)
+	// Filter to allowed bundles once; the slice is reused for pre-registration,
+	// processing, and GC.
+	allowedBundles := make([]*zip.File, 0, len(zipReader.File))
+	for _, f := range zipReader.File {
+		if !u.isBundleAllowed(f.Name) {
+			slog.InfoContext(ctx, "skipping bundle (not in allowlist)", "bundle", f.Name)
 			continue
 		}
-		names = append(names, bundleF.Name)
+		allowedBundles = append(allowedBundles, f)
+	}
+
+	// Pre-register all allowed bundles so that Initialized() correctly reports
+	// not-ready until every bundle has been processed at least once. Without
+	// this, the health-check probe can observe a window where only completed
+	// bundles have rows (all with valid timestamps) and prematurely latch
+	// initialized=true.
+	for _, f := range allowedBundles {
+		if _, err := u.metadataStore.GetOrSetLastVulnerabilityUpdate(ctx, f.Name, prevTime); err != nil {
+			return false, fmt.Errorf("pre-registering bundle %s: %w", f.Name, err)
+		}
+	}
+	slog.InfoContext(ctx, "pre-registered vulnerability bundles", "count", len(allowedBundles))
+
+	// Process each vulnerability bundle in the .zip archive.
+	for _, bundleF := range allowedBundles {
 		bundleCtx := log.With(ctx, "bundle", bundleF.Name)
 		slog.InfoContext(bundleCtx, "starting bundle update")
 		if err := u.updateBundle(bundleCtx, bundleF, zipTime, prevTime); err != nil {
@@ -446,6 +462,10 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 
 	// Clean updaters that were deleted (not in the zip and older than this update).
 	// Safe to be run concurrently.
+	names := make([]string, 0, len(allowedBundles))
+	for _, f := range allowedBundles {
+		names = append(names, f.Name)
+	}
 	err = u.metadataStore.GCVulnerabilityUpdates(ctx, names, zipTime)
 	if err != nil {
 		return false, fmt.Errorf("cleaning vuln updates: %w", err)
@@ -470,7 +490,7 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 		return nil
 	}
 
-	// Ensure there is an update timestamp for this bundle, and check if it's newer
+	// Get the last update timestamp for this bundle and check if it's newer
 	// than this update.
 	lastTime, err := u.metadataStore.GetOrSetLastVulnerabilityUpdate(lCtx, zipF.Name, prevTime)
 	if err != nil {

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -68,8 +68,6 @@ func testHTTPServer(t *testing.T, content func(r *http.Request) io.ReadSeeker) (
 }
 
 func TestMultiBundleUpdate(t *testing.T) {
-	t.Setenv("ROX_SCANNER_V4_MULTI_BUNDLE", "true")
-
 	// TODO(ROX-26236): Test with zst files, as a chunk of the updater function is currently untested.
 	srv, now := testHTTPServer(t, func(r *http.Request) io.ReadSeeker {
 		accept := r.Header.Get("X-Scanner-V4-Accept")
@@ -149,6 +147,81 @@ func TestMultiBundleUpdate(t *testing.T) {
 	err = u.Update(test.Logging(t))
 	assert.NoError(t, err)
 	assert.Equal(t, dists, u.KnownDistributions())
+}
+
+func TestMultiBundleUpdate_PreRegistration(t *testing.T) {
+	bundleNames := []string{"alpine.json.zst", "nvd.json.zst", "rhel-vex.json.zst"}
+
+	srv, now := testHTTPServer(t, func(_ *http.Request) io.ReadSeeker {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		for _, name := range bundleNames {
+			_, err := zw.Create(name)
+			require.NoError(t, err)
+		}
+		require.NoError(t, zw.Close())
+		return bytes.NewReader(buf.Bytes())
+	})
+
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockMatcherStore(ctrl)
+	metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
+
+	prevTime := now.Add(-time.Minute)
+
+	u := &Updater{
+		locker:        &testLocker{locker: updates.NewLocalLockSource()},
+		store:         store,
+		metadataStore: metadataStore,
+		client:        srv.Client(),
+		urls:          []string{srv.URL},
+		root:          t.TempDir(),
+		skipGC:        true,
+		importFunc:    func(_ context.Context, _ io.Reader) error { return nil },
+		retryDelay:    1 * time.Second,
+		retryMax:      1,
+		distManager:   newDistManager(store),
+	}
+
+	// GetLastVulnerabilityUpdate at start of runMultiBundleUpdate.
+	metadataStore.EXPECT().
+		GetLastVulnerabilityUpdate(gomock.Any()).
+		Return(prevTime, nil)
+
+	// Pre-registration phase: GetOrSetLastVulnerabilityUpdate for each bundle.
+	// These must all complete before any processing-phase calls.
+	preReg := make([]*gomock.Call, len(bundleNames))
+	for i, name := range bundleNames {
+		preReg[i] = metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), name, prevTime).
+			Return(prevTime, nil)
+	}
+
+	// Processing phase: each updateBundle calls GetOrSetLastVulnerabilityUpdate.
+	// Return zipTime (now) so updateBundle skips actual import (no zst decoding needed).
+	// Constrained to happen AFTER all pre-registration calls.
+	for _, name := range bundleNames {
+		call := metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), name, prevTime).
+			Return(now, nil)
+		for _, pre := range preReg {
+			call.After(pre)
+		}
+	}
+
+	// GC and Initialized at end of runMultiBundleUpdate.
+	metadataStore.EXPECT().
+		GCVulnerabilityUpdates(gomock.Any(), gomock.Any(), now).
+		Return(nil)
+	store.EXPECT().
+		Distributions(gomock.Any()).
+		Return(nil, nil)
+	metadataStore.EXPECT().
+		GetLastVulnerabilityUpdate(gomock.Any()).
+		Return(now, nil)
+
+	err := u.Update(test.Logging(t))
+	assert.NoError(t, err)
 }
 
 func TestFetch(t *testing.T) {


### PR DESCRIPTION
## Description

Scanner V4 matcher's readiness probe can pass before all vulnerability bundles are loaded. `Initialized()` queries the oldest `update_timestamp` from `last_vuln_update`, but rows are only inserted when a bundle starts processing inside `updateBundle`. Between bundle completions, bundles that haven't started yet have no rows, so the query sees only completed rows with valid timestamps and prematurely latches `initialized=true`.

Observed in [CI flake](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21098/pull-ci-stackrox-stackrox-master-ocp-4-21-qa-e2e-tests/2070218339795341312)

The fix adds a pre-registration pass in `runMultiBundleUpdate`: after opening the zip and filtering to allowed bundles, `GetOrSetLastVulnerabilityUpdate` is called for each allowed bundle before any processing begins. This inserts  placeholder rows (via `INSERT ON CONFLICT DO NOTHING`) so that `Initialized()` sees zero-time rows for unprocessed bundles and correctly reports not-ready.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

Unit tests
