### PR TITLE
fix(retest): trigger /retest for failing e2e GitHub Actions checks

### DIFF
--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -16,16 +16,22 @@ import (
 
 var allowedCheckFailurePrefixes = []string{
 	"codecov/",
+}
+
+var retestableCheckPrefixes = []string{
 	"e2e-",
 }
 
 func isAllowedCheckFailure(name string) bool {
-	for _, prefix := range allowedCheckFailurePrefixes {
-		if strings.HasPrefix(name, prefix) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(allowedCheckFailurePrefixes, func(prefix string) bool {
+		return strings.HasPrefix(name, prefix)
+	})
+}
+
+func isRetestableCheck(name string) bool {
+	return slices.ContainsFunc(retestableCheckPrefixes, func(prefix string) bool {
+		return strings.HasPrefix(name, prefix)
+	})
 }
 
 const s = "stackrox"
@@ -75,8 +81,15 @@ issues:
 		}
 		log.Printf("#%d has %d completed checks", prNumber, len(checks))
 
-		for name, status := range checks {
-			if !status && !isAllowedCheckFailure(name) {
+		for name, passed := range checks {
+			if passed {
+				continue
+			}
+			if isRetestableCheck(name) {
+				log.Printf("#%d has a failing retestable check (%s)", prNumber, name)
+				continue
+			}
+			if !isAllowedCheckFailure(name) {
 				log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
 				continue issues
 			}
@@ -102,7 +115,7 @@ issues:
 			continue
 		}
 		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
-		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatuses(statuses, userComments))
+		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatuses(statuses, userComments, checks))
 		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
 	}
 	return nil
@@ -183,7 +196,7 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 
 const retestComment = "/retest"
 
