### PR TITLE
ROX-35118: Header for Virtual Machine CVE single page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
@@ -1,10 +1,14 @@
+import { useCallback } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
-import { Breadcrumb, BreadcrumbItem, PageSection } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Divider, PageSection } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import useRestQuery from 'hooks/useRestQuery';
+import { getVMCVEDetail } from 'services/VirtualMachineService';
 
 import { getOverviewPagePath } from '../../utils/searchUtils';
+import VirtualMachineCvePageHeader from './VirtualMachineCvePageHeader';
 
 const virtualMachineCveOverviewCvePath = getOverviewPagePath('VirtualMachine', {
     entityTab: 'CVE',
@@ -12,6 +16,9 @@ const virtualMachineCveOverviewCvePath = getOverviewPagePath('VirtualMachine', {
 
 function VirtualMachineCvePage() {
     const { cveId } = useParams<{ cveId: string }>();
+
+    const fetchCveDetail = useCallback(() => getVMCVEDetail(cveId ?? ''), [cveId]);
+    const { data: cveDetail } = useRestQuery(fetchCveDetail);
 
     return (
         <>
@@ -23,6 +30,10 @@ function VirtualMachineCvePage() {
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>{cveId}</BreadcrumbItem>
                 </Breadcrumb>
+            </PageSection>
+            <Divider component="div" />
+            <PageSection hasBodyWrapper={false}>
+                <VirtualMachineCvePageHeader cveDetail={cveDetail} />
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
@@ -23,7 +23,7 @@ function VirtualMachineCvePage() {
     return (
         <>
             <PageTitle title={`Virtual Machine CVEs - ${cveId}`} />
-            <PageSection hasBodyWrapper={false}>
+            <PageSection>
                 <Breadcrumb>
                     <BreadcrumbItemLink to={virtualMachineCveOverviewCvePath}>
                         CVEs
@@ -32,7 +32,7 @@ function VirtualMachineCvePage() {
                 </Breadcrumb>
             </PageSection>
             <Divider component="div" />
-            <PageSection hasBodyWrapper={false}>
+            <PageSection>
                 <VirtualMachineCvePageHeader cveDetail={cveDetail} />
             </PageSection>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePageHeader.tsx
@@ -1,0 +1,46 @@
+import { Content, Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import { getDateTime } from 'utils/dateUtils';
+
+import type { VMCVEDetail } from 'services/VirtualMachineService';
+import { formatEpssProbabilityAsPercent } from '../../WorkloadCves/Tables/table.utils';
+import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
+
+type VirtualMachineCvePageHeaderProps = {
+    cveDetail: VMCVEDetail | undefined;
+};
+
+function VirtualMachineCvePageHeader({ cveDetail }: VirtualMachineCvePageHeaderProps) {
+    if (!cveDetail) {
+        return (
+            <HeaderLoadingSkeleton
+                nameScreenreaderText="Loading CVE name"
+                metadataScreenreaderText="Loading CVE metadata"
+            />
+        );
+    }
+
+    return (
+        <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
+            <Title headingLevel="h1">{cveDetail.cve}</Title>
+            <LabelGroup numLabels={3}>
+                <Label>
+                    EPSS probability: {formatEpssProbabilityAsPercent(cveDetail.epssProbability)}
+                </Label>
+                <Label>First discovered in system: {getDateTime(cveDetail.firstDiscovered)}</Label>
+                <Label>Published: {getDateTime(cveDetail.publishedOn)}</Label>
+            </LabelGroup>
+            {cveDetail.summary && <Content component="p">{cveDetail.summary}</Content>}
+            {cveDetail.link && (
+                <ExternalLink>
+                    <a href={cveDetail.link} target="_blank" rel="noopener noreferrer">
+                        View in Red Hat CVE database
+                    </a>
+                </ExternalLink>
+            )}
+        </Flex>
+    );
+}
+
+export default VirtualMachineCvePageHeader;

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -118,6 +118,26 @@ export type ListVMCVEsResponse = {
     totalCount: number;
 };
 
+export type VMCVEDetail = {
+    cve: string;
+    summary: string;
+    link: string;
+    epssProbability: number;
+    publishedOn: string;
+    firstDiscovered: string;
+    affectedVmCount: number;
+    totalVmCount: number;
+    affectedGuestOsCount: number;
+    vmSeverityCounts: VulnCountBySeverity;
+    topCvss: number;
+};
+
+export function getVMCVEDetail(cveId: string): Promise<VMCVEDetail> {
+    return axios
+        .get<VMCVEDetail>(`/v2/virtualmachines/cves/${cveId}`)
+        .then((response) => response.data);
+}
+
 export function listVMCVEs({ page, perPage }: SearchQueryOptions): Promise<ListVMCVEsResponse> {
     const params = buildNestedRawQueryParams({ page, perPage });
     return axios


### PR DESCRIPTION
## Description

Add a header to the virtual machine CVE detail page. Displays the CVE name, labels for EPSS probability, first discovered in system, and published date, a summary description, and a "View in Red Hat CVE database" external link. Data is fetched from `GET /v2/virtualmachines/cves/{cveId}` (`GetVMCVEDetail`).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [ ] **CVE detail page**: Navigate to a CVE from the overview table, verify header renders with CVE name, 3 labels, description, and external link
- [ ] **EPSS label**: Shows formatted EPSS probability percentage
- [ ] **Date labels**: First discovered and published dates render correctly
- [ ] **External link**: "View in Red Hat CVE database" opens correct URL in new tab
- [ ] **Loading state**: Skeleton displays while data is fetching
- [ ] **Breadcrumb**: Still navigates back to overview CVE tab

<img width="1899" height="630" alt="Screenshot 2026-06-29 at 2 27 22 PM" src="https://github.com/user-attachments/assets/41bf8ad8-ce18-4d8a-a223-d1777e7e27dd" />
