### PR TITLE
fix(ui): Align UI with BE init container types

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/policyWizard.helpers.ts
+++ b/ui/apps/platform/cypress/integration/policies/policyWizard.helpers.ts
@@ -141,12 +141,10 @@ export function verifyPolicyDetails(policyName: string, expectations: PolicyDeta
     }
 
     if (expectations.filters) {
-        /* TODO: uncomment this once backend persistence is implemented
         cy.contains('h2', 'Policy filters');
         cy.contains('dt', 'Container types')
             .next('dd')
             .should('contain', expectations.filters.containerTypes);
-        */
     }
 }
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/policy.ts
@@ -135,17 +135,6 @@ export const LastUpdated: CompoundSearchFilterAttribute = {
     inputType: 'date-picker',
 };
 
-export const SkipContainerType: CompoundSearchFilterAttribute = {
-    displayName: 'Skip container type',
-    filterChipLabel: 'Skip container type',
-    searchTerm: 'Skip Container Type',
-    inputType: 'select',
-    featureFlagDependency: ['ROX_EVALUATION_FILTER', 'ROX_INIT_CONTAINER_SUPPORT'],
-    inputProps: {
-        options: [{ value: 'SKIP_INIT', label: 'Skip init containers' }],
-    },
-};
-
 export const policyAttributes = [
     Name,
     Category,

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyFiltersSection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyFiltersSection.tsx
@@ -21,7 +21,7 @@ function getContainerTypeLabel(
     }
 
     const skipped = evaluationFilter?.skipContainerTypes ?? [];
-    if (skipped.includes('SKIP_INIT')) {
+    if (skipped.includes('INIT')) {
         return 'Skip init containers';
     }
     return null;

--- a/ui/apps/platform/src/Containers/Policies/Table/PolicyEvaluationFilterLabels.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PolicyEvaluationFilterLabels.tsx
@@ -25,7 +25,7 @@ function PolicyEvaluationFilterLabels({
 
     if (
         isFeatureFlagEnabled('ROX_INIT_CONTAINER_SUPPORT') &&
-        evaluationFilter.skipContainerTypes?.includes('SKIP_INIT')
+        evaluationFilter.skipContainerTypes?.includes('INIT')
     ) {
         labels.push({ text: 'Skips init', color: 'blue' });
     }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/StepFilters/PolicyFiltersForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/StepFilters/PolicyFiltersForm.tsx
@@ -38,7 +38,7 @@ function PolicyFiltersForm() {
         }
     }, [containerFilterDisabled, skipContainerTypes.length, setFieldValue]);
 
-    const skipInit = skipContainerTypes.includes('SKIP_INIT');
+    const skipInit = skipContainerTypes.includes('INIT');
 
     const containerTypeDescription = skipInit
         ? 'Policy will skip init containers.'
@@ -47,7 +47,7 @@ function PolicyFiltersForm() {
     function handleSkipInitChange() {
         setFieldValue(
             'evaluationFilter.skipContainerTypes',
-            toggleItemInArray(skipContainerTypes, 'SKIP_INIT')
+            toggleItemInArray(skipContainerTypes, 'INIT')
         );
     }
 

--- a/ui/apps/platform/src/Containers/Policies/policiesSearchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Policies/policiesSearchFilterConfig.ts
@@ -6,7 +6,6 @@ import {
     LifecycleStage,
     Name,
     Severity,
-    SkipContainerType,
     Status,
 } from 'Components/CompoundSearchFilter/attributes/policy';
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
@@ -22,7 +21,6 @@ export const policySearchFilterConfig: CompoundSearchFilterEntity = {
         LifecycleStage,
         Name,
         Severity,
-        SkipContainerType,
         Status,
     ],
 };

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -160,14 +160,14 @@ export type PolicyMitreAttackVector = {
 };
 
 // Will match proto enum SkipContainerType in storage/policy.proto
-export type SkipContainerType = 'SKIP_INIT';
+export type ContainerType = 'INIT';
 
 // Will match proto enum SkipImageLayers in storage/policy.proto
 export type SkipImageLayers = 'SKIP_NONE' | 'SKIP_BASE' | 'SKIP_APP';
 
 // Will match proto message EvaluationFilter in storage/policy.proto
 export type EvaluationFilter = {
-    skipContainerTypes: SkipContainerType[];
+    skipContainerTypes: ContainerType[];
     // TODO: reimplement once backend support is available - demo code was deleted at the same time this comment was added
     // skipImageLayers: SkipImageLayers;
 };

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -159,13 +159,10 @@ export type PolicyMitreAttackVector = {
     techniques: string[]; // technique ids
 };
 
-// Will match proto enum SkipContainerType in storage/policy.proto
 export type ContainerType = 'INIT';
 
-// Will match proto enum SkipImageLayers in storage/policy.proto
 export type SkipImageLayers = 'SKIP_NONE' | 'SKIP_BASE' | 'SKIP_APP';
 
-// Will match proto message EvaluationFilter in storage/policy.proto
 export type EvaluationFilter = {
     skipContainerTypes: ContainerType[];
     // TODO: reimplement once backend support is available - demo code was deleted at the same time this comment was added

--- a/ui/apps/platform/src/types/searchOptions.ts
+++ b/ui/apps/platform/src/types/searchOptions.ts
@@ -325,8 +325,6 @@ export const searchFieldLabels = [
     'Component Layer Type',
     //
     'Policy Last Updated',
-    'Skip Container Type',
-    'Skip Image Layers',
     //
     // Following are helper fields used for sorting
     // For example, "SORTPolicyName" field should be used to sort policies when the query sort field is "PolicyName"


### PR DESCRIPTION
## Description

Fixes for the "Skip init containers" policy functionality in the UI:

- Swap `SKIP_INIT` from the original implementation draft for the production `INIT` enum
- Remove `Skip init containers` filter, which is not applicable to the policies list
- Uncomment test assertion that would have caught the above issue

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Manual verification of the Policy creation workflow.

Verification via e2e test suite.
