### PR TITLE
fix(ci): replace paths-ignore in check-crd-compatibility

### DIFF
--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -11,15 +11,18 @@ on:
     - opened
     - reopened
     - synchronize
-    paths-ignore:
-    - 'ui/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   check-crd-compatibility:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11


### PR DESCRIPTION
## Description

`paths-ignore: ui/**` on `check-crd-compatibility.yaml` causes the workflow to not run at all for UI-only PRs. Since `check-crd-compatibility` is a required status check in the branch ruleset, the check never gets created and the PR is permanently blocked.

Fix: replace `paths-ignore` with the `detect-changes` reusable workflow + job-level `if:` condition, which reports a "skipped" status that satisfies the required check.

The following commit temporarily targets `.github/` instead of `ui/` in detect-changes to verify the skip behavior on this PR. This was reverted after verification below.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

check-crd-compatibility passing with the `detect-changes` directory set to `.github`:
<img width="805" height="305" alt="image" src="https://github.com/user-attachments/assets/2b09aa78-c6ee-41a6-98f2-06a9706500d2" />
<img width="977" height="438" alt="image" src="https://github.com/user-attachments/assets/e2cfe646-2d37-4e86-a801-60dc6c2decd7" />

