### PR TITLE
ROX-35307: wait for severity policy enforcement in AC test setup

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -108,20 +108,42 @@ class AdmissionControllerTest extends BaseSpecification {
 
         // Wait for policy propagation to sensor and admission controller
         // Verify by attempting to create a deployment that should be blocked
-        def testDeployment = new Deployment()
-                .setName("setup-verification")
+        def latestTagDeployment = new Deployment()
+                .setName("setup-verification-latest")
                 .setNamespace(TEST_NAMESPACE)
                 .setImage(BUSYBOX_LATEST_TAG_IMAGE)
                 .addLabel("app", "test")
 
         withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
-            def created = orchestrator.createDeploymentNoWait(testDeployment)
+            def created = orchestrator.createDeploymentNoWait(latestTagDeployment)
             assert !created // Should be blocked by latest tag policy
         }
 
         // Clean up if somehow it was created
         try {
-            orchestrator.deleteDeployment(testDeployment)
+            orchestrator.deleteDeployment(latestTagDeployment)
+        } catch (Exception ignored) {
+            // Expected - deployment should not exist
+        }
+
+        // Wait for severity policy enforcement with cached scan data to propagate
+        // to the admission controller. The image was pre-scanned above, but the AC
+        // may not have fetched scan results from Central yet.
+        def severityDeployment = new Deployment()
+                .setName("setup-verification-severity")
+                .setNamespace(TEST_NAMESPACE)
+                .setImagePrefetcherAffinity()
+                .setImage(SCAN_INLINE_IMAGE_NAME_WITH_SHA)
+                .addLabel("app", "test")
+
+        withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
+            def created = orchestrator.createDeploymentNoWait(severityDeployment)
+            assert !created // Should be blocked by severity policy
+        }
+
+        // Clean up if somehow it was created
+        try {
+            orchestrator.deleteDeployment(severityDeployment)
         } catch (Exception ignored) {
             // Expected - deployment should not exist
         }


### PR DESCRIPTION
## Description

Fixes flaky `AdmissionControllerTest` severity test failures caused by a race condition in the test setup.

The admission controller severity test ("Fixable Severity at least Important") was intermittently failing because the admission controller had not yet fetched scan data from Central by the time the test ran. The test `setupSpec()` already verified that the "Latest tag" policy was being enforced (a fast-path check that doesn't require image enrichment), but it never verified that the severity policy was also being enforced. The severity policy requires the admission controller to have cached scan results from Central, which is a slower path.

Building on the scan data assertions added in #21457, this PR adds a retry loop in `setupSpec()` that attempts to create a deployment using the pre-scanned image. This warms the admission controller's image cache by forcing it to fetch scan results from Central. The loop retries until the deployment is blocked by the severity policy, matching the existing pattern used for the "Latest tag" policy verification.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

This change modifies only test infrastructure (the `setupSpec()` of `AdmissionControllerTest.groovy`), so validation relies on CI execution of the admission controller E2E test suite. The retry loop follows the same proven pattern already in use for the "Latest tag" policy verification. The added assertions on scan data provide early failure with actionable diagnostics if the test preconditions are not met.
