### PR TITLE
chore(feed): cap exponential backoff

### DIFF
--- a/.github/workflows/scripts/scanner-update-nvd-api.py
+++ b/.github/workflows/scripts/scanner-update-nvd-api.py
@@ -14,6 +14,8 @@ logging.basicConfig(
 BASE_URL = os.getenv('SCANNER_NVD_URL', "https://services.nvd.nist.gov/rest/json/cves/2.0")
 API_KEY = os.getenv('SCANNER_NVD_API_KEY', None)
 
+BACKOFF_TABLE = [15, 30, 60, 120, 240, 300]
+
 
 class ApiLoader:
     def __init__(self):
@@ -46,8 +48,8 @@ class ApiLoader:
     def fetch_data(start, end):
         index, total = 0, 0
         logging.info(f"Fetching page from {start} to {end}")
-        backoff_time = 10
         max_retries = 10
+        attempt = 0
 
         while total == 0 or index < total:
             try:
@@ -72,17 +74,16 @@ class ApiLoader:
                     yield {"cve": item['cve']}
 
                 index += data['resultsPerPage']
-                max_retries = 10  # Reset retries
-                backoff_time = 1
+                attempt = 0
             except Exception as e:
-                logging.error(f"Failed to download page at index {index}: {e}")
-                if max_retries > 0:
-                    logging.info(f"Retrying in {backoff_time} seconds...")
-                    time.sleep(backoff_time)
-                    backoff_time *= 2  # Increase the backoff time exponentially
-                    max_retries -= 1
+                if attempt < max_retries:
+                    backoff = BACKOFF_TABLE[min(attempt, len(BACKOFF_TABLE) - 1)]
+                    logging.warning(f"Failed to download page at index {index} (attempt {attempt + 1}/{max_retries + 1}): {e}")
+                    logging.info(f"Retrying in {backoff} seconds...")
+                    time.sleep(backoff)
+                    attempt += 1
                 else:
-                    raise  # Re-raise the exception if max retries have been exceeded
+                    raise
             time.sleep(2)
 
     @staticmethod

--- a/.github/workflows/scripts/scanner-update-nvd-feeds.py
+++ b/.github/workflows/scripts/scanner-update-nvd-feeds.py
@@ -20,6 +20,9 @@ logging.basicConfig(
 
 DEFAULT_BASE_URL = "https://nvd.nist.gov/feeds/json/cve/2.0/"
 
+BACKOFF_TABLE = [15, 30, 60, 120, 240, 300]
+
+
 class FeedLoader:
 
     log = logging.getLogger("FeedLoader")
@@ -29,9 +32,8 @@ class FeedLoader:
 
     def fetch(self, year):
         url = parse.urljoin(self._base_url, f"nvdcve-2.0-{year}.json.gz")
-        backoff_time = 10
         max_retries = 10
-        while True:
+        for attempt in range(max_retries + 1):
             try:
                 self.log.info("fetching and decompressing: %s", url)
                 with request.urlopen(url, timeout=120) as resp:
@@ -39,12 +41,11 @@ class FeedLoader:
                         data = json.load(gz)
                 break
             except Exception as e:
-                if max_retries > 0:
-                    self.log.warning("failed to fetch %s: %s", url, e)
-                    self.log.info("retrying in %d seconds...", backoff_time)
-                    time.sleep(backoff_time)
-                    backoff_time *= 2
-                    max_retries -= 1
+                if attempt < max_retries:
+                    backoff = BACKOFF_TABLE[min(attempt, len(BACKOFF_TABLE) - 1)]
+                    self.log.warning("failed to fetch %s (attempt %d/%d): %s", url, attempt + 1, max_retries + 1, e)
+                    self.log.info("retrying in %d seconds...", backoff)
+                    time.sleep(backoff)
                 else:
                     raise
         yield from (v for v in data["vulnerabilities"]


### PR DESCRIPTION
## Description

Similar to https://github.com/stackrox/scanner/pull/3357 in the scanner repo, cap the exponential backoff.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No automated tests added

### How I validated my change

CI via `pr-update-scanner-nvd` label.
