### PR TITLE
ROX-32949: reactive DNF/RPM scanning in roxagent (Phase 1)

### DIFF
--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -30,6 +30,14 @@ type rescanner struct {
 	mappingFilePath string
 	interval        time.Duration
 
+	// reactiveCh, when set by the caller (runServe wires in the RPM
+	// watcher's Triggered() channel), lets Run start a rescan immediately
+	// instead of waiting for the next periodic tick. Left nil when
+	// reactive scanning is unavailable (e.g. the watcher failed to start):
+	// a nil channel blocks forever in Run's select, so that case simply
+	// never fires and Run falls back to periodic-only scanning.
+	reactiveCh <-chan struct{}
+
 	// scanFn defaults to the package scan function; tests override it to
 	// inject failures. factsFn defaults to the package discoverFacts
 	// function; tests override it to avoid exercising the real
@@ -39,7 +47,7 @@ type rescanner struct {
 	// substitute a function returning a manually driven channel for
 	// precise control over Run's loop.
 	scanFn   func(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, error)
-	factsFn  func(hostPath string) map[string]string
+	factsFn  func(hostPath, trigger string) map[string]string
 	newDelay func(d time.Duration) <-chan time.Time
 }
 
@@ -55,33 +63,44 @@ func newRescanner(cache *vsockserver.ReportCache, hostPath, mappingFilePath stri
 	}
 }
 
-// Run rescans every r.interval, publishing each successful result to cache.
-// If a rescan fails, the next attempt is scheduled sooner than the full
-// interval - with exponential backoff, capped at both rescanRetryMaxBackoff
-// and r.interval itself, so a retry is never slower than just waiting for
-// the next scheduled rescan would be. Blocks until ctx is cancelled.
+// Run rescans every r.interval, or immediately whenever r.reactiveCh fires,
+// publishing each successful result to cache. Both triggers share this one
+// loop and code path — reactive and scheduled rescans differ only in the
+// "trigger" fact stamped onto the result (see scanTriggerScheduled/
+// scanTriggerReactive) — so a reactive rescan also resets delay, meaning a
+// routine rescan never immediately follows one that just refreshed the same
+// data. If a rescan fails, the next attempt is scheduled sooner than the
+// full interval - with exponential backoff, capped at both
+// rescanRetryMaxBackoff and r.interval itself, so a retry is never slower
+// than just waiting for the next scheduled rescan would be. Blocks until
+// ctx is cancelled.
 func (r *rescanner) Run(ctx context.Context) {
 	backoff := rescanRetryBaseBackoff
 	delay := r.newDelay(r.interval)
 	for {
+		var trigger string
 		select {
 		case <-ctx.Done():
 			return
 		case <-delay:
-			log.Info("Starting rescan")
-			report, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath)
-			if err != nil {
-				retryIn := min(backoff, r.interval)
-				log.Errorf("Rescan failed: %v; trying again in %v", err, retryIn)
-				backoff = min(backoff*2, rescanRetryMaxBackoff)
-				delay = r.newDelay(retryIn)
-				continue
-			}
-			r.cache.SetReport(report, r.factsFn(r.hostPath))
-			log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
-			backoff = rescanRetryBaseBackoff
-			delay = r.newDelay(r.interval)
+			trigger = scanTriggerScheduled
+		case <-r.reactiveCh:
+			trigger = scanTriggerReactive
 		}
+
+		log.Infof("Starting %s rescan", trigger)
+		report, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath)
+		if err != nil {
+			retryIn := min(backoff, r.interval)
+			log.Errorf("%s rescan failed: %v; trying again in %v", trigger, err, retryIn)
+			backoff = min(backoff*2, rescanRetryMaxBackoff)
+			delay = r.newDelay(retryIn)
+			continue
+		}
+		r.cache.SetReport(report, r.factsFn(r.hostPath, trigger))
+		log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
+		backoff = rescanRetryBaseBackoff
+		delay = r.newDelay(r.interval)
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -30,6 +30,14 @@ type rescanner struct {
 	mappingFilePath string
 	interval        time.Duration
 
+	// reactiveCh, when set by the caller (runServe wires in the RPM
+	// watcher's Triggered() channel), lets Run start a rescan immediately
+	// instead of waiting for the next periodic tick. Left nil when
+	// reactive scanning is unavailable (e.g. the watcher failed to start):
+	// a nil channel blocks forever in Run's select, so that case simply
+	// never fires and Run falls back to periodic-only scanning.
+	reactiveCh <-chan struct{}
+
 	// scanFn defaults to scanWithDiagnostics, which returns the facts
 	// alongside the report from the same DiscoveredData probe used for
 	// diagnostics logging, rather than making Run probe the filesystem a
@@ -39,7 +47,7 @@ type rescanner struct {
 	// not a no-op. newDelay defaults to time.After (a one-shot timer);
 	// tests substitute a function returning a manually driven channel for
 	// precise control over Run's loop.
-	scanFn   func(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, map[string]string, error)
+	scanFn   func(ctx context.Context, hostPath, mappingFilePath, trigger string) (*v4.IndexReport, map[string]string, error)
 	newDelay func(d time.Duration) <-chan time.Time
 }
 
@@ -54,33 +62,44 @@ func newRescanner(cache *vsockserver.ReportCache, hostPath, mappingFilePath stri
 	}
 }
 
-// Run rescans every r.interval, publishing each successful result to cache.
-// If a rescan fails, the next attempt is scheduled sooner than the full
-// interval - with exponential backoff, capped at both rescanRetryMaxBackoff
-// and r.interval itself, so a retry is never slower than just waiting for
-// the next scheduled rescan would be. Blocks until ctx is cancelled.
+// Run rescans every r.interval, or immediately whenever r.reactiveCh fires,
+// publishing each successful result to cache. Both triggers share this one
+// loop and code path — reactive and scheduled rescans differ only in the
+// "trigger" fact stamped onto the result (see scanTriggerScheduled/
+// scanTriggerReactive) — so a reactive rescan also resets delay, meaning a
+// routine rescan never immediately follows one that just refreshed the same
+// data. If a rescan fails, the next attempt is scheduled sooner than the
+// full interval - with exponential backoff, capped at both
+// rescanRetryMaxBackoff and r.interval itself, so a retry is never slower
+// than just waiting for the next scheduled rescan would be. Blocks until
+// ctx is cancelled.
 func (r *rescanner) Run(ctx context.Context) {
 	backoff := rescanRetryBaseBackoff
 	delay := r.newDelay(r.interval)
 	for {
+		var trigger string
 		select {
 		case <-ctx.Done():
 			return
 		case <-delay:
-			log.Info("Starting rescan")
-			report, facts, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath)
-			if err != nil {
-				retryIn := min(backoff, r.interval)
-				log.Errorf("Rescan failed: %v; trying again in %v", err, retryIn)
-				backoff = min(backoff*2, rescanRetryMaxBackoff)
-				delay = r.newDelay(retryIn)
-				continue
-			}
-			r.cache.SetReport(report, facts)
-			log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
-			backoff = rescanRetryBaseBackoff
-			delay = r.newDelay(r.interval)
+			trigger = scanTriggerScheduled
+		case <-r.reactiveCh:
+			trigger = scanTriggerReactive
 		}
+
+		log.Infof("Starting %s rescan", trigger)
+		report, facts, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath, trigger)
+		if err != nil {
+			retryIn := min(backoff, r.interval)
+			log.Errorf("%s rescan failed: %v; trying again in %v", trigger, err, retryIn)
+			backoff = min(backoff*2, rescanRetryMaxBackoff)
+			delay = r.newDelay(retryIn)
+			continue
+		}
+		r.cache.SetReport(report, facts)
+		log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
+		backoff = rescanRetryBaseBackoff
+		delay = r.newDelay(r.interval)
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
@@ -22,7 +22,7 @@ import (
 // a safe default.
 func testRescanner() *rescanner {
 	r := newRescanner(&vsockserver.ReportCache{}, "", "", time.Hour)
-	r.factsFn = func(string) map[string]string { return nil }
+	r.factsFn = func(string, string) map[string]string { return nil }
 	return r
 }
 
@@ -137,6 +137,44 @@ func TestRescanner_Run(t *testing.T) {
 
 			assert.Equal(t, 2, concurrency.WithLock1(&mu, func() int { return calls }), "the failed rescan was never retried")
 			assert.Equal(t, r.interval, ticker.lastReset(), "a successful rescan should reschedule after the full interval, resetting backoff")
+		})
+	})
+
+	t.Run("should rescan immediately when the reactive channel fires, tagged as reactive", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			r := testRescanner()
+			ticker := newFakeTicker()
+			defer ticker.close()
+			r.newDelay = ticker.newDelay
+			reactiveCh := make(chan struct{}, 1)
+			r.reactiveCh = reactiveCh
+			var mu sync.Mutex
+			var triggers []string
+			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, error) {
+				return &v4.IndexReport{HashId: "ok"}, nil
+			}
+			r.factsFn = func(_, trigger string) map[string]string {
+				concurrency.WithLock(&mu, func() { triggers = append(triggers, trigger) })
+				return nil
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			stopped := r.runAsync(ctx)
+			defer func() {
+				cancel()
+				<-stopped
+			}()
+			synctest.Wait() // Run is blocked waiting for the first tick
+
+			reactiveCh <- struct{}{}
+			synctest.Wait()
+			assert.Equal(t, []string{scanTriggerReactive}, concurrency.WithLock1(&mu, func() []string { return triggers }))
+			assert.Equal(t, r.interval, ticker.lastReset(), "a reactive rescan should reset the periodic delay too")
+
+			ticker.fire()
+			synctest.Wait()
+			assert.Equal(t, []string{scanTriggerReactive, scanTriggerScheduled},
+				concurrency.WithLock1(&mu, func() []string { return triggers }))
 		})
 	})
 

