### PR TITLE
ROX-35412: Add Secrets page under Risk left nav

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,5 +1,6 @@
 import withAuth from '../../helpers/basicAuth';
 import navigationSelectors from '../../selectors/navigation';
+import { hasFeatureFlag } from '../../helpers/features';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import pf6 from '../../selectors/pf6';
 
@@ -19,7 +20,8 @@ describe('Risk', () => {
         it('should have selected item in nav bar', () => {
             visitRiskDeployments('Platform view');
 
-            cy.get(RiskPageSelectors.risk).should('have.class', 'pf-m-current');
+            const navText = hasFeatureFlag('ROX_UI_SECRETS_PAGE_MIGRATION') ? 'Workloads' : 'Risk';
+            cy.get(`${pf6.navItem} a:contains("${navText}")`).should('have.class', 'pf-m-current');
         });
 
         it('should maintain active horizontal nav state on detail page for each view', () => {

--- a/ui/apps/platform/cypress/integration/risk/secrets.test.ts
+++ b/ui/apps/platform/cypress/integration/risk/secrets.test.ts
@@ -1,0 +1,54 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { assertCannotFindThePage, visit } from '../../helpers/visit';
+import navSelectors from '../../selectors/navigation';
+
+describe('Risk - Secrets page', () => {
+    withAuth();
+
+    describe('with ROX_UI_SECRETS_PAGE_MIGRATION feature flag enabled', () => {
+        before(function () {
+            if (!hasFeatureFlag('ROX_UI_SECRETS_PAGE_MIGRATION')) {
+                this.skip();
+            }
+        });
+
+        it('should render the Secrets page with the correct heading', () => {
+            visit('/main/risk/secrets');
+
+            cy.get('h1:contains("Secrets")');
+        });
+
+        it('should show Risk as an expandable nav section with Workloads and Secrets children', () => {
+            visit('/main/risk/secrets');
+
+            cy.get(`${navSelectors.navExpandable}:contains("Risk")`);
+            cy.get(`${navSelectors.nestedNavLinks}:contains("Workloads")`);
+            cy.get(`${navSelectors.nestedNavLinks}:contains("Secrets")`).should(
+                'have.class',
+                'pf-m-current'
+            );
+        });
+    });
+
+    describe('without ROX_UI_SECRETS_PAGE_MIGRATION feature flag', () => {
+        before(function () {
+            if (hasFeatureFlag('ROX_UI_SECRETS_PAGE_MIGRATION')) {
+                this.skip();
+            }
+        });
+
+        it('should not render the Secrets page', () => {
+            visit('/main/risk/secrets');
+
+            assertCannotFindThePage();
+        });
+
+        it('should show Risk as a plain nav link, not an expandable section', () => {
+            visit('/main/risk/workloads');
+
+            cy.get(`${navSelectors.navLinks}:contains("Risk")`);
+            cy.get(`${navSelectors.navExpandable}:contains("Risk")`).should('not.exist');
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -35,6 +35,7 @@ import {
     policiesBasePath,
     policyManagementBasePath,
     riskBasePath,
+    riskSecretsBasePath,
     riskWorkloadsBasePath,
     searchPath,
     systemConfigPath,
@@ -208,6 +209,10 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     'policy-management': {
         component: asyncComponent(() => import('Containers/PolicyManagement/PolicyManagementPage')),
         path: policyManagementBasePath,
+    },
+    'risk/secrets': {
+        component: asyncComponent(() => import('Containers/Risk/Secrets/SecretsPage')),
+        path: riskSecretsBasePath,
     },
     'risk/workloads': {
         component: asyncComponent(() => import('Containers/Risk/RiskRoutes')),

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -31,6 +31,7 @@ import {
     listeningEndpointsBasePath,
     networkBasePath,
     policyManagementBasePath,
+    riskSecretsBasePath,
     riskWorkloadsBasePath,
     systemConfigPath,
     systemHealthPath,
@@ -58,11 +59,11 @@ import './NavigationSidebar.css';
 // Child conditional title finds path to decide presence or absence of counterpart child.
 // Parent conditional title finds key to decide presence or absence of counterpart parent.
 const keyForNetwork = 'Network';
+const keyForRisk = 'Risk';
 const keyForPlatformConfiguration = 'Platform Configuration';
 const keyForCompliance = 'Compliance';
 const keyForVulnerabilities = 'Vulnerability Management';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDescription[] {
     const vulnerabilityManagementChildren: ChildDescription[] = [
         {
@@ -197,12 +198,36 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
             path: configManagementPath,
             routeKey: 'configmanagement',
         },
-        {
-            type: 'link',
-            content: 'Risk',
-            path: riskWorkloadsBasePath,
-            routeKey: 'risk/workloads',
-        },
+        ...((isFeatureFlagEnabled('ROX_UI_SECRETS_PAGE_MIGRATION')
+            ? [
+                  {
+                      type: 'parent',
+                      title: 'Risk',
+                      key: keyForRisk,
+                      children: [
+                          {
+                              type: 'link',
+                              content: 'Workloads',
+                              path: riskWorkloadsBasePath,
+                              routeKey: 'risk/workloads',
+                          },
+                          {
+                              type: 'link',
+                              content: 'Secrets',
+                              path: riskSecretsBasePath,
+                              routeKey: 'risk/secrets',
+                          },
+                      ],
+                  },
+              ]
+            : [
+                  {
+                      type: 'link',
+                      content: 'Risk',
+                      path: riskWorkloadsBasePath,
+                      routeKey: 'risk/workloads',
+                  },
+              ]) satisfies NavDescription[]),
         {
             type: 'parent',
             title: 'Platform Configuration',

--- a/ui/apps/platform/src/Containers/Risk/Secrets/SecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Secrets/SecretsPage.tsx
@@ -1,0 +1,18 @@
+import { Flex, PageSection, Title } from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+
+function SecretsPage() {
+    return (
+        <>
+            <PageTitle title="Risk - Secrets" />
+            <PageSection>
+                <Flex direction={{ default: 'column' }}>
+                    <Title headingLevel="h1">Secrets</Title>
+                </Flex>
+            </PageSection>
+        </>
+    );
+}
+
+export default SecretsPage;

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -67,6 +67,7 @@ export const riskWorkloadPath = `${riskWorkloadsBasePath}/:deploymentId?`;
 export const riskUserWorkloadsViewPath = `${riskWorkloadsBasePath}?filteredWorkflowView=Applications view`;
 export const riskPlatformViewPath = `${riskWorkloadsBasePath}?filteredWorkflowView=Platform view`;
 export const riskFullViewPath = `${riskWorkloadsBasePath}?filteredWorkflowView=Full view`;
+export const riskSecretsBasePath = `${riskBasePath}/secrets`;
 export const searchPath = `${mainPath}/search`;
 export const secretsPath = `${mainPath}/configmanagement/secrets/:secretId?`;
 export const systemConfigPath = `${mainPath}/systemconfig`;
@@ -180,6 +181,8 @@ export type RouteKey =
     | 'listening-endpoints'
     | 'network-graph'
     | 'policy-management'
+    // Risk secrets must precede generic risk in Body for route specificity.
+    | 'risk/secrets'
     // Risk workloads must precede generic risk in Body for route specificity.
     | 'risk/workloads'
     | 'risk'
@@ -312,6 +315,10 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
             // 'Integration',
             'WorkflowAdministration',
         ]),
+    },
+    'risk/secrets': {
+        featureFlagRequirements: allEnabled(['ROX_UI_SECRETS_PAGE_MIGRATION']),
+        resourceAccessRequirements: everyResource(['Secret']),
     },
     'risk/workloads': {
         resourceAccessRequirements: everyResource(['Deployment']),


### PR DESCRIPTION
## Description

Adds stub "Secrets" page under Risk, and conditionally restructures the Risk left navigation item.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Without flag:
<img width="1137" height="609" alt="image" src="https://github.com/user-attachments/assets/56f46bb2-447f-4d17-b84b-a150facdc8e2" />

With flag:
<img width="1137" height="609" alt="image" src="https://github.com/user-attachments/assets/3c022657-13e4-4da2-b55f-7606d6f8b4ff" />
<img width="1137" height="609" alt="image" src="https://github.com/user-attachments/assets/9af6b523-9492-4ed8-b01e-d15f5c0ee058" />

