### PR TITLE
ROX-35427: reduce VM E2E pipeline metric flakiness

### DIFF
--- a/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
@@ -28,7 +28,7 @@ os.environ["ROX_SCANNER_V4"] = "true"
 # The rhel-vex bundle alone has ~3M records and can take >30 min to import.
 # Drops alpine, aws, debian, oracle, osv, photon, suse, ubuntu (unused for RHEL guests).
 os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "rhel-vex,stackrox-rhel-csaf,manual,epss,nvd"
-os.environ["SCANNER_V4_VULN_READINESS_TIMEOUT"] = "3600"
+os.environ["SCANNER_V4_VULN_READINESS_TIMEOUT"] = "7200"
 # Avoid default rate limiting of VM index reports set to 1 report per minute per VM.
 os.environ["ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE"] = "10"
 os.environ["VM_IMAGES"] = ",".join([

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -44,10 +45,15 @@ const (
 	metricsPoll    = 10 * time.Second
 )
 
+type pipelineMetricsSnapshot struct {
+	compliance testmetrics.Metrics
+	sensor     testmetrics.Metrics
+}
+
 // assertPipelineMetrics scrapes compliance and sensor metrics, retrying until
 // all pipeline assertions pass or the timeout expires.
 // vmNodeName must be non-empty so compliance metrics are scoped to the VM's local collector pod.
-func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string) {
+func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string, before, midpoint pipelineMetricsSnapshot) {
 	tt, ok := t.(*testing.T)
 	require.True(t, ok, "assertPipelineMetrics requires *testing.T")
 
@@ -62,53 +68,177 @@ func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.T
 	senTarget := s.sensorTarget()
 
 	assert.EventuallyWithT(tt, func(ct *assert.CollectT) {
-		comp, err := testmetrics.ScrapeComponent(ctx, s.k8sClient, compTarget)
-		if !assert.NoError(ct, err, "scrape compliance") {
+		after, err := s.scrapePipelineMetrics(ctx, compTarget, senTarget)
+		if !assert.NoError(ct, err, "scrape pipeline metrics") {
 			return
 		}
-		sen, err := testmetrics.ScrapeComponent(ctx, s.k8sClient, senTarget)
-		if !assert.NoError(ct, err, "scrape sensor") {
-			return
-		}
-		assertPipeline(ct, comp, sen)
+		assertPipeline(ct, before, midpoint, after)
 	}, metricsTimeout, metricsPoll)
 }
 
-func assertPositive(t *assert.CollectT, m testmetrics.Metrics, name string, labels ...string) float64 {
-	val, found := m.GetValue(name, labels...)
-	assert.Truef(t, found, "%s should be present", name)
-	assert.Greaterf(t, val, float64(0), "%s should be > 0", name)
-	return val
+func (s *VMScanningSuite) mustScrapePipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string) pipelineMetricsSnapshot {
+	require.NotEmpty(t, vmNodeName,
+		"VM node name must be known before asserting pipeline metrics; "+
+			"cluster-wide collector scraping is not supported because it conflates metrics from unrelated VMs")
+
+	compTarget := s.complianceTarget(vmNodeName)
+	s.logf("pipeline metrics: VM node=%q, compliance selector=%q field=%q",
+		vmNodeName, compTarget.LabelSelector, compTarget.FieldSelector)
+
+	senTarget := s.sensorTarget()
+	snapshot, err := s.scrapePipelineMetrics(ctx, compTarget, senTarget)
+	require.NoError(t, err, "scrape pipeline metrics baseline")
+	return snapshot
 }
 
-func assertZero(t *assert.CollectT, m testmetrics.Metrics, name string, labels ...string) {
-	val, found := m.GetValue(name, labels...)
-	if !found {
-		return
+func (s *VMScanningSuite) scrapePipelineMetrics(ctx context.Context, compTarget, senTarget testmetrics.ScrapeTarget) (pipelineMetricsSnapshot, error) {
+	comp, err := testmetrics.ScrapeComponent(ctx, s.k8sClient, compTarget)
+	if err != nil {
+		return pipelineMetricsSnapshot{}, err
 	}
-	assert.Equalf(t, float64(0), val, "%s should be 0", name)
+	sen, err := testmetrics.ScrapeComponent(ctx, s.k8sClient, senTarget)
+	if err != nil {
+		return pipelineMetricsSnapshot{}, err
+	}
+	return pipelineMetricsSnapshot{
+		compliance: comp,
+		sensor:     sen,
+	}, nil
 }
 
-func assertPipeline(t *assert.CollectT, comp, sen testmetrics.Metrics) {
-	// Compliance relay: full receive → send → ack cycle.
-	compReceived := assertPositive(t, comp, "rox_compliance_virtual_machine_relay_index_reports_received_total")
-	compSentOK := assertPositive(t, comp, "rox_compliance_virtual_machine_relay_index_reports_sent_total", "failed", "false")
-	assertPositive(t, comp, "rox_compliance_virtual_machine_relay_connections_accepted_total")
-	assertPositive(t, comp, "rox_compliance_virtual_machine_relay_acks_received_total")
-	assertZero(t, comp, "rox_compliance_virtual_machine_relay_index_reports_sent_total", "failed", "true")
-	assertZero(t, comp, "rox_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total")
+type metricObservation struct {
+	value   float64
+	present bool
+}
 
-	// Sensor: full receive → send → ack cycle.
-	senReceived := assertPositive(t, sen, "rox_sensor_virtual_machine_index_reports_received_total")
-	senSentOK := assertPositive(t, sen, "rox_sensor_virtual_machine_index_reports_sent_total", "status", "success")
-	assertPositive(t, sen, "rox_sensor_virtual_machine_index_report_acks_received_total", "action", "ACK")
-	assertZero(t, sen, "rox_sensor_virtual_machine_index_reports_sent_total", "status", "error")
-	assertZero(t, sen, "rox_sensor_virtual_machine_index_reports_sent_total", "status", "central not ready")
-	assertZero(t, sen, "rox_sensor_virtual_machine_index_report_enqueue_blocked_total")
+func metricObservationFor(m testmetrics.Metrics, name string, labels ...string) metricObservation {
+	val, found := m.GetValue(name, labels...)
+	return metricObservation{
+		value:   val,
+		present: found,
+	}
+}
 
-	// Relational invariants: can't send more than received.
-	assert.GreaterOrEqualf(t, compReceived, compSentOK,
-		"compliance: received (%.0f) should be >= sent_ok (%.0f)", compReceived, compSentOK)
-	assert.GreaterOrEqualf(t, senReceived, senSentOK,
-		"sensor: received (%.0f) should be >= sent_ok (%.0f)", senReceived, senSentOK)
+func (o metricObservation) valueOrZero() float64 {
+	if !o.present {
+		return 0
+	}
+	return o.value
+}
+
+func formatMetricObservation(o metricObservation) string {
+	if !o.present {
+		return "<absent>"
+	}
+	return fmt.Sprintf("%.0f", o.value)
+}
+
+func assertMetricDelta(t *assert.CollectT, before, after testmetrics.Metrics, want float64, name string, labels ...string) {
+	beforeObs := metricObservationFor(before, name, labels...)
+	afterObs := metricObservationFor(after, name, labels...)
+	got := afterObs.valueOrZero() - beforeObs.valueOrZero()
+	assert.Truef(t, afterObs.present,
+		"%s should be present after the scenario (before=%s after=%s delta=%.0f)",
+		name, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
+	assert.Equalf(t, want, got, "%s delta should be %.0f (before=%s after=%s delta=%.0f)",
+		name, want, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
+}
+
+func assertMetricDeltaAtLeast(t *assert.CollectT, before, after testmetrics.Metrics, wantMin float64, name string, labels ...string) {
+	beforeObs := metricObservationFor(before, name, labels...)
+	afterObs := metricObservationFor(after, name, labels...)
+	got := afterObs.valueOrZero() - beforeObs.valueOrZero()
+	assert.Truef(t, afterObs.present,
+		"%s should be present after the scenario (before=%s after=%s delta=%.0f)",
+		name, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
+	assert.GreaterOrEqualf(t, got, wantMin, "%s delta should be >= %.0f (before=%s after=%s delta=%.0f)",
+		name, wantMin, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
+}
+
+func assertMetricZeroOrAbsentDelta(t *assert.CollectT, before, after testmetrics.Metrics, name string, labels ...string) {
+	beforeObs := metricObservationFor(before, name, labels...)
+	afterObs := metricObservationFor(after, name, labels...)
+	got := afterObs.valueOrZero() - beforeObs.valueOrZero()
+	assert.Equalf(t, float64(0), got, "%s delta should be 0 or absent (before=%s after=%s delta=%.0f)",
+		name, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
+}
+
+func metricDelta(before, after testmetrics.Metrics, name string, labels ...string) float64 {
+	afterObs := metricObservationFor(after, name, labels...)
+	beforeObs := metricObservationFor(before, name, labels...)
+	return afterObs.valueOrZero() - beforeObs.valueOrZero()
+}
+
+type metricPhaseDeltas struct {
+	firstRun float64
+	rescan   float64
+	total    float64
+}
+
+func metricPhaseDeltasFor(before, midpoint, after testmetrics.Metrics, name string, labels ...string) metricPhaseDeltas {
+	return metricPhaseDeltas{
+		firstRun: metricDelta(before, midpoint, name, labels...),
+		rescan:   metricDelta(midpoint, after, name, labels...),
+		total:    metricDelta(before, after, name, labels...),
+	}
+}
+
+// assertPipeline verifies the two-report scenario using three metric snapshots:
+// baseline before the first roxagent run, midpoint after the first report is
+// visible in Central and just before rescan, and final after the rescan path
+// completes. The main contract is that two ACKs make it all the way back to
+// compliance; the other metrics help localize failures when that contract is not met.
+func assertPipeline(t *assert.CollectT, before, midpoint, after pipelineMetricsSnapshot) {
+	complianceBefore := before.compliance
+	complianceMidpoint := midpoint.compliance
+	complianceAfter := after.compliance
+	sensorBefore := before.sensor
+	sensorMidpoint := midpoint.sensor
+	sensorAfter := after.sensor
+
+	complianceACKMetric := "rox_compliance_virtual_machine_index_acks_from_sensor_total"
+	sensorACKMetric := "rox_sensor_virtual_machine_index_report_acks_received_total"
+	complianceIngressMetric := "rox_compliance_virtual_machine_relay_index_reports_received_total"
+
+	complianceACKDeltas := metricPhaseDeltasFor(complianceBefore, complianceMidpoint, complianceAfter, complianceACKMetric, "action", "ACK")
+	sensorACKDeltas := metricPhaseDeltasFor(sensorBefore, sensorMidpoint, sensorAfter, sensorACKMetric, "action", "ACK")
+	complianceIngressDeltas := metricPhaseDeltasFor(complianceBefore, complianceMidpoint, complianceAfter, complianceIngressMetric)
+
+	// Primary end-to-end assertion: the two roxagent runs in this test should
+	// yield exactly two ACKs returning from Sensor to compliance.
+	assert.Equalf(t, float64(2), complianceACKDeltas.total,
+		"%s delta should be 2; compliance ACKs firstRun=%.0f rescan=%.0f total=%.0f; "+
+			"sensor ACKs firstRun=%.0f rescan=%.0f total=%.0f; "+
+			"compliance relay ingress firstRun=%.0f rescan=%.0f total=%.0f",
+		complianceACKMetric,
+		complianceACKDeltas.firstRun, complianceACKDeltas.rescan, complianceACKDeltas.total,
+		sensorACKDeltas.firstRun, sensorACKDeltas.rescan, sensorACKDeltas.total,
+		complianceIngressDeltas.firstRun, complianceIngressDeltas.rescan, complianceIngressDeltas.total)
+
+	// Breadcrumbs: use "at least 2" because this test sends two reports, so a
+	// healthy path should move these counters by at least two, but they are also
+	// shared cumulative metrics that may legitimately observe extra activity
+	// (for example retries or other VM traffic). Requiring equality here would
+	// make the diagnostics more flaky than the primary compliance ACK check.
+	assertMetricDeltaAtLeast(t, sensorBefore, sensorAfter, 2,
+		sensorACKMetric, "action", "ACK")
+	assertMetricDeltaAtLeast(t, complianceBefore, complianceAfter, 2,
+		complianceIngressMetric)
+
+	// Happy-path guardrails: none of the known error or backpressure counters
+	// should move during the two-report scenario.
+	assertMetricZeroOrAbsentDelta(t, complianceBefore, complianceAfter,
+		"rox_compliance_virtual_machine_index_acks_from_sensor_total", "action", "NACK")
+	assertMetricZeroOrAbsentDelta(t, complianceBefore, complianceAfter,
+		"rox_compliance_virtual_machine_relay_index_reports_sent_total", "failed", "true")
+	assertMetricZeroOrAbsentDelta(t, complianceBefore, complianceAfter,
+		"rox_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total")
+	assertMetricZeroOrAbsentDelta(t, sensorBefore, sensorAfter,
+		"rox_sensor_virtual_machine_index_report_acks_received_total", "action", "NACK")
+	assertMetricZeroOrAbsentDelta(t, sensorBefore, sensorAfter,
+		"rox_sensor_virtual_machine_index_reports_sent_total", "status", "error")
+	assertMetricZeroOrAbsentDelta(t, sensorBefore, sensorAfter,
+		"rox_sensor_virtual_machine_index_reports_sent_total", "status", "central not ready")
+	assertMetricZeroOrAbsentDelta(t, sensorBefore, sensorAfter,
+		"rox_sensor_virtual_machine_index_report_enqueue_blocked_total")
 }

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -133,17 +133,6 @@ func formatMetricObservation(o metricObservation) string {
 	return fmt.Sprintf("%.0f", o.value)
 }
 
-func assertMetricDelta(t *assert.CollectT, before, after testmetrics.Metrics, want float64, name string, labels ...string) {
-	beforeObs := metricObservationFor(before, name, labels...)
-	afterObs := metricObservationFor(after, name, labels...)
-	got := afterObs.valueOrZero() - beforeObs.valueOrZero()
-	assert.Truef(t, afterObs.present,
-		"%s should be present after the scenario (before=%s after=%s delta=%.0f)",
-		name, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
-	assert.Equalf(t, want, got, "%s delta should be %.0f (before=%s after=%s delta=%.0f)",
-		name, want, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
-}
-
 func assertMetricDeltaAtLeast(t *assert.CollectT, before, after testmetrics.Metrics, wantMin float64, name string, labels ...string) {
 	beforeObs := metricObservationFor(before, name, labels...)
 	afterObs := metricObservationFor(after, name, labels...)

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -148,7 +148,7 @@ func assertMetricZeroOrAbsentDelta(t *assert.CollectT, before, after testmetrics
 	beforeObs := metricObservationFor(before, name, labels...)
 	afterObs := metricObservationFor(after, name, labels...)
 	got := afterObs.valueOrZero() - beforeObs.valueOrZero()
-	assert.Equalf(t, float64(0), got, "%s delta should be 0 or absent (before=%s after=%s delta=%.0f)",
+	assert.Zerof(t, got, "%s delta should be 0 or absent (before=%s after=%s delta=%.0f)",
 		name, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
 }
 
@@ -185,9 +185,9 @@ func assertPipeline(t *assert.CollectT, before, midpoint, after pipelineMetricsS
 	sensorMidpoint := midpoint.sensor
 	sensorAfter := after.sensor
 
-	complianceACKMetric := "rox_compliance_virtual_machine_index_acks_from_sensor_total"
-	sensorACKMetric := "rox_sensor_virtual_machine_index_report_acks_received_total"
-	complianceIngressMetric := "rox_compliance_virtual_machine_relay_index_reports_received_total"
+	const complianceACKMetric = "rox_compliance_virtual_machine_index_acks_from_sensor_total"
+	const sensorACKMetric = "rox_sensor_virtual_machine_index_report_acks_received_total"
+	const complianceIngressMetric = "rox_compliance_virtual_machine_relay_index_reports_received_total"
 
 	complianceACKDeltas := metricPhaseDeltasFor(complianceBefore, complianceMidpoint, complianceAfter, complianceACKMetric, "action", "ACK")
 	sensorACKDeltas := metricPhaseDeltasFor(sensorBefore, sensorMidpoint, sensorAfter, sensorACKMetric, "action", "ACK")

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -23,7 +23,15 @@ func (s *VMScanningSuite) TestScanPipeline() {
 
 		s.T().Run(vm.Name, func(t *testing.T) {
 			var first *v2.VirtualMachine
+			var metricsBefore pipelineMetricsSnapshot
+			var metricsMidpoint pipelineMetricsSnapshot
 			roxagentOK := false
+
+			// Capture the shared cumulative metrics before the two roxagent runs so
+			// the final pipeline assertion can check this VM's expected deltas.
+			t.Run("MetricsBaseline", func(t *testing.T) {
+				metricsBefore = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
+			})
 
 			t.Run("RunRoxagent", func(t *testing.T) {
 				t.Logf("running roxagent: sudo env ROXAGENT_REPO2CPE_URL=%s %s --verbose",
@@ -73,6 +81,13 @@ func (s *VMScanningSuite) TestScanPipeline() {
 					"scan.operating_system should be populated via Sensor DiscoveredData")
 			})
 
+			// Snapshot metrics after the first report is fully visible in Central and
+			// before kicking off the rescan. This is used for diagnostics without
+			// making the midpoint another strict gate.
+			t.Run("MetricsMidpoint", func(t *testing.T) {
+				metricsMidpoint = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
+			})
+
 			beforeTime := s.mustGetScanTimestamp(first.GetId())
 			var rescan *v2.VirtualMachine
 
@@ -99,7 +114,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			}
 
 			t.Run("PipelineMetrics", func(t *testing.T) {
-				s.assertPipelineMetrics(s.ctx, t, vm.NodeName)
+				s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore, metricsMidpoint)
 			})
 
 			t.Run("ConsistencyCheck", func(t *testing.T) {

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -88,13 +88,13 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			// Snapshot metrics after the first report is fully visible in Central and
 			// before kicking off the rescan. This is used for diagnostics without
 			// making the midpoint another strict gate.
-			if metricsChecksEnabled {
-				if ok := t.Run("MetricsMidpoint", func(t *testing.T) {
-					metricsMidpoint = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
-				}); !ok {
-					t.Log("skipping PipelineMetrics: midpoint metric scrape failed")
-					metricsChecksEnabled = false
+			if ok := t.Run("MetricsMidpoint", func(t *testing.T) {
+				if !metricsChecksEnabled {
+					t.Skip("skipping: baseline metric scrape failed")
 				}
+				metricsMidpoint = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
+			}); !ok {
+				metricsChecksEnabled = false
 			}
 
 			beforeTime := s.mustGetScanTimestamp(first.GetId())
@@ -122,15 +122,12 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				return
 			}
 
-			if metricsChecksEnabled {
-				t.Run("PipelineMetrics", func(t *testing.T) {
-					s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore, metricsMidpoint)
-				})
-			} else {
-				t.Run("PipelineMetrics", func(t *testing.T) {
+			t.Run("PipelineMetrics", func(t *testing.T) {
+				if !metricsChecksEnabled {
 					t.Skip("metric prerequisite scrape failed earlier in this VM scenario")
-				})
-			}
+				}
+				s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore, metricsMidpoint)
+			})
 
 			t.Run("ConsistencyCheck", func(t *testing.T) {
 				fetched := s.mustGetVM(rescan.GetId())

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -25,13 +25,17 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			var first *v2.VirtualMachine
 			var metricsBefore pipelineMetricsSnapshot
 			var metricsMidpoint pipelineMetricsSnapshot
+			metricsChecksEnabled := true
 			roxagentOK := false
 
 			// Capture the shared cumulative metrics before the two roxagent runs so
 			// the final pipeline assertion can check this VM's expected deltas.
-			t.Run("MetricsBaseline", func(t *testing.T) {
+			if ok := t.Run("MetricsBaseline", func(t *testing.T) {
 				metricsBefore = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
-			})
+			}); !ok {
+				t.Log("skipping PipelineMetrics: baseline metric scrape failed")
+				metricsChecksEnabled = false
+			}
 
 			t.Run("RunRoxagent", func(t *testing.T) {
 				t.Logf("running roxagent: sudo env ROXAGENT_REPO2CPE_URL=%s %s --verbose",
@@ -84,9 +88,14 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			// Snapshot metrics after the first report is fully visible in Central and
 			// before kicking off the rescan. This is used for diagnostics without
 			// making the midpoint another strict gate.
-			t.Run("MetricsMidpoint", func(t *testing.T) {
-				metricsMidpoint = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
-			})
+			if metricsChecksEnabled {
+				if ok := t.Run("MetricsMidpoint", func(t *testing.T) {
+					metricsMidpoint = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
+				}); !ok {
+					t.Log("skipping PipelineMetrics: midpoint metric scrape failed")
+					metricsChecksEnabled = false
+				}
+			}
 
 			beforeTime := s.mustGetScanTimestamp(first.GetId())
 			var rescan *v2.VirtualMachine
@@ -113,9 +122,15 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				return
 			}
 
-			t.Run("PipelineMetrics", func(t *testing.T) {
-				s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore, metricsMidpoint)
-			})
+			if metricsChecksEnabled {
+				t.Run("PipelineMetrics", func(t *testing.T) {
+					s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore, metricsMidpoint)
+				})
+			} else {
+				t.Run("PipelineMetrics", func(t *testing.T) {
+					t.Skip("metric prerequisite scrape failed earlier in this VM scenario")
+				})
+			}
 
 			t.Run("ConsistencyCheck", func(t *testing.T) {
 				fetched := s.mustGetVM(rescan.GetId())


### PR DESCRIPTION
Addition: this also bumps the Scanner v4 readiness timeout to 2hrs (the change from 40m to 1hr in #21475 was insufficient).

## Description

### What was the problem?

`TestVMScanning/TestScanPipeline/*/PipelineMetrics` was flaking because it
asserted relational invariants on shared cumulative metrics:

- compliance `index_reports_received >= index_reports_sent{failed="false"}`
- sensor `index_reports_received >= index_reports_sent{status="success"}`

Those checks assumed a stable 1:1 relationship between receive-side and
send-side counters, but the implementation does not guarantee that. Compliance
and Sensor can legitimately increment send-side counters because of retries or
resends, and the metrics are shared at node- or component-scope rather than
being isolated per VM report. That let the test fail even when the VM scanning
pipeline itself was healthy.

### What is the solution?

This PR changes the test to assert on the scenario contract we actually care
about: the test sends two VM index reports, so two ACKs should make it back to
compliance over the full scenario window.

To make that measurable, the test now captures metric snapshots at three
phases:

- before the first `roxagent` run
- after the first report is visible in Central and just before rescan
- after the rescan path completes

The final assertion uses the full-window delta of the compliance ACK metric as
the primary end-to-end check. The midpoint snapshot is only diagnostic: it
helps show whether the first run or the rescan stalled without turning the
midpoint into another strict gate.

The remaining metric checks are split into:

- relaxed breadcrumbs using `>= 2`, because these counters are still shared and
  cumulative
- zero-or-absent error-path guards for NACKs, failed sends, CID mismatches, and
  backpressure

The metric lookup semantics are also explicit now: positive-path checks require
the metric series to exist after the scenario, while error-path guards treat
`0` and `absent` as equivalent.

### Alternatives considered

We considered several other ways to reduce the flake and decided against them
for this PR:

- **Keep exact equality on all breadcrumb metrics.** Rejected because that
  would move the flake to other shared cumulative counters instead of removing
  the brittle assumption.
- **Add per-VM or per-report production metrics or labels.** This would
  likely be the easiest way to make the test stable, but in practice it would
  require labels like VM name or VM ID to correlate one report path with one
  test VM. That would make the metrics unreasonable for production
  environments because of cardinality, churn, and overall observability cost,
  and it would still broaden this PR substantially.
- **Plumb a stronger per-report correlation signal through the ACK path.**
  Likely the cleanest long-term solution, but much larger than needed for this
  fix because it would require more protocol and state changes.
- **Restructure or serialize the suite more aggressively.** Could reduce some
  background noise, but would increase harness complexity and would not by
  itself fix the original bad metric invariant.
- **Remove `PipelineMetrics` entirely.** Rejected for now because that would
  remove the test's explicit observability checks for the VM index report
  pipeline. The broader VM vulnerability-management work in
  [`ROX-32148`](https://redhat.atlassian.net/browse/ROX-32148) is likely to
  reshape this area significantly and may be the better point to redesign or
  replace this test with something more stable. Until then, keeping a narrower
  and less brittle version still provides useful end-to-end coverage and better
  failure diagnostics than dropping this part of the test outright.

### Why this is better than the original test

The original test asked shared counters to prove a relation they did not
guarantee. This change instead:

- anchors the assertion to the actual two-report scenario the test creates
- compares phase-based deltas instead of raw cumulative totals
- keeps enough breadcrumbs to diagnose where the path stalled
- keeps the PR scoped to the test instead of expanding into broader product
  instrumentation

### Why this is not 100% bulletproof

This change removes the specific brittle invariant that caused the CI failures,
but it does not make the test mathematically immune to all future flakes. The
primary ACK metric is still a shared cumulative signal rather than a
per-report-correlated one, so extra ACK activity in the same scope could still
perturb exact totals.

There are still good reasons to expect this to be mostly stable in practice,
even when multiple VMs land on the same node:

- the suite already drives `roxagent` serially per VM rather than in parallel
- the test captures a baseline before the first run, a midpoint after the first
  scan is fully visible in Central, and a final snapshot after the rescan path
  completes, so the assertion window is tied to one VM's explicit two-report
  scenario rather than to long-lived raw totals
- the midpoint and breadcrumb checks help show whether movement happened during
  the first run or the rescan, which should make future failures easier to
  reason about instead of leaving only one aggregate number at the end
- the relaxed breadcrumb checks avoid reintroducing equality-based flakes on
  other shared counters while still verifying that the path moved in the
  expected direction

So the remaining risk is narrower than before: we are no longer asking shared
send/receive counters to prove a relation they do not guarantee, but we are
still relying on one shared ACK counter for the exact total.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI runs:
1. [Scanner didn't deploy](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21462/pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests/2071707147925721088) 
