### PR TITLE
ROX-35303: remove vestigial KeyedMutex from image datastores

### DIFF
--- a/central/image/datastore/datastore_impl.go
+++ b/central/image/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/image/datastore/store"
 	"github.com/stackrox/rox/central/image/views"
 	"github.com/stackrox/rox/central/metrics"
@@ -14,7 +13,6 @@ import (
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/images/enricher"
 	imageTypes "github.com/stackrox/rox/pkg/images/types"
@@ -32,8 +30,6 @@ var (
 )
 
 type datastoreImpl struct {
-	keyedMutex *concurrency.KeyedMutex
-
 	storage store.Store
 
 	risks riskDS.DataStore
@@ -51,8 +47,6 @@ func newDatastoreImpl(storage store.Store, risks riskDS.DataStore,
 
 		imageRanker:          imageRanker,
 		imageComponentRanker: imageComponentRanker,
-
-		keyedMutex: concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize),
 	}
 	return ds
 }
@@ -261,9 +255,6 @@ func (ds *datastoreImpl) UpsertImage(ctx context.Context, image *storage.Image) 
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-
-	ds.keyedMutex.Lock(image.GetId())
-	defer ds.keyedMutex.Unlock(image.GetId())
 
 	ds.updateComponentRisk(image)
 	enricher.FillScanStats(image)

--- a/central/imagev2/datastore/datastore_impl.go
+++ b/central/imagev2/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/imagev2/datastore/store"
 	"github.com/stackrox/rox/central/imagev2/views"
 	"github.com/stackrox/rox/central/metrics"
@@ -14,7 +13,6 @@ import (
 	riskDS "github.com/stackrox/rox/central/risk/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
@@ -32,8 +30,6 @@ var (
 )
 
 type datastoreImpl struct {
-	keyedMutex *concurrency.KeyedMutex
-
 	storage store.Store
 
 	risks riskDS.DataStore
@@ -51,8 +47,6 @@ func newDatastoreImpl(storage store.Store, risks riskDS.DataStore,
 
 		imageRanker:          imageRanker,
 		imageComponentRanker: imageComponentRanker,
-
-		keyedMutex: concurrency.NewKeyedMutex(globaldb.DefaultDataStorePoolSize),
 	}
 	return ds
 }
@@ -285,9 +279,6 @@ func (ds *datastoreImpl) UpsertImage(ctx context.Context, image *storage.ImageV2
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-
-	ds.keyedMutex.Lock(image.GetId())
-	defer ds.keyedMutex.Unlock(image.GetId())
 
 	ds.updateComponentRisk(image)
 	utils.FillScanStatsV2(image)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The per-image KeyedMutex in both V1 and V2 image datastores was
introduced in 2019 (PR #2714) to protect a read-modify-write cycle
(GetImage -> merge -> UpsertImage -> AddToIndex) that lived in the
datastore layer. That logic has since moved into the store upsert(),
which has its own keyFence.DoStatusWithLock serialization on image ID
and component IDs.

Today the datastore mutex wraps only pure in-memory mutations
(updateComponentRisk, FillScanStats) on caller-local objects and a
thread-safe ranker.Add -- none of which need external synchronization.

The redundant lock causes the TestImageCVEView flake (ROX-35303):
upserting ~11K CVEs under -race + cgocheck2 exceeds the 30s mutex
watchdog (MUTEX_WATCHDOG_TIMEOUT_SECS=30 set in the Makefile) and
SIGABRTs the test.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

UT and CI should be sufficient here.