### PR TITLE
ROX-33621: Port roxagent host-probing diagnostics to pull mode

### DIFF
--- a/compliance/virtualmachines/roxagent/cmd/diagnostics.go
+++ b/compliance/virtualmachines/roxagent/cmd/diagnostics.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"errors"
+	"io/fs"
+	"maps"
+	"os"
+	"slices"
+
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+)
+
+// logFilesystemDiagnostics logs a compact summary of host filesystem facts
+// (DNF version, entitlement certificates, repo files) that are useful for
+// debugging scan issues, regardless of whether the report ends up empty.
+func logFilesystemDiagnostics(hostPath string) {
+	switch hostprobe.DetectDNFVersion(hostPath) {
+	case hostprobe.DNFVersion5:
+		log.Info("DNF history DB (v5) found")
+	case hostprobe.DNFVersion4:
+		log.Info("DNF history DB (v4) found")
+	default:
+		log.Warn("DNF history DB not found!")
+	}
+
+	hasEntitlement, err := hostprobe.HasEntitlementCertKeyPair(hostPath)
+	if err != nil {
+		log.Warnf("Entitlement certificates not found: %v", err)
+	} else if !hasEntitlement {
+		log.Warn("Entitlement certificates not found")
+	} else {
+		log.Info("Entitlement certificates found")
+	}
+
+	allReposDirs := append(slices.Clone(hostprobe.DNF4ReposDirs), hostprobe.DNF5ReposDirPath)
+	hasRepo, err := hostprobe.HasAnyRepoFile(os.DirFS(hostPath), allReposDirs)
+	if err != nil {
+		logRepoError(err)
+		return
+	}
+	if !hasRepo {
+		log.Info("Repo dirs are present but contain 0 .repo files")
+		return
+	}
+	log.Info("Repo dirs contain .repo files")
+}
+
+func logRepoError(err error) {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		log.Info("No repo directories found")
+	case errors.Is(err, fs.ErrPermission):
+		log.Warnf("Repo directories are not readable: %v", err)
+	default:
+		log.Infof("Repo directories are unavailable: %v", err)
+	}
+}
+
+// logIndexReportDiagnostics logs a summary of the freshly generated index
+// report so that "0 packages scanned" issues can be diagnosed from agent
+// logs alone. Repository/distribution listings are truncated to the first
+// 10 entries to keep logs bounded on hosts with many repos.
+func logIndexReportDiagnostics(report *v4.IndexReport) {
+	const maxListedEntries = 10
+
+	contents := report.GetContents()
+
+	numPkgs := len(contents.GetPackages())
+	numRepos := len(contents.GetRepositories())
+	numDists := len(contents.GetDistributions())
+	numEnvs := len(contents.GetEnvironments())
+
+	log.Infof("Index report summary: packages=%d, repositories=%d, distributions=%d, environments=%d",
+		numPkgs, numRepos, numDists, numEnvs)
+
+	repos := contents.GetRepositories()
+	for repoIdx, id := range slices.Sorted(maps.Keys(repos)) {
+		repo := repos[id]
+		log.Infof("Repository (%d of %d) id=%q name=%q key=%q cpe=%q",
+			repoIdx+1, numRepos, id, repo.GetName(), repo.GetKey(), repo.GetCpe())
+		if repoIdx+1 >= maxListedEntries && numRepos > maxListedEntries {
+			log.Infof("  (%d more truncated for brevity)", numRepos-maxListedEntries)
+			break
+		}
+	}
+	dists := contents.GetDistributions()
+	for distIdx, id := range slices.Sorted(maps.Keys(dists)) {
+		dist := dists[id]
+		log.Infof("Distribution (%d of %d) id=%s name=%q version=%q cpe=%q did=%q",
+			distIdx+1, numDists, id, dist.GetName(), dist.GetVersion(), dist.GetCpe(), dist.GetDid())
+		if distIdx+1 >= maxListedEntries && numDists > maxListedEntries {
+			log.Infof("  (%d more truncated for brevity)", numDists-maxListedEntries)
+			break
+		}
+	}
+
+	if numRepos == 0 {
+		log.Warn("Index report contains 0 repositories. Packages will be marked as UNSCANNED.")
+	}
+}

--- a/compliance/virtualmachines/roxagent/cmd/diagnostics.go
+++ b/compliance/virtualmachines/roxagent/cmd/diagnostics.go
@@ -4,37 +4,45 @@ import (
 	"errors"
 	"io/fs"
 	"maps"
-	"os"
 	"slices"
 
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 )
 
 // logFilesystemDiagnostics logs a compact summary of host filesystem facts
 // (DNF version, entitlement certificates, repo files) that are useful for
 // debugging scan issues, regardless of whether the report ends up empty.
-func logFilesystemDiagnostics(hostPath string) {
-	switch hostprobe.DetectDNFVersion(hostPath) {
-	case hostprobe.DNFVersion5:
+//
+// DNF version and entitlement status are read from d, the DiscoveredData
+// scanWithDiagnostics already computed for this same hostPath - reprobing
+// them here would just repeat, on every scan and rescan, filesystem checks
+// discovery.DiscoverVMData already did. Repo-file presence is the one fact
+// still probed directly: DiscoveredData only carries a found/not-found
+// flag, not the reason (missing dir vs. unreadable vs. empty) that
+// logRepoError distinguishes for debugging "0 repositories" issues.
+func logFilesystemDiagnostics(hostPath string, d *v1.DiscoveredData) {
+	switch {
+	case slices.Contains(d.GetDnfStatus(), v1.DnfStatusFlag_DNF_V5_HISTORY_DB_FOUND):
 		log.Info("DNF history DB (v5) found")
-	case hostprobe.DNFVersion4:
+	case slices.Contains(d.GetDnfStatus(), v1.DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND):
 		log.Info("DNF history DB (v4) found")
 	default:
 		log.Warn("DNF history DB not found!")
 	}
 
-	hasEntitlement, err := hostprobe.HasEntitlementCertKeyPair(hostPath)
-	if err != nil {
-		log.Warnf("Entitlement certificates not found: %v", err)
-	} else if !hasEntitlement {
-		log.Warn("Entitlement certificates not found")
-	} else {
+	switch d.GetActivationStatus() {
+	case v1.ActivationStatus_ACTIVE:
 		log.Info("Entitlement certificates found")
+	case v1.ActivationStatus_INACTIVE:
+		log.Warn("Entitlement certificates not found")
+	default:
+		log.Warn("Entitlement certificate status could not be determined")
 	}
 
 	allReposDirs := append(slices.Clone(hostprobe.DNF4ReposDirs), hostprobe.DNF5ReposDirPath)
-	hasRepo, err := hostprobe.HasAnyRepoFile(os.DirFS(hostPath), allReposDirs)
+	hasRepo, err := hostprobe.HasAnyRepoFileAt(hostPath, allReposDirs)
 	if err != nil {
 		logRepoError(err)
 		return

--- a/compliance/virtualmachines/roxagent/cmd/diagnostics_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/diagnostics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,32 +74,44 @@ func TestLogRepoError(t *testing.T) {
 }
 
 // TestLogFilesystemDiagnostics exercises logFilesystemDiagnostics against
-// synthetic hostPath layouts covering DNF4/DNF5 detection, entitlement
-// presence/absence, and repo-file presence/absence. As with the other
-// diagnostics tests, only "does not panic" is asserted.
+// every DnfStatusFlag/ActivationStatus combination it branches on (fed in
+// directly via DiscoveredData, the way scanWithDiagnostics's already-probed
+// data flows in) crossed with repo-file presence/absence/error on disk,
+// which is the one fact this function still probes itself. As with the
+// other diagnostics tests, only "does not panic" is asserted.
 func TestLogFilesystemDiagnostics(t *testing.T) {
-	t.Run("dnf4 host with entitlement and repo files", func(t *testing.T) {
-		hostPath := t.TempDir()
-		writeFile(t, hostprobe.HostPathFor(hostPath, hostprobe.DNF4HistoryDBPath), "db")
-		writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.EntitlementDirPath), "1-key.pem"), "k")
-		writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.EntitlementDirPath), "1.pem"), "c")
-		writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.YumReposDirPath), "redhat.repo"), "[baseos]")
+	tests := map[string]*v1.DiscoveredData{
+		"dnf4 detected, activated": {
+			DnfStatus:        []v1.DnfStatusFlag{v1.DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND},
+			ActivationStatus: v1.ActivationStatus_ACTIVE,
+		},
+		"dnf5 detected, inactive": {
+			DnfStatus:        []v1.DnfStatusFlag{v1.DnfStatusFlag_DNF_V5_HISTORY_DB_FOUND},
+			ActivationStatus: v1.ActivationStatus_INACTIVE,
+		},
+		"neither dnf version detected, activation unspecified": {},
+	}
 
-		assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath) })
-	})
+	for name, d := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Run("repo files present", func(t *testing.T) {
+				hostPath := t.TempDir()
+				writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.YumReposDirPath), "redhat.repo"), "[baseos]")
+				assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath, d) })
+			})
 
-	t.Run("dnf5 host with no entitlement and no repo files", func(t *testing.T) {
-		hostPath := t.TempDir()
-		writeFile(t, hostprobe.HostPathFor(hostPath, hostprobe.DNF5HistoryDBPath), "db")
-		require.NoError(t, os.MkdirAll(hostprobe.HostPathFor(hostPath, hostprobe.YumReposDirPath), 0o755))
+			t.Run("repo dir present but empty", func(t *testing.T) {
+				hostPath := t.TempDir()
+				require.NoError(t, os.MkdirAll(hostprobe.HostPathFor(hostPath, hostprobe.YumReposDirPath), 0o755))
+				assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath, d) })
+			})
 
