### PR TITLE
ROX-35504: Redirect /main/risk to /main/risk/workloads

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
+++ b/ui/apps/platform/cypress/integration/risk/Risk.helpers.js
@@ -8,7 +8,7 @@ import { visit } from '../../helpers/visit';
 
 // visit
 
-const basePath = '/main/risk';
+const basePath = '/main/risk/workloads';
 
 export const deploymentswithprocessinfoAlias = 'deploymentswithprocessinfo';
 export const deploymentscountAlias = 'deploymentscount';

--- a/ui/apps/platform/cypress/integration/risk/riskRedirect.test.js
+++ b/ui/apps/platform/cypress/integration/risk/riskRedirect.test.js
@@ -1,0 +1,33 @@
+import withAuth from '../../helpers/basicAuth';
+import { visit } from '../../helpers/visit';
+
+describe('Risk redirect', () => {
+    withAuth();
+
+    it('should redirect /main/risk to /main/risk/workloads', () => {
+        visit('/main/risk');
+
+        cy.location('pathname').should('eq', '/main/risk/workloads');
+        cy.get('h1:contains("Risk")');
+    });
+
+    it('should redirect /main/risk with query params to /main/risk/workloads', () => {
+        visit('/main/risk?filteredWorkflowView=Full view');
+
+        cy.location('pathname').should('eq', '/main/risk/workloads');
+        cy.location('search').should('contain', 'filteredWorkflowView=Full%20view');
+    });
+
+    it('should redirect /main/risk/<deploymentId> to /main/risk/workloads/<deploymentId>', () => {
+        visit('/main/risk/fake-deployment-id');
+
+        cy.location('pathname').should('eq', '/main/risk/workloads/fake-deployment-id');
+    });
+
+    it('should redirect /main/risk/<deploymentId> with query params', () => {
+        visit('/main/risk/fake-deployment-id?filteredWorkflowView=Applications view');
+
+        cy.location('pathname').should('eq', '/main/risk/workloads/fake-deployment-id');
+        cy.location('search').should('contain', 'filteredWorkflowView=Applications%20view');
+    });
+});

--- a/ui/apps/platform/cypress/integration/risk/riskSearchToPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/risk/riskSearchToPolicy.test.js
@@ -2,7 +2,7 @@ import withAuth from '../../helpers/basicAuth';
 
 import { selectors as riskSelectors } from './Risk.selectors';
 
