### PR TITLE
ROX-35054: Remove Stopper in Resolver PubSub path

### DIFF
--- a/sensor/common/centralbound/bridge.go
+++ b/sensor/common/centralbound/bridge.go
@@ -1,0 +1,82 @@
+package centralbound
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	"github.com/stackrox/rox/sensor/common/unimplemented"
+)
+
+const defaultBufferSize = 100
+
+var log = logging.LoggerForModule()
+
+// Bridge is a SensorComponent that subscribes to the CentralBound PubSub
+// topic and forwards received events to a ResponsesC channel. This allows
+// components to publish Central-bound messages via PubSub instead of
+// maintaining their own ResponsesC channels, enabling incremental migration.
+type Bridge struct {
+	unimplemented.Receiver
+
+	responsesC chan *message.ExpiringMessage
+	stopper    concurrency.Stopper
+}
+
+// NewBridge creates a bridge that subscribes to the CentralBound PubSub topic
+// and exposes received messages through ResponsesC.
+func NewBridge(dispatcher common.PubSubDispatcher) (*Bridge, error) {
+	b := &Bridge{
+		responsesC: make(chan *message.ExpiringMessage, defaultBufferSize),
+		stopper:    concurrency.NewStopper(),
+	}
+	if err := dispatcher.RegisterConsumerToLane(
+		pubsub.CentralBoundBridgeConsumer,
+		pubsub.CentralBoundTopic,
+		pubsub.CentralBoundLane,
+		b.handleEvent,
+	); err != nil {
+		return nil, errors.Wrap(err, "registering central-bound bridge consumer")
+	}
+	return b, nil
+}
+
+func (b *Bridge) handleEvent(e pubsub.Event) error {
+	evt, ok := e.(*CentralBoundEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", e)
+	}
+	if evt.IsExpired() {
+		return nil
+	}
+	select {
+	case b.responsesC <- evt.Msg:
+	case <-b.stopper.Flow().StopRequested():
+	}
+	return nil
+}
+
+// Start is a no-op; the consumer is registered at construction time.
+func (b *Bridge) Start() error { return nil }
+
+// Stop closes the ResponsesC channel so centralSenderImpl's forwardResponses
+// goroutine exits cleanly.
+func (b *Bridge) Stop() {
+	b.stopper.Client().Stop()
+	close(b.responsesC)
+}
+
+// Notify is a no-op; the bridge does not react to lifecycle events.
+func (b *Bridge) Notify(_ common.SensorComponentEvent) {}
+
+// Capabilities returns nil; the bridge has no capabilities to advertise.
+func (b *Bridge) Capabilities() []centralsensor.SensorCapability { return nil }
+
+// ResponsesC returns the channel carrying messages destined for Central.
+func (b *Bridge) ResponsesC() <-chan *message.ExpiringMessage { return b.responsesC }
+
+// Name returns the component name used in logging.
+func (b *Bridge) Name() string { return "centralbound.Bridge" }

--- a/sensor/common/centralbound/bridge.go
+++ b/sensor/common/centralbound/bridge.go
@@ -59,11 +59,11 @@ func (b *Bridge) handleEvent(e pubsub.Event) error {
 // Start is a no-op; the consumer is registered at construction time.
 func (b *Bridge) Start() error { return nil }
 
-// Stop closes the ResponsesC channel so centralSenderImpl's forwardResponses
-// goroutine exits cleanly.
+// Stop signals the bridge to stop forwarding events. It does not close
+// responsesC because the PubSub dispatcher may still invoke handleEvent
+// until Sensor tears it down later in the shutdown sequence.
 func (b *Bridge) Stop() {
 	b.stopper.Client().Stop()
-	close(b.responsesC)
 }
 
 // Notify is a no-op; the bridge does not react to lifecycle events.

--- a/sensor/common/centralbound/bridge.go
+++ b/sensor/common/centralbound/bridge.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
@@ -12,8 +11,6 @@ import (
 )
 
 const defaultBufferSize = 100
-
-var log = logging.LoggerForModule()
 
 // Bridge is a SensorComponent that subscribes to the CentralBound PubSub
 // topic and forwards received events to a ResponsesC channel. This allows

--- a/sensor/common/centralbound/bridge_bench_test.go
+++ b/sensor/common/centralbound/bridge_bench_test.go
@@ -1,0 +1,49 @@
+package centralbound
+
+// Benchmark for Central-bound bridge delivery through a real PubSub dispatcher.
+//
+//   go test -bench=Benchmark -benchmem -count=10 -run='^$' \
+//     ./sensor/common/centralbound/ > bench_bridge.txt
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+)
+
+func BenchmarkBridgeDelivery(b *testing.B) {
+	disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
+		},
+	))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer disp.Stop()
+
+	bridge, err := NewBridge(disp)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	evt := &CentralBoundEvent{Msg: message.New(&central.MsgFromSensor{})}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if err := disp.Publish(evt); err != nil {
+			b.Fatal(err)
+		}
+		for len(bridge.responsesC) == 0 {
+			runtime.Gosched()
+		}
+		<-bridge.responsesC
+	}
+}

