### PR TITLE
feat(scanner): add --certs-secret flag to scannerctl

### DIFF
--- a/scanner/cmd/scannerctl/certs_secret.go
+++ b/scanner/cmd/scannerctl/certs_secret.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/stackrox/rox/pkg/mtls"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	defaultCertsSecret    = "central-tls"
+	defaultCertsNamespace = "stackrox"
+)
+
+// certsSecretFileMap maps Kubernetes secret data keys to the file names
+// expected by the mtls package. The boolean indicates whether the key is
+// required for mTLS authentication.
+var certsSecretFileMap = map[string]struct {
+	fileName string
+	required bool
+}{
+	"ca.pem":     {mtls.CACertFileName, true},
+	"ca-key.pem": {mtls.CAKeyFileName, false},
+	"cert.pem":   {mtls.ServiceCertFileName, true},
+	"key.pem":    {mtls.ServiceKeyFileName, true},
+}
+
+// parseCertsSecret parses a secret reference into namespace and name.
+// Accepted formats: "namespace/name" or "name" (namespace defaults to stackrox).
+func parseCertsSecret(ref string) (namespace, name string, err error) {
+	if ref == "" {
+		return "", "", fmt.Errorf("empty secret reference")
+	}
+	if i := strings.IndexByte(ref, '/'); i >= 0 {
+		namespace, name = ref[:i], ref[i+1:]
+		if namespace == "" || name == "" {
+			return "", "", fmt.Errorf("invalid secret reference %q: expected [namespace/]name", ref)
+		}
+		return namespace, name, nil
+	}
+	return defaultCertsNamespace, ref, nil
+}
+
+// loadCertsFromSecret fetches TLS certificate data from a Kubernetes secret
+// and writes it to a temporary directory. The mtls package requires file paths,
+// so in-memory injection is not possible without modifying shared infrastructure.
+func loadCertsFromSecret(ctx context.Context, secretRef string) (certsDir string, cleanup func(), err error) {
+	namespace, name, err := parseCertsSecret(secretRef)
+	if err != nil {
+		return "", nil, err
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil)
+	restConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return "", nil, fmt.Errorf("loading kubeconfig: %w", err)
+	}
+	restConfig.Timeout = 10 * time.Second
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating kubernetes client: %w", err)
+	}
+
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", nil, fmt.Errorf("fetching secret %s/%s: %w", namespace, name, err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "scannerctl-certs-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+	cleanup = func() { os.RemoveAll(tmpDir) }
+
+	var missing []string
+	for secretKey, entry := range certsSecretFileMap {
+		data, ok := secret.Data[secretKey]
+		if !ok {
+			if entry.required {
+				missing = append(missing, secretKey)
+			}
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, entry.fileName), data, 0o600); err != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("writing %s: %w", entry.fileName, err)
+		}
+	}
+	if len(missing) > 0 {
+		cleanup()
+		return "", nil, fmt.Errorf("secret %s/%s is missing required keys: %v", namespace, name, missing)
+	}
+
+	return tmpDir, cleanup, nil
+}

--- a/scanner/cmd/scannerctl/certs_secret_test.go
+++ b/scanner/cmd/scannerctl/certs_secret_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCertsSecret(t *testing.T) {
+	tests := map[string]struct {
+		input     string
+		namespace string
+		name      string
+		wantErr   bool
+	}{
+		"name only defaults to stackrox namespace": {
+			input:     "central-tls",
+			namespace: "stackrox",
+			name:      "central-tls",
+		},
+		"explicit namespace": {
+			input:     "my-ns/my-secret",
+			namespace: "my-ns",
+			name:      "my-secret",
+		},
+		"stackrox namespace explicit": {
+			input:     "stackrox/central-tls",
+			namespace: "stackrox",
+			name:      "central-tls",
+		},
+		"missing namespace before slash": {
+			input:   "/secret",
+			wantErr: true,
+		},
+		"missing name after slash": {
+			input:   "namespace/",
+			wantErr: true,
+		},
+		"empty string": {
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ns, n, err := parseCertsSecret(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.namespace, ns)
+			assert.Equal(t, tc.name, n)
+		})
+	}
+}
+
+func TestCertsSecretFileMap(t *testing.T) {
+	assert.Equal(t, mtls.CACertFileName, certsSecretFileMap["ca.pem"].fileName)
+	assert.True(t, certsSecretFileMap["ca.pem"].required)
+	assert.Equal(t, mtls.CAKeyFileName, certsSecretFileMap["ca-key.pem"].fileName)
+	assert.False(t, certsSecretFileMap["ca-key.pem"].required)
+	assert.Equal(t, mtls.ServiceCertFileName, certsSecretFileMap["cert.pem"].fileName)
+	assert.True(t, certsSecretFileMap["cert.pem"].required)
+	assert.Equal(t, mtls.ServiceKeyFileName, certsSecretFileMap["key.pem"].fileName)
+	assert.True(t, certsSecretFileMap["key.pem"].required)
+}

