### PR TITLE
ROX-35413: Add ListSecretsExtended API with rel links

### DIFF
--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -14288,8 +14288,10 @@ func (resolver *secretResolver) Namespace(ctx context.Context) string {
 }
 
 func (resolver *secretResolver) Relationship(ctx context.Context) (*secretRelationshipResolver, error) {
-	resolver.ensureData(ctx)
 	value := resolver.data.GetRelationship()
+	if resolver.data == nil {
+		value = resolver.list.GetRelationship()
+	}
 	return resolver.root.wrapSecretRelationship(value, true, nil)
 }
 

--- a/central/secret/service/service_impl.go
+++ b/central/secret/service/service_impl.go
@@ -30,6 +30,7 @@ var (
 			v1.SecretService_GetSecret_FullMethodName,
 			v1.SecretService_CountSecrets_FullMethodName,
 			v1.SecretService_ListSecrets_FullMethodName,
+			v1.SecretService_ListSecretsExtended_FullMethodName,
 		},
 	})
 )

--- a/central/secret/service/service_impl.go
+++ b/central/secret/service/service_impl.go
@@ -57,16 +57,15 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 	return ctx, authorizer.Authorized(ctx, fullMethodName)
 }
 
-// GetSecret returns the secret for the id.
-func (s *serviceImpl) GetSecret(ctx context.Context, request *v1.ResourceByID) (*storage.Secret, error) {
-	secret, exists, err := s.secrets.GetSecret(ctx, request.GetId())
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.Wrapf(errox.NotFound, "secret with id '%s' does not exist", request.GetId())
-	}
+// common interface for secrets and list secrets based on identifying fields.
+type secretIdentity interface {
+	GetClusterId() string
+	GetNamespace() string
+	GetName() string
+}
 
