### PR TITLE
chore(ci): Reduce `wait-for-images` use in E2E tests

### DIFF
--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -18,9 +18,6 @@ defaults:
 
 jobs:
   gke-byodb-test:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -7,6 +7,10 @@ on:
         description: Image tag to test.
         type: string
         required: true
+      should-run:
+        description: true if should really run the job. false - otherwise, i.e. the job should be skipped.
+        type: boolean
+        required: true
 
 permissions:
   contents: read
@@ -18,6 +22,7 @@ defaults:
 
 jobs:
   gke-byodb-test:
+    if: inputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -1,19 +1,12 @@
 name: e2e-byodb-test
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-    - '*'
-    branches:
-    - master
-    - release-*
-  pull_request:
-    types:
-    - opened
-    - reopened
-    - synchronize
-    - labeled
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to test.
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,58 +17,14 @@ defaults:
     shell: bash
 
 jobs:
-  wait-for-images:
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-byodb-test') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
-      )
-    runs-on: ubuntu-slim
-    outputs:
-      tag: ${{ steps.build-tag.outputs.tag }}
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        persist-credentials: false
-    - uses: ./.github/actions/handle-tagged-build
-    - name: Compute build tag
-      id: build-tag
-      run: |
-        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
-        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
-        echo "operator_tag=$(BUILD_TAG="${tag}" make -C operator --quiet --no-print-directory tag)" | tee -a "$GITHUB_ENV"
-    - name: Wait for images
-      uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
-      with:
-        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-        image: |
-          rhacs-eng/central-db:${{ env.tag }}
-          rhacs-eng/collector:${{ env.tag }}
-          rhacs-eng/fact:${{ env.tag }}
-          rhacs-eng/main:${{ env.tag }}
-          rhacs-eng/roxctl:${{ env.tag }}
-          rhacs-eng/scanner-db-slim:${{ env.tag }}
-          rhacs-eng/scanner-db:${{ env.tag }}
-          rhacs-eng/scanner-slim:${{ env.tag }}
-          rhacs-eng/scanner-v4-db:${{ env.tag }}
-          rhacs-eng/scanner-v4:${{ env.tag }}
-          rhacs-eng/scanner:${{ env.tag }}
-          rhacs-eng/stackrox-operator:${{ env.operator_tag }}
-
   gke-byodb-test:
-    needs: [ wait-for-images ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
-      BUILD_TAG: ${{ needs.wait-for-images.outputs.tag }}
+      MAIN_IMAGE_TAG: ${{ inputs.tag }}
+      BUILD_TAG: ${{ inputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       CI_JOB_NAME: gke-byodb-test

--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   gke-byodb-test:
-    if: inputs.should-run == 'true'
+    if: inputs.should-run
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -1,19 +1,12 @@
 name: e2e-db-backup-restore-test
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-    - '*'
-    branches:
-    - master
-    - release-*
-  pull_request:
-    types:
-    - opened
-    - reopened
-    - synchronize
-    - labeled
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to test.
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,63 +17,11 @@ defaults:
     shell: bash
 
 jobs:
-  detect-changes:
-    uses: ./.github/workflows/detect-changes.yml
-
-  wait-for-images:
-    needs: detect-changes
-    if: >-
-      !needs.detect-changes.outputs.ui_only &&
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-db-backup-restore-test') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
-      )
-    runs-on: ubuntu-slim
-    outputs:
-      tag: ${{ steps.build-tag.outputs.tag }}
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        persist-credentials: false
-    - uses: ./.github/actions/handle-tagged-build
-    - name: Compute build tag
-      id: build-tag
-      run: |
-        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
-        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
-        echo "operator_tag=$(BUILD_TAG="${tag}" make -C operator --quiet --no-print-directory tag)" | tee -a "$GITHUB_ENV"
-    - name: Wait for images
-      uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
-      with:
-        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-        image: |
-          rhacs-eng/central-db:${{ env.tag }}
-          rhacs-eng/collector:${{ env.tag }}
-          rhacs-eng/fact:${{ env.tag }}
-          rhacs-eng/main:${{ env.tag }}
-          rhacs-eng/roxctl:${{ env.tag }}
-          rhacs-eng/scanner-db-slim:${{ env.tag }}
-          rhacs-eng/scanner-db:${{ env.tag }}
-          rhacs-eng/scanner-slim:${{ env.tag }}
-          rhacs-eng/scanner-v4-db:${{ env.tag }}
-          rhacs-eng/scanner-v4:${{ env.tag }}
-          rhacs-eng/scanner:${{ env.tag }}
-          rhacs-eng/stackrox-operator:${{ env.operator_tag }}
-
   gke-db-backup-restore-test:
-    needs: [ wait-for-images ]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
-      BUILD_TAG: ${{ needs.wait-for-images.outputs.tag }}
+      MAIN_IMAGE_TAG: ${{ inputs.tag }}
+      BUILD_TAG: ${{ inputs.tag }}
       CI_JOB_NAME: gke-db-backup-restore-test
       ARTIFACT_DIR: ./junit-reports
       LOAD_BALANCER: lb

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   gke-db-backup-restore-test:
-    if: inputs.should-run == 'true'
+    if: inputs.should-run
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -7,6 +7,10 @@ on:
         description: Image tag to test.
         type: string
         required: true
+      should-run:
+        description: true if should really run the job. false - otherwise, i.e. the job should be skipped.
+        type: boolean
+        required: true
 
 permissions:
   contents: read
@@ -18,6 +22,7 @@ defaults:
 
 jobs:
   gke-db-backup-restore-test:
+    if: inputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -23,9 +23,10 @@ defaults:
     shell: bash
 
 jobs:
+
+  # Determines whether we should dispatch jobs that call real E2E workflows.
+  # This allows to skip running E2E tests on draft PRs without corresponding labels or on untrusted forks.
   should-dispatch:
-    if: >-
-      github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-slim
     outputs:
       dispatch-any: ${{ steps.determine.outputs.dispatch-any }}
@@ -86,9 +87,10 @@ jobs:
 
             write('dispatch-any', dispatch_any)
 
+  # Waits for images to be built so we don't start testing until they are available.
   wait-for-images:
-    if: >-
-      github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+    needs: [should-dispatch]
+    if: needs.should-dispatch.outputs.dispatch-any == 'true'
     runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.build-tag.outputs.tag }}
@@ -129,14 +131,8 @@ jobs:
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
   dispatch-e2e-byodb-test:
-    needs: [wait-for-images]
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-byodb-test') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
-      )
+    needs: [wait-for-images, should-dispatch]
+    if: needs.should-dispatch.outputs.e2e-byodb-test == 'true'
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
@@ -146,14 +142,8 @@ jobs:
       cancel-in-progress: true
 
   dispatch-e2e-db-backup-restore-test:
-    needs: [wait-for-images]
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-db-backup-restore-test') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
-      )
+    needs: [wait-for-images, should-dispatch]
+    if: needs.should-dispatch.outputs.e2e-db-backup-restore-test == 'true'
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
@@ -163,14 +153,8 @@ jobs:
       cancel-in-progress: true
 
   dispatch-e2e-gke-upgrade-tests:
-    needs: [wait-for-images]
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-gke-upgrade-tests') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-gke-upgrade-tests')
-      )
+    needs: [wait-for-images, should-dispatch]
+    if: needs.should-dispatch.outputs.e2e-gke-upgrade-tests == 'true'
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
@@ -180,14 +164,8 @@ jobs:
       cancel-in-progress: true
 
   dispatch-e2e-nongroovy-tests:
-    needs: [wait-for-images]
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-nongroovy-tests') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-nongroovy-tests')
-      )
+    needs: [wait-for-images, should-dispatch]
+    if: needs.should-dispatch.outputs.e2e-nongroovy-tests == 'true'
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -152,7 +152,7 @@ jobs:
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-byodb-test }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-byodb-test == 'true' }}
     secrets: inherit
     concurrency:
       group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -163,7 +163,7 @@ jobs:
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-db-backup-restore-test }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-db-backup-restore-test == 'true' }}
     secrets: inherit
     concurrency:
       group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -174,7 +174,7 @@ jobs:
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-gke-upgrade-tests }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-gke-upgrade-tests == 'true' }}
     secrets: inherit
     concurrency:
       group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -185,7 +185,7 @@ jobs:
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-nongroovy-tests }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-nongroovy-tests == 'true' }}
     secrets: inherit
     concurrency:
       group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -116,7 +116,7 @@ jobs:
       # env:
       #   MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
     concurrency:
-      group: wait-for-images-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
     - name: Checkout repo
@@ -151,46 +151,46 @@ jobs:
           rhacs-eng/stackrox-operator-bundle:v${{ env.operator_tag }}
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
-  dispatch-e2e-byodb-test:
+  e2e-byodb-test:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-byodb-test == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
     concurrency:
-      group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  dispatch-e2e-db-backup-restore-test:
+  e2e-db-backup-restore-test:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-db-backup-restore-test == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
     concurrency:
-      group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  dispatch-e2e-gke-upgrade-tests:
+  e2e-gke-upgrade-tests:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-gke-upgrade-tests == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
     concurrency:
-      group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  dispatch-e2e-nongroovy-tests:
+  e2e-nongroovy-tests:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-nongroovy-tests == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
     concurrency:
-      group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -115,6 +115,9 @@ jobs:
       ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
       # env:
       #   MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
+    concurrency:
+      group: wait-for-images-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
     - name: Checkout repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -33,10 +33,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       dispatch-any: ${{ steps.determine.outputs.dispatch-any }}
-      e2e-byodb-test: ${{ steps.determine.outputs.e2e-byodb-test }}
-      e2e-db-backup-restore-test: ${{ steps.determine.outputs.e2e-db-backup-restore-test }}
-      e2e-gke-upgrade-tests: ${{ steps.determine.outputs.e2e-gke-upgrade-tests }}
-      e2e-nongroovy-tests: ${{ steps.determine.outputs.e2e-nongroovy-tests }}
+      jobs: ${{ steps.determine.outputs.jobs }}
     steps:
     - name: Determine whether should dispatch workflows
       id: determine
@@ -51,6 +48,7 @@ jobs:
         all_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         ui_only_change: ${{ needs.detect-changes.outputs.ui_only }}
       run: |
+        import json
         import os
         from types import SimpleNamespace
 
@@ -85,24 +83,20 @@ jobs:
             return False
 
         with open(os.environ['GITHUB_OUTPUT'], mode='at', encoding='utf-8') as file:
-            def write(job, decision):
-                line = f'{job}={str(decision).lower()}'
+            def write(job, val):
+                line = f'{job}={val}'
                 print(line)
                 file.write(line + '\n')
 
-            dispatch_any = False
+            jobs = { job: should_run(job) for job in [
+                    'e2e-byodb-test',
+                    'e2e-db-backup-restore-test',
+                    'e2e-gke-upgrade-tests',
+                    'e2e-nongroovy-tests',
+                ]}
 
-            for job in [
-                'e2e-byodb-test',
-                'e2e-db-backup-restore-test',
-                'e2e-gke-upgrade-tests',
-                'e2e-nongroovy-tests',
-            ]:
-                dispatch = should_run(job)
-                dispatch_any = dispatch_any or dispatch
-                write(job, dispatch)
-
-            write('dispatch-any', dispatch_any)
+            write('jobs', json.dumps(jobs))
+            write('dispatch-any', str(any(jobs.values())).lower())
 
   # Waits for images to be built so we don't start testing until they are available.
   wait-for-images:
@@ -156,7 +150,7 @@ jobs:
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-byodb-test == 'true' }}
+      should-run: ${{ fromJSON(needs.should-dispatch.outputs.jobs).e2e-byodb-test }}
     secrets: inherit
     concurrency:
       group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -167,7 +161,7 @@ jobs:
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-db-backup-restore-test == 'true' }}
+      should-run: ${{ fromJSON(needs.should-dispatch.outputs.jobs).e2e-db-backup-restore-test }}
     secrets: inherit
     concurrency:
       group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -178,7 +172,7 @@ jobs:
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-gke-upgrade-tests == 'true' }}
+      should-run: ${{ fromJSON(needs.should-dispatch.outputs.jobs).e2e-gke-upgrade-tests }}
     secrets: inherit
     concurrency:
       group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -189,7 +183,7 @@ jobs:
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs.e2e-nongroovy-tests == 'true' }}
+      should-run: ${{ fromJSON(needs.should-dispatch.outputs.jobs).e2e-nongroovy-tests }}
     secrets: inherit
     concurrency:
       group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -25,12 +25,12 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork && github.event_name != 'pull_request'
+      github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.build-tag.outputs.tag }}
       operator_tag: ${{ steps.build-tag.outputs.operator_tag }}
-    env:
+    # env:
       ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
       # MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
     steps:
@@ -78,3 +78,6 @@ jobs:
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
     secrets: inherit
+    concurrency:
+      group: e2e-byodb-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -40,28 +40,22 @@ jobs:
       shell: python
       env:
         PYTHONUNBUFFERED: "1"
-        event_name: ${{ github.event_name }}
-        event_action: ${{ github.event.action }}
-        labeled_with: ${{ github.event.label.name }}
-        is_fork: ${{ github.event.pull_request.head.repo.fork }}
-        is_draft: ${{ github.event.pull_request.draft }}
-        all_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-        ui_only_change: ${{ needs.detect-changes.outputs.ui_only }}
+        input__event_name: ${{ github.event_name }}
+        input__event_action: ${{ github.event.action }}
+        input__labeled_with: ${{ github.event.label.name }}
+        input__is_fork: ${{ github.event.pull_request.head.repo.fork }}
+        input__is_draft: ${{ github.event.pull_request.draft }}
+        input__all_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        input__ui_only_change: ${{ needs.detect-changes.outputs.ui_only }}
       run: |
         import json
         import os
         from types import SimpleNamespace
 
-        input = SimpleNamespace(
-            **{var: os.environ[var] for var in (
-                'event_name',
-                'event_action',
-                'labeled_with',
-                'is_fork',
-                'is_draft',
-                'all_labels',
-                'ui_only_change',
-            )})
+        input = SimpleNamespace(**{
+            key.removeprefix('input__'): val
+            for (key, val) in os.environ.items()
+            if key.startswith('input__')})
         for k, v in vars(input).items():
             print(f'{k} = {v}')
 

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -140,10 +140,10 @@ jobs:
 
   dispatch-e2e-byodb-test:
     needs: [wait-for-images, should-dispatch]
-    if: needs.should-dispatch.outputs.e2e-byodb-test == 'true'
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-byodb-test }}
     secrets: inherit
     concurrency:
       group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -151,10 +151,10 @@ jobs:
 
   dispatch-e2e-db-backup-restore-test:
     needs: [wait-for-images, should-dispatch]
