### PR TITLE
fix: log index create in backgroundmigration on debug lvl

### DIFF
--- a/pkg/postgres/schema/all.go
+++ b/pkg/postgres/schema/all.go
@@ -141,7 +141,7 @@ func ApplyAllIndexes(ctx context.Context, db postgres.DB, stmtTimeout time.Durat
 	}
 
 	log.Infof("Reconciling %d indexes: %d exist, %d invalid, %d to create",
-		len(desired), len(desired)-len(toCreate), len(toDrop), len(toCreate))
+			len(desired), len(desired)-len(toCreate), len(toDrop), len(toCreate))
 
 	for _, idx := range toDrop {
 		if err := dropInvalidIndex(ctx, db, idx.Name, stmtTimeout); err != nil {
@@ -150,7 +150,7 @@ func ApplyAllIndexes(ctx context.Context, db postgres.DB, stmtTimeout time.Durat
 	}
 
 	for _, idx := range toCreate {
-		log.Infof("Creating index: %s", idx.Name)
+		log.Debugf("Creating index: %s", idx.Name)
 		stmtCtx, cancel := context.WithTimeout(ctx, stmtTimeout)
 		_, err := db.Exec(stmtCtx, idx.CreateSQL)
 		cancel()

--- a/pkg/postgres/schema/all.go
+++ b/pkg/postgres/schema/all.go
@@ -141,7 +141,7 @@ func ApplyAllIndexes(ctx context.Context, db postgres.DB, stmtTimeout time.Durat
 	}
 
 	log.Infof("Reconciling %d indexes: %d exist, %d invalid, %d to create",
-			len(desired), len(desired)-len(toCreate), len(toDrop), len(toCreate))
+		len(desired), len(desired)-len(toCreate), len(toDrop), len(toCreate))
 
 	for _, idx := range toDrop {
 		if err := dropInvalidIndex(ctx, db, idx.Name, stmtTimeout); err != nil {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The log for reconciling indexes is causing a lot of noise in PSQL integration tests, because it's printing on every test setup. This PR moves it to debug log level.

```
pkg/postgres/schema: 2026/07/06 06:05:38.677590 all.go:153: Info: Creating index: clustercveedges_cveid
pkg/postgres/schema: 2026/07/06 06:05:38.678664 all.go:153: Info: Creating index: complianceintegrations_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.679935 all.go:153: Info: Creating index: complianceoperatorscanconfigurationv2clusters_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.681345 all.go:153: Info: Creating index: complianceoperatorprofilev2_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.682585 all.go:153: Info: Creating index: complianceoperatorscanv2_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.683746 all.go:153: Info: Creating index: complianceoperatorrulev2_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.685045 all.go:153: Info: Creating index: complianceoperatorcheckresultv2_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.687429 all.go:153: Info: Creating index: complianceoperatorclusterscanconfigstatuses_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.688305 all.go:153: Info: Creating index: complianceoperatorremediationv2_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.689601 all.go:153: Info: Creating index: complianceoperatorscansettingbindingv2_sac_filter
pkg/postgres/schema: 2026/07/06 06:05:38.690966 all.go:153: Info: Creating index: 
...
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