--- a/sensor/common/centralbound/bridge_test.go
+++ b/sensor/common/centralbound/bridge_test.go
@@ -99,15 +99,18 @@ type wrongEvent struct{}
 func (w *wrongEvent) Topic() pubsub.Topic { return pubsub.CentralBoundTopic }
 func (w *wrongEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLane }
 
-func TestBridge_StopClosesChannel(t *testing.T) {
+func TestBridge_HandleEventAfterStopDoesNotPanic(t *testing.T) {
 	capturing := &capturingDispatcher{}
 	b, err := NewBridge(capturing)
 	require.NoError(t, err)
 
 	b.Stop()
 
-	_, open := <-b.ResponsesC()
-	assert.False(t, open, "ResponsesC must be closed after Stop()")
+	assert.NotPanics(t, func() {
+		_ = capturing.callback(&CentralBoundEvent{
+			Msg: message.New(&central.MsgFromSensor{}),
+		})
+	})
 }
 
 func TestBridge_ConcurrentPublish(t *testing.T) {

--- a/sensor/common/centralbound/bridge_test.go
+++ b/sensor/common/centralbound/bridge_test.go
@@ -1,0 +1,180 @@
+package centralbound
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingDispatcher struct {
+	consumerID pubsub.ConsumerID
+	topic      pubsub.Topic
+	laneID     pubsub.LaneID
+	callback   pubsub.EventCallback
+}
+
+func (c *capturingDispatcher) RegisterConsumer(_ pubsub.ConsumerID, _ pubsub.Topic, _ pubsub.EventCallback) error {
+	return nil
+}
+
+func (c *capturingDispatcher) RegisterConsumerToLane(id pubsub.ConsumerID, t pubsub.Topic, l pubsub.LaneID, cb pubsub.EventCallback) error {
+	c.consumerID = id
+	c.topic = t
+	c.laneID = l
+	c.callback = cb
+	return nil
+}
+
+func (c *capturingDispatcher) Publish(_ pubsub.Event) error { return nil }
+func (c *capturingDispatcher) Stop()                        {}
+
+func TestBridge_RegistrationWiring(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	assert.Equal(t, pubsub.CentralBoundBridgeConsumer, capturing.consumerID)
+	assert.Equal(t, pubsub.CentralBoundTopic, capturing.topic)
+	assert.Equal(t, pubsub.CentralBoundLane, capturing.laneID)
+	require.NotNil(t, capturing.callback)
+}
+
+func TestBridge_ReceivesEvent(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	msg := message.New(&central.MsgFromSensor{})
+	require.NoError(t, capturing.callback(&CentralBoundEvent{Msg: msg}))
+
+	select {
+	case received := <-b.ResponsesC():
+		assert.Same(t, msg, received)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout: expected message on ResponsesC")
+	}
+}
+
+func TestBridge_SkipsExpiredEvent(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, capturing.callback(&CentralBoundEvent{
+		Msg: message.NewExpiring(ctx, &central.MsgFromSensor{}),
+	}))
+
+	select {
+	case msg := <-b.ResponsesC():
+		t.Fatalf("expected no message, got %v", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBridge_RejectsWrongEventType(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	_, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	err = capturing.callback(&wrongEvent{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+type wrongEvent struct{}
+
+func (w *wrongEvent) Topic() pubsub.Topic { return pubsub.CentralBoundTopic }
+func (w *wrongEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLane }
+
+func TestBridge_StopClosesChannel(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	b.Stop()
+
+	_, open := <-b.ResponsesC()
+	assert.False(t, open, "ResponsesC must be closed after Stop()")
+}
+
+func TestBridge_ConcurrentPublish(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = capturing.callback(&CentralBoundEvent{
+				Msg: message.New(&central.MsgFromSensor{}),
+			})
+		}()
+	}
+
+	received := 0
+	done := make(chan struct{})
+	go func() {
+		for range b.ResponsesC() {
+			received++
+			if received == goroutines {
+				close(done)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	select {
+	case <-done:
+		assert.Equal(t, goroutines, received)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout: received %d/%d messages", received, goroutines)
+	}
+}
+
+func TestBridge_RealDispatcher(t *testing.T) {
+	disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
+		},
+	))
+	require.NoError(t, err)
+	defer disp.Stop()
+
+	b, err := NewBridge(disp)
+	require.NoError(t, err)
+
+	msg := message.New(&central.MsgFromSensor{})
+	require.NoError(t, disp.Publish(&CentralBoundEvent{Msg: msg}))
+
+	select {
+	case received := <-b.ResponsesC():
+		assert.Same(t, msg, received)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout: expected message on ResponsesC via real dispatcher")
+	}
+}
+
+func TestBridge_Name(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+	assert.Equal(t, "centralbound.Bridge", b.Name())
+}

--- a/sensor/common/centralbound/event.go
+++ b/sensor/common/centralbound/event.go
@@ -16,5 +16,8 @@ func (e *CentralBoundEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLan
 
 // IsExpired delegates to the wrapped message's context.
 func (e *CentralBoundEvent) IsExpired() bool {
+	if e.Msg == nil {
+		return false
+	}
 	return e.Msg.IsExpired()
 }

--- a/sensor/common/centralbound/event.go
+++ b/sensor/common/centralbound/event.go
@@ -1,0 +1,20 @@
+package centralbound
+
+import (
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// CentralBoundEvent wraps a message destined for Central as a PubSub event.
+// Components publish these instead of writing directly to their ResponsesC channel.
+type CentralBoundEvent struct {
+	Msg *message.ExpiringMessage
+}
+
+func (e *CentralBoundEvent) Topic() pubsub.Topic { return pubsub.CentralBoundTopic }
+func (e *CentralBoundEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLane }
+
+// IsExpired delegates to the wrapped message's context.
+func (e *CentralBoundEvent) IsExpired() bool {
+	return e.Msg.IsExpired()
+}

--- a/sensor/common/centralbound/event_test.go
+++ b/sensor/common/centralbound/event_test.go
@@ -1,0 +1,33 @@
+package centralbound
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCentralBoundEvent_TopicAndLane(t *testing.T) {
+	e := &CentralBoundEvent{Msg: message.New(nil)}
+	assert.Equal(t, pubsub.CentralBoundTopic, e.Topic())
+	assert.Equal(t, pubsub.CentralBoundLane, e.Lane())
+}
+
+func TestCentralBoundEvent_IsExpired(t *testing.T) {
+	t.Run("nil context is not expired", func(t *testing.T) {
+		e := &CentralBoundEvent{Msg: &message.ExpiringMessage{}}
+		assert.False(t, e.IsExpired())
+	})
+	t.Run("active context is not expired", func(t *testing.T) {
+		e := &CentralBoundEvent{Msg: message.New(nil)}
+		assert.False(t, e.IsExpired())
+	})
+	t.Run("cancelled context is expired", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		e := &CentralBoundEvent{Msg: message.NewExpiring(ctx, nil)}
+		assert.True(t, e.IsExpired())
+	})
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,7 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	CentralBoundBridgeConsumer
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		CentralBoundBridgeConsumer:             "CentralBoundBridge",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	CentralBoundLane
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		CentralBoundLane:               "CentralBound",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	CentralBoundTopic
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		CentralBoundTopic:               "CentralBound",
 	}
 )
 

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -10,18 +10,20 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
-type pubSubRegister interface {
+type pubSubDispatcher interface {
 	RegisterConsumerToLane(pubsub.ConsumerID, pubsub.Topic, pubsub.LaneID, pubsub.EventCallback) error
+	Publish(pubsub.Event) error
 }
 
 // New instantiates an output Queue component.
-func New(detector detector.Detector, queueSize int, dispatcher pubSubRegister) (component.OutputQueue, error) {
+func New(detector detector.Detector, queueSize int, dispatcher pubSubDispatcher) (component.OutputQueue, error) {
 	ch := make(chan *component.ResourceEvent, queueSize)
 	forwardQueue := make(chan *message.ExpiringMessage, queueSize)
 	outputQueue := &outputQueueImpl{
 		detector:     detector,
 		innerQueue:   ch,
 		forwardQueue: forwardQueue,
+		dispatcher:   dispatcher,
 		stopper:      concurrency.NewStopper(),
 	}
 	if features.SensorInternalPubSub.Enabled() {

--- a/sensor/kubernetes/eventpipeline/output/output_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_bench_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/centralbound"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
 	"github.com/stackrox/rox/sensor/common/pubsub/lane"
@@ -25,21 +27,29 @@ func benchOutputQueue(b *testing.B, pubsubEnabled bool, forwardCount int, makeEv
 	det.EXPECT().ReprocessDeployments(gomock.Any()).AnyTimes()
 	det.EXPECT().ProcessDeployment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	var disp testDispatcher
-	var reg pubSubRegister
+	var disp pubSubDispatcher
+	var responsesC <-chan *message.ExpiringMessage
 	if pubsubEnabled {
 		d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
 			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
 		}))
 		if err != nil {
 			b.Fatal(err)
 		}
 		b.Cleanup(d.Stop)
+
+		bridge, err := centralbound.NewBridge(d)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Cleanup(bridge.Stop)
+
 		disp = d
-		reg = d
+		responsesC = bridge.ResponsesC()
 	}
 
-	q, err := New(det, 1024, reg)
+	q, err := New(det, 1024, disp)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -47,6 +57,10 @@ func benchOutputQueue(b *testing.B, pubsubEnabled bool, forwardCount int, makeEv
 		b.Fatal(err)
 	}
 	b.Cleanup(q.Stop)
+
+	if !pubsubEnabled {
+		responsesC = q.ResponsesC()
+	}
 
 	b.ResetTimer()
 	for b.Loop() {
@@ -60,7 +74,7 @@ func benchOutputQueue(b *testing.B, pubsubEnabled bool, forwardCount int, makeEv
 			q.Send(event)
 		}
 		for range forwardCount {
-			<-q.ResponsesC()
+			<-responsesC
 		}
 	}
 }

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -53,9 +53,7 @@ func (q *outputQueueImpl) Start() error {
 // Stop the outputQueueImpl component
 func (q *outputQueueImpl) Stop() {
 	if features.SensorInternalPubSub.Enabled() {
-		// No goroutine was started; signal stopped so the Wait below returns immediately.
-		// TODO(ROX-35054): Remove stopper usage once ResponsesC is migrated to PubSub.
-		q.stopper.Flow().ReportStopped()
+		return
 	}
 	if !q.stopper.Client().Stopped().IsDone() {
 		defer func() {
@@ -68,11 +66,6 @@ func (q *outputQueueImpl) Stop() {
 // ProcessResourceEvent is the PubSub callback invoked by the dispatcher when a resolved
 // resource event is published by the resolver (ResolvedResourceEventTopic).
 func (q *outputQueueImpl) ProcessResourceEvent(event pubsub.Event) error {
-	select {
-	case <-q.stopper.Flow().StopRequested():
-		return nil
-	default:
-	}
 	msg, ok := event.(*component.ResourceEvent)
 	if !ok {
 		return errors.New("unable to convert event to *component.ResourceEvent")

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common/centralbound"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/metrics"
@@ -14,10 +16,13 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
+var log = logging.LoggerForModule()
+
 type outputQueueImpl struct {
 	innerQueue   chan *component.ResourceEvent
 	forwardQueue chan *message.ExpiringMessage
 	detector     detector.Detector
+	dispatcher   pubSubDispatcher
 	stopper      concurrency.Stopper
 }
 
@@ -28,8 +33,12 @@ func (q *outputQueueImpl) Send(msg *component.ResourceEvent) {
 	metrics.IncOutputChannelSize()
 }
 
-// ResponsesC returns the MsgFromSensor channel
+// ResponsesC returns the MsgFromSensor channel. In PubSub mode, messages are
+// published to the CentralBound topic instead, so this returns nil.
 func (q *outputQueueImpl) ResponsesC() <-chan *message.ExpiringMessage {
+	if features.SensorInternalPubSub.Enabled() {
+		return nil
+	}
 	return q.forwardQueue
 }
 
@@ -78,7 +87,14 @@ func (q *outputQueueImpl) processMsg(msg *component.ResourceEvent) bool {
 	}
 	for _, resourceUpdates := range msg.ForwardMessages {
 		expiringMessage := message.NewExpiring(msg.Context, wrapSensorEvent(resourceUpdates))
-		if !expiringMessage.IsExpired() {
+		if expiringMessage.IsExpired() {
+			continue
+		}
+		if features.SensorInternalPubSub.Enabled() {
+			if err := q.dispatcher.Publish(&centralbound.CentralBoundEvent{Msg: expiringMessage}); err != nil {
+				log.Errorf("Failed to publish central-bound event: %v", err)
+			}
+		} else {
 			select {
 			case q.forwardQueue <- expiringMessage:
 			case <-q.stopper.Flow().StopRequested():

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/centralbound"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
@@ -20,20 +21,14 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// testDispatcher extends pubSubRegister with Publish and Stop so tests can
-// send events through the real dispatcher machinery.
-type testDispatcher interface {
-	pubSubRegister
-	Publish(pubsub.Event) error
-	Stop()
-}
-
-// outputTestEnv bundles the output queue, its dispatcher (if pubsub), and a
-// helper to send events through the correct path.
+// outputTestEnv bundles the output queue, its dispatcher (if pubsub), and the
+// central-bound bridge so tests can send events through the correct path and
+// read back forwarded messages regardless of mode.
 type outputTestEnv struct {
 	queue    component.OutputQueue
 	pubsub   bool
-	dispatch testDispatcher
+	dispatch pubSubDispatcher
+	bridge   *centralbound.Bridge
 }
 
 func newOutputTestEnv(t *testing.T, det *mocks.MockDetector, pubsubEnabled bool, queueSize int) *outputTestEnv {
@@ -41,13 +36,20 @@ func newOutputTestEnv(t *testing.T, det *mocks.MockDetector, pubsubEnabled bool,
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
 
 	env := &outputTestEnv{pubsub: pubsubEnabled}
-	var reg pubSubRegister
+	var reg pubSubDispatcher
 	if pubsubEnabled {
 		d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
 			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
 		}))
 		require.NoError(t, err)
 		t.Cleanup(d.Stop)
+
+		bridge, err := centralbound.NewBridge(d)
+		require.NoError(t, err)
+		env.bridge = bridge
+		t.Cleanup(bridge.Stop)
+
 		env.dispatch = d
 		reg = d
 	}
@@ -65,6 +67,13 @@ func (e *outputTestEnv) send(t *testing.T, event *component.ResourceEvent) {
 	} else {
 		e.queue.Send(event)
 	}
+}
+
+func (e *outputTestEnv) responsesC() <-chan *message.ExpiringMessage {
+	if e.pubsub {
+		return e.bridge.ResponsesC()
+	}
+	return e.queue.ResponsesC()
 }
 
 func shouldHaveForwarded(t *testing.T, ch <-chan *message.ExpiringMessage) {
@@ -130,7 +139,7 @@ func Test_OutputQueue_ExpiringMessages(t *testing.T) {
 
 					env.send(t, tc.message)
 					synctest.Wait()
-					tc.assertion(t, env.queue.ResponsesC())
+					tc.assertion(t, env.responsesC())
 				})
 			})
 		}
@@ -182,7 +191,7 @@ func Test_OutputQueue_ForwardMessages(t *testing.T) {
 
 					env.send(t, tc.message)
 					synctest.Wait()
-					tc.assertion(t, env.queue.ResponsesC())
+					tc.assertion(t, env.responsesC())
 				})
 			})
 		}
@@ -236,6 +245,7 @@ func Test_ProcessResourceEvent_WrongType(t *testing.T) {
 
 	d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
 		lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+		lane.NewBlockingLane(pubsub.CentralBoundLane),
 	}))
 	require.NoError(t, err)
 	t.Cleanup(d.Stop)
@@ -258,9 +268,14 @@ func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
 
 		d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
 			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
 		}))
 		require.NoError(t, err)
 		t.Cleanup(d.Stop)
+
+		bridge, err := centralbound.NewBridge(d)
+		require.NoError(t, err)
+		defer bridge.Stop()
 
 		q, err := New(det, 10, d)
 		assert.NoError(t, err)
@@ -274,6 +289,15 @@ func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
 		event.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
 		assert.NoError(t, d.Publish(event))
 		synctest.Wait()
-		shouldNotHaveForwarded(t, q.ResponsesC())
+		shouldNotHaveForwarded(t, bridge.ResponsesC())
 	})
+}
+
+func Test_OutputQueue_PubSubEnabled_ResponsesCReturnsNil(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	ctrl := gomock.NewController(t)
+	det := mocks.NewMockDetector(ctrl)
+
+	env := newOutputTestEnv(t, det, true, 10)
+	assert.Nil(t, env.queue.ResponsesC(), "ResponsesC must return nil in PubSub mode")
 }

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -260,36 +260,24 @@ func Test_ProcessResourceEvent_WrongType(t *testing.T) {
 	assert.ErrorContains(t, err, "unable to convert event to *component.ResourceEvent")
 }
 