-    if: needs.should-dispatch.outputs.e2e-db-backup-restore-test == 'true'
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-db-backup-restore-test }}
     secrets: inherit
     concurrency:
       group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -162,10 +162,10 @@ jobs:
 
   dispatch-e2e-gke-upgrade-tests:
     needs: [wait-for-images, should-dispatch]
-    if: needs.should-dispatch.outputs.e2e-gke-upgrade-tests == 'true'
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-gke-upgrade-tests }}
     secrets: inherit
     concurrency:
       group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -173,10 +173,10 @@ jobs:
 
   dispatch-e2e-nongroovy-tests:
     needs: [wait-for-images, should-dispatch]
-    if: needs.should-dispatch.outputs.e2e-nongroovy-tests == 'true'
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-nongroovy-tests }}
     secrets: inherit
     concurrency:
       group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -55,7 +55,7 @@ jobs:
         from types import SimpleNamespace
 
         input = SimpleNamespace(
-            **{k: os.environ[k] for k in (
+            **{var: os.environ[var] for var in (
                 'event_name',
                 'event_action',
                 'labeled_with',
@@ -112,9 +112,9 @@ jobs:
     outputs:
       tag: ${{ steps.build-tag.outputs.tag }}
       operator_tag: ${{ steps.build-tag.outputs.operator_tag }}
-      # env:
       ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
-      # MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
+      # env:
+      #   MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
     steps:
     - name: Checkout repo
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -145,6 +145,7 @@ jobs:
           rhacs-eng/scanner-v4-db:${{ env.tag }}
           rhacs-eng/scanner-v4:${{ env.tag }}
           rhacs-eng/scanner:${{ env.tag }}
+          rhacs-eng/stackrox-operator-bundle:v${{ env.operator_tag }}
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
   dispatch-e2e-byodb-test:

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -23,6 +23,69 @@ defaults:
     shell: bash
 
 jobs:
+  should-dispatch:
+    if: >-
+      github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-slim
+    outputs:
+      dispatch-any: ${{ steps.determine.outputs.dispatch-any }}
+      e2e-byodb-test: ${{ steps.determine.outputs.e2e-byodb-test }}
+      e2e-db-backup-restore-test: ${{ steps.determine.outputs.e2e-db-backup-restore-test }}
+      e2e-gke-upgrade-tests: ${{ steps.determine.outputs.e2e-gke-upgrade-tests }}
+      e2e-nongroovy-tests: ${{ steps.determine.outputs.e2e-nongroovy-tests }}
+    steps:
+    - name: Determine whether should dispatch workflows
+      id: determine
+      shell: python
+      env:
+        PYTHONUNBUFFERED: "1"
+      run: |
+        import os
+        from types import SimpleNamespace
+
+        input = SimpleNamespace(
+            event_name='${{ github.event_name }}',
+            event_action='${{ github.event.action }}',
+            labeled_with='${{ github.event.label.name }}',
+            is_fork='${{ github.event.pull_request.head.repo.fork }}',
+            is_draft='${{ github.event.pull_request.draft }}',
+            all_labels="${{ join(github.event.pull_request.labels.*.name, ',') }}",
+        )
+        print(input)
+
+        def should_run(job):
+            if input.is_fork == 'true':
+                return False
+            if input.event_action == 'labeled' and input.labeled_with != job:
+                return False
+            if input.event_name != 'pull_request':
+                return True
+            if input.is_draft != 'true':
+                return True
+            if f',{input.all_labels},'.find(f',{job},') >= 0:
+                return True
+            return False
+
+        with open(os.environ['GITHUB_OUTPUT'], mode='at', encoding='utf-8') as file:
+            def write(job, decision):
+                line = f'{job}={str(decision).lower()}'
+                print(line)
+                file.write(line + '\n')
+
+            dispatch_any = False
+
+            for job in [
+                'e2e-byodb-test',
+                'e2e-db-backup-restore-test',
+                'e2e-gke-upgrade-tests',
+                'e2e-nongroovy-tests',
+            ]:
+                dispatch = should_run(job)
+                dispatch_any = dispatch_any or dispatch
+                write(job, dispatch)
+
+            write('dispatch-any', dispatch_any)
+
   wait-for-images:
     if: >-
       github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -23,10 +23,13 @@ defaults:
     shell: bash
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
 
   # Determines whether we should dispatch jobs that call real E2E workflows.
   # This allows to skip running E2E tests on draft PRs without corresponding labels or on untrusted forks.
   should-dispatch:
+    needs: [ detect-changes ]
     runs-on: ubuntu-slim
     outputs:
       dispatch-any: ${{ steps.determine.outputs.dispatch-any }}
@@ -46,6 +49,7 @@ jobs:
         is_fork: ${{ github.event.pull_request.head.repo.fork }}
         is_draft: ${{ github.event.pull_request.draft }}
         all_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        ui_only_change: ${{ needs.detect-changes.outputs.ui_only }}
       run: |
         import os
         from types import SimpleNamespace
@@ -58,6 +62,7 @@ jobs:
                 'is_fork',
                 'is_draft',
                 'all_labels',
+                'ui_only_change',
             )})
         for k, v in vars(input).items():
             print(f'{k} = {v}')
@@ -69,6 +74,10 @@ jobs:
                 return False
             if input.event_name != 'pull_request':
                 return True
+            if input.ui_only_change == 'true':
+                # For now, all the workflows that we dispatch should be skipped for PRs that only change UI.
+                # As we add more E2E test workflows, we may want to make this more flexible.
+                return False
             if input.is_draft != 'true':
                 return True
             if f',{input.all_labels},'.find(f',{job},') >= 0:
@@ -97,13 +106,13 @@ jobs:
 
   # Waits for images to be built so we don't start testing until they are available.
   wait-for-images:
-    needs: [should-dispatch]
+    needs: [ should-dispatch ]
     if: needs.should-dispatch.outputs.dispatch-any == 'true'
     runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.build-tag.outputs.tag }}
       operator_tag: ${{ steps.build-tag.outputs.operator_tag }}
