### PR TITLE
fix(scanner):  rc_ref does not overwrite production bundles

### DIFF
--- a/.github/workflows/scripts/scanner-get-released-tags.sh
+++ b/.github/workflows/scripts/scanner-get-released-tags.sh
@@ -87,10 +87,6 @@ while read -r line; do
 
     read -r version ref <<< "$line"
 
-    # We only append `-rc` if reference is a "release version" reference, and
-    # use RC is true, setting to false by default.
-    append_rc="false"
-
     case $ref in
         heads/*)
             resolved_tag="${ref#heads/}"
@@ -101,7 +97,6 @@ while read -r line; do
         *)
             # Assume anything else is a release version reference.
             resolved_tag=${version_map[$ref]:-}
-            [[ "$use_rc" == "true" ]] && append_rc="true"
             ;;
     esac
 
@@ -127,7 +122,8 @@ while read -r line; do
             ;;
     esac
 
-    if [[ "$append_rc" == "true" ]]; then
+    # RC builds upload to the RC stream (e.g. v2-rc).
+    if [[ "$use_rc" == "true" ]]; then
         version="$version-rc"
     fi
 


### PR DESCRIPTION
## Description

When triggering the vulnerability bundle workflow with `rc_ref` and a `heads/*` or `tags/*` reference, the `-rc` suffix was not appended to the version stream. This meant the bundle would be uploaded to the production stream (e.g., `v2`) instead of the RC stream (`v2-rc`).

The `-rc` suffix was only appended for "release version" references (the `*` case in the ref format switch), but `heads/*` and `tags/*` refs bypassed that logic entirely. This fix moves the `-rc` append to apply for all ref formats when `SCANNER_RELEASE_ALLOW_RC` is set.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready

### How I validated my change

Read the script logic and traced the code path for each ref format (`heads/*`, `tags/*`, `*`) with `SCANNER_RELEASE_ALLOW_RC=true`. Before the fix, only the `*` case set `append_rc="true"`. After the fix, all three cases append `-rc` when `use_rc` is `true`.