### PR TITLE
ci: Replace paths-ignore with detect-changes for UI-only skip

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -77,11 +77,10 @@ jobs:
 
           anchored=$(printf '^%s$\n' "${files[@]}")
 
-          # Self-check disabled for testing: detect-changes.yml is in this PR
-          # if echo "${anchored}" | grep -qF "^${WORKFLOW_FILE_PATH}$"; then
-          #   echo "detect-changes.yml modified, running all jobs" >&2
-          #   exit 0
-          # fi
+          if echo "${anchored}" | grep -qF "^${WORKFLOW_FILE_PATH}$"; then
+            echo "detect-changes.yml modified, running all jobs" >&2
+            exit 0
+          fi
 
           if [[ -n "${RUN_ALL}" ]]; then
             while IFS= read -r pattern; do
@@ -100,8 +99,8 @@ jobs:
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
 
-            if ! echo "${anchored}" | grep -qv '^\^\.github/'; then
-              echo "All changed files are under .github/" >&2
+            if ! echo "${anchored}" | grep -qv '^\^ui/'; then
+              echo "All changed files are under ui/" >&2
               echo "ui_only=true" >> "${GITHUB_OUTPUT}"
             fi
           fi

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -77,10 +77,11 @@ jobs:
 
           anchored=$(printf '^%s$\n' "${files[@]}")
 
-          if echo "${anchored}" | grep -qF "^${WORKFLOW_FILE_PATH}$"; then
-            echo "detect-changes.yml modified, running all jobs" >&2
-            exit 0
-          fi
+          # Self-check disabled for testing: detect-changes.yml is in this PR
+          # if echo "${anchored}" | grep -qF "^${WORKFLOW_FILE_PATH}$"; then
+          #   echo "detect-changes.yml modified, running all jobs" >&2
+          #   exit 0
+          # fi
 
           if [[ -n "${RUN_ALL}" ]]; then
             while IFS= read -r pattern; do
@@ -99,8 +100,8 @@ jobs:
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
 
-            if ! echo "${anchored}" | grep -qv '^\^ui/'; then
-              echo "All changed files are under ui/" >&2
+            if ! echo "${anchored}" | grep -qv '^\^\.github/'; then
+              echo "All changed files are under .github/" >&2
               echo "ui_only=true" >> "${GITHUB_OUTPUT}"
             fi
           fi

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -14,16 +14,19 @@ on:
     - reopened
     - synchronize
     - labeled
-    paths-ignore:
-    - 'ui/**'
 
 defaults:
   run:
     shell: bash
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   wait-for-images:
+    needs: detect-changes
     if: >-
+      !needs.detect-changes.outputs.ui_only &&
       (github.event.action != 'labeled' || github.event.label.name == 'e2e-db-backup-restore-test') &&
       !github.event.pull_request.head.repo.fork && (
         github.event_name != 'pull_request' ||

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -14,16 +14,19 @@ on:
     - reopened
     - synchronize
     - labeled
-    paths-ignore:
-    - 'ui/**'
 
 defaults:
   run:
     shell: bash
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   wait-for-images:
+    needs: detect-changes
     if: >-
+      !needs.detect-changes.outputs.ui_only &&
       (github.event.action != 'labeled' || github.event.label.name == 'e2e-nongroovy-tests') &&
       !github.event.pull_request.head.repo.fork && (
         github.event_name != 'pull_request' ||

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -12,11 +12,14 @@ on:
     - opened
     - reopened
     - synchronize
-    paths-ignore:
-    - 'ui/**'
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   db-integration-tests:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.11@sha256:cea78f2b3a5a38c9ccda678712daaed90b7c372d6b5df963feb758b32dccebe1 # ratchet:quay.io/stackrox-io/apollo-ci:scanner-test-0.5.11

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -35,7 +35,6 @@ jobs:
 
   go:
     needs: detect-changes
-    if: ${{ !needs.detect-changes.outputs.ui_only }}
     strategy:
       fail-fast: false
       matrix:
@@ -109,7 +108,6 @@ jobs:
 
   go-postgres:
     needs: detect-changes
-    if: ${{ !needs.detect-changes.outputs.ui_only }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Partial revert/change of https://github.com/stackrox/stackrox/pull/21274

Replaces `paths-ignore: ui/**` with the `detect-changes` reusable workflow + job-level `if:` conditions on 3 workflows. `paths-ignore` makes the entire job invisible which causes required jobs to block merging the PR.

Also reverts the skip of `go` and `go-postgres` short term, as Claude suggests the `detect-changes` approach will not work correctly with matrix jobs and the recommended alternatives are not something I want to implement at this point:
1. Adding "skip" jobs ala `go-skip-ui` that report the same job name (feels hacky and intuitive)
2. Adding a gate to matrix jobs to pass early (much more invasive change)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI inspection with `.github` as the target directory. This change was [reverted](https://github.com/stackrox/stackrox/pull/21484/changes/30b1054928bb5b711baf0c4cc48f9b5f47859c01) after verification back to `ui/` as the target directory.
<img width="356" height="656" alt="image" src="https://github.com/user-attachments/assets/794047e1-d810-41ed-ba63-e492d178d48d" />

<img width="356" height="656" alt="image" src="https://github.com/user-attachments/assets/25344cd6-619e-4460-8d51-1f27f2d32ad4" />