--- a/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
@@ -70,7 +70,7 @@ func TestRescanner_Run(t *testing.T) {
 			r.newDelay = ticker.newDelay
 			var mu sync.Mutex
 			var calls int
-			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, map[string]string, error) {
+			r.scanFn = func(_ context.Context, _, _, _ string) (*v4.IndexReport, map[string]string, error) {
 				report, err := concurrency.WithLock2(&mu, func() (*v4.IndexReport, error) {
 					calls++
 					return &v4.IndexReport{HashId: "ok"}, nil
@@ -106,7 +106,7 @@ func TestRescanner_Run(t *testing.T) {
 			r.newDelay = ticker.newDelay
 			var mu sync.Mutex
 			var calls int
-			r.scanFn = func(_ context.Context, _, _ string) (*v4.IndexReport, map[string]string, error) {
+			r.scanFn = func(_ context.Context, _, _, _ string) (*v4.IndexReport, map[string]string, error) {
 				report, err := concurrency.WithLock2(&mu, func() (*v4.IndexReport, error) {
 					calls++
 					if calls == 1 {
@@ -137,6 +137,41 @@ func TestRescanner_Run(t *testing.T) {
 
 			assert.Equal(t, 2, concurrency.WithLock1(&mu, func() int { return calls }), "the failed rescan was never retried")
 			assert.Equal(t, r.interval, ticker.lastReset(), "a successful rescan should reschedule after the full interval, resetting backoff")
+		})
+	})
+
+	t.Run("should rescan immediately when the reactive channel fires, tagged as reactive", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			r := testRescanner()
+			ticker := newFakeTicker()
+			defer ticker.close()
+			r.newDelay = ticker.newDelay
+			reactiveCh := make(chan struct{}, 1)
+			r.reactiveCh = reactiveCh
+			var mu sync.Mutex
+			var triggers []string
+			r.scanFn = func(_ context.Context, _, _, trigger string) (*v4.IndexReport, map[string]string, error) {
+				concurrency.WithLock(&mu, func() { triggers = append(triggers, trigger) })
+				return &v4.IndexReport{HashId: "ok"}, nil, nil
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			stopped := r.runAsync(ctx)
+			defer func() {
+				cancel()
+				<-stopped
+			}()
+			synctest.Wait() // Run is blocked waiting for the first tick
+
+			reactiveCh <- struct{}{}
+			synctest.Wait()
+			assert.Equal(t, []string{scanTriggerReactive}, concurrency.WithLock1(&mu, func() []string { return triggers }))
+			assert.Equal(t, r.interval, ticker.lastReset(), "a reactive rescan should reset the periodic delay too")
+
+			ticker.fire()
+			synctest.Wait()
+			assert.Equal(t, []string{scanTriggerReactive, scanTriggerScheduled},
+				concurrency.WithLock1(&mu, func() []string { return triggers }))
 		})
 	})
 

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/compliance/node/index"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/discovery"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/watch"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/sync"
@@ -52,6 +53,12 @@ const (
 	// in-flight-connection slot (see vsockserver.WithConnDeadline).
 	minConnDeadline = 5 * time.Second
 	maxConnDeadline = 5 * time.Minute
+)
+
+// scan_trigger fact values shared with Sensor's vmscraper/facts.go.
+const (
+	scanTriggerScheduled = "scheduled"
+	scanTriggerReactive  = "reactive"
 )
 
 // ServeCmd returns the "serve" cobra subcommand for pull-mode operation.
@@ -122,11 +129,22 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	cache := &vsockserver.ReportCache{}
 	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
 
+	// Reactive scanning is best-effort: if the watcher can't start (e.g. no
+	// watchable RPM directory, inotify limit hit), roxagent logs a warning
+	// and falls back to periodic-only scanning rather than failing startup.
+	rpmWatcher, watchErr := watch.New(cfg.hostPath)
+	if watchErr != nil {
+		log.Warnf("Reactive DNF/RPM scanning disabled, falling back to periodic-only scanning: %v", watchErr)
+	} else {
+		defer func() { _ = rpmWatcher.Close() }()
+		vmRescanner.reactiveCh = rpmWatcher.Triggered()
+	}
+
 	report, err := scan(ctx, cfg.hostPath, mappingCachePath)
 	if err != nil {
 		return fmt.Errorf("initial scan: %w", err)
 	}
-	cache.SetReport(report, discoverFacts(cfg.hostPath))
+	cache.SetReport(report, discoverFacts(cfg.hostPath, scanTriggerScheduled))
 	log.Infof("Initial scan complete, report cached. Num packages: %d", len(report.GetContents().GetPackages()))
 
 	handler := vsockserver.NewHandler(cache, agentVersion)
@@ -196,13 +214,17 @@ func scan(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexRepor
 	return index.NewNodeIndexer(cfg).IndexNode(ctx)
 }
 
-func discoverFacts(hostPath string) map[string]string {
+// discoverFacts probes hostPath for DiscoveredData and converts it to the
+// flat string map cache.SetReport expects. trigger is stamped onto the
+// returned facts so Sensor can tell a reactive rescan from a scheduled one.
+func discoverFacts(hostPath, trigger string) map[string]string {
 	d := discovery.DiscoverVMData(hostPath)
 	return map[string]string{
 		"detected_os":         d.GetDetectedOs().String(),
 		"os_version":          d.GetOsVersion(),
 		"activation_status":   d.GetActivationStatus().String(),
 		"dnf_metadata_status": d.GetDnfMetadataStatus().String(),
+		"scan_trigger":        trigger,
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/compliance/node/index"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/discovery"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/watch"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
@@ -55,6 +56,13 @@ const (
 	// in-flight-connection slot (see vsockserver.WithConnDeadline).
 	minConnDeadline = 5 * time.Second
 	maxConnDeadline = 5 * time.Minute
+)
+
+// scan_trigger fact values shared with Sensor's vmscraper/facts.go. See
+// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+const (
+	scanTriggerScheduled = "scheduled"
+	scanTriggerReactive  = "reactive"
 )
 
 // ServeCmd returns the "serve" cobra subcommand for pull-mode operation.
@@ -125,7 +133,18 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	cache := &vsockserver.ReportCache{}
 	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
 
-	report, facts, err := scanWithDiagnostics(ctx, cfg.hostPath, mappingCachePath)
+	// Reactive scanning is best-effort: if the watcher can't start (e.g. no
+	// watchable RPM directory, inotify limit hit), roxagent logs a warning
+	// and falls back to periodic-only scanning rather than failing startup.
+	rpmWatcher, watchErr := watch.New(cfg.hostPath)
+	if watchErr != nil {
+		log.Warnf("Reactive DNF/RPM scanning disabled, falling back to periodic-only scanning: %v", watchErr)
+	} else {
+		defer func() { _ = rpmWatcher.Close() }()
+		vmRescanner.reactiveCh = rpmWatcher.Triggered()
+	}
+
+	report, facts, err := scanWithDiagnostics(ctx, cfg.hostPath, mappingCachePath, scanTriggerScheduled)
 	if err != nil {
 		return fmt.Errorf("initial scan: %w", err)
 	}
@@ -195,8 +214,10 @@ func logMappingDownloadResult(url, cachePath string) func(err error, duration ti
 // DiscoveredData is computed once here and returned as facts alongside the
 // report, rather than left for the caller to recompute via discoverFacts:
 // that would probe the same filesystem facts (DNF version, entitlement)
-// this function already probed for logFilesystemDiagnostics.
-func scanWithDiagnostics(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, map[string]string, error) {
+// this function already probed for logFilesystemDiagnostics. trigger is
+// stamped onto the returned facts (see the scan_trigger fact) so Sensor can
+// tell a reactive rescan (RPM watcher fired) from a scheduled one.
+func scanWithDiagnostics(ctx context.Context, hostPath, mappingFilePath, trigger string) (*v4.IndexReport, map[string]string, error) {
 	// This may slow the indexing process down by 1-2 seconds, but the diagnostics are invaluable for debugging.
 	d := discovery.DiscoverVMData(hostPath)
 	logFilesystemDiagnostics(hostPath, d)
@@ -207,7 +228,7 @@ func scanWithDiagnostics(ctx context.Context, hostPath, mappingFilePath string) 
 	}
 
 	logIndexReportDiagnostics(report)
-	return report, discoveredDataFacts(d), nil
+	return report, discoveredDataFacts(d, trigger), nil
 }
 
 // scan indexes the VM filesystem at hostPath, consulting the
@@ -232,17 +253,18 @@ func scan(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexRepor
 // this: it already has DiscoveredData in hand from its own diagnostics
 // logging and converts it directly via discoveredDataFacts, so as not to
 // probe the filesystem a second time for the same facts.
-func discoverFacts(hostPath string) map[string]string {
-	return discoveredDataFacts(discovery.DiscoverVMData(hostPath))
+func discoverFacts(hostPath, trigger string) map[string]string {
+	return discoveredDataFacts(discovery.DiscoverVMData(hostPath), trigger)
 }
 
-func discoveredDataFacts(d *v1.DiscoveredData) map[string]string {
+func discoveredDataFacts(d *v1.DiscoveredData, trigger string) map[string]string {
 	return map[string]string{
 		"detected_os":         d.GetDetectedOs().String(),
 		"os_version":          d.GetOsVersion(),
 		"activation_status":   d.GetActivationStatus().String(),
 		"dnf_metadata_status": d.GetDnfMetadataStatus().String(),
 		"dnf_status":          formatDnfStatusFlags(d.GetDnfStatus()),
+		"scan_trigger":        trigger,
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -58,8 +58,7 @@ const (
 	maxConnDeadline = 5 * time.Minute
 )
 
-// scan_trigger fact values shared with Sensor's vmscraper/facts.go. See
-// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+// scan_trigger fact values shared with Sensor's vmscraper/facts.go.
 const (
 	scanTriggerScheduled = "scheduled"
 	scanTriggerReactive  = "reactive"

--- a/compliance/virtualmachines/roxagent/cmd/serve_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve_test.go
@@ -110,12 +110,22 @@ func TestFormatDnfStatusFlags(t *testing.T) {
 }
 
 func TestDiscoverFacts(t *testing.T) {
-	facts := discoverFacts(t.TempDir())
+	facts := discoverFacts(t.TempDir(), scanTriggerScheduled)
 
 	assert.Contains(t, facts, "detected_os")
 	assert.Contains(t, facts, "os_version")
 	assert.Contains(t, facts, "activation_status")
 	assert.Contains(t, facts, "dnf_metadata_status")
+}
+
+func TestDiscoverFacts_IncludesScanTrigger(t *testing.T) {
+	hostPath := t.TempDir()
+
+	reactiveFacts := discoverFacts(hostPath, scanTriggerReactive)
+	assert.Equal(t, "reactive", reactiveFacts["scan_trigger"])
+
+	scheduledFacts := discoverFacts(hostPath, scanTriggerScheduled)
+	assert.Equal(t, "scheduled", scheduledFacts["scan_trigger"])
 }
 
 func TestSelfSignedCert(t *testing.T) {

--- a/compliance/virtualmachines/roxagent/cmd/serve_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve_test.go
@@ -75,12 +75,22 @@ func TestRunServe_ValidatesFlags(t *testing.T) {
 }
 
 func TestDiscoverFacts(t *testing.T) {
-	facts := discoverFacts(t.TempDir())
+	facts := discoverFacts(t.TempDir(), scanTriggerScheduled)
 
 	assert.Contains(t, facts, "detected_os")
 	assert.Contains(t, facts, "os_version")
 	assert.Contains(t, facts, "activation_status")
 	assert.Contains(t, facts, "dnf_metadata_status")
+}
+
+func TestDiscoverFacts_IncludesScanTrigger(t *testing.T) {
+	hostPath := t.TempDir()
+
+	reactiveFacts := discoverFacts(hostPath, scanTriggerReactive)
+	assert.Equal(t, "reactive", reactiveFacts["scan_trigger"])
+
+	scheduledFacts := discoverFacts(hostPath, scanTriggerScheduled)
+	assert.Equal(t, "scheduled", scheduledFacts["scan_trigger"])
 }
 
 func TestSelfSignedCert(t *testing.T) {

--- a/compliance/virtualmachines/roxagent/watch/log.go
+++ b/compliance/virtualmachines/roxagent/watch/log.go
@@ -1,0 +1,5 @@
+package watch
+
+import "github.com/stackrox/rox/pkg/logging"
+
+var log = logging.LoggerForModule()

--- a/compliance/virtualmachines/roxagent/watch/watch.go
+++ b/compliance/virtualmachines/roxagent/watch/watch.go
@@ -5,9 +5,11 @@ package watch
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 )
 
 // candidateRPMDirs are RPM database directories to watch for package-change
@@ -55,7 +57,7 @@ func New(hostPath string) (*Watcher, error) {
 func addFirstWatchableDir(fsw *fsnotify.Watcher, hostPath string, dirs []string) (string, error) {
 	var errs []error
 	for _, dir := range dirs {
-		path := hostprobe.HostPathFor(hostPath, dir)
+		path := hostPathFor(hostPath, dir)
 		if err := fsw.Add(path); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", path, err))
 			continue
@@ -63,6 +65,16 @@ func addFirstWatchableDir(fsw *fsnotify.Watcher, hostPath string, dirs []string)
 		return path, nil
 	}
 	return "", fmt.Errorf("no watchable RPM database directory found: %w", errors.Join(errs...))
+}
+
+// hostPathFor converts an absolute system path into the corresponding path
+// under hostPath. Same join+clean approach as discovery.hostPathFor.
+func hostPathFor(hostPath, path string) string {
+	if hostPath == "" || hostPath == string(os.PathSeparator) {
+		return path
+	}
+	trimmedPath := strings.TrimPrefix(path, string(os.PathSeparator))
+	return filepath.Clean(filepath.Join(hostPath, trimmedPath))
 }
 
 func (w *Watcher) run() {

--- a/compliance/virtualmachines/roxagent/watch/watch.go
+++ b/compliance/virtualmachines/roxagent/watch/watch.go
@@ -1,0 +1,112 @@
+// Package watch detects changes to the local RPM package database so
+// roxagent can rescan sooner than its periodic interval allows.
+package watch
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
+)
+
+// candidateRPMDirs are RPM database directories to watch for package-change
+// signals, in preference order (modern layout first). We watch the
+// directories, not a specific DB file: RPM transactions commit via
+// create/rename/write of WAL or temp files rather than a single in-place
+// write, so watching the containing directory reliably catches all of these
+// (the fsnotify-recommended pattern for this kind of change detection).
+var candidateRPMDirs = []string{
+	"/usr/lib/sysimage/rpm", // rpm >= 4.16, sqlite backend (RHEL 9+/Fedora)
+	"/var/lib/rpm",          // older layout (RHEL 7/8), or a symlink to the above
+}
+
+// Watcher signals when the RPM package database changes on disk.
+type Watcher struct {
+	fsw       *fsnotify.Watcher
+	triggerCh chan struct{}
+}
+
+// New starts watching the first existing, watchable RPM database directory
+// under hostPath. Returns an error if none of the candidate directories
+// could be watched; callers should treat this as best-effort and fall back
+// to periodic-only scanning rather than failing startup.
+func New(hostPath string) (*Watcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("creating fsnotify watcher: %w", err)
+	}
+
+	dir, err := addFirstWatchableDir(fsw, hostPath, candidateRPMDirs)
+	if err != nil {
+		_ = fsw.Close()
+		return nil, err
+	}
+	log.Infof("Watching %q for reactive RPM/DNF change detection", dir)
+
+	w := &Watcher{
+		fsw:       fsw,
+		triggerCh: make(chan struct{}, 1),
+	}
+	go w.run()
+	return w, nil
+}
+
+func addFirstWatchableDir(fsw *fsnotify.Watcher, hostPath string, dirs []string) (string, error) {
+	var errs []error
+	for _, dir := range dirs {
+		path := hostprobe.HostPathFor(hostPath, dir)
+		if err := fsw.Add(path); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", path, err))
+			continue
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf("no watchable RPM database directory found: %w", errors.Join(errs...))
+}
+
+func (w *Watcher) run() {
+	for {
+		select {
+		case event, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			if !isRelevant(event) {
+				continue
+			}
+			// Non-blocking send: the first event in a burst queues a
+			// trigger; every subsequent event while it's still pending is
+			// dropped, collapsing a whole RPM transaction's writes into one
+			// pending rescan. This is trivial coalescing, not a debounce —
+			// see the design doc for why that's an accepted Phase 1
+			// limitation (a rescan can start mid-transaction; the next
+			// trigger picks up the final state).
+			select {
+			case w.triggerCh <- struct{}{}:
+			default:
+			}
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			log.Warnf("RPM database watcher error: %v", err)
+		}
+	}
+}
+
+func isRelevant(event fsnotify.Event) bool {
+	return event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename)
+}
+
+// Triggered returns a channel that receives a value shortly after a change
+// is detected in the watched RPM database directory. Multiple changes before
+// the channel is drained collapse into a single pending trigger.
+func (w *Watcher) Triggered() <-chan struct{} {
+	return w.triggerCh
+}
+
+// Close stops the underlying fsnotify watcher.
+func (w *Watcher) Close() error {
+	return w.fsw.Close()
+}

--- a/compliance/virtualmachines/roxagent/watch/watch_test.go
+++ b/compliance/virtualmachines/roxagent/watch/watch_test.go
@@ -1,0 +1,121 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const eventWaitTimeout = 2 * time.Second
+
+func TestNew_NoCandidateDirectory_ReturnsError(t *testing.T) {
+	hostPath := t.TempDir() // empty: neither candidate directory exists
+
+	w, err := New(hostPath)
+	require.Error(t, err)
+	require.Nil(t, w)
+}
+
+func TestNew_WatchesLegacyRPMDir(t *testing.T) {
+	hostPath := t.TempDir()
+	rpmDir := hostprobe.HostPathFor(hostPath, "/var/lib/rpm")
+	require.NoError(t, os.MkdirAll(rpmDir, 0o755))
+
+	w, err := New(hostPath)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	defer func() { _ = w.Close() }()
+
+	require.NoError(t, os.WriteFile(filepath.Join(rpmDir, "rpmdb.sqlite"), []byte("x"), 0o644))
+
+	select {
+	case <-w.Triggered():
+	case <-time.After(eventWaitTimeout):
+		t.Fatal("expected a trigger after writing to the watched directory")
+	}
+}
+
+func TestNew_PrefersModernRPMDirWhenBothExist(t *testing.T) {
+	hostPath := t.TempDir()
+	modernDir := hostprobe.HostPathFor(hostPath, "/usr/lib/sysimage/rpm")
+	legacyDir := hostprobe.HostPathFor(hostPath, "/var/lib/rpm")
+	require.NoError(t, os.MkdirAll(modernDir, 0o755))
+	require.NoError(t, os.MkdirAll(legacyDir, 0o755))
+
+	w, err := New(hostPath)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	defer func() { _ = w.Close() }()
+
+	// A write in the non-preferred legacy dir must NOT be seen, proving the
+	// modern (first candidate) directory is the one actually being watched.
+	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "ignored"), []byte("x"), 0o644))
+	select {
+	case <-w.Triggered():
+		t.Fatal("should not see events from the non-preferred legacy directory")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(modernDir, "rpmdb.sqlite"), []byte("x"), 0o644))
+	select {
+	case <-w.Triggered():
+	case <-time.After(eventWaitTimeout):
+		t.Fatal("expected a trigger after writing to the preferred modern directory")
+	}
+}
+
+func TestWatcher_CoalescesBurstOfEvents(t *testing.T) {
+	hostPath := t.TempDir()
+	rpmDir := hostprobe.HostPathFor(hostPath, "/var/lib/rpm")
+	require.NoError(t, os.MkdirAll(rpmDir, 0o755))
+
+	w, err := New(hostPath)
+	require.NoError(t, err)
+	defer func() { _ = w.Close() }()
+
+	// Simulate a whole RPM transaction's worth of rapid writes.
+	for i := range 10 {
+		require.NoError(t, os.WriteFile(filepath.Join(rpmDir, fmt.Sprintf("f%d", i)), []byte("x"), 0o644))
+	}
+
+	select {
+	case <-w.Triggered():
+	case <-time.After(eventWaitTimeout):
+		t.Fatal("expected a trigger after the write burst")
+	}
+
+	// The burst must collapse into exactly one pending trigger: no second
+	// value should already be queued behind it.
+	select {
+	case <-w.Triggered():
+		t.Fatal("burst of events should collapse into a single trigger, not a backlog")
+	default:
+	}
+}
+
+func TestIsRelevant(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		op       fsnotify.Op
+		expected bool
+	}{
+		"write is relevant":      {op: fsnotify.Write, expected: true},
+		"create is relevant":     {op: fsnotify.Create, expected: true},
+		"rename is relevant":     {op: fsnotify.Rename, expected: true},
+		"chmod is not relevant":  {op: fsnotify.Chmod, expected: false},
+		"remove is not relevant": {op: fsnotify.Remove, expected: false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, isRelevant(fsnotify.Event{Op: tc.op}))
+		})
+	}
+}

--- a/compliance/virtualmachines/roxagent/watch/watch_test.go
+++ b/compliance/virtualmachines/roxagent/watch/watch_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/internal/hostprobe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +24,7 @@ func TestNew_NoCandidateDirectory_ReturnsError(t *testing.T) {
 
 func TestNew_WatchesLegacyRPMDir(t *testing.T) {
 	hostPath := t.TempDir()
-	rpmDir := hostprobe.HostPathFor(hostPath, "/var/lib/rpm")
+	rpmDir := hostPathFor(hostPath, "/var/lib/rpm")
 	require.NoError(t, os.MkdirAll(rpmDir, 0o755))
 
 	w, err := New(hostPath)
@@ -44,8 +43,8 @@ func TestNew_WatchesLegacyRPMDir(t *testing.T) {
 
 func TestNew_PrefersModernRPMDirWhenBothExist(t *testing.T) {
 	hostPath := t.TempDir()
-	modernDir := hostprobe.HostPathFor(hostPath, "/usr/lib/sysimage/rpm")
-	legacyDir := hostprobe.HostPathFor(hostPath, "/var/lib/rpm")
+	modernDir := hostPathFor(hostPath, "/usr/lib/sysimage/rpm")
+	legacyDir := hostPathFor(hostPath, "/var/lib/rpm")
 	require.NoError(t, os.MkdirAll(modernDir, 0o755))
 	require.NoError(t, os.MkdirAll(legacyDir, 0o755))
 
@@ -73,7 +72,7 @@ func TestNew_PrefersModernRPMDirWhenBothExist(t *testing.T) {
 
 func TestWatcher_CoalescesBurstOfEvents(t *testing.T) {
 	hostPath := t.TempDir()
-	rpmDir := hostprobe.HostPathFor(hostPath, "/var/lib/rpm")
+	rpmDir := hostPathFor(hostPath, "/var/lib/rpm")
 	require.NoError(t, os.MkdirAll(rpmDir, 0o755))
 
 	w, err := New(hostPath)

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/facebookincubator/nvdtools v0.1.5
 	github.com/fatih/color v1.19.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/georgysavva/scany/v2 v2.1.4
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.4

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -17,14 +17,18 @@ import (
 type Handler interface {
 	common.ComplianceComponent
 
-	Send(ctx context.Context, vm *v1.IndexReport) error
-	// SendReactive enqueues a report produced by a reactive (event-triggered)
-	// rescan with priority over Send: at most one pending reactive report is
-	// kept per VM, and it is delivered ahead of the routine queue.
-	// generatedAt is roxagent's report-generation timestamp
-	// (ResponseMeta.report_generated_at), used only to measure Sensor-side
-	// delivery latency; it is never forwarded to Central.
-	SendReactive(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error
+	// Send enqueues a report for delivery to Central. Delivery is Fair FIFO
+	// across VMs: reports are handed to Central in the order their VM first
+	// queued one, regardless of trigger type. generatedAt is roxagent's
+	// report-generation timestamp (ResponseMeta.report_generated_at) for a
+	// reactive (event-triggered) report, or the zero value for a routine
+	// scheduled one; it is used only to measure Sensor-side reactive-update
+	// delivery latency and is never forwarded to Central. If this VM
+	// already has a not-yet-delivered report queued, the new one replaces
+	// it in place (coalescing) rather than queuing alongside it or moving
+	// its position in the queue — only the latest report for a VM is ever
+	// meaningful.
+	Send(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error
 }
 
 // VirtualMachineStore interface to the VirtualMachine store
@@ -42,6 +46,5 @@ func NewHandler(store VirtualMachineStore) Handler {
 		lock:         &sync.RWMutex{},
 		stopper:      concurrency.NewStopper(),
 		store:        store,
-		reactiveWake: make(chan struct{}, 1),
 	}
 }

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -17,6 +18,13 @@ type Handler interface {
 	common.ComplianceComponent
 
 	Send(ctx context.Context, vm *v1.IndexReport) error
+	// SendReactive enqueues a report produced by a reactive (event-triggered)
+	// rescan with priority over Send: at most one pending reactive report is
+	// kept per VM, and it is delivered ahead of the routine queue.
+	// generatedAt is roxagent's report-generation timestamp
+	// (ResponseMeta.report_generated_at), used only to measure Sensor-side
+	// delivery latency; it is never forwarded to Central.
+	SendReactive(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error
 }
 
 // VirtualMachineStore interface to the VirtualMachine store
@@ -34,5 +42,6 @@ func NewHandler(store VirtualMachineStore) Handler {
 		lock:         &sync.RWMutex{},
 		stopper:      concurrency.NewStopper(),
 		store:        store,
+		reactiveWake: make(chan struct{}, 1),
 	}
 }

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -40,6 +40,27 @@ type handlerImpl struct {
 	toCompliance chan common.MessageToComplianceWithAddress
 	indexReports chan *v1.IndexReport
 	store        VirtualMachineStore
+
+	// reactiveMu guards reactivePending. Separate from lock (which guards
+	// Start/Stop/Send channel lifecycle) since it protects independent state
+	// that is accessed far more frequently.
+	reactiveMu sync.Mutex
+	// reactivePending holds at most one not-yet-delivered reactive report
+	// per VM ID. A reactive send for a VM that already has a pending entry
+	// replaces it — only the newest report is ever meaningful. Bounded by
+	// the number of VMs Sensor knows about, not an arbitrary constant.
+	reactivePending map[virtualmachine.VMID]*reactiveEntry
+	// reactiveWake signals the run() loop that reactivePending has a new
+	// entry. Buffered size 1 with non-blocking sends: a pending wake-up
+	// already covers any further upserts until it's consumed.
+	reactiveWake chan struct{}
+}
+
+// reactiveEntry pairs a reactive report with the roxagent-reported scan time
+// used for SLA latency measurement (never forwarded to Central).
+type reactiveEntry struct {
+	report      *v1.IndexReport
+	generatedAt time.Time
 }
 
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -56,6 +77,54 @@ func (h *handlerImpl) ComplianceC() <-chan common.MessageToComplianceWithAddress
 }
 
 func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
+	if err := h.checkSendPreconditions(vm.GetVsockCid()); err != nil {
+		return err
+	}
+
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+
+	return h.enqueueScheduled(ctx, vm)
+}
+
+// SendReactive enqueues a report produced by a reactive (event-triggered)
+// rescan with priority over Send. At most one pending reactive report is
+// kept per VM: a newer report for the same VM replaces an older,
+// not-yet-delivered one rather than queueing alongside it, since only the
+// latest report is ever meaningful (mirrors the generation-counter semantics
+// already in the VSOCK protocol).
+func (h *handlerImpl) SendReactive(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error {
+	if err := h.checkSendPreconditions(vm.GetVsockCid()); err != nil {
+		return err
+	}
+
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+
+	vmID, err := h.resolveVMIDForReactive(vm.GetVsockCid())
+	if err != nil {
+		// VM identity isn't resolvable yet (e.g. just connected). Fall back
+		// to the normal path instead of silently dropping a reactive update
+		// — it will still be retried on the next scheduled poll either way.
+		log.Warnf("Reactive index report for vsock_cid=%q could not be prioritized (%v); using the normal queue instead", vm.GetVsockCid(), err)
+		return h.enqueueScheduled(ctx, vm)
+	}
+
+	concurrency.WithLock(&h.reactiveMu, func() {
+		if h.reactivePending == nil {
+			h.reactivePending = make(map[virtualmachine.VMID]*reactiveEntry)
+		}
+		h.reactivePending[vmID] = &reactiveEntry{report: vm, generatedAt: generatedAt}
+	})
+
+	select {
+	case h.reactiveWake <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (h *handlerImpl) checkSendPreconditions(vsockCID string) error {
 	if h.stopper.Client().Stopped().IsDone() {
 		return errox.InvariantViolation.CausedBy(errInputChanClosed)
 	}
@@ -63,14 +132,17 @@ func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
 		return errox.NotImplemented.CausedBy(errCapabilityNotSupported)
 	}
 	if !h.centralReady.IsDone() {
-		log.Warnf("Cannot send index report for virtual machine with vsock_cid=%q to Central because Central is not reachable", vm.GetVsockCid())
+		log.Warnf("Cannot send index report for virtual machine with vsock_cid=%q to Central because Central is not reachable", vsockCID)
 		metrics.IndexReportsSent.With(metrics.StatusCentralNotReadyLabels).Inc()
 		return errox.ResourceExhausted.CausedBy(errCentralNotReachable)
 	}
+	return nil
+}
 
-	h.lock.RLock()
-	defer h.lock.RUnlock()
-
+// enqueueScheduled is the original Send() body: enqueues onto the bounded
+// indexReports channel, blocking up to ctx's deadline and recording
+// backpressure metrics.
+func (h *handlerImpl) enqueueScheduled(ctx context.Context, vm *v1.IndexReport) error {
 	blockingStart := time.Now()
 	blocked := false
 	outcome := metrics.IndexReportEnqueueOutcomeSuccess
@@ -105,6 +177,37 @@ func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
 	case h.indexReports <- vm:
 		return nil
 	}
+}
+
+// resolveVMIDForReactive looks up the VM identity for a reactive report so it
+// can be prioritized per-VM. Deliberately kept separate from
+// newMessageToCentral's resolution (used at dequeue time for every report,
+// with its own outcome-metric labels) to avoid touching that already-tested
+// path.
+func (h *handlerImpl) resolveVMIDForReactive(vsockCIDStr string) (virtualmachine.VMID, error) {
+	cid, err := strconv.ParseUint(vsockCIDStr, 10, 32)
+	if err != nil {
+		return "", errors.Wrapf(err, "invalid vsock CID %q", vsockCIDStr)
+	}
+	vmInfo := h.store.GetFromCID(uint32(cid))
+	if vmInfo == nil {
+		return "", errors.Wrapf(errVirtualMachineNotFound, "vsock CID %q", vsockCIDStr)
+	}
+	return vmInfo.ID, nil
+}
+
+// popReactivePending removes and returns one arbitrary entry from
+// reactivePending, if any. Go map iteration order is randomized, which is
+// fine here: with at most one entry per VM and no ordering promised between
+// different VMs' reactive updates, any order is correct.
+func (h *handlerImpl) popReactivePending() (*reactiveEntry, bool) {
+	return concurrency.WithLock2(&h.reactiveMu, func() (*reactiveEntry, bool) {
+		for vmID, entry := range h.reactivePending {
+			delete(h.reactivePending, vmID)
+			return entry, true
+		}
+		return nil, false
+	})
 }
 
 func (h *handlerImpl) Name() string {
@@ -205,15 +308,24 @@ func (h *handlerImpl) run(indexReports <-chan *v1.IndexReport) (toCentral <-chan
 		}()
 		log.Debugf("virtual machine index report handler is running")
 		for {
+			// Priority path: always drain a pending reactive report before
+			// considering anything from the routine indexReports channel.
+			if entry, ok := h.popReactivePending(); ok {
+				h.handleIndexReport(ch2Central, entry.report, entry.generatedAt)
+				continue
+			}
 			select {
 			case <-h.stopper.Flow().StopRequested():
 				return
+			case <-h.reactiveWake:
+				// A reactive report just arrived; loop back to the top so
+				// the priority check above drains it before indexReports.
 			case indexReport, ok := <-indexReports:
 				if !ok {
 					h.stopper.Flow().StopWithError(errInputChanClosed)
 					return
 				}
-				h.handleIndexReport(ch2Central, indexReport)
+				h.handleIndexReport(ch2Central, indexReport, time.Time{})
 			}
 		}
 	}()
@@ -298,6 +410,7 @@ func (h *handlerImpl) forwardToCompliance(
 func (h *handlerImpl) handleIndexReport(
 	toCentral chan *message.ExpiringMessage,
 	indexReport *v1.IndexReport,
+	generatedAt time.Time,
 ) {
 	startTime := time.Now()
 	outcome := metrics.IndexReportHandlingMessageToCentralSuccess
@@ -324,6 +437,10 @@ func (h *handlerImpl) handleIndexReport(
 	}
 	h.sendIndexReportEvent(toCentral, msg)
 	metrics.IndexReportsSent.With(metrics.StatusSuccessLabels).Inc()
+
+	if !generatedAt.IsZero() {
+		metrics.VirtualMachineReactiveIndexReportLatencySeconds.Observe(time.Since(generatedAt).Seconds())
+	}
 }
 
 func (h *handlerImpl) newMessageToCentral(indexReport *v1.IndexReport) (*message.ExpiringMessage, string, error) {

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -38,29 +38,30 @@ type handlerImpl struct {
 	stopper      concurrency.Stopper
 	toCentral    <-chan *message.ExpiringMessage
 	toCompliance chan common.MessageToComplianceWithAddress
-	indexReports chan *v1.IndexReport
+	indexReports chan *slot
 	store        VirtualMachineStore
 
-	// reactiveMu guards reactivePending. Separate from lock (which guards
-	// Start/Stop/Send channel lifecycle) since it protects independent state
-	// that is accessed far more frequently.
-	reactiveMu sync.Mutex
-	// reactivePending holds at most one not-yet-delivered reactive report
-	// per VM ID. A reactive send for a VM that already has a pending entry
-	// replaces it — only the newest report is ever meaningful. Bounded by
-	// the number of VMs Sensor knows about, not an arbitrary constant.
-	reactivePending map[virtualmachine.VMID]*reactiveEntry
-	// reactiveWake signals the run() loop that reactivePending has a new
-	// entry. Buffered size 1 with non-blocking sends: a pending wake-up
-	// already covers any further upserts until it's consumed.
-	reactiveWake chan struct{}
+	// slotsMu guards pending. Separate from lock (which guards
+	// Start/Stop/Send channel lifecycle) since it protects independent
+	// state that is accessed far more frequently.
+	slotsMu sync.Mutex
+	// pending tracks, per vsock CID, the slot currently queued in
+	// indexReports for that VM (if any). It exists purely to support
+	// coalescing (see slot doc comment) and never holds more entries than
+	// indexReports has capacity for, since a VM can only be in this map
+	// while it also occupies a slot in the channel.
+	pending map[string]*slot
 }
 
-// reactiveEntry pairs a reactive report with the roxagent-reported scan time
-// used for SLA latency measurement (never forwarded to Central).
-type reactiveEntry struct {
+// slot is the unit carried through indexReports. It is a pointer so that a
+// coalescing Send can mutate an already-queued entry in place instead of
+// enqueuing a second one for the same VM. That's what gives delivery its
+// Fair FIFO property: a VM's position in the queue never changes once
+// queued, only the contents of its slot can, right up until it's consumed.
+type slot struct {
+	vsockCID    string
 	report      *v1.IndexReport
-	generatedAt time.Time
+	generatedAt time.Time // zero for scheduled reports
 }
 
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -76,50 +77,44 @@ func (h *handlerImpl) ComplianceC() <-chan common.MessageToComplianceWithAddress
 	return h.toCompliance
 }
 
-func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
-	if err := h.checkSendPreconditions(vm.GetVsockCid()); err != nil {
+// Send enqueues report for delivery to Central, keeping delivery Fair FIFO
+// across VMs while coalescing per VM: see the Handler.Send doc comment.
+func (h *handlerImpl) Send(ctx context.Context, report *v1.IndexReport, generatedAt time.Time) error {
+	if err := h.checkSendPreconditions(report.GetVsockCid()); err != nil {
 		return err
 	}
 
 	h.lock.RLock()
 	defer h.lock.RUnlock()
 
-	return h.enqueueScheduled(ctx, vm)
-}
-
-// SendReactive enqueues a report produced by a reactive (event-triggered)
-// rescan with priority over Send. At most one pending reactive report is
-// kept per VM: a newer report for the same VM replaces an older,
-// not-yet-delivered one rather than queueing alongside it, since only the
-// latest report is ever meaningful (mirrors the generation-counter semantics
-// already in the VSOCK protocol).
-func (h *handlerImpl) SendReactive(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error {
-	if err := h.checkSendPreconditions(vm.GetVsockCid()); err != nil {
-		return err
-	}
-
-	h.lock.RLock()
-	defer h.lock.RUnlock()
-
-	vmID, err := h.resolveVMIDForReactive(vm.GetVsockCid())
-	if err != nil {
-		// VM identity isn't resolvable yet (e.g. just connected). Fall back
-		// to the normal path instead of silently dropping a reactive update
-		// — it will still be retried on the next scheduled poll either way.
-		log.Warnf("Reactive index report for vsock_cid=%q could not be prioritized (%v); using the normal queue instead", vm.GetVsockCid(), err)
-		return h.enqueueScheduled(ctx, vm)
-	}
-
-	concurrency.WithLock(&h.reactiveMu, func() {
-		if h.reactivePending == nil {
-			h.reactivePending = make(map[virtualmachine.VMID]*reactiveEntry)
+	cid := report.GetVsockCid()
+	var newSlot *slot
+	concurrency.WithLock(&h.slotsMu, func() {
+		if s := h.pending[cid]; s != nil {
+			// Coalesce: this VM already has a slot queued. Mutate it in
+			// place so the newest report wins, without moving its position
+			// in indexReports.
+			s.report, s.generatedAt = report, generatedAt
+			return
 		}
-		h.reactivePending[vmID] = &reactiveEntry{report: vm, generatedAt: generatedAt}
+		newSlot = &slot{vsockCID: cid, report: report, generatedAt: generatedAt}
+		h.pending[cid] = newSlot
 	})
+	if newSlot == nil {
+		return nil
+	}
 
-	select {
-	case h.reactiveWake <- struct{}{}:
-	default:
+	if err := h.enqueueScheduled(ctx, newSlot); err != nil {
+		// The slot never made it into indexReports, so nothing will ever
+		// clear this map entry. Free it now so a future Send for this VM
+		// isn't silently coalesced into a slot that will never be
+		// delivered.
+		concurrency.WithLock(&h.slotsMu, func() {
+			if h.pending[cid] == newSlot {
+				delete(h.pending, cid)
+			}
+		})
+		return err
 	}
 	return nil
 }
@@ -139,10 +134,9 @@ func (h *handlerImpl) checkSendPreconditions(vsockCID string) error {
 	return nil
 }
 
-// enqueueScheduled is the original Send() body: enqueues onto the bounded
-// indexReports channel, blocking up to ctx's deadline and recording
-// backpressure metrics.
-func (h *handlerImpl) enqueueScheduled(ctx context.Context, vm *v1.IndexReport) error {
+// enqueueScheduled enqueues a slot onto the bounded indexReports channel,
+// blocking up to ctx's deadline and recording backpressure metrics.
+func (h *handlerImpl) enqueueScheduled(ctx context.Context, s *slot) error {
 	blockingStart := time.Now()
 	blocked := false
 	outcome := metrics.IndexReportEnqueueOutcomeSuccess
@@ -158,7 +152,7 @@ func (h *handlerImpl) enqueueScheduled(ctx context.Context, vm *v1.IndexReport) 
 	select {
 	case <-ctx.Done():
 		// Handled in the next select statement
-	case h.indexReports <- vm:
+	case h.indexReports <- s:
 		return nil
 	default:
 		blocked = true
@@ -174,40 +168,9 @@ func (h *handlerImpl) enqueueScheduled(ctx context.Context, vm *v1.IndexReport) 
 		}
 		outcome = metrics.IndexReportEnqueueOutcomeCanceled
 		return ctx.Err() //nolint:wrapcheck
-	case h.indexReports <- vm:
+	case h.indexReports <- s:
 		return nil
 	}
-}
-
-// resolveVMIDForReactive looks up the VM identity for a reactive report so it
-// can be prioritized per-VM. Deliberately kept separate from
-// newMessageToCentral's resolution (used at dequeue time for every report,
-// with its own outcome-metric labels) to avoid touching that already-tested
-// path.
-func (h *handlerImpl) resolveVMIDForReactive(vsockCIDStr string) (virtualmachine.VMID, error) {
-	cid, err := strconv.ParseUint(vsockCIDStr, 10, 32)
-	if err != nil {
-		return "", errors.Wrapf(err, "invalid vsock CID %q", vsockCIDStr)
-	}
-	vmInfo := h.store.GetFromCID(uint32(cid))
-	if vmInfo == nil {
-		return "", errors.Wrapf(errVirtualMachineNotFound, "vsock CID %q", vsockCIDStr)
-	}
-	return vmInfo.ID, nil
-}
-
-// popReactivePending removes and returns one arbitrary entry from
-// reactivePending, if any. Go map iteration order is randomized, which is
-// fine here: with at most one entry per VM and no ordering promised between
-// different VMs' reactive updates, any order is correct.
-func (h *handlerImpl) popReactivePending() (*reactiveEntry, bool) {
-	return concurrency.WithLock2(&h.reactiveMu, func() (*reactiveEntry, bool) {
-		for vmID, entry := range h.reactivePending {
-			delete(h.reactivePending, vmID)
-			return entry, true
-		}
-		return nil, false
-	})
 }
 
 func (h *handlerImpl) Name() string {
@@ -270,7 +233,8 @@ func (h *handlerImpl) Start() error {
 	if h.toCentral != nil || h.indexReports != nil || h.toCompliance != nil {
 		return errStartMoreThanOnce
 	}
-	h.indexReports = make(chan *v1.IndexReport, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
+	h.indexReports = make(chan *slot, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
+	h.pending = make(map[string]*slot)
 	h.toCompliance = make(chan common.MessageToComplianceWithAddress, 1)
 	h.toCentral = h.run(h.indexReports)
 	return nil
@@ -294,12 +258,16 @@ func (h *handlerImpl) Stop() {
 		close(h.indexReports)
 		h.indexReports = nil
 	}
+	// h.pending is intentionally left as-is: Start() always reinitializes it
+	// unconditionally, and nil-ing it here would race with an in-flight
+	// Send() that already passed checkSendPreconditions before Stop() ran
+	// (it re-checks h.stopper only, not h.pending), causing a nil-map write.
 }
 
 // run handles the virtual machine data and forwards it to Central.
 // This is the only goroutine that writes into the toCentral channel, thus it is
 // responsible for creating and closing that chan.
-func (h *handlerImpl) run(indexReports <-chan *v1.IndexReport) (toCentral <-chan *message.ExpiringMessage) {
+func (h *handlerImpl) run(indexReports <-chan *slot) (toCentral <-chan *message.ExpiringMessage) {
 	ch2Central := make(chan *message.ExpiringMessage)
 	go func() {
 		defer func() {
@@ -308,24 +276,25 @@ func (h *handlerImpl) run(indexReports <-chan *v1.IndexReport) (toCentral <-chan
 		}()
 		log.Debugf("virtual machine index report handler is running")
 		for {
-			// Priority path: always drain a pending reactive report before
-			// considering anything from the routine indexReports channel.
-			if entry, ok := h.popReactivePending(); ok {
-				h.handleIndexReport(ch2Central, entry.report, entry.generatedAt)
-				continue
-			}
 			select {
 			case <-h.stopper.Flow().StopRequested():
 				return
-			case <-h.reactiveWake:
-				// A reactive report just arrived; loop back to the top so
-				// the priority check above drains it before indexReports.
-			case indexReport, ok := <-indexReports:
+			case s, ok := <-indexReports:
 				if !ok {
 					h.stopper.Flow().StopWithError(errInputChanClosed)
 					return
 				}
-				h.handleIndexReport(ch2Central, indexReport, time.Time{})
+				var report *v1.IndexReport
+				var generatedAt time.Time
+				concurrency.WithLock(&h.slotsMu, func() {
+					report, generatedAt = s.report, s.generatedAt
+					// Clearing the map entry here (before delivery) lets
+					// this VM queue a fresh slot immediately, rather than
+					// waiting for a potentially slow downstream delivery
+					// to finish.
+					delete(h.pending, s.vsockCID)
+				})
+				h.handleIndexReport(ch2Central, report, generatedAt)
 			}
 		}
 	}()

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -45,6 +45,7 @@ func (s *virtualMachineHandlerSuite) SetupTest() {
 		lock:         &sync.RWMutex{},
 		stopper:      concurrency.NewStopper(),
 		store:        s.store,
+		reactiveWake: make(chan struct{}, 1),
 	}
 	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported})
 }
@@ -742,6 +743,166 @@ func (s *virtualMachineHandlerSuite) TestStart_CalledTwice() {
 
 	err = s.handler.Start()
 	s.Require().ErrorIs(err, errStartMoreThanOnce)
+}
+
+func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedScheduledBacklog() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	s.handler.Notify(common.SensorComponentEventCentralReachable)
+	defer s.handler.Stop()
+
+	report1 := &v1.IndexReport{VsockCid: "1"}
+	report2 := &v1.IndexReport{VsockCid: "2"}
+	report3 := &v1.IndexReport{VsockCid: "3"}
+
+	s.store.EXPECT().GetFromCID(uint32(1)).Return(&virtualmachine.Info{ID: "vm-1"}).AnyTimes()
+	s.store.EXPECT().GetFromCID(uint32(2)).Return(&virtualmachine.Info{ID: "vm-2"}).AnyTimes()
+	s.store.EXPECT().GetFromCID(uint32(3)).Return(&virtualmachine.Info{ID: "vm-3"}).AnyTimes()
+
+	// report1 is picked up by run()'s single goroutine and blocks trying to
+	// hand it to ResponsesC() (nobody is reading yet), which pins the loop
+	// mid-iteration before it can look at anything queued afterward.
+	s.Require().NoError(s.handler.Send(context.Background(), report1))
+
+	// While run() is blocked delivering report1, queue a scheduled backlog
+	// entry (report2) and then a reactive entry (report3). Because the
+	// reactive path is checked first on every loop iteration, report3 must
+	// come out ahead of report2 once report1's delivery is unblocked.
+	// Give run() a moment to actually reach the blocking send for report1
+	// before queueing more — this is a small, generous sleep, not a tight
+	// race: the assertions below tolerate the goroutine being slightly
+	// slower, they just require it to not have consumed report2 yet, which
+	// it structurally cannot do until report1's send unblocks.
+	time.Sleep(50 * time.Millisecond)
+	s.Require().NoError(s.handler.Send(context.Background(), report2))
+	s.Require().NoError(s.handler.SendReactive(context.Background(), report3, time.Now()))
+
+	var received []string
+	for range 3 {
+		select {
+		case msg := <-s.handler.ResponsesC():
+			received = append(received, msg.GetEvent().GetId())
+		case <-time.After(time.Second):
+			s.Fail("timed out waiting for a message", "received so far: %v", received)
+		}
+	}
+
+	s.Require().Len(received, 3)
+	s.Equal("vm-1", received[0], "report1 was already in flight before the reactive report existed")
+	s.Equal("vm-3", received[1], "the reactive report must be delivered ahead of the queued scheduled backlog")
+	s.Equal("vm-2", received[2], "the scheduled backlog entry is delivered last")
+}
+
+func (s *virtualMachineHandlerSuite) TestSendReactive_UpsertReplacesOlderPendingForSameVM() {
+	// Deliberately does not call Start(): no run() consumer goroutine means
+	// reactivePending is only ever touched by this test goroutine, so it can
+	// be inspected directly and deterministically after both sends.
+	s.handler.indexReports = make(chan *v1.IndexReport, 1)
+	s.handler.centralReady.Signal()
+
+	s.store.EXPECT().GetFromCID(uint32(9)).Return(&virtualmachine.Info{ID: "vm-9"}).Times(2)
+
+	older := &v1.IndexReport{VsockCid: "9"}
+	newer := &v1.IndexReport{VsockCid: "9"}
+
+	s.Require().NoError(s.handler.SendReactive(context.Background(), older, time.Now()))
+	s.Require().NoError(s.handler.SendReactive(context.Background(), newer, time.Now()))
+
+	s.handler.reactiveMu.Lock()
+	defer s.handler.reactiveMu.Unlock()
+	s.Require().Len(s.handler.reactivePending, 1, "reactivePending must never grow past one entry per VM")
+	s.Same(newer, s.handler.reactivePending["vm-9"].report, "the newer report must replace the older one, never queue alongside it")
+}
+
+func (s *virtualMachineHandlerSuite) TestSendReactive_FallsBackToScheduledQueueWhenVMUnknown() {
+	// Deliberately does not call Start(): with no run() consumer goroutine
+	// racing to drain indexReports, the test can read the fallback message
+	// off it directly and deterministically.
+	s.handler.indexReports = make(chan *v1.IndexReport, 1)
+	s.handler.centralReady.Signal()
+
+	s.store.EXPECT().GetFromCID(uint32(42)).Return(nil)
+
+	report := &v1.IndexReport{VsockCid: "42"}
+	err := s.handler.SendReactive(context.Background(), report, time.Now())
+	s.Require().NoError(err, "an unresolvable VM must not cause the reactive update to be dropped")
+
+	s.handler.reactiveMu.Lock()
+	pendingLen := len(s.handler.reactivePending)
+	s.handler.reactiveMu.Unlock()
+	s.Equal(0, pendingLen, "an unresolvable VM's report must not be added to reactivePending")
+
+	select {
+	case got := <-s.handler.indexReports:
+		s.Equal("42", got.GetVsockCid(), "it must instead land on the normal scheduled queue")
+	case <-time.After(time.Second):
+		s.Fail("expected the report to fall back onto the scheduled queue")
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestSendReactive_CentralNotReachable() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	report := &v1.IndexReport{VsockCid: "1"}
+	err = s.handler.SendReactive(context.Background(), report, time.Now())
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errCentralNotReachable)
+	s.Require().ErrorIs(err, errox.ResourceExhausted)
+}
+
+func (s *virtualMachineHandlerSuite) TestPopReactivePending_EmptyReturnsFalse() {
+	entry, ok := s.handler.popReactivePending()
+	s.False(ok)
+	s.Nil(entry)
+}
+
+func (s *virtualMachineHandlerSuite) TestSendReactive_ConcurrentUpsertsAreRaceFreeAndBounded() {
+	// Deliberately does not call Start(): no run() consumer goroutine
+	// draining reactivePending means the map's final contents can be
+	// inspected deterministically once all senders finish, while -race
+	// still exercises real concurrent access to reactiveMu/reactivePending
+	// from every sending goroutine below.
+	const numVMs = 40
+	const sendsPerVM = 25
+
+	s.handler.indexReports = make(chan *v1.IndexReport, numVMs*sendsPerVM)
+	s.handler.centralReady.Signal()
+
+	for i := range numVMs {
+		s.store.EXPECT().GetFromCID(uint32(i)).Return(&virtualmachine.Info{
+			ID: virtualmachine.VMID(fmt.Sprintf("vm-%d", i)),
+		}).AnyTimes()
+	}
+
+	// Repeated concurrent sends per VM exercise the upsert-replace path
+	// under contention, not just the first-insert path.
+	wg := sync.WaitGroup{}
+	for i := range numVMs {
+		cid := fmt.Sprintf("%d", i)
+		for range sendsPerVM {
+			wg.Go(func() {
+				report := &v1.IndexReport{VsockCid: cid}
+				err := s.handler.SendReactive(context.Background(), report, time.Now())
+				s.Require().NoError(err)
+			})
+		}
+	}
+	wg.Wait()
+
+	// Exactly one pending entry per VM survives concurrent upserts —
+	// reactivePending must never grow past fleet size, regardless of how
+	// many reactive sends raced for the same VM.
+	s.handler.reactiveMu.Lock()
+	defer s.handler.reactiveMu.Unlock()
+	s.Require().Len(s.handler.reactivePending, numVMs)
+	for i := range numVMs {
+		vmID := virtualmachine.VMID(fmt.Sprintf("vm-%d", i))
+		entry, ok := s.handler.reactivePending[vmID]
+		s.Require().True(ok, "expected a pending reactive entry for %s", vmID)
+		s.Equal(fmt.Sprintf("%d", i), entry.report.GetVsockCid())
+	}
 }
 
 func TestVmIDFromResourceID(t *testing.T) {

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -15,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/sensor/common"
@@ -46,7 +46,7 @@ func (s *virtualMachineHandlerSuite) SetupTest() {
 		lock:         &sync.RWMutex{},
 		stopper:      concurrency.NewStopper(),
 		store:        s.store,
-		reactiveWake: make(chan struct{}, 1),
+		pending:      make(map[string]*slot),
 	}
 	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported})
 }
@@ -75,7 +75,7 @@ func (s *virtualMachineHandlerSuite) TestSend() {
 	// Test that the goroutine processes sent VMs.
 	vm := &v1.IndexReport{VsockCid: cid}
 	go func() {
-		err := s.handler.Send(context.Background(), vm)
+		err := s.handler.Send(context.Background(), vm, time.Time{})
 		s.Require().NoError(err)
 	}()
 
@@ -135,7 +135,7 @@ func (s *virtualMachineHandlerSuite) TestConcurrentSends() {
 					}
 					cont++
 				})
-				err := s.handler.Send(ctx, req)
+				err := s.handler.Send(ctx, req, time.Time{})
 				s.Require().NoError(err)
 			}
 		}(i)
@@ -172,7 +172,7 @@ func (s *virtualMachineHandlerSuite) TestVirtualMachineNotFound() {
 	vm := &v1.IndexReport{VsockCid: cid}
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
-		err := s.handler.Send(context.Background(), vm)
+		err := s.handler.Send(context.Background(), vm, time.Time{})
 		s.Require().NoError(err)
 	})
 
@@ -199,7 +199,7 @@ func (s *virtualMachineHandlerSuite) TestInvalidCID() {
 	vm := &v1.IndexReport{VsockCid: cid}
 	wg := sync.WaitGroup{}
 	wg.Go(func() {
-		err := s.handler.Send(context.Background(), vm)
+		err := s.handler.Send(context.Background(), vm, time.Time{})
 		s.Require().NoError(err)
 	})
 
@@ -214,6 +214,11 @@ func (s *virtualMachineHandlerSuite) TestInvalidCID() {
 }
 
 func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	s.handler.Notify(common.SensorComponentEventCentralReachable)
+	defer s.handler.Stop()
+
 	vmID := virtualmachine.VMID("test-vm")
 	cases := map[string]struct {
 		vsockCID string
@@ -229,29 +234,16 @@ func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			synctest.Test(s.T(), func(t *testing.T) {
-				handler := &handlerImpl{
-					centralReady: concurrency.NewSignal(),
-					lock:         &sync.RWMutex{},
-					stopper:      concurrency.NewStopper(),
-					store:        s.store,
-				}
-				err := handler.Start()
+			go func() {
+				err := s.handler.Send(context.Background(), &v1.IndexReport{
+					VmId:     string(vmID),
+					VsockCid: tc.vsockCID,
+				}, time.Time{})
 				s.Require().NoError(err)
-				handler.Notify(common.SensorComponentEventCentralReachable)
-				defer handler.Stop()
+			}()
 
-				go func() {
-					err := handler.Send(context.Background(), &v1.IndexReport{
-						VmId:     string(vmID),
-						VsockCid: tc.vsockCID,
-					})
-					s.Require().NoError(err)
-				}()
-
-				synctest.Wait()
-
-				msg := <-handler.ResponsesC()
+			select {
+			case msg := <-s.handler.ResponsesC():
 				s.Require().NotNil(msg)
 				sensorEvent := msg.GetEvent()
 				s.Require().NotNil(sensorEvent)
@@ -261,7 +253,9 @@ func (s *virtualMachineHandlerSuite) TestSend_ResolveByVmID() {
 				s.Assert().Equal(string(vmID), indexEvent.GetId())
 				s.Assert().Equal(string(vmID), indexEvent.GetIndex().GetVmId())
 				s.Assert().Equal(tc.vsockCID, indexEvent.GetIndex().GetVsockCid())
-			})
+			case <-time.After(time.Second):
+				s.Fail("Expected message to be sent to central")
+			}
 		})
 	}
 }
@@ -706,7 +700,7 @@ func (s *virtualMachineHandlerSuite) TestSend_CapabilityNotSupported() {
 	vm := &v1.IndexReport{VsockCid: cid}
 
 	// Send should return errCapabilityNotSupported when capability is absent
-	err := s.handler.Send(context.Background(), vm)
+	err := s.handler.Send(context.Background(), vm, time.Time{})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, errCapabilityNotSupported)
 	s.Require().ErrorIs(err, errox.NotImplemented)
@@ -719,7 +713,7 @@ func (s *virtualMachineHandlerSuite) TestSend_AfterStop() {
 	s.handler.Stop()
 
 	vm := &v1.IndexReport{VsockCid: "1"}
-	err = s.handler.Send(context.Background(), vm)
+	err = s.handler.Send(context.Background(), vm, time.Time{})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, errInputChanClosed)
 	s.Require().ErrorIs(err, errox.InvariantViolation)
@@ -731,7 +725,7 @@ func (s *virtualMachineHandlerSuite) TestSend_CentralNotReachable() {
 	defer s.handler.Stop()
 
 	vm := &v1.IndexReport{VsockCid: "1"}
-	err = s.handler.Send(context.Background(), vm)
+	err = s.handler.Send(context.Background(), vm, time.Time{})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, errCentralNotReachable)
 	s.Require().ErrorIs(err, errox.ResourceExhausted)
@@ -757,7 +751,7 @@ func (s *virtualMachineHandlerSuite) reactiveLatencySampleCount() uint64 {
 	return m.GetHistogram().GetSampleCount()
 }
 
-func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedScheduledBacklog() {
+func (s *virtualMachineHandlerSuite) TestSend_FairFIFO_ReactiveDoesNotJumpAheadOfOtherVMs() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	s.handler.Notify(common.SensorComponentEventCentralReachable)
@@ -776,20 +770,20 @@ func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedSched
 	// report1 is picked up by run()'s single goroutine and blocks trying to
 	// hand it to ResponsesC() (nobody is reading yet), which pins the loop
 	// mid-iteration before it can look at anything queued afterward.
-	s.Require().NoError(s.handler.Send(context.Background(), report1))
+	s.Require().NoError(s.handler.Send(context.Background(), report1, time.Time{}))
 
 	// While run() is blocked delivering report1, queue a scheduled backlog
-	// entry (report2) and then a reactive entry (report3). Because the
-	// reactive path is checked first on every loop iteration, report3 must
-	// come out ahead of report2 once report1's delivery is unblocked.
+	// entry for a different VM (report2), then a reactive entry for yet
+	// another VM (report3). Fair FIFO means report3 must NOT come out ahead
+	// of the already-queued report2, even though it's reactive.
 	// Give run() a moment to actually reach the blocking send for report1
 	// before queueing more — this is a small, generous sleep, not a tight
 	// race: the assertions below tolerate the goroutine being slightly
 	// slower, they just require it to not have consumed report2 yet, which
 	// it structurally cannot do until report1's send unblocks.
 	time.Sleep(50 * time.Millisecond)
-	s.Require().NoError(s.handler.Send(context.Background(), report2))
-	s.Require().NoError(s.handler.SendReactive(context.Background(), report3, time.Now()))
+	s.Require().NoError(s.handler.Send(context.Background(), report2, time.Time{}))
+	s.Require().NoError(s.handler.Send(context.Background(), report3, time.Now()))
 
 	var received []string
 	for range 3 {
@@ -802,127 +796,166 @@ func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedSched
 	}
 
 	s.Require().Len(received, 3)
-	s.Equal("vm-1", received[0], "report1 was already in flight before the reactive report existed")
-	s.Equal("vm-3", received[1], "the reactive report must be delivered ahead of the queued scheduled backlog")
-	s.Equal("vm-2", received[2], "the scheduled backlog entry is delivered last")
+	s.Equal("vm-1", received[0], "report1 was already in flight before report3 existed")
+	s.Equal("vm-2", received[1], "report2 was queued first among the two backlog entries")
+	s.Equal("vm-3", received[2], "a reactive report must not jump ahead of an already-queued different VM")
 
-	// Only report3 (the reactive one) should have observed the SLA latency
-	// histogram: report1 and report2 went through the scheduled path with a
-	// zero-value generatedAt, which handleIndexReport must not record.
+	// Only report3 (the reactive one, non-zero generatedAt) should have
+	// observed the SLA latency histogram.
 	s.Equal(initialLatencyCount+1, s.reactiveLatencySampleCount(),
 		"exactly one observation (the reactive report) should be recorded; the two scheduled reports must not add samples")
 }
 
-func (s *virtualMachineHandlerSuite) TestSendReactive_UpsertReplacesOlderPendingForSameVM() {
+func (s *virtualMachineHandlerSuite) TestSend_CoalescesSecondSendForSameVMKeepingQueuePosition() {
 	// Deliberately does not call Start(): no run() consumer goroutine means
-	// reactivePending is only ever touched by this test goroutine, so it can
-	// be inspected directly and deterministically after both sends.
-	s.handler.indexReports = make(chan *v1.IndexReport, 1)
+	// pending/indexReports are only ever touched by this test goroutine, so
+	// they can be inspected directly and deterministically.
+	s.handler.indexReports = make(chan *slot, 2)
 	s.handler.centralReady.Signal()
-
-	s.store.EXPECT().GetFromCID(uint32(9)).Return(&virtualmachine.Info{ID: "vm-9"}).Times(2)
 
 	older := &v1.IndexReport{VsockCid: "9"}
+	other := &v1.IndexReport{VsockCid: "10"}
 	newer := &v1.IndexReport{VsockCid: "9"}
 
-	s.Require().NoError(s.handler.SendReactive(context.Background(), older, time.Now()))
-	s.Require().NoError(s.handler.SendReactive(context.Background(), newer, time.Now()))
+	s.Require().NoError(s.handler.Send(context.Background(), older, time.Time{}))
+	s.Require().NoError(s.handler.Send(context.Background(), other, time.Time{}))
+	generatedAt := time.Now()
+	s.Require().NoError(s.handler.Send(context.Background(), newer, generatedAt))
 
-	s.handler.reactiveMu.Lock()
-	defer s.handler.reactiveMu.Unlock()
-	s.Require().Len(s.handler.reactivePending, 1, "reactivePending must never grow past one entry per VM")
-	s.Same(newer, s.handler.reactivePending["vm-9"].report, "the newer report must replace the older one, never queue alongside it")
+	s.Require().Len(s.handler.pending, 2, "coalescing must not add a second map entry for vsock_cid=9")
+
+	// Exactly two slots ever reached the channel: "older"/"newer" coalesced
+	// into one slot at "older"'s original (first) queue position, and
+	// "other" is a distinct, second slot — never a third entry.
+	first := <-s.handler.indexReports
+	s.Same(newer, first.report, "the coalesced slot must carry the latest report")
+	s.Equal(generatedAt, first.generatedAt)
+	s.Equal("9", first.vsockCID)
+
+	second := <-s.handler.indexReports
+	s.Same(other, second.report, "the other VM's slot must be unaffected and still second in line")
 }
 
-func (s *virtualMachineHandlerSuite) TestSendReactive_FallsBackToScheduledQueueWhenVMUnknown() {
-	// Deliberately does not call Start(): with no run() consumer goroutine
-	// racing to drain indexReports, the test can read the fallback message
-	// off it directly and deterministically.
-	s.handler.indexReports = make(chan *v1.IndexReport, 1)
-	s.handler.centralReady.Signal()
+func (s *virtualMachineHandlerSuite) TestSend_QueuesFreshSlotOnceInFlightSlotIsConsumed() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	s.handler.Notify(common.SensorComponentEventCentralReachable)
+	defer s.handler.Stop()
 
-	s.store.EXPECT().GetFromCID(uint32(42)).Return(nil)
+	s.store.EXPECT().GetFromCID(uint32(5)).Return(&virtualmachine.Info{ID: "vm-5"}).AnyTimes()
 
-	report := &v1.IndexReport{VsockCid: "42"}
-	err := s.handler.SendReactive(context.Background(), report, time.Now())
-	s.Require().NoError(err, "an unresolvable VM must not cause the reactive update to be dropped")
-
-	s.handler.reactiveMu.Lock()
-	pendingLen := len(s.handler.reactivePending)
-	s.handler.reactiveMu.Unlock()
-	s.Equal(0, pendingLen, "an unresolvable VM's report must not be added to reactivePending")
+	first := &v1.IndexReport{VsockCid: "5"}
+	s.Require().NoError(s.handler.Send(context.Background(), first, time.Time{}))
 
 	select {
-	case got := <-s.handler.indexReports:
-		s.Equal("42", got.GetVsockCid(), "it must instead land on the normal scheduled queue")
+	case msg := <-s.handler.ResponsesC():
+		s.Equal("vm-5", msg.GetEvent().GetId())
 	case <-time.After(time.Second):
-		s.Fail("expected the report to fall back onto the scheduled queue")
+		s.Fail("timed out waiting for the first message")
+	}
+
+	// run() clears the pending entry before handing the slot's contents to
+	// handleIndexReport, but that happens on its own goroutine; poll briefly
+	// rather than asserting immediately after the receive above.
+	s.Eventually(func() bool {
+		s.handler.slotsMu.Lock()
+		defer s.handler.slotsMu.Unlock()
+		return len(s.handler.pending) == 0
+	}, time.Second, 10*time.Millisecond, "expected vm-5's pending entry to be cleared after consumption")
+
+	second := &v1.IndexReport{VsockCid: "5"}
+	s.Require().NoError(s.handler.Send(context.Background(), second, time.Time{}))
+
+	select {
+	case msg := <-s.handler.ResponsesC():
+		s.Equal("vm-5", msg.GetEvent().GetId())
+	case <-time.After(time.Second):
+		s.Fail("timed out waiting for the second message")
 	}
 }
 
-func (s *virtualMachineHandlerSuite) TestSendReactive_CentralNotReachable() {
-	err := s.handler.Start()
-	s.Require().NoError(err)
-	defer s.handler.Stop()
-
-	report := &v1.IndexReport{VsockCid: "1"}
-	err = s.handler.SendReactive(context.Background(), report, time.Now())
-	s.Require().Error(err)
-	s.Require().ErrorIs(err, errCentralNotReachable)
-	s.Require().ErrorIs(err, errox.ResourceExhausted)
-}
-
-func (s *virtualMachineHandlerSuite) TestPopReactivePending_EmptyReturnsFalse() {
-	entry, ok := s.handler.popReactivePending()
-	s.False(ok)
-	s.Nil(entry)
-}
-
-func (s *virtualMachineHandlerSuite) TestSendReactive_ConcurrentUpsertsAreRaceFreeAndBounded() {
+func (s *virtualMachineHandlerSuite) TestSend_ConcurrentSendsCoalesceRaceFreeAndBounded() {
 	// Deliberately does not call Start(): no run() consumer goroutine
-	// draining reactivePending means the map's final contents can be
+	// draining indexReports means the map's final contents can be
 	// inspected deterministically once all senders finish, while -race
-	// still exercises real concurrent access to reactiveMu/reactivePending
-	// from every sending goroutine below.
+	// still exercises real concurrent access to slotsMu/pending from every
+	// sending goroutine below.
 	const numVMs = 40
 	const sendsPerVM = 25
 
-	s.handler.indexReports = make(chan *v1.IndexReport, numVMs*sendsPerVM)
+	s.handler.indexReports = make(chan *slot, numVMs)
 	s.handler.centralReady.Signal()
 
-	for i := range numVMs {
-		s.store.EXPECT().GetFromCID(uint32(i)).Return(&virtualmachine.Info{
-			ID: virtualmachine.VMID(fmt.Sprintf("vm-%d", i)),
-		}).AnyTimes()
-	}
-
-	// Repeated concurrent sends per VM exercise the upsert-replace path
-	// under contention, not just the first-insert path.
+	// Repeated concurrent sends per VM exercise the coalescing path under
+	// contention, not just the first-insert path.
 	wg := sync.WaitGroup{}
 	for i := range numVMs {
 		cid := fmt.Sprintf("%d", i)
 		for range sendsPerVM {
 			wg.Go(func() {
 				report := &v1.IndexReport{VsockCid: cid}
-				err := s.handler.SendReactive(context.Background(), report, time.Now())
+				err := s.handler.Send(context.Background(), report, time.Now())
 				s.Require().NoError(err)
 			})
 		}
 	}
 	wg.Wait()
 
-	// Exactly one pending entry per VM survives concurrent upserts —
-	// reactivePending must never grow past fleet size, regardless of how
-	// many reactive sends raced for the same VM.
-	s.handler.reactiveMu.Lock()
-	defer s.handler.reactiveMu.Unlock()
-	s.Require().Len(s.handler.reactivePending, numVMs)
-	for i := range numVMs {
-		vmID := virtualmachine.VMID(fmt.Sprintf("vm-%d", i))
-		entry, ok := s.handler.reactivePending[vmID]
-		s.Require().True(ok, "expected a pending reactive entry for %s", vmID)
-		s.Equal(fmt.Sprintf("%d", i), entry.report.GetVsockCid())
+	// Exactly one slot per VM ever reached the channel, regardless of how
+	// many sends raced for the same VM: indexReports must never hold more
+	// than one entry per VM at a time.
+	s.Len(s.handler.indexReports, numVMs)
+	seen := set.NewStringSet()
+	for range numVMs {
+		got := <-s.handler.indexReports
+		s.True(seen.Add(got.vsockCID), "each VM must appear at most once in indexReports, got a duplicate for %s", got.vsockCID)
 	}
+}
+
+func (s *virtualMachineHandlerSuite) TestSend_ConcurrentWithStopDoesNotPanicOnNilPendingMap() {
+	// Regression test: checkSendPreconditions only checks h.stopper, not
+	// h.pending, so a Send() can pass that check and then race Stop(). Stop()
+	// must never leave a window where such a Send() writes to a nilled-out
+	// pending map (see the comment on h.pending in Stop()). Success here is
+	// simply "no panic, no goroutine leak" under -race; drive many
+	// concurrent senders against a single Stop() to make the race window
+	// likely to be hit.
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	s.handler.Notify(common.SensorComponentEventCentralReachable)
+
+	s.store.EXPECT().GetFromCID(gomock.Any()).Return(&virtualmachine.Info{ID: "vm"}).AnyTimes()
+
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for range s.handler.ResponsesC() {
+		}
+	}()
+
+	const numSenders = 50
+	wg := sync.WaitGroup{}
+	for i := range numSenders {
+		cid := fmt.Sprintf("%d", i)
+		wg.Go(func() {
+			// Mirrors real callers (e.g. service_impl.go), which always pass
+			// a bounded context: enqueueScheduled blocks on the channel send
+			// with no deadline of its own, so without a timeout here a Send()
+			// racing Stop() after the run() consumer has exited would block
+			// forever instead of returning an error.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			report := &v1.IndexReport{VsockCid: cid}
+			// The error is intentionally ignored: Send legitimately fails
+			// once Stop() wins the race against it. The only property this
+			// test asserts is that it never panics.
+			_ = s.handler.Send(ctx, report, time.Time{})
+		})
+	}
+
+	s.handler.Stop()
+	wg.Wait()
+	<-drainDone
 }
 
 func TestVmIDFromResourceID(t *testing.T) {

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -801,8 +801,13 @@ func (s *virtualMachineHandlerSuite) TestSend_FairFIFO_ReactiveDoesNotJumpAheadO
 	s.Equal("vm-3", received[2], "a reactive report must not jump ahead of an already-queued different VM")
 
 	// Only report3 (the reactive one, non-zero generatedAt) should have
-	// observed the SLA latency histogram.
-	s.Equal(initialLatencyCount+1, s.reactiveLatencySampleCount(),
+	// observed the SLA latency histogram. Observe runs after the blocking
+	// send into ResponsesC returns, so poll briefly for the sample rather
+	// than asserting on the count in the same instant the third message
+	// arrives.
+	s.Eventually(func() bool {
+		return s.reactiveLatencySampleCount() == initialLatencyCount+1
+	}, time.Second, 10*time.Millisecond,
 		"exactly one observation (the reactive report) should be recorded; the two scheduled reports must not add samples")
 }
 

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -745,6 +746,17 @@ func (s *virtualMachineHandlerSuite) TestStart_CalledTwice() {
 	s.Require().ErrorIs(err, errStartMoreThanOnce)
 }
 
+// reactiveLatencySampleCount reads the current sample count (number of
+// Observe() calls) of the SLA-measurement histogram directly off the
+// collector, since it's a plain Histogram (not a vec) shared across tests:
+// testutil.CollectAndCount would only ever report 1 (one time series exists),
+// not how many observations were made, so callers must compare deltas.
+func (s *virtualMachineHandlerSuite) reactiveLatencySampleCount() uint64 {
+	var m dto.Metric
+	s.Require().NoError(vmmetrics.VirtualMachineReactiveIndexReportLatencySeconds.Write(&m))
+	return m.GetHistogram().GetSampleCount()
+}
+
 func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedScheduledBacklog() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
@@ -758,6 +770,8 @@ func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedSched
 	s.store.EXPECT().GetFromCID(uint32(1)).Return(&virtualmachine.Info{ID: "vm-1"}).AnyTimes()
 	s.store.EXPECT().GetFromCID(uint32(2)).Return(&virtualmachine.Info{ID: "vm-2"}).AnyTimes()
 	s.store.EXPECT().GetFromCID(uint32(3)).Return(&virtualmachine.Info{ID: "vm-3"}).AnyTimes()
+
+	initialLatencyCount := s.reactiveLatencySampleCount()
 
 	// report1 is picked up by run()'s single goroutine and blocks trying to
 	// hand it to ResponsesC() (nobody is reading yet), which pins the loop
@@ -791,6 +805,12 @@ func (s *virtualMachineHandlerSuite) TestSendReactive_DeliveredBeforeQueuedSched
 	s.Equal("vm-1", received[0], "report1 was already in flight before the reactive report existed")
 	s.Equal("vm-3", received[1], "the reactive report must be delivered ahead of the queued scheduled backlog")
 	s.Equal("vm-2", received[2], "the scheduled backlog entry is delivered last")
+
+	// Only report3 (the reactive one) should have observed the SLA latency
+	// histogram: report1 and report2 went through the scheduled path with a
+	// zero-value generatedAt, which handleIndexReport must not record.
+	s.Equal(initialLatencyCount+1, s.reactiveLatencySampleCount(),
+		"exactly one observation (the reactive report) should be recorded; the two scheduled reports must not add samples")
 }
 
 func (s *virtualMachineHandlerSuite) TestSendReactive_UpsertReplacesOlderPendingForSameVM() {

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	central "github.com/stackrox/rox/generated/internalapi/central"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -155,6 +156,20 @@ func (m *MockHandler) Send(ctx context.Context, vm *v1.IndexReport) error {
 func (mr *MockHandlerMockRecorder) Send(ctx, vm any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockHandler)(nil).Send), ctx, vm)
+}
+
+// SendReactive mocks base method.
+func (m *MockHandler) SendReactive(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendReactive", ctx, vm, generatedAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendReactive indicates an expected call of SendReactive.
+func (mr *MockHandlerMockRecorder) SendReactive(ctx, vm, generatedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendReactive", reflect.TypeOf((*MockHandler)(nil).SendReactive), ctx, vm, generatedAt)
 }
 
 // Start mocks base method.

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -145,31 +145,17 @@ func (mr *MockHandlerMockRecorder) ResponsesC() *gomock.Call {
 }
 
 // Send mocks base method.
-func (m *MockHandler) Send(ctx context.Context, vm *v1.IndexReport) error {
+func (m *MockHandler) Send(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Send", ctx, vm)
+	ret := m.ctrl.Call(m, "Send", ctx, vm, generatedAt)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockHandlerMockRecorder) Send(ctx, vm any) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Send(ctx, vm, generatedAt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockHandler)(nil).Send), ctx, vm)
-}
-
-// SendReactive mocks base method.
-func (m *MockHandler) SendReactive(ctx context.Context, vm *v1.IndexReport, generatedAt time.Time) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendReactive", ctx, vm, generatedAt)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SendReactive indicates an expected call of SendReactive.
-func (mr *MockHandlerMockRecorder) SendReactive(ctx, vm, generatedAt any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendReactive", reflect.TypeOf((*MockHandler)(nil).SendReactive), ctx, vm, generatedAt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockHandler)(nil).Send), ctx, vm, generatedAt)
 }
 
 // Start mocks base method.

--- a/sensor/common/virtualmachine/index/service_impl.go
+++ b/sensor/common/virtualmachine/index/service_impl.go
@@ -88,7 +88,9 @@ func (s *serviceImpl) UpsertVirtualMachineIndexReport(ctx context.Context, req *
 	metrics.IndexReportsReceived.Inc()
 	timeoutCtx, cancel := context.WithTimeout(ctx, indexReportSendTimeout)
 	defer cancel()
-	if err := s.handler.Send(timeoutCtx, ir); err != nil {
+	// Push-mode reports have no reactive/scheduled distinction; zero value
+	// means this send isn't observed by the reactive-latency histogram.
+	if err := s.handler.Send(timeoutCtx, ir, time.Time{}); err != nil {
 		return &sensor.UpsertVirtualMachineIndexReportResponse{
 			Success: false,
 		}, errors.Wrapf(err, "sending virtual machine index report with vsock_cid=%q to Central", ir.GetVsockCid())

--- a/sensor/common/virtualmachine/index/service_impl_test.go
+++ b/sensor/common/virtualmachine/index/service_impl_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -142,8 +143,8 @@ func (s *virtualMachineServiceSuite) TestUpsertVirtualMachine_PushSuppressedForA
 
 	var sendCalled bool
 	mockHandler := mocks.NewMockHandler(s.ctrl)
-	mockHandler.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ *v1.IndexReport) error {
+	mockHandler.EXPECT().Send(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *v1.IndexReport, _ time.Time) error {
 			sendCalled = true
 			return nil
 		},

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -118,8 +118,7 @@ var IndexReportEnqueueBlockedTotal = prometheus.NewCounter(
 // VirtualMachineReactiveIndexReportLatencySeconds measures end-to-end latency
 // from roxagent producing a reactively-triggered report
 // (ResponseMeta.report_generated_at) to Sensor successfully handing it off
-// toward Central. Used to validate the ~5 minute reactive-update SLA. See
-// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+// toward Central. Used to validate the ~5 minute reactive-update SLA.
 var VirtualMachineReactiveIndexReportLatencySeconds = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -118,6 +118,21 @@ var IndexReportEnqueueBlockedTotal = prometheus.NewCounter(
 	},
 )
 
+// VirtualMachineReactiveIndexReportLatencySeconds measures end-to-end latency
+// from roxagent producing a reactively-triggered report
+// (ResponseMeta.report_generated_at) to Sensor successfully handing it off
+// toward Central. Used to validate the ~5 minute reactive-update SLA. See
+// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+var VirtualMachineReactiveIndexReportLatencySeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "virtual_machine_reactive_index_report_latency_seconds",
+		Help:      "End-to-end latency from roxagent producing a reactive index report to Sensor handing it to Central",
+		Buckets:   prometheus.ExponentialBuckets(1, 2, 12), // 1s to ~34min
+	},
+)
+
 // VMDiscoveredData is a counter for VM discovered data grouped by detected OS and status values.
 var VMDiscoveredData = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -140,6 +155,20 @@ var VMDiscoveredDataDNFStatus = prometheus.NewCounterVec(
 		Help:      "Total number of DNF status flags observed in VM index reports received by Sensor",
 	},
 	[]string{"dnf_status"},
+)
+
+// VMDiscoveredDataScanTrigger is a counter for the scan trigger classification
+// ("scheduled", "reactive", or "unknown" for older agents) reported by
+// roxagent alongside each pulled report, letting operators see reactive-scan
+// volume over time.
+var VMDiscoveredDataScanTrigger = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "virtual_machine_discovered_data_scan_trigger_total",
+		Help:      "Total number of VM index reports received by Sensor grouped by scan trigger (scheduled, reactive, or unknown)",
+	},
+	[]string{"scan_trigger"},
 )
 
 // IndexReportAcksReceived counts ACK/NACK responses received from Central for VM index reports.
@@ -287,8 +316,10 @@ func init() {
 		IndexReportProcessingDurationMilliseconds,
 		IndexReportBlockingEnqueueDurationMilliseconds,
 		IndexReportEnqueueBlockedTotal,
+		VirtualMachineReactiveIndexReportLatencySeconds,
 		VMDiscoveredData,
 		VMDiscoveredDataDNFStatus,
+		VMDiscoveredDataScanTrigger,
 		IndexReportAcksReceived,
 		// Pull-mode metrics.
 		PullDialDurationSeconds,

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -121,8 +121,7 @@ var IndexReportEnqueueBlockedTotal = prometheus.NewCounter(
 // VirtualMachineReactiveIndexReportLatencySeconds measures end-to-end latency
 // from roxagent producing a reactively-triggered report
 // (ResponseMeta.report_generated_at) to Sensor successfully handing it off
-// toward Central. Used to validate the ~5 minute reactive-update SLA. See
-// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+// toward Central. Used to validate the ~5 minute reactive-update SLA.
 var VirtualMachineReactiveIndexReportLatencySeconds = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -115,6 +115,21 @@ var IndexReportEnqueueBlockedTotal = prometheus.NewCounter(
 	},
 )
 
+// VirtualMachineReactiveIndexReportLatencySeconds measures end-to-end latency
+// from roxagent producing a reactively-triggered report
+// (ResponseMeta.report_generated_at) to Sensor successfully handing it off
+// toward Central. Used to validate the ~5 minute reactive-update SLA. See
+// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+var VirtualMachineReactiveIndexReportLatencySeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "virtual_machine_reactive_index_report_latency_seconds",
+		Help:      "End-to-end latency from roxagent producing a reactive index report to Sensor handing it to Central",
+		Buckets:   prometheus.ExponentialBuckets(1, 2, 12), // 1s to ~34min
+	},
+)
+
 // VMDiscoveredData is a counter for VM discovered data grouped by detected OS and status values.
 var VMDiscoveredData = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -124,6 +139,20 @@ var VMDiscoveredData = prometheus.NewCounterVec(
 		Help:      "Total number of VM index reports received by Sensor grouped by detected OS and discovered data status values",
 	},
 	[]string{"detected_os", "activation_status", "dnf_metadata_status"},
+)
+
+// VMDiscoveredDataScanTrigger is a counter for the scan trigger classification
+// ("scheduled", "reactive", or "unknown" for older agents) reported by
+// roxagent alongside each pulled report, letting operators see reactive-scan
+// volume over time.
+var VMDiscoveredDataScanTrigger = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "virtual_machine_discovered_data_scan_trigger_total",
+		Help:      "Total number of VM index reports received by Sensor grouped by scan trigger (scheduled, reactive, or unknown)",
+	},
+	[]string{"scan_trigger"},
 )
 
 // IndexReportAcksReceived counts ACK/NACK responses received from Central for VM index reports.
@@ -262,7 +291,9 @@ func init() {
 		IndexReportProcessingDurationMilliseconds,
 		IndexReportBlockingEnqueueDurationMilliseconds,
 		IndexReportEnqueueBlockedTotal,
+		VirtualMachineReactiveIndexReportLatencySeconds,
 		VMDiscoveredData,
+		VMDiscoveredDataScanTrigger,
 		IndexReportAcksReceived,
 		// Pull-mode metrics.
 		PullDialDurationSeconds,

--- a/sensor/common/virtualmachine/vmscraper/facts.go
+++ b/sensor/common/virtualmachine/vmscraper/facts.go
@@ -1,0 +1,66 @@
+package vmscraper
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
+)
+
+const (
+	// scanTriggerFactKey is the ResponseMeta.facts key roxagent sets to
+	// classify why a report was generated.
+	scanTriggerFactKey = "scan_trigger"
+	// scanTriggerReactive is the scanTriggerFactKey value for reports
+	// produced by a reactive (event-triggered) rescan, as opposed to a
+	// routine scheduled one.
+	scanTriggerReactive = "reactive"
+	// scanTriggerScheduled is the scanTriggerFactKey value for reports
+	// produced by a routine, non-reactive scan.
+	scanTriggerScheduled = "scheduled"
+)
+
+// isReactiveTrigger reports whether facts indicate a reactive rescan. Absent
+// or unrecognized values default to false (scheduled), the safe default for
+// older roxagent versions that don't set this fact.
+func isReactiveTrigger(facts map[string]string) bool {
+	return facts[scanTriggerFactKey] == scanTriggerReactive
+}
+
+// logAndRecordDiscoveredFacts logs and records metrics for the VM facts
+// (detected OS, activation status, scan trigger) that roxagent reports
+// alongside every pulled index report. This mirrors the logging/metrics that
+// push-mode agents produce via UpsertVirtualMachineIndexReport, so operators
+// see the same "VM discovered data" signal regardless of which transport mode
+// delivered it.
+func logAndRecordDiscoveredFacts(key string, facts map[string]string) {
+	if len(facts) == 0 {
+		return
+	}
+
+	detectedOS := facts["detected_os"]
+	osVersion := facts["os_version"]
+	activationStatus := facts["activation_status"]
+	dnfMetadataStatus := facts["dnf_metadata_status"]
+	scanTrigger := facts[scanTriggerFactKey]
+
+	log.Debugf("VMScraper: VM discovered data for %q: detected_os=%s, os_version=%q, activation_status=%s, scan_trigger=%q",
+		key, detectedOS, osVersion, activationStatus, scanTrigger)
+
+	metrics.VMDiscoveredData.With(prometheus.Labels{
+		"detected_os":         detectedOS,
+		"activation_status":   activationStatus,
+		"dnf_metadata_status": dnfMetadataStatus,
+	}).Inc()
+	recordScanTriggerMetric(scanTrigger)
+}
+
+// recordScanTriggerMetric records the scan_trigger classification, whitelisting
+// known values and falling back to "unknown" for anything else (older
+// roxagent versions that don't set the fact yet, typos, or future trigger
+// types). roxagent-supplied data crosses a trust boundary, so this bounds the
+// metric's label cardinality rather than passing arbitrary values through.
+func recordScanTriggerMetric(scanTrigger string) {
+	if scanTrigger != scanTriggerReactive && scanTrigger != scanTriggerScheduled {
+		scanTrigger = "unknown"
+	}
+	metrics.VMDiscoveredDataScanTrigger.WithLabelValues(scanTrigger).Inc()
+}

--- a/sensor/common/virtualmachine/vmscraper/facts.go
+++ b/sensor/common/virtualmachine/vmscraper/facts.go
@@ -7,17 +7,18 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 )
 
-// scanTriggerFactKey is the ResponseMeta.facts key roxagent sets to classify
-// why a report was generated.
-const scanTriggerFactKey = "scan_trigger"
-
-// scanTriggerReactive is the scanTriggerFactKey value for reports produced by
-// a reactive (event-triggered) rescan, as opposed to a routine scheduled one.
-const scanTriggerReactive = "reactive"
-
-// scanTriggerScheduled is the scanTriggerFactKey value for reports produced
-// by a routine, non-reactive scan.
-const scanTriggerScheduled = "scheduled"
+const (
+	// scanTriggerFactKey is the ResponseMeta.facts key roxagent sets to
+	// classify why a report was generated.
+	scanTriggerFactKey = "scan_trigger"
+	// scanTriggerReactive is the scanTriggerFactKey value for reports
+	// produced by a reactive (event-triggered) rescan, as opposed to a
+	// routine scheduled one.
+	scanTriggerReactive = "reactive"
+	// scanTriggerScheduled is the scanTriggerFactKey value for reports
+	// produced by a routine, non-reactive scan.
+	scanTriggerScheduled = "scheduled"
+)
 
 // isReactiveTrigger reports whether facts indicate a reactive rescan. Absent
 // or unrecognized values default to false (scheduled), the safe default for

--- a/sensor/common/virtualmachine/vmscraper/facts.go
+++ b/sensor/common/virtualmachine/vmscraper/facts.go
@@ -8,8 +8,7 @@ import (
 )
 
 // scanTriggerFactKey is the ResponseMeta.facts key roxagent sets to classify
-// why a report was generated. See
-// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+// why a report was generated.
 const scanTriggerFactKey = "scan_trigger"
 
 // scanTriggerReactive is the scanTriggerFactKey value for reports produced by

--- a/sensor/common/virtualmachine/vmscraper/facts.go
+++ b/sensor/common/virtualmachine/vmscraper/facts.go
@@ -7,11 +7,32 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 )
 
+// scanTriggerFactKey is the ResponseMeta.facts key roxagent sets to classify
+// why a report was generated. See
+// docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md.
+const scanTriggerFactKey = "scan_trigger"
+
+// scanTriggerReactive is the scanTriggerFactKey value for reports produced by
+// a reactive (event-triggered) rescan, as opposed to a routine scheduled one.
+const scanTriggerReactive = "reactive"
+
+// scanTriggerScheduled is the scanTriggerFactKey value for reports produced
+// by a routine, non-reactive scan.
+const scanTriggerScheduled = "scheduled"
+
+// isReactiveTrigger reports whether facts indicate a reactive rescan. Absent
+// or unrecognized values default to false (scheduled), the safe default for
+// older roxagent versions that don't set this fact.
+func isReactiveTrigger(facts map[string]string) bool {
+	return facts[scanTriggerFactKey] == scanTriggerReactive
+}
+
 // logAndRecordDiscoveredFacts logs and records metrics for the VM facts
-// (detected OS, activation status, DNF status) that roxagent reports alongside
-// every pulled index report. This mirrors the logging/metrics that push-mode
-// agents produce via UpsertVirtualMachineIndexReport, so operators see the same
-// "VM discovered data" signal regardless of which transport mode delivered it.
+// (detected OS, activation status, DNF status, scan trigger) that roxagent
+// reports alongside every pulled index report. This mirrors the logging/metrics
+// that push-mode agents produce via UpsertVirtualMachineIndexReport, so
+// operators see the same "VM discovered data" signal regardless of which
+// transport mode delivered it.
 func logAndRecordDiscoveredFacts(key string, facts map[string]string) {
 	if len(facts) == 0 {
 		return
@@ -22,9 +43,10 @@ func logAndRecordDiscoveredFacts(key string, facts map[string]string) {
 	activationStatus := facts["activation_status"]
 	dnfMetadataStatus := facts["dnf_metadata_status"]
 	dnfStatus := facts["dnf_status"]
+	scanTrigger := facts[scanTriggerFactKey]
 
-	log.Debugf("VMScraper: VM discovered data for %q: detected_os=%s, os_version=%q, activation_status=%s, dnf_status=[%s]",
-		key, detectedOS, osVersion, activationStatus, dnfStatus)
+	log.Debugf("VMScraper: VM discovered data for %q: detected_os=%s, os_version=%q, activation_status=%s, dnf_status=[%s], scan_trigger=%q",
+		key, detectedOS, osVersion, activationStatus, dnfStatus, scanTrigger)
 
 	metrics.VMDiscoveredData.With(prometheus.Labels{
 		"detected_os":         detectedOS,
@@ -32,6 +54,7 @@ func logAndRecordDiscoveredFacts(key string, facts map[string]string) {
 		"dnf_metadata_status": dnfMetadataStatus,
 	}).Inc()
 	recordDnfStatusMetrics(dnfStatus)
+	recordScanTriggerMetric(scanTrigger)
 }
 
 // recordDnfStatusMetrics splits the comma-joined "name1, name2" DNF status
@@ -48,4 +71,16 @@ func recordDnfStatusMetrics(dnfStatus string) {
 		}
 		metrics.VMDiscoveredDataDNFStatus.WithLabelValues(name).Inc()
 	}
+}
+
+// recordScanTriggerMetric records the scan_trigger classification, whitelisting
+// known values and falling back to "unknown" for anything else (older
+// roxagent versions that don't set the fact yet, typos, or future trigger
+// types). roxagent-supplied data crosses a trust boundary, so this bounds the
+// metric's label cardinality rather than passing arbitrary values through.
+func recordScanTriggerMetric(scanTrigger string) {
+	if scanTrigger != scanTriggerReactive && scanTrigger != scanTriggerScheduled {
+		scanTrigger = "unknown"
+	}
+	metrics.VMDiscoveredDataScanTrigger.WithLabelValues(scanTrigger).Inc()
 }

--- a/sensor/common/virtualmachine/vmscraper/facts_test.go
+++ b/sensor/common/virtualmachine/vmscraper/facts_test.go
@@ -1,0 +1,68 @@
+package vmscraper
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogAndRecordDiscoveredFacts(t *testing.T) {
+	t.Run("empty facts map records nothing", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown"))
+		logAndRecordDiscoveredFacts("ns/vm-empty", nil)
+		assert.Equal(t, before, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown")))
+	})
+
+	t.Run("populated facts increment discovered data metric", func(t *testing.T) {
+		facts := map[string]string{
+			"detected_os":         "RHEL",
+			"os_version":          "9.7",
+			"activation_status":   "ACTIVE",
+			"dnf_metadata_status": "AVAILABLE",
+		}
+
+		beforeData := testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE"))
+		logAndRecordDiscoveredFacts("ns/vm-1", facts)
+		assert.Equal(t, beforeData+1, testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE")))
+	})
+
+	t.Run("records scan_trigger metric for a reactive report", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("reactive"))
+		logAndRecordDiscoveredFacts("ns/vm-3", map[string]string{"scan_trigger": "reactive"})
+		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("reactive")))
+	})
+
+	t.Run("missing scan_trigger records the unknown label (older agents)", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown"))
+		logAndRecordDiscoveredFacts("ns/vm-4", map[string]string{"detected_os": "RHEL"})
+		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown")))
+	})
+
+	t.Run("garbage scan_trigger value records the unknown label", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown"))
+		logAndRecordDiscoveredFacts("ns/vm-5", map[string]string{"scan_trigger": "bogus-value"})
+		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown")))
+	})
+}
+
+func TestIsReactiveTrigger(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		facts    map[string]string
+		expected bool
+	}{
+		"reactive fact returns true":        {facts: map[string]string{"scan_trigger": "reactive"}, expected: true},
+		"scheduled fact returns false":      {facts: map[string]string{"scan_trigger": "scheduled"}, expected: false},
+		"absent fact defaults to false":     {facts: map[string]string{}, expected: false},
+		"nil facts default to false":        {facts: nil, expected: false},
+		"unrecognized value defaults false": {facts: map[string]string{"scan_trigger": "bogus"}, expected: false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, isReactiveTrigger(tc.facts))
+		})
+	}
+}

--- a/sensor/common/virtualmachine/vmscraper/facts_test.go
+++ b/sensor/common/virtualmachine/vmscraper/facts_test.go
@@ -40,4 +40,42 @@ func TestLogAndRecordDiscoveredFacts(t *testing.T) {
 		logAndRecordDiscoveredFacts("ns/vm-2", map[string]string{"dnf_status": "none"})
 		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataDNFStatus.WithLabelValues("none")))
 	})