-		assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath) })
-	})
-
-	t.Run("bare host with nothing present", func(t *testing.T) {
-		hostPath := t.TempDir()
-		assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath) })
-	})
+			t.Run("repo dir missing", func(t *testing.T) {
+				hostPath := t.TempDir()
+				assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath, d) })
+			})
+		})
+	}
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/compliance/virtualmachines/roxagent/cmd/diagnostics_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/diagnostics_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// indexReportWith builds a minimal *v4.IndexReport with numRepos repositories
+// and numDists distributions, keyed "id-0", "id-1", ... so that
+// logIndexReportDiagnostics's truncation logic can be exercised deterministically.
+func indexReportWith(numRepos, numDists int) *v4.IndexReport {
+	repos := make(map[string]*v4.Repository, numRepos)
+	for i := range numRepos {
+		id := fmt.Sprintf("repo-%02d", i)
+		repos[id] = &v4.Repository{Name: id, Key: "key", Cpe: "cpe"}
+	}
+	dists := make(map[string]*v4.Distribution, numDists)
+	for i := range numDists {
+		id := fmt.Sprintf("dist-%02d", i)
+		dists[id] = &v4.Distribution{Name: id, Version: "1", Cpe: "cpe", Did: "did"}
+	}
+	return &v4.IndexReport{
+		Contents: &v4.Contents{
+			Repositories:  repos,
+			Distributions: dists,
+		},
+	}
+}
+
+// TestLogIndexReportDiagnostics exercises every branch of the truncation and
+// zero-repositories logic. Assertions are limited to "does not panic": the
+// function only produces log output, so branch/statement coverage is the
+// goal here, not asserting exact log content.
+func TestLogIndexReportDiagnostics(t *testing.T) {
+	tests := map[string]*v4.IndexReport{
+		"nil report":                      nil,
+		"report with nil contents":        {},
+		"empty contents":                  indexReportWith(0, 0),
+		"fewer than truncation threshold": indexReportWith(3, 2),
+		"exactly at truncation threshold": indexReportWith(10, 10),
+		"over truncation threshold":       indexReportWith(15, 12),
+	}
+
+	for name, report := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.NotPanics(t, func() { logIndexReportDiagnostics(report) })
+		})
+	}
+}
+
+// TestLogRepoError exercises every branch of logRepoError's errors.Is switch.
+func TestLogRepoError(t *testing.T) {
+	tests := map[string]error{
+		"not exist":  fmt.Errorf("wrapped: %w", fs.ErrNotExist),
+		"permission": fmt.Errorf("wrapped: %w", fs.ErrPermission),
+		"other":      errors.New("some other failure"),
+	}
+
+	for name, err := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.NotPanics(t, func() { logRepoError(err) })
+		})
+	}
+}
+
+// TestLogFilesystemDiagnostics exercises logFilesystemDiagnostics against
+// synthetic hostPath layouts covering DNF4/DNF5 detection, entitlement
+// presence/absence, and repo-file presence/absence. As with the other
+// diagnostics tests, only "does not panic" is asserted.
+func TestLogFilesystemDiagnostics(t *testing.T) {
+	t.Run("dnf4 host with entitlement and repo files", func(t *testing.T) {
+		hostPath := t.TempDir()
+		writeFile(t, hostprobe.HostPathFor(hostPath, hostprobe.DNF4HistoryDBPath), "db")
+		writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.EntitlementDirPath), "1-key.pem"), "k")
+		writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.EntitlementDirPath), "1.pem"), "c")
+		writeFile(t, filepath.Join(hostprobe.HostPathFor(hostPath, hostprobe.YumReposDirPath), "redhat.repo"), "[baseos]")
+
+		assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath) })
+	})
+
+	t.Run("dnf5 host with no entitlement and no repo files", func(t *testing.T) {
+		hostPath := t.TempDir()
+		writeFile(t, hostprobe.HostPathFor(hostPath, hostprobe.DNF5HistoryDBPath), "db")
+		require.NoError(t, os.MkdirAll(hostprobe.HostPathFor(hostPath, hostprobe.YumReposDirPath), 0o755))
+
+		assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath) })
+	})
+
+	t.Run("bare host with nothing present", func(t *testing.T) {
+		hostPath := t.TempDir()
+		assert.NotPanics(t, func() { logFilesystemDiagnostics(hostPath) })
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}

--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -30,7 +30,7 @@ type rescanner struct {
 	mappingFilePath string
 	interval        time.Duration
 
-	// scanFn defaults to the package scan function; tests override it to
+	// scanFn defaults to scanWithDiagnostics; tests override it to
 	// inject failures. factsFn defaults to the package discoverFacts
 	// function; tests override it to avoid exercising the real
 	// filesystem, since discoverFacts otherwise reads real host paths
@@ -49,7 +49,7 @@ func newRescanner(cache *vsockserver.ReportCache, hostPath, mappingFilePath stri
 		hostPath:        hostPath,
 		mappingFilePath: mappingFilePath,
 		interval:        interval,
-		scanFn:          scan,
+		scanFn:          scanWithDiagnostics,
 		factsFn:         discoverFacts,
 		newDelay:        time.After,
 	}

--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -30,16 +30,16 @@ type rescanner struct {
 	mappingFilePath string
 	interval        time.Duration
 
-	// scanFn defaults to scanWithDiagnostics; tests override it to
-	// inject failures. factsFn defaults to the package discoverFacts
-	// function; tests override it to avoid exercising the real
-	// filesystem, since discoverFacts otherwise reads real host paths
-	// (e.g. hostPath="" resolves to "/etc/pki/entitlement" et al., not a
-	// no-op). newDelay defaults to time.After (a one-shot timer); tests
-	// substitute a function returning a manually driven channel for
+	// scanFn defaults to scanWithDiagnostics, which returns the facts
+	// alongside the report from the same DiscoveredData probe used for
+	// diagnostics logging, rather than making Run probe the filesystem a
+	// second time for them. Tests override scanFn to inject failures and
+	// avoid exercising the real filesystem, since hostPath="" otherwise
+	// resolves to real absolute host paths (e.g. "/etc/pki/entitlement"),
+	// not a no-op. newDelay defaults to time.After (a one-shot timer);
+	// tests substitute a function returning a manually driven channel for
 	// precise control over Run's loop.
-	scanFn   func(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, error)
-	factsFn  func(hostPath string) map[string]string
+	scanFn   func(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, map[string]string, error)
 	newDelay func(d time.Duration) <-chan time.Time
 }
 
@@ -50,7 +50,6 @@ func newRescanner(cache *vsockserver.ReportCache, hostPath, mappingFilePath stri
 		mappingFilePath: mappingFilePath,
 		interval:        interval,
 		scanFn:          scanWithDiagnostics,
-		factsFn:         discoverFacts,
 		newDelay:        time.After,
 	}
 }
@@ -69,7 +68,7 @@ func (r *rescanner) Run(ctx context.Context) {
 			return
 		case <-delay:
 			log.Info("Starting rescan")
-			report, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath)
+			report, facts, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath)
 			if err != nil {
 				retryIn := min(backoff, r.interval)
 				log.Errorf("Rescan failed: %v; trying again in %v", err, retryIn)
@@ -77,7 +76,7 @@ func (r *rescanner) Run(ctx context.Context) {
 				delay = r.newDelay(retryIn)
 				continue
 			}
-			r.cache.SetReport(report, r.factsFn(r.hostPath))
+			r.cache.SetReport(report, facts)
 			log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
 			backoff = rescanRetryBaseBackoff
 			delay = r.newDelay(r.interval)

--- a/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
@@ -16,14 +16,12 @@ import (
 
 // testRescanner returns a rescanner with a long default interval so tests
 // that don't care about the periodic loop never trigger it by accident.
-// factsFn is stubbed out so Run never exercises the real discoverFacts,
-// which - unlike scanFn - has no test-friendly no-op input; hostPath=""
-// resolves to real absolute host paths (e.g. "/etc/pki/entitlement"), not
-// a safe default.
+// Every test overrides scanFn directly, so Run never exercises the real
+// scanWithDiagnostics, which - unlike the stub - has no test-friendly no-op
+// input; hostPath="" resolves to real absolute host paths (e.g.
+// "/etc/pki/entitlement"), not a safe default.
 func testRescanner() *rescanner {
-	r := newRescanner(&vsockserver.ReportCache{}, "", "", time.Hour)
-	r.factsFn = func(string) map[string]string { return nil }
-	return r
+	return newRescanner(&vsockserver.ReportCache{}, "", "", time.Hour)
 }
 
 // fakeTicker is a newDelay func driven manually by a test: fire triggers a
@@ -72,11 +70,12 @@ func TestRescanner_Run(t *testing.T) {
 			r.newDelay = ticker.newDelay
 			var mu sync.Mutex
 			var calls int
-			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, error) {
-				return concurrency.WithLock2(&mu, func() (*v4.IndexReport, error) {
+			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, map[string]string, error) {
+				report, err := concurrency.WithLock2(&mu, func() (*v4.IndexReport, error) {
 					calls++
 					return &v4.IndexReport{HashId: "ok"}, nil
 				})
+				return report, nil, err
 			}
 
 			ctx, cancel := context.WithCancel(t.Context())
@@ -107,14 +106,15 @@ func TestRescanner_Run(t *testing.T) {
 			r.newDelay = ticker.newDelay
 			var mu sync.Mutex
 			var calls int
-			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, error) {
-				return concurrency.WithLock2(&mu, func() (*v4.IndexReport, error) {
+			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, map[string]string, error) {
+				report, err := concurrency.WithLock2(&mu, func() (*v4.IndexReport, error) {
 					calls++
 					if calls == 1 {
 						return nil, errors.New("transient scan error")
 					}
 					return &v4.IndexReport{HashId: "ok"}, nil
 				})
+				return report, nil, err
 			}
 
 			ctx, cancel := context.WithCancel(t.Context())

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -124,11 +124,11 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	cache := &vsockserver.ReportCache{}
 	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
 
-	report, err := scanWithDiagnostics(ctx, cfg.hostPath, mappingCachePath)
+	report, facts, err := scanWithDiagnostics(ctx, cfg.hostPath, mappingCachePath)
 	if err != nil {
 		return fmt.Errorf("initial scan: %w", err)
 	}
-	cache.SetReport(report, discoverFacts(cfg.hostPath))
+	cache.SetReport(report, facts)
 	log.Infof("Initial scan complete, report cached. Num packages: %d", len(report.GetContents().GetPackages()))
 
 	handler := vsockserver.NewHandler(cache, agentVersion)
@@ -174,17 +174,23 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 // in push mode, so scan issues (e.g. "0 packages" or "0 repositories") can be
 // triaged from agent logs regardless of transport mode. Used for both the
 // initial scan and every periodic rescan (see newRescanner's scanFn).
-func scanWithDiagnostics(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, error) {
+//
+// DiscoveredData is computed once here and returned as facts alongside the
+// report, rather than left for the caller to recompute via discoverFacts:
+// that would probe the same filesystem facts (DNF version, entitlement)
+// this function already probed for logFilesystemDiagnostics.
+func scanWithDiagnostics(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, map[string]string, error) {
 	// This may slow the indexing process down by 1-2 seconds, but the diagnostics are invaluable for debugging.
-	logFilesystemDiagnostics(hostPath)
+	d := discovery.DiscoverVMData(hostPath)
+	logFilesystemDiagnostics(hostPath, d)
 
 	report, err := scan(ctx, hostPath, mappingFilePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	logIndexReportDiagnostics(report)
-	return report, nil
+	return report, discoveredDataFacts(d), nil
 }
 
 // scan indexes the VM filesystem at hostPath, consulting the
@@ -202,8 +208,16 @@ func scan(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexRepor
 	return index.NewNodeIndexer(cfg).IndexNode(ctx)
 }
 
+// discoverFacts probes hostPath for DiscoveredData and converts it to the
+// flat string map cache.SetReport expects. scanWithDiagnostics does not call
+// this: it already has DiscoveredData in hand from its own diagnostics
+// logging and converts it directly via discoveredDataFacts, so as not to
+// probe the filesystem a second time for the same facts.
 func discoverFacts(hostPath string) map[string]string {
-	d := discovery.DiscoverVMData(hostPath)
+	return discoveredDataFacts(discovery.DiscoverVMData(hostPath))
+}
+
+func discoveredDataFacts(d *v1.DiscoveredData) map[string]string {
 	return map[string]string{
 		"detected_os":         d.GetDetectedOs().String(),
 		"os_version":          d.GetOsVersion(),

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/mdlayher/vsock"
@@ -21,6 +23,7 @@ import (
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/discovery"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -121,7 +124,7 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	cache := &vsockserver.ReportCache{}
 	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
 
-	report, err := scan(ctx, cfg.hostPath, mappingCachePath)
+	report, err := scanWithDiagnostics(ctx, cfg.hostPath, mappingCachePath)
 	if err != nil {
 		return fmt.Errorf("initial scan: %w", err)
 	}
@@ -166,6 +169,24 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	return nil
 }
 
+// scanWithDiagnostics runs the node indexer and surrounds it with filesystem
+// and report diagnostics logging. This mirrors the diagnostics roxagent logs
+// in push mode, so scan issues (e.g. "0 packages" or "0 repositories") can be
+// triaged from agent logs regardless of transport mode. Used for both the
+// initial scan and every periodic rescan (see newRescanner's scanFn).
+func scanWithDiagnostics(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, error) {
+	// This may slow the indexing process down by 1-2 seconds, but the diagnostics are invaluable for debugging.
+	logFilesystemDiagnostics(hostPath)
+
+	report, err := scan(ctx, hostPath, mappingFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	logIndexReportDiagnostics(report)
+	return report, nil
+}
+
 // scan indexes the VM filesystem at hostPath, consulting the
 // repository-to-CPE mapping data cached at mappingFilePath. It never makes
 // a network call itself: mappingRefresher is solely responsible for
@@ -188,7 +209,20 @@ func discoverFacts(hostPath string) map[string]string {
 		"os_version":          d.GetOsVersion(),
 		"activation_status":   d.GetActivationStatus().String(),
 		"dnf_metadata_status": d.GetDnfMetadataStatus().String(),
+		"dnf_status":          formatDnfStatusFlags(d.GetDnfStatus()),
 	}
+}
+
+func formatDnfStatusFlags(flags []v1.DnfStatusFlag) string {
+	if len(flags) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(flags))
+	for _, f := range flags {
+		names = append(names, f.String())
+	}
+	slices.Sort(names)
+	return strings.Join(names, ", ")
 }
 
 // selfSignedCert generates a self-signed ECDSA TLS certificate.

--- a/compliance/virtualmachines/roxagent/cmd/serve_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,6 +71,40 @@ func TestRunServe_ValidatesFlags(t *testing.T) {
 			tt.mutate(&cfg)
 			err := runServe(t.Context(), cfg)
 			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+func TestFormatDnfStatusFlags(t *testing.T) {
+	tests := map[string]struct {
+		flags    []v1.DnfStatusFlag
+		expected string
+	}{
+		"nil flags": {
+			flags:    nil,
+			expected: "none",
+		},
+		"empty flags": {
+			flags:    []v1.DnfStatusFlag{},
+			expected: "none",
+		},
+		"single flag": {
+			flags:    []v1.DnfStatusFlag{v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND},
+			expected: "DNF_REPO_CONFIG_FOUND",
+		},
+		"multiple flags are sorted": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND,
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+			},
+			expected: "DNF_REPO_CONFIG_FOUND, DNF_V4_CACHE_FOUND, DNF_V4_HISTORY_DB_FOUND",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatDnfStatusFlags(tt.flags))
 		})
 	}
 }

--- a/compliance/virtualmachines/roxagent/discovery/discovery.go
+++ b/compliance/virtualmachines/roxagent/discovery/discovery.go
@@ -3,40 +3,23 @@ package discovery
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/set"
 )
 
 var log = logging.LoggerForModule()
 
 const (
-	osReleasePath         = "/etc/os-release"
-	entitlementDirPath    = "/etc/pki/entitlement"
-	dnfCacheDirPath       = "/var/cache/dnf"
-	entitlementKeySuffix  = "-key.pem"
-	entitlementCertSuffix = ".pem"
-	// osReleaseIDKey is the key name for the ID field in /etc/os-release.
-	osReleaseIDKey = "ID"
-	// osReleaseVersionIDKey is the key name for the VERSION_ID field in /etc/os-release.
+	osReleaseIDKey        = "ID"
 	osReleaseVersionIDKey = "VERSION_ID"
-	// rhelOSID is the value of the ID field in /etc/os-release for Red Hat Enterprise Linux.
-	rhelOSID = "rhel"
+	rhelOSID              = "rhel"
 )
-
-var defaultReposDirs = []string{
-	"/etc/yum.repos.d",
-	"/etc/yum/repos.d",
-	"/etc/distro.repos.d",
-}
 
 // DiscoverVMData discovers VM metadata from the host system.
 // Returns discovered data with defaults (UNKNOWN/UNSPECIFIED) if discovery fails.
@@ -48,7 +31,7 @@ func DiscoverVMData(hostPath string) *v1.DiscoveredData {
 	// and extracts VERSION_ID field as the OS version. Falls back to UNKNOWN for non-RHEL systems.
 	// This behavior is based on assumptions about /etc/os-release format and RHEL-specific values.
 	// Future improvements may include support for other OS types and more robust version detection.
-	detectedOS, osVersion, err := discoverOSAndVersionWithPath(hostPathFor(hostPath, osReleasePath))
+	detectedOS, osVersion, err := discoverOSAndVersionWithPath(hostprobe.HostPathFor(hostPath, hostprobe.OSReleasePath))
 	if err != nil {
 		log.Infof("Unable to discover OS and version: %v", err)
 	} else {
@@ -62,37 +45,25 @@ func DiscoverVMData(hostPath string) *v1.DiscoveredData {
 	// otherwise INACTIVE. This behavior is based on assumptions about RHEL entitlement certificate naming
 	// conventions and file structure. Future improvements may include actual certificate validation and
 	// support for other activation mechanisms.
-	activationStatus, err := discoverActivationStatusWithPath(hostPathFor(hostPath, entitlementDirPath))
+	activationStatus, err := discoverActivationStatus(hostPath)
 	if err != nil {
 		log.Infof("Observations during discovering activation status: %v", err)
 	}
 	// Some errors are of a warning nature, so we still set the discovery result.
 	result.ActivationStatus = activationStatus
 
-	// Discover DNF metadata status.
-	dnfStatus, err := discoverDnfMetadataStatusWithPaths(
-		hostPath,
-		defaultReposDirs,
-		dnfCacheDirPath,
+	// Discover granular DNF status flags and derive the legacy metadata status.
+	dnfFlags, err := discoverDnfStatusFlags(hostPath,
+		hostprobe.DNF4ReposDirs, []string{hostprobe.DNF5ReposDirPath},
+		hostprobe.DNF4CacheDirPath, hostprobe.DNF5CacheDirPath,
 	)
 	if err != nil {
-		log.Infof("Observations during discovering DNF metadata status: %v", err)
+		log.Debugf("Observations during discovering DNF status flags: %v", err)
 	}
-	// Some errors are of a warning nature, so we still set the discovery result.
-	result.DnfMetadataStatus = dnfStatus
+	result.DnfStatus = dnfFlags
+	result.DnfMetadataStatus = deriveLegacyDnfMetadataStatus(dnfFlags)
 
 	return result
-}
-
-func hostPathFor(hostPath, path string) string {
-	if hostPath == "" || hostPath == string(os.PathSeparator) {
-		return path
-	}
-	// This join+clean approach is safe (no escape from hostPath) only when
-	// the input path is absolute (e.g., "/etc/os-release"). For example,
-	// hostPath="/host", path="/../etc/os-release" would clean to "/etc/os-release".
-	trimmedPath := strings.TrimPrefix(path, string(os.PathSeparator))
-	return filepath.Clean(filepath.Join(hostPath, trimmedPath))
 }
 
 // discoverOSAndVersionWithPath reads os-release from the given path and returns DetectedOS and OSVersion.
@@ -115,7 +86,6 @@ func discoverOSAndVersionWithPath(path string) (v1.DetectedOS, string, error) {
 		return v1.DetectedOS_UNKNOWN, "", fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	// Determine DetectedOS based on ID field
 	var detectedOS v1.DetectedOS
 	if id, ok := osRelease[osReleaseIDKey]; ok && strings.TrimSpace(id) == rhelOSID {
 		detectedOS = v1.DetectedOS_RHEL
@@ -123,7 +93,6 @@ func discoverOSAndVersionWithPath(path string) (v1.DetectedOS, string, error) {
 		detectedOS = v1.DetectedOS_UNKNOWN
 	}
 
-	// Get OS version from VERSION_ID
 	var osVersion string
 	if versionID, ok := osRelease[osReleaseVersionIDKey]; ok {
 		if detectedOS != v1.DetectedOS_UNKNOWN {
@@ -193,137 +162,14 @@ var osReleaseDQReplacer = strings.NewReplacer(
 	`\$`, `$`,
 )
 
-// discoverActivationStatusWithPath checks the given path for matching cert/key pairs.
-func discoverActivationStatusWithPath(path string) (v1.ActivationStatus, error) {
-	entries, err := os.ReadDir(path)
+// discoverActivationStatus checks the host for matching entitlement cert/key pairs.
+func discoverActivationStatus(hostPath string) (v1.ActivationStatus, error) {
+	hasPair, err := hostprobe.HasEntitlementCertKeyPair(hostPath)
 	if err != nil {
-		return v1.ActivationStatus_ACTIVATION_UNSPECIFIED, fmt.Errorf("reading %s: %w", path, err)
+		return v1.ActivationStatus_ACTIVATION_UNSPECIFIED, err
 	}
-
-	// Build sets of base names (without suffix) for keys and certs
-	keyBases := set.NewStringSet()
-	certBases := set.NewStringSet()
-
-	// The `entries` are already sorted by name, so optimistically we just need to check two files.
-	// We can stop when first matching pair is found.
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-
-		name := entry.Name()
-		if before, ok := strings.CutSuffix(name, entitlementKeySuffix); ok {
-			base := before
-			keyBases.Add(base)
-			if certBases.Contains(base) {
-				return v1.ActivationStatus_ACTIVE, nil
-			}
-		} else if before, ok := strings.CutSuffix(name, entitlementCertSuffix); ok {
-			base := before
-			certBases.Add(base)
-			if keyBases.Contains(base) {
-				return v1.ActivationStatus_ACTIVE, nil
-			}
-		}
+	if hasPair {
+		return v1.ActivationStatus_ACTIVE, nil
 	}
-
 	return v1.ActivationStatus_INACTIVE, nil
-}
-
-// discoverDnfMetadataStatusWithPaths checks both repos and cache directories.
-// Currently assumes RHEL DNF setup: checks for both (1) at least one *.repo file in a default reposdir
-// (/etc/yum.repos.d, /etc/yum/repos.d, /etc/distro.repos.d) and (2) at least one directory in
-// /var/cache/dnf containing "-rpms-" in its name. Metadata is considered AVAILABLE only if both
-// conditions are met.
-func discoverDnfMetadataStatusWithPaths(hostPath string, reposDirPaths []string, cacheDirPath string) (v1.DnfMetadataStatus, error) {
-	hasRepoDir, hasRepoFile, err := discoverDnfRepoFilePresence(hostPath, reposDirPaths)
-	if !hasRepoDir {
-		return v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED, err
-	}
-	if !hasRepoFile {
-		return v1.DnfMetadataStatus_UNAVAILABLE, err
-	}
-
-	hasCacheRepoDir, err := discoverDnfCacheRepoDirPresence(hostPath, cacheDirPath)
-	if err != nil {
-		return v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED, err
-	}
-
-	if hasCacheRepoDir {
-		return v1.DnfMetadataStatus_AVAILABLE, nil
-	}
-	return v1.DnfMetadataStatus_UNAVAILABLE, nil
-}
-
-// discoverDnfRepoFilePresence reports whether any default reposdir contains a *.repo file.
-// Assumptions and behavior:
-//   - Uses the default DNF reposdir locations: /etc/yum.repos.d, /etc/yum/repos.d, /etc/distro.repos.d.
-//   - Returns hasDir=true when at least one reposdir is readable.
-//   - Returns hasRepo=true as soon as a *.repo file is found in any reposdir.
-//   - If reposdirs are unreadable, or contain no *.repo files, returns an aggregated error describing each failure.
-//   - There is no support for DNF 5 defaults currently.
-//   - Tested against DNF 4 defaults (libdnf ConfigMain.cpp):
-//     https://github.com/rpm-software-management/libdnf/blob/53839f5bd88f378e57a1f1671b3db48d29984e24/libdnf/conf/ConfigMain.cpp
-//   - DNF 5 uses a different reposdir list (/etc/yum.repos.d, /etc/distro.repos.d, /usr/share/dnf5/repos.d),
-//     so this logic may miss repos configured only in the DNF 5 default path:
-//     https://github.com/rpm-software-management/dnf5/blob/185eaef1e0ad663bdb827a2179ab1df574a27d88/include/libdnf5/conf/const.hpp
-func discoverDnfRepoFilePresence(hostPath string, reposDirPaths []string) (hasDir, hasRepo bool, err error) {
-	if len(reposDirPaths) == 0 {
-		return false, false, errors.New("missing repository directories")
-	}
-
-	// Check for repo files in default reposdir locations.
-	var repoDirErrs *multierror.Error
-	for _, reposDirPath := range reposDirPaths {
-		reposPath := hostPathFor(hostPath, reposDirPath)
-		repoEntries, err := os.ReadDir(reposPath)
-		if err != nil {
-			repoDirErrs = multierror.Append(repoDirErrs, fmt.Errorf("reading %q: %w", reposPath, err))
-			continue
-		}
-		// If at least one directory exists and is readable, we don't need to return DNF_METADATA_UNSPECIFIED.
-		hasDir = true
-
-		for _, entry := range repoEntries {
-			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".repo") {
-				return true, true, nil
-			}
-		}
-		repoDirErrs = multierror.Append(repoDirErrs, fmt.Errorf("no .repo files found in %q", reposPath))
-
-	}
-
-	return hasDir, hasRepo, repoDirErrs.ErrorOrNil()
-}
-
-// discoverDnfCacheRepoDirPresence reports whether the DNF cache contains repo directories.
-// Assumptions and behavior:
-//   - Uses the default system cachedir at /var/cache/dnf (libdnf Const.hpp):
-//     https://github.com/rpm-software-management/libdnf/blob/53839f5bd88f378e57a1f1671b3db48d29984e24/libdnf/conf/Const.hpp
-//   - Treats any subdirectory containing "-rpms-" as a repo cache directory.
-//   - Returns true as soon as a matching directory is found.
-//   - If the cache directory is missing, returns an "unsupported OS detected" error.
-//   - If the cache directory exists but cannot be read, returns a read error.
-//   - There is no support for DNF 5 defaults currently.
-//   - Tested against DNF 4 defaults; DNF 5 uses /var/cache/libdnf5:
-//     https://github.com/rpm-software-management/dnf5/blob/185eaef1e0ad663bdb827a2179ab1df574a27d88/include/libdnf5/conf/const.hpp
-func discoverDnfCacheRepoDirPresence(hostPath, cacheDirPath string) (bool, error) {
-	cachePath := hostPathFor(hostPath, cacheDirPath)
-	cacheEntries, err := os.ReadDir(cachePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, fmt.Errorf("unsupported OS detected: missing %s: %w", cachePath, err)
-		}
-		return false, fmt.Errorf("reading %s: %w", cachePath, err)
-	}
-
-	for _, entry := range cacheEntries {
-		if entry.IsDir() {
-			// Check if it looks like a repo directory (contains "-rpms-" pattern)
-			if strings.Contains(entry.Name(), "-rpms-") {
-				return true, nil
-			}
-		}
-	}
-	return false, nil
 }

--- a/compliance/virtualmachines/roxagent/discovery/discovery_test.go
+++ b/compliance/virtualmachines/roxagent/discovery/discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,7 +89,6 @@ VERSION_ID="12"`,
 			err := os.WriteFile(testOsReleasePath, []byte(tt.osRelease), 0644)
 			require.NoError(t, err)
 
-			// Use a testable version that accepts a path
 			detectedOS, osVersion, err := discoverOSAndVersionWithPath(testOsReleasePath)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedOS, detectedOS)
@@ -120,135 +120,6 @@ func TestDiscoverOSAndVersion_MalformedOSRelease(t *testing.T) {
 	assert.Equal(t, "", osVersion)
 }
 
-func TestDiscoverDnfRepoFilePresence(t *testing.T) {
-	tests := map[string]struct {
-		setup            func(t *testing.T) (string, []string)
-		expectedHasDir   bool
-		expectedHasRepo  bool
-		expectedErrParts []string
-	}{
-		"should return true when repo file exists in reposdir": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				reposDirPath := "/etc/yum.repos.d"
-				reposPath := hostPathFor(hostPath, reposDirPath)
-				require.NoError(t, os.MkdirAll(reposPath, 0750))
-				repoFilePath := filepath.Join(reposPath, "test.repo")
-				require.NoError(t, os.WriteFile(repoFilePath, []byte("content"), 0600))
-				return hostPath, []string{reposDirPath}
-			},
-			expectedHasDir:  true,
-			expectedHasRepo: true,
-		},
-		"should return error when all reposdirs are unreadable": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				return hostPath, []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
-			},
-			expectedHasDir:   false,
-			expectedHasRepo:  false,
-			expectedErrParts: []string{"reading", "no such file or directory"},
-		},
-		"should return error when reposdirs are readable but no repo files exist": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				reposDirPaths := []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
-				for _, reposDirPath := range reposDirPaths {
-					reposPath := hostPathFor(hostPath, reposDirPath)
-					require.NoError(t, os.MkdirAll(reposPath, 0750))
-					require.NoError(t, os.WriteFile(filepath.Join(reposPath, "not-a-repo.txt"), []byte("content"), 0600))
-				}
-				return hostPath, reposDirPaths
-			},
-			expectedHasDir:   true,
-			expectedHasRepo:  false,
-			expectedErrParts: []string{"no .repo files found"},
-		},
-		"should return true when repo file exists even if other reposdir is missing": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				reposDirPaths := []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
-				reposPath := hostPathFor(hostPath, reposDirPaths[0])
-				require.NoError(t, os.MkdirAll(reposPath, 0750))
-				require.NoError(t, os.WriteFile(filepath.Join(reposPath, "example.repo"), []byte("content"), 0600))
-				return hostPath, reposDirPaths
-			},
-			expectedHasDir:  true,
-			expectedHasRepo: true,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			hostPath, reposDirPaths := tt.setup(t)
-			hasDir, hasRepo, err := discoverDnfRepoFilePresence(hostPath, reposDirPaths)
-			assert.Equal(t, tt.expectedHasDir, hasDir)
-			assert.Equal(t, tt.expectedHasRepo, hasRepo)
-			if len(tt.expectedErrParts) == 0 {
-				assert.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			for _, part := range tt.expectedErrParts {
-				assert.ErrorContains(t, err, part)
-			}
-		})
-	}
-}
-
-func TestDiscoverDnfCacheRepoDirPresence(t *testing.T) {
-	tests := map[string]struct {
-		setup            func(t *testing.T) (string, string)
-		expectedFound    bool
-		expectedErrParts []string
-	}{
-		"should return true when cache dir contains repo directory": {
-			setup: func(t *testing.T) (string, string) {
-				hostPath := t.TempDir()
-				cacheDirPath := "/var/cache/dnf"
-				cachePath := hostPathFor(hostPath, cacheDirPath)
-				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "rhel-9-for-x86_64-appstream-rpms-123"), 0750))
-				return hostPath, cacheDirPath
-			},
-			expectedFound: true,
-		},
-		"should return false when cache dir has no repo directories": {
-			setup: func(t *testing.T) (string, string) {
-				hostPath := t.TempDir()
-				cacheDirPath := "/var/cache/dnf"
-				cachePath := hostPathFor(hostPath, cacheDirPath)
-				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "some-other-dir"), 0750))
-				return hostPath, cacheDirPath
-			},
-			expectedFound: false,
-		},
-		"should return error when cache dir is missing": {
-			setup: func(t *testing.T) (string, string) {
-				hostPath := t.TempDir()
-				return hostPath, "/var/cache/dnf"
-			},
-			expectedFound:    false,
-			expectedErrParts: []string{"unsupported OS detected: missing"},
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			hostPath, cacheDirPath := tt.setup(t)
-			found, err := discoverDnfCacheRepoDirPresence(hostPath, cacheDirPath)
-			assert.Equal(t, tt.expectedFound, found)
-			if len(tt.expectedErrParts) == 0 {
-				assert.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			for _, part := range tt.expectedErrParts {
-				assert.ErrorContains(t, err, part)
-			}
-		})
-	}
-}
-
 func TestParseOSRelease_QuotedValues(t *testing.T) {
 	input := strings.NewReader(`# comment
 ID='rhel'
@@ -261,58 +132,6 @@ NAME="Red Hat \$NAME"
 	assert.Equal(t, "rhel", values["ID"])
 	assert.Equal(t, "9.4", values["VERSION_ID"])
 	assert.Equal(t, "Red Hat $NAME", values["NAME"])
-}
-
-func TestHostPathFor(t *testing.T) {
-	tests := []struct {
-		name     string
-		hostPath string
-		path     string
-		expected string
-	}{
-		{
-			name:     "Empty host path uses original path",
-			hostPath: "",
-			path:     "/etc/os-release",
-			expected: "/etc/os-release",
-		},
-		{
-			name:     "Root host path uses original path",
-			hostPath: "/",
-			path:     "/etc/os-release",
-			expected: "/etc/os-release",
-		},
-		{
-			name:     "Prefix host path joins with absolute path",
-			hostPath: "/host",
-			path:     "/etc/os-release",
-			expected: "/host/etc/os-release",
-		},
-		{
-			name:     "Prefix host path joins with nested path",
-			hostPath: "/host/rootfs",
-			path:     "/var/cache/dnf",
-			expected: "/host/rootfs/var/cache/dnf",
-		},
-		{
-			name:     "Cleaned path removes dot segments",
-			hostPath: "/root/../host",
-			path:     "/var/lib/../cache//dnf/",
-			expected: "/host/var/cache/dnf",
-		},
-		{
-			name:     "Cleaned path collapses extra slashes",
-			hostPath: "/host//",
-			path:     "/etc/os-release",
-			expected: "/host/etc/os-release",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, hostPathFor(tt.hostPath, tt.path))
-		})
-	}
 }
 
 func TestDiscoverActivationStatus(t *testing.T) {
@@ -377,15 +196,16 @@ func TestDiscoverActivationStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
+			hostPath := t.TempDir()
+			entitlementDir := hostprobe.HostPathFor(hostPath, hostprobe.EntitlementDirPath)
+			require.NoError(t, os.MkdirAll(entitlementDir, 0755))
 
 			for _, filename := range tt.files {
-				filePath := filepath.Join(tmpDir, filename)
-				err := os.WriteFile(filePath, []byte("test content"), 0644)
+				err := os.WriteFile(filepath.Join(entitlementDir, filename), []byte("test content"), 0644)
 				require.NoError(t, err)
 			}
 
-			activationStatus, err := discoverActivationStatusWithPath(tmpDir)
+			activationStatus, err := discoverActivationStatus(hostPath)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, activationStatus)
 		})
@@ -393,167 +213,9 @@ func TestDiscoverActivationStatus(t *testing.T) {
 }
 
 func TestDiscoverActivationStatus_MissingDir(t *testing.T) {
-	tmpDir := t.TempDir()
-	missingPath := filepath.Join(tmpDir, "nonexistent")
+	hostPath := t.TempDir()
 
-	activationStatus, err := discoverActivationStatusWithPath(missingPath)
+	activationStatus, err := discoverActivationStatus(hostPath)
 	assert.Error(t, err)
 	assert.Equal(t, v1.ActivationStatus_ACTIVATION_UNSPECIFIED, activationStatus)
-}
-
-func TestDiscoverDnfMetadataStatus(t *testing.T) {
-	tests := map[string]struct {
-		reposDirs      []string
-		repoDirFiles   map[string][]string
-		cacheDirs      []string
-		expectedStatus v1.DnfMetadataStatus
-		expectedErrs   []string
-	}{
-		"should report available when repo file and cache dir exist": {
-			reposDirs:      []string{"yum.repos.d"},
-			repoDirFiles:   map[string][]string{"yum.repos.d": {"rhel9.repo"}},
-			cacheDirs:      []string{"rhel-9-for-x86_64-appstream-rpms-3dc6dc0880df5476"},
-			expectedStatus: v1.DnfMetadataStatus_AVAILABLE,
-		},
-		"should report available when repo file is in second reposdir": {
-			reposDirs: []string{"yum.repos.d", "yum/repos.d"},
-			repoDirFiles: map[string][]string{
-				"yum.repos.d": {},
-				"yum/repos.d": {"rhel9.repo"},
-			},
-			cacheDirs:      []string{"rhel-9-for-x86_64-appstream-rpms-3dc6dc0880df5476"},
-			expectedStatus: v1.DnfMetadataStatus_AVAILABLE,
-		},
-		"should report available with multiple repo files and cache dirs": {
-			reposDirs: []string{"yum.repos.d"},
-			repoDirFiles: map[string][]string{
-				"yum.repos.d": {"baseos.repo", "appstream.repo"},
-			},
-			cacheDirs: []string{
-				"rhel-9-for-x86_64-appstream-rpms-3dc6dc0880df5476",
-				"rhel-9-for-x86_64-baseos-rpms-a2cdae14f4ed6c20",
-			},
-			expectedStatus: v1.DnfMetadataStatus_AVAILABLE,
-		},
-		"should report unavailable when no repo files exist": {
-			reposDirs:      []string{"yum.repos.d"},
-			repoDirFiles:   map[string][]string{"yum.repos.d": {}},
-			cacheDirs:      []string{"rhel-9-for-x86_64-appstream-rpms-3dc6dc0880df5476"},
-			expectedStatus: v1.DnfMetadataStatus_UNAVAILABLE,
-			expectedErrs:   []string{"no .repo files found"},
-		},
-		"should report unavailable when no cache dirs exist": {
-			reposDirs:      []string{"yum.repos.d"},
-			repoDirFiles:   map[string][]string{"yum.repos.d": {"rhel9.repo"}},
-			cacheDirs:      []string{},
-			expectedStatus: v1.DnfMetadataStatus_UNAVAILABLE,
-		},
-		"should report unavailable when cache dir lacks -rpms- pattern": {
-			reposDirs:      []string{"yum.repos.d"},
-			repoDirFiles:   map[string][]string{"yum.repos.d": {"rhel9.repo"}},
-			cacheDirs:      []string{"some-other-dir"},
-			expectedStatus: v1.DnfMetadataStatus_UNAVAILABLE,
-		},
-		"should report unavailable for empty directories": {
-			reposDirs:      []string{"yum.repos.d"},
-			repoDirFiles:   map[string][]string{"yum.repos.d": {}},
-			cacheDirs:      []string{},
-			expectedStatus: v1.DnfMetadataStatus_UNAVAILABLE,
-			expectedErrs:   []string{"no .repo files found"},
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			cacheDir := filepath.Join(tmpDir, "dnf")
-			require.NoError(t, os.MkdirAll(cacheDir, 0755))
-
-			reposDirPaths := make([]string, 0, len(tt.reposDirs))
-			for _, dir := range tt.reposDirs {
-				dirPath := filepath.Join(tmpDir, dir)
-				reposDirPaths = append(reposDirPaths, dirPath)
-				if files, ok := tt.repoDirFiles[dir]; ok {
-					require.NoError(t, os.MkdirAll(dirPath, 0755))
-					for _, filename := range files {
-						filePath := filepath.Join(dirPath, filename)
-						err := os.WriteFile(filePath, []byte("[repo]\nname=test"), 0644)
-						require.NoError(t, err)
-					}
-				}
-			}
-
-			for _, dirname := range tt.cacheDirs {
-				dirPath := filepath.Join(cacheDir, dirname)
-				err := os.MkdirAll(dirPath, 0755)
-				require.NoError(t, err)
-			}
-
-			dnfStatus, err := discoverDnfMetadataStatusWithPaths("", reposDirPaths, cacheDir)
-			if len(tt.expectedErrs) == 0 {
-				assert.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				for _, expectedErr := range tt.expectedErrs {
-					assert.ErrorContains(t, err, expectedErr)
-				}
-			}
-			assert.Equal(t, tt.expectedStatus, dnfStatus)
-		})
-	}
-}
-
-func TestDiscoverDnfMetadataStatus_MissingDirs(t *testing.T) {
-	tests := map[string]struct {
-		reposDirs     []string
-		repoDirFiles  map[string][]string
-		cacheDir      string
-		setupCache    func(string) error
-		errorContains string
-	}{
-		"should return error when repos dir is missing": {
-			reposDirs:     []string{"nonexistent-repos"},
-			repoDirFiles:  map[string][]string{},
-			cacheDir:      "dnf",
-			setupCache:    func(path string) error { return os.MkdirAll(path, 0755) },
-			errorContains: "reading",
-		},
-		"should return error when cache dir is missing": {
-			reposDirs: []string{"yum.repos.d"},
-			repoDirFiles: map[string][]string{
-				"yum.repos.d": {"test.repo"},
-			},
-			cacheDir:      "nonexistent-cache",
-			setupCache:    nil,
-			errorContains: "unsupported OS detected: missing",
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			cacheDirPath := filepath.Join(tmpDir, tt.cacheDir)
-			if tt.setupCache != nil {
-				require.NoError(t, tt.setupCache(cacheDirPath))
-			}
-
-			reposDirPaths := make([]string, 0, len(tt.reposDirs))
-			for _, dir := range tt.reposDirs {
-				dirPath := filepath.Join(tmpDir, dir)
-				reposDirPaths = append(reposDirPaths, dirPath)
-				if files, ok := tt.repoDirFiles[dir]; ok {
-					require.NoError(t, os.MkdirAll(dirPath, 0755))
-					for _, filename := range files {
-						filePath := filepath.Join(dirPath, filename)
-						require.NoError(t, os.WriteFile(filePath, []byte("[repo]"), 0644))
-					}
-				}
-			}
-
-			dnfStatus, err := discoverDnfMetadataStatusWithPaths("", reposDirPaths, cacheDirPath)
-			assert.Error(t, err)
-			assert.ErrorContains(t, err, tt.errorContains)
-			assert.Equal(t, v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED, dnfStatus)
-		})
-	}
 }

--- a/compliance/virtualmachines/roxagent/discovery/dnf.go
+++ b/compliance/virtualmachines/roxagent/discovery/dnf.go
@@ -1,0 +1,164 @@
+package discovery
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+)
+
+// discoverDnfRepoFilePresence reports whether any of the given reposdirs contains a *.repo file.
+//   - Returns hasDir=true when at least one reposdir is readable.
+//   - Returns hasRepo=true as soon as a *.repo file is found in any reposdir.
+//   - If reposdirs are unreadable or contain no *.repo files, returns an aggregated error.
+func discoverDnfRepoFilePresence(hostPath string, reposDirPaths []string) (hasDir, hasRepo bool, err error) {
+	if len(reposDirPaths) == 0 {
+		return false, false, errors.New("missing repository directories")
+	}
+
+	var repoDirErrs *multierror.Error
+	for _, reposDirPath := range reposDirPaths {
+		reposPath := hostprobe.HostPathFor(hostPath, reposDirPath)
+		repoEntries, err := os.ReadDir(reposPath)
+		if err != nil {
+			repoDirErrs = multierror.Append(repoDirErrs, fmt.Errorf("reading %q: %w", reposPath, err))
+			continue
+		}
+		hasDir = true
+
+		for _, entry := range repoEntries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".repo") {
+				return true, true, nil
+			}
+		}
+		repoDirErrs = multierror.Append(repoDirErrs, fmt.Errorf("no .repo files found in %q", reposPath))
+
+	}
+
+	return hasDir, hasRepo, repoDirErrs.ErrorOrNil()
+}
+
+// discoverDnf4CacheRepoDirPresence reports whether hostPath/cacheDirPath looks like a DNF4 package cache:
+// subdirectories whose names contain "-rpms-" under the cache root (e.g. /var/cache/dnf).
+//
+// DNF4 default layout (libdnf Const.hpp):
+// https://github.com/rpm-software-management/libdnf/blob/53839f5bd88f378e57a1f1671b3db48d29984e24/libdnf/conf/Const.hpp
+func discoverDnf4CacheRepoDirPresence(hostPath, cacheDirPath string) (hasDir, hasRepo bool, err error) {
+	cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+	cacheEntries, err := os.ReadDir(cachePath)
+	if err != nil {
+		return false, false, fmt.Errorf("reading %s: %w", cachePath, err)
+	}
+	hasRepo = slices.ContainsFunc(cacheEntries, func(e os.DirEntry) bool {
+		return e.IsDir() && strings.Contains(e.Name(), "-rpms-")
+	})
+	return true, hasRepo, nil
+}
+
+// discoverDnf5CacheRepoDirPresence reports whether hostPath/cacheDirPath looks like a DNF5/libdnf5 cache root
+// (e.g. /var/cache/libdnf5): any subdirectory indicates repository cache layout.
+//
+// DNF5 defaults (libdnf5 const.hpp):
+// https://github.com/rpm-software-management/dnf5/blob/185eaef1e0ad663bdb827a2179ab1df574a27d88/include/libdnf5/conf/const.hpp
+func discoverDnf5CacheRepoDirPresence(hostPath, cacheDirPath string) (hasDir, hasRepo bool, err error) {
+	cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+	cacheEntries, err := os.ReadDir(cachePath)
+	if err != nil {
+		return false, false, fmt.Errorf("reading %s: %w", cachePath, err)
+	}
+	hasRepo = slices.ContainsFunc(cacheEntries, func(e os.DirEntry) bool {
+		return e.IsDir()
+	})
+	return true, hasRepo, nil
+}
+
+// deriveLegacyDnfMetadataStatus maps DnfStatusFlag values to the deprecated
+// DnfMetadataStatus enum for backward compatibility with 4.10 tech-preview agents.
+func deriveLegacyDnfMetadataStatus(flags []v1.DnfStatusFlag) v1.DnfMetadataStatus {
+	if len(flags) == 0 {
+		return v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED
+	}
+	hasRepo, hasCache := false, false
+	for _, f := range flags {
+		switch f {
+		case v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND:
+			hasRepo = true
+		case v1.DnfStatusFlag_DNF_V4_CACHE_FOUND, v1.DnfStatusFlag_DNF_V5_CACHE_FOUND:
+			hasCache = true
+		}
+	}
+	if !hasRepo && !hasCache {
+		return v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED
+	}
+	if hasRepo && hasCache {
+		return v1.DnfMetadataStatus_AVAILABLE
+	}
+	return v1.DnfMetadataStatus_UNAVAILABLE
+}
+
+// discoverDnf4CachePresent checks for a DNF4 package cache at cacheDirPath.
+func discoverDnf4CachePresent(hostPath, cacheDirPath string) (bool, error) {
+	if cacheDirPath == "" {
+		return false, nil
+	}
+	_, found, err := discoverDnf4CacheRepoDirPresence(hostPath, cacheDirPath)
+	return found, err
+}
+
+// discoverDnf5CachePresent checks for a DNF5/libdnf5 package cache at cacheDirPath.
+func discoverDnf5CachePresent(hostPath, cacheDirPath string) (bool, error) {
+	if cacheDirPath == "" {
+		return false, nil
+	}
+	_, found, err := discoverDnf5CacheRepoDirPresence(hostPath, cacheDirPath)
+	return found, err
+}
+
+// discoverDnfStatusFlags probes the host filesystem for individual DNF-related
+// facts and returns all that apply. DNF4 and DNF5 paths are probed independently.
+func discoverDnfStatusFlags(hostPath string, dnf4ReposDirs, dnf5ReposDirs []string, dnf4CacheDirPath, dnf5CacheDirPath string) ([]v1.DnfStatusFlag, error) {
+	var flags []v1.DnfStatusFlag
+	var errs []error
+
+	_, v4RepoFound, v4RepoErr := discoverDnfRepoFilePresence(hostPath, dnf4ReposDirs)
+	_, v5RepoFound, v5RepoErr := discoverDnfRepoFilePresence(hostPath, dnf5ReposDirs)
+	if v4RepoFound || v5RepoFound {
+		flags = append(flags, v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND)
+	} else {
+		appendNonNil(&errs, v4RepoErr, v5RepoErr)
+	}
+
+	v4Cache, v4CacheErr := discoverDnf4CachePresent(hostPath, dnf4CacheDirPath)
+	v5Cache, v5CacheErr := discoverDnf5CachePresent(hostPath, dnf5CacheDirPath)
+	if v4Cache {
+		flags = append(flags, v1.DnfStatusFlag_DNF_V4_CACHE_FOUND)
+	}
+	if v5Cache {
+		flags = append(flags, v1.DnfStatusFlag_DNF_V5_CACHE_FOUND)
+	}
+	if !v4Cache && !v5Cache {
+		appendNonNil(&errs, v4CacheErr, v5CacheErr)
+	}
+
+	switch hostprobe.DetectDNFVersion(hostPath) {
+	case hostprobe.DNFVersion5:
+		flags = append(flags, v1.DnfStatusFlag_DNF_V5_HISTORY_DB_FOUND)
+	case hostprobe.DNFVersion4:
+		flags = append(flags, v1.DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND)
+	}
+
+	return flags, errors.Join(errs...)
+}
+
+func appendNonNil(errs *[]error, ee ...error) {
+	for _, e := range ee {
+		if e != nil {
+			*errs = append(*errs, e)
+		}
+	}
+}

--- a/compliance/virtualmachines/roxagent/discovery/dnf.go
+++ b/compliance/virtualmachines/roxagent/discovery/dnf.go
@@ -7,74 +7,23 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 )
 