-func shouldRetestFailedStatuses(statuses map[string]string, comments []string) bool {
+func shouldRetestFailedStatuses(statuses map[string]string, comments []string, checks map[string]bool) bool {
 	retested := 0
 	for _, c := range comments {
 		if c == retestComment {
@@ -192,6 +205,12 @@ func shouldRetestFailedStatuses(statuses map[string]string, comments []string) b
 	}
 	if retested > 3 {
 		return false
+	}
+
+	for name, passed := range checks {
+		if !passed && isRetestableCheck(name) {
+			return true
+		}
 	}
 
 	for _, status := range statuses {

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -22,14 +22,8 @@ var retestableCheckPrefixes = []string{
 	"e2e-",
 }
 
-func isAllowedCheckFailure(name string) bool {
-	return slices.ContainsFunc(allowedCheckFailurePrefixes, func(prefix string) bool {
-		return strings.HasPrefix(name, prefix)
-	})
-}
-
-func isRetestableCheck(name string) bool {
-	return slices.ContainsFunc(retestableCheckPrefixes, func(prefix string) bool {
+func hasAnyPrefix(name string, prefixes []string) bool {
+	return slices.ContainsFunc(prefixes, func(prefix string) bool {
 		return strings.HasPrefix(name, prefix)
 	})
 }
@@ -81,8 +75,9 @@ issues:
 		}
 		log.Printf("#%d has %d completed checks", prNumber, len(checks))
 
+		skippableCheckPrefixes := slices.Concat(allowedCheckFailurePrefixes, retestableCheckPrefixes)
 		for name, passed := range checks {
-			if passed || isAllowedCheckFailure(name) || isRetestableCheck(name) {
+			if passed || hasAnyPrefix(name, skippableCheckPrefixes) {
 				continue
 			}
 			log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
@@ -202,7 +197,7 @@ func shouldRetestFailedStatusesAndChecks(statuses map[string]string, comments []
 	}
 
 	for name, passed := range checks {
-		if !passed && isRetestableCheck(name) {
+		if !passed && hasAnyPrefix(name, retestableCheckPrefixes) {
 			return true
 		}
 	}

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -82,17 +82,11 @@ issues:
 		log.Printf("#%d has %d completed checks", prNumber, len(checks))
 
 		for name, passed := range checks {
-			if passed {
+			if passed || isAllowedCheckFailure(name) || isRetestableCheck(name) {
 				continue
 			}
-			if isRetestableCheck(name) {
-				log.Printf("#%d has a failing retestable check (%s)", prNumber, name)
-				continue
-			}
-			if !isAllowedCheckFailure(name) {
-				log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
-				continue issues
-			}
+			log.Printf("#%d has a failing check (%s), skipping", prNumber, name)
+			continue issues
 		}
 
 		statuses, err := statusesForPR(ctx, client, prDetails.GetStatusesURL())
@@ -115,7 +109,7 @@ issues:
 			continue
 		}
 		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
-		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatuses(statuses, userComments, checks))
+		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatusesAndChecks(statuses, userComments, checks))
 		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
 	}
 	return nil
@@ -196,7 +190,7 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 
 const retestComment = "/retest"
 
-func shouldRetestFailedStatuses(statuses map[string]string, comments []string, checks map[string]bool) bool {
+func shouldRetestFailedStatusesAndChecks(statuses map[string]string, comments []string, checks map[string]bool) bool {
 	retested := 0
 	for _, c := range comments {
 		if c == retestComment {

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -231,26 +231,23 @@ func Test_retestNTimes(t *testing.T) {
 }
 
 func Test_shouldRetest(t *testing.T) {
-	tests := []struct {
-		name     string
+	tests := map[string]struct {
 		statuses map[string]string
 		comments []string
+		checks   map[string]bool
 		want     bool
 	}{
-		{
-			name:     "nil",
+		"nil": {
 			statuses: nil,
 			comments: nil,
 			want:     false,
 		},
-		{
-			name:     "empty",
+		"empty": {
 			statuses: map[string]string{},
 			comments: []string{},
 			want:     false,
 		},
-		{
-			name: "all success",
+		"all success": {
 			statuses: map[string]string{
 				"a": "success",
 				"b": "success",
@@ -259,8 +256,7 @@ func Test_shouldRetest(t *testing.T) {
 			comments: []string{},
 			want:     false,
 		},
-		{
-			name: "one failure",
+		"one failure": {
 			statuses: map[string]string{
 				"a": "success",
 				"b": "failure",
@@ -269,8 +265,7 @@ func Test_shouldRetest(t *testing.T) {
 			comments: []string{},
 			want:     true,
 		},
-		{
-			name: "one failure but already retested",
+		"one failure but already retested once": {
 			statuses: map[string]string{
 				"a": "success",
 				"b": "failure",
@@ -279,8 +274,7 @@ func Test_shouldRetest(t *testing.T) {
 			comments: []string{"/retest"},
 			want:     true,
 		},
-		{
-			name: "one failure but already retested",
+		"one failure but already retested too many times": {
 			statuses: map[string]string{
 				"a": "success",
 				"b": "failure",
@@ -289,10 +283,36 @@ func Test_shouldRetest(t *testing.T) {
 			comments: []string{"/retest", "/retest", "/retest", "/retest"},
 			want:     false,
 		},
+		"failed e2e check triggers retest": {
+			statuses: map[string]string{},
+			comments: []string{},
+			checks:   map[string]bool{"e2e-gke-tests": false},
+			want:     true,
+		},
+		"failed e2e check but already retested too many times": {
+			statuses: map[string]string{},
+			comments: []string{"/retest", "/retest", "/retest", "/retest"},
+			checks:   map[string]bool{"e2e-gke-tests": false},
+			want:     false,
+		},
+		"failed e2e check with prow success": {
+			statuses: map[string]string{
+				"a": "success",
+			},
+			comments: []string{},
+			checks:   map[string]bool{"e2e-gke-tests": false},
+			want:     true,
+		},
+		"passing e2e check does not trigger retest": {
+			statuses: map[string]string{},
+			comments: []string{},
+			checks:   map[string]bool{"e2e-gke-tests": true},
+			want:     false,
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shouldRetestFailedStatuses(tt.statuses, tt.comments)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := shouldRetestFailedStatuses(tt.statuses, tt.comments, tt.checks)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -312,7 +312,7 @@ func Test_shouldRetest(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := shouldRetestFailedStatuses(tt.statuses, tt.comments, tt.checks)
+			got := shouldRetestFailedStatusesAndChecks(tt.statuses, tt.comments, tt.checks)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Description

Previously `e2e-*` checks were in `allowedCheckFailurePrefixes`, meaning failures were silently ignored. Move them to a new `retestableCheckPrefixes` category so failing e2e checks trigger a `/retest` comment.

Partially generated by AI

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests