### PR TITLE
chore(ci): Remove `dispatch-` from e2e GHA job names

### DIFF
--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -139,7 +139,7 @@ jobs:
           rhacs-eng/stackrox-operator-bundle:v${{ env.operator_tag }}
           rhacs-eng/stackrox-operator:${{ env.operator_tag }}
 
-  dispatch-e2e-byodb-test:
+  e2e-byodb-test:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-byodb-test.yaml
     with:
@@ -150,7 +150,7 @@ jobs:
       group: e2e-byodb-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  dispatch-e2e-db-backup-restore-test:
+  e2e-db-backup-restore-test:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-db-backup-restore-test.yaml
     with:
@@ -161,7 +161,7 @@ jobs:
       group: e2e-db-backup-restore-test-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  dispatch-e2e-gke-upgrade-tests:
+  e2e-gke-upgrade-tests:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-gke-upgrade-tests.yaml
     with:
@@ -172,7 +172,7 @@ jobs:
       group: e2e-gke-upgrade-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
-  dispatch-e2e-nongroovy-tests:
+  e2e-nongroovy-tests:
     needs: [ wait-for-images, should-dispatch ]
     uses: ./.github/workflows/e2e-nongroovy-tests.yaml
     with:


### PR DESCRIPTION
## Description

This would unblock configuring branch protection rules.

Context: https://redhat-internal.slack.com/archives/C0321S70YK1/p1783351501680789?thread_ts=1781279714.665499&cid=C0321S70YK1

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Nope.

### How I validated my change

Did not. Will only check job names in CI.