### PR TITLE
chore(scanner): bump claircore to fix alias insertion deadlock

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -38,6 +38,13 @@ openshift_ci_mods
 openshift_ci_import_creds
 create_exit_trap
 
+# Enable Scanner V4 by default for all e2e jobs. openshift/release currently
+# hardcodes ROX_SCANNER_V4=false; this override can be removed once that is
+# dropped. Individual job scripts can opt out via os.environ["ROX_SCANNER_V4"].
+#
+# TODO(ROX-35345): remove this
+export ROX_SCANNER_V4=true
+
 ci_export CI_JOB_NAME "$ci_job"
 
 case "$ci_job" in

--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.0
-	github.com/quay/claircore v1.5.53-0.20260707004258-056d5d6861dc
+	github.com/quay/claircore v1.5.54
 	github.com/quay/claircore/toolkit v1.6.1
 	github.com/quay/zlog/v2 v2.1.1
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1176,8 +1176,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.21.0 h1:Qh/e6TlBjZf+XLLqNCqFGmCU6Kj/2Bu7kj3oAc0UnXc=
 github.com/prometheus/procfs v0.21.0/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/quay/claircore v1.5.53-0.20260707004258-056d5d6861dc h1:0cVVzSL5jAAzx1BWJGaNzpmPbv3ZajyDA9DM5iY3z4c=
-github.com/quay/claircore v1.5.53-0.20260707004258-056d5d6861dc/go.mod h1:gdGZL96h2k8nWXAesV+1z6xKswlSTcbALNsglVkBhTA=
+github.com/quay/claircore v1.5.54 h1:NC7+QfwV8yo/KJ/B8mz1GD8BIG16aIJ3FuHcBTnsjL4=
+github.com/quay/claircore v1.5.54/go.mod h1:hOp0JqY8vOZPdBakFRt3JwG8q4K+gnRkG9RGzt1DoB4=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.6.1 h1:a3X1v28n5bo05T94cBlaoPU8xYCErRGPM3l6AlmYWj4=
 github.com/quay/claircore/toolkit v1.6.1/go.mod h1:dTzlp1pgNchc+CN73HJiG9+e0ygU54QPt397eXnGGo4=


### PR DESCRIPTION
## Description