+
+	t.Run("records scan_trigger metric for a reactive report", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("reactive"))
+		logAndRecordDiscoveredFacts("ns/vm-3", map[string]string{"scan_trigger": "reactive"})
+		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("reactive")))
+	})
+
+	t.Run("missing scan_trigger records the unknown label (older agents)", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown"))
+		logAndRecordDiscoveredFacts("ns/vm-4", map[string]string{"detected_os": "RHEL"})
+		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown")))
+	})
+
+	t.Run("garbage scan_trigger value records the unknown label", func(t *testing.T) {
+		before := testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown"))
+		logAndRecordDiscoveredFacts("ns/vm-5", map[string]string{"scan_trigger": "bogus-value"})
+		assert.Equal(t, before+1, testutil.ToFloat64(metrics.VMDiscoveredDataScanTrigger.WithLabelValues("unknown")))
+	})
+}
+
+func TestIsReactiveTrigger(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		facts    map[string]string
+		expected bool
+	}{
+		"reactive fact returns true":        {facts: map[string]string{"scan_trigger": "reactive"}, expected: true},
+		"scheduled fact returns false":      {facts: map[string]string{"scan_trigger": "scheduled"}, expected: false},
+		"absent fact defaults to false":     {facts: map[string]string{}, expected: false},
+		"nil facts default to false":        {facts: nil, expected: false},
+		"unrecognized value defaults false": {facts: map[string]string{"scan_trigger": "bogus"}, expected: false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, isReactiveTrigger(tc.facts))
+		})
+	}
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -62,6 +62,12 @@ type VMDialer interface {
 // IndexReportSender sends index reports toward Central.
 type IndexReportSender interface {
 	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error
+	// SendReactive sends a report produced by a reactive (event-triggered)
+	// rescan, giving it delivery priority over Send. generatedAt is the
+	// report's roxagent-side generation time
+	// (ResponseMeta.report_generated_at), used to measure reactive-update
+	// delivery latency.
+	SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error
 }
 
 // ProtocolClient performs the request/response protocol over a stream.
@@ -355,7 +361,14 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 
-	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
+	if isReactiveTrigger(result.Meta.GetFacts()) {
+		generatedAt := result.Meta.GetReportGeneratedAt().AsTime()
+		if err := s.sender.SendReactive(vmCtx, vm, result.IndexReport, generatedAt); err != nil {
+			log.Errorf("VMScraper: sending reactive %q report to Central failed: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
+			return false
+		}
+	} else if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
 		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
 		return false

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -62,13 +62,12 @@ type VMDialer interface {
 
 // IndexReportSender sends index reports toward Central.
 type IndexReportSender interface {
-	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error
-	// SendReactive sends a report produced by a reactive (event-triggered)
-	// rescan, giving it delivery priority over Send. generatedAt is the
-	// report's roxagent-side generation time
-	// (ResponseMeta.report_generated_at), used to measure reactive-update
-	// delivery latency.
-	SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error
+	// Send sends a report toward Central. generatedAt is the report's
+	// roxagent-side generation time (ResponseMeta.report_generated_at) for
+	// a reactive (event-triggered) report, or the zero value for a routine
+	// scheduled one; it is used only to measure reactive-update delivery
+	// latency, never to influence delivery order.
+	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error
 }
 
 // ProtocolClient performs the request/response protocol over a stream.
@@ -351,14 +350,14 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 
+	// generatedAt is the zero value for scheduled reports; it only affects
+	// whether this send is observed by the reactive-latency histogram, not
+	// delivery order (see IndexReportSender.Send).
+	var generatedAt time.Time
 	if isReactiveTrigger(result.Meta.GetFacts()) {
-		generatedAt := result.Meta.GetReportGeneratedAt().AsTime()
-		if err := s.sender.SendReactive(vmCtx, vm, result.IndexReport, generatedAt); err != nil {
-			log.Errorf("VMScraper: sending reactive %q report to Central failed: %v", key, err)
-			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
-			return false
-		}
-	} else if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
+		generatedAt = result.Meta.GetReportGeneratedAt().AsTime()
+	}
+	if err := s.sender.Send(vmCtx, vm, result.IndexReport, generatedAt); err != nil {
 		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
 		return false

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -61,13 +61,12 @@ type VMDialer interface {
 
 // IndexReportSender sends index reports toward Central.
 type IndexReportSender interface {
-	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error
-	// SendReactive sends a report produced by a reactive (event-triggered)
-	// rescan, giving it delivery priority over Send. generatedAt is the
-	// report's roxagent-side generation time
-	// (ResponseMeta.report_generated_at), used to measure reactive-update
-	// delivery latency.
-	SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error
+	// Send sends a report toward Central. generatedAt is the report's
+	// roxagent-side generation time (ResponseMeta.report_generated_at) for
+	// a reactive (event-triggered) report, or the zero value for a routine
+	// scheduled one; it is used only to measure reactive-update delivery
+	// latency, never to influence delivery order.
+	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error
 }
 
 // ProtocolClient performs the request/response protocol over a stream.
@@ -361,14 +360,14 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 
+	// generatedAt is the zero value for scheduled reports; it only affects
+	// whether this send is observed by the reactive-latency histogram, not
+	// delivery order (see IndexReportSender.Send).
+	var generatedAt time.Time
 	if isReactiveTrigger(result.Meta.GetFacts()) {
-		generatedAt := result.Meta.GetReportGeneratedAt().AsTime()
-		if err := s.sender.SendReactive(vmCtx, vm, result.IndexReport, generatedAt); err != nil {
-			log.Errorf("VMScraper: sending reactive %q report to Central failed: %v", key, err)
-			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
-			return false
-		}
-	} else if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
+		generatedAt = result.Meta.GetReportGeneratedAt().AsTime()
+	}
+	if err := s.sender.Send(vmCtx, vm, result.IndexReport, generatedAt); err != nil {
 		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
 		return false

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -63,6 +63,12 @@ type VMDialer interface {
 // IndexReportSender sends index reports toward Central.
 type IndexReportSender interface {
 	Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error
+	// SendReactive sends a report produced by a reactive (event-triggered)
+	// rescan, giving it delivery priority over Send. generatedAt is the
+	// report's roxagent-side generation time
+	// (ResponseMeta.report_generated_at), used to measure reactive-update
+	// delivery latency.
+	SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error
 }
 
 // ProtocolClient performs the request/response protocol over a stream.
@@ -345,7 +351,14 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 
-	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
+	if isReactiveTrigger(result.Meta.GetFacts()) {
+		generatedAt := result.Meta.GetReportGeneratedAt().AsTime()
+		if err := s.sender.SendReactive(vmCtx, vm, result.IndexReport, generatedAt); err != nil {
+			log.Errorf("VMScraper: sending reactive %q report to Central failed: %v", key, err)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
+			return false
+		}
+	} else if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
 		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
 		return false

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -104,19 +104,13 @@ func (m *mockProtocolClient) reset() {
 }
 
 type mockSender struct {
-	sent                []*v4.IndexReport
-	sentReactive        []*v4.IndexReport
-	reactiveGeneratedAt []time.Time
+	sent            []*v4.IndexReport
+	sentGeneratedAt []time.Time
 }
 
-func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
 	m.sent = append(m.sent, report)
-	return nil
-}
-
-func (m *mockSender) SendReactive(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
-	m.sentReactive = append(m.sentReactive, report)
-	m.reactiveGeneratedAt = append(m.reactiveGeneratedAt, generatedAt)
+	m.sentGeneratedAt = append(m.sentGeneratedAt, generatedAt)
 	return nil
 }
 
@@ -641,7 +635,7 @@ func TestHandleGetReportError_ClassifiesEveryErrorCode(t *testing.T) {
 	}
 }
 
-func TestVMScraper_RoutesReactiveTriggerToSendReactive(t *testing.T) {
+func TestVMScraper_PassesGeneratedAtForReactiveTrigger(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
@@ -653,13 +647,12 @@ func TestVMScraper_RoutesReactiveTriggerToSendReactive(t *testing.T) {
 	s := newTestScraper(store, sender, dialer, client)
 	s.pollOnce(context.Background())
 
-	assert.Empty(t, sender.sent, "reactive report should not go through Send")
-	require.Len(t, sender.sentReactive, 1)
-	require.Len(t, sender.reactiveGeneratedAt, 1)
-	assert.WithinDuration(t, generatedAt, sender.reactiveGeneratedAt[0], time.Second)
+	require.Len(t, sender.sent, 1)
+	require.Len(t, sender.sentGeneratedAt, 1)
+	assert.WithinDuration(t, generatedAt, sender.sentGeneratedAt[0], time.Second)
 }
 
-func TestVMScraper_DefaultsToScheduledWhenTriggerFactAbsent(t *testing.T) {
+func TestVMScraper_DefaultsToZeroGeneratedAtWhenTriggerFactAbsent(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
@@ -670,8 +663,9 @@ func TestVMScraper_DefaultsToScheduledWhenTriggerFactAbsent(t *testing.T) {
 	s := newTestScraper(store, sender, dialer, client)
 	s.pollOnce(context.Background())
 
-	assert.Len(t, sender.sent, 1, "should default to the scheduled path when scan_trigger is absent")
-	assert.Empty(t, sender.sentReactive)
+	require.Len(t, sender.sent, 1)
+	require.Len(t, sender.sentGeneratedAt, 1)
+	assert.True(t, sender.sentGeneratedAt[0].IsZero(), "should pass a zero generatedAt when scan_trigger is absent")
 }
 
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
@@ -736,15 +730,11 @@ type safeSender struct {
 	sent int
 }
 
-func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.IndexReport) error {
+func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.IndexReport, _ time.Time) error {
 	s.mu.Lock()
 	s.sent++
 	s.mu.Unlock()
 	return nil
-}
-
-func (s *safeSender) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, _ time.Time) error {
-	return s.Send(ctx, vm, report)
 }
 
 func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // --- Mocks ---
@@ -103,11 +104,19 @@ func (m *mockProtocolClient) reset() {
 }
 
 type mockSender struct {
-	sent []*v4.IndexReport
+	sent                []*v4.IndexReport
+	sentReactive        []*v4.IndexReport
+	reactiveGeneratedAt []time.Time
 }
 
 func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
 	m.sent = append(m.sent, report)
+	return nil
+}
+
+func (m *mockSender) SendReactive(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
+	m.sentReactive = append(m.sentReactive, report)
+	m.reactiveGeneratedAt = append(m.reactiveGeneratedAt, generatedAt)
 	return nil
 }
 
@@ -131,6 +140,19 @@ func makeReport(gen uint32) *vsockclient.GetReportResult {
 		},
 		Meta: &pb.ResponseMeta{
 			ReportGeneration: gen,
+		},
+	}
+}
+
+func makeReactiveReport(gen uint32, generatedAt time.Time) *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		IndexReport: &v4.IndexReport{
+			State: "IndexFinished",
+		},
+		Meta: &pb.ResponseMeta{
+			ReportGeneration:  gen,
+			Facts:             map[string]string{"scan_trigger": "reactive"},
+			ReportGeneratedAt: timestamppb.New(generatedAt),
 		},
 	}
 }
