### PR TITLE
fix(ci): mitigate scanner-v4-matcher timeout in VM e2e

### DIFF
--- a/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
@@ -24,6 +24,11 @@ os.environ["SENSOR_HELM_MANAGED"] = "true"
 os.environ["INSTALL_CNV_OPERATOR"] = "true"
 os.environ["ROX_VIRTUAL_MACHINES"] = "true"
 os.environ["ROX_SCANNER_V4"] = "true"
+# Selectively enable vulnerability bundles to prevent timeouts of matcher not being ready in 40 minutes.
+# The rhel-vex bundle alone has ~3M records and can take >30 min to import.
+# Drops alpine, aws, debian, oracle, osv, photon, suse, ubuntu (unused for RHEL guests).
+os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "rhel-vex,stackrox-rhel-csaf,manual,epss,nvd"
+os.environ["SCANNER_V4_VULN_READINESS_TIMEOUT"] = "3600"
 # Avoid default rate limiting of VM index reports set to 1 report per minute per VM.
 os.environ["ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE"] = "10"
 os.environ["VM_IMAGES"] = ",".join([


### PR DESCRIPTION
## Description

The `branch-ci-stackrox-stackrox-master-ocp-4-21-merge-vm-scanning-e2e-tests` job has been failing
repeatedly with `scanner-v4-matcher` unable to pass its K8s readiness probe within the default
2400s timeout when `SCANNER_V4_MATCHER_READINESS=vulnerability` is set.

Manual inspection of the matcher pod logs from a [recent failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-21-merge-vm-scanning-e2e-tests/2071674536696221696)
revealed the root cause: the `rhel-vex` vulnerability bundle has grown to ~3M records and takes
over 30 minutes to import into the DB on its own. Combined with the other bundles, the total
initial import exceeds 47 minutes — well past the 40-minute timeout. The test never even starts;
StackRox deployment itself fails.

There is no dedicated JIRA ticket for this flake because the failure is not specific to the VM
scanning test logic — it's an infrastructure-level matcher readiness issue. However, the pattern is
clearly repeating across multiple CI runs for this job, so this change mitigates it from the
VM scanning side.

This change:
- **Trims the vuln bundle allowlist** to only bundles relevant for RHEL 8/9/10 guests
  (`rhel-vex`, `stackrox-rhel-csaf`, `manual`, `epss`, `nvd`), dropping ~12 minutes of
  unnecessary alpine/debian/osv/ubuntu imports.
- **Extends the matcher readiness timeout** to 3600s (60 min) as additional safety margin.

Scanner team has been notified about the `rhel-vex` bundle size growth to discuss longer-term
improvements to the initial import performance.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Manually inspected matcher pod logs from the failing CI run (`gcloud storage cp` from
  `gs://stackrox-ci-artifacts/...scanner-v4-matcher...log`) and confirmed the bundle import
  timeline exceeds the 2400s timeout.
- Only multiple CI e2e runs can provide any evidence