Bump claircore to include the alias insertion deadlock fix (quay/claircore#1891). When multiple matcher replicas import vulnerability bundles concurrently, they deadlocked on the `alias_namespace` table. The fix moves alias inserts outside the transaction.

Also enables Scanner V4 in CI e2e tests by setting `ROX_SCANNER_V4=true` in `dispatch.sh` (same approach as #21098).

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests (Scanner V4 enabled in CI)

### How I validated my change

This enabled Scanner V4 in CI.

**CI (all pass):** 7/7 Prow e2e jobs passed with `ROX_SCANNER_V4=true`, including GKE and OpenShift suites. No OOM kills, no test failures. Scanner V4 matcher readiness (vulnerability import) took 19–39 min across jobs, within the 40-min CI timeout.

| Job | Matcher ready in |
|-----|-----------------|
| gke-nongroovy-e2e-tests | 25m |
| gke-qa-e2e-tests | 30m |
| gke-ui-e2e-tests | 39m |
| ocp-4-12-nongroovy-e2e-tests | 19m |
| ocp-4-21-nongroovy-e2e-tests | 25m |
| ocp-4-22-nongroovy-e2e-tests | 27m |

**Manual cluster testing:** Deployed on GKE and OpenShift clusters with 1 and 3 matcher replicas. Verified vuln rows > 0 (~8.4M), zero deadlocks, import time ~39 min (down from ~55 min baseline). See quay/claircore#1934 comments for detailed results.

#### Manual cluster testing on this PR's image

```
Date:             2026-07-17
Variant:          claircore PR #1891 merged (no memory optimization)
ClairCore commit: 910c3c5e on main
StackRox commit:  d355bbdd2d on branch claircore-1934-test
Image tag:        4.12.x-535-gd355bbdd2d
Cluster:          GKE jvdm-steelhead (12h lifespan)
Matcher replicas: 1
Storage class:    premium-rwo
```

Links: [PR #1891](https://github.com/quay/claircore/pull/1891), [stackrox#21503](https://github.com/stackrox/stackrox/pull/21503), [claircore-1934-test branch](https://github.com/stackrox/stackrox/tree/claircore-1934-test)

Compared against: [`runs/2026-07-15-baseline-rerun/`](/home/jvmartin/tmp/open/rox-32912-not-affected/results/claircore-1934/runs/2026-07-15-baseline-rerun/run-log.md) (OpenShift, same code on fork branch)

#### Image verification

Confirm the deployed image uses the intended claircore commit, not a stale or wrong branch.

```
$ grep 'quay/claircore' go.mod | grep -v toolkit | grep -v indirect
      github.com/quay/claircore v1.5.53-0.20260717161407-910c3c5ea267
```

Direct dependency on claircore main (no replace directive). Includes merged PR #1891 commits `f70c12d1`, `074c3168`, `40ee9061`. **PASS**

#### Cluster verification

Confirm no leftover deployment from a previous test and the expected storage class is available.

```
$ kubectl get ns stackrox
Error from server (NotFound): namespaces "stackrox" not found

$ kubectl get storageclass | grep premium
premium-rwo   pd.csi.storage.gke.io   Delete   WaitForFirstConsumer   true   5m53s
```

**PASS**

#### Metrics collection

Start polling `kubectl top pod` every 30s before deploying, so we capture memory from the very beginning of the import (which starts immediately on pod startup).

```
Polling PID: 1233918 (writing to kubectl-top.log)
```

**PASS**

#### Deploy

Install StackRox with the test image and verify the matcher pod is running with the correct image tag and replica count.

```
$ kubectl get pods -n stackrox | grep scanner-v4-matcher
scanner-v4-matcher-5bf54fbc85-p5jzs   1/1   Running   0   2m10s

$ kubectl -n stackrox get deploy scanner-v4-matcher -o jsonpath='{.spec.template.spec.containers[0].image}'
quay.io/rhacs-eng/scanner-v4:4.12.x-535-gd355bbdd2d
```

1 matcher replica, correct image. **PASS**

#### Heap profiling

Capture Go heap snapshots via pprof at key moments during the import to identify what's consuming memory. Port-forward to the matcher's debug endpoint on port 9443.

```
$ curl -sk https://localhost:9443/debug/heap --output heap-XX.pb.gz
```

| Profile | Timestamp (UTC) | Bundle phase | kubectl top | File size |
|---------|-----------------|-------------|-------------|-----------|
| heap-01 | 19:09:57 | early (pre-osv) | — | 11,974 |
| heap-02 | 19:26:58 | rhel-vex (7s in) | — | 57,375 |
| heap-03 | 19:33:58 | rhel-vex (~7min in) | 1364 MiB | 62,611 |
| heap-04 | 19:41:01 | rhel-vex (~14min, 11s before end) | 1471 MiB | 64,764 |
| heap-05 | 20:01:31 | post-import (idle) | 1071 MiB | 72,043 |

All 5 profiles captured. Port-forward restarted before heap-05. **PASS**

#### Timing

Extract per-bundle import durations from matcher logs to verify the fix doesn't regress import performance.

```
$ kubectl logs deploy/scanner-v4-matcher -c matcher | grep -E '"starting bundle|"completed bundle'
```

| Bundle | Start (UTC) | End (UTC) | Duration |
|--------|-------------|-----------|----------|
| alpine | 19:18:41 | 19:18:55 | 14s |
| aws | 19:18:55 | 19:19:21 | 26s |
| cisa-kev | 19:19:21 | 19:19:21 | <1s |
| debian | 19:19:21 | 19:19:47 | 26s |
| epss | 19:19:47 | 19:20:55 | 1m8s |
| manual | 19:20:55 | 19:20:55 | <1s |
| nvd | 19:20:55 | 19:21:57 | 1m2s |
| oracle | 19:21:57 | 19:23:32 | 1m35s |
| osv | 19:23:32 | 19:26:23 | 2m51s |
| photon | 19:26:23 | 19:26:51 | 28s |
| rhel-vex | 19:26:51 | 19:41:12 | **14m21s** |
| stackrox-rhel-csaf | 19:41:12 | 19:41:25 | 13s |
| suse | 19:41:25 | 19:52:40 | 11m15s |
| ubuntu | 19:52:40 | 19:58:03 | 5m23s |
| **Total** | **19:18:41** | **20:01:26** | **~39 min** |

All 14 bundles completed (new: `cisa-kev.json.zst`). **PASS**

#### Errors and deadlocks
Grep matcher logs for deadlocks or import errors. The deadlock fix is the whole point of this change; zero deadlocks confirms it works.

```
$ kubectl logs deploy/scanner-v4-matcher -c matcher | grep -iE 'deadlock|error' | grep -v 'connection refused'
{"level":"ERROR","msg":"errors encountered during updater run","reason":"received status code 404 querying update endpoint"}
{"level":"ERROR","msg":"errors encountered during updater run","reason":"received status code 404 querying update endpoint"}
```


Two 404 errors during startup — Central's update endpoint wasn't ready when the matcher first tried to fetch bundles. Transient startup race, not import errors. Deadlocks: **0**. Import errors: **0**. **PASS**

#### DB validation

Query the database directly to confirm vulnerabilities were actually inserted. The iterator exhaustion bug caused zero vuln rows with no log errors, so this is the only way to detect that class of failure.

```
$ kubectl exec deploy/scanner-v4-db -c db -- psql -U postgres -t -c "SELECT count(*) FROM vuln"
 8424326

$ kubectl exec deploy/scanner-v4-db -c db -- psql -U postgres -t -c "SELECT count(*) FROM alias"
 571880

$ kubectl exec deploy/scanner-v4-db -c db -- psql -U postgres -t -c "SELECT count(*) FROM last_vuln_update"
 14
```

Raw output saved to `db-vuln-count.txt`, `db-alias-count.txt`, `db-bundle-count.txt`. **PASS**

#### Summary

| Metric | This run (GKE) | Baseline rerun (OCP, Jul 15) | Pass/Fail |
|--------|----------------|------------------------------|-----------|
| vuln rows | 8,424,326 | 8,272,857 | PASS |
| alias rows | 571,880 | 570,401 | PASS |
| bundles completed | 14 | 13 | PASS (new: cisa-kev) |
| Deadlocks | 0 | 0 | PASS |
| Import errors | 0 | 0 | PASS |
| Total import time | ~39 min | ~41 min | PASS |
| rhel-vex duration | 14m21s | 14m31s | PASS |
| Peak memory (kubectl top) | 1471 MiB (14min mark) | 1585 MiB | BASELINE |
| Post-import memory | 1071 MiB | 776 MiB | — |
| Heap profiles captured | 5/5 | 5/5 | PASS |

**Overall verdict: PASS**

#### Evidence files

All in [`runs/2026-07-17-pr1891-gke/`](/home/jvmartin/tmp/open/rox-32912-not-affected/results/claircore-1934/runs/2026-07-17-pr1891-gke/):

```
bundle-timing.log          — raw matcher log lines for timing
errors.log                 — filtered error/deadlock lines
db-vuln-count.txt          — raw kubectl exec output: vuln count
db-alias-count.txt         — raw kubectl exec output: alias count
db-bundle-count.txt        — raw kubectl exec output: bundle count
kubectl-top.log            — periodic kubectl top snapshots (30s interval)
profile-log.txt            — automated capture script log with timestamps
heap-01-early.pb.gz        — Go heap profile: early import
heap-02-rhelvex-start.pb.gz — Go heap profile: rhel-vex start
heap-03-rhelvex-mid.pb.gz  — Go heap profile: rhel-vex ~7min
heap-04-rhelvex-end.pb.gz  — Go heap profile: rhel-vex ~14min
heap-05-post-import.pb.gz  — Go heap profile: post-import idle
script-output.log          — full script stdout
```
