### PR TITLE
ROX-36263: Wire pruning GC into central-worker

### DIFF
--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -134,6 +134,12 @@ func SetPostgresTest(t *testing.T, db postgres.DB) postgres.DB {
 
 // InitializePostgres creates and returns returns a global database instance.
 func InitializePostgres(ctx context.Context) postgres.DB {
+	return InitializePostgresWithPoolSize(ctx, 0)
+}
+
+// InitializePostgresWithPoolSize creates a global database instance with an overridden
+// connection pool size. If maxConns is 0, the default from the DSN is used.
+func InitializePostgresWithPoolSize(ctx context.Context, maxConns int32) postgres.DB {
 	pgSync.Do(func() {
 		_, dbConfig, err := pgconfig.GetPostgresConfig()
 		if err != nil {
@@ -141,11 +147,12 @@ func InitializePostgres(ctx context.Context) postgres.DB {
 		}
 
 		if !pgconfig.IsExternalDatabase() {
-			// Get the active database name for the connection
 			activeDB := pgconfig.GetActiveDB()
-
-			// Set the connection to be the active database.
 			dbConfig.ConnConfig.Database = activeDB
+		}
+
+		if maxConns > 0 {
+			dbConfig.MaxConns = maxConns
 		}
 
 		if err := retry.WithRetry(func() error {

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stackrox/rox/central/pruning"
 	"github.com/stackrox/rox/central/version"
 	vStore "github.com/stackrox/rox/central/version/store"
-	migratorLock "github.com/stackrox/rox/migrator/lock"
+	"github.com/stackrox/rox/pkg/dblock"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
@@ -69,7 +69,7 @@ func main() {
 
 func waitForMigrations(ctx context.Context) {
 	err := retry.WithRetry(func() error {
-		acquired, release, err := migratorLock.TryAcquireMigrationLock(ctx, globaldb.GetPostgres())
+		acquired, release, err := dblock.TryAcquireAdvisoryLock(ctx, globaldb.GetPostgres(), dblock.MigrationLockID)
 		if err != nil {
 			return retry.MakeRetryable(err)
 		}

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -10,20 +10,19 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/central/pruning"
 	"github.com/stackrox/rox/central/version"
 	vStore "github.com/stackrox/rox/central/version/store"
+	migratorLock "github.com/stackrox/rox/migrator/lock"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
-	"github.com/stackrox/rox/pkg/postgres"
-	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/premain"
 	"github.com/stackrox/rox/pkg/retry"
 )
 
 const (
-	dbOpenRetries             = 10
-	dbTimeBetweenRetries      = 10 * time.Second
 	healthAddr                = ":8082"
 	defaultWorkerPoolMaxConns = 20
 )
@@ -38,59 +37,65 @@ func main() {
 
 	log.Infof("Starting central-worker")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
-	db := initDB(ctx)
-	defer db.Close()
+	poolVal := workerPoolSize.IntegerSetting()
+	if poolVal < 1 || poolVal > math.MaxInt32 {
+		log.Fatalf("ROX_WORKER_DB_POOL_MAX_CONNS must be between 1 and %d, got %d", math.MaxInt32, poolVal)
+	}
+	globaldb.InitializePostgresWithPoolSize(ctx, int32(poolVal))
+	log.Infof("DB pool initialized with max_conns=%d", poolVal)
 
-	ensureDBCurrent(db)
+	waitForMigrations(ctx)
+	ensureDBCurrent()
 
 	startHealthServer()
 
 	go startMetricsServer()
+
+	pruning.Singleton().Start()
+	log.Infof("Pruning GC started")
 
 	log.Infof("central-worker is ready")
 
 	waitForTerminationSignal()
 
 	log.Infof("central-worker shutting down")
+
+	pruning.Singleton().Stop()
+
+	globaldb.Close()
 }
 
-func initDB(ctx context.Context) postgres.DB {
-	_, dbConfig, err := pgconfig.GetPostgresConfig()
+func waitForMigrations(ctx context.Context) {
+	err := retry.WithRetry(func() error {
+		acquired, release, err := migratorLock.TryAcquireMigrationLock(ctx, globaldb.GetPostgres())
+		if err != nil {
+			return retry.MakeRetryable(err)
+		}
+		if !acquired {
+			return retry.MakeRetryable(errMigratorRunning)
+		}
+		release()
+		return nil
+	}, retry.Tries(30), retry.BetweenAttempts(func(attempt int) {
+		log.Infof("Migrator lock held, waiting for migrations to complete (attempt %d)...", attempt+1)
+		time.Sleep(10 * time.Second)
+	}))
 	if err != nil {
-		log.Fatalf("Could not parse postgres config: %v", err)
+		log.Fatalf("Timed out waiting for migrations to complete: %v", err)
 	}
-
-	if !pgconfig.IsExternalDatabase() {
-		activeDB := pgconfig.GetActiveDB()
-		dbConfig.ConnConfig.Database = activeDB
-	}
-
-	poolVal := workerPoolSize.IntegerSetting()
-	if poolVal < 1 || poolVal > math.MaxInt32 {
-		log.Fatalf("ROX_WORKER_DB_POOL_MAX_CONNS must be between 1 and %d, got %d", math.MaxInt32, poolVal)
-	}
-	dbConfig.MaxConns = int32(poolVal)
-
-	var db postgres.DB
-	if err := retry.WithRetry(func() error {
-		db, err = postgres.New(ctx, dbConfig)
-		return err
-	}, retry.Tries(dbOpenRetries), retry.BetweenAttempts(func(attempt int) {
-		time.Sleep(dbTimeBetweenRetries)
-	}), retry.OnFailedAttempts(func(err error) {
-		log.Errorf("open database: %v", err)
-	})); err != nil {
-		log.Fatalf("Timed out trying to open database: %v", err)
-	}
-
-	return db
+	log.Infof("Migrations complete, proceeding with startup")
 }
 
-func ensureDBCurrent(db postgres.DB) {
-	versionStore := vStore.NewPostgres(db)
+var errMigratorRunning = retryableError("migrator is still running")
+
+type retryableError string
+
+func (e retryableError) Error() string { return string(e) }
+
+func ensureDBCurrent() {
+	versionStore := vStore.NewPostgres(globaldb.GetPostgres())
 	if err := version.Ensure(versionStore); err != nil {
 		log.Fatalf("DB version check failed. Migrations may not be complete: %v", err)
 	}

--- a/migrator/lock/lock.go
+++ b/migrator/lock/lock.go
@@ -7,14 +7,8 @@ import (
 	"github.com/stackrox/rox/pkg/postgres"
 )
 
-const (
-	// migrationAdvisoryLockID is a unique identifier for the migration advisory lock.
-	// This value is arbitrary but must be consistent across all Central instances.
-	migrationAdvisoryLockID int64 = 7_517_845_236_103_920_641
-)
-
 // TryAcquireMigrationLock attempts to acquire the migration advisory lock without blocking.
 // Returns whether the lock was acquired, a release function (nil if not acquired), and any error.
 func TryAcquireMigrationLock(ctx context.Context, pool postgres.DB) (bool, func(), error) {
-	return dblock.TryAcquireAdvisoryLock(ctx, pool, migrationAdvisoryLockID)
+	return dblock.TryAcquireAdvisoryLock(ctx, pool, dblock.MigrationLockID)
 }

--- a/pkg/dblock/lock_ids.go
+++ b/pkg/dblock/lock_ids.go
@@ -3,6 +3,7 @@ package dblock
 // Advisory lock IDs are random int64 values generated via crypto/rand.
 // New IDs must not collide with existing ones.
 const (
+	MigrationLockID       int64 = 7_517_845_236_103_920_641
 	PruningGCLockID       int64 = 7_293_581_046_138_294_017
 	ReportSchedulerLockID int64 = 4_618_739_250_183_647_293
 )


### PR DESCRIPTION
## Description

Wires pruning into the central-worker with proper DB pool sizing and migration readiness.

- Uses `globaldb.InitializePostgresWithPoolSize()` to set worker pool to 20 connections (configurable via `ROX_WORKER_DB_POOL_MAX_CONNS`)
- Waits for the migrator advisory lock to be released before starting, ensuring schema migrations are complete
- Starts `pruning.Singleton()` using the same code path as Central — no code duplication
- Advisory lock (from PR 4) ensures only one instance runs pruning at a time

### New globaldb API
- `InitializePostgresWithPoolSize(ctx, maxConns)` — like `InitializePostgres` but overrides pool size. When maxConns is 0, the default from the DSN is used. Central continues to use `InitializePostgres()` unchanged.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests

### How I validated my change

Worker binary compiles clean. Manually validated on GKE — worker starts with pool_max_conns=20, waits for migrations, then starts pruning.

Part 7 of 9 in the central-worker PR stack for ROX-32705.