-// discoverDnfRepoFilePresence reports whether any of the given reposdirs contains a *.repo file.
-//   - Returns hasDir=true when at least one reposdir is readable.
-//   - Returns hasRepo=true as soon as a *.repo file is found in any reposdir.
-//   - If reposdirs are unreadable or contain no *.repo files, returns an aggregated error.
-func discoverDnfRepoFilePresence(hostPath string, reposDirPaths []string) (hasDir, hasRepo bool, err error) {
-	if len(reposDirPaths) == 0 {
-		return false, false, errors.New("missing repository directories")
+// discoverDnfCachePresent reports whether hostPath/cacheDirPath contains a
+// subdirectory matching isRepoCacheDir. An empty cacheDirPath means "not
+// probed for this DNF version" and reports false with no error.
+func discoverDnfCachePresent(hostPath, cacheDirPath string, isRepoCacheDir func(os.DirEntry) bool) (bool, error) {
+	if cacheDirPath == "" {
+		return false, nil
 	}
-
-	var repoDirErrs *multierror.Error
-	for _, reposDirPath := range reposDirPaths {
-		reposPath := hostprobe.HostPathFor(hostPath, reposDirPath)
-		repoEntries, err := os.ReadDir(reposPath)
-		if err != nil {
-			repoDirErrs = multierror.Append(repoDirErrs, fmt.Errorf("reading %q: %w", reposPath, err))
-			continue
-		}
-		hasDir = true
-
-		for _, entry := range repoEntries {
-			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".repo") {
-				return true, true, nil
-			}
-		}
-		repoDirErrs = multierror.Append(repoDirErrs, fmt.Errorf("no .repo files found in %q", reposPath))
-
-	}
-
-	return hasDir, hasRepo, repoDirErrs.ErrorOrNil()
-}
-
-// discoverDnf4CacheRepoDirPresence reports whether hostPath/cacheDirPath looks like a DNF4 package cache:
-// subdirectories whose names contain "-rpms-" under the cache root (e.g. /var/cache/dnf).
-//
-// DNF4 default layout (libdnf Const.hpp):
-// https://github.com/rpm-software-management/libdnf/blob/53839f5bd88f378e57a1f1671b3db48d29984e24/libdnf/conf/Const.hpp
-func discoverDnf4CacheRepoDirPresence(hostPath, cacheDirPath string) (hasDir, hasRepo bool, err error) {
 	cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
 	cacheEntries, err := os.ReadDir(cachePath)
 	if err != nil {
-		return false, false, fmt.Errorf("reading %s: %w", cachePath, err)
+		return false, fmt.Errorf("reading %s: %w", cachePath, err)
 	}
-	hasRepo = slices.ContainsFunc(cacheEntries, func(e os.DirEntry) bool {
-		return e.IsDir() && strings.Contains(e.Name(), "-rpms-")
-	})
-	return true, hasRepo, nil
-}
-
-// discoverDnf5CacheRepoDirPresence reports whether hostPath/cacheDirPath looks like a DNF5/libdnf5 cache root
-// (e.g. /var/cache/libdnf5): any subdirectory indicates repository cache layout.
-//
-// DNF5 defaults (libdnf5 const.hpp):
-// https://github.com/rpm-software-management/dnf5/blob/185eaef1e0ad663bdb827a2179ab1df574a27d88/include/libdnf5/conf/const.hpp
-func discoverDnf5CacheRepoDirPresence(hostPath, cacheDirPath string) (hasDir, hasRepo bool, err error) {
-	cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
-	cacheEntries, err := os.ReadDir(cachePath)
-	if err != nil {
-		return false, false, fmt.Errorf("reading %s: %w", cachePath, err)
-	}
-	hasRepo = slices.ContainsFunc(cacheEntries, func(e os.DirEntry) bool {
-		return e.IsDir()
-	})
-	return true, hasRepo, nil
+	return slices.ContainsFunc(cacheEntries, isRepoCacheDir), nil
 }
 
 // deriveLegacyDnfMetadataStatus maps DnfStatusFlag values to the deprecated
@@ -101,22 +50,28 @@ func deriveLegacyDnfMetadataStatus(flags []v1.DnfStatusFlag) v1.DnfMetadataStatu
 	return v1.DnfMetadataStatus_UNAVAILABLE
 }
 
