### PR TITLE
ROX-35184: bump js-cookie to 3.0.7 to fix CVE-2026-46625

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -11359,9 +11359,9 @@
             "integrity": "sha1-gW0R2BqK/yQWA9Gc5XYeE+Qdd0U= sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
         },
         "node_modules/js-cookie": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-            "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+            "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -200,7 +200,8 @@
         "connected-react-router": {
             "react": "^18.0.0"
         },
-        "react-dropzone": "14.3.2"
+        "react-dropzone": "14.3.2",
+        "js-cookie": "^3.0.7"
     },
     "browserslist": [
         "Chrome >= 80"


### PR DESCRIPTION
## Description

Added an npm override for `js-cookie` to force resolution to 3.0.7, since @segment/analytics-next pins it to 3.0.1. There's an upstream PR to update it but it hasn't merged yet. Will switch to the proper package update once that lands.


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Only used internally by `@segment/analytics-next`.