### PR TITLE
ROX-35223: PoC for compliance trends over time

### DIFF
--- a/central/complianceoperator/v2/checkresults/datastore/datastore.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore.go
@@ -60,6 +60,9 @@ type DataStore interface {
 
 	// DeleteOldResults scan results from a previous run
 	DeleteOldResults(ctx context.Context, lastStartedTimestamp *timestamppb.Timestamp, scanRefID string, includeCurrent bool) error
+
+	// ComplianceTrendResults retrieves pass/fail/error counts grouped by scan run time
+	ComplianceTrendResults(ctx context.Context, query *v1.Query) ([]*ComplianceTrendDataPoint, error)
 }
 
 // New returns the datastore wrapper for compliance operator check results

--- a/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/checkresults/datastore/datastore_impl.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -10,9 +9,9 @@ import (
 	"github.com/stackrox/rox/central/metrics"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/schema"
-	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
@@ -23,11 +22,7 @@ import (
 
 var (
 	complianceSAC = sac.ForResource(resources.Compliance)
-)
-
-const (
-	lastStartedTimestampColumnName = "laststartedtime"
-	scanRefIDColumnName            = "scanrefid"
+	log           = logging.LoggerForModule()
 )
 
 type datastoreImpl struct {
@@ -392,23 +387,45 @@ func (d *datastoreImpl) withCountByResultSelectQuery(q *v1.Query, countOn search
 	return cloned
 }
 
-func (d *datastoreImpl) DeleteOldResults(ctx context.Context, lastStartedTimestamp *timestamppb.Timestamp, scanRefID string, includeCurrent bool) error {
-	if scanRefID == "" || lastStartedTimestamp == nil {
+func (d *datastoreImpl) DeleteOldResults(_ context.Context, _ *timestamppb.Timestamp, _ string, _ bool) error {
+	// PoC ROX-35223: Disabled to allow historical compliance results to accumulate across scan runs.
+	log.Debug("DeleteOldResults is disabled to retain historical compliance data for trending")
+	return nil
+}
+
+func (d *datastoreImpl) ComplianceTrendResults(ctx context.Context, query *v1.Query) ([]*ComplianceTrendDataPoint, error) {
+	defer metrics.SetDatastoreFunctionDuration(time.Now(), "ComplianceOperatorCheckResultV2", "ComplianceTrendResults")
+
+	cloned := query.CloneVT()
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(search.ComplianceOperatorCheckLastStartedTime).Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{
+			search.ComplianceOperatorCheckLastStartedTime.String(),
+		},
+	}
+
+	if cloned.GetPagination() == nil {
+		cloned.Pagination = &v1.QueryPagination{}
+	}
+	if cloned.GetPagination().GetSortOptions() == nil {
+		cloned.Pagination.SortOptions = []*v1.QuerySortOption{
+			{
+				Field: search.ComplianceOperatorCheckLastStartedTime.String(),
+			},
+		}
+	}
+
+	countQuery := d.withCountByResultSelectQuery(cloned, search.ComplianceOperatorCheckLastStartedTime)
+	var results []*ComplianceTrendDataPoint
+	err := pgSearch.RunSelectRequestForSchemaFn[ComplianceTrendDataPoint](ctx, d.db, schema.ComplianceOperatorCheckResultV2Schema, countQuery, func(r *ComplianceTrendDataPoint) error {
+		results = append(results, r)
 		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	if err := lastStartedTimestamp.CheckValid(); err != nil {
-		return err
-	}
-	deleteFmt := "DELETE FROM %s WHERE %s = $1 AND (%s < $2 OR %s IS NULL)"
-	if includeCurrent {
-		deleteFmt = "DELETE FROM %s WHERE %s = $1 AND (%s <= $2 OR %s IS NULL)"
-	}
-	deleteStmt := fmt.Sprintf(deleteFmt,
-		schema.ComplianceOperatorCheckResultV2TableName,
-		scanRefIDColumnName,
-		lastStartedTimestampColumnName,
-		lastStartedTimestampColumnName,
-	)
-	_, err := d.db.Exec(ctx, deleteStmt, scanRefID, protocompat.NilOrTime(lastStartedTimestamp))
-	return err
+
+	return results, nil
 }

--- a/central/complianceoperator/v2/checkresults/datastore/mocks/datastore.go
+++ b/central/complianceoperator/v2/checkresults/datastore/mocks/datastore.go
@@ -105,6 +105,21 @@ func (mr *MockDataStoreMockRecorder) ComplianceProfileResults(ctx, query any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComplianceProfileResults", reflect.TypeOf((*MockDataStore)(nil).ComplianceProfileResults), ctx, query)
 }
 
+// ComplianceTrendResults mocks base method.
+func (m *MockDataStore) ComplianceTrendResults(ctx context.Context, query *v1.Query) ([]*datastore.ComplianceTrendDataPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ComplianceTrendResults", ctx, query)
+	ret0, _ := ret[0].([]*datastore.ComplianceTrendDataPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ComplianceTrendResults indicates an expected call of ComplianceTrendResults.
+func (mr *MockDataStoreMockRecorder) ComplianceTrendResults(ctx, query any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComplianceTrendResults", reflect.TypeOf((*MockDataStore)(nil).ComplianceTrendResults), ctx, query)
+}
+
 // CountByField mocks base method.
 func (m *MockDataStore) CountByField(ctx context.Context, query *v1.Query, field search.FieldLabel) (int, error) {
 	m.ctrl.T.Helper()

--- a/central/complianceoperator/v2/checkresults/datastore/stats_views.go
+++ b/central/complianceoperator/v2/checkresults/datastore/stats_views.go
@@ -45,6 +45,18 @@ type ResourceResultCountByProfile struct {
 	ProfileName        string `db:"compliance_profile_name"`
 }
 
+// ComplianceTrendDataPoint represents a single data point in a compliance trend over time
+type ComplianceTrendDataPoint struct {
+	LastStartedTime    *time.Time `db:"compliance_check_last_started_time"`
+	PassCount          int        `db:"compliance_pass_count"`
+	FailCount          int        `db:"compliance_fail_count"`
+	ErrorCount         int        `db:"compliance_error_count"`
+	InfoCount          int        `db:"compliance_info_count"`
+	ManualCount        int        `db:"compliance_manual_count"`
+	NotApplicableCount int        `db:"compliance_not_applicable_count"`
+	InconsistentCount  int        `db:"compliance_inconsistent_count"`
+}
+
 // ResourceResultsByProfile represents shape of the stats query for compliance operator results
 type ResourceResultsByProfile struct {
 	PassCount          int    `db:"compliance_pass_count"`

--- a/central/complianceoperator/v2/checkresults/stats/service/service_impl.go
+++ b/central/complianceoperator/v2/checkresults/stats/service/service_impl.go
@@ -44,6 +44,7 @@ var (
 			v2.ComplianceResultsStatsService_GetComplianceOverallClusterStats_FullMethodName,
 			v2.ComplianceResultsStatsService_GetComplianceClusterStats_FullMethodName,
 			v2.ComplianceResultsStatsService_GetComplianceProfileCheckStats_FullMethodName,
+			v2.ComplianceResultsStatsService_GetComplianceScanTrends_FullMethodName,
 		},
 	})
 
@@ -370,6 +371,25 @@ func (s *serviceImpl) GetComplianceClusterStats(ctx context.Context, request *v2
 	return &v2.ListComplianceClusterOverallStatsResponse{
 		ScanStats:  storagetov2.ComplianceV2ClusterOverallStats(scanResults, clusterErrors),
 		TotalCount: int32(count),
+	}, nil
+}
+
+// GetComplianceScanTrends returns compliance pass/fail counts grouped by scan time
+func (s *serviceImpl) GetComplianceScanTrends(ctx context.Context, query *v2.RawQuery) (*v2.ListComplianceScanTrendResponse, error) {
+	parsedQuery, err := search.ParseQuery(query.GetQuery(), search.MatchAllIfEmpty())
+	if err != nil {
+		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to parse query %v", err)
+	}
+
+	paginated.FillPaginationV2(parsedQuery, query.GetPagination(), maxPaginationLimit)
+
+	trendResults, err := s.complianceResultsDS.ComplianceTrendResults(ctx, parsedQuery)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to retrieve compliance trend stats for query %v", query)
+	}
+
+	return &v2.ListComplianceScanTrendResponse{
+		DataPoints: storagetov2.ComplianceV2TrendDataPoints(trendResults),
 	}, nil
 }
 

--- a/central/convert/internaltov2storage/compliance_check_results.go
+++ b/central/convert/internaltov2storage/compliance_check_results.go
@@ -37,7 +37,7 @@ var (
 func ComplianceOperatorCheckResult(sensorData *central.ComplianceOperatorCheckResultV2, clusterID string, clusterName string) *storage.ComplianceOperatorCheckResultV2 {
 	lastStartedTimestamp, _ := protocompat.ParseRFC3339NanoTimestamp(sensorData.GetAnnotations()[LastScannedAnnotationKey])
 	return &storage.ComplianceOperatorCheckResultV2{
-		Id:              sensorData.GetId(),
+		Id:              BuildCheckResultID(sensorData.GetId(), lastStartedTimestamp),
 		CheckId:         sensorData.GetCheckId(),
 		CheckName:       sensorData.GetCheckName(),
 		ClusterId:       clusterID,

--- a/central/convert/internaltov2storage/utils.go
+++ b/central/convert/internaltov2storage/utils.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
@@ -34,6 +35,16 @@ func BuildNameRefID(clusterID string, name string) string {
 func idToDNSFriendlyName(id string) string {
 	const ssgPrefix = "xccdf_org.ssgproject.content_rule_"
 	return strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(id, ssgPrefix), "_", "-"))
+}
+
+// BuildCheckResultID generates a deterministic ID for a check result that is unique per scan run.
+// It combines the original K8s UID with the scan's lastStartedTimestamp so that each scan run
+// produces distinct rows while maintaining idempotency within the same run.
+func BuildCheckResultID(originalID string, lastStartedTimestamp *protocompat.Timestamp) string {
+	if lastStartedTimestamp == nil {
+		return originalID
+	}
+	return buildDeterministicID(originalID, protocompat.ConvertTimestampToTimeOrNil(lastStartedTimestamp).String())
 }
 
 func buildDeterministicID(part1 string, part2 string) string {

--- a/central/convert/storagetov2/compliance_results_stats_service.go
+++ b/central/convert/storagetov2/compliance_results_stats_service.go
@@ -153,6 +153,51 @@ func ComplianceV2ProfileStats(resultCounts []*datastore.ResourceResultCountByPro
 	return convertedResults
 }
 
+// ComplianceV2TrendDataPoints converts trend data points to the v2 API response format
+func ComplianceV2TrendDataPoints(dataPoints []*datastore.ComplianceTrendDataPoint) []*v2.ComplianceScanTrendDataPoint {
+	var converted []*v2.ComplianceScanTrendDataPoint
+	for _, dp := range dataPoints {
+		var scanTime *types.Timestamp
+		if dp.LastStartedTime != nil {
+			scanTime = protoconv.ConvertTimeToTimestampOrNil(*dp.LastStartedTime)
+		}
+		converted = append(converted, &v2.ComplianceScanTrendDataPoint{
+			ScanTime: scanTime,
+			CheckStats: []*v2.ComplianceCheckStatusCount{
+				{
+					Count:  int32(dp.PassCount),
+					Status: v2.ComplianceCheckStatus_PASS,
+				},
+				{
+					Count:  int32(dp.FailCount),
+					Status: v2.ComplianceCheckStatus_FAIL,
+				},
+				{
+					Count:  int32(dp.ErrorCount),
+					Status: v2.ComplianceCheckStatus_ERROR,
+				},
+				{
+					Count:  int32(dp.InfoCount),
+					Status: v2.ComplianceCheckStatus_INFO,
+				},
+				{
+					Count:  int32(dp.ManualCount),
+					Status: v2.ComplianceCheckStatus_MANUAL,
+				},
+				{
+					Count:  int32(dp.NotApplicableCount),
+					Status: v2.ComplianceCheckStatus_NOT_APPLICABLE,
+				},
+				{
+					Count:  int32(dp.InconsistentCount),
+					Status: v2.ComplianceCheckStatus_INCONSISTENT,
+				},
+			},
+		})
+	}
+	return converted
+}
+
 func convertBenchmarks(incoming []*storage.ComplianceOperatorBenchmarkV2) []*v2.ComplianceBenchmark {
 	var convertedBenchmarks []*v2.ComplianceBenchmark
 	for _, benchmark := range incoming {

--- a/generated/api/v2/compliance_results_stats_service.pb.go
+++ b/generated/api/v2/compliance_results_stats_service.pb.go
@@ -449,6 +449,104 @@ func (x *ListComplianceClusterScanStatsResponse) GetTotalCount() int32 {
 	return 0
 }
 
+// ComplianceScanTrendDataPoint represents a single data point in a compliance trend over time
+type ComplianceScanTrendDataPoint struct {
+	state         protoimpl.MessageState        `protogen:"open.v1"`
+	ScanTime      *timestamppb.Timestamp        `protobuf:"bytes,1,opt,name=scan_time,json=scanTime,proto3" json:"scan_time,omitempty"`
+	CheckStats    []*ComplianceCheckStatusCount `protobuf:"bytes,2,rep,name=check_stats,json=checkStats,proto3" json:"check_stats,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComplianceScanTrendDataPoint) Reset() {
+	*x = ComplianceScanTrendDataPoint{}
+	mi := &file_api_v2_compliance_results_stats_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComplianceScanTrendDataPoint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComplianceScanTrendDataPoint) ProtoMessage() {}
+
+func (x *ComplianceScanTrendDataPoint) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_compliance_results_stats_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComplianceScanTrendDataPoint.ProtoReflect.Descriptor instead.
+func (*ComplianceScanTrendDataPoint) Descriptor() ([]byte, []int) {
+	return file_api_v2_compliance_results_stats_service_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ComplianceScanTrendDataPoint) GetScanTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ScanTime
+	}
+	return nil
+}
+
+func (x *ComplianceScanTrendDataPoint) GetCheckStats() []*ComplianceCheckStatusCount {
+	if x != nil {
+		return x.CheckStats
+	}
+	return nil
+}
+
+// ListComplianceScanTrendResponse provides compliance trends over time
+type ListComplianceScanTrendResponse struct {
+	state         protoimpl.MessageState          `protogen:"open.v1"`
+	DataPoints    []*ComplianceScanTrendDataPoint `protobuf:"bytes,1,rep,name=data_points,json=dataPoints,proto3" json:"data_points,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListComplianceScanTrendResponse) Reset() {
+	*x = ListComplianceScanTrendResponse{}
+	mi := &file_api_v2_compliance_results_stats_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListComplianceScanTrendResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListComplianceScanTrendResponse) ProtoMessage() {}
+
+func (x *ListComplianceScanTrendResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_compliance_results_stats_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListComplianceScanTrendResponse.ProtoReflect.Descriptor instead.
+func (*ListComplianceScanTrendResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_compliance_results_stats_service_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ListComplianceScanTrendResponse) GetDataPoints() []*ComplianceScanTrendDataPoint {
+	if x != nil {
+		return x.DataPoints
+	}
+	return nil
+}
+
 var File_api_v2_compliance_results_stats_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_compliance_results_stats_service_proto_rawDesc = "" +
@@ -494,7 +592,15 @@ const file_api_v2_compliance_results_stats_service_proto_rawDesc = "" +
 	"\n" +
 	"scan_stats\x18\x01 \x03(\v2\x1e.v2.ComplianceClusterScanStatsR\tscanStats\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +
-	"totalCount2\xbc\t\n" +
+	"totalCount\"\x98\x01\n" +
+	"\x1cComplianceScanTrendDataPoint\x127\n" +
+	"\tscan_time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\bscanTime\x12?\n" +
+	"\vcheck_stats\x18\x02 \x03(\v2\x1e.v2.ComplianceCheckStatusCountR\n" +
+	"checkStats\"d\n" +
+	"\x1fListComplianceScanTrendResponse\x12A\n" +
+	"\vdata_points\x18\x01 \x03(\v2 .v2.ComplianceScanTrendDataPointR\n" +
+	"dataPoints2\xb4\n" +
+	"\n" +
 	"\x1dComplianceResultsStatsService\x12\xa7\x01\n" +
 	"\x19GetComplianceProfileStats\x12#.v2.ComplianceProfileResultsRequest\x1a*.v2.ListComplianceProfileScanStatsResponse\"9\x82\xd3\xe4\x93\x023\x121/v2/compliance/scan/stats/profiles/{profile_name}\x12\x82\x01\n" +
 	"\x1aGetComplianceProfilesStats\x12\f.v2.RawQuery\x1a*.v2.ListComplianceProfileScanStatsResponse\"*\x82\xd3\xe4\x93\x02$\x12\"/v2/compliance/scan/stats/profiles\x12\xb6\x01\n" +
@@ -502,7 +608,8 @@ const file_api_v2_compliance_results_stats_service_proto_rawDesc = "" +
 	"\x1eGetComplianceProfileCheckStats\x12!.v2.ComplianceProfileCheckRequest\x1a .v2.ListComplianceProfileResults\"M\x82\xd3\xe4\x93\x02G\x12E/v2/compliance/scan/stats/profiles/{profile_name}/checks/{check_name}\x12\xb0\x01\n" +
 	"\x1dGetComplianceClusterScanStats\x12 .v2.ComplianceScanClusterRequest\x1a*.v2.ListComplianceClusterScanStatsResponse\"A\x82\xd3\xe4\x93\x02;\x129/v2/compliance/stats/configurations/clusters/{cluster_id}\x12\x92\x01\n" +
 	" GetComplianceOverallClusterStats\x12\f.v2.RawQuery\x1a-.v2.ListComplianceClusterOverallStatsResponse\"1\x82\xd3\xe4\x93\x02+\x12)/v2/compliance/scan/stats/overall/cluster\x12\xb3\x01\n" +
-	"\x19GetComplianceClusterStats\x12#.v2.ComplianceProfileResultsRequest\x1a-.v2.ListComplianceClusterOverallStatsResponse\"B\x82\xd3\xe4\x93\x02<\x12:/v2/compliance/scan/stats/profiles/{profile_name}/clustersB'\n" +
+	"\x19GetComplianceClusterStats\x12#.v2.ComplianceProfileResultsRequest\x1a-.v2.ListComplianceClusterOverallStatsResponse\"B\x82\xd3\xe4\x93\x02<\x12:/v2/compliance/scan/stats/profiles/{profile_name}/clusters\x12v\n" +
+	"\x17GetComplianceScanTrends\x12\f.v2.RawQuery\x1a#.v2.ListComplianceScanTrendResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v2/compliance/scan/stats/trendsB'\n" +
 	"\x18io.stackrox.proto.api.v2Z\v./api/v2;v2X\x02b\x06proto3"
 
 var (
@@ -517,7 +624,7 @@ func file_api_v2_compliance_results_stats_service_proto_rawDescGZIP() []byte {
 	return file_api_v2_compliance_results_stats_service_proto_rawDescData
 }
 
-var file_api_v2_compliance_results_stats_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_api_v2_compliance_results_stats_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_api_v2_compliance_results_stats_service_proto_goTypes = []any{
 	(*ComplianceScanStatsShim)(nil),                   // 0: v2.ComplianceScanStatsShim
 	(*ComplianceProfileScanStats)(nil),                // 1: v2.ComplianceProfileScanStats
@@ -526,46 +633,53 @@ var file_api_v2_compliance_results_stats_service_proto_goTypes = []any{
 	(*ListComplianceProfileScanStatsResponse)(nil),    // 4: v2.ListComplianceProfileScanStatsResponse
 	(*ListComplianceClusterProfileStatsResponse)(nil), // 5: v2.ListComplianceClusterProfileStatsResponse
 	(*ListComplianceClusterScanStatsResponse)(nil),    // 6: v2.ListComplianceClusterScanStatsResponse
-	(*ComplianceCheckStatusCount)(nil),                // 7: v2.ComplianceCheckStatusCount
-	(*timestamppb.Timestamp)(nil),                     // 8: google.protobuf.Timestamp
-	(*ComplianceBenchmark)(nil),                       // 9: v2.ComplianceBenchmark
-	(*ComplianceScanCluster)(nil),                     // 10: v2.ComplianceScanCluster
-	(*RawQuery)(nil),                                  // 11: v2.RawQuery
-	(*ComplianceProfileResultsRequest)(nil),           // 12: v2.ComplianceProfileResultsRequest
-	(*ComplianceProfileCheckRequest)(nil),             // 13: v2.ComplianceProfileCheckRequest
-	(*ListComplianceProfileResults)(nil),              // 14: v2.ListComplianceProfileResults
-	(*ListComplianceClusterOverallStatsResponse)(nil), // 15: v2.ListComplianceClusterOverallStatsResponse
+	(*ComplianceScanTrendDataPoint)(nil),              // 7: v2.ComplianceScanTrendDataPoint
+	(*ListComplianceScanTrendResponse)(nil),           // 8: v2.ListComplianceScanTrendResponse
+	(*ComplianceCheckStatusCount)(nil),                // 9: v2.ComplianceCheckStatusCount
+	(*timestamppb.Timestamp)(nil),                     // 10: google.protobuf.Timestamp
+	(*ComplianceBenchmark)(nil),                       // 11: v2.ComplianceBenchmark
+	(*ComplianceScanCluster)(nil),                     // 12: v2.ComplianceScanCluster
+	(*RawQuery)(nil),                                  // 13: v2.RawQuery
+	(*ComplianceProfileResultsRequest)(nil),           // 14: v2.ComplianceProfileResultsRequest
+	(*ComplianceProfileCheckRequest)(nil),             // 15: v2.ComplianceProfileCheckRequest
+	(*ListComplianceProfileResults)(nil),              // 16: v2.ListComplianceProfileResults
+	(*ListComplianceClusterOverallStatsResponse)(nil), // 17: v2.ListComplianceClusterOverallStatsResponse
 }
 var file_api_v2_compliance_results_stats_service_proto_depIdxs = []int32{
-	7,  // 0: v2.ComplianceScanStatsShim.check_stats:type_name -> v2.ComplianceCheckStatusCount
-	8,  // 1: v2.ComplianceScanStatsShim.last_scan:type_name -> google.protobuf.Timestamp
-	7,  // 2: v2.ComplianceProfileScanStats.check_stats:type_name -> v2.ComplianceCheckStatusCount
-	9,  // 3: v2.ComplianceProfileScanStats.benchmarks:type_name -> v2.ComplianceBenchmark
+	9,  // 0: v2.ComplianceScanStatsShim.check_stats:type_name -> v2.ComplianceCheckStatusCount
+	10, // 1: v2.ComplianceScanStatsShim.last_scan:type_name -> google.protobuf.Timestamp
+	9,  // 2: v2.ComplianceProfileScanStats.check_stats:type_name -> v2.ComplianceCheckStatusCount
+	11, // 3: v2.ComplianceProfileScanStats.benchmarks:type_name -> v2.ComplianceBenchmark
 	0,  // 4: v2.ComplianceClusterScanStats.scan_stats:type_name -> v2.ComplianceScanStatsShim
-	10, // 5: v2.ComplianceClusterScanStats.cluster:type_name -> v2.ComplianceScanCluster
-	11, // 6: v2.ComplianceScanClusterRequest.query:type_name -> v2.RawQuery
+	12, // 5: v2.ComplianceClusterScanStats.cluster:type_name -> v2.ComplianceScanCluster
+	13, // 6: v2.ComplianceScanClusterRequest.query:type_name -> v2.RawQuery
 	1,  // 7: v2.ListComplianceProfileScanStatsResponse.scan_stats:type_name -> v2.ComplianceProfileScanStats
 	1,  // 8: v2.ListComplianceClusterProfileStatsResponse.scan_stats:type_name -> v2.ComplianceProfileScanStats
 	2,  // 9: v2.ListComplianceClusterScanStatsResponse.scan_stats:type_name -> v2.ComplianceClusterScanStats
-	12, // 10: v2.ComplianceResultsStatsService.GetComplianceProfileStats:input_type -> v2.ComplianceProfileResultsRequest
-	11, // 11: v2.ComplianceResultsStatsService.GetComplianceProfilesStats:input_type -> v2.RawQuery
-	3,  // 12: v2.ComplianceResultsStatsService.GetComplianceProfilesClusterStats:input_type -> v2.ComplianceScanClusterRequest
-	13, // 13: v2.ComplianceResultsStatsService.GetComplianceProfileCheckStats:input_type -> v2.ComplianceProfileCheckRequest
-	3,  // 14: v2.ComplianceResultsStatsService.GetComplianceClusterScanStats:input_type -> v2.ComplianceScanClusterRequest
-	11, // 15: v2.ComplianceResultsStatsService.GetComplianceOverallClusterStats:input_type -> v2.RawQuery
-	12, // 16: v2.ComplianceResultsStatsService.GetComplianceClusterStats:input_type -> v2.ComplianceProfileResultsRequest
-	4,  // 17: v2.ComplianceResultsStatsService.GetComplianceProfileStats:output_type -> v2.ListComplianceProfileScanStatsResponse
-	4,  // 18: v2.ComplianceResultsStatsService.GetComplianceProfilesStats:output_type -> v2.ListComplianceProfileScanStatsResponse
-	5,  // 19: v2.ComplianceResultsStatsService.GetComplianceProfilesClusterStats:output_type -> v2.ListComplianceClusterProfileStatsResponse
-	14, // 20: v2.ComplianceResultsStatsService.GetComplianceProfileCheckStats:output_type -> v2.ListComplianceProfileResults
-	6,  // 21: v2.ComplianceResultsStatsService.GetComplianceClusterScanStats:output_type -> v2.ListComplianceClusterScanStatsResponse
-	15, // 22: v2.ComplianceResultsStatsService.GetComplianceOverallClusterStats:output_type -> v2.ListComplianceClusterOverallStatsResponse
-	15, // 23: v2.ComplianceResultsStatsService.GetComplianceClusterStats:output_type -> v2.ListComplianceClusterOverallStatsResponse
-	17, // [17:24] is the sub-list for method output_type
-	10, // [10:17] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	10, // 10: v2.ComplianceScanTrendDataPoint.scan_time:type_name -> google.protobuf.Timestamp
+	9,  // 11: v2.ComplianceScanTrendDataPoint.check_stats:type_name -> v2.ComplianceCheckStatusCount
+	7,  // 12: v2.ListComplianceScanTrendResponse.data_points:type_name -> v2.ComplianceScanTrendDataPoint
+	14, // 13: v2.ComplianceResultsStatsService.GetComplianceProfileStats:input_type -> v2.ComplianceProfileResultsRequest
+	13, // 14: v2.ComplianceResultsStatsService.GetComplianceProfilesStats:input_type -> v2.RawQuery
+	3,  // 15: v2.ComplianceResultsStatsService.GetComplianceProfilesClusterStats:input_type -> v2.ComplianceScanClusterRequest
+	15, // 16: v2.ComplianceResultsStatsService.GetComplianceProfileCheckStats:input_type -> v2.ComplianceProfileCheckRequest
+	3,  // 17: v2.ComplianceResultsStatsService.GetComplianceClusterScanStats:input_type -> v2.ComplianceScanClusterRequest
+	13, // 18: v2.ComplianceResultsStatsService.GetComplianceOverallClusterStats:input_type -> v2.RawQuery
+	14, // 19: v2.ComplianceResultsStatsService.GetComplianceClusterStats:input_type -> v2.ComplianceProfileResultsRequest
+	13, // 20: v2.ComplianceResultsStatsService.GetComplianceScanTrends:input_type -> v2.RawQuery
+	4,  // 21: v2.ComplianceResultsStatsService.GetComplianceProfileStats:output_type -> v2.ListComplianceProfileScanStatsResponse
+	4,  // 22: v2.ComplianceResultsStatsService.GetComplianceProfilesStats:output_type -> v2.ListComplianceProfileScanStatsResponse
+	5,  // 23: v2.ComplianceResultsStatsService.GetComplianceProfilesClusterStats:output_type -> v2.ListComplianceClusterProfileStatsResponse
+	16, // 24: v2.ComplianceResultsStatsService.GetComplianceProfileCheckStats:output_type -> v2.ListComplianceProfileResults
+	6,  // 25: v2.ComplianceResultsStatsService.GetComplianceClusterScanStats:output_type -> v2.ListComplianceClusterScanStatsResponse
+	17, // 26: v2.ComplianceResultsStatsService.GetComplianceOverallClusterStats:output_type -> v2.ListComplianceClusterOverallStatsResponse
+	17, // 27: v2.ComplianceResultsStatsService.GetComplianceClusterStats:output_type -> v2.ListComplianceClusterOverallStatsResponse
+	8,  // 28: v2.ComplianceResultsStatsService.GetComplianceScanTrends:output_type -> v2.ListComplianceScanTrendResponse
+	21, // [21:29] is the sub-list for method output_type
+	13, // [13:21] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_compliance_results_stats_service_proto_init() }
@@ -581,7 +695,7 @@ func file_api_v2_compliance_results_stats_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_compliance_results_stats_service_proto_rawDesc), len(file_api_v2_compliance_results_stats_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/api/v2/compliance_results_stats_service.pb.gw.go
+++ b/generated/api/v2/compliance_results_stats_service.pb.gw.go
@@ -386,6 +386,41 @@ func local_request_ComplianceResultsStatsService_GetComplianceClusterStats_0(ctx
 	return msg, metadata, err
 }
 
+var filter_ComplianceResultsStatsService_GetComplianceScanTrends_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_ComplianceResultsStatsService_GetComplianceScanTrends_0(ctx context.Context, marshaler runtime.Marshaler, client ComplianceResultsStatsServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RawQuery
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ComplianceResultsStatsService_GetComplianceScanTrends_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetComplianceScanTrends(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ComplianceResultsStatsService_GetComplianceScanTrends_0(ctx context.Context, marshaler runtime.Marshaler, server ComplianceResultsStatsServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RawQuery
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ComplianceResultsStatsService_GetComplianceScanTrends_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetComplianceScanTrends(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterComplianceResultsStatsServiceHandlerServer registers the http handlers for service ComplianceResultsStatsService to "mux".
 // UnaryRPC     :call ComplianceResultsStatsServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -531,6 +566,26 @@ func RegisterComplianceResultsStatsServiceHandlerServer(ctx context.Context, mux
 			return
 		}
 		forward_ComplianceResultsStatsService_GetComplianceClusterStats_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ComplianceResultsStatsService_GetComplianceScanTrends_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v2.ComplianceResultsStatsService/GetComplianceScanTrends", runtime.WithHTTPPathPattern("/v2/compliance/scan/stats/trends"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ComplianceResultsStatsService_GetComplianceScanTrends_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ComplianceResultsStatsService_GetComplianceScanTrends_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -691,6 +746,23 @@ func RegisterComplianceResultsStatsServiceHandlerClient(ctx context.Context, mux
 		}
 		forward_ComplianceResultsStatsService_GetComplianceClusterStats_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ComplianceResultsStatsService_GetComplianceScanTrends_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v2.ComplianceResultsStatsService/GetComplianceScanTrends", runtime.WithHTTPPathPattern("/v2/compliance/scan/stats/trends"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ComplianceResultsStatsService_GetComplianceScanTrends_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ComplianceResultsStatsService_GetComplianceScanTrends_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -702,6 +774,7 @@ var (
 	pattern_ComplianceResultsStatsService_GetComplianceClusterScanStats_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"v2", "compliance", "stats", "configurations", "clusters", "cluster_id"}, ""))
 	pattern_ComplianceResultsStatsService_GetComplianceOverallClusterStats_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 2, 5}, []string{"v2", "compliance", "scan", "stats", "overall", "cluster"}, ""))
 	pattern_ComplianceResultsStatsService_GetComplianceClusterStats_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"v2", "compliance", "scan", "stats", "profiles", "profile_name", "clusters"}, ""))
+	pattern_ComplianceResultsStatsService_GetComplianceScanTrends_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 2, 4}, []string{"v2", "compliance", "scan", "stats", "trends"}, ""))
 )
 
 var (
@@ -712,4 +785,5 @@ var (
 	forward_ComplianceResultsStatsService_GetComplianceClusterScanStats_0     = runtime.ForwardResponseMessage
 	forward_ComplianceResultsStatsService_GetComplianceOverallClusterStats_0  = runtime.ForwardResponseMessage
 	forward_ComplianceResultsStatsService_GetComplianceClusterStats_0         = runtime.ForwardResponseMessage
+	forward_ComplianceResultsStatsService_GetComplianceScanTrends_0           = runtime.ForwardResponseMessage
 )

--- a/generated/api/v2/compliance_results_stats_service.swagger.json
+++ b/generated/api/v2/compliance_results_stats_service.swagger.json
@@ -501,6 +501,82 @@
         ]
       }
     },
+    "/v2/compliance/scan/stats/trends": {
+      "get": {
+        "summary": "GetComplianceScanTrends returns compliance pass/fail counts grouped by scan time",
+        "operationId": "ComplianceResultsStatsService_GetComplianceScanTrends",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v2ListComplianceScanTrendResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pagination.limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pagination.offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pagination.sortOption.field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "pagination.sortOption.reversed",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "pagination.sortOption.aggregateBy.aggrFunc",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "UNSET",
+              "COUNT",
+              "MIN",
+              "MAX"
+            ],
+            "default": "UNSET"
+          },
+          {
+            "name": "pagination.sortOption.aggregateBy.distinct",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "ComplianceResultsStatsService"
+        ]
+      }
+    },
     "/v2/compliance/stats/configurations/clusters/{clusterId}": {
       "get": {
         "summary": "GetComplianceClusterScanStats lists the current scan stats for a cluster for each scan configuration",
@@ -823,6 +899,23 @@
       },
       "title": "ComplianceScanStatsShim models statistics of checks for a given scan configuration"
     },
+    "v2ComplianceScanTrendDataPoint": {
+      "type": "object",
+      "properties": {
+        "scanTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "checkStats": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2ComplianceCheckStatusCount"
+          }
+        }
+      },
+      "title": "ComplianceScanTrendDataPoint represents a single data point in a compliance trend over time"
+    },
     "v2ListComplianceClusterOverallStatsResponse": {
       "type": "object",
       "properties": {
@@ -916,6 +1009,19 @@
         }
       },
       "title": "ListComplianceProfileScanStatsResponse provides stats for the profiles within the scans"