-// discoverDnf4CachePresent checks for a DNF4 package cache at cacheDirPath.
+// discoverDnf4CachePresent reports whether a DNF4 package cache exists at
+// cacheDirPath: a subdirectory whose name contains "-rpms-" under the cache
+// root (e.g. /var/cache/dnf).
+//
+// DNF4 default layout (libdnf Const.hpp):
+// https://github.com/rpm-software-management/libdnf/blob/53839f5bd88f378e57a1f1671b3db48d29984e24/libdnf/conf/Const.hpp
 func discoverDnf4CachePresent(hostPath, cacheDirPath string) (bool, error) {
-	if cacheDirPath == "" {
-		return false, nil
-	}
-	_, found, err := discoverDnf4CacheRepoDirPresence(hostPath, cacheDirPath)
-	return found, err
+	return discoverDnfCachePresent(hostPath, cacheDirPath, func(e os.DirEntry) bool {
+		return e.IsDir() && strings.Contains(e.Name(), "-rpms-")
+	})
 }
 
-// discoverDnf5CachePresent checks for a DNF5/libdnf5 package cache at cacheDirPath.
+// discoverDnf5CachePresent reports whether a DNF5/libdnf5 package cache exists
+// at cacheDirPath (e.g. /var/cache/libdnf5): any subdirectory indicates a
+// repository cache layout.
+//
+// DNF5 defaults (libdnf5 const.hpp):
+// https://github.com/rpm-software-management/dnf5/blob/185eaef1e0ad663bdb827a2179ab1df574a27d88/include/libdnf5/conf/const.hpp
 func discoverDnf5CachePresent(hostPath, cacheDirPath string) (bool, error) {
-	if cacheDirPath == "" {
-		return false, nil
-	}
-	_, found, err := discoverDnf5CacheRepoDirPresence(hostPath, cacheDirPath)
-	return found, err
+	return discoverDnfCachePresent(hostPath, cacheDirPath, func(e os.DirEntry) bool {
+		return e.IsDir()
+	})
 }
 
 // discoverDnfStatusFlags probes the host filesystem for individual DNF-related
