### PR TITLE
fix(ci): OSCI image prefetch issues [4.10]

### DIFF
--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -31,6 +31,7 @@ quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine
 quay.io/rhacs-eng/qa-multi-arch:nginx-1-17-1
 quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.12
+quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1
 quay.io/rhacs-eng/qa-multi-arch:nginx-latest
 quay.io/rhacs-eng/qa-multi-arch:nginx-unprivileged-1.25.2


### PR DESCRIPTION
## Description

We try to apply some of the changes attempted to workaround some image prefetch issues.

https://github.com/stackrox/stackrox/pull/19287 is the inspiration. 

The OSCI failure looks like :

```
{orchestratormanager.OrchestratorManagerException: The deployment did not start or reach replica ready state - if this job uses image prefetch check that this image is in the jobs prefetch list e.g. qa-tests-backend/scripts/images-to-prefetch.txt - quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728 orchestratormanager.OrchestratorManagerException orchestratormanager.OrchestratorManagerException: The deployment did not start or reach replica ready state - if this job uses image prefetch check that this image is in the jobs prefetch list e.g. qa-tests-backend/scripts/images-to-prefetch.txt - quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728
	at app//orchestratormanager.Kubernetes.waitForDeploymentAndPopulateInfo(Kubernetes.groovy:2081)
	at app//orchestratormanager.Kubernetes.batchCreateDeployments(Kubernetes.groovy:239)
	at app//K8sEventDetectionTest.setupSpec(K8sEventDetectionTest.groovy:43)
	Suppressed: java.lang.NullPointerException: Cannot invoke "io.stackrox.proto.storage.PolicyOuterClass$ListPolicy.getId()" because the return value of "org.codehaus.groovy.runtime.DefaultGroovyMethods.find(java.util.Collection, groovy.lang.Closure)" is null
		at Services.getPolicyByName(Services.groovy:98)
		at K8sEventDetectionTest.cleanupSpec(K8sEventDetectionTest.groovy:72)
}
```