+    },
+    "v2ListComplianceScanTrendResponse": {
+      "type": "object",
+      "properties": {
+        "dataPoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v2ComplianceScanTrendDataPoint"
+          }
+        }
+      },
+      "title": "ListComplianceScanTrendResponse provides compliance trends over time"
     },
     "v2Pagination": {
       "type": "object",

--- a/generated/api/v2/compliance_results_stats_service_grpc.pb.go
+++ b/generated/api/v2/compliance_results_stats_service_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	ComplianceResultsStatsService_GetComplianceClusterScanStats_FullMethodName     = "/v2.ComplianceResultsStatsService/GetComplianceClusterScanStats"
 	ComplianceResultsStatsService_GetComplianceOverallClusterStats_FullMethodName  = "/v2.ComplianceResultsStatsService/GetComplianceOverallClusterStats"
 	ComplianceResultsStatsService_GetComplianceClusterStats_FullMethodName         = "/v2.ComplianceResultsStatsService/GetComplianceClusterStats"
+	ComplianceResultsStatsService_GetComplianceScanTrends_FullMethodName           = "/v2.ComplianceResultsStatsService/GetComplianceScanTrends"
 )
 
 // ComplianceResultsStatsServiceClient is the client API for ComplianceResultsStatsService service.
@@ -55,6 +56,8 @@ type ComplianceResultsStatsServiceClient interface {
 	// Deprecated in favor of GetComplianceClusterStats
 	GetComplianceOverallClusterStats(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*ListComplianceClusterOverallStatsResponse, error)
 	GetComplianceClusterStats(ctx context.Context, in *ComplianceProfileResultsRequest, opts ...grpc.CallOption) (*ListComplianceClusterOverallStatsResponse, error)
+	// GetComplianceScanTrends returns compliance pass/fail counts grouped by scan time
+	GetComplianceScanTrends(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*ListComplianceScanTrendResponse, error)
 }
 
 type complianceResultsStatsServiceClient struct {
@@ -135,6 +138,16 @@ func (c *complianceResultsStatsServiceClient) GetComplianceClusterStats(ctx cont
 	return out, nil
 }
 
+func (c *complianceResultsStatsServiceClient) GetComplianceScanTrends(ctx context.Context, in *RawQuery, opts ...grpc.CallOption) (*ListComplianceScanTrendResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListComplianceScanTrendResponse)
+	err := c.cc.Invoke(ctx, ComplianceResultsStatsService_GetComplianceScanTrends_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ComplianceResultsStatsServiceServer is the server API for ComplianceResultsStatsService service.
 // All implementations should embed UnimplementedComplianceResultsStatsServiceServer
 // for forward compatibility.
@@ -162,6 +175,8 @@ type ComplianceResultsStatsServiceServer interface {
 	// Deprecated in favor of GetComplianceClusterStats
 	GetComplianceOverallClusterStats(context.Context, *RawQuery) (*ListComplianceClusterOverallStatsResponse, error)
 	GetComplianceClusterStats(context.Context, *ComplianceProfileResultsRequest) (*ListComplianceClusterOverallStatsResponse, error)
+	// GetComplianceScanTrends returns compliance pass/fail counts grouped by scan time
+	GetComplianceScanTrends(context.Context, *RawQuery) (*ListComplianceScanTrendResponse, error)
 }
 
 // UnimplementedComplianceResultsStatsServiceServer should be embedded to have
@@ -191,6 +206,9 @@ func (UnimplementedComplianceResultsStatsServiceServer) GetComplianceOverallClus
 }
 func (UnimplementedComplianceResultsStatsServiceServer) GetComplianceClusterStats(context.Context, *ComplianceProfileResultsRequest) (*ListComplianceClusterOverallStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetComplianceClusterStats not implemented")
+}
+func (UnimplementedComplianceResultsStatsServiceServer) GetComplianceScanTrends(context.Context, *RawQuery) (*ListComplianceScanTrendResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetComplianceScanTrends not implemented")
 }
 func (UnimplementedComplianceResultsStatsServiceServer) testEmbeddedByValue() {}
 
@@ -338,6 +356,24 @@ func _ComplianceResultsStatsService_GetComplianceClusterStats_Handler(srv interf
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ComplianceResultsStatsService_GetComplianceScanTrends_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RawQuery)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ComplianceResultsStatsServiceServer).GetComplianceScanTrends(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ComplianceResultsStatsService_GetComplianceScanTrends_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ComplianceResultsStatsServiceServer).GetComplianceScanTrends(ctx, req.(*RawQuery))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ComplianceResultsStatsService_ServiceDesc is the grpc.ServiceDesc for ComplianceResultsStatsService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -372,6 +408,10 @@ var ComplianceResultsStatsService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetComplianceClusterStats",
 			Handler:    _ComplianceResultsStatsService_GetComplianceClusterStats_Handler,
