### PR TITLE
ROX-35187: Fix race in TestUpdaterDownloadsBundleFromHTTP

### DIFF
--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -273,7 +273,6 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 	// the updater fires its first download immediately on startup and the
 	// retry interval is clamped to 5 minutes.
 	s.logf("Verifying bundle URL is reachable from within the cluster")
-	wgetCmd := fmt.Sprintf("wget -q -O /dev/null %s", bundleURL)
 	mustEventually(t, testCtx, func() error {
 		podList, err := s.k8s.CoreV1().Pods(ns).List(testCtx, metaV1.ListOptions{
 			LabelSelector: fmt.Sprintf("app=%s", deploymentName),

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -284,7 +284,7 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 		if len(podList.Items) == 0 {
 			return fmt.Errorf("no pods found for deployment %q", deploymentName)
 		}
-		out, err := exec.CommandContext(testCtx, "kubectl", "exec", "-n", ns, podList.Items[0].Name, "--", "sh", "-c", wgetCmd).CombinedOutput()
+		out, err := exec.CommandContext(testCtx, "kubectl", "exec", "-n", ns, podList.Items[0].Name, "--", "wget", "-q", "-O", "/dev/null", bundleURL).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("wget failed: %s: %w", string(out), err)
 		}

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"slices"
 	"testing"
 	"time"
@@ -266,6 +267,30 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 
 	bundleURL := fmt.Sprintf("http://%s.%s.svc/bundle.json", deploymentName, ns)
 	s.logf("Bundle URL: %s", bundleURL)
+
+	// Service endpoints may not be routable immediately after the deployment
+	// is marked ready. Verify reachability before restarting Central, because
+	// the updater fires its first download immediately on startup and the
+	// retry interval is clamped to 5 minutes.
+	s.logf("Verifying bundle URL is reachable from within the cluster")
+	wgetCmd := fmt.Sprintf("wget -q -O /dev/null %s", bundleURL)
+	mustEventually(t, testCtx, func() error {
+		podList, err := s.k8s.CoreV1().Pods(ns).List(testCtx, metaV1.ListOptions{
+			LabelSelector: fmt.Sprintf("app=%s", deploymentName),
+		})
+		if err != nil {
+			return fmt.Errorf("listing pods: %w", err)
+		}
+		if len(podList.Items) == 0 {
+			return fmt.Errorf("no pods found for deployment %q", deploymentName)
+		}
+		out, err := exec.CommandContext(testCtx, "kubectl", "exec", "-n", ns, podList.Items[0].Name, "--", "sh", "-c", wgetCmd).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("wget failed: %s: %w", string(out), err)
+		}
+		return nil
+	}, 2*time.Second, "bundle URL not yet reachable")
+	s.logf("Bundle URL is reachable")
 
 	// The watcher must poll frequently so it picks up the file the updater writes.
 	defer func() {


### PR DESCRIPTION
## Description

`TestUpdaterDownloadsBundleFromHTTP` has been flaking consistently since June 18 (ROX-35187, 9 failures across multiple CI runs). The test deploys an nginx pod behind a Kubernetes Service and restarts Central with the bundle URL. Central's file downloader fires its first download immediately on startup, but Service endpoints may not be routable yet at that point. When the first download fails, the retry interval is clamped to a 5-minute minimum, which can exceed the remaining test context timeout.

The fix adds a retry loop that verifies the bundle URL is reachable from within the cluster before restarting Central. This is the same pattern already used in `TestOfflineModeIgnoresHTTPUpdater` on PR #21428.

**Alternatives considered**: lowering the 5-minute minimum download interval for test scenarios. Deferred as a follow-up because the reachability precondition is the more robust fix — it addresses the actual problem (service not ready) rather than masking it with faster retries.

## Verification

### Stability: 10/10 passes on OCP 4 cluster

| Run | Duration | Result |
|-----|----------|--------|
| 1 | 64s | PASS |
| 2 | 62s | PASS |
| 3 | 64s | PASS |
| 4 | 64s | PASS |
| 5 | 94s | PASS |
| 6 | 64s | PASS |
| 7 | 64s | PASS |
| 8 | 64s | PASS |
| 9 | 64s | PASS |
| 10 | 64s | PASS |

### Retry path verification

To confirm the retry loop actually exercises its retry logic (not just passing on the first attempt), the test was temporarily modified to delay service creation by 8 seconds after the reachability check starts. The retry loop correctly retried 4 times before succeeding:

```
11:29:57 Verifying bundle URL is reachable (service creation delayed 8s)
11:29:58 bundle URL not yet reachable: wget failed: bad address 'key-bundle-server.stackrox.svc'
11:30:00 bundle URL not yet reachable: wget failed: bad address 'key-bundle-server.stackrox.svc'
11:30:03 bundle URL not yet reachable: wget failed: bad address 'key-bundle-server.stackrox.svc'
11:30:05 (delayed) Creating service "key-bundle-server" now
11:30:06 bundle URL not yet reachable: wget failed: bad address (DNS not propagated yet)
11:30:09 Bundle URL is reachable  <-- succeeds after DNS propagates
```

Test passed (75s) with the delayed service creation, confirming the retry mechanism works as expected.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Ran the test 10 times on an OCP 4 cluster — all passed
- Verified the retry path is exercised by temporarily delaying service creation — the retry loop correctly retried 4 times before the service became reachable