### PR TITLE
ROX-35507: use tmpfs for PostgreSQL data in unit tests

### DIFF
--- a/.github/test-images/postgres-ci.conf
+++ b/.github/test-images/postgres-ci.conf
@@ -1,0 +1,11 @@
+# Shared PostgreSQL settings for CI unit tests and benchmarks.
+# Mounted into sclorg containers via /opt/app-root/src/postgresql-cfg/ and copied
+# into /etc/postgresql/*/main/conf.d/ for the runner's pre-installed Postgres.
+# tmpfs has limited space; minimize WAL footprint since durability is irrelevant.
+listen_addresses = 'localhost'
+fsync = off
+full_page_writes = off
+wal_level = minimal
+max_wal_senders = 0
+max_wal_size = 64MB
+synchronous_commit = off

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -124,17 +124,22 @@ jobs:
     env:
       POSTGRES_PASSWORD: testpassword
     steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+
     # Runner's postgres is initialized with C.UTF-8 locale (GHA default).
     # Tests (e.g. central/splunk) require byte-order collation.
     - name: Start Postgres (pre-installed)
       if: matrix.pg == 'default'
       run: |
+        # Run on tmpfs to avoid disk I/O overhead in tests.
+        PG_VER=$(pg_lsclusters -h | awk '{print $1}')
+        sudo pg_dropcluster --stop "$PG_VER" main
+        sudo mount -t tmpfs -o size=1G tmpfs /var/lib/postgresql
         # the unit tests expect a local postgres with passwordless access.
-        sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
+        sudo pg_createcluster "$PG_VER" main -- --auth=trust
+        sudo cp .github/test-images/postgres-ci.conf "/etc/postgresql/$PG_VER/main/conf.d/ci.conf"
         sudo systemctl start postgresql.service
-
-    - name: Checkout
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
 
     # Image pinned in .github/test-images/postgres.dockerfile (Dependabot auto-bumps).
     - name: Start Postgres (${{ matrix.pg }})
@@ -142,6 +147,8 @@ jobs:
       run: |
         docker build -t postgres-test -f .github/test-images/postgres.dockerfile .
         docker run --rm -d --name postgres --network=host \
+          --tmpfs /var/lib/pgsql/data:rw,size=1G \
+          -v "$GITHUB_WORKSPACE/.github/test-images/postgres-ci.conf:/opt/app-root/src/postgresql-cfg/ci.conf:ro" \
           -e POSTGRESQL_ADMIN_PASSWORD="$POSTGRES_PASSWORD" \
           -e LANG=C.UTF-8 \
           postgres-test
@@ -201,18 +208,20 @@ jobs:
     needs: detect-changes
     if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
-    env:
-      BUILD_TAG: 0.0.0
-      SHORTCOMMIT: "0000000"
     steps:
-    - name: Start Postgres
-      run: |
-        # the unit tests expect a local postgres with passwordless access. Change  host to 'trust'
-        sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
-        sudo systemctl start postgresql.service
-
     - name: Checkout
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+
+    - name: Start Postgres
+      run: |
+        # Run on tmpfs to avoid disk I/O overhead in tests.
+        PG_VER=$(pg_lsclusters -h | awk '{print $1}')
+        sudo pg_dropcluster --stop "$PG_VER" main
+        sudo mount -t tmpfs -o size=1G tmpfs /var/lib/postgresql
+        # the unit tests expect a local postgres with passwordless access.
+        sudo pg_createcluster "$PG_VER" main -- --auth=trust
+        sudo cp .github/test-images/postgres-ci.conf "/etc/postgresql/$PG_VER/main/conf.d/ci.conf"
+        sudo systemctl start postgresql.service
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -223,11 +232,20 @@ jobs:
 
     - name: Is Postgres ready
       run: |
-        timeout 60 bash -c 'until pg_isready; do sleep 1; done' \
+        timeout 60 bash -c 'until pg_isready -h 127.0.0.1; do sleep 1; done' \
           || { sudo journalctl -u postgresql --no-pager -n 20; exit 1; }
 
     - name: Go Bench Tests
       run: make go-postgres-bench-tests
+
+    - name: Postgres diagnostics
+      if: failure()
+      run: |
+        pg_isready -h 127.0.0.1 || true
+        pg_lsclusters || true
+        df -h /var/lib/postgresql || true
+        sudo journalctl -u postgresql --no-pager -n 40 || true
+        sudo cat /var/log/postgresql/postgresql-*-main.log | tail -60 || true
 
     - name: Generate junit report
       if: always()


### PR DESCRIPTION
## Description

Speed up PostgreSQL-backed CI unit tests by running database data on tmpfs instead of the runner disk.

- Recreate the runner Postgres cluster on a 1G tmpfs mount for `go-postgres` (default) and `go-bench`.
- Run PG15 Docker jobs with a 1G tmpfs data dir and mount shared WAL tuning config.
- Add `.github/test-images/postgres-ci.conf` used by both host Postgres (`conf.d/`) and sclorg PG15 containers (`/opt/app-root/src/postgresql-cfg/`).
- WAL settings are minimized for CI so tmpfs does not fill during `sql_integration` tests.
- Move checkout before Postgres startup so the shared config file is available.
- Add Postgres diagnostics on `go-bench` failure (readiness, disk usage, journal/logs).

- https://github.com/orgs/community/discussions/126453

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Test-only infrastructure change; existing `go-postgres` integration suite exercises `ForT()` across ~392 call sites. No new tests added.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI