### PR TITLE
ROX-36258: Add central-worker binary skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,6 +501,7 @@ main-build-dockerized: build-volumes
 main-build-nodeps:
 	$(GOBUILD) \
 		central \
+		central/worker \
 		compliance/cmd/compliance \
 		config-controller \
 		migrator \
@@ -681,6 +682,7 @@ docker-build-roxctl-image:
 copy-go-binaries-to-image-dir:
 	cp bin/linux_$(GOARCH)/central image/rhel/bin/central
 	cp bin/linux_$(GOARCH)/config-controller image/rhel/bin/config-controller
+	cp bin/linux_$(GOARCH)/worker image/rhel/bin/central-worker
 ifdef CI
 	cp bin/linux_amd64/roxctl image/rhel/bin/roxctl-linux-amd64
 	cp bin/linux_arm64/roxctl image/rhel/bin/roxctl-linux-arm64

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/stackrox/rox/central/version"
+	vStore "github.com/stackrox/rox/central/version/store"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgconfig"
+	"github.com/stackrox/rox/pkg/premain"
+	"github.com/stackrox/rox/pkg/retry"
+)
+
+const (
+	dbOpenRetries         = 10
+	dbTimeBetweenRetries  = 10 * time.Second
+	healthAddr            = ":8082"
+)
+
+var log = logging.LoggerForModule()
+
+func main() {
+	premain.StartMain()
+
+	log.Infof("Starting central-worker")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db := initDB(ctx)
+	defer db.Close()
+
+	ensureDBCurrent(db)
+
+	healthSrv := startHealthServer()
+
+	log.Infof("central-worker is ready")
+
+	waitForTerminationSignal()
+
+	log.Infof("central-worker shutting down")
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := healthSrv.Shutdown(shutdownCtx); err != nil {
+		log.Errorf("Health server shutdown error: %v", err)
+	}
+}
+
+func initDB(ctx context.Context) postgres.DB {
+	_, dbConfig, err := pgconfig.GetPostgresConfig()
+	if err != nil {
+		log.Fatalf("Could not parse postgres config: %v", err)
+	}
+
+	if !pgconfig.IsExternalDatabase() {
+		activeDB := pgconfig.GetActiveDB()
+		dbConfig.ConnConfig.Database = activeDB
+	}
+
+	poolMaxConns := env.RegisterIntegerSetting("ROX_WORKER_DB_POOL_MAX_CONNS", 20)
+	dbConfig.MaxConns = int32(poolMaxConns.IntegerSetting())
+
+	var db postgres.DB
+	if err := retry.WithRetry(func() error {
+		db, err = postgres.New(ctx, dbConfig)
+		return err
+	}, retry.Tries(dbOpenRetries), retry.BetweenAttempts(func(attempt int) {
+		time.Sleep(dbTimeBetweenRetries)
+	}), retry.OnFailedAttempts(func(err error) {
+		log.Errorf("open database: %v", err)
+	})); err != nil {
+		log.Fatalf("Timed out trying to open database: %v", err)
+	}
+
+	return db
+}
+
+func ensureDBCurrent(db postgres.DB) {
+	versionStore := vStore.NewPostgres(db)
+	if err := version.Ensure(versionStore); err != nil {
+		log.Fatalf("DB version check failed. Migrations may not be complete: %v", err)
+	}
+	log.Infof("DB version verified")
+}
+
+func startHealthServer() *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{
+		Addr:    healthAddr,
+		Handler: mux,
+	}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Errorf("Health server error: %v", err)
+		}
+	}()
+	return srv
+}
+
+func waitForTerminationSignal() {
+	signalsC := make(chan os.Signal, 1)
+	signal.Notify(signalsC, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-signalsC
+	log.Infof("Caught %s signal", sig)
+}

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -12,6 +12,7 @@ import (
 	vStore "github.com/stackrox/rox/central/version/store"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/premain"
@@ -40,6 +41,8 @@ func main() {
 	ensureDBCurrent(db)
 
 	healthSrv := startHealthServer()
+
+	go startMetricsServer()
 
 	log.Infof("central-worker is ready")
 
@@ -109,6 +112,11 @@ func startHealthServer() *http.Server {
 		}
 	}()
 	return srv
+}
+
+func startMetricsServer() {
+	pkgMetrics.NewServer(pkgMetrics.CentralWorkerSubsystem, pkgMetrics.NewTLSConfigurerFromEnv()).RunForever()
+	pkgMetrics.GatherThrottleMetricsForever(pkgMetrics.CentralWorkerSubsystem.String())
 }
 
 func waitForTerminationSignal() {

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -20,12 +20,16 @@ import (
 )
 
 const (
-	dbOpenRetries         = 10
-	dbTimeBetweenRetries  = 10 * time.Second
-	healthAddr            = ":8082"
+	dbOpenRetries              = 10
+	dbTimeBetweenRetries       = 10 * time.Second
+	healthAddr                 = ":8082"
+	defaultWorkerPoolMaxConns  = 20
 )
 
-var log = logging.LoggerForModule()
+var (
+	log            = logging.LoggerForModule()
+	workerPoolSize = env.RegisterIntegerSetting("ROX_WORKER_DB_POOL_MAX_CONNS", defaultWorkerPoolMaxConns)
+)
 
 func main() {
 	premain.StartMain()
@@ -40,7 +44,7 @@ func main() {
 
 	ensureDBCurrent(db)
 
-	healthSrv := startHealthServer()
+	startHealthServer()
 
 	go startMetricsServer()
 
@@ -49,11 +53,6 @@ func main() {
 	waitForTerminationSignal()
 
 	log.Infof("central-worker shutting down")
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer shutdownCancel()
-	if err := healthSrv.Shutdown(shutdownCtx); err != nil {
-		log.Errorf("Health server shutdown error: %v", err)
-	}
 }
 
 func initDB(ctx context.Context) postgres.DB {
@@ -67,8 +66,11 @@ func initDB(ctx context.Context) postgres.DB {
 		dbConfig.ConnConfig.Database = activeDB
 	}
 
-	poolMaxConns := env.RegisterIntegerSetting("ROX_WORKER_DB_POOL_MAX_CONNS", 20)
-	dbConfig.MaxConns = int32(poolMaxConns.IntegerSetting())
+	poolVal := workerPoolSize.IntegerSetting()
+	if poolVal < 1 {
+		log.Fatalf("ROX_WORKER_DB_POOL_MAX_CONNS must be >= 1, got %d", poolVal)
+	}
+	dbConfig.MaxConns = int32(poolVal)
 
 	var db postgres.DB
 	if err := retry.WithRetry(func() error {
@@ -93,7 +95,7 @@ func ensureDBCurrent(db postgres.DB) {
 	log.Infof("DB version verified")
 }
 
-func startHealthServer() *http.Server {
+func startHealthServer() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -106,12 +108,19 @@ func startHealthServer() *http.Server {
 		Addr:    healthAddr,
 		Handler: mux,
 	}
+
+	errCh := make(chan error, 1)
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Errorf("Health server error: %v", err)
+			errCh <- err
 		}
 	}()
-	return srv
+
+	select {
+	case err := <-errCh:
+		log.Fatalf("Health server failed to start: %v", err)
+	case <-time.After(1 * time.Second):
+	}
 }
 
 func startMetricsServer() {

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"math"
 	"net/http"
 	"os"
@@ -112,7 +113,7 @@ func startHealthServer() {
 
 	errCh := make(chan error, 1)
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
 	}()

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -20,10 +21,10 @@ import (
 )
 
 const (
-	dbOpenRetries              = 10
-	dbTimeBetweenRetries       = 10 * time.Second
-	healthAddr                 = ":8082"
-	defaultWorkerPoolMaxConns  = 20
+	dbOpenRetries             = 10
+	dbTimeBetweenRetries      = 10 * time.Second
+	healthAddr                = ":8082"
+	defaultWorkerPoolMaxConns = 20
 )
 
 var (
@@ -67,8 +68,8 @@ func initDB(ctx context.Context) postgres.DB {
 	}
 
 	poolVal := workerPoolSize.IntegerSetting()
-	if poolVal < 1 {
-		log.Fatalf("ROX_WORKER_DB_POOL_MAX_CONNS must be >= 1, got %d", poolVal)
+	if poolVal < 1 || poolVal > math.MaxInt32 {
+		log.Fatalf("ROX_WORKER_DB_POOL_MAX_CONNS must be between 1 and %d, got %d", math.MaxInt32, poolVal)
 	}
 	dbConfig.MaxConns = int32(poolVal)
 
@@ -121,6 +122,12 @@ func startHealthServer() {
 		log.Fatalf("Health server failed to start: %v", err)
 	case <-time.After(1 * time.Second):
 	}
+
+	go func() {
+		if err := <-errCh; err != nil {
+			log.Fatalf("Health server failed: %v", err)
+		}
+	}()
 }
 
 func startMetricsServer() {

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -92,6 +92,7 @@ COPY bin/kubernetes-sensor  /stackrox/bin/kubernetes-sensor
 COPY bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
 COPY bin/admission-control  /stackrox/bin/admission-control
 COPY bin/config-controller  /stackrox/bin/config-controller
+COPY bin/central-worker     /stackrox/bin/central-worker
 COPY bin/roxagent           /stackrox/bin/roxagent
 COPY bin/roxctl*            /assets/downloads/cli/
 

--- a/image/rhel/static-bin/central-worker
+++ b/image/rhel/static-bin/central-worker
@@ -1,0 +1,1 @@
+entrypoint-wrapper.sh

--- a/pkg/metrics/subsystems.go
+++ b/pkg/metrics/subsystems.go
@@ -6,6 +6,7 @@ type Subsystem string
 // These consts enumerate all the subsystems that expose Prometheus metrics.
 const (
 	CentralSubsystem          Subsystem = "central"
+	CentralWorkerSubsystem    Subsystem = "central_worker"
 	SensorSubsystem           Subsystem = "sensor"
 	AdmissionControlSubsystem Subsystem = "admission_control"
 	ComplianceSubsystem       Subsystem = "compliance"


### PR DESCRIPTION
## Description

Introduces the `central-worker` binary entrypoint with DB connection, version verification, health/readiness probes, and Prometheus metrics endpoint. Wires it into the Makefile build targets, Dockerfile, and static-bin wrapper. No business logic yet — this is the deployment target for extracted jobs.

- `central/worker/main.go` — entrypoint with DB init, health server, metrics server, signal handling
- `pkg/metrics/subsystems.go` — adds `CentralWorkerSubsystem`
- Makefile: added to `$(GOBUILD)` list and binary copy step
- Dockerfile: COPY to `/stackrox/bin/central-worker`
- `image/rhel/static-bin/central-worker` — symlink to `entrypoint-wrapper.sh`

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests

### How I validated my change

Binary compiles and passes `go vet`. Follows the config-controller pattern.

Part 2 of 9 in the central-worker PR stack for ROX-32705.