### PR TITLE
ROX-36257: Add PostgreSQL LISTEN/NOTIFY infrastructure

### DIFF
--- a/pkg/postgres/notify/channels.go
+++ b/pkg/postgres/notify/channels.go
@@ -1,0 +1,7 @@
+package notify
+
+const (
+	ReportConfigChanged    = "report_config_changed"
+	ReportRequestSubmitted = "report_request_submitted"
+	ReportRequestCancelled = "report_request_cancelled"
+)

--- a/pkg/postgres/notify/listener.go
+++ b/pkg/postgres/notify/listener.go
@@ -63,7 +63,7 @@ func (l *Listener) listenLoop(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("acquiring connection: %w", err)
 	}
-	defer conn.Close(context.Background())
+	defer func() { _ = conn.Close(context.Background()) }()
 
 	for _, ch := range l.channels {
 		if _, err := conn.Exec(ctx, "LISTEN "+pgx.Identifier{ch}.Sanitize()); err != nil {

--- a/pkg/postgres/notify/listener.go
+++ b/pkg/postgres/notify/listener.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -20,7 +21,7 @@ const reconnectDelay = 5 * time.Second
 type Handler func(channel, payload string)
 
 // Listener listens on one or more PostgreSQL NOTIFY channels and dispatches
-// notifications to a handler. It holds a dedicated connection from the pool
+// notifications to a handler. It holds a dedicated connection outside the pool
 // for the lifetime of the listener and automatically reconnects on failure.
 type Listener struct {
 	db       postgres.DB
@@ -58,19 +59,14 @@ func (l *Listener) Listen(ctx context.Context) {
 }
 
 func (l *Listener) listenLoop(ctx context.Context) error {
-	conn, err := l.db.Acquire(ctx)
+	conn, err := hijackConn(ctx, l.db)
 	if err != nil {
 		return fmt.Errorf("acquiring connection: %w", err)
 	}
-	defer conn.Release()
-
-	pgxConn, err := underlyingConn(conn)
-	if err != nil {
-		return err
-	}
+	defer conn.Close(context.Background())
 
 	for _, ch := range l.channels {
-		if _, err := pgxConn.Exec(ctx, "LISTEN "+ch); err != nil {
+		if _, err := conn.Exec(ctx, "LISTEN "+pgx.Identifier{ch}.Sanitize()); err != nil {
 			return fmt.Errorf("LISTEN %s: %w", ch, err)
 		}
 	}
@@ -78,7 +74,7 @@ func (l *Listener) listenLoop(ctx context.Context) error {
 	log.Infof("Notification listener started on channels: %v", l.channels)
 
 	for {
-		notification, err := pgxConn.WaitForNotification(ctx)
+		notification, err := conn.WaitForNotification(ctx)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -92,18 +88,23 @@ func (l *Listener) listenLoop(ctx context.Context) error {
 func (l *Listener) dispatchNotification(n *pgconn.Notification) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("Panic in notification handler for channel %q: %v", n.Channel, r)
+			log.Errorf("Panic in notification handler for channel %q: %v\n%s", n.Channel, r, debug.Stack())
 		}
 	}()
 	l.handler(n.Channel, n.Payload)
 }
 
-// underlyingConn extracts the *pgx.Conn from the pool wrapper.
-// pgxpool.Conn exposes .Conn() which returns the underlying *pgx.Conn
-// that has WaitForNotification.
-func underlyingConn(conn *postgres.Conn) (*pgx.Conn, error) {
-	if c, ok := conn.PgxPoolConn.(*pgxpool.Conn); ok {
-		return c.Conn(), nil
+// hijackConn acquires a connection from the pool and permanently removes it
+// via Hijack. The caller owns the returned *pgx.Conn and must close it.
+func hijackConn(ctx context.Context, db postgres.DB) (*pgx.Conn, error) {
+	poolConn, err := db.Acquire(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("cannot extract *pgx.Conn from connection wrapper (type: %T)", conn.PgxPoolConn)
+	c, ok := poolConn.PgxPoolConn.(*pgxpool.Conn)
+	if !ok {
+		poolConn.Release()
+		return nil, fmt.Errorf("cannot hijack connection (type: %T)", poolConn.PgxPoolConn)
+	}
+	return c.Hijack(), nil
 }

--- a/pkg/postgres/notify/listener.go
+++ b/pkg/postgres/notify/listener.go
@@ -1,0 +1,109 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+var log = logging.LoggerForModule()
+
+const reconnectDelay = 5 * time.Second
+
+// Handler is called for each notification received on a listened channel.
+type Handler func(channel, payload string)
+
+// Listener listens on one or more PostgreSQL NOTIFY channels and dispatches
+// notifications to a handler. It holds a dedicated connection from the pool
+// for the lifetime of the listener and automatically reconnects on failure.
+type Listener struct {
+	db       postgres.DB
+	channels []string
+	handler  Handler
+}
+
+// NewListener creates a Listener that will LISTEN on the given channels and
+// call handler for each notification received.
+func NewListener(db postgres.DB, handler Handler, channels ...string) *Listener {
+	return &Listener{
+		db:       db,
+		channels: channels,
+		handler:  handler,
+	}
+}
+
+// Listen blocks until ctx is cancelled, listening for notifications and
+// dispatching them to the handler. It reconnects automatically on connection
+// loss.
+func (l *Listener) Listen(ctx context.Context) {
+	for {
+		if err := l.listenLoop(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Errorf("Notification listener error: %v, reconnecting in %v", err, reconnectDelay)
+			select {
+			case <-time.After(reconnectDelay):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+func (l *Listener) listenLoop(ctx context.Context) error {
+	conn, err := l.db.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring connection: %w", err)
+	}
+	defer conn.Release()
+
+	pgxConn, err := underlyingConn(conn)
+	if err != nil {
+		return err
+	}
+
+	for _, ch := range l.channels {
+		if _, err := pgxConn.Exec(ctx, "LISTEN "+ch); err != nil {
+			return fmt.Errorf("LISTEN %s: %w", ch, err)
+		}
+	}
+
+	log.Infof("Notification listener started on channels: %v", l.channels)
+
+	for {
+		notification, err := pgxConn.WaitForNotification(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("waiting for notification: %w", err)
+		}
+		l.dispatchNotification(notification)
+	}
+}
+
+func (l *Listener) dispatchNotification(n *pgconn.Notification) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("Panic in notification handler for channel %q: %v", n.Channel, r)
+		}
+	}()
+	l.handler(n.Channel, n.Payload)
+}
+
+// underlyingConn extracts the *pgx.Conn from the pool wrapper.
+// pgxpool.Conn exposes .Conn() which returns the underlying *pgx.Conn
+// that has WaitForNotification.
+func underlyingConn(conn *postgres.Conn) (*pgx.Conn, error) {
+	if c, ok := conn.PgxPoolConn.(*pgxpool.Conn); ok {
+		return c.Conn(), nil
+	}
+	return nil, fmt.Errorf("cannot extract *pgx.Conn from connection wrapper (type: %T)", conn.PgxPoolConn)
+}

--- a/pkg/postgres/notify/listener_test.go
+++ b/pkg/postgres/notify/listener_test.go
@@ -1,0 +1,158 @@
+//go:build sql_integration
+
+package notify
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stretchr/testify/suite"
+)
+
+type ListenNotifySuite struct {
+	suite.Suite
+	pool postgres.DB
+	ctx  context.Context
+}
+
+func TestListenNotifySuite(t *testing.T) {
+	suite.Run(t, new(ListenNotifySuite))
+}
+
+func (s *ListenNotifySuite) SetupTest() {
+	s.ctx = context.Background()
+	source := pgtest.GetConnectionString(s.T())
+	config, err := postgres.ParseConfig(source)
+	s.Require().NoError(err)
+	pool, err := postgres.New(s.ctx, config)
+	s.Require().NoError(err)
+	s.pool = pool
+}
+
+func (s *ListenNotifySuite) TearDownTest() {
+	if s.pool != nil {
+		s.pool.Close()
+	}
+}
+
+func (s *ListenNotifySuite) TestNotifyAndReceive() {
+	received := make(chan struct {
+		channel string
+		payload string
+	}, 1)
+
+	handler := func(channel, payload string) {
+		received <- struct {
+			channel string
+			payload string
+		}{channel, payload}
+	}
+
+	listener := NewListener(s.pool, handler, "test_channel")
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	go listener.Listen(ctx)
+
+	// Give the listener time to connect and register LISTEN.
+	time.Sleep(200 * time.Millisecond)
+
+	err := Notify(s.ctx, s.pool, "test_channel", "hello")
+	s.Require().NoError(err)
+
+	select {
+	case msg := <-received:
+		s.Equal("test_channel", msg.channel)
+		s.Equal("hello", msg.payload)
+	case <-time.After(5 * time.Second):
+		s.Fail("timed out waiting for notification")
+	}
+}
+
+func (s *ListenNotifySuite) TestMultipleChannels() {
+	received := make(chan struct {
+		channel string
+		payload string
+	}, 10)
+
+	handler := func(channel, payload string) {
+		received <- struct {
+			channel string
+			payload string
+		}{channel, payload}
+	}
+
+	listener := NewListener(s.pool, handler, "chan_a", "chan_b")
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	go listener.Listen(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	s.Require().NoError(Notify(s.ctx, s.pool, "chan_a", "msg_a"))
+	s.Require().NoError(Notify(s.ctx, s.pool, "chan_b", "msg_b"))
+
+	messages := make(map[string]string)
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-received:
+			messages[msg.channel] = msg.payload
+		case <-time.After(5 * time.Second):
+			s.Fail("timed out waiting for notification")
+		}
+	}
+
+	s.Equal("msg_a", messages["chan_a"])
+	s.Equal("msg_b", messages["chan_b"])
+}
+
+func (s *ListenNotifySuite) TestUnrelatedChannelIgnored() {
+	received := make(chan string, 1)
+
+	handler := func(channel, payload string) {
+		received <- payload
+	}
+
+	listener := NewListener(s.pool, handler, "my_channel")
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	go listener.Listen(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	s.Require().NoError(Notify(s.ctx, s.pool, "other_channel", "should_not_see"))
+
+	select {
+	case <-received:
+		s.Fail("should not have received notification on unrelated channel")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+func (s *ListenNotifySuite) TestContextCancellationStopsListener() {
+	handler := func(channel, payload string) {}
+
+	listener := NewListener(s.pool, handler, "stop_test")
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	done := make(chan struct{})
+	go func() {
+		listener.Listen(ctx)
+		close(done)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		s.Fail("listener did not stop after context cancellation")
+	}
+}

--- a/pkg/postgres/notify/notifier.go
+++ b/pkg/postgres/notify/notifier.go
@@ -1,0 +1,18 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// Notify sends a notification on the given channel with the given payload.
+// The notification is delivered to any connections currently LISTENing on the channel.
+func Notify(ctx context.Context, db postgres.DB, channel, payload string) error {
+	_, err := db.Exec(ctx, "SELECT pg_notify($1, $2)", channel, payload)
+	if err != nil {
+		return fmt.Errorf("pg_notify on channel %q: %w", channel, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Adds a reusable `pkg/postgres/notify` package for inter-process coordination via PostgreSQL pub-sub channels. This is the foundation for Central-to-worker communication without gRPC.

- `Listener`: acquires a dedicated connection from the pool, runs LISTEN, dispatches notifications via callback, auto-reconnects on connection loss
- `Notify()`: wraps `pg_notify()` for sending notifications
- Channel constants for report config changes and request submission/cancellation
- Integration tests (`sql_integration` build tag)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Package compiles and passes `go vet`. Integration tests cover: notify/receive round-trip, multiple channels, channel isolation, and context cancellation.

Part 1 of 8 in the central-worker PR stack for ROX-32705.