### PR TITLE
ROX-35116: CVE list view for virtual machines overview page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCVEsTable.tsx
@@ -1,0 +1,118 @@
+import { useCallback } from 'react';
+import { Flex, Pagination } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import CvssFormatted from 'Components/CvssFormatted';
+import DateDistance from 'Components/DateDistance';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
+import { listVMCVEs } from 'services/VirtualMachineService';
+import { getTableUIState } from 'utils/getTableUIState';
+
+import SeverityCountLabels from '../../components/SeverityCountLabels';
+import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
+import { formatEpssProbabilityAsPercent } from '../../WorkloadCves/Tables/table.utils';
+
+function VirtualMachineCVEsTable() {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+
+    const fetchVirtualMachineCVEs = useCallback(
+        () => listVMCVEs({ page, perPage }),
+        [page, perPage]
+    );
+    const { data, isLoading, error } = useRestQuery(fetchVirtualMachineCVEs);
+
+    const tableState = getTableUIState({
+        isLoading,
+        data: data?.cves ?? [],
+        error,
+        searchFilter: {},
+    });
+
+    return (
+        <>
+            <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+                <Pagination
+                    itemCount={data?.totalCount ?? 0}
+                    perPage={perPage}
+                    page={page}
+                    onSetPage={(_, newPage) => setPage(newPage)}
+                    onPerPageSelect={(_, newPerPage) => {
+                        setPerPage(newPerPage);
+                    }}
+                />
+            </Flex>
+            <Table
+                borders={tableState.type === 'COMPLETE'}
+                variant="compact"
+                aria-live="polite"
+                aria-busy={isLoading ? 'true' : 'false'}
+            >
+                <Thead noWrap>
+                    <Tr>
+                        <Th>CVE</Th>
+                        <Th>Virtual machines by severity</Th>
+                        <Th>Top CVSS</Th>
+                        <Th>Affected virtual machines</Th>
+                        <Th>EPSS probability</Th>
+                        <Th>First discovered</Th>
+                    </Tr>
+                </Thead>
+                <TbodyUnified
+                    tableState={tableState}
+                    colSpan={6}
+                    emptyProps={{
+                        message:
+                            'No CVEs have been detected for virtual machines across your secured clusters',
+                    }}
+                    renderer={({ data }) => (
+                        <Tbody>
+                            {data.map((virtualMachineCve) => {
+                                const severityCounts = virtualMachineCve.vmSeverityCounts;
+                                return (
+                                    <Tr key={virtualMachineCve.cve}>
+                                        <Td dataLabel="CVE" modifier="nowrap">
+                                            {virtualMachineCve.cve}
+                                        </Td>
+                                        <Td dataLabel="Virtual machines by severity">
+                                            <SeverityCountLabels
+                                                criticalCount={severityCounts?.critical?.total ?? 0}
+                                                importantCount={
+                                                    severityCounts?.important?.total ?? 0
+                                                }
+                                                moderateCount={severityCounts?.moderate?.total ?? 0}
+                                                lowCount={severityCounts?.low?.total ?? 0}
+                                                unknownCount={severityCounts?.unknown?.total ?? 0}
+                                                entity="virtual machine"
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Top CVSS">
+                                            <CvssFormatted
+                                                cvss={virtualMachineCve.topCvss}
+                                                scoreVersion={virtualMachineCve.cvssVersion}
+                                            />
+                                        </Td>
+                                        <Td dataLabel="Affected virtual machines">
+                                            {`${virtualMachineCve.affectedVmCount} / ${virtualMachineCve.totalVmCount} affected VMs`}
+                                        </Td>
+                                        <Td dataLabel="EPSS probability">
+                                            {formatEpssProbabilityAsPercent(
+                                                virtualMachineCve.epssProbability
+                                            )}
+                                        </Td>
+                                        <Td dataLabel="First discovered">
+                                            <DateDistance date={virtualMachineCve.publishedOn} />
+                                        </Td>
+                                    </Tr>
+                                );
+                            })}
+                        </Tbody>
+                    )}
+                />
+            </Table>
+        </>
+    );
+}
+
+export default VirtualMachineCVEsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
@@ -1,12 +1,32 @@
-import { Content, Flex, PageSection, Title } from '@patternfly/react-core';
+import {
+    Content,
+    Flex,
+    PageSection,
+    Title,
+    ToggleGroup,
+    ToggleGroupItem,
+} from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import TechnologyPreviewLabel from 'Components/PatternFly/PreviewLabel/TechnologyPreviewLabel';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 
+import { virtualMachineEntityTabValues } from '../../types';
 import VirtualMachineScanScopeAlert from '../components/VirtualMachineScanScopeAlert';
