### PR TITLE
ROX-36261: Add ROX_CENTRAL_WORKER_ENABLED flag

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -380,7 +380,11 @@ func startServices() {
 
 	reprocessor.Singleton().Start()
 	suppress.Singleton().Start()
-	pruning.Singleton().Start()
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		pruning.Singleton().Start()
+	} else {
+		log.Info("Pruning is managed by central-worker, skipping start in Central")
+	}
 	if baseImageWatcher.Enabled() {
 		baseImageWatcher.Singleton().Start()
 	}
@@ -1037,7 +1041,11 @@ func waitForTerminationSignal() {
 	stoppables := []stoppableWithName{
 		{reprocessor.Singleton(), "reprocessor loop"},
 		{suppress.Singleton(), "cve unsuppress loop"},
-		{pruning.Singleton(), "garbage collector"},
+	}
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		stoppables = append(stoppables, stoppableWithName{pruning.Singleton(), "garbage collector"})
+	}
+	stoppables = append(stoppables, []stoppableWithName{
 		{gatherer.Singleton(), "network graph default external sources gatherer"},
 		{vulnRequestManager.Singleton(), "vuln deferral requests expiry loop"},
 		{phonehomeClient.Singleton().Gatherer(), "telemetry gatherer"},
@@ -1047,14 +1055,16 @@ func waitForTerminationSignal() {
 		{gcp.Singleton(), "GCP cloud credentials manager"},
 		{cloudSourcesManager.Singleton(), "cloud sources manager"},
 		{administrationEventHandler.Singleton(), "administration events handler"},
-	}
+	}...)
 
 	if baseImageWatcher.Enabled() {
 		stoppables = append(stoppables, stoppableWithName{baseImageWatcher.Singleton(), "base image watcher"})
 	}
 
-	stoppables = append(stoppables,
-		stoppableWithName{vulnReportV2Scheduler.Singleton(), "vuln reports v2 scheduler"})
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		stoppables = append(stoppables,
+			stoppableWithName{vulnReportV2Scheduler.Singleton(), "vuln reports v2 scheduler"})
+	}
 
 	if features.ComplianceReporting.Enabled() {
 		stoppables = append(stoppables,

--- a/central/main.go
+++ b/central/main.go
@@ -380,7 +380,11 @@ func startServices() {
 
 	reprocessor.Singleton().Start()
 	suppress.Singleton().Start()
-	pruning.Singleton().Start()
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		pruning.Singleton().Start()
+	} else {
+		log.Info("Pruning is managed by central-worker, skipping start in Central")
+	}
 	if baseImageWatcher.Enabled() {
 		baseImageWatcher.Singleton().Start()
 	}
@@ -1035,7 +1039,11 @@ func waitForTerminationSignal() {
 	stoppables := []stoppableWithName{
 		{reprocessor.Singleton(), "reprocessor loop"},
 		{suppress.Singleton(), "cve unsuppress loop"},
-		{pruning.Singleton(), "garbage collector"},
+	}
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		stoppables = append(stoppables, stoppableWithName{pruning.Singleton(), "garbage collector"})
+	}
+	stoppables = append(stoppables, []stoppableWithName{
 		{gatherer.Singleton(), "network graph default external sources gatherer"},
 		{vulnRequestManager.Singleton(), "vuln deferral requests expiry loop"},
 		{phonehomeClient.Singleton().Gatherer(), "telemetry gatherer"},
@@ -1045,14 +1053,16 @@ func waitForTerminationSignal() {
 		{gcp.Singleton(), "GCP cloud credentials manager"},
 		{cloudSourcesManager.Singleton(), "cloud sources manager"},
 		{administrationEventHandler.Singleton(), "administration events handler"},
-	}
+	}...)
 
 	if baseImageWatcher.Enabled() {
 		stoppables = append(stoppables, stoppableWithName{baseImageWatcher.Singleton(), "base image watcher"})
 	}
 
-	stoppables = append(stoppables,
-		stoppableWithName{vulnReportV2Scheduler.Singleton(), "vuln reports v2 scheduler"})
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		stoppables = append(stoppables,
+			stoppableWithName{vulnReportV2Scheduler.Singleton(), "vuln reports v2 scheduler"})
+	}
 
 	if features.ComplianceReporting.Enabled() {
 		stoppables = append(stoppables,

--- a/central/reports/service/v2/singleton.go
+++ b/central/reports/service/v2/singleton.go
@@ -9,6 +9,7 @@ import (
 	snapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	"github.com/stackrox/rox/central/reports/validation"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -19,9 +20,11 @@ var (
 
 func initialize() {
 	scheduler := schedulerV2.Singleton()
-	// Start() also queues previously pending reports and scheduled reports, so running it in a separate routine to prevent
-	// blocking main routine
-	go scheduler.Start(globaldb.GetPostgres())
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		go scheduler.Start(globaldb.GetPostgres())
+	} else {
+		log.Info("Report scheduling is managed by central-worker, skipping start in Central")
+	}
 	collectionDatastore, _ := collectionDS.Singleton()
 	svc = New(reportConfigDS.Singleton(), snapshotDS.Singleton(), collectionDatastore, notifierDS.Singleton(), scheduler,
 		blobDS.Singleton(), validation.Singleton())

--- a/central/reports/service/v2/singleton.go
+++ b/central/reports/service/v2/singleton.go
@@ -8,6 +8,7 @@ import (
 	snapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	"github.com/stackrox/rox/central/reports/validation"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -18,9 +19,11 @@ var (
 
 func initialize() {
 	scheduler := schedulerV2.Singleton()
-	// Start() also queues previously pending reports and scheduled reports, so running it in a separate routine to prevent
-	// blocking main routine
-	go scheduler.Start()
+	if !env.CentralWorkerEnabled.BooleanSetting() {
+		go scheduler.Start()
+	} else {
+		log.Info("Report scheduling is managed by central-worker, skipping start in Central")
+	}
 	collectionDatastore, _ := collectionDS.Singleton()
 	svc = New(reportConfigDS.Singleton(), snapshotDS.Singleton(), collectionDatastore, notifierDS.Singleton(), scheduler,
 		blobDS.Singleton(), validation.Singleton())

--- a/pkg/env/central_worker.go
+++ b/pkg/env/central_worker.go
@@ -1,0 +1,5 @@
+package env
+
+var (
+	CentralWorkerEnabled = RegisterBooleanSetting("ROX_CENTRAL_WORKER_ENABLED", false)
+)


### PR DESCRIPTION
## Description

When `ROX_CENTRAL_WORKER_ENABLED=true`, Central skips starting the pruning GC and vulnerability report scheduler. These will be run by the central-worker deployment instead. Defaults to `false` to preserve existing behavior.

- New env var in `pkg/env/central_worker.go`
- `startServices()` gates pruning and reporting behind the flag
- `waitForTerminationSignal()` conditionally adds pruning/reporting to stoppables
- Report service singleton conditionally starts the scheduler

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests

### How I validated my change

Central compiles clean with and without the flag.

Part 5 of 8 in the central-worker PR stack for ROX-32705.