-    # env:
+      # env:
       ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
       # MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
     steps:
@@ -139,7 +148,7 @@ jobs:
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
   dispatch-e2e-byodb-test:
-    needs: [wait-for-images, should-dispatch]
+    needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
@@ -150,7 +159,7 @@ jobs:
       cancel-in-progress: true
 
   dispatch-e2e-db-backup-restore-test:
-    needs: [wait-for-images, should-dispatch]
+    needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
@@ -161,7 +170,7 @@ jobs:
       cancel-in-progress: true
 
   dispatch-e2e-gke-upgrade-tests:
-    needs: [wait-for-images, should-dispatch]
+    needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
@@ -172,7 +181,7 @@ jobs:
       cancel-in-progress: true
 
   dispatch-e2e-nongroovy-tests:
-    needs: [wait-for-images, should-dispatch]
+    needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -81,3 +81,20 @@ jobs:
     concurrency:
       group: e2e-byodb-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
+
+  e2e-db-backup-restore:
+    needs: [wait-for-images]
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e-db-backup-restore-test') &&
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
+      )
+    uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
+    with:
+      tag: ${{ needs.wait-for-images.outputs.tag }}
+    secrets: inherit
+    concurrency:
+      group: e2e-db-backup-restore-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -115,7 +115,7 @@ jobs:
       ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
       # env:
       #   MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
-    concurrency:
+    concurrency: &e2e-concurrency
       group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
@@ -158,9 +158,7 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+    concurrency: *e2e-concurrency
 
   e2e-db-backup-restore-test:
     needs: [ wait-for-images, should-dispatch ]
@@ -169,9 +167,7 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+    concurrency: *e2e-concurrency
 
   e2e-gke-upgrade-tests:
     needs: [ wait-for-images, should-dispatch ]
@@ -180,9 +176,7 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+    concurrency: *e2e-concurrency
 
   e2e-nongroovy-tests:
     needs: [ wait-for-images, should-dispatch ]
@@ -191,6 +185,4 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+    concurrency: *e2e-concurrency

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -40,19 +40,27 @@ jobs:
       shell: python
       env:
         PYTHONUNBUFFERED: "1"
+        event_name: ${{ github.event_name }}
+        event_action: ${{ github.event.action }}
+        labeled_with: ${{ github.event.label.name }}
+        is_fork: ${{ github.event.pull_request.head.repo.fork }}
+        is_draft: ${{ github.event.pull_request.draft }}
+        all_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
       run: |
         import os
         from types import SimpleNamespace
 
         input = SimpleNamespace(
-            event_name='${{ github.event_name }}',
-            event_action='${{ github.event.action }}',
-            labeled_with='${{ github.event.label.name }}',
-            is_fork='${{ github.event.pull_request.head.repo.fork }}',
-            is_draft='${{ github.event.pull_request.draft }}',
-            all_labels="${{ join(github.event.pull_request.labels.*.name, ',') }}",
-        )
-        print(input)
+            **{k: os.environ[k] for k in (
+                'event_name',
+                'event_action',
+                'labeled_with',
+                'is_fork',
+                'is_draft',
+                'all_labels',
+            )})
+        for k, v in vars(input).items():
+            print(f'{k} = {v}')
 
         def should_run(job):
             if input.is_fork == 'true':

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -65,7 +65,7 @@ jobs:
           rhacs-eng/scanner:${{ env.tag }}
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
-  e2e-byodb:
+  dispatch-e2e-byodb-test:
     needs: [wait-for-images]
     if: >-
       (github.event.action != 'labeled' || github.event.label.name == 'e2e-byodb-test') &&
@@ -79,10 +79,10 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
     secrets: inherit
     concurrency:
-      group: e2e-byodb-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  e2e-db-backup-restore:
+  dispatch-e2e-db-backup-restore-test:
     needs: [wait-for-images]
     if: >-
       (github.event.action != 'labeled' || github.event.label.name == 'e2e-db-backup-restore-test') &&
@@ -96,10 +96,10 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
     secrets: inherit
     concurrency:
-      group: e2e-db-backup-restore-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  e2e-gke-upgrade:
+  dispatch-e2e-gke-upgrade-tests:
     needs: [wait-for-images]
     if: >-
       (github.event.action != 'labeled' || github.event.label.name == 'e2e-gke-upgrade-tests') &&
@@ -113,10 +113,10 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
     secrets: inherit
     concurrency:
-      group: e2e-gke-upgrade-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  e2e-nongroovy:
+  dispatch-e2e-nongroovy-tests:
     needs: [wait-for-images]
     if: >-
       (github.event.action != 'labeled' || github.event.label.name == 'e2e-nongroovy-tests') &&

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -98,3 +98,20 @@ jobs:
     concurrency:
       group: e2e-db-backup-restore-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
+
+  e2e-gke-upgrade:
+    needs: [wait-for-images]
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e-gke-upgrade-tests') &&
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-gke-upgrade-tests')
+      )
+    uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
+    with:
+      tag: ${{ needs.wait-for-images.outputs.tag }}
+    secrets: inherit
+    concurrency:
+      group: e2e-gke-upgrade-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -1,0 +1,80 @@
+name: e2e-dispatch
+
+on:
+  push:
+    tags:
+    - '*'
+    branches:
+    - master
+    - release-*
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  wait-for-images:
+    if: >-
+      !github.event.pull_request.head.repo.fork && github.event_name != 'pull_request'
+    runs-on: ubuntu-slim
+    outputs:
+      tag: ${{ steps.build-tag.outputs.tag }}
+      operator_tag: ${{ steps.build-tag.outputs.operator_tag }}
+    env:
+      ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
+      # MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        persist-credentials: false
+    - uses: ./.github/actions/handle-tagged-build
+    - name: Compute build tag
+      id: build-tag
+      run: |
+        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
+        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
+        echo "operator_tag=$(BUILD_TAG="${tag}" make -C operator --quiet --no-print-directory tag)" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
+    - name: Wait for images
+      uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
+      with:
+        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+        image: |
+          rhacs-eng/central-db:${{ env.tag }}
+          rhacs-eng/collector:${{ env.tag }}
+          rhacs-eng/fact:${{ env.tag }}
+          rhacs-eng/main:${{ env.tag }}
+          rhacs-eng/roxctl:${{ env.tag }}
+          rhacs-eng/scanner-db-slim:${{ env.tag }}
+          rhacs-eng/scanner-db:${{ env.tag }}
+          rhacs-eng/scanner-slim:${{ env.tag }}
+          rhacs-eng/scanner-v4-db:${{ env.tag }}
+          rhacs-eng/scanner-v4:${{ env.tag }}
+          rhacs-eng/scanner:${{ env.tag }}
+          rhacs-eng/stackrox-operator:${{ env.operator_tag }}
+
+  e2e-byodb:
+    needs: [wait-for-images]
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e-byodb-test') &&
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
+      )
+    uses: ./.github/workflows/e2e-byodb-test.yaml
+    with:
+      tag: ${{ needs.wait-for-images.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -116,7 +116,7 @@ jobs:
       # env:
       #   MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
     concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: wait-for-images-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
     - name: Checkout repo
@@ -151,46 +151,46 @@ jobs:
           rhacs-eng/stackrox-operator-bundle:v${{ env.operator_tag }}
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
-  e2e-byodb-test:
+  dispatch-e2e-byodb-test:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-byodb-test == 'true' }}
     secrets: inherit
     concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  e2e-db-backup-restore-test:
+  dispatch-e2e-db-backup-restore-test:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-db-backup-restore-test == 'true' }}
     secrets: inherit
     concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  e2e-gke-upgrade-tests:
+  dispatch-e2e-gke-upgrade-tests:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-gke-upgrade-tests == 'true' }}
     secrets: inherit
     concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  e2e-nongroovy-tests:
+  dispatch-e2e-nongroovy-tests:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:
       tag: ${{ needs.wait-for-images.outputs.tag }}
-      should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
+      should-run: ${{ needs.should-dispatch.outputs.e2e-nongroovy-tests == 'true' }}
     secrets: inherit
     concurrency:
-      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -115,3 +115,20 @@ jobs:
     concurrency:
       group: e2e-gke-upgrade-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
+
+  e2e-nongroovy:
+    needs: [wait-for-images]
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e-nongroovy-tests') &&
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-nongroovy-tests')
+      )
+    uses: ./.github/workflows/e2e-nongroovy-tests.yaml
+    with:
+      tag: ${{ needs.wait-for-images.outputs.tag }}
+    secrets: inherit
+    concurrency:
+      group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -115,7 +115,7 @@ jobs:
       ## MAIN_IMAGE_TAG can be used for overriding when you want to run workflows for particular images.
       # env:
       #   MAIN_IMAGE_TAG: 4.12.x-350-gc76d76b0fb
-    concurrency: &e2e-concurrency
+    concurrency:
       group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
@@ -158,7 +158,9 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency: *e2e-concurrency
+    concurrency:
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
   e2e-db-backup-restore-test:
     needs: [ wait-for-images, should-dispatch ]