+// getDeploymentRelationships returns the deployment relationships for a secret.
+func (s *serviceImpl) getDeploymentRelationships(ctx context.Context, secret secretIdentity) ([]*storage.SecretDeploymentRelationship, error) {
 	psr := search.NewQueryBuilder().
 		AddExactMatches(search.ClusterID, secret.GetClusterId()).
 		AddExactMatches(search.Namespace, secret.GetNamespace()).
@@ -77,7 +76,6 @@ func (s *serviceImpl) GetSecret(ctx context.Context, request *v1.ResourceByID) (
 	if err != nil {
 		return nil, err
 	}
-
 	var deployments []*storage.SecretDeploymentRelationship
 	for _, r := range deploymentResults {
 		deployments = append(deployments, &storage.SecretDeploymentRelationship{
@@ -85,6 +83,24 @@ func (s *serviceImpl) GetSecret(ctx context.Context, request *v1.ResourceByID) (
 			Name: r.GetName(),
 		})
 	}
+	return deployments, nil
+}
+
+// GetSecret returns the secret for the id.
+func (s *serviceImpl) GetSecret(ctx context.Context, request *v1.ResourceByID) (*storage.Secret, error) {
+	secret, exists, err := s.secrets.GetSecret(ctx, request.GetId())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.Wrapf(errox.NotFound, "secret with id '%s' does not exist", request.GetId())
+	}
+
+	deployments, err := s.getDeploymentRelationships(ctx, secret)
+	if err != nil {
+		return nil, err
+	}
+
 	secret.Relationship = &storage.SecretRelationship{
 		DeploymentRelationships: deployments,
 	}
@@ -106,18 +122,54 @@ func (s *serviceImpl) CountSecrets(ctx context.Context, request *v1.RawQuery) (*
 	return &v1.CountSecretsResponse{Count: int32(numSecrets)}, nil
 }
 
-// ListSecrets returns all secrets that match the query.
-func (s *serviceImpl) ListSecrets(ctx context.Context, request *v1.RawQuery) (*v1.ListSecretsResponse, error) {
+func (s *serviceImpl) listSecrets(ctx context.Context, request *v1.ListSecretsExtendedRequest) ([]*storage.ListSecret, error) {
+	rawQuery := request.GetQuery()
 	// Fill in query.
-	parsedQuery, err := search.ParseQuery(request.GetQuery(), search.MatchAllIfEmpty())
+	parsedQuery, err := search.ParseQuery(rawQuery.GetQuery(), search.MatchAllIfEmpty())
 	if err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
 	// Fill in pagination.
-	paginated.FillPagination(parsedQuery, request.GetPagination(), maxSecretsReturned)
+	paginated.FillPagination(parsedQuery, rawQuery.GetPagination(), maxSecretsReturned)
 
 	secrets, err := s.secrets.SearchListSecrets(ctx, parsedQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	// This N+1 query pattern is only used when the caller explicitly requests the relationships, so
+	// is acceptable in the opt-in case.
+	if request.GetIncludeRelationships() {
+		for _, secret := range secrets {
+			deployments, err := s.getDeploymentRelationships(ctx, secret)
+			if err != nil {
+				return nil, err
+			}
+			secret.Relationship = &storage.SecretRelationship{
+				DeploymentRelationships: deployments,
+			}
+		}
+	}
+
+	return secrets, nil
+}
+
+// ListSecrets returns all secrets that match the query.
+func (s *serviceImpl) ListSecrets(ctx context.Context, request *v1.RawQuery) (*v1.ListSecretsResponse, error) {
+	secrets, err := s.listSecrets(ctx, &v1.ListSecretsExtendedRequest{
+		Query:                request,
+		IncludeRelationships: false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &v1.ListSecretsResponse{Secrets: secrets}, nil
+}
+
+// ListSecretsExtended returns all secrets that match the query and optionally includes their workload relationships.
+func (s *serviceImpl) ListSecretsExtended(ctx context.Context, request *v1.ListSecretsExtendedRequest) (*v1.ListSecretsResponse, error) {
+	secrets, err := s.listSecrets(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/central/secret/service/service_impl_test.go
+++ b/central/secret/service/service_impl_test.go
@@ -180,3 +180,78 @@ func (suite *SecretServiceTestSuite) TestSearchSecretFailure() {
 	_, actualErr := suite.service.ListSecrets((context.Context)(nil), &v1.RawQuery{})
 	suite.True(strings.Contains(actualErr.Error(), expectedError.Error()))
 }
+
+// Test that when we search secrets without including relationships, the deployment relationships are not queried.
+func (suite *SecretServiceTestSuite) TestSearchSecretsExtendedWithoutIncludeRelationships() {
+	expectedSecrets := []*storage.ListSecret{
+		{Id: "id1"},
+	}
+
+	emptyWithPag := search.EmptyQuery()
+	emptyWithPag.Pagination = &v1.QueryPagination{
+		Limit: maxSecretsReturned,
+	}
+
+	suite.mockSecretStore.EXPECT().SearchListSecrets(gomock.Any(), emptyWithPag).Return([]*storage.ListSecret{
+		{Id: "id1"},
+	}, nil)
+	suite.mockDeploymentStore.EXPECT().SearchDeployments(gomock.Any(), gomock.Any()).Times(0)
+
+	response, err := suite.service.ListSecretsExtended((context.Context)(nil), &v1.ListSecretsExtendedRequest{IncludeRelationships: false})
+	protoassert.SlicesEqual(suite.T(), expectedSecrets, response.GetSecrets())
+	suite.NoError(err)
+}
+
+// Test that when we list secrets with including relationships, the deployment relationships are queried.
+func (suite *SecretServiceTestSuite) TestSearchSecretsExtendedWithIncludeRelationships() {
+	emptyWithPag := search.EmptyQuery()
+	emptyWithPag.Pagination = &v1.QueryPagination{
+		Limit: maxSecretsReturned,
+	}
+	secret := &storage.ListSecret{
+		Id:        "id1",
+		Name:      "secretname",
+		ClusterId: "cluster",
+		Namespace: "namespace",
+	}
+
+	suite.mockSecretStore.EXPECT().SearchListSecrets(gomock.Any(), emptyWithPag).Return([]*storage.ListSecret{secret}, nil)
+	psr := search.NewQueryBuilder().
+		AddExactMatches(search.ClusterID, secret.GetClusterId()).
+		AddExactMatches(search.Namespace, secret.GetNamespace()).
+		AddExactMatches(search.SecretName, secret.GetName()).
+		ProtoQuery()
+	suite.mockDeploymentStore.EXPECT().SearchDeployments(gomock.Any(), psr).Return([]*v1.SearchResult{
+		{Id: "d1", Name: "deployment1"},
+	}, nil)
+
+	response, err := suite.service.ListSecretsExtended((context.Context)(nil), &v1.ListSecretsExtendedRequest{IncludeRelationships: true})
+
+	expectedSecrets := []*storage.ListSecret{
+		{
+			Id:        "id1",
+			Name:      "secretname",
+			ClusterId: "cluster",
+			Namespace: "namespace",
+			Relationship: &storage.SecretRelationship{DeploymentRelationships: []*storage.SecretDeploymentRelationship{
+				{Id: "d1", Name: "deployment1"},
+			}},
+		},
+	}
+	protoassert.SlicesEqual(suite.T(), expectedSecrets, response.GetSecrets())
+	suite.NoError(err)
+}
+
+func (suite *SecretServiceTestSuite) TestSearchSecretsExtendedWithIncludeRelationshipsFailure() {
+	emptyWithPag := search.EmptyQuery()
+	emptyWithPag.Pagination = &v1.QueryPagination{
+		Limit: maxSecretsReturned,
+	}
+	suite.mockSecretStore.EXPECT().SearchListSecrets(gomock.Any(), emptyWithPag).Return([]*storage.ListSecret{
+		{Id: "id1"},
+	}, nil)
+	suite.mockDeploymentStore.EXPECT().SearchDeployments(gomock.Any(), gomock.Any()).Return(([]*v1.SearchResult)(nil), errors.New("failure"))
+
+	_, err := suite.service.ListSecretsExtended((context.Context)(nil), &v1.ListSecretsExtendedRequest{IncludeRelationships: true})
+	suite.Error(err)
+}

--- a/generated/api/v1/secret_service.pb.go
+++ b/generated/api/v1/secret_service.pb.go
@@ -159,6 +159,58 @@ func (x *CountSecretsResponse) GetCount() int32 {
 	return 0
 }
 
+type ListSecretsExtendedRequest struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Query                *RawQuery              `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	IncludeRelationships bool                   `protobuf:"varint,2,opt,name=include_relationships,json=includeRelationships,proto3" json:"include_relationships,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ListSecretsExtendedRequest) Reset() {
+	*x = ListSecretsExtendedRequest{}
+	mi := &file_api_v1_secret_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSecretsExtendedRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSecretsExtendedRequest) ProtoMessage() {}
+
+func (x *ListSecretsExtendedRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_secret_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSecretsExtendedRequest.ProtoReflect.Descriptor instead.
+func (*ListSecretsExtendedRequest) Descriptor() ([]byte, []int) {
+	return file_api_v1_secret_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ListSecretsExtendedRequest) GetQuery() *RawQuery {
+	if x != nil {
+		return x.Query
+	}
+	return nil
+}
+
+func (x *ListSecretsExtendedRequest) GetIncludeRelationships() bool {
+	if x != nil {
+		return x.IncludeRelationships
+	}
+	return false
+}
+
 var File_api_v1_secret_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_secret_service_proto_rawDesc = "" +
@@ -170,11 +222,15 @@ const file_api_v1_secret_service_proto_rawDesc = "" +
 	"\x13ListSecretsResponse\x12-\n" +
 	"\asecrets\x18\x01 \x03(\v2\x13.storage.ListSecretR\asecrets\",\n" +
 	"\x14CountSecretsResponse\x12\x14\n" +
-	"\x05count\x18\x01 \x01(\x05R\x05count2\xf6\x01\n" +
+	"\x05count\x18\x01 \x01(\x05R\x05count\"u\n" +
+	"\x1aListSecretsExtendedRequest\x12\"\n" +
+	"\x05query\x18\x01 \x01(\v2\f.v1.RawQueryR\x05query\x123\n" +
+	"\x15include_relationships\x18\x02 \x01(\bR\x14includeRelationships2\xe3\x02\n" +
 	"\rSecretService\x12H\n" +
 	"\tGetSecret\x12\x10.v1.ResourceByID\x1a\x0f.storage.Secret\"\x18\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/secrets/{id}\x12P\n" +
 	"\fCountSecrets\x12\f.v1.RawQuery\x1a\x18.v1.CountSecretsResponse\"\x18\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/secretscount\x12I\n" +
-	"\vListSecrets\x12\f.v1.RawQuery\x1a\x17.v1.ListSecretsResponse\"\x13\x82\xd3\xe4\x93\x02\r\x12\v/v1/secretsB'\n" +
+	"\vListSecrets\x12\f.v1.RawQuery\x1a\x17.v1.ListSecretsResponse\"\x13\x82\xd3\xe4\x93\x02\r\x12\v/v1/secrets\x12k\n" +
+	"\x13ListSecretsExtended\x12\x1e.v1.ListSecretsExtendedRequest\x1a\x17.v1.ListSecretsResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/secretsextendedB'\n" +
 	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x02b\x06proto3"
 
 var (
@@ -189,30 +245,34 @@ func file_api_v1_secret_service_proto_rawDescGZIP() []byte {
 	return file_api_v1_secret_service_proto_rawDescData
 }
 
-var file_api_v1_secret_service_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_api_v1_secret_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_api_v1_secret_service_proto_goTypes = []any{
-	(*SecretList)(nil),           // 0: v1.SecretList
-	(*ListSecretsResponse)(nil),  // 1: v1.ListSecretsResponse
-	(*CountSecretsResponse)(nil), // 2: v1.CountSecretsResponse
-	(*storage.Secret)(nil),       // 3: storage.Secret
-	(*storage.ListSecret)(nil),   // 4: storage.ListSecret
-	(*ResourceByID)(nil),         // 5: v1.ResourceByID
-	(*RawQuery)(nil),             // 6: v1.RawQuery
+	(*SecretList)(nil),                 // 0: v1.SecretList
+	(*ListSecretsResponse)(nil),        // 1: v1.ListSecretsResponse
+	(*CountSecretsResponse)(nil),       // 2: v1.CountSecretsResponse
+	(*ListSecretsExtendedRequest)(nil), // 3: v1.ListSecretsExtendedRequest
+	(*storage.Secret)(nil),             // 4: storage.Secret
+	(*storage.ListSecret)(nil),         // 5: storage.ListSecret
+	(*RawQuery)(nil),                   // 6: v1.RawQuery
+	(*ResourceByID)(nil),               // 7: v1.ResourceByID
 }
 var file_api_v1_secret_service_proto_depIdxs = []int32{
-	3, // 0: v1.SecretList.secrets:type_name -> storage.Secret
-	4, // 1: v1.ListSecretsResponse.secrets:type_name -> storage.ListSecret
-	5, // 2: v1.SecretService.GetSecret:input_type -> v1.ResourceByID
-	6, // 3: v1.SecretService.CountSecrets:input_type -> v1.RawQuery
-	6, // 4: v1.SecretService.ListSecrets:input_type -> v1.RawQuery
-	3, // 5: v1.SecretService.GetSecret:output_type -> storage.Secret
-	2, // 6: v1.SecretService.CountSecrets:output_type -> v1.CountSecretsResponse
-	1, // 7: v1.SecretService.ListSecrets:output_type -> v1.ListSecretsResponse
-	5, // [5:8] is the sub-list for method output_type
-	2, // [2:5] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	4, // 0: v1.SecretList.secrets:type_name -> storage.Secret
+	5, // 1: v1.ListSecretsResponse.secrets:type_name -> storage.ListSecret
+	6, // 2: v1.ListSecretsExtendedRequest.query:type_name -> v1.RawQuery
+	7, // 3: v1.SecretService.GetSecret:input_type -> v1.ResourceByID
+	6, // 4: v1.SecretService.CountSecrets:input_type -> v1.RawQuery
+	6, // 5: v1.SecretService.ListSecrets:input_type -> v1.RawQuery
+	3, // 6: v1.SecretService.ListSecretsExtended:input_type -> v1.ListSecretsExtendedRequest
+	4, // 7: v1.SecretService.GetSecret:output_type -> storage.Secret
+	2, // 8: v1.SecretService.CountSecrets:output_type -> v1.CountSecretsResponse
+	1, // 9: v1.SecretService.ListSecrets:output_type -> v1.ListSecretsResponse
+	1, // 10: v1.SecretService.ListSecretsExtended:output_type -> v1.ListSecretsResponse
+	7, // [7:11] is the sub-list for method output_type
+	3, // [3:7] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_secret_service_proto_init() }
@@ -228,7 +288,7 @@ func file_api_v1_secret_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v1_secret_service_proto_rawDesc), len(file_api_v1_secret_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/api/v1/secret_service.pb.gw.go
+++ b/generated/api/v1/secret_service.pb.gw.go
@@ -144,6 +144,41 @@ func local_request_SecretService_ListSecrets_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+var filter_SecretService_ListSecretsExtended_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_SecretService_ListSecretsExtended_0(ctx context.Context, marshaler runtime.Marshaler, client SecretServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListSecretsExtendedRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_SecretService_ListSecretsExtended_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListSecretsExtended(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_SecretService_ListSecretsExtended_0(ctx context.Context, marshaler runtime.Marshaler, server SecretServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListSecretsExtendedRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_SecretService_ListSecretsExtended_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListSecretsExtended(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterSecretServiceHandlerServer registers the http handlers for service SecretService to "mux".
 // UnaryRPC     :call SecretServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -209,6 +244,26 @@ func RegisterSecretServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_SecretService_ListSecrets_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_SecretService_ListSecretsExtended_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v1.SecretService/ListSecretsExtended", runtime.WithHTTPPathPattern("/v1/secretsextended"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_SecretService_ListSecretsExtended_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SecretService_ListSecretsExtended_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -301,17 +356,36 @@ func RegisterSecretServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_SecretService_ListSecrets_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_SecretService_ListSecretsExtended_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v1.SecretService/ListSecretsExtended", runtime.WithHTTPPathPattern("/v1/secretsextended"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SecretService_ListSecretsExtended_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_SecretService_ListSecretsExtended_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_SecretService_GetSecret_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "secrets", "id"}, ""))
-	pattern_SecretService_CountSecrets_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secretscount"}, ""))
-	pattern_SecretService_ListSecrets_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secrets"}, ""))
+	pattern_SecretService_GetSecret_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "secrets", "id"}, ""))
+	pattern_SecretService_CountSecrets_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secretscount"}, ""))
+	pattern_SecretService_ListSecrets_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secrets"}, ""))
+	pattern_SecretService_ListSecretsExtended_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secretsextended"}, ""))
 )
 
 var (
-	forward_SecretService_GetSecret_0    = runtime.ForwardResponseMessage
-	forward_SecretService_CountSecrets_0 = runtime.ForwardResponseMessage
-	forward_SecretService_ListSecrets_0  = runtime.ForwardResponseMessage
+	forward_SecretService_GetSecret_0           = runtime.ForwardResponseMessage
+	forward_SecretService_CountSecrets_0        = runtime.ForwardResponseMessage
+	forward_SecretService_ListSecrets_0         = runtime.ForwardResponseMessage
+	forward_SecretService_ListSecretsExtended_0 = runtime.ForwardResponseMessage
 )

--- a/generated/api/v1/secret_service.swagger.json
+++ b/generated/api/v1/secret_service.swagger.json
@@ -429,7 +429,7 @@
         },
         "relationship": {
           "$ref": "#/definitions/storageSecretRelationship",
-          "description": "`relationship` is only retrieved in very specific circumstances and has to be explicitly requested by the caller.  \nAs such the N+1 query pattern to populate it is an acceptable pattern.  By default relationship will be nil."
+          "description": "`relationship` is only retrieved in very specific circumstances and has to be explicitly requested by the caller.\nAs such the N+1 query pattern to populate it is an acceptable pattern.  By default relationship will be nil."
         }
       }
     },

--- a/generated/api/v1/secret_service.swagger.json
+++ b/generated/api/v1/secret_service.swagger.json
@@ -198,6 +198,88 @@
           "SecretService"
         ]
       }
+    },
+    "/v1/secretsextended": {
+      "get": {
+        "summary": "ListSecretsExtended returns the list of secrets with optional extended information.",
+        "operationId": "SecretService_ListSecretsExtended",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSecretsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "query.query",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "query.pagination.limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "query.pagination.offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "query.pagination.sortOption.field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "query.pagination.sortOption.reversed",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "query.pagination.sortOption.aggregateBy.aggrFunc",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "UNSET",
+              "COUNT",
+              "MIN",
+              "MAX"
+            ],
+            "default": "UNSET"
+          },
+          {
+            "name": "query.pagination.sortOption.aggregateBy.distinct",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "includeRelationships",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "SecretService"
+        ]
+      }
     }
   },
   "definitions": {
@@ -344,6 +426,10 @@
         "createdAt": {
           "type": "string",
           "format": "date-time"
+        },
+        "relationship": {
+          "$ref": "#/definitions/storageSecretRelationship",
+          "description": "`relationship` is only retrieved in very specific circumstances and has to be explicitly requested by the caller.  \nAs such the N+1 query pattern to populate it is an acceptable pattern.  By default relationship will be nil."
         }
       }
     },
@@ -554,6 +640,18 @@
           "description": "This field is under development. It is not supported on any REST APIs."
         }
       }
+    },
+    "v1RawQuery": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string"
+        },
+        "pagination": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      },
+      "description": "RawQuery represents the search query string.\nThe format of the query string is \"<field name>:<value,value,...>+<field name>:<value, value,...>+...\"\nFor example:\nTo search for deployments named \"central\" and \"sensor\" in the namespace \"stackrox\", the query string would be\n\"Deployment:central,sensor+Namespace:stackrox\"\nRawQuery is used in ListAPIs to search for a particular object."
     },
     "v1SortOption": {
       "type": "object",

--- a/generated/api/v1/secret_service_grpc.pb.go
+++ b/generated/api/v1/secret_service_grpc.pb.go
@@ -20,9 +20,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SecretService_GetSecret_FullMethodName    = "/v1.SecretService/GetSecret"
-	SecretService_CountSecrets_FullMethodName = "/v1.SecretService/CountSecrets"
-	SecretService_ListSecrets_FullMethodName  = "/v1.SecretService/ListSecrets"
+	SecretService_GetSecret_FullMethodName           = "/v1.SecretService/GetSecret"
+	SecretService_CountSecrets_FullMethodName        = "/v1.SecretService/CountSecrets"
+	SecretService_ListSecrets_FullMethodName         = "/v1.SecretService/ListSecrets"
+	SecretService_ListSecretsExtended_FullMethodName = "/v1.SecretService/ListSecretsExtended"
 )
 
 // SecretServiceClient is the client API for SecretService service.
@@ -35,6 +36,8 @@ type SecretServiceClient interface {
 	CountSecrets(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*CountSecretsResponse, error)
 	// ListSecrets returns the list of secrets.
 	ListSecrets(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*ListSecretsResponse, error)
+	// ListSecretsExtended returns the list of secrets with optional extended information.
+	ListSecretsExtended(ctx context.Context, in *ListSecretsExtendedRequest, opts ...grpc.CallOption) (*ListSecretsResponse, error)
 }
 
 type secretServiceClient struct {
@@ -75,6 +78,16 @@ func (c *secretServiceClient) ListSecrets(ctx context.Context, in *RawQuery, opt
 	return out, nil
 }
 
+func (c *secretServiceClient) ListSecretsExtended(ctx context.Context, in *ListSecretsExtendedRequest, opts ...grpc.CallOption) (*ListSecretsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSecretsResponse)
+	err := c.cc.Invoke(ctx, SecretService_ListSecretsExtended_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SecretServiceServer is the server API for SecretService service.
 // All implementations should embed UnimplementedSecretServiceServer
 // for forward compatibility.
@@ -85,6 +98,8 @@ type SecretServiceServer interface {
 	CountSecrets(context.Context, *RawQuery) (*CountSecretsResponse, error)
 	// ListSecrets returns the list of secrets.
 	ListSecrets(context.Context, *RawQuery) (*ListSecretsResponse, error)
+	// ListSecretsExtended returns the list of secrets with optional extended information.
+	ListSecretsExtended(context.Context, *ListSecretsExtendedRequest) (*ListSecretsResponse, error)
 }
 
 // UnimplementedSecretServiceServer should be embedded to have
@@ -102,6 +117,9 @@ func (UnimplementedSecretServiceServer) CountSecrets(context.Context, *RawQuery)
 }
 func (UnimplementedSecretServiceServer) ListSecrets(context.Context, *RawQuery) (*ListSecretsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSecrets not implemented")
+}
+func (UnimplementedSecretServiceServer) ListSecretsExtended(context.Context, *ListSecretsExtendedRequest) (*ListSecretsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSecretsExtended not implemented")
 }
 func (UnimplementedSecretServiceServer) testEmbeddedByValue() {}
 
@@ -177,6 +195,24 @@ func _SecretService_ListSecrets_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SecretService_ListSecretsExtended_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSecretsExtendedRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SecretServiceServer).ListSecretsExtended(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SecretService_ListSecretsExtended_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SecretServiceServer).ListSecretsExtended(ctx, req.(*ListSecretsExtendedRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SecretService_ServiceDesc is the grpc.ServiceDesc for SecretService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -195,6 +231,10 @@ var SecretService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListSecrets",
 			Handler:    _SecretService_ListSecrets_Handler,
+		},
+		{
+			MethodName: "ListSecretsExtended",
+			Handler:    _SecretService_ListSecretsExtended_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/generated/api/v1/secret_service_vtproto.pb.go
+++ b/generated/api/v1/secret_service_vtproto.pb.go
@@ -91,6 +91,24 @@ func (m *CountSecretsResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ListSecretsExtendedRequest) CloneVT() *ListSecretsExtendedRequest {
+	if m == nil {
+		return (*ListSecretsExtendedRequest)(nil)
+	}
+	r := new(ListSecretsExtendedRequest)
+	r.Query = m.Query.CloneVT()
+	r.IncludeRelationships = m.IncludeRelationships
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ListSecretsExtendedRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *SecretList) EqualVT(that *SecretList) bool {
 	if this == that {
 		return true
@@ -181,6 +199,28 @@ func (this *CountSecretsResponse) EqualVT(that *CountSecretsResponse) bool {
 
 func (this *CountSecretsResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*CountSecretsResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ListSecretsExtendedRequest) EqualVT(that *ListSecretsExtendedRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Query.EqualVT(that.Query) {
+		return false
+	}
+	if this.IncludeRelationships != that.IncludeRelationships {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ListSecretsExtendedRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ListSecretsExtendedRequest)
 	if !ok {
 		return false
 	}
@@ -338,6 +378,59 @@ func (m *CountSecretsResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
+func (m *ListSecretsExtendedRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListSecretsExtendedRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ListSecretsExtendedRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.IncludeRelationships {
+		i--
+		if m.IncludeRelationships {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Query != nil {
+		size, err := m.Query.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *SecretList) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -390,6 +483,23 @@ func (m *CountSecretsResponse) SizeVT() (n int) {
 	_ = l
 	if m.Count != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Count))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ListSecretsExtendedRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Query != nil {
+		l = m.Query.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.IncludeRelationships {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -651,6 +761,113 @@ func (m *CountSecretsResponse) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *ListSecretsExtendedRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListSecretsExtendedRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListSecretsExtendedRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &RawQuery{}
+			}
+			if err := m.Query.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeRelationships", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeRelationships = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *SecretList) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -885,6 +1102,113 @@ func (m *CountSecretsResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListSecretsExtendedRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListSecretsExtendedRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListSecretsExtendedRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &RawQuery{}
+			}
+			if err := m.Query.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeRelationships", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeRelationships = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/secret.pb.go
+++ b/generated/storage/secret.pb.go
@@ -229,14 +229,17 @@ func (x *Secret) GetRelationship() *SecretRelationship {
 }
 
 type ListSecret struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	ClusterId     string                 `protobuf:"bytes,7,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
-	ClusterName   string                 `protobuf:"bytes,3,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
-	Namespace     string                 `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Types         []SecretType           `protobuf:"varint,5,rep,packed,name=types,proto3,enum=storage.SecretType" json:"types,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Id          string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name        string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	ClusterId   string                 `protobuf:"bytes,7,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	ClusterName string                 `protobuf:"bytes,3,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
+	Namespace   string                 `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Types       []SecretType           `protobuf:"varint,5,rep,packed,name=types,proto3,enum=storage.SecretType" json:"types,omitempty"`
+	CreatedAt   *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	// `relationship` is only retrieved in very specific circumstances and has to be explicitly requested by the caller.
+	// As such the N+1 query pattern to populate it is an acceptable pattern.  By default relationship will be nil.
+	Relationship  *SecretRelationship `protobuf:"bytes,8,opt,name=relationship,proto3" json:"relationship,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -316,6 +319,13 @@ func (x *ListSecret) GetTypes() []SecretType {
 func (x *ListSecret) GetCreatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *ListSecret) GetRelationship() *SecretRelationship {
+	if x != nil {
+		return x.Relationship
 	}
 	return nil
 }
@@ -910,7 +920,7 @@ const file_storage_secret_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf6\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb7\x02\n" +
 	"\n" +
 	"ListSecret\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -921,7 +931,8 @@ const file_storage_secret_proto_rawDesc = "" +
 	"\tnamespace\x18\x04 \x01(\tR\tnamespace\x12)\n" +
 	"\x05types\x18\x05 \x03(\x0e2\x13.storage.SecretTypeR\x05types\x129\n" +
 	"\n" +
-	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xe5\x01\n" +
+	"created_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12?\n" +
+	"\frelationship\x18\b \x01(\v2\x1b.storage.SecretRelationshipR\frelationship\"\xe5\x01\n" +
 	"\x12SecretRelationship\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12]\n" +
 	"\x17container_relationships\x18\x04 \x03(\v2$.storage.SecretContainerRelationshipR\x16containerRelationships\x12`\n" +
@@ -1021,21 +1032,22 @@ var file_storage_secret_proto_depIdxs = []int32{
 	3,  // 4: storage.Secret.relationship:type_name -> storage.SecretRelationship
 	0,  // 5: storage.ListSecret.types:type_name -> storage.SecretType
 	13, // 6: storage.ListSecret.created_at:type_name -> google.protobuf.Timestamp
-	5,  // 7: storage.SecretRelationship.container_relationships:type_name -> storage.SecretContainerRelationship
-	4,  // 8: storage.SecretRelationship.deployment_relationships:type_name -> storage.SecretDeploymentRelationship
-	12, // 9: storage.ImagePullSecret.registries:type_name -> storage.ImagePullSecret.Registry
-	0,  // 10: storage.SecretDataFile.type:type_name -> storage.SecretType
-	8,  // 11: storage.SecretDataFile.cert:type_name -> storage.Cert
-	6,  // 12: storage.SecretDataFile.image_pull_secret:type_name -> storage.ImagePullSecret
-	9,  // 13: storage.Cert.subject:type_name -> storage.CertName
-	9,  // 14: storage.Cert.issuer:type_name -> storage.CertName
-	13, // 15: storage.Cert.start_date:type_name -> google.protobuf.Timestamp
-	13, // 16: storage.Cert.end_date:type_name -> google.protobuf.Timestamp
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	3,  // 7: storage.ListSecret.relationship:type_name -> storage.SecretRelationship
+	5,  // 8: storage.SecretRelationship.container_relationships:type_name -> storage.SecretContainerRelationship
+	4,  // 9: storage.SecretRelationship.deployment_relationships:type_name -> storage.SecretDeploymentRelationship
+	12, // 10: storage.ImagePullSecret.registries:type_name -> storage.ImagePullSecret.Registry
+	0,  // 11: storage.SecretDataFile.type:type_name -> storage.SecretType
+	8,  // 12: storage.SecretDataFile.cert:type_name -> storage.Cert
+	6,  // 13: storage.SecretDataFile.image_pull_secret:type_name -> storage.ImagePullSecret
+	9,  // 14: storage.Cert.subject:type_name -> storage.CertName
+	9,  // 15: storage.Cert.issuer:type_name -> storage.CertName
+	13, // 16: storage.Cert.start_date:type_name -> google.protobuf.Timestamp
+	13, // 17: storage.Cert.end_date:type_name -> google.protobuf.Timestamp
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_storage_secret_proto_init() }

--- a/generated/storage/secret_vtproto.pb.go
+++ b/generated/storage/secret_vtproto.pb.go
@@ -78,6 +78,7 @@ func (m *ListSecret) CloneVT() *ListSecret {
 	r.ClusterName = m.ClusterName
 	r.Namespace = m.Namespace
 	r.CreatedAt = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.CreatedAt).CloneVT())
+	r.Relationship = m.Relationship.CloneVT()
 	if rhs := m.Types; rhs != nil {
 		tmpContainer := make([]SecretType, len(rhs))
 		copy(tmpContainer, rhs)
@@ -410,6 +411,9 @@ func (this *ListSecret) EqualVT(that *ListSecret) bool {
 		return false
 	}
 	if this.ClusterId != that.ClusterId {
+		return false
+	}
+	if !this.Relationship.EqualVT(that.Relationship) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -921,6 +925,16 @@ func (m *ListSecret) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Relationship != nil {
+		size, err := m.Relationship.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
 	}
 	if len(m.ClusterId) > 0 {
 		i -= len(m.ClusterId)
@@ -1627,6 +1641,10 @@ func (m *ListSecret) SizeVT() (n int) {
 	}
 	l = len(m.ClusterId)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Relationship != nil {
+		l = m.Relationship.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -2757,6 +2775,42 @@ func (m *ListSecret) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.ClusterId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Relationship", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Relationship == nil {
+				m.Relationship = &SecretRelationship{}
+			}
+			if err := m.Relationship.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5099,6 +5153,42 @@ func (m *ListSecret) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.ClusterId = stringValue
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Relationship", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Relationship == nil {
+				m.Relationship = &SecretRelationship{}
+			}
+			if err := m.Relationship.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/api/v1/secret_service.proto
+++ b/proto/api/v1/secret_service.proto
@@ -29,6 +29,11 @@ message CountSecretsResponse {
   int32 count = 1;
 }
 
+message ListSecretsExtendedRequest {
+  RawQuery query = 1;
+  bool include_relationships = 2;
+}
+
 service SecretService {
   // GetSecret returns a secret given its ID.
   rpc GetSecret(ResourceByID) returns (storage.Secret) {
@@ -43,5 +48,10 @@ service SecretService {
   // ListSecrets returns the list of secrets.
   rpc ListSecrets(RawQuery) returns (ListSecretsResponse) {
     option (google.api.http) = {get: "/v1/secrets"};
+  }
+
+  // ListSecretsExtended returns the list of secrets with optional extended information.
+  rpc ListSecretsExtended(ListSecretsExtendedRequest) returns (ListSecretsResponse) {
+    option (google.api.http) = {get: "/v1/secretsextended"};
   }
 }

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -17110,6 +17110,11 @@
                 "id": 6,
                 "name": "created_at",
                 "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 8,
+                "name": "relationship",
+                "type": "SecretRelationship"
               }
             ]
           },

--- a/proto/storage/secret.proto
+++ b/proto/storage/secret.proto
@@ -43,6 +43,9 @@ message ListSecret {
   string namespace = 4;
   repeated SecretType types = 5;
   google.protobuf.Timestamp created_at = 6;
+  // `relationship` is only retrieved in very specific circumstances and has to be explicitly requested by the caller.
+  // As such the N+1 query pattern to populate it is an acceptable pattern.  By default relationship will be nil.
+  SecretRelationship relationship = 8;
 }
 
 // Relationships with other objects.


### PR DESCRIPTION
## Description

Adds a `ListSecretsExtended` API that introduces an optional `include_relationships` parameter that defaults to `false`. When present and `true`, this will include related deployments in the API response in the same structure as seen in the `GetSecret` API.

This contribution was not written by AI, but was reviewed/discussed/argued with by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

With `includeRelationships` parameter omitted:
<img width="1711" height="997" alt="image" src="https://github.com/user-attachments/assets/d2818fad-39c3-4e52-9b71-09c7b8b40838" />



With `includeRelationships` parameter as `true`:
<img width="1711" height="997" alt="image" src="https://github.com/user-attachments/assets/9ffdc96c-6ba0-4dd6-ba8b-a799a00ace56" />