+import VirtualMachineCVEsTable from './VirtualMachineCVEsTable';
 import VirtualMachinesCvesTable from './VirtualMachinesCvesTable';
 
 function VirtualMachineCvesOverviewPage() {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isEnhancedDataModelEnabled = isFeatureFlagEnabled(
+        'ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL'
+    );
+    const [activeEntityTabKey, setActiveEntityTabKey] = useURLStringUnion(
+        'entityTab',
+        virtualMachineEntityTabValues
+    );
+
     return (
         <>
             <PageTitle title="Virtual Machine CVEs Overview" />
@@ -23,7 +43,28 @@ function VirtualMachineCvesOverviewPage() {
             </PageSection>
             <PageSection hasBodyWrapper={false}>
                 <VirtualMachineScanScopeAlert />
-                <VirtualMachinesCvesTable />
+                {isEnhancedDataModelEnabled && (
+                    <ToggleGroup aria-label="Entity type toggle items">
+                        <ToggleGroupItem
+                            text="CVEs"
+                            buttonId="CVE"
+                            isSelected={activeEntityTabKey === 'CVE'}
+                            onChange={() => setActiveEntityTabKey('CVE')}
+                        />
+                        <ToggleGroupItem
+                            text="Virtual Machines"
+                            buttonId="VirtualMachine"
+                            isSelected={activeEntityTabKey === 'VirtualMachine'}
+                            onChange={() => setActiveEntityTabKey('VirtualMachine')}
+                        />
+                    </ToggleGroup>
+                )}
+                {isEnhancedDataModelEnabled && activeEntityTabKey === 'CVE' && (
+                    <VirtualMachineCVEsTable />
+                )}
+                {(!isEnhancedDataModelEnabled || activeEntityTabKey === 'VirtualMachine') && (
+                    <VirtualMachinesCvesTable />
+                )}
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
@@ -87,7 +87,7 @@ function VirtualMachinesCvesTableEnhanced() {
         () => listVMs({ searchFilter, page, perPage, sortOption }),
         [searchFilter, page, perPage, sortOption]
     );
-    const { data, isLoading, error } = useRestQuery(fetchVirtualMachines);
+    const { data, isLoading, error } = useRestQuery(fetchVMs);
     const tableState = getTableUIState({
         isLoading,
         data: data?.vms ?? [],

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
@@ -87,7 +87,7 @@ function VirtualMachinesCvesTableEnhanced() {
         () => listVMs({ searchFilter, page, perPage, sortOption }),
         [searchFilter, page, perPage, sortOption]
     );
-    const { data, isLoading, error } = useRestQuery(fetchVMs);
+    const { data, isLoading, error } = useRestQuery(fetchVirtualMachines);
     const tableState = getTableUIState({
         isLoading,
         data: data?.vms ?? [],

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -101,3 +101,26 @@ export function listVMs({
         .get<ListVMsResponse>(`/v2/virtualmachines/vms?${params}`)
         .then((response) => response.data);
 }
+
+export type VMCVEListItem = {
+    cve: string;
+    vmSeverityCounts: VulnCountBySeverity;
+    topCvss: number;
+    cvssVersion: string;
+    affectedVmCount: number;
+    totalVmCount: number;
+    epssProbability: number;
+    publishedOn: string; // ISO 8601 date string
+};
+
+export type ListVMCVEsResponse = {
+    cves: VMCVEListItem[];
+    totalCount: number;
+};
+
+export function listVMCVEs({ page, perPage }: SearchQueryOptions): Promise<ListVMCVEsResponse> {
+    const params = buildNestedRawQueryParams({ page, perPage });
+    return axios
+        .get<ListVMCVEsResponse>(`/v2/virtualmachines/cves?${params}`)
+        .then((response) => response.data);
+}


### PR DESCRIPTION
## Description

Add CVE table to the virtual machine vulnerabilities overview page, behind the `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL` feature flag. 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] **Feature flag OFF**: Overview page shows only the existing VMs table with no entity tabs
- [x] **Feature flag ON**: CVEs and Virtual Machines toggle tabs appear
- [x] **CVE tab**: Table loads and displays rows with all 6 columns populated
- [x] **VM tab**: Existing VMs table renders correctly (no regressions)
- [x] **Pagination**: Page navigation and per-page selection work on the CVE table
- [x] **Empty state**: Empty state message displays when no CVEs are returned
- [x] **Tab persistence**: Selected tab persists in the URL via `entityTab` query param

<img width="2156" height="989" alt="Screenshot 2026-06-29 at 2 00 04 PM" src="https://github.com/user-attachments/assets/23338bad-3040-4b51-8878-112778ee12cc" />