@@ -125,8 +80,8 @@ func discoverDnfStatusFlags(hostPath string, dnf4ReposDirs, dnf5ReposDirs []stri
 	var flags []v1.DnfStatusFlag
 	var errs []error
 
-	_, v4RepoFound, v4RepoErr := discoverDnfRepoFilePresence(hostPath, dnf4ReposDirs)
-	_, v5RepoFound, v5RepoErr := discoverDnfRepoFilePresence(hostPath, dnf5ReposDirs)
+	v4RepoFound, v4RepoErr := hostprobe.HasAnyRepoFileAt(hostPath, dnf4ReposDirs)
+	v5RepoFound, v5RepoErr := hostprobe.HasAnyRepoFileAt(hostPath, dnf5ReposDirs)
 	if v4RepoFound || v5RepoFound {
 		flags = append(flags, v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND)
 	} else {

--- a/compliance/virtualmachines/roxagent/discovery/dnf_test.go
+++ b/compliance/virtualmachines/roxagent/discovery/dnf_test.go
@@ -1,0 +1,496 @@
+package discovery
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverDnfRepoFilePresence(t *testing.T) {
+	tests := map[string]struct {
+		setup            func(t *testing.T) (string, []string)
+		expectedHasDir   bool
+		expectedHasRepo  bool
+		expectedErrParts []string
+	}{
+		"should return true when repo file exists in reposdir": {
+			setup: func(t *testing.T) (string, []string) {
+				hostPath := t.TempDir()
+				reposDirPath := "/etc/yum.repos.d"
+				reposPath := hostprobe.HostPathFor(hostPath, reposDirPath)
+				require.NoError(t, os.MkdirAll(reposPath, 0750))
+				repoFilePath := filepath.Join(reposPath, "test.repo")
+				require.NoError(t, os.WriteFile(repoFilePath, []byte("content"), 0600))
+				return hostPath, []string{reposDirPath}
+			},
+			expectedHasDir:  true,
+			expectedHasRepo: true,
+		},
+		"should return error when all reposdirs are unreadable": {
+			setup: func(t *testing.T) (string, []string) {
+				hostPath := t.TempDir()
+				return hostPath, []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
+			},
+			expectedHasDir:   false,
+			expectedHasRepo:  false,
+			expectedErrParts: []string{"reading", "no such file or directory"},
+		},
+		"should return error when reposdirs are readable but no repo files exist": {
+			setup: func(t *testing.T) (string, []string) {
+				hostPath := t.TempDir()
+				reposDirPaths := []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
+				for _, reposDirPath := range reposDirPaths {
+					reposPath := hostprobe.HostPathFor(hostPath, reposDirPath)
+					require.NoError(t, os.MkdirAll(reposPath, 0750))
+					require.NoError(t, os.WriteFile(filepath.Join(reposPath, "not-a-repo.txt"), []byte("content"), 0600))
+				}
+				return hostPath, reposDirPaths
+			},
+			expectedHasDir:   true,
+			expectedHasRepo:  false,
+			expectedErrParts: []string{"no .repo files found"},
+		},
+		"should return true when repo file exists even if other reposdir is missing": {
+			setup: func(t *testing.T) (string, []string) {
+				hostPath := t.TempDir()
+				reposDirPaths := []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
+				reposPath := hostprobe.HostPathFor(hostPath, reposDirPaths[0])
+				require.NoError(t, os.MkdirAll(reposPath, 0750))
+				require.NoError(t, os.WriteFile(filepath.Join(reposPath, "example.repo"), []byte("content"), 0600))
+				return hostPath, reposDirPaths
+			},
+			expectedHasDir:  true,
+			expectedHasRepo: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hostPath, reposDirPaths := tt.setup(t)
+			hasDir, hasRepo, err := discoverDnfRepoFilePresence(hostPath, reposDirPaths)
+			assert.Equal(t, tt.expectedHasDir, hasDir)
+			assert.Equal(t, tt.expectedHasRepo, hasRepo)
+			if len(tt.expectedErrParts) == 0 {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, part := range tt.expectedErrParts {
+				assert.Contains(t, err.Error(), part)
+			}
+		})
+	}
+}
+
+func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
+	tests := map[string]struct {
+		setup            func(t *testing.T) (hostPath string, cacheDirPath string)
+		expectedHasDir   bool
+		expectedFound    bool
+		expectedErrParts []string
+	}{
+		"true when cache dir contains repo directory": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				cacheDirPath := "/var/cache/dnf"
+				cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "rhel-9-for-x86_64-appstream-rpms-123"), 0750))
+				return hostPath, cacheDirPath
+			},
+			expectedHasDir: true,
+			expectedFound:  true,
+		},
+		"false when cache dir has no repo directories": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				cacheDirPath := "/var/cache/dnf"
+				cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+				require.NoError(t, os.MkdirAll(cachePath, 0750))
+				return hostPath, cacheDirPath
+			},
+			expectedHasDir: true,
+			expectedFound:  false,
+		},
+		"false when cache has subdirs but none match -rpms- pattern": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				cacheDirPath := "/var/cache/dnf"
+				cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "fedora"), 0750))
+				return hostPath, cacheDirPath
+			},
+			expectedHasDir: true,
+			expectedFound:  false,
+		},
+		"error when cache dir is missing": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				return hostPath, "/var/cache/dnf"
+			},
+			expectedHasDir:   false,
+			expectedFound:    false,
+			expectedErrParts: []string{"reading"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hostPath, cacheDirPath := tt.setup(t)
+			hasDir, found, err := discoverDnf4CacheRepoDirPresence(hostPath, cacheDirPath)
+			assert.Equal(t, tt.expectedHasDir, hasDir)
+			assert.Equal(t, tt.expectedFound, found)
+			if len(tt.expectedErrParts) == 0 {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, part := range tt.expectedErrParts {
+				assert.Contains(t, err.Error(), part)
+			}
+		})
+	}
+}
+
+func TestDiscoverDnf5CacheRepoDirPresence(t *testing.T) {
+	tests := map[string]struct {
+		setup            func(t *testing.T) (hostPath string, cacheDirPath string)
+		expectedHasDir   bool
+		expectedFound    bool
+		expectedErrParts []string
+	}{
+		"true when cache dir has repository entries": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				cacheDirPath := "/var/cache/libdnf5"
+				cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "fedora"), 0750))
+				return hostPath, cacheDirPath
+			},
+			expectedHasDir: true,
+			expectedFound:  true,
+		},
+		"false when cache root exists but has no subdirectories": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				cacheDirPath := "/var/cache/libdnf5"
+				cachePath := hostprobe.HostPathFor(hostPath, cacheDirPath)
+				require.NoError(t, os.MkdirAll(cachePath, 0750))
+				return hostPath, cacheDirPath
+			},
+			expectedHasDir: true,
+			expectedFound:  false,
+		},
+		"error when cache dir is missing": {
+			setup: func(t *testing.T) (string, string) {
+				hostPath := t.TempDir()
+				return hostPath, "/var/cache/libdnf5"
+			},
+			expectedHasDir:   false,
+			expectedFound:    false,
+			expectedErrParts: []string{"reading"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hostPath, cacheDirPath := tt.setup(t)
+			hasDir, found, err := discoverDnf5CacheRepoDirPresence(hostPath, cacheDirPath)
+			assert.Equal(t, tt.expectedHasDir, hasDir)
+			assert.Equal(t, tt.expectedFound, found)
+			if len(tt.expectedErrParts) == 0 {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, part := range tt.expectedErrParts {
+				assert.Contains(t, err.Error(), part)
+			}
+		})
+	}
+}
+
+// TestDiscoverDnfStatusFlags exercises discoverDnfStatusFlags's flag-combination
+// and error-aggregation logic against synthetic directory layouts identified by
+// arbitrary absolute paths. History-DB detection (which depends on hostPath,
+// not on the repos/cache args) is covered separately by
+// TestDiscoverDnfStatusFlags_RealPaths.
+func TestDiscoverDnfStatusFlags(t *testing.T) {
+	tests := map[string]struct {
+		setup         func(t *testing.T) (dnf4Repos, dnf5Repos []string, dnf4Cache, dnf5Cache string)
+		expectedFlags []v1.DnfStatusFlag
+		errorContains string
+	}{
+		"repo and v4 cache found": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				repoDir := filepath.Join(tmp, "yum.repos.d")
+				require.NoError(t, os.MkdirAll(repoDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(repoDir, "rhel9.repo"), []byte("[repo]"), 0644))
+				cacheDir := filepath.Join(tmp, "dnf")
+				require.NoError(t, os.MkdirAll(filepath.Join(cacheDir, "rhel-9-for-x86_64-appstream-rpms-abc"), 0755))
+				return []string{repoDir}, nil, cacheDir, ""
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+			},
+		},
+		"repo and v5 cache found": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				repoDir := filepath.Join(tmp, "repos.d")
+				require.NoError(t, os.MkdirAll(repoDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(repoDir, "fedora.repo"), []byte("[repo]"), 0644))
+				cacheDir := filepath.Join(tmp, "libdnf5")
+				require.NoError(t, os.MkdirAll(filepath.Join(cacheDir, "fedora"), 0755))
+				return nil, []string{repoDir}, "", cacheDir
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V5_CACHE_FOUND,
+			},
+		},
+		"repo found in second of two reposdirs": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				emptyDir := filepath.Join(tmp, "yum.repos.d")
+				repoDir := filepath.Join(tmp, "yum", "repos.d")
+				require.NoError(t, os.MkdirAll(emptyDir, 0755))
+				require.NoError(t, os.MkdirAll(repoDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(repoDir, "rhel9.repo"), []byte("[repo]"), 0644))
+				return []string{emptyDir, repoDir}, nil, "", ""
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+			},
+		},
+		"cache dir readable but no -rpms- subdirs: no cache flag, no error": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				repoDir := filepath.Join(tmp, "yum.repos.d")
+				require.NoError(t, os.MkdirAll(repoDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(repoDir, "rhel9.repo"), []byte("[repo]"), 0644))
+				cacheDir := filepath.Join(tmp, "dnf")
+				require.NoError(t, os.MkdirAll(filepath.Join(cacheDir, "fedora"), 0755))
+				return []string{repoDir}, nil, cacheDir, ""
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+			},
+		},
+		"no repo files, cache exists": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				repoDir := filepath.Join(tmp, "yum.repos.d")
+				require.NoError(t, os.MkdirAll(repoDir, 0755))
+				cacheDir := filepath.Join(tmp, "dnf")
+				require.NoError(t, os.MkdirAll(filepath.Join(cacheDir, "rhel-9-for-x86_64-appstream-rpms-abc"), 0755))
+				return []string{repoDir}, nil, cacheDir, ""
+			},
+			expectedFlags: []v1.DnfStatusFlag{v1.DnfStatusFlag_DNF_V4_CACHE_FOUND},
+			errorContains: "no .repo files found",
+		},
+		"reposdir does not exist, cache exists": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				cacheDir := filepath.Join(tmp, "dnf")
+				require.NoError(t, os.MkdirAll(cacheDir, 0755))
+				return []string{filepath.Join(tmp, "nonexistent-repos")}, nil, cacheDir, ""
+			},
+			expectedFlags: nil,
+			errorContains: "reading",
+		},
+		"repos exist, cache dir does not exist": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				repoDir := filepath.Join(tmp, "yum.repos.d")
+				require.NoError(t, os.MkdirAll(repoDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(repoDir, "rhel9.repo"), []byte("[repo]"), 0644))
+				return []string{repoDir}, nil, filepath.Join(tmp, "nonexistent-cache"), ""
+			},
+			expectedFlags: []v1.DnfStatusFlag{v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND},
+			errorContains: "reading",
+		},
+		"neither reposdir nor cache dir exist": {
+			setup: func(t *testing.T) ([]string, []string, string, string) {
+				tmp := t.TempDir()
+				return []string{filepath.Join(tmp, "yum.repos.d")}, nil, filepath.Join(tmp, "dnf"), ""
+			},
+			expectedFlags: nil,
+			errorContains: "reading",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			dnf4Repos, dnf5Repos, dnf4Cache, dnf5Cache := tt.setup(t)
+			flags, err := discoverDnfStatusFlags("", dnf4Repos, dnf5Repos, dnf4Cache, dnf5Cache)
+			assert.Equal(t, tt.expectedFlags, flags)
+			if tt.errorContains == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.errorContains)
+		})
+	}
+}
+
+// TestDiscoverDnfStatusFlags_RealPaths is an end-to-end smoke test that runs
+// discoverDnfStatusFlags against the actual hostprobe path constants used in
+// production, including history-DB detection (which is keyed off hostPath).
+func TestDiscoverDnfStatusFlags_RealPaths(t *testing.T) {
+	tests := map[string]struct {
+		setup         func(t *testing.T) string
+		expectedFlags []v1.DnfStatusFlag
+		expectedErr   error
+	}{
+		"all flags present (dnf4)": {
+			setup: func(t *testing.T) string {
+				hp := t.TempDir()
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "etc/yum.repos.d"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(hp, "etc/yum.repos.d/redhat.repo"), []byte("[baseos]"), 0644))
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "var/cache/dnf/rhel-9-for-x86_64-baseos-rpms-abc"), 0755))
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "var/lib/dnf"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(hp, "var/lib/dnf/history.sqlite"), []byte("db"), 0644))
+				return hp
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+				v1.DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND,
+			},
+		},
+		"all flags present (dnf5)": {
+			setup: func(t *testing.T) string {
+				hp := t.TempDir()
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "usr/share/dnf5/repos.d"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(hp, "usr/share/dnf5/repos.d/redhat.repo"), []byte("[baseos]"), 0644))
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "var/cache/libdnf5/fedora"), 0755))
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "usr/lib/sysimage/libdnf5"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(hp, "usr/lib/sysimage/libdnf5/transaction_history.sqlite"), []byte("db"), 0644))
+				return hp
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V5_CACHE_FOUND,
+				v1.DnfStatusFlag_DNF_V5_HISTORY_DB_FOUND,
+			},
+		},
+		"repo config and cache present but no history DB (cloud image)": {
+			setup: func(t *testing.T) string {
+				hp := t.TempDir()
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "etc/yum.repos.d"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(hp, "etc/yum.repos.d/redhat.repo"), []byte("[baseos]"), 0644))
+				require.NoError(t, os.MkdirAll(filepath.Join(hp, "var/cache/dnf/rhel-9-for-x86_64-baseos-rpms-abc"), 0755))
+				return hp
+			},
+			expectedFlags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+			},
+		},
+		"empty host path": {
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			expectedFlags: nil,
+			expectedErr:   fs.ErrNotExist,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hostPath := tt.setup(t)
+			flags, err := discoverDnfStatusFlags(hostPath,
+				hostprobe.DNF4ReposDirs, []string{hostprobe.DNF5ReposDirPath},
+				hostprobe.DNF4CacheDirPath, hostprobe.DNF5CacheDirPath,
+			)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedFlags, flags)
+		})
+	}
+}
+
+func TestDeriveLegacyDnfMetadataStatus(t *testing.T) {
+	tests := map[string]struct {
+		flags    []v1.DnfStatusFlag
+		expected v1.DnfMetadataStatus
+	}{
+		"nil flags": {
+			flags:    nil,
+			expected: v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED,
+		},
+		"empty flags": {
+			flags:    []v1.DnfStatusFlag{},
+			expected: v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED,
+		},
+		"repo and v4 cache": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_AVAILABLE,
+		},
+		"repo and v5 cache": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V5_CACHE_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_AVAILABLE,
+		},
+		"repo and cache with history flags": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+				v1.DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_AVAILABLE,
+		},
+		"repo only": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_REPO_CONFIG_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_UNAVAILABLE,
+		},
+		"v4 cache only": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_UNAVAILABLE,
+		},
+		"v5 cache only": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_V5_CACHE_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_UNAVAILABLE,
+		},
+		"both caches, no repo": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_V4_CACHE_FOUND,
+				v1.DnfStatusFlag_DNF_V5_CACHE_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_UNAVAILABLE,
+		},
+		"history db only": {
+			flags: []v1.DnfStatusFlag{
+				v1.DnfStatusFlag_DNF_V5_HISTORY_DB_FOUND,
+			},
+			expected: v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, deriveLegacyDnfMetadataStatus(tt.flags))
+		})
+	}
+}