@@ -619,6 +641,39 @@ func TestHandleGetReportError_ClassifiesEveryErrorCode(t *testing.T) {
 	}
 }
 
+func TestVMScraper_RoutesReactiveTriggerToSendReactive(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	generatedAt := time.Now().Add(-2 * time.Second)
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReactiveReport(1, generatedAt)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	assert.Empty(t, sender.sent, "reactive report should not go through Send")
+	require.Len(t, sender.sentReactive, 1)
+	require.Len(t, sender.reactiveGeneratedAt, 1)
+	assert.WithinDuration(t, generatedAt, sender.reactiveGeneratedAt[0], time.Second)
+}
+
+func TestVMScraper_DefaultsToScheduledWhenTriggerFactAbsent(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)}, // no facts set
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	assert.Len(t, sender.sent, 1, "should default to the scheduled path when scan_trigger is absent")
+	assert.Empty(t, sender.sentReactive)
+}
+
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
 	return &VMScraper{
 		store:                 store,
@@ -686,6 +741,10 @@ func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.Index
 	s.sent++
 	s.mu.Unlock()
 	return nil
+}
+
+func (s *safeSender) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, _ time.Time) error {
+	return s.Send(ctx, vm, report)
 }
 
 func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // --- Mocks ---
@@ -105,11 +106,19 @@ func (m *mockProtocolClient) reset() {
 }
 
 type mockSender struct {
-	sent []*v4.IndexReport
+	sent                []*v4.IndexReport
+	sentReactive        []*v4.IndexReport
+	reactiveGeneratedAt []time.Time
 }
 
 func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
 	m.sent = append(m.sent, report)
+	return nil
+}
+
+func (m *mockSender) SendReactive(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
+	m.sentReactive = append(m.sentReactive, report)
+	m.reactiveGeneratedAt = append(m.reactiveGeneratedAt, generatedAt)
 	return nil
 }
 
@@ -131,6 +140,19 @@ func makeReport(gen uint32) *vsockclient.GetReportResult {
 		},
 		Meta: &pb.ResponseMeta{
 			ReportGeneration: gen,
+		},
+	}
+}
+
+func makeReactiveReport(gen uint32, generatedAt time.Time) *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		IndexReport: &v4.IndexReport{
+			State: "IndexFinished",
+		},
+		Meta: &pb.ResponseMeta{
+			ReportGeneration:  gen,
+			Facts:             map[string]string{"scan_trigger": "reactive"},
+			ReportGeneratedAt: timestamppb.New(generatedAt),
 		},
 	}
 }
@@ -693,6 +715,39 @@ func cachedGeneration(t *testing.T, s *VMScraper, key string) uint32 {
 	})
 }
 
+func TestVMScraper_RoutesReactiveTriggerToSendReactive(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	generatedAt := time.Now().Add(-2 * time.Second)
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReactiveReport(1, generatedAt)},
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	assert.Empty(t, sender.sent, "reactive report should not go through Send")
+	require.Len(t, sender.sentReactive, 1)
+	require.Len(t, sender.reactiveGeneratedAt, 1)
+	assert.WithinDuration(t, generatedAt, sender.reactiveGeneratedAt[0], time.Second)
+}
+
+func TestVMScraper_DefaultsToScheduledWhenTriggerFactAbsent(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)}, // no facts set
+	}
+
+	s := newTestScraper(store, sender, dialer, client)
+	s.pollOnce(context.Background())
+
+	assert.Len(t, sender.sent, 1, "should default to the scheduled path when scan_trigger is absent")
+	assert.Empty(t, sender.sentReactive)
+}
+
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
 	return &VMScraper{
 		store:                 store,
@@ -760,6 +815,10 @@ func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.Index
 	s.sent++
 	s.mu.Unlock()
 	return nil
+}
+
+func (s *safeSender) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, _ time.Time) error {
+	return s.Send(ctx, vm, report)
 }
 
 func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -502,7 +502,7 @@ type gateSender struct {
 	sent    []*v4.IndexReport
 }
 
