### PR TITLE
fix(feed): Improve NVD feed download resilience

### DIFF
--- a/.github/workflows/scripts/scanner-update-nvd-api.py
+++ b/.github/workflows/scripts/scanner-update-nvd-api.py
@@ -47,7 +47,7 @@ class ApiLoader:
         index, total = 0, 0
         logging.info(f"Fetching page from {start} to {end}")
         backoff_time = 10
-        max_retries = 5
+        max_retries = 10
 
         while total == 0 or index < total:
             try:
@@ -72,7 +72,7 @@ class ApiLoader:
                     yield {"cve": item['cve']}
 
                 index += data['resultsPerPage']
-                max_retries = 5  # Reset retries
+                max_retries = 10  # Reset retries
                 backoff_time = 1
             except Exception as e:
                 logging.error(f"Failed to download page at index {index}: {e}")

--- a/.github/workflows/scripts/scanner-update-nvd-api.py
+++ b/.github/workflows/scripts/scanner-update-nvd-api.py
@@ -47,7 +47,7 @@ class ApiLoader:
         index, total = 0, 0
         logging.info(f"Fetching page from {start} to {end}")
         backoff_time = 10
-        max_retries = 3
+        max_retries = 5
 
         while total == 0 or index < total:
             try:
@@ -62,7 +62,7 @@ class ApiLoader:
                 req = request.Request(url)
                 req.headers = {'apiKey': API_KEY}
 
-                with request.urlopen(req, timeout=45) as response:
+                with request.urlopen(req, timeout=120) as response:
                     data = json.loads(response.read().decode())
 
                 total = data['totalResults']
@@ -72,7 +72,7 @@ class ApiLoader:
                     yield {"cve": item['cve']}
 
                 index += data['resultsPerPage']
-                max_retries = 3  # Reset retries
+                max_retries = 5  # Reset retries
                 backoff_time = 1
             except Exception as e:
                 logging.error(f"Failed to download page at index {index}: {e}")