-func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
+func Test_PubSubEnabled_StopIsNoOp(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 		ctrl := gomock.NewController(t)
 		det := mocks.NewMockDetector(ctrl)
+		det.EXPECT().ReprocessDeployments()
 
-		d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
-			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
-			lane.NewBlockingLane(pubsub.CentralBoundLane),
-		}))
-		require.NoError(t, err)
-		t.Cleanup(d.Stop)
+		env := newOutputTestEnv(t, det, true, 10)
+		require.NoError(t, env.queue.Start())
 
-		bridge, err := centralbound.NewBridge(d)
-		require.NoError(t, err)
-		defer bridge.Stop()
+		env.queue.Stop()
 
-		q, err := New(det, 10, d)
-		assert.NoError(t, err)
-		assert.NoError(t, q.Start())
-		q.Stop()
-
-		event := &component.ResourceEvent{
+		env.send(t, &component.ResourceEvent{
 			Context:         context.Background(),
 			ForwardMessages: []*central.SensorEvent{{Id: "x"}},
-		}
-		event.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
-		assert.NoError(t, d.Publish(event))
+		})
 		synctest.Wait()
-		shouldNotHaveForwarded(t, bridge.ResponsesC())
+		shouldHaveForwarded(t, env.responsesC())
 	})
 }
 

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -80,8 +80,12 @@ func (p *eventPipeline) ProcessMessage(_ context.Context, msg *central.MsgToSens
 	return nil
 }
 