@@ -167,7 +169,9 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency: *e2e-concurrency
+    concurrency:
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
   e2e-gke-upgrade-tests:
     needs: [ wait-for-images, should-dispatch ]
@@ -176,7 +180,9 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency: *e2e-concurrency
+    concurrency:
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
   e2e-nongroovy-tests:
     needs: [ wait-for-images, should-dispatch ]
@@ -185,4 +191,6 @@ jobs:
       tag: ${{ needs.wait-for-images.outputs.tag }}
       should-run: ${{ needs.should-dispatch.outputs[github.job] == 'true' }}
     secrets: inherit
-    concurrency: *e2e-concurrency
+    concurrency:
+      group: ${{ github.job }}-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -7,6 +7,10 @@ on:
         description: Image tag to test.
         type: string
         required: true
+      should-run:
+        description: true if should really run the job. false - otherwise, i.e. the job should be skipped.
+        type: boolean
+        required: true
 
 permissions:
   contents: read
@@ -20,6 +24,7 @@ jobs:
 
   # Verifies Central DB upgrades/rollbacks.
   gke-upgrade-tests-central:
+    if: inputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}
@@ -163,6 +168,7 @@ jobs:
 
   # Verifies we can do Postgres major version upgrade.
   gke-upgrade-tests-postgres:
+    if: inputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}
@@ -305,6 +311,7 @@ jobs:
 
   # Verifies Sensor/Secured Cluster `upgrader` (applicable to manifest installations only).
   gke-upgrade-tests-sensor:
+    if: inputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -1,19 +1,12 @@
 name: e2e-gke-upgrade-tests
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-    - '*'
-    branches:
-    - master
-    - release-*
-  pull_request:
-    types:
-    - opened
-    - reopened
-    - synchronize
-    - labeled
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to test.
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -23,60 +16,12 @@ defaults:
   run:
     shell: bash
 
-jobs:
-  wait-for-images:
-    if: >-
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-gke-upgrade-tests') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-gke-upgrade-tests')
-      )
-    runs-on: ubuntu-slim
-    outputs:
-      tag: ${{ steps.get-tag.outputs.tag }}
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        persist-credentials: false
-    - uses: ./.github/actions/handle-tagged-build
-    - name: Get image tag
-      id: get-tag
-      run: |
-        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
-        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
-        echo "operator_tag=$(BUILD_TAG="${tag}" make -C operator --quiet --no-print-directory tag)" | tee -a "$GITHUB_ENV"
-    - name: Wait for images
-      uses: stackrox/actions/release/wait-for-image@79f8a64e6701be953c23ef1718fcc186a2fb0d0d # ratchet:stackrox/actions/release/wait-for-image@v1
-      with:
-        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-        image: |
-          rhacs-eng/central-db:${{ env.tag }}
-          rhacs-eng/collector:${{ env.tag }}
-          rhacs-eng/fact:${{ env.tag }}
-          rhacs-eng/main:${{ env.tag }}
-          rhacs-eng/roxctl:${{ env.tag }}
-          rhacs-eng/scanner-db-slim:${{ env.tag }}
-          rhacs-eng/scanner-db:${{ env.tag }}
-          rhacs-eng/scanner-slim:${{ env.tag }}
-          rhacs-eng/scanner-v4-db:${{ env.tag }}
-          rhacs-eng/scanner-v4:${{ env.tag }}
-          rhacs-eng/scanner:${{ env.tag }}
-          rhacs-eng/stackrox-operator:${{ env.operator_tag }}
-
-  # Verifies Central DB upgrades/rollbacks.
+jobs:  # Verifies Central DB upgrades/rollbacks.
   gke-upgrade-tests-central:
-    needs: [ wait-for-images ]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-gke-upgrade-tests-central
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
-      BUILD_TAG: ${{ needs.wait-for-images.outputs.tag }}
+      MAIN_IMAGE_TAG: ${{ inputs.tag }}
+      BUILD_TAG: ${{ inputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
       # The cluster name must be no longer than 26 characters.
@@ -216,14 +161,10 @@ jobs:
 
   # Verifies we can do Postgres major version upgrade.
   gke-upgrade-tests-postgres:
-    needs: [ wait-for-images ]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-gke-upgrade-tests-postgres
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
-      BUILD_TAG: ${{ needs.wait-for-images.outputs.tag }}
+      MAIN_IMAGE_TAG: ${{ inputs.tag }}
+      BUILD_TAG: ${{ inputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
       # The cluster name must be no longer than 26 characters.
@@ -362,14 +303,10 @@ jobs:
 
   # Verifies Sensor/Secured Cluster `upgrader` (applicable to manifest installations only).
   gke-upgrade-tests-sensor:
-    needs: [ wait-for-images ]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-gke-upgrade-tests-sensor
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
-      BUILD_TAG: ${{ needs.wait-for-images.outputs.tag }}
+      MAIN_IMAGE_TAG: ${{ inputs.tag }}
+      BUILD_TAG: ${{ inputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
       # The cluster name must be no longer than 26 characters.

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -24,7 +24,7 @@ jobs:
 
   # Verifies Central DB upgrades/rollbacks.
   gke-upgrade-tests-central:
-    if: inputs.should-run == 'true'
+    if: inputs.should-run
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}
@@ -168,7 +168,7 @@ jobs:
 
   # Verifies we can do Postgres major version upgrade.
   gke-upgrade-tests-postgres:
-    if: inputs.should-run == 'true'
+    if: inputs.should-run
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}
@@ -311,7 +311,7 @@ jobs:
 
   # Verifies Sensor/Secured Cluster `upgrader` (applicable to manifest installations only).
   gke-upgrade-tests-sensor:
-    if: inputs.should-run == 'true'
+    if: inputs.should-run
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -16,7 +16,9 @@ defaults:
   run:
     shell: bash
 
-jobs:  # Verifies Central DB upgrades/rollbacks.
+jobs:
+
+  # Verifies Central DB upgrades/rollbacks.
   gke-upgrade-tests-central:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   gke-nongroovy-e2e-tests:
-    if: inputs.should-run == 'true'
+    if: inputs.should-run
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -1,19 +1,12 @@
 name: e2e-nongroovy-tests
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-    - '*'
-    branches:
-    - master
-    - release-*
-  pull_request:
-    types:
-    - opened
-    - reopened
-    - synchronize
-    - labeled
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to test.
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,63 +17,11 @@ defaults:
     shell: bash
 
 jobs:
-  detect-changes:
-    uses: ./.github/workflows/detect-changes.yml
-
-  wait-for-images:
-    needs: detect-changes
-    if: >-
-      !needs.detect-changes.outputs.ui_only &&
-      (github.event.action != 'labeled' || github.event.label.name == 'e2e-nongroovy-tests') &&
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        !github.event.pull_request.draft ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-nongroovy-tests')
-      )
-    runs-on: ubuntu-slim
-    outputs:
-      tag: ${{ steps.build-tag.outputs.tag }}
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
-        persist-credentials: false
-    - uses: ./.github/actions/handle-tagged-build
-    - name: Compute build tag
-      id: build-tag
-      run: |
-        tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
-        echo "tag=$tag" | tee -a "$GITHUB_OUTPUT" -a "$GITHUB_ENV"
-        echo "operator_tag=$(BUILD_TAG="${tag}" make -C operator --quiet --no-print-directory tag)" | tee -a "$GITHUB_ENV"
-    - name: Wait for images
-      uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
-      with:
-        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
-        image: |
-          rhacs-eng/central-db:${{ env.tag }}
-          rhacs-eng/collector:${{ env.tag }}
-          rhacs-eng/fact:${{ env.tag }}
-          rhacs-eng/main:${{ env.tag }}
-          rhacs-eng/roxctl:${{ env.tag }}
-          rhacs-eng/scanner-db-slim:${{ env.tag }}
-          rhacs-eng/scanner-db:${{ env.tag }}
-          rhacs-eng/scanner-slim:${{ env.tag }}
-          rhacs-eng/scanner-v4-db:${{ env.tag }}
-          rhacs-eng/scanner-v4:${{ env.tag }}
-          rhacs-eng/scanner:${{ env.tag }}
-          rhacs-eng/stackrox-operator:${{ env.operator_tag }}
-
   gke-nongroovy-e2e-tests:
-    needs: [ wait-for-images ]
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
-      MAIN_IMAGE_TAG: ${{ needs.wait-for-images.outputs.tag }}
-      BUILD_TAG: ${{ needs.wait-for-images.outputs.tag }}
+      MAIN_IMAGE_TAG: ${{ inputs.tag }}
+      BUILD_TAG: ${{ inputs.tag }}
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
       CI_JOB_NAME: gke-nongroovy-e2e-tests

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -7,6 +7,10 @@ on:
         description: Image tag to test.
         type: string
         required: true
+      should-run:
+        description: true if should really run the job. false - otherwise, i.e. the job should be skipped.
+        type: boolean
+        required: true
 
 permissions:
   contents: read
@@ -18,6 +22,7 @@ defaults:
 
 jobs:
   gke-nongroovy-e2e-tests:
+    if: inputs.should-run == 'true'
     runs-on: ubuntu-latest
     env:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}


### PR DESCRIPTION
## Description

Context/discussion thread: https://redhat-internal.slack.com/archives/C0321S70YK1/p1782833488180039?thread_ts=1782139688.440169&cid=C0321S70YK1

This consolidates all GHA-driven E2E workflows to be dispatched from a single point to reduce the duplication in `wait-for-images` job and to make run/not-run decisions all in one place consistently.
* I hope this would allow us in the future to more easily make changes that allow running E2E tests on forks.
* Claude says there's a limit of 20 sub-workflows that can be dispatched via `uses`/`workflow_call` from a workflow. If/when we hit this limit, we'd have to set up another `e2e-dispatch.yaml` copy.
* Here I made all four subworkflows be skipped if it's a PR with UI-only change. Also, this is effective only for PRs now, in branch pushes we'll have it all running.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change to tests themselves.

### How I validated my change

By observing GHA CI.