-const riskUrl = '/main/risk';
+const riskUrl = '/main/risk/workloads';
 const policiesUrl = '/main/policy-management/policies';
 const policySelectors = {
     nextButton: '.btn:contains("Next")',

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { Card, Content } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { riskBasePath } from 'routePaths';
+import { riskWorkloadsBasePath } from 'routePaths';
 import type { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import type { ListDeployment } from 'types/deployment.proto';
@@ -110,7 +110,7 @@ function ListeningEndpointsTable({
                                 }}
                             />
                             <Td dataLabel="Deployment">
-                                <Link to={`${riskBasePath}/${id}`}>{name}</Link>
+                                <Link to={`${riskWorkloadsBasePath}/${id}`}>{name}</Link>
                             </Td>
                             <Td dataLabel="Cluster">{cluster}</Td>
                             <Td dataLabel="Namespace">{namespace}</Td>

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRisk.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRisk.tsx
@@ -3,7 +3,7 @@ import { Flex, FlexItem, Title } from '@patternfly/react-core';
 
 import WidgetCard from 'Components/PatternFly/WidgetCard';
 import useURLSearch from 'hooks/useURLSearch';
-import { riskBasePath } from 'routePaths';
+import { riskWorkloadsBasePath } from 'routePaths';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import DeploymentsAtMostRiskTable from './DeploymentsAtMostRiskTable';
 import useDeploymentsAtRisk from '../hooks/useDeploymentsAtRisk';
@@ -27,7 +27,7 @@ function DeploymentsAtMostRisk() {
                         <Title headingLevel="h2">Deployments at most risk</Title>
                     </FlexItem>
                     <FlexItem>
-                        <Link to={`${riskBasePath}?${urlQueryString}`}>View all</Link>
+                        <Link to={`${riskWorkloadsBasePath}?${urlQueryString}`}>View all</Link>
                     </FlexItem>
                 </Flex>
             }

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/DeploymentsAtMostRiskTable.tsx
@@ -3,7 +3,7 @@ import { Truncate } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import type { ListDeployment } from 'types/deployment.proto';
-import { getLinkToDeploymentInNetworkGraph, riskBasePath } from 'routePaths';
+import { getLinkToDeploymentInNetworkGraph, riskWorkloadsBasePath } from 'routePaths';
 import type { SearchFilter } from 'types/search';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 
@@ -12,7 +12,7 @@ function riskPageLinkToDeployment(id: string, name: string, searchFilter: Search
         ...searchFilter,
         Deployment: name,
     });
-    return `${riskBasePath}/${id}?${query}`;
+    return `${riskWorkloadsBasePath}/${id}?${query}`;
 }
 
 type DeploymentsAtMostRiskTableProps = {

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -35,6 +35,7 @@ import {
     policiesBasePath,
     policyManagementBasePath,
     riskBasePath,
+    riskWorkloadsBasePath,
     searchPath,
     systemConfigPath,
     systemHealthPath,
@@ -208,8 +209,12 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         component: asyncComponent(() => import('Containers/PolicyManagement/PolicyManagementPage')),
         path: policyManagementBasePath,
     },
-    risk: {
+    'risk/workloads': {
         component: asyncComponent(() => import('Containers/Risk/RiskRoutes')),
+        path: riskWorkloadsBasePath,
+    },
+    risk: {
+        component: RiskRedirect,
         path: riskBasePath,
     },
     search: {
@@ -305,6 +310,12 @@ function WorkloadCvesRedirect() {
         vulnerabilitiesAllImagesPath
     );
 
+    return <Navigate to={`${newPath}${location.search}`} replace />;
+}
+
+function RiskRedirect() {
+    const location = useLocation();
+    const newPath = location.pathname.replace(riskBasePath, riskWorkloadsBasePath);
     return <Navigate to={`${newPath}${location.search}`} replace />;
 }
 

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/HorizontalSubnav.tsx
@@ -5,7 +5,7 @@ import { Nav } from '@patternfly/react-core';
 
 import {
     everyResource,
-    riskBasePath,
+    riskWorkloadsBasePath,
     someResource,
     violationsBasePath,
     vulnerabilitiesAllImagesPath,
@@ -46,7 +46,7 @@ type SubnavRouteConfig = {
 const subnavRoutes: SubnavRouteConfig[] = [
     {
         key: 'risk',
-        patterns: [`${riskBasePath}/*`],
+        patterns: [`${riskWorkloadsBasePath}/*`],
         component: RiskSubnav,
         resourceAccessRequirements: everyResource(['Deployment']),
     },

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -31,7 +31,7 @@ import {
     listeningEndpointsBasePath,
     networkBasePath,
     policyManagementBasePath,
-    riskBasePath,
+    riskWorkloadsBasePath,
     systemConfigPath,
     systemHealthPath,
     violationsBasePath,
@@ -200,8 +200,8 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
         {
             type: 'link',
             content: 'Risk',
-            path: riskBasePath,
-            routeKey: 'risk',
+            path: riskWorkloadsBasePath,
+            routeKey: 'risk/workloads',
         },
         {
             type: 'parent',

--- a/ui/apps/platform/src/Containers/Risk/DeploymentNameColumn.tsx
+++ b/ui/apps/platform/src/Containers/Risk/DeploymentNameColumn.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from '@patternfly/react-core';
 import { CheckIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import useFilteredWorkflowViewURLState from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
-import { riskBasePath } from 'routePaths';
+import { riskWorkloadsBasePath } from 'routePaths';
 
 type DeploymentNameColumnProps = {
     original: {
@@ -18,7 +18,7 @@ export function DeploymentNameColumn({ original }: DeploymentNameColumnProps) {
     const isSuspicious = find(original.baselineStatuses, {
         anomalousProcessesExecuted: true,
     });
-    const url = `${riskBasePath}/${original.deployment.id}?filteredWorkflowView=${filteredWorkflowView}`;
+    const url = `${riskWorkloadsBasePath}/${original.deployment.id}?filteredWorkflowView=${filteredWorkflowView}`;
     // Borrow layout from IconText component.
     return (
         <div className="flex items-center">

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.test.ts
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.test.ts
@@ -27,15 +27,19 @@ describe('resolveParams', () => {
 
 describe('buildViewLinkUrl', () => {
     it('should resolve :id in a simple path', () => {
-        expect(buildViewLinkUrl('/main/risk/:id', { id: 'abc123' }, undefined)).toBe(
-            '/main/risk/abc123'
+        expect(buildViewLinkUrl('/main/risk/workloads/:id', { id: 'abc123' }, undefined)).toBe(
+            '/main/risk/workloads/abc123'
         );
     });
 
     it('should append searchParams to a simple path', () => {
         expect(
-            buildViewLinkUrl('/main/risk/:id', { id: 'abc123' }, 'filteredWorkflowView=Full view')
-        ).toBe('/main/risk/abc123?filteredWorkflowView=Full view');
+            buildViewLinkUrl(
+                '/main/risk/workloads/:id',
+                { id: 'abc123' },
+                'filteredWorkflowView=Full view'
+            )
+        ).toBe('/main/risk/workloads/abc123?filteredWorkflowView=Full view');
     });
 
     it('should resolve :params in basePath query string separately from path', () => {
@@ -53,10 +57,14 @@ describe('buildViewLinkUrl', () => {
     });
 
     it('should fall back to the path pattern when :param has no value', () => {
-        expect(buildViewLinkUrl('/main/risk/:id', {}, undefined)).toBe('/main/risk/:id');
+        expect(buildViewLinkUrl('/main/risk/workloads/:id', {}, undefined)).toBe(
+            '/main/risk/workloads/:id'
+        );
     });
 
     it('should handle path without any :params or query', () => {
-        expect(buildViewLinkUrl('/main/risk', {}, undefined)).toBe('/main/risk');
+        expect(buildViewLinkUrl('/main/risk/workloads', {}, undefined)).toBe(
+            '/main/risk/workloads'
+        );
     });
 });

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -6,7 +6,7 @@ import {
     clustersBasePath,
     configManagementPath,
     policiesBasePath,
-    riskBasePath,
+    riskWorkloadsBasePath,
     violationsBasePath,
     vulnerabilitiesAllImagesPath,
     vulnerabilitiesNodeCvesPath,
@@ -41,9 +41,9 @@ type SearchLinkDescriptor = {
 };
 
 const filterOnRisk: SearchLinkDescriptor = {
-    basePath: riskBasePath,
+    basePath: riskWorkloadsBasePath,
     linkText: 'Risk',
-    routeKey: 'risk',
+    routeKey: 'risk/workloads',
     searchParams: 'filteredWorkflowView=Full view',
 };
 
@@ -89,9 +89,9 @@ function getSearchResultCategoryMap(
             },
             viewLinks: [
                 {
-                    basePath: `${riskBasePath}/:id`,
+                    basePath: `${riskWorkloadsBasePath}/:id`,
                     linkText: 'Risk',
-                    routeKey: 'risk',
+                    routeKey: 'risk/workloads',
                     searchParams: 'filteredWorkflowView=Full view',
                 },
             ],

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -62,10 +62,11 @@ export const policyCategoriesPath = `${policyManagementBasePath}/policy-categori
 export const deprecatedPoliciesBasePath = `${mainPath}/policies`;
 export const deprecatedPoliciesPath = `${deprecatedPoliciesBasePath}/:policyId?/:command?`;
 export const riskBasePath = `${mainPath}/risk`;
-export const riskPath = `${riskBasePath}/:deploymentId?`;
-export const riskUserWorkloadsViewPath = `${riskBasePath}?filteredWorkflowView=Applications view`;
-export const riskPlatformViewPath = `${riskBasePath}?filteredWorkflowView=Platform view`;
-export const riskFullViewPath = `${riskBasePath}?filteredWorkflowView=Full view`;
+export const riskWorkloadsBasePath = `${riskBasePath}/workloads`;
+export const riskWorkloadPath = `${riskWorkloadsBasePath}/:deploymentId?`;
+export const riskUserWorkloadsViewPath = `${riskWorkloadsBasePath}?filteredWorkflowView=Applications view`;
+export const riskPlatformViewPath = `${riskWorkloadsBasePath}?filteredWorkflowView=Platform view`;
+export const riskFullViewPath = `${riskWorkloadsBasePath}?filteredWorkflowView=Full view`;
 export const searchPath = `${mainPath}/search`;
 export const secretsPath = `${mainPath}/configmanagement/secrets/:secretId?`;
 export const systemConfigPath = `${mainPath}/systemconfig`;
@@ -179,6 +180,8 @@ export type RouteKey =
     | 'listening-endpoints'
     | 'network-graph'
     | 'policy-management'
+    // Risk workloads must precede generic risk in Body for route specificity.
+    | 'risk/workloads'
     | 'risk'
     | 'search'
     | 'system-health'
@@ -310,6 +313,10 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
             'WorkflowAdministration',
         ]),
     },
+    'risk/workloads': {
+        resourceAccessRequirements: everyResource(['Deployment']),
+    },
+    // Retained for backward compatibility, will redirect to risk/workloads
     risk: {
         resourceAccessRequirements: everyResource(['Deployment']),
     },

--- a/ui/apps/platform/src/utils/URLGenerator.js
+++ b/ui/apps/platform/src/utils/URLGenerator.js
@@ -8,7 +8,8 @@ import {
     clustersBasePath,
     clustersPathWithParam,
     policiesPath,
-    riskPath,
+    riskWorkloadPath,
+    riskWorkloadsBasePath,
     secretsPath,
     urlEntityListTypes,
     urlEntityTypes,
@@ -28,9 +29,9 @@ const legacyPathMap = {
         [pageTypes.DASHBOARD]: clustersBasePath,
     },
     [useCases.RISK]: {
-        [pageTypes.ENTITY]: riskPath,
-        [pageTypes.LIST]: '/main/risk',
-        [pageTypes.DASHBOARD]: '/main/risk',
+        [pageTypes.ENTITY]: riskWorkloadPath,
+        [pageTypes.LIST]: riskWorkloadsBasePath,
+        [pageTypes.DASHBOARD]: riskWorkloadsBasePath,
     },
     [useCases.SECRET]: {
         [pageTypes.ENTITY]: secretsPath,

--- a/ui/apps/platform/src/utils/URLParser.ts
+++ b/ui/apps/platform/src/utils/URLParser.ts
@@ -11,7 +11,7 @@ import {
     accessControlPath,
     clustersPathWithParam,
     policiesPath,
-    riskPath,
+    riskWorkloadPath,
     urlEntityListTypes,
     urlEntityTypes,
     userRolePath,
@@ -28,7 +28,7 @@ type ParamsWithContext = {
 
 const nonWorkflowUseCasePathEntries = Object.entries({
     CLUSTERS: clustersPathWithParam,
-    RISK: riskPath,
+    RISK: riskWorkloadPath,
     VIOLATIONS: violationsPath,
     POLICIES: policiesPath,
     USER: userRolePath, // however, it matches workflow list path

--- a/ui/apps/platform/src/utils/URLService.js
+++ b/ui/apps/platform/src/utils/URLService.js
@@ -10,7 +10,8 @@ import Raven from 'raven-js';
 
 import {
     policiesPath,
-    riskPath,
+    riskWorkloadPath,
+    riskWorkloadsBasePath,
     secretsPath,
     urlEntityListTypes,
     urlEntityTypes,
@@ -90,9 +91,9 @@ function getPath(urlParams) {
 
     const legacyPathMap = {
         [useCases.RISK]: {
-            [pageTypes.ENTITY]: riskPath,
-            [pageTypes.LIST]: '/main/risk',
-            [pageTypes.DASHBOARD]: '/main/risk',
+            [pageTypes.ENTITY]: riskWorkloadPath,
+            [pageTypes.LIST]: riskWorkloadsBasePath,
+            [pageTypes.DASHBOARD]: riskWorkloadsBasePath,
         },
         [useCases.SECRET]: {
             [pageTypes.ENTITY]: secretsPath,


### PR DESCRIPTION
## Description

With the upcoming addition of Secrets to the Risk subsection, and likely RBAC addition after, this sets up risk link redirects so we have a cohesive structure moving forward:
`/risk -> /risk/workloads (for backwards compat)`
`/risk/workloads`
`/risk/secrets`
`/risk/rbac`

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual testing the UI and verifying existing functionality works.

Existing e2e tests for RIsk.

New e2e tests to validate redirects are working correctly.