--- a/compliance/virtualmachines/roxagent/discovery/dnf_test.go
+++ b/compliance/virtualmachines/roxagent/discovery/dnf_test.go
@@ -12,86 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDiscoverDnfRepoFilePresence(t *testing.T) {
-	tests := map[string]struct {
-		setup            func(t *testing.T) (string, []string)
-		expectedHasDir   bool
-		expectedHasRepo  bool
-		expectedErrParts []string
-	}{
-		"should return true when repo file exists in reposdir": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				reposDirPath := "/etc/yum.repos.d"
-				reposPath := hostprobe.HostPathFor(hostPath, reposDirPath)
-				require.NoError(t, os.MkdirAll(reposPath, 0750))
-				repoFilePath := filepath.Join(reposPath, "test.repo")
-				require.NoError(t, os.WriteFile(repoFilePath, []byte("content"), 0600))
-				return hostPath, []string{reposDirPath}
-			},
-			expectedHasDir:  true,
-			expectedHasRepo: true,
-		},
-		"should return error when all reposdirs are unreadable": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				return hostPath, []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
-			},
-			expectedHasDir:   false,
-			expectedHasRepo:  false,
-			expectedErrParts: []string{"reading", "no such file or directory"},
-		},
-		"should return error when reposdirs are readable but no repo files exist": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				reposDirPaths := []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
-				for _, reposDirPath := range reposDirPaths {
-					reposPath := hostprobe.HostPathFor(hostPath, reposDirPath)
-					require.NoError(t, os.MkdirAll(reposPath, 0750))
-					require.NoError(t, os.WriteFile(filepath.Join(reposPath, "not-a-repo.txt"), []byte("content"), 0600))
-				}
-				return hostPath, reposDirPaths
-			},
-			expectedHasDir:   true,
-			expectedHasRepo:  false,
-			expectedErrParts: []string{"no .repo files found"},
-		},
-		"should return true when repo file exists even if other reposdir is missing": {
-			setup: func(t *testing.T) (string, []string) {
-				hostPath := t.TempDir()
-				reposDirPaths := []string{"/etc/yum.repos.d", "/etc/yum/repos.d"}
-				reposPath := hostprobe.HostPathFor(hostPath, reposDirPaths[0])
-				require.NoError(t, os.MkdirAll(reposPath, 0750))
-				require.NoError(t, os.WriteFile(filepath.Join(reposPath, "example.repo"), []byte("content"), 0600))
-				return hostPath, reposDirPaths
-			},
-			expectedHasDir:  true,
-			expectedHasRepo: true,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			hostPath, reposDirPaths := tt.setup(t)
-			hasDir, hasRepo, err := discoverDnfRepoFilePresence(hostPath, reposDirPaths)
-			assert.Equal(t, tt.expectedHasDir, hasDir)
-			assert.Equal(t, tt.expectedHasRepo, hasRepo)
-			if len(tt.expectedErrParts) == 0 {
-				assert.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			for _, part := range tt.expectedErrParts {
-				assert.Contains(t, err.Error(), part)
-			}
-		})
-	}
-}
-
-func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
+func TestDiscoverDnf4CachePresent(t *testing.T) {
 	tests := map[string]struct {
 		setup            func(t *testing.T) (hostPath string, cacheDirPath string)
-		expectedHasDir   bool
 		expectedFound    bool
 		expectedErrParts []string
 	}{
@@ -103,8 +26,7 @@ func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
 				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "rhel-9-for-x86_64-appstream-rpms-123"), 0750))
 				return hostPath, cacheDirPath
 			},
-			expectedHasDir: true,
-			expectedFound:  true,
+			expectedFound: true,
 		},
 		"false when cache dir has no repo directories": {
 			setup: func(t *testing.T) (string, string) {
@@ -114,8 +36,7 @@ func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
 				require.NoError(t, os.MkdirAll(cachePath, 0750))
 				return hostPath, cacheDirPath
 			},
-			expectedHasDir: true,
-			expectedFound:  false,
+			expectedFound: false,
 		},
 		"false when cache has subdirs but none match -rpms- pattern": {
 			setup: func(t *testing.T) (string, string) {
@@ -125,15 +46,19 @@ func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
 				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "fedora"), 0750))
 				return hostPath, cacheDirPath
 			},
-			expectedHasDir: true,
-			expectedFound:  false,
+			expectedFound: false,
+		},
+		"false with no error when cacheDirPath is empty": {
+			setup: func(t *testing.T) (string, string) {
+				return t.TempDir(), ""
+			},
+			expectedFound: false,
 		},
 		"error when cache dir is missing": {
 			setup: func(t *testing.T) (string, string) {
 				hostPath := t.TempDir()
 				return hostPath, "/var/cache/dnf"
 			},
-			expectedHasDir:   false,
 			expectedFound:    false,
 			expectedErrParts: []string{"reading"},
 		},
@@ -142,8 +67,7 @@ func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			hostPath, cacheDirPath := tt.setup(t)
-			hasDir, found, err := discoverDnf4CacheRepoDirPresence(hostPath, cacheDirPath)
-			assert.Equal(t, tt.expectedHasDir, hasDir)
+			found, err := discoverDnf4CachePresent(hostPath, cacheDirPath)
 			assert.Equal(t, tt.expectedFound, found)
 			if len(tt.expectedErrParts) == 0 {
 				assert.NoError(t, err)
@@ -157,10 +81,9 @@ func TestDiscoverDnf4CacheRepoDirPresence(t *testing.T) {
 	}
 }
 