--- a/.github/workflows/scripts/scanner-update-nvd-feeds.py
+++ b/.github/workflows/scripts/scanner-update-nvd-feeds.py
@@ -5,9 +5,11 @@ Fetch NVD data from the JSON 2.0 feed archives and save into files.
 """
 
 import gzip
+import io
 import json
 import logging
 import os
+import time
 from urllib import request
 from urllib import parse
 
@@ -27,10 +29,24 @@ class FeedLoader:
 
     def fetch(self, year):
         url = parse.urljoin(self._base_url, f"nvdcve-2.0-{year}.json.gz")
-        self.log.info("fetching and decompressing: %s", url)
-        with request.urlopen(url, timeout=60) as resp:
-            with gzip.GzipFile(fileobj=resp) as gz:
-                data = json.load(gz)
+        backoff_time = 10
+        max_retries = 5
+        while True:
+            try:
+                self.log.info("fetching and decompressing: %s", url)
+                with request.urlopen(url, timeout=120) as resp:
+                    with gzip.GzipFile(fileobj=io.BytesIO(resp.read())) as gz:
+                        data = json.load(gz)
+                break
+            except Exception as e:
+                if max_retries > 0:
+                    self.log.warning("failed to fetch %s: %s", url, e)
+                    self.log.info("retrying in %d seconds...", backoff_time)
+                    time.sleep(backoff_time)
+                    backoff_time *= 2
+                    max_retries -= 1
+                else:
+                    raise
         yield from (v for v in data["vulnerabilities"]
         if v["cve"]["vulnStatus"].lower() != "rejected")
 

--- a/.github/workflows/scripts/scanner-update-nvd-feeds.py
+++ b/.github/workflows/scripts/scanner-update-nvd-feeds.py
@@ -30,7 +30,7 @@ class FeedLoader:
     def fetch(self, year):
         url = parse.urljoin(self._base_url, f"nvdcve-2.0-{year}.json.gz")
         backoff_time = 10
-        max_retries = 5
+        max_retries = 10
         while True:
             try:
                 self.log.info("fetching and decompressing: %s", url)


### PR DESCRIPTION
## Description

The NVD feed and API update scripts are failing in CI due to timeouts and incomplete reads from the NVD servers. Larger responses consistently exceed the current timeout values and exhaust retry budgets.

- Increase HTTP request timeout from 60s/45s to 120s in both scripts
- Add retry logic with exponential backoff to the feeds script (previously had none — a single timeout killed the entire run)
- Increase max retries from 3 to 10 in the API script
- Buffer the gzip response into memory before decompression in the feeds script so truncated downloads are caught as retryable errors

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

no tests modified

### How I validated my change

CI in this PR (`pr-update-scanner-nvd`) + locally


```
 $ python3 scanner-update-nvd-feeds.py dignore
2026-06-30 10:38:09,317: INFO: root fetching '2002' to 'dignore/2002.nvd.json'
2026-06-30 10:38:09,317: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2002.json.gz
2026-06-30 10:38:38,211: INFO: root fetching '2003' to 'dignore/2003.nvd.json'
2026-06-30 10:38:38,211: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2003.json.gz
2026-06-30 10:38:44,775: INFO: root fetching '2004' to 'dignore/2004.nvd.json'
2026-06-30 10:38:44,775: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2004.json.gz
2026-06-30 10:39:13,291: INFO: root fetching '2005' to 'dignore/2005.nvd.json'
2026-06-30 10:39:13,291: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2005.json.gz
2026-06-30 10:39:46,311: INFO: root fetching '2006' to 'dignore/2006.nvd.json'
2026-06-30 10:39:46,312: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2006.json.gz
2026-06-30 10:40:24,076: INFO: root fetching '2007' to 'dignore/2007.nvd.json'
2026-06-30 10:40:24,077: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2007.json.gz
2026-06-30 10:41:07,300: INFO: root fetching '2008' to 'dignore/2008.nvd.json'
2026-06-30 10:41:07,300: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2008.json.gz
2026-06-30 10:42:15,118: INFO: root fetching '2009' to 'dignore/2009.nvd.json'
2026-06-30 10:42:15,118: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2009.json.gz
2026-06-30 10:43:01,119: INFO: root fetching '2010' to 'dignore/2010.nvd.json'
2026-06-30 10:43:01,119: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2010.json.gz
2026-06-30 10:44:08,033: INFO: root fetching '2011' to 'dignore/2011.nvd.json'
2026-06-30 10:44:08,034: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2011.json.gz
2026-06-30 10:45:00,118: INFO: root fetching '2012' to 'dignore/2012.nvd.json'
2026-06-30 10:45:00,119: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2012.json.gz
2026-06-30 10:46:23,745: INFO: root fetching '2013' to 'dignore/2013.nvd.json'
2026-06-30 10:46:23,745: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2013.json.gz
2026-06-30 10:47:34,350: WARNING: FeedLoader failed to fetch https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2013.json.gz: IncompleteRead(2059720 bytes read, 3737796 more expected)
2026-06-30 10:47:34,350: INFO: FeedLoader retrying in 10 seconds...
2026-06-30 10:47:44,353: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2013.json.gz
2026-06-30 10:48:44,696: INFO: root fetching '2014' to 'dignore/2014.nvd.json'
2026-06-30 10:48:44,696: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2014.json.gz
2026-06-30 10:49:41,196: INFO: root fetching '2015' to 'dignore/2015.nvd.json'
2026-06-30 10:49:41,196: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2015.json.gz
2026-06-30 10:50:25,236: INFO: root fetching '2016' to 'dignore/2016.nvd.json'
2026-06-30 10:50:25,236: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2016.json.gz
2026-06-30 10:52:16,340: INFO: root fetching '2017' to 'dignore/2017.nvd.json'
2026-06-30 10:52:16,341: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2017.json.gz
2026-06-30 10:53:26,697: INFO: root fetching '2018' to 'dignore/2018.nvd.json'
2026-06-30 10:53:26,698: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2018.json.gz
2026-06-30 10:55:11,627: WARNING: FeedLoader failed to fetch https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2018.json.gz: IncompleteRead(5527625 bytes read, 2725119 more expected)
2026-06-30 10:55:11,627: INFO: FeedLoader retrying in 10 seconds...
2026-06-30 10:55:21,632: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2018.json.gz
2026-06-30 10:56:58,286: INFO: root fetching '2019' to 'dignore/2019.nvd.json'
2026-06-30 10:56:58,286: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2019.json.gz
2026-06-30 10:58:55,134: INFO: root fetching '2020' to 'dignore/2020.nvd.json'
2026-06-30 10:58:55,134: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2020.json.gz
2026-06-30 11:02:06,519: INFO: root fetching '2021' to 'dignore/2021.nvd.json'
2026-06-30 11:02:06,520: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2021.json.gz
2026-06-30 11:05:09,899: INFO: root fetching '2022' to 'dignore/2022.nvd.json'
2026-06-30 11:05:09,900: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2022.json.gz
2026-06-30 11:09:03,250: INFO: root fetching '2023' to 'dignore/2023.nvd.json'
2026-06-30 11:09:03,251: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2023.json.gz
2026-06-30 11:13:57,304: INFO: root fetching '2024' to 'dignore/2024.nvd.json'
2026-06-30 11:13:57,305: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2024.json.gz
2026-06-30 11:18:20,115: INFO: root fetching '2025' to 'dignore/2025.nvd.json'
2026-06-30 11:18:20,115: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2025.json.gz
2026-06-30 11:22:23,032: INFO: root fetching '2026' to 'dignore/2026.nvd.json'
2026-06-30 11:22:23,033: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2026.json.gz
2026-06-30 11:25:56,482: WARNING: FeedLoader failed to fetch https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2026.json.gz: IncompleteRead(8584537 bytes read, 6503597 more expected)
2026-06-30 11:25:56,483: INFO: FeedLoader retrying in 10 seconds...
2026-06-30 11:26:06,489: INFO: FeedLoader fetching and decompressing: https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-2026.json.gz
```