+		},
+		{
+			MethodName: "GetComplianceScanTrends",
+			Handler:    _ComplianceResultsStatsService_GetComplianceScanTrends_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/generated/api/v2/compliance_results_stats_service_vtproto.pb.go
+++ b/generated/api/v2/compliance_results_stats_service_vtproto.pb.go
@@ -191,6 +191,53 @@ func (m *ListComplianceClusterScanStatsResponse) CloneMessageVT() proto.Message 
 	return m.CloneVT()
 }
 
+func (m *ComplianceScanTrendDataPoint) CloneVT() *ComplianceScanTrendDataPoint {
+	if m == nil {
+		return (*ComplianceScanTrendDataPoint)(nil)
+	}
+	r := new(ComplianceScanTrendDataPoint)
+	r.ScanTime = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.ScanTime).CloneVT())
+	if rhs := m.CheckStats; rhs != nil {
+		tmpContainer := make([]*ComplianceCheckStatusCount, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.CheckStats = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ComplianceScanTrendDataPoint) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ListComplianceScanTrendResponse) CloneVT() *ListComplianceScanTrendResponse {
+	if m == nil {
+		return (*ListComplianceScanTrendResponse)(nil)
+	}
+	r := new(ListComplianceScanTrendResponse)
+	if rhs := m.DataPoints; rhs != nil {
+		tmpContainer := make([]*ComplianceScanTrendDataPoint, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.DataPoints = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ListComplianceScanTrendResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *ComplianceScanStatsShim) EqualVT(that *ComplianceScanStatsShim) bool {
 	if this == that {
 		return true
@@ -445,6 +492,75 @@ func (this *ListComplianceClusterScanStatsResponse) EqualVT(that *ListCompliance
 
 func (this *ListComplianceClusterScanStatsResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*ListComplianceClusterScanStatsResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ComplianceScanTrendDataPoint) EqualVT(that *ComplianceScanTrendDataPoint) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.ScanTime).EqualVT((*timestamppb1.Timestamp)(that.ScanTime)) {
+		return false
+	}
+	if len(this.CheckStats) != len(that.CheckStats) {
+		return false
+	}
+	for i, vx := range this.CheckStats {
+		vy := that.CheckStats[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ComplianceCheckStatusCount{}
+			}
+			if q == nil {
+				q = &ComplianceCheckStatusCount{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ComplianceScanTrendDataPoint) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ComplianceScanTrendDataPoint)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ListComplianceScanTrendResponse) EqualVT(that *ListComplianceScanTrendResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.DataPoints) != len(that.DataPoints) {
+		return false
+	}
+	for i, vx := range this.DataPoints {
+		vy := that.DataPoints[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ComplianceScanTrendDataPoint{}
+			}
+			if q == nil {
+				q = &ComplianceScanTrendDataPoint{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ListComplianceScanTrendResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ListComplianceScanTrendResponse)
 	if !ok {
 		return false
 	}
@@ -864,6 +980,106 @@ func (m *ListComplianceClusterScanStatsResponse) MarshalToSizedBufferVT(dAtA []b
 	return len(dAtA) - i, nil
 }
 
+func (m *ComplianceScanTrendDataPoint) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ComplianceScanTrendDataPoint) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ComplianceScanTrendDataPoint) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.CheckStats) > 0 {
+		for iNdEx := len(m.CheckStats) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.CheckStats[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.ScanTime != nil {
+		size, err := (*timestamppb1.Timestamp)(m.ScanTime).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ListComplianceScanTrendResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListComplianceScanTrendResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ListComplianceScanTrendResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DataPoints) > 0 {
+		for iNdEx := len(m.DataPoints) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.DataPoints[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ComplianceScanStatsShim) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1022,6 +1238,42 @@ func (m *ListComplianceClusterScanStatsResponse) SizeVT() (n int) {
 	}
 	if m.TotalCount != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.TotalCount))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ComplianceScanTrendDataPoint) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ScanTime != nil {
+		l = (*timestamppb1.Timestamp)(m.ScanTime).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.CheckStats) > 0 {
+		for _, e := range m.CheckStats {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ListComplianceScanTrendResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.DataPoints) > 0 {
+		for _, e := range m.DataPoints {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2023,6 +2275,212 @@ func (m *ListComplianceClusterScanStatsResponse) UnmarshalVT(dAtA []byte) error 
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ComplianceScanTrendDataPoint) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ComplianceScanTrendDataPoint: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ComplianceScanTrendDataPoint: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ScanTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ScanTime == nil {
+				m.ScanTime = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.ScanTime).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CheckStats", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CheckStats = append(m.CheckStats, &ComplianceCheckStatusCount{})
+			if err := m.CheckStats[len(m.CheckStats)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListComplianceScanTrendResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListComplianceScanTrendResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListComplianceScanTrendResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataPoints", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataPoints = append(m.DataPoints, &ComplianceScanTrendDataPoint{})
+			if err := m.DataPoints[len(m.DataPoints)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -3073,6 +3531,212 @@ func (m *ListComplianceClusterScanStatsResponse) UnmarshalVTUnsafe(dAtA []byte) 
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ComplianceScanTrendDataPoint) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ComplianceScanTrendDataPoint: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ComplianceScanTrendDataPoint: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ScanTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ScanTime == nil {
+				m.ScanTime = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.ScanTime).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CheckStats", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CheckStats = append(m.CheckStats, &ComplianceCheckStatusCount{})
+			if err := m.CheckStats[len(m.CheckStats)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListComplianceScanTrendResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListComplianceScanTrendResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListComplianceScanTrendResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataPoints", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataPoints = append(m.DataPoints, &ComplianceScanTrendDataPoint{})
+			if err := m.DataPoints[len(m.DataPoints)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/api/v2/compliance_results_stats_service.proto
+++ b/proto/api/v2/compliance_results_stats_service.proto
@@ -58,6 +58,17 @@ message ListComplianceClusterScanStatsResponse {
   int32 total_count = 2;
 }
 
+// ComplianceScanTrendDataPoint represents a single data point in a compliance trend over time
+message ComplianceScanTrendDataPoint {
+  google.protobuf.Timestamp scan_time = 1;
+  repeated ComplianceCheckStatusCount check_stats = 2;
+}
+
+// ListComplianceScanTrendResponse provides compliance trends over time
+message ListComplianceScanTrendResponse {
+  repeated ComplianceScanTrendDataPoint data_points = 1;
+}
+
 service ComplianceResultsStatsService {
   // GetComplianceProfileStats lists current scan stats grouped by profile
   // Optional RawQuery query fields can be combined.
@@ -101,5 +112,10 @@ service ComplianceResultsStatsService {
 
   rpc GetComplianceClusterStats(ComplianceProfileResultsRequest) returns (ListComplianceClusterOverallStatsResponse) {
     option (google.api.http) = {get: "/v2/compliance/scan/stats/profiles/{profile_name}/clusters"};
+  }
+
+  // GetComplianceScanTrends returns compliance pass/fail counts grouped by scan time
+  rpc GetComplianceScanTrends(RawQuery) returns (ListComplianceScanTrendResponse) {
+    option (google.api.http) = {get: "/v2/compliance/scan/stats/trends"};
   }
 }


### PR DESCRIPTION
## Description

PoC for retaining historical compliance scan results and exposing a trending API.

**Problem**: ACS overwrites check results on every scan run (K8s UID reuse as PK + active deletion), making compliance-over-time analysis impossible.

**Changes**:
- Generate scan-run-aware IDs (UUID v5 from K8s UID + scan timestamp) so each run produces distinct rows
- Disable `DeleteOldResults` so historical data accumulates
- Add `GET /v2/compliance/scan/stats/trends` endpoint returning pass/fail counts grouped by scan time
- Add datastore method, conversion layer, and proto definitions for the trending API

**Known breaks (deferred)**:
- Report generation aggregates across all historical runs (inflated counts)
- Coverage page stats will show inflated numbers
- Fix: filter existing queries to latest scan run only

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All existing unit tests pass across affected packages (conversion, pipeline, datastore, stats service, report manager, scan watcher)
- Build compiles cleanly
- PoC — needs validation on a real cluster with multiple scan runs