### PR TITLE
ROX-35606: feat(helm): add redHatSigningKeyBundle value

### DIFF
--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -85,6 +85,7 @@ central:
       configMaps: null # [string]
       secrets: null # [string]
   extraMounts: null # [dict]
+  redHatSigningKeyBundle: null # string
   db:
     nodeSelector: null # string | dict
     tolerations: null # [dict]

--- a/image/templates/helm/stackrox-central/templates/00-redhat-signing-key-bundle.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/00-redhat-signing-key-bundle.yaml.htpl
@@ -1,0 +1,20 @@
+{{- include "srox.init" . -}}
+
+{{- if ._rox.central.redHatSigningKeyBundle }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redhat-signing-key-bundle
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "srox.labels" (list . "configmap" "redhat-signing-key-bundle") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "configmap" "redhat-signing-key-bundle") | nindent 4 }}
+    [<- if not .Operator >]
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/resource-policy": keep
+    [<- end >]
+data:
+  bundle.json: |
+    {{- ._rox.central.redHatSigningKeyBundle | nindent 4 }}
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -194,6 +194,11 @@ spec:
           mountPath: /var/run/secrets/openshift/serviceaccount
           readOnly: true
         {{- end }}
+        {{- if ._rox.central.redHatSigningKeyBundle }}
+        - name: redhat-signing-key-bundle
+          mountPath: /tmp/redhat-signing-keys/
+          readOnly: true
+        {{- end }}
         {{- if ._rox.central.notifierSecretsEncryption }}
         {{- if ._rox.central.notifierSecretsEncryption.enabled }}
         - name: central-encryption-key-chain
@@ -282,6 +287,12 @@ spec:
               path: token
               audience: openshift
               expirationSeconds: 3600
+      {{- end }}
+      {{- if ._rox.central.redHatSigningKeyBundle }}
+      - name: redhat-signing-key-bundle
+        configMap:
+          name: redhat-signing-key-bundle
+          optional: true
       {{- end }}
       {{- if ._rox.central.notifierSecretsEncryption }}
       {{- if ._rox.central.notifierSecretsEncryption.enabled }}

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -239,6 +239,13 @@
 #       mount:
 #         mountPath: /etc/my-config-data
 #
+#     # Red Hat signing key bundle for offline environments. When set, the bundle
+#     # JSON is mounted read-only into Central at /tmp/redhat-signing-keys/ for
+#     # image signature verification. The expected format is:
+#     #   {"keys": [{"name": "<key-name>", "type": "cosign", "pem": "<PEM>"}]}
+#     # Use --set-file central.redHatSigningKeyBundle=bundle.json
+#     redHatSigningKeyBundle: null
+#
 #   # Public configuration options for the StackRox Central DB:
 #   db:
 #     # If you want to enforce StackRox Central DB to only run on certain nodes, you can specify

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/redhat-signing-key-bundle.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/redhat-signing-key-bundle.test.yaml
@@ -1,0 +1,57 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+tests:
+- name: "ConfigMap is not created with default settings"
+  expect: |
+    .configmaps["redhat-signing-key-bundle"] | assertThat(. == null)
+
+- name: "ConfigMap is not created with empty string"
+  set:
+    central.redHatSigningKeyBundle: ""
+  expect: |
+    .configmaps["redhat-signing-key-bundle"] | assertThat(. == null)
+    [.deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.mountPath == "/tmp/redhat-signing-keys/")] | assertThat(length == 0)
+
+- name: "No volume mount at /tmp/redhat-signing-keys with default settings"
+  expect: |
+    [.deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.mountPath == "/tmp/redhat-signing-keys/")] | assertThat(length == 0)
+
+- name: "ConfigMap is created when redHatSigningKeyBundle is set"
+  values:
+    central:
+      redHatSigningKeyBundle: |
+        {"keys": [{"name": "test-key", "pem": "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----\n"}]}
+  expect: |
+    .configmaps["redhat-signing-key-bundle"] | assertThat(. != null)
+    .configmaps["redhat-signing-key-bundle"].data["bundle.json"] | assertThat(contains("test-key"))
+
+- name: "Volume mount is added when redHatSigningKeyBundle is set"
+  values:
+    central:
+      redHatSigningKeyBundle: |
+        {"keys": [{"name": "test-key", "pem": "test"}]}
+  expect: |
+    .deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(. != null)
+    .deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(.mountPath == "/tmp/redhat-signing-keys/")
+    .deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(.readOnly == true)
+
+- name: "Volume definition references the ConfigMap with optional"
+  values:
+    central:
+      redHatSigningKeyBundle: |
+        {"keys": [{"name": "test-key", "pem": "test"}]}
+  expect: |
+    .deployments.central.spec.template.spec.volumes[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(. != null)
+    .deployments.central.spec.template.spec.volumes[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(.configMap != null)
+    .deployments.central.spec.template.spec.volumes[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(.configMap.name == "redhat-signing-key-bundle")
+    .deployments.central.spec.template.spec.volumes[]
+      | select(.name == "redhat-signing-key-bundle") | assertThat(.configMap.optional == true)


### PR DESCRIPTION
## Description

Add a Helm value `central.redHatSigningKeyBundle` that accepts signing key
bundle JSON content. When set, the chart creates a ConfigMap
`redhat-signing-key-bundle` and mounts it read-only at
`/tmp/redhat-signing-keys/` in the Central container, where the existing
file watcher reads from. This enables offline/air-gapped customers to
inject a Red Hat signing key bundle at install/upgrade time that persists
across pod restarts.

No Go code changes. The existing watcher at
`central/signatureintegration/datastore/key_bundle.go` already polls this
path.

**User workflow:**
```bash
helm install stackrox-central-services ... \
  --set-file central.redHatSigningKeyBundle=bundle.json
```

The ConfigMap uses `helm.sh/resource-policy: keep` to persist across
upgrades (same pattern as `additional-ca`).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- 6 helmtest cases pass (default, empty string, ConfigMap creation, volume mount, volume definition, no-mount default)
- In-cluster on ga-ocp4-cron: created ConfigMap manually, patched deployment, verified mount at `/tmp/redhat-signing-keys/bundle.json`, Central watcher logged `Updated Red Hat signature integration with 1 key(s) from bundle: [release-key-3]`
- Central pod healthy after mount

Partially generated by AI.