-func (g *gateSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+func (g *gateSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, _ time.Time) error {
 	g.mu.Lock()
 	g.n++
 	n := g.n

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -106,19 +106,13 @@ func (m *mockProtocolClient) reset() {
 }
 
 type mockSender struct {
-	sent                []*v4.IndexReport
-	sentReactive        []*v4.IndexReport
-	reactiveGeneratedAt []time.Time
+	sent            []*v4.IndexReport
+	sentGeneratedAt []time.Time
 }
 
-func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
 	m.sent = append(m.sent, report)
-	return nil
-}
-
-func (m *mockSender) SendReactive(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
-	m.sentReactive = append(m.sentReactive, report)
-	m.reactiveGeneratedAt = append(m.reactiveGeneratedAt, generatedAt)
+	m.sentGeneratedAt = append(m.sentGeneratedAt, generatedAt)
 	return nil
 }
 
@@ -715,7 +709,7 @@ func cachedGeneration(t *testing.T, s *VMScraper, key string) uint32 {
 	})
 }
 
-func TestVMScraper_RoutesReactiveTriggerToSendReactive(t *testing.T) {
+func TestVMScraper_PassesGeneratedAtForReactiveTrigger(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
@@ -727,13 +721,12 @@ func TestVMScraper_RoutesReactiveTriggerToSendReactive(t *testing.T) {
 	s := newTestScraper(store, sender, dialer, client)
 	s.pollOnce(context.Background())
 
-	assert.Empty(t, sender.sent, "reactive report should not go through Send")
-	require.Len(t, sender.sentReactive, 1)
-	require.Len(t, sender.reactiveGeneratedAt, 1)
-	assert.WithinDuration(t, generatedAt, sender.reactiveGeneratedAt[0], time.Second)
+	require.Len(t, sender.sent, 1)
+	require.Len(t, sender.sentGeneratedAt, 1)
+	assert.WithinDuration(t, generatedAt, sender.sentGeneratedAt[0], time.Second)
 }
 
-func TestVMScraper_DefaultsToScheduledWhenTriggerFactAbsent(t *testing.T) {
+func TestVMScraper_DefaultsToZeroGeneratedAtWhenTriggerFactAbsent(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
@@ -744,8 +737,9 @@ func TestVMScraper_DefaultsToScheduledWhenTriggerFactAbsent(t *testing.T) {
 	s := newTestScraper(store, sender, dialer, client)
 	s.pollOnce(context.Background())
 
-	assert.Len(t, sender.sent, 1, "should default to the scheduled path when scan_trigger is absent")
-	assert.Empty(t, sender.sentReactive)
+	require.Len(t, sender.sent, 1)
+	require.Len(t, sender.sentGeneratedAt, 1)
+	assert.True(t, sender.sentGeneratedAt[0].IsZero(), "should pass a zero generatedAt when scan_trigger is absent")
 }
 
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
@@ -810,15 +804,11 @@ type safeSender struct {
 	sent int
 }
 
-func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.IndexReport) error {
+func (s *safeSender) Send(_ context.Context, _ *virtualmachine.Info, _ *v4.IndexReport, _ time.Time) error {
 	s.mu.Lock()
 	s.sent++
 	s.mu.Unlock()
 	return nil
-}
-
-func (s *safeSender) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, _ time.Time) error {
-	return s.Send(ctx, vm, report)
 }
 
 func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {

--- a/sensor/kubernetes/fake/virtualmachines.go
+++ b/sensor/kubernetes/fake/virtualmachines.go
@@ -385,7 +385,7 @@ func (w *WorkloadManager) sendOneIndexReport(
 		return
 	}
 
-	if err := w.vmIndexReportHandler.Send(ctx, report); err != nil {
+	if err := w.vmIndexReportHandler.Send(ctx, report, time.Time{}); err != nil {
 		// Don't log errors during shutdown
 		if ctx.Err() == nil {
 			log.Debugf("Failed to send index report for VM %d: %v", vsockCID, err)

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -360,3 +360,17 @@ func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.In
 	}
 	return nil
 }
+
+func (a *vmScraperSenderAdapter) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
+	var cidStr string
+	if vm.VSOCKCID != nil {
+		cidStr = strconv.FormatUint(uint64(*vm.VSOCKCID), 10)
+	}
+	if err := a.handler.SendReactive(ctx, &v1.IndexReport{
+		VsockCid: cidStr,
+		IndexV4:  report,
+	}, generatedAt); err != nil {
+		return errors.Wrap(err, "sending reactive index report")
+	}
+	return nil
+}

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -347,7 +347,7 @@ type vmScraperSenderAdapter struct {
 	handler vmIndex.Handler
 }
 
-func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error {
+func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
 	if vm == nil {
 		return errors.New("virtual machine info is nil")
 	}
@@ -359,22 +359,8 @@ func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.In
 		VsockCid: cidStr,
 		VmId:     string(vm.ID),
 		IndexV4:  report,
-	}); err != nil {
-		return errors.Wrap(err, "sending index report")
-	}
-	return nil
-}
-
-func (a *vmScraperSenderAdapter) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
-	var cidStr string
-	if vm.VSOCKCID != nil {
-		cidStr = strconv.FormatUint(uint64(*vm.VSOCKCID), 10)
-	}
-	if err := a.handler.SendReactive(ctx, &v1.IndexReport{
-		VsockCid: cidStr,
-		IndexV4:  report,
 	}, generatedAt); err != nil {
-		return errors.Wrap(err, "sending reactive index report")
+		return errors.Wrap(err, "sending index report")
 	}
 	return nil
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -364,3 +364,17 @@ func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.In
 	}
 	return nil
 }