-// ResponsesC implements common.SensorComponent
+// ResponsesC implements common.SensorComponent. In PubSub mode, messages are
+// published to the CentralBound topic via the output queue, so this returns nil.
 func (p *eventPipeline) ResponsesC() <-chan *message.ExpiringMessage {
+	if features.SensorInternalPubSub.Enabled() {
+		return nil
+	}
 	return p.eventsC
 }
 
@@ -117,12 +121,17 @@ func (p *eventPipeline) Start() error {
 		return errors.Wrap(err, "starting resolver component")
 	}
 
-	go p.forwardMessages()
+	if !features.SensorInternalPubSub.Enabled() {
+		go p.forwardMessages()
+	}
 	return nil
 }
 
 // Stop implements common.SensorComponent
 func (p *eventPipeline) Stop() {
+	if features.SensorInternalPubSub.Enabled() {
+		p.stopper.Flow().ReportStopped()
+	}
 	if !p.stopper.Client().Stopped().IsDone() {
 		defer func() {
 			_ = p.stopper.Client().Stopped().Wait()

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -99,6 +99,8 @@ func (s *eventPipelineSuite) readExpired() {
 }
 
 func (s *eventPipelineSuite) Test_OfflineModeCases() {
+	s.T().Setenv(features.SensorInternalPubSub.EnvVar(), "false")
+
 	outputC := make(chan *message.ExpiringMessage, 10)
 	s.outputQueue.EXPECT().ResponsesC().
 		AnyTimes().Return(outputC)
@@ -132,6 +134,8 @@ func (s *eventPipelineSuite) Test_OfflineModeCases() {
 }
 
 func (s *eventPipelineSuite) Test_OfflineMode() {
+	s.T().Setenv(features.SensorInternalPubSub.EnvVar(), "false")
+
 	outputC := make(chan *message.ExpiringMessage, 10)
 	s.outputQueue.EXPECT().ResponsesC().
 		AnyTimes().Return(outputC)

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,7 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sensor/queue"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
+	"github.com/stackrox/rox/sensor/common/centralbound"
 	"github.com/stackrox/rox/sensor/common/compliance"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/configmap"
@@ -201,6 +202,14 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		imageService,
 		enhancer,
 		complianceService,
+	}
+
+	if features.SensorInternalPubSub.Enabled() {
+		centralBoundBridge, err := centralbound.NewBridge(internalMessageDispatcher)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating central-bound bridge")
+		}
+		components = append(components, centralBoundBridge)
 	}
 
 	var virtualMachineHandler vmIndex.Handler


### PR DESCRIPTION
## Description
  Follow-up to ROX-34880. Migrates the output queue's `ResponsesC` channel to PubSub and removes the stopper from the PubSub code path.

  **Problem**: In the PubSub path, `outputQueueImpl` still relied on a `concurrency.Stopper` for lifecycle management — a leftover from the legacy goroutine-based design.
  `Stop()` had to manually call `ReportStopped()` as a workaround since no goroutine was started.

  **Solution**: `processMsg` now publishes a `ForwardEvent` via the dispatcher instead of writing to the `forwardQueue` channel. The event pipeline registers as a consumer
  of `OutputForwardTopic` and bridges messages into a `pubsubForwardC` channel that `forwardMessages` reads from. This eliminates the stopper from the PubSub path
  entirely — `Stop()` becomes a no-op and `ProcessResourceEvent` no longer checks `StopRequested()`.

  The legacy channel path is unchanged. No alternative approaches were considered — this was the planned follow-up outlined in the ROX-35054 TODO left by ROX-34880.

  > [!NOTE]
  > This change was partially generated with the help of AI.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a
  [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [ ] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - All output queue and event pipeline unit tests pass with both `ROX_SENSOR_PUBSUB=true` and `false`
  - Race detector clean
  - Benchmarks confirm PubSub forwarding path works end-to-end
  - 
## Edit (2026-07-09)
  
  Rebased on top of ROX-35647 → ROX-35640. Both must merge before this PR is viable.

  With `ResponsesC` migrated to the Central-bound PubSub bridge, the stopper in the output queue's PubSub path is no longer needed. `Stop()` is now a
  no-op in PubSub mode — lifecycle is managed by the dispatcher's lane, not the stopper. The stop guard in `ProcessResourceEvent` is removed for the
  same reason.