--- a/scanner/cmd/scannerctl/main.go
+++ b/scanner/cmd/scannerctl/main.go
@@ -19,6 +19,9 @@ import (
 // factory is the global scanner client factory.
 var factory scannerFactory
 
+// certsCleanup removes temporary certificate files created by --certs-secret.
+var certsCleanup func()
+
 // scannerFactory holds the data to create scanner clients.
 type scannerFactory []client.Option
 
@@ -61,31 +64,59 @@ func rootCmd(ctx context.Context) *cobra.Command {
 		"certs",
 		"",
 		"Path to directory containing scanner certificates.")
-	cmd.PersistentPreRun = func(_ *cobra.Command, _ []string) {
-		if *certsPath != "" {
-			// Certs flag configures the identity environment.
+	certsSecret := flags.String(
+		"certs-secret",
+		"",
+		fmt.Sprintf("Load certificates from a Kubernetes secret ([namespace/]name). "+
+			"Namespace defaults to %q. Uses the current kubeconfig context. "+
+			"Default: %s/%s.", defaultCertsNamespace, defaultCertsNamespace, defaultCertsSecret))
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		certsDir := *certsPath
+
+		if *certsPath != "" && cmd.Flags().Changed("certs-secret") {
+			return fmt.Errorf("--certs and --certs-secret are mutually exclusive")
+		}
+
+		if certsDir == "" {
+			ref := defaultCertsSecret
+			if cmd.Flags().Changed("certs-secret") {
+				ref = *certsSecret
+			}
+			dir, cleanup, err := loadCertsFromSecret(cmd.Context(), ref)
+			if err != nil {
+				if cmd.Flags().Changed("certs-secret") {
+					return fmt.Errorf("loading certs from secret: %w", err)
+				}
+				log.Printf("could not load default secret %s (use --certs or --certs-secret to configure): %v", ref, err)
+			} else {
+				certsDir = dir
+				certsCleanup = cleanup
+			}
+		}
+
+		if certsDir != "" {
 			utils.CrashOnError(
 				os.Setenv(mtls.CAFileEnvName,
-					filepath.Join(*certsPath, mtls.CACertFileName)))
+					filepath.Join(certsDir, mtls.CACertFileName)))
 			utils.CrashOnError(
 				os.Setenv(mtls.CAKeyFileEnvName,
-					filepath.Join(*certsPath, mtls.CAKeyFileName)))
+					filepath.Join(certsDir, mtls.CAKeyFileName)))
 			utils.CrashOnError(
 				os.Setenv(mtls.CertFilePathEnvName,
-					filepath.Join(*certsPath, mtls.ServiceCertFileName)))
+					filepath.Join(certsDir, mtls.ServiceCertFileName)))
 			utils.CrashOnError(
 				os.Setenv(mtls.KeyFileEnvName,
-					filepath.Join(*certsPath, mtls.ServiceKeyFileName)))
+					filepath.Join(certsDir, mtls.ServiceKeyFileName)))
 		}
 
 		indexerAddr, err := cmd.Flags().GetString("indexer-address")
 		if err != nil {
-			log.Fatalf("getting indexer-address: %v", err)
+			return fmt.Errorf("getting indexer-address: %w", err)
 		}
 
 		matcherAddr, err := cmd.Flags().GetString("matcher-address")
 		if err != nil {
-			log.Fatalf("getting matcher-address: %v", err)
+			return fmt.Errorf("getting matcher-address: %w", err)
 		}
 
 		// Set options for the gRPC connection.
@@ -105,6 +136,7 @@ func rootCmd(ctx context.Context) *cobra.Command {
 		}
 		// Create the client factory.
 		factory = opts
+		return nil
 	}
 	cmd.AddCommand(scanCmd(ctx))
 	cmd.AddCommand(scaleCmd(ctx))
@@ -113,26 +145,35 @@ func rootCmd(ctx context.Context) *cobra.Command {
 	return &cmd
 }
 
-func main() {
-	// Create a context that is cancellable on the usual command line signals. Double
-	// signal forcefully exits.
+func run() int {
 	ctx, cancel := context.WithCancel(context.Background())
-	defer ctx.Done()
+	defer cancel()
+	defer func() {
+		if certsCleanup != nil {
+			certsCleanup()
+		}
+	}()
 	go func() {
 		sigC := make(chan os.Signal, 1)
 		signal.Notify(sigC, unix.SIGINT, unix.SIGTERM)
 		sig := <-sigC
 		log.Printf("%s caught, shutting down...", sig)
-		// Cancel the main context.
 		cancel()
 		go func() {
-			// A second signal will forcefully quit.
 			<-sigC
+			if certsCleanup != nil {
+				certsCleanup()
+			}
 			os.Exit(1)
 		}()
 	}()
-	// Execute command.
 	if err := rootCmd(ctx).Execute(); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return 1
 	}
+	return 0
+}
+
+func main() {
+	os.Exit(run())
 }


### PR DESCRIPTION
## Description

Adds a `--certs-secret` flag to `scannerctl` that loads TLS certificates directly from a Kubernetes secret via the current kubeconfig, removing the need to manually extract certs to disk before scanning.

The flag accepts `[namespace/]name` notation — namespace defaults to `stackrox`. When neither `--certs` nor `--certs-secret` is provided, `stackrox/central-tls` is tried automatically (failure is a warning, not an error).

In-memory cert injection was considered but is not feasible without modifying the shared `pkg/mtls` package, which reads files via `os.ReadFile` and `tls.LoadX509KeyPair`. Instead, certs are written to a temp directory that is cleaned up on process exit via `defer` in `run()`.

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed
- [ ] documentation PR is created and is linked above OR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Built scannerctl from the branch and scanned OCP images against a staging ACS cluster using all three flag forms: default (no flag), name-only (`--certs-secret central-tls`), and explicit namespace (`--certs-secret stackrox/central-tls`). Verified successful mTLS authentication, scan completion, and temp directory cleanup after exit.