+
+func (a *vmScraperSenderAdapter) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
+	var cidStr string
+	if vm.VSOCKCID != nil {
+		cidStr = strconv.FormatUint(uint64(*vm.VSOCKCID), 10)
+	}
+	if err := a.handler.SendReactive(ctx, &v1.IndexReport{
+		VsockCid: cidStr,
+		IndexV4:  report,
+	}, generatedAt); err != nil {
+		return errors.Wrap(err, "sending reactive index report")
+	}
+	return nil
+}

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -343,7 +343,7 @@ type vmScraperSenderAdapter struct {
 	handler vmIndex.Handler
 }
 
-func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error {
+func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
 	if vm == nil {
 		return errors.New("virtual machine info is nil")
 	}
@@ -355,22 +355,8 @@ func (a *vmScraperSenderAdapter) Send(ctx context.Context, vm *virtualmachine.In
 		VsockCid: cidStr,
 		VmId:     string(vm.ID),
 		IndexV4:  report,
-	}); err != nil {
-		return errors.Wrap(err, "sending index report")
-	}
-	return nil
-}
-
-func (a *vmScraperSenderAdapter) SendReactive(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport, generatedAt time.Time) error {
-	var cidStr string
-	if vm.VSOCKCID != nil {
-		cidStr = strconv.FormatUint(uint64(*vm.VSOCKCID), 10)
-	}
-	if err := a.handler.SendReactive(ctx, &v1.IndexReport{
-		VsockCid: cidStr,
-		IndexV4:  report,
 	}, generatedAt); err != nil {
-		return errors.Wrap(err, "sending reactive index report")
+		return errors.Wrap(err, "sending index report")
 	}
 	return nil
 }

