### PR TITLE
ROX-35294: retry SA update on conflict in VM e2e setup

### DIFF
--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -478,20 +479,29 @@ func (s *VMScanningSuite) ensureImagePullSecret(ctx context.Context) {
 	}
 	require.NoError(s.T(), err, "ensure image pull secret %q in namespace %q", vmImagePullSecretName, s.namespace)
 
-	sa, err := s.waitForDefaultServiceAccount(ctx)
-	require.NoError(s.T(), err, "get default service account in namespace %q", s.namespace)
-	hasRef := false
-	for _, ref := range sa.ImagePullSecrets {
-		if ref.Name == vmImagePullSecretName {
-			hasRef = true
-			break
+	// Wait for the default SA to exist before attempting the update.
+	_, err = s.waitForDefaultServiceAccount(ctx)
+	require.NoError(s.T(), err, "wait for default service account in namespace %q", s.namespace)
+
+	// The SA controller may still be mutating the freshly-created default SA
+	// (e.g. patching token secrets), so a single Get+Update can hit an
+	// optimistic concurrency conflict. Retry exactly like the DaemonSet
+	// update in ensureComplianceMetricsEnv.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sa, getErr := s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Get(ctx, "default", metaV1.GetOptions{})
+		if getErr != nil {
+			return getErr
 		}
-	}
-	if !hasRef {
+		for _, ref := range sa.ImagePullSecrets {
+			if ref.Name == vmImagePullSecretName {
+				return nil
+			}
+		}
 		sa.ImagePullSecrets = append(sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
-		_, err = s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Update(ctx, sa, metaV1.UpdateOptions{})
-		require.NoError(s.T(), err, "link image pull secret to default service account in namespace %q", s.namespace)
-	}
+		_, updateErr := s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Update(ctx, sa, metaV1.UpdateOptions{})
+		return updateErr
+	})
+	require.NoError(s.T(), err, "link image pull secret to default service account in namespace %q", s.namespace)
 	s.logf("provision VMs: image pull secret %q ready in namespace %q", vmImagePullSecretName, s.namespace)
 }
 


### PR DESCRIPTION
## Description

The `default` ServiceAccount in a freshly-created namespace may be concurrently
mutated by the SA controller (e.g. token secret patching), causing the
image-pull-secret link update to fail with an optimistic concurrency conflict
(`"the object has been modified"`).

Wrap the Get+Update in `retry.RetryOnConflict`, matching the existing pattern
used for the DaemonSet update in `ensureComplianceMetricsEnv`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Test-only change (e2e test harness); no unit test is practical since the conflict requires a real API server race. Validation will come from CI: the flake tracked in ROX-35294 should stop recurring.
