### PR TITLE
ROX-35307: assert data in admission controller severity test setup

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -1,5 +1,6 @@
 import static util.Helpers.withRetry
 
+import io.stackrox.proto.storage.Cve.VulnerabilitySeverity
 import io.stackrox.proto.storage.ImageOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.ScopeOuterClass
@@ -88,6 +89,20 @@ class AdmissionControllerTest extends BaseSpecification {
         ImageOuterClass.Image image = ImageService.getImage(imageId, false)
         assert image
         assert !image.getNotesList().contains(ImageOuterClass.Image.Note.MISSING_METADATA)
+        assert !image.getNotesList().contains(ImageOuterClass.Image.Note.MISSING_SCAN_DATA)
+        assert image.getScan() != null : "Image scan data is null after scanning"
+        assert image.getScan().getComponentsList().size() > 0 : "Image has no scan components"
+
+        def hasFixableImportantVuln = image.getScan().getComponentsList().any { component ->
+            component.getVulnsList().any { vuln ->
+                vuln.getSeverity().getNumber() >=
+                    VulnerabilitySeverity.IMPORTANT_VULNERABILITY_SEVERITY.getNumber() &&
+                vuln.getFixedBy() != ""
+            }
+        }
+        assert hasFixableImportantVuln :
+            "Image ${SCAN_INLINE_IMAGE_NAME_WITH_SHA} has no fixable vulnerabilities with severity >= Important. " +
+            "The severity policy test will fail without matching vulnerabilities."
 
         orchestrator.ensureNamespaceExists(TEST_NAMESPACE)
 


### PR DESCRIPTION
## Description

The admission controller test `AdmissionControllerTest` uses the "Fixable Severity at least Important" policy to verify that deployments with vulnerable images are blocked. However, the `setupSpec()` method did not validate that the pre-scanned image actually contained scan data with fixable vulnerabilities of severity >= Important. When scan data was missing or the image lacked qualifying vulnerabilities, the severity-based enforcement test case ("blocked by enforced severity policy (cached scan)") would fail with a misleading error, making it difficult to diagnose the root cause.

This change adds assertions to the `setupSpec()` method to fail fast with clear diagnostic messages if the scanned image is missing scan data or lacks the fixable Important+ vulnerabilities that the severity policy test depends on. Specifically:

- Asserts the image does not have `MISSING_SCAN_DATA` note
- Asserts the scan object is non-null and contains components
- Asserts at least one component has a fixable vulnerability with severity >= Important

This makes test failures easier to diagnose by surfacing the actual problem (missing/insufficient scan data) rather than a downstream enforcement failure.

Ref: [ROX-35307](https://redhat.atlassian.net/browse/ROX-35307)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

This is a test-only change that adds precondition assertions to the admission controller e2e test setup. The assertions validate that scan data and qualifying vulnerabilities exist before running severity-based enforcement tests. Validation will come from CI runs of the `AdmissionControllerTest` suite.


[ROX-35307]: https://redhat.atlassian.net/browse/ROX-35307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