-func TestDiscoverDnf5CacheRepoDirPresence(t *testing.T) {
+func TestDiscoverDnf5CachePresent(t *testing.T) {
 	tests := map[string]struct {
 		setup            func(t *testing.T) (hostPath string, cacheDirPath string)
-		expectedHasDir   bool
 		expectedFound    bool
 		expectedErrParts []string
 	}{
@@ -172,8 +95,7 @@ func TestDiscoverDnf5CacheRepoDirPresence(t *testing.T) {
 				require.NoError(t, os.MkdirAll(filepath.Join(cachePath, "fedora"), 0750))
 				return hostPath, cacheDirPath
 			},
-			expectedHasDir: true,
-			expectedFound:  true,
+			expectedFound: true,
 		},
 		"false when cache root exists but has no subdirectories": {
 			setup: func(t *testing.T) (string, string) {
@@ -183,15 +105,19 @@ func TestDiscoverDnf5CacheRepoDirPresence(t *testing.T) {
 				require.NoError(t, os.MkdirAll(cachePath, 0750))
 				return hostPath, cacheDirPath
 			},
-			expectedHasDir: true,
-			expectedFound:  false,
+			expectedFound: false,
+		},
+		"false with no error when cacheDirPath is empty": {
+			setup: func(t *testing.T) (string, string) {
+				return t.TempDir(), ""
+			},
+			expectedFound: false,
 		},
 		"error when cache dir is missing": {
 			setup: func(t *testing.T) (string, string) {
 				hostPath := t.TempDir()
 				return hostPath, "/var/cache/libdnf5"
 			},
-			expectedHasDir:   false,
 			expectedFound:    false,
 			expectedErrParts: []string{"reading"},
 		},
@@ -200,8 +126,7 @@ func TestDiscoverDnf5CacheRepoDirPresence(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			hostPath, cacheDirPath := tt.setup(t)
-			hasDir, found, err := discoverDnf5CacheRepoDirPresence(hostPath, cacheDirPath)
-			assert.Equal(t, tt.expectedHasDir, hasDir)
+			found, err := discoverDnf5CachePresent(hostPath, cacheDirPath)
 			assert.Equal(t, tt.expectedFound, found)
 			if len(tt.expectedErrParts) == 0 {
 				assert.NoError(t, err)
@@ -285,6 +210,9 @@ func TestDiscoverDnfStatusFlags(t *testing.T) {
 			},
 		},
 		"no repo files, cache exists": {
+			// A readable-but-empty reposdir is not itself an error condition
+			// (see hostprobe.HasAnyRepoFile): absence of the flag already
+			// conveys "no repo config found".
 			setup: func(t *testing.T) ([]string, []string, string, string) {
 				tmp := t.TempDir()
 				repoDir := filepath.Join(tmp, "yum.repos.d")
@@ -294,7 +222,6 @@ func TestDiscoverDnfStatusFlags(t *testing.T) {
 				return []string{repoDir}, nil, cacheDir, ""
 			},
 			expectedFlags: []v1.DnfStatusFlag{v1.DnfStatusFlag_DNF_V4_CACHE_FOUND},
-			errorContains: "no .repo files found",
 		},
 		"reposdir does not exist, cache exists": {
 			setup: func(t *testing.T) ([]string, []string, string, string) {
@@ -304,7 +231,7 @@ func TestDiscoverDnfStatusFlags(t *testing.T) {
 				return []string{filepath.Join(tmp, "nonexistent-repos")}, nil, cacheDir, ""
 			},
 			expectedFlags: nil,
-			errorContains: "reading",
+			errorContains: "no such file or directory",
 		},
 		"repos exist, cache dir does not exist": {
 			setup: func(t *testing.T) ([]string, []string, string, string) {

--- a/compliance/virtualmachines/roxagent/internal/hostprobe/probe.go
+++ b/compliance/virtualmachines/roxagent/internal/hostprobe/probe.go
@@ -1,0 +1,154 @@
+package hostprobe
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var log = logging.LoggerForModule()
+
+const (
+	// OSReleasePath is the canonical location of os-release on Linux hosts.
+	OSReleasePath = "/etc/os-release"
+	// EntitlementDirPath is the default RHSM entitlement certificate directory.
+	EntitlementDirPath = "/etc/pki/entitlement"
+	// YumReposDirPath is the default directory containing yum/dnf .repo files.
+	YumReposDirPath = "/etc/yum.repos.d"
+	// DNF5ReposDirPath is the dnf5-specific repos.d directory.
+	// https://github.com/rpm-software-management/dnf5/blob/185eaef1e0ad663bdb827a2179ab1df574a27d88/include/libdnf5/conf/const.hpp
+	DNF5ReposDirPath = "/usr/share/dnf5/repos.d"
+
+	// DNF4HistoryDBPath is the dnf4 transaction history SQLite database path.
+	DNF4HistoryDBPath = "/var/lib/dnf/history.sqlite"
+	// DNF5HistoryDBPath is the dnf5/libdnf5 transaction history SQLite database path.
+	DNF5HistoryDBPath = "/usr/lib/sysimage/libdnf5/transaction_history.sqlite"
+
+	// DNF4CacheDirPath is the default dnf4 package cache directory.
+	DNF4CacheDirPath = "/var/cache/dnf"
+	// DNF5CacheDirPath is the default dnf5/libdnf5 package cache directory.
+	DNF5CacheDirPath = "/var/cache/libdnf5"
+
+	entitlementKeySuffix  = "-key.pem"
+	entitlementCertSuffix = ".pem"
+)
+
+// DNF4ReposDirs are the default DNF4 reposdir locations.
+// https://github.com/rpm-software-management/libdnf/blob/53839f5bd88f378e57a1f1671b3db48d29984e24/libdnf/conf/ConfigMain.cpp
+var DNF4ReposDirs = []string{
+	"/etc/yum.repos.d",
+	"/etc/yum/repos.d",
+	"/etc/distro.repos.d",
+}
+
+type DNFVersion int
+
+const (
+	// DNFVersionUnknown indicates no known dnf history database was detected.
+	DNFVersionUnknown DNFVersion = iota
+	// DNFVersion4 indicates dnf4 transaction history was detected.
+	DNFVersion4
+	// DNFVersion5 indicates dnf5/libdnf5 transaction history was detected.
+	DNFVersion5
+)
+
+// HostPathFor converts an absolute system path into the corresponding path under hostPath.
+func HostPathFor(hostPath, path string) string {
+	if hostPath == "" || hostPath == string(os.PathSeparator) {
+		return path
+	}
+	// The join+clean approach below is safe (no escape from hostPath) only
+	// when the input path is absolute (e.g., "/etc/os-release"). All current
+	// call sites pass hardcoded absolute constants; guard against a future
+	// caller passing a relative/attacker-influenced path that could escape
+	// hostPath, e.g. hostPath="/host", path="/../etc/os-release" would clean
+	// to "/etc/os-release".
+	if !filepath.IsAbs(path) {
+		log.Warnf("HostPathFor: expected absolute path, got %q; returning as-is", path)
+		return path
+	}
+	trimmedPath := strings.TrimPrefix(path, string(os.PathSeparator))
+	return filepath.Clean(filepath.Join(hostPath, trimmedPath))
+}
+
+// DetectDNFVersion returns the detected dnf major version from history DB paths.
+func DetectDNFVersion(hostPath string) DNFVersion {
+	if _, err := os.Stat(HostPathFor(hostPath, DNF5HistoryDBPath)); err == nil {
+		return DNFVersion5
+	}
+	if _, err := os.Stat(HostPathFor(hostPath, DNF4HistoryDBPath)); err == nil {
+		return DNFVersion4
+	}
+	return DNFVersionUnknown
+}
+
+// HasEntitlementCertKeyPair reports whether a matching entitlement cert/key pair exists.
+func HasEntitlementCertKeyPair(hostPath string) (bool, error) {
+	return hasEntitlementCertKeyPairAtPath(HostPathFor(hostPath, EntitlementDirPath))
+}
+
+// hasEntitlementCertKeyPairAtPath checks a directory for matching entitlement cert/key pairs.
+// The entries returned by os.ReadDir are sorted by name, so a cert/key pair
+// ("NNN.pem" followed by "NNN-key.pem") is typically found after checking just
+// a few files. We return on the first match.
+func hasEntitlementCertKeyPairAtPath(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	keyBases := make(map[string]struct{})
+	certBases := make(map[string]struct{})
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if before, ok := strings.CutSuffix(name, entitlementKeySuffix); ok {
+			base := before
+			keyBases[base] = struct{}{}
+			if _, found := certBases[base]; found {
+				return true, nil
+			}
+			continue
+		}
+		if before, ok := strings.CutSuffix(name, entitlementCertSuffix); ok {
+			base := before
+			certBases[base] = struct{}{}
+			if _, found := keyBases[base]; found {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// HasAnyRepoFile reports whether any of the given repo directory paths contain
+// at least one *.repo file. If no directory contains a *.repo file, ReadDir
+// failures are aggregated with [errors.Join] and returned (nil error when every
+// inspected directory was readable but empty of *.repo files). Directory paths
+// are interpreted relative to fsys (leading slashes are stripped).
+func HasAnyRepoFile(fsys fs.FS, dirs []string) (bool, error) {
+	var errs []error
+	for _, dirPath := range dirs {
+		rel := strings.TrimPrefix(dirPath, "/")
+		entries, err := fs.ReadDir(fsys, rel)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".repo") {
+				return true, nil
+			}
+		}
+	}
+	return false, errors.Join(errs...)
+}

--- a/compliance/virtualmachines/roxagent/internal/hostprobe/probe.go
+++ b/compliance/virtualmachines/roxagent/internal/hostprobe/probe.go
@@ -110,16 +110,14 @@ func hasEntitlementCertKeyPairAtPath(path string) (bool, error) {
 			continue
 		}
 		name := entry.Name()
-		if before, ok := strings.CutSuffix(name, entitlementKeySuffix); ok {
-			base := before
+		if base, ok := strings.CutSuffix(name, entitlementKeySuffix); ok {
 			keyBases[base] = struct{}{}
 			if _, found := certBases[base]; found {
 				return true, nil
 			}
 			continue
 		}
-		if before, ok := strings.CutSuffix(name, entitlementCertSuffix); ok {
-			base := before
+		if base, ok := strings.CutSuffix(name, entitlementCertSuffix); ok {
 			certBases[base] = struct{}{}
 			if _, found := keyBases[base]; found {
 				return true, nil

--- a/compliance/virtualmachines/roxagent/internal/hostprobe/probe.go
+++ b/compliance/virtualmachines/roxagent/internal/hostprobe/probe.go
@@ -150,3 +150,14 @@ func HasAnyRepoFile(fsys fs.FS, dirs []string) (bool, error) {
 	}
 	return false, errors.Join(errs...)
 }
+
+// HasAnyRepoFileAt is a hostPath-based convenience wrapper around
+// [HasAnyRepoFile] for callers that don't already hold an fs.FS. hostPath=""
+// is treated the same as "/", consistent with [HostPathFor].
+func HasAnyRepoFileAt(hostPath string, dirs []string) (bool, error) {
+	root := hostPath
+	if root == "" {
+		root = string(os.PathSeparator)
+	}
+	return HasAnyRepoFile(os.DirFS(root), dirs)
+}

--- a/compliance/virtualmachines/roxagent/internal/hostprobe/probe_test.go
+++ b/compliance/virtualmachines/roxagent/internal/hostprobe/probe_test.go
@@ -85,6 +85,34 @@ func TestHasAnyRepoFile(t *testing.T) {
 	})
 }
 
+func TestHasAnyRepoFileAt(t *testing.T) {
+	t.Run("finds repo file under hostPath prefix", func(t *testing.T) {
+		hostPath := t.TempDir()
+		reposDir := HostPathFor(hostPath, YumReposDirPath)
+		require.NoError(t, os.MkdirAll(reposDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(reposDir, "baseos.repo"), []byte("[baseos]"), 0o644))
+
+		found, err := HasAnyRepoFileAt(hostPath, []string{YumReposDirPath})
+		require.NoError(t, err)
+		require.True(t, found)
+	})
+
+	t.Run("returns false with error when dir is missing under hostPath prefix", func(t *testing.T) {
+		hostPath := t.TempDir()
+		found, err := HasAnyRepoFileAt(hostPath, []string{YumReposDirPath})
+		require.Error(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("empty hostPath behaves the same as hostPath=/", func(t *testing.T) {
+		dirs := []string{"/definitely-not-a-real-repos-dir-xyz"}
+		foundEmpty, errEmpty := HasAnyRepoFileAt("", dirs)
+		foundRoot, errRoot := HasAnyRepoFileAt("/", dirs)
+		require.Equal(t, foundRoot, foundEmpty)
+		require.Equal(t, errRoot == nil, errEmpty == nil)
+	})
+}
+
 // unreadableDirFS wraps an fs.FS to return a fixed error for ReadDir on a specific path
 type unreadableDirFS struct {
 	fs.FS

--- a/compliance/virtualmachines/roxagent/internal/hostprobe/probe_test.go
+++ b/compliance/virtualmachines/roxagent/internal/hostprobe/probe_test.go
@@ -1,0 +1,235 @@
+package hostprobe
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasAnyRepoFile(t *testing.T) {
+	t.Run("finds repo file in single dir", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"etc/yum.repos.d/baseos.repo": &fstest.MapFile{Data: []byte("[baseos]")},
+			"etc/yum.repos.d/README.txt":  &fstest.MapFile{Data: []byte("not a repo")},
+		}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath})
+		require.NoError(t, err)
+		require.True(t, found)
+	})
+
+	t.Run("finds repo file across multiple dirs", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"usr/share/dnf5/repos.d/fedora.repo": &fstest.MapFile{Data: []byte("[fedora]")},
+		}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath, DNF5ReposDirPath})
+		require.NoError(t, err)
+		require.True(t, found)
+	})
+
+	t.Run("returns false when dirs exist but have no repo files", func(t *testing.T) {
+		fsys := fstest.MapFS{
+			"etc/yum.repos.d/README.txt": &fstest.MapFile{Data: []byte("not a repo")},
+		}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath})
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("returns false with error when all dirs missing", func(t *testing.T) {
+		fsys := fstest.MapFS{}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath, DNF5ReposDirPath})
+		require.Error(t, err)
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		require.False(t, found)
+	})
+
+	t.Run("skips unreadable dir and finds repo in another", func(t *testing.T) {
+		fsys := &unreadableDirFS{
+			FS:  fstest.MapFS{"usr/share/dnf5/repos.d/fedora.repo": &fstest.MapFile{Data: []byte("[fedora]")}},
+			dir: "etc/yum.repos.d",
+			err: fs.ErrPermission,
+		}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath, DNF5ReposDirPath})
+		require.NoError(t, err)
+		require.True(t, found)
+	})
+
+	t.Run("returns false when all dirs fail", func(t *testing.T) {
+		fsys := &unreadableDirFS{
+			FS:  fstest.MapFS{},
+			dir: "etc/yum.repos.d",
+			err: fs.ErrPermission,
+		}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath})
+		require.Error(t, err)
+		require.ErrorIs(t, err, fs.ErrPermission)
+		require.False(t, found)
+	})
+
+	t.Run("returns partial ReadDir errors when some dirs fail and none have repos", func(t *testing.T) {
+		fsys := &unreadableDirFS{
+			FS: fstest.MapFS{
+				"etc/yum.repos.d/README.txt": &fstest.MapFile{Data: []byte("x")},
+			},
+			dir: "usr/share/dnf5/repos.d",
+			err: fs.ErrPermission,
+		}
+		found, err := HasAnyRepoFile(fsys, []string{YumReposDirPath, DNF5ReposDirPath})
+		require.Error(t, err)
+		require.ErrorIs(t, err, fs.ErrPermission)
+		require.False(t, found)
+	})
+}
+
+// unreadableDirFS wraps an fs.FS to return a fixed error for ReadDir on a specific path
+type unreadableDirFS struct {
+	fs.FS
+	// return `err` when reading from `dir`
+	dir string
+	err error
+}
+
+func (f *unreadableDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == f.dir {
+		return nil, f.err
+	}
+	return fs.ReadDir(f.FS, name)
+}
+
+func TestHostPathFor(t *testing.T) {
+	t.Run("empty host path uses original path", func(t *testing.T) {
+		require.Equal(t, "/etc/os-release", HostPathFor("", "/etc/os-release"))
+	})
+
+	t.Run("root host path uses original path", func(t *testing.T) {
+		require.Equal(t, "/etc/os-release", HostPathFor("/", "/etc/os-release"))
+	})
+
+	t.Run("prefixes host path and cleans", func(t *testing.T) {
+		require.Equal(t, "/host/etc/os-release", HostPathFor("/host//", "/etc/os-release"))
+		require.Equal(t, "/host/var/cache/dnf", HostPathFor("/root/../host", "/var/lib/../cache//dnf/"))
+	})
+
+	t.Run("non-absolute path returned as-is instead of risking an escape from hostPath", func(t *testing.T) {
+		require.Equal(t, "../etc/os-release", HostPathFor("/host", "../etc/os-release"))
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	hostPath := t.TempDir()
+	target := HostPathFor(hostPath, "/etc/os-release")
+	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
+	require.NoError(t, os.WriteFile(target, []byte("ID=rhel"), 0o644))
+
+	require.FileExists(t, HostPathFor(hostPath, "/etc/os-release"))
+	require.NoFileExists(t, HostPathFor(hostPath, "/etc/missing"))
+}
+
+func TestDetectDNFVersion(t *testing.T) {
+	t.Run("unknown when no history db exists", func(t *testing.T) {
+		hostPath := t.TempDir()
+		require.Equal(t, DNFVersionUnknown, DetectDNFVersion(hostPath))
+	})
+
+	t.Run("detects dnf4", func(t *testing.T) {
+		hostPath := t.TempDir()
+		p := HostPathFor(hostPath, DNF4HistoryDBPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("db"), 0o644))
+		require.Equal(t, DNFVersion4, DetectDNFVersion(hostPath))
+	})
+
+	t.Run("detects dnf5", func(t *testing.T) {
+		hostPath := t.TempDir()
+		p := HostPathFor(hostPath, DNF5HistoryDBPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("db"), 0o644))
+		require.Equal(t, DNFVersion5, DetectDNFVersion(hostPath))
+	})
+
+	t.Run("prefers dnf5 when both exist", func(t *testing.T) {
+		hostPath := t.TempDir()
+		p4 := HostPathFor(hostPath, DNF4HistoryDBPath)
+		p5 := HostPathFor(hostPath, DNF5HistoryDBPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p4), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p5), 0o755))
+		require.NoError(t, os.WriteFile(p4, []byte("db4"), 0o644))
+		require.NoError(t, os.WriteFile(p5, []byte("db5"), 0o644))
+		require.Equal(t, DNFVersion5, DetectDNFVersion(hostPath))
+	})
+
+	t.Run("falls back to dnf4 when dnf5 path is broken symlink", func(t *testing.T) {
+		hostPath := t.TempDir()
+		p4 := HostPathFor(hostPath, DNF4HistoryDBPath)
+		p5 := HostPathFor(hostPath, DNF5HistoryDBPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p4), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p5), 0o755))
+		require.NoError(t, os.WriteFile(p4, []byte("db4"), 0o644))
+		require.NoError(t, os.Symlink(filepath.Join(hostPath, "does-not-exist.sqlite"), p5))
+
+		require.Equal(t, DNFVersion4, DetectDNFVersion(hostPath))
+	})
+}
+
+func Test_hasEntitlementCertKeyPairAtPath(t *testing.T) {
+	t.Run("returns true when matching pair exists", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "111-key.pem"), []byte("k"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "111.pem"), []byte("c"), 0o644))
+		ok, err := hasEntitlementCertKeyPairAtPath(dir)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("returns false for mismatched files", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "111-key.pem"), []byte("k"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "222.pem"), []byte("c"), 0o644))
+		ok, err := hasEntitlementCertKeyPairAtPath(dir)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("ignores directories and returns true when valid pair exists", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "111-key.pem"), []byte("k"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "111.pem"), []byte("c"), 0o644))
+		ok, err := hasEntitlementCertKeyPairAtPath(dir)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("returns error for missing directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "missing")
+		ok, err := hasEntitlementCertKeyPairAtPath(dir)
+		require.Error(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("returns error when path is file, not directory", func(t *testing.T) {
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "entitlement")
+		require.NoError(t, os.WriteFile(filePath, []byte("not a dir"), 0o644))
+
+		ok, err := hasEntitlementCertKeyPairAtPath(filePath)
+		require.Error(t, err)
+		require.False(t, ok)
+	})
+}
+
+func TestHasEntitlementCertKeyPair(t *testing.T) {
+	hostPath := t.TempDir()
+	entitlementDir := HostPathFor(hostPath, EntitlementDirPath)
+	require.NoError(t, os.MkdirAll(entitlementDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(entitlementDir, "3341241341658386286-key.pem"), []byte("k"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(entitlementDir, "3341241341658386286.pem"), []byte("c"), 0o644))
+
+	ok, err := HasEntitlementCertKeyPair(hostPath)
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/generated/internalapi/virtualmachine/v1/index_report.pb.go
+++ b/generated/internalapi/virtualmachine/v1/index_report.pb.go
@@ -121,6 +121,8 @@ func (ActivationStatus) EnumDescriptor() ([]byte, []int) {
 }
 
 // DnfMetadataStatus indicates whether DNF metadata is available.
+// Deprecated: use DnfStatusFlag instead.
+// Was used by roxagents released with 4.10 (tech-preview)
 type DnfMetadataStatus int32
 
 const (
@@ -168,6 +170,69 @@ func (x DnfMetadataStatus) Number() protoreflect.EnumNumber {
 // Deprecated: Use DnfMetadataStatus.Descriptor instead.
 func (DnfMetadataStatus) EnumDescriptor() ([]byte, []int) {
 	return file_internalapi_virtualmachine_v1_index_report_proto_rawDescGZIP(), []int{2}
+}
+
+// DnfStatusFlag represents individual facts about the DNF state on a VM.
+// Multiple flags can be reported simultaneously to give a complete picture.
+type DnfStatusFlag int32
+
+const (
+	// DNF repo configuration files (.repo) are present.
+	DnfStatusFlag_DNF_REPO_CONFIG_FOUND DnfStatusFlag = 0
+	// DNF4 package cache directories exist (e.g. /var/cache/dnf with -rpms- subdirs).
+	DnfStatusFlag_DNF_V4_CACHE_FOUND DnfStatusFlag = 1
+	// DNF5/libdnf5 package cache directories exist (e.g. /var/cache/libdnf5 with subdirs).
+	DnfStatusFlag_DNF_V5_CACHE_FOUND DnfStatusFlag = 2
+	// DNF4 transaction history database exists (var/lib/dnf/history.sqlite).
+	DnfStatusFlag_DNF_V4_HISTORY_DB_FOUND DnfStatusFlag = 3
+	// DNF5/libdnf5 transaction history database exists
+	// (usr/lib/sysimage/libdnf5/transaction_history.sqlite).
+	DnfStatusFlag_DNF_V5_HISTORY_DB_FOUND DnfStatusFlag = 4
+)
+
+// Enum value maps for DnfStatusFlag.
+var (
+	DnfStatusFlag_name = map[int32]string{
+		0: "DNF_REPO_CONFIG_FOUND",
+		1: "DNF_V4_CACHE_FOUND",
+		2: "DNF_V5_CACHE_FOUND",
+		3: "DNF_V4_HISTORY_DB_FOUND",
+		4: "DNF_V5_HISTORY_DB_FOUND",
+	}
+	DnfStatusFlag_value = map[string]int32{
+		"DNF_REPO_CONFIG_FOUND":   0,
+		"DNF_V4_CACHE_FOUND":      1,
+		"DNF_V5_CACHE_FOUND":      2,
+		"DNF_V4_HISTORY_DB_FOUND": 3,
+		"DNF_V5_HISTORY_DB_FOUND": 4,
+	}
+)
+
+func (x DnfStatusFlag) Enum() *DnfStatusFlag {
+	p := new(DnfStatusFlag)
+	*p = x
+	return p
+}
+
+func (x DnfStatusFlag) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DnfStatusFlag) Descriptor() protoreflect.EnumDescriptor {
+	return file_internalapi_virtualmachine_v1_index_report_proto_enumTypes[3].Descriptor()
+}
+
+func (DnfStatusFlag) Type() protoreflect.EnumType {
+	return &file_internalapi_virtualmachine_v1_index_report_proto_enumTypes[3]
+}
+
+func (x DnfStatusFlag) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DnfStatusFlag.Descriptor instead.
+func (DnfStatusFlag) EnumDescriptor() ([]byte, []int) {
+	return file_internalapi_virtualmachine_v1_index_report_proto_rawDescGZIP(), []int{3}
 }
 
 // VMReport is the message sent over vsock from roxagent to relay.
@@ -231,11 +296,16 @@ type DiscoveredData struct {
 	// detected_os will be extracted from '/etc/os-release' or similar source.
 	DetectedOs DetectedOS `protobuf:"varint,1,opt,name=detected_os,json=detectedOs,proto3,enum=virtualmachine.v1.DetectedOS" json:"detected_os,omitempty"`
 	// os_version will be extracted from '/etc/os-release' or similar source.
-	OsVersion         string            `protobuf:"bytes,2,opt,name=os_version,json=osVersion,proto3" json:"os_version,omitempty"`
-	ActivationStatus  ActivationStatus  `protobuf:"varint,3,opt,name=activation_status,json=activationStatus,proto3,enum=virtualmachine.v1.ActivationStatus" json:"activation_status,omitempty"`
+	OsVersion        string           `protobuf:"bytes,2,opt,name=os_version,json=osVersion,proto3" json:"os_version,omitempty"`
+	ActivationStatus ActivationStatus `protobuf:"varint,3,opt,name=activation_status,json=activationStatus,proto3,enum=virtualmachine.v1.ActivationStatus" json:"activation_status,omitempty"`
+	// Deprecated: use dnf_status instead.
 	DnfMetadataStatus DnfMetadataStatus `protobuf:"varint,4,opt,name=dnf_metadata_status,json=dnfMetadataStatus,proto3,enum=virtualmachine.v1.DnfMetadataStatus" json:"dnf_metadata_status,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// dnf_status reports multiple independent facts about the DNF state.
+	// Unlike the single-value dnf_metadata_status, this captures all observed
+	// conditions simultaneously (e.g., metadata available but history DB missing).
+	DnfStatus     []DnfStatusFlag `protobuf:"varint,5,rep,packed,name=dnf_status,json=dnfStatus,proto3,enum=virtualmachine.v1.DnfStatusFlag" json:"dnf_status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DiscoveredData) Reset() {
@@ -294,6 +364,13 @@ func (x *DiscoveredData) GetDnfMetadataStatus() DnfMetadataStatus {
 		return x.DnfMetadataStatus
 	}
 	return DnfMetadataStatus_DNF_METADATA_UNSPECIFIED
+}
+
+func (x *DiscoveredData) GetDnfStatus() []DnfStatusFlag {
+	if x != nil {
+		return x.DnfStatus
+	}
+	return nil
 }
 
 // The index report is collected from the virtual machine agent and contains
@@ -413,14 +490,16 @@ const file_internalapi_virtualmachine_v1_index_report_proto_rawDesc = "" +
 	"0internalapi/virtualmachine/v1/index_report.proto\x12\x11virtualmachine.v1\x1a)internalapi/scanner/v4/index_report.proto\"\x99\x01\n" +
 	"\bVMReport\x12A\n" +
 	"\findex_report\x18\x01 \x01(\v2\x1e.virtualmachine.v1.IndexReportR\vindexReport\x12J\n" +
-	"\x0fdiscovered_data\x18\x02 \x01(\v2!.virtualmachine.v1.DiscoveredDataR\x0ediscoveredData\"\x97\x02\n" +
+	"\x0fdiscovered_data\x18\x02 \x01(\v2!.virtualmachine.v1.DiscoveredDataR\x0ediscoveredData\"\xd8\x02\n" +
 	"\x0eDiscoveredData\x12>\n" +
 	"\vdetected_os\x18\x01 \x01(\x0e2\x1d.virtualmachine.v1.DetectedOSR\n" +
 	"detectedOs\x12\x1d\n" +
 	"\n" +
 	"os_version\x18\x02 \x01(\tR\tosVersion\x12P\n" +
 	"\x11activation_status\x18\x03 \x01(\x0e2#.virtualmachine.v1.ActivationStatusR\x10activationStatus\x12T\n" +
-	"\x13dnf_metadata_status\x18\x04 \x01(\x0e2$.virtualmachine.v1.DnfMetadataStatusR\x11dnfMetadataStatus\"^\n" +
+	"\x13dnf_metadata_status\x18\x04 \x01(\x0e2$.virtualmachine.v1.DnfMetadataStatusR\x11dnfMetadataStatus\x12?\n" +
+	"\n" +
+	"dnf_status\x18\x05 \x03(\x0e2 .virtualmachine.v1.DnfStatusFlagR\tdnfStatus\"^\n" +
 	"\vIndexReport\x12\x1b\n" +
 	"\tvsock_cid\x18\x01 \x01(\tR\bvsockCid\x122\n" +
 	"\bindex_v4\x18\x02 \x01(\v2\x17.scanner.v4.IndexReportR\aindexV4\"X\n" +
@@ -439,7 +518,13 @@ const file_internalapi_virtualmachine_v1_index_report_proto_rawDesc = "" +
 	"\x11DnfMetadataStatus\x12\x1c\n" +
 	"\x18DNF_METADATA_UNSPECIFIED\x10\x00\x12\r\n" +
 	"\tAVAILABLE\x10\x01\x12\x0f\n" +
-	"\vUNAVAILABLE\x10\x02B$Z\"./internalapi/virtualmachine/v1;v1b\x06proto3"
+	"\vUNAVAILABLE\x10\x02*\x94\x01\n" +
+	"\rDnfStatusFlag\x12\x19\n" +
+	"\x15DNF_REPO_CONFIG_FOUND\x10\x00\x12\x16\n" +
+	"\x12DNF_V4_CACHE_FOUND\x10\x01\x12\x16\n" +
+	"\x12DNF_V5_CACHE_FOUND\x10\x02\x12\x1b\n" +
+	"\x17DNF_V4_HISTORY_DB_FOUND\x10\x03\x12\x1b\n" +
+	"\x17DNF_V5_HISTORY_DB_FOUND\x10\x04B$Z\"./internalapi/virtualmachine/v1;v1b\x06proto3"
 
 var (
 	file_internalapi_virtualmachine_v1_index_report_proto_rawDescOnce sync.Once
@@ -453,31 +538,33 @@ func file_internalapi_virtualmachine_v1_index_report_proto_rawDescGZIP() []byte 
 	return file_internalapi_virtualmachine_v1_index_report_proto_rawDescData
 }
 
-var file_internalapi_virtualmachine_v1_index_report_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_internalapi_virtualmachine_v1_index_report_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_internalapi_virtualmachine_v1_index_report_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_virtualmachine_v1_index_report_proto_goTypes = []any{
 	(DetectedOS)(0),          // 0: virtualmachine.v1.DetectedOS
 	(ActivationStatus)(0),    // 1: virtualmachine.v1.ActivationStatus
 	(DnfMetadataStatus)(0),   // 2: virtualmachine.v1.DnfMetadataStatus
-	(*VMReport)(nil),         // 3: virtualmachine.v1.VMReport
-	(*DiscoveredData)(nil),   // 4: virtualmachine.v1.DiscoveredData
-	(*IndexReport)(nil),      // 5: virtualmachine.v1.IndexReport
-	(*IndexReportEvent)(nil), // 6: virtualmachine.v1.IndexReportEvent
-	(*v4.IndexReport)(nil),   // 7: scanner.v4.IndexReport
+	(DnfStatusFlag)(0),       // 3: virtualmachine.v1.DnfStatusFlag
+	(*VMReport)(nil),         // 4: virtualmachine.v1.VMReport
+	(*DiscoveredData)(nil),   // 5: virtualmachine.v1.DiscoveredData
+	(*IndexReport)(nil),      // 6: virtualmachine.v1.IndexReport
+	(*IndexReportEvent)(nil), // 7: virtualmachine.v1.IndexReportEvent
+	(*v4.IndexReport)(nil),   // 8: scanner.v4.IndexReport
 }
 var file_internalapi_virtualmachine_v1_index_report_proto_depIdxs = []int32{
-	5, // 0: virtualmachine.v1.VMReport.index_report:type_name -> virtualmachine.v1.IndexReport
-	4, // 1: virtualmachine.v1.VMReport.discovered_data:type_name -> virtualmachine.v1.DiscoveredData
+	6, // 0: virtualmachine.v1.VMReport.index_report:type_name -> virtualmachine.v1.IndexReport
+	5, // 1: virtualmachine.v1.VMReport.discovered_data:type_name -> virtualmachine.v1.DiscoveredData
 	0, // 2: virtualmachine.v1.DiscoveredData.detected_os:type_name -> virtualmachine.v1.DetectedOS
 	1, // 3: virtualmachine.v1.DiscoveredData.activation_status:type_name -> virtualmachine.v1.ActivationStatus
 	2, // 4: virtualmachine.v1.DiscoveredData.dnf_metadata_status:type_name -> virtualmachine.v1.DnfMetadataStatus
-	7, // 5: virtualmachine.v1.IndexReport.index_v4:type_name -> scanner.v4.IndexReport
-	5, // 6: virtualmachine.v1.IndexReportEvent.index:type_name -> virtualmachine.v1.IndexReport
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	3, // 5: virtualmachine.v1.DiscoveredData.dnf_status:type_name -> virtualmachine.v1.DnfStatusFlag
+	8, // 6: virtualmachine.v1.IndexReport.index_v4:type_name -> scanner.v4.IndexReport
+	6, // 7: virtualmachine.v1.IndexReportEvent.index:type_name -> virtualmachine.v1.IndexReport
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_virtualmachine_v1_index_report_proto_init() }
@@ -490,7 +577,7 @@ func file_internalapi_virtualmachine_v1_index_report_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_virtualmachine_v1_index_report_proto_rawDesc), len(file_internalapi_virtualmachine_v1_index_report_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/generated/internalapi/virtualmachine/v1/index_report_vtproto.pb.go
+++ b/generated/internalapi/virtualmachine/v1/index_report_vtproto.pb.go
@@ -48,6 +48,11 @@ func (m *DiscoveredData) CloneVT() *DiscoveredData {
 	r.OsVersion = m.OsVersion
 	r.ActivationStatus = m.ActivationStatus
 	r.DnfMetadataStatus = m.DnfMetadataStatus
+	if rhs := m.DnfStatus; rhs != nil {
+		tmpContainer := make([]DnfStatusFlag, len(rhs))
+		copy(tmpContainer, rhs)
+		r.DnfStatus = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -140,6 +145,15 @@ func (this *DiscoveredData) EqualVT(that *DiscoveredData) bool {
 	}
 	if this.DnfMetadataStatus != that.DnfMetadataStatus {
 		return false
+	}
+	if len(this.DnfStatus) != len(that.DnfStatus) {
+		return false
+	}
+	for i, vx := range this.DnfStatus {
+		vy := that.DnfStatus[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -281,6 +295,27 @@ func (m *DiscoveredData) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DnfStatus) > 0 {
+		var pksize2 int
+		for _, num := range m.DnfStatus {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.DnfStatus {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x2a
 	}
 	if m.DnfMetadataStatus != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DnfMetadataStatus))
@@ -455,6 +490,13 @@ func (m *DiscoveredData) SizeVT() (n int) {
 	}
 	if m.DnfMetadataStatus != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.DnfMetadataStatus))
+	}
+	if len(m.DnfStatus) > 0 {
+		l = 0
+		for _, e := range m.DnfStatus {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
 	}
 	n += len(m.unknownFields)
 	return n
@@ -742,6 +784,75 @@ func (m *DiscoveredData) UnmarshalVT(dAtA []byte) error {
 				if b < 0x80 {
 					break
 				}
+			}
+		case 5:
+			if wireType == 0 {
+				var v DnfStatusFlag
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= DnfStatusFlag(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.DnfStatus = append(m.DnfStatus, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.DnfStatus) == 0 {
+					m.DnfStatus = make([]DnfStatusFlag, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v DnfStatusFlag
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= DnfStatusFlag(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.DnfStatus = append(m.DnfStatus, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field DnfStatus", wireType)
 			}
 		default:
 			iNdEx = preIndex
@@ -1255,6 +1366,75 @@ func (m *DiscoveredData) UnmarshalVTUnsafe(dAtA []byte) error {
 				if b < 0x80 {
 					break
 				}
+			}
+		case 5:
+			if wireType == 0 {
+				var v DnfStatusFlag
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= DnfStatusFlag(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.DnfStatus = append(m.DnfStatus, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.DnfStatus) == 0 {
+					m.DnfStatus = make([]DnfStatusFlag, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v DnfStatusFlag
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= DnfStatusFlag(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.DnfStatus = append(m.DnfStatus, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field DnfStatus", wireType)
 			}
 		default:
 			iNdEx = preIndex

--- a/proto/internalapi/virtualmachine/v1/index_report.proto
+++ b/proto/internalapi/virtualmachine/v1/index_report.proto
@@ -22,7 +22,12 @@ message DiscoveredData {
   // os_version will be extracted from '/etc/os-release' or similar source.
   string os_version = 2;
   ActivationStatus activation_status = 3;
+  // Deprecated: use dnf_status instead.
   DnfMetadataStatus dnf_metadata_status = 4;
+  // dnf_status reports multiple independent facts about the DNF state.
+  // Unlike the single-value dnf_metadata_status, this captures all observed
+  // conditions simultaneously (e.g., metadata available but history DB missing).
+  repeated DnfStatusFlag dnf_status = 5;
 }
 
 // DetectedOS describes the OS detected by roxagent.
@@ -40,10 +45,28 @@ enum ActivationStatus {
 }
 
 // DnfMetadataStatus indicates whether DNF metadata is available.
+// Deprecated: use DnfStatusFlag instead.
+// Was used by roxagents released with 4.10 (tech-preview)
 enum DnfMetadataStatus {
   DNF_METADATA_UNSPECIFIED = 0;
   AVAILABLE = 1;
   UNAVAILABLE = 2;
+}
+
+// DnfStatusFlag represents individual facts about the DNF state on a VM.
+// Multiple flags can be reported simultaneously to give a complete picture.
+enum DnfStatusFlag {
+  // DNF repo configuration files (.repo) are present.
+  DNF_REPO_CONFIG_FOUND = 0;
+  // DNF4 package cache directories exist (e.g. /var/cache/dnf with -rpms- subdirs).
+  DNF_V4_CACHE_FOUND = 1;
+  // DNF5/libdnf5 package cache directories exist (e.g. /var/cache/libdnf5 with subdirs).
+  DNF_V5_CACHE_FOUND = 2;
+  // DNF4 transaction history database exists (var/lib/dnf/history.sqlite).
+  DNF_V4_HISTORY_DB_FOUND = 3;
+  // DNF5/libdnf5 transaction history database exists
+  // (usr/lib/sysimage/libdnf5/transaction_history.sqlite).
+  DNF_V5_HISTORY_DB_FOUND = 4;
 }
 
 // The index report is collected from the virtual machine agent and contains


### PR DESCRIPTION
## Description

PR #19458 refactored roxagent's push-mode host-probing/diagnostics code
(shared `hostprobe` layer, DNF4/DNF5-aware `DnfStatusFlag` facts, scan
diagnostics logging) but was closed because it touched the push-mode
packages (`index/`, `lock/`, `vsock/`, `common/config.go`) that #21436 is
about to delete as part of the VSOCK pull-mode migration (see
[ADR-0006](https://github.com/stackrox/architecture-decision-records/blob/piotr/ADR-0006-vsock-pull-mode/stackrox/ADR-0006-vm-scanning-vsock-pull-mode.md)).

The probing/diagnostics logic itself is transport-agnostic — it just
inspects the VM filesystem (`/etc/os-release`, DNF cache/reposdir/history-DB
paths, entitlement certs) given a `hostPath` prefix. Pull mode's own
`discovery/discovery.go` (added in #21435) reimplements the same kind of
checks, but without the DNF5 support or diagnostics logging #19458 added.
While porting this over, an additional gap surfaced: `vmscraper` already
receives roxagent's discovered facts in every `GetReport` response
(`ResponseMeta.Facts`), but silently drops them — pulled VMs never produced
the `VM discovered data` log line or metrics that push-mode VMs did. That
gap is addressed in the follow-up #21515, stacked on top of this PR.

This PR:
- Adds `internal/hostprobe`, a shared host-filesystem probing layer (DNF4
  and DNF5 history-DB/cache/reposdir locations, entitlement cert/key pair
  matching, OS-release parsing), ported unchanged from #19458.
- Replaces pull-mode discovery's single-value DNF detection with
  `DiscoveredData.dnf_status` (new repeated `DnfStatusFlag` proto field),
  so DNF4 and DNF5 facts are captured independently instead of collapsing
  into one deprecated enum value. `dnf_metadata_status` is kept, now
  deprecated, for backward compatibility with already-deployed 4.10
  tech-preview agents.
- Adds scan diagnostics logging to `roxagent serve`'s scan/rescan loop:
  filesystem facts before scanning, and an index-report summary with an
  explicit "0 repositories -> UNSCANNED" warning after scanning.

`vmscraper`/`service_impl.go` wiring for these facts (logging and metrics
on both transport modes) is a separate follow-up: #21515.

Based on `master` (introduces the pull-mode `discovery/` and `vsockserver/`
packages this PR extends, added in #21435, already merged).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [ ] Manually verified on a cluster

AI-Assisted: cursor, ~90% generated (ported/adapted from the closed PR #19458 onto the pull-mode stack), user directed scope and reviewed the analysis.