--- a/sensor/kubernetes/sensor/vm_scraper_sender_adapter_test.go
+++ b/sensor/kubernetes/sensor/vm_scraper_sender_adapter_test.go
@@ -3,6 +3,7 @@ package sensor
 import (
 	"context"
 	"testing"
+	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -52,8 +53,8 @@ func TestVMScraperSenderAdapter_Send(t *testing.T) {
 
 			if !tc.wantErr {
 				handler.EXPECT().
-					Send(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, report *v1.IndexReport) error {
+					Send(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, report *v1.IndexReport, _ time.Time) error {
 						assert.Equal(t, tc.wantVmID, report.GetVmId())
 						assert.Equal(t, tc.wantVsockCid, report.GetVsockCid())
 						assert.Equal(t, "IndexFinished", report.GetIndexV4().GetState())
@@ -61,7 +62,7 @@ func TestVMScraperSenderAdapter_Send(t *testing.T) {
 					})
 			}
 
-			err := adapter.Send(t.Context(), tc.vm, &v4.IndexReport{State: "IndexFinished"})
+			err := adapter.Send(t.Context(), tc.vm, &v4.IndexReport{State: "IndexFinished"}, time.Time{})
 			if tc.wantErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
## Description

Phase 1 of reactive DNF/RPM package-change scanning ([ROX-32949](https://redhat.atlassian.net/browse/ROX-32949)). Today `roxagent serve` only rescans on a fixed 4h timer, so a package change can take up to 4h to reach Central. This adds an `fsnotify`-based watcher on the RPM database directory that triggers an immediate rescan on change, and makes Sensor prioritize delivery of these reactive reports so the ~5 minute update SLA actually holds under load.

Design doc: `docs/superpowers/specs/2026-07-03-reactive-dnf-scanning-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-03-reactive-dnf-scanning-phase1.md`

### What changed
- `roxagent`: new `watch` package watches `/usr/lib/sysimage/rpm` (falling back to `/var/lib/rpm`) via `fsnotify`, with trivial buffered-channel coalescing of event bursts. Wired into `runServe`'s existing `select` loop as a third case alongside the periodic ticker — no protocol changes. Watcher failures are best-effort (falls back to periodic-only scanning, logs a warning).
- Every cached report is now tagged with a `scan_trigger` fact (`scheduled`/`reactive`) via the existing `ResponseMeta.facts` map.
- Sensor's `VMScraper` classifies each pulled report via this fact and routes reactive ones through a new `Handler.SendReactive` path instead of the routine `Send` path.
- `handlerImpl` gains a per-VM "latest pending reactive report" map (bounded by fleet size, not an arbitrary channel size) that's drained ahead of the routine `indexReports` channel, so a reactive update can't get stuck behind a backlog of routine traffic.
- New Prometheus metrics: `virtual_machine_reactive_index_report_latency_seconds` (end-to-end SLA measurement) and `virtual_machine_discovered_data_scan_trigger_total` (scheduled/reactive/unknown volume).

### Considered alternatives
- A second fixed-capacity channel for reactive reports (rejected — any constant is either too small at fleet scale or an unjustified memory-growth knob; the per-VM map is self-bounded by the number of VMs Sensor already tracks).
- A new VSOCK protocol field for the trigger type (rejected for now — the existing generation-counter + `facts` map is sufficient; a proto field is deferred to Phase 2 if scale testing shows it's needed).

### Explicitly out of scope (Phase 2, see design doc)
- Debounce/quiet-period timer (Phase 1 only does trivial event coalescing, no debounce).
- Storm/rate-limit protection and `--reactive-scan`/`--reactive-debounce` CLI flags.
- Alerting on the reactive-latency metric.
- 10,000-VM delivery scale testing and any changes to the generic `sensor/common/sensor/buffered_stream.go` gRPC buffer (flagged in the design doc as a known, deliberately-unaddressed risk at scale).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md) — ships unconditionally on per Phase 1 design (no feature flag added), please confirm this is acceptable
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- New unit tests for every new/changed unit: the `watch` package (directory-preference resolution, event coalescing, event-type filtering), `roxagent serve`'s `discoverFacts`/`scan_trigger` tagging, Sensor's `isReactiveTrigger` classification and `scan_trigger`/reactive-latency metrics, and `handlerImpl`'s priority path (delivery-ordering, per-VM upsert-replace semantics under concurrent access, fallback-to-scheduled-queue when a VM isn't yet resolvable, and the SLA-latency histogram observation).
- All touched packages pass `go test -race`: `compliance/virtualmachines/roxagent/...`, `sensor/common/virtualmachine/...`, `sensor/kubernetes/sensor/...`.
- `go build` for both `roxagent` and `sensor`, `gofmt`, `go vet`, and `golangci-lint` are clean; `go mod tidy` produces no unexpected diff beyond promoting `fsnotify` to a direct dependency.

[ROX-32949]: https://redhat.atlassian.net/browse/ROX-32949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