### PR TITLE
ROX-36264: Wire vulnerability reporting into worker

### DIFF
--- a/central/notifier/service/service.go
+++ b/central/notifier/service/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/integrationhealth"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifier"
+	"github.com/stackrox/rox/pkg/postgres"
 )
 
 var (
@@ -30,12 +31,14 @@ func New(storage datastore.DataStore,
 	processor notifier.Processor,
 	policyCleaner policycleaner.PolicyCleaner,
 	reporter integrationhealth.Reporter,
-	cryptoKey string) Service {
+	cryptoKey string,
+	db postgres.DB) Service {
 	return &serviceImpl{
 		storage:       storage,
 		processor:     processor,
 		policyCleaner: policyCleaner,
 		reporter:      reporter,
 		cryptoKey:     cryptoKey,
+		db:            db,
 	}
 }

--- a/central/notifier/service/service_impl.go
+++ b/central/notifier/service/service_impl.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifier"
 	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
+	"github.com/stackrox/rox/pkg/postgres"
+	pgNotify "github.com/stackrox/rox/pkg/postgres/notify"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/secrets"
 	"google.golang.org/grpc"
@@ -58,6 +60,7 @@ type serviceImpl struct {
 	processor notifier.Processor
 	reporter  integrationhealth.Reporter
 	cryptoKey string
+	db        postgres.DB
 
 	policyCleaner policycleaner.PolicyCleaner
 }
@@ -164,6 +167,7 @@ func (s *serviceImpl) UpdateNotifier(ctx context.Context, request *v1.UpdateNoti
 		return nil, err
 	}
 	s.processor.UpdateNotifier(ctx, notifier)
+	s.notifyWorker(ctx, request.GetNotifier().GetId())
 	return &v1.Empty{}, nil
 }
 
@@ -195,6 +199,7 @@ func (s *serviceImpl) PostNotifier(ctx context.Context, request *storage.Notifie
 	}
 	request.Id = id
 	s.processor.UpdateNotifier(ctx, notifier)
+	s.notifyWorker(ctx, id)
 
 	if err = s.reporter.Register(request.GetId(), request.GetName(), storage.IntegrationHealth_NOTIFIER); err != nil {
 		return nil, err
@@ -266,10 +271,20 @@ func (s *serviceImpl) DeleteNotifier(ctx context.Context, request *v1.DeleteNoti
 	}
 
 	s.processor.RemoveNotifier(ctx, request.GetId())
+	s.notifyWorker(ctx, request.GetId())
 	if err := s.reporter.RemoveIntegrationHealth(request.GetId()); err != nil {
 		return nil, err
 	}
 	return &v1.Empty{}, nil
+}
+
+func (s *serviceImpl) notifyWorker(ctx context.Context, notifierID string) {
+	if s.db == nil {
+		return
+	}
+	if err := pgNotify.Notify(ctx, s.db, pgNotify.NotifierChanged, notifierID); err != nil {
+		log.Errorf("Failed to notify worker of notifier change %s: %v", notifierID, err)
+	}
 }
 
 func (s *serviceImpl) reconcileUpdateNotifierRequest(ctx context.Context, updateRequest *v1.UpdateNotifierRequest) error {

--- a/central/notifier/service/singleton.go
+++ b/central/notifier/service/singleton.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/stackrox/rox/central/integrationhealth/reporter"
+	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/policycleaner"
 	"github.com/stackrox/rox/central/notifier/processor"
@@ -33,6 +34,7 @@ func initialize() {
 		policycleaner.Singleton(),
 		reporter.Singleton(),
 		cryptoKey,
+		globaldb.GetPostgres(),
 	)
 }
 

--- a/central/notifier/service/singleton.go
+++ b/central/notifier/service/singleton.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"github.com/stackrox/rox/central/integrationhealth/reporter"
 	"github.com/stackrox/rox/central/globaldb"
+	"github.com/stackrox/rox/central/integrationhealth/reporter"
 	"github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/notifier/policycleaner"
 	"github.com/stackrox/rox/central/notifier/processor"

--- a/central/reports/scheduler/v2/mocks/scheduler.go
+++ b/central/reports/scheduler/v2/mocks/scheduler.go
@@ -73,6 +73,20 @@ func (mr *MockSchedulerMockRecorder) CancelReportRequest(ctx, reportID any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReportRequest", reflect.TypeOf((*MockScheduler)(nil).CancelReportRequest), ctx, reportID)
 }
 
+// GetScheduledConfigIDs mocks base method.
+func (m *MockScheduler) GetScheduledConfigIDs() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScheduledConfigIDs")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetScheduledConfigIDs indicates an expected call of GetScheduledConfigIDs.
+func (mr *MockSchedulerMockRecorder) GetScheduledConfigIDs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScheduledConfigIDs", reflect.TypeOf((*MockScheduler)(nil).GetScheduledConfigIDs))
+}
+
 // RemoveReportSchedule mocks base method.
 func (m *MockScheduler) RemoveReportSchedule(reportConfigID string) {
 	m.ctrl.T.Helper()

--- a/central/reports/scheduler/v2/reportgenerator/report_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen.go
@@ -3,7 +3,6 @@ package reportgenerator
 import (
 	"context"
 
-	"github.com/graph-gophers/graphql-go"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	imageCVE2DS "github.com/stackrox/rox/central/cve/image/v2/datastore"
@@ -39,7 +38,6 @@ func New(
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
 	imageCVE2DataStore imageCVE2DS.DataStore,
-	schema *graphql.Schema,
 ) ReportGenerator {
 	return newReportGeneratorImpl(
 		db,
@@ -52,7 +50,6 @@ func New(
 		clusterDatastore,
 		namespaceDatastore,
 		imageCVE2DataStore,
-		schema,
 	)
 }
 
@@ -67,7 +64,6 @@ func newReportGeneratorImpl(
 	clusterDatastore clusterDS.DataStore,
 	namespaceDatastore namespaceDS.DataStore,
 	imageCVE2Datastore imageCVE2DS.DataStore,
-	schema *graphql.Schema,
 ) *reportGeneratorImpl {
 	return &reportGeneratorImpl{
 		reportSnapshotStore:     reportSnapshotStore,
@@ -80,6 +76,5 @@ func newReportGeneratorImpl(
 		imageCVE2Datastore:      imageCVE2Datastore,
 		blobStore:               blobStore,
 		db:                      db,
-		Schema:                  schema,
 	}
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	"github.com/stackrox/rox/central/graphql/resolvers"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
@@ -96,11 +95,10 @@ func (bts *FlatDataModelReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 
 	// set up tables
 	bts.watchedImageDatastore = watchedImageDS.GetTestPostgresDataStore(bts.b, bts.testDB.DB)
-	var schema *graphql.Schema
 	// TODO(ROX-30117): Remove conditional when FlattenImageData feature flag is removed.
 	if features.FlattenImageData.Enabled() {
 		imgV2DataStore := resolvers.CreateTestImageV2Datastore(bts.b, bts.testDB, mockCtrl)
-		bts.resolver, schema = resolvers.SetupTestResolver(bts.b,
+		bts.resolver, _ = resolvers.SetupTestResolver(bts.b,
 			imagesView.NewImageView(bts.testDB.DB),
 			imgV2DataStore,
 			resolvers.CreateTestImageComponentV2Datastore(bts.b, bts.testDB, mockCtrl),
@@ -110,7 +108,7 @@ func (bts *FlatDataModelReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 		)
 	} else {
 		imageDataStore := resolvers.CreateTestImageDatastore(bts.b, bts.testDB, mockCtrl)
-		bts.resolver, schema = resolvers.SetupTestResolver(bts.b,
+		bts.resolver, _ = resolvers.SetupTestResolver(bts.b,
 			imagesView.NewImageView(bts.testDB.DB),
 			imageDataStore,
 			resolvers.CreateTestImageComponentV2Datastore(bts.b, bts.testDB, mockCtrl),
@@ -127,7 +125,7 @@ func (bts *FlatDataModelReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 
 	bts.reportGenerator = newReportGeneratorImpl(bts.testDB, nil, bts.resolver.DeploymentDataStore,
 		bts.watchedImageDatastore, collectionQueryResolver, nil, nil, bts.clusterDatastore,
-		bts.namespaceDatastore, bts.resolver.ImageCVEV2DataStore, schema)
+		bts.namespaceDatastore, bts.resolver.ImageCVEV2DataStore)
 }
 
 func BenchmarkEntityScopeReportGenerator(b *testing.B) {
@@ -136,11 +134,10 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 	testDB := pgtest.ForT(b)
 
 	watchedImageDatastore := watchedImageDS.GetTestPostgresDataStore(b, testDB.DB)
-	var schema *graphql.Schema
 	var resolver *resolvers.Resolver
 	if features.FlattenImageData.Enabled() {
 		imgV2DataStore := resolvers.CreateTestImageV2Datastore(b, testDB, mockCtrl)
-		resolver, schema = resolvers.SetupTestResolver(b,
+		resolver, _ = resolvers.SetupTestResolver(b,
 			imagesView.NewImageView(testDB.DB),
 			imgV2DataStore,
 			resolvers.CreateTestImageComponentV2Datastore(b, testDB, mockCtrl),
@@ -150,7 +147,7 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		)
 	} else {
 		imageDataStore := resolvers.CreateTestImageDatastore(b, testDB, mockCtrl)
-		resolver, schema = resolvers.SetupTestResolver(b,
+		resolver, _ = resolvers.SetupTestResolver(b,
 			imagesView.NewImageView(testDB.DB),
 			imageDataStore,
 			resolvers.CreateTestImageComponentV2Datastore(b, testDB, mockCtrl),
@@ -166,7 +163,7 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 
 	reportGenerator := newReportGeneratorImpl(testDB, nil, resolver.DeploymentDataStore,
 		watchedImageDatastore, nil, nil, nil, clusterDatastore,
-		nsDatastore, resolver.ImageCVEV2DataStore, schema)
+		nsDatastore, resolver.ImageCVEV2DataStore)
 
 	clusters := []*storage.Cluster{
 		{Id: uuid.NewV4().String(), Name: "c1"},

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"slices"
 	"time"
-
-
 	"github.com/pkg/errors"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
@@ -43,6 +41,7 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
+	"time"
 )
 
 var (

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -37,7 +37,6 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
-	"time"
 )
 
 var (

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
+
 	"github.com/pkg/errors"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
@@ -82,8 +82,6 @@ type reportGeneratorImpl struct {
 	namespaceDatastore      namespaceDS.DataStore
 	imageCVE2Datastore      imageCVE2DS.DataStore
 	db                      postgres.DB
-
-	Schema *graphql.Schema
 }
 
 type ImageCVEInterface interface {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -41,7 +41,6 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
-	"time"
 )
 
 var (

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"slices"
 	"time"
+
 	"github.com/pkg/errors"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
+
 	"github.com/pkg/errors"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
@@ -77,8 +77,6 @@ type reportGeneratorImpl struct {
 	namespaceDatastore      namespaceDS.DataStore
 	imageCVE2Datastore      imageCVE2DS.DataStore
 	db                      postgres.DB
-
-	Schema *graphql.Schema
 }
 
 type ImageCVEInterface interface {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"slices"
 	"time"
-
-
 	"github.com/pkg/errors"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
@@ -39,6 +37,7 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
+	"time"
 )
 
 var (

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	"github.com/stackrox/rox/central/graphql/resolvers"
@@ -73,10 +72,9 @@ func (s *NewDataModelEnhancedReportingTestSuite) SetupSuite() {
 
 	// TODO(ROX-30117): Remove conditional when FlattenImageData feature flag is removed.
 	var resolver *resolvers.Resolver
-	var schema *graphql.Schema
 	if features.FlattenImageData.Enabled() {
 		imgV2DataStore := resolvers.CreateTestImageV2Datastore(s.T(), s.testDB, mockCtrl)
-		resolver, schema = resolvers.SetupTestResolver(s.T(),
+		resolver, _ = resolvers.SetupTestResolver(s.T(),
 			imagesView.NewImageView(s.testDB.DB),
 			imgV2DataStore,
 			resolvers.CreateTestImageComponentV2Datastore(s.T(), s.testDB, mockCtrl),
@@ -86,7 +84,7 @@ func (s *NewDataModelEnhancedReportingTestSuite) SetupSuite() {
 		)
 	} else {
 		imageDataStore := resolvers.CreateTestImageDatastore(s.T(), s.testDB, mockCtrl)
-		resolver, schema = resolvers.SetupTestResolver(s.T(),
+		resolver, _ = resolvers.SetupTestResolver(s.T(),
 			imagesView.NewImageView(s.testDB.DB),
 			imageDataStore,
 			resolvers.CreateTestImageComponentV2Datastore(s.T(), s.testDB, mockCtrl),
@@ -165,7 +163,7 @@ func (s *NewDataModelEnhancedReportingTestSuite) SetupSuite() {
 
 	s.reportGenerator = newReportGeneratorImpl(s.testDB, nil, resolver.DeploymentDataStore,
 		s.watchedImageDatastore, collectionQueryResolver, nil, blobStore, s.clusterDatastore,
-		s.namespaceDatastore, resolver.ImageCVEV2DataStore, schema)
+		s.namespaceDatastore, resolver.ImageCVEV2DataStore)
 }
 func (s *NewDataModelEnhancedReportingTestSuite) upsertManyWatchedImages(images []*storage.Image) {
 	for _, img := range images {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_memory_bench_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_memory_bench_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	"github.com/stackrox/rox/central/graphql/resolvers"
@@ -53,10 +52,9 @@ func setupMemoryBench(b *testing.B, numNamespacesPerCluster, numDeploymentsPerNa
 	watchedImageDatastore := watchedImageDS.GetTestPostgresDataStore(b, testDB.DB)
 
 	var resolver *resolvers.Resolver
-	var schema *graphql.Schema
 	if features.FlattenImageData.Enabled() {
 		imgV2DataStore := resolvers.CreateTestImageV2Datastore(b, testDB, mockCtrl)
-		resolver, schema = resolvers.SetupTestResolver(b,
+		resolver, _ = resolvers.SetupTestResolver(b,
 			imagesView.NewImageView(testDB.DB),
 			imgV2DataStore,
 			resolvers.CreateTestImageComponentV2Datastore(b, testDB, mockCtrl),
@@ -66,7 +64,7 @@ func setupMemoryBench(b *testing.B, numNamespacesPerCluster, numDeploymentsPerNa
 		)
 	} else {
 		imageDataStore := resolvers.CreateTestImageDatastore(b, testDB, mockCtrl)
-		resolver, schema = resolvers.SetupTestResolver(b,
+		resolver, _ = resolvers.SetupTestResolver(b,
 			imagesView.NewImageView(testDB.DB),
 			imageDataStore,
 			resolvers.CreateTestImageComponentV2Datastore(b, testDB, mockCtrl),
@@ -89,7 +87,7 @@ func setupMemoryBench(b *testing.B, numNamespacesPerCluster, numDeploymentsPerNa
 
 	rg := newReportGeneratorImpl(testDB, reportSnapshotStore, resolver.DeploymentDataStore,
 		watchedImageDatastore, collectionQueryResolver, nil, blobStore, clusterDatastore,
-		nsDatastore, resolver.ImageCVEV2DataStore, schema)
+		nsDatastore, resolver.ImageCVEV2DataStore)
 
 	// pgtest limits all pools to pool_max_conns=1 which is too restrictive for
 	// report generation. Use a shared pool with enough connections.

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -91,7 +91,7 @@ func (s *ViewBasedReportingTestSuite) SetupTest() {
 
 	s.reportGenerator = newReportGeneratorImpl(s.testDB, nil, s.resolver.DeploymentDataStore,
 		s.watchedImageDatastore, nil, nil, s.blobStore, s.clusterDatastore,
-		s.namespaceDatastore, s.resolver.ImageCVEV2DataStore, nil)
+		s.namespaceDatastore, s.resolver.ImageCVEV2DataStore)
 }
 
 func (s *ViewBasedReportingTestSuite) TearDownTest() {

--- a/central/reports/scheduler/v2/reportgenerator/singleton.go
+++ b/central/reports/scheduler/v2/reportgenerator/singleton.go
@@ -1,20 +1,17 @@
 package reportgenerator
 
 import (
-	"github.com/graph-gophers/graphql-go"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
 	imageCVE2DS "github.com/stackrox/rox/central/cve/image/v2/datastore"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/globaldb"
-	"github.com/stackrox/rox/central/graphql/resolvers"
 	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	watchedImageDS "github.com/stackrox/rox/central/watchedimage/datastore"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -24,8 +21,6 @@ var (
 
 func initialize() {
 	_, collectionQueryRes := collectionDS.Singleton()
-	schema, err := graphql.ParseSchema(resolvers.Schema(), resolvers.New())
-	utils.CrashOnError(err)
 	rg = New(globaldb.GetPostgres(),
 		reportSnapshotDS.Singleton(),
 		deploymentDS.Singleton(),
@@ -36,7 +31,6 @@ func initialize() {
 		clusterDS.Singleton(),
 		namespaceDS.Singleton(),
 		imageCVE2DS.Singleton(),
-		schema,
 	)
 }
 

--- a/central/reports/scheduler/v2/scheduler.go
+++ b/central/reports/scheduler/v2/scheduler.go
@@ -16,6 +16,8 @@ type Scheduler interface {
 	UpsertReportSchedule(reportConfig *storage.ReportConfiguration) error
 	// RemoveReportSchedule removes the given report configuration from scheduled execution.
 	RemoveReportSchedule(reportConfigID string)
+	// GetScheduledConfigIDs returns the IDs of all report configurations that have active schedules.
+	GetScheduledConfigIDs() []string
 
 	// CanSubmitReportRequest returns true if the given user can submit an on-demand report request for the given report configuration.
 	CanSubmitReportRequest(user *storage.SlimUser, reportConfig *storage.ReportConfiguration) (bool, error)

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -5,9 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/graphql/resolvers"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
@@ -68,7 +66,6 @@ type scheduler struct {
 	// request is enqueued or when a report completes. Reset when no runnable report
 	// is found across any queue.
 	readyForReports concurrency.Signal
-	Schema          *graphql.Schema
 
 	/* Concurrency and synchronization related fields */
 	// isStarted will make sure only one scheduling routine runs for an instance of scheduler
@@ -98,19 +95,14 @@ func New(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore rep
 
 	cronScheduler := cron.New()
 	cronScheduler.Start()
-	ourSchema, err := graphql.ParseSchema(resolvers.Schema(), resolvers.New())
-	if err != nil {
-		panic(err)
-	}
 	return newSchedulerImpl(reportConfigDatastore, reportSnapshotStore, collectionDatastore, notifierDatastore,
-		imageReportGenerator, nodeReportGenerator, validator, cronScheduler, ourSchema)
+		imageReportGenerator, nodeReportGenerator, validator, cronScheduler)
 }
 
 func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore reportSnapshotDS.DataStore,
 	collectionDatastore collectionDS.DataStore, notifierDatastore notifierDS.DataStore,
 	imageReportGenerator reportGen.ReportGenerator, nodeReportGenerator reportGen.ReportGenerator,
-	validator *validation.Validator, cronScheduler *cron.Cron,
-	schema *graphql.Schema) *scheduler {
+	validator *validation.Validator, cronScheduler *cron.Cron) *scheduler {
 
 	imageQueue := reportqueue.New()
 	queues := []queueGeneratorBinding{
@@ -137,7 +129,6 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		nextQueueIdx:           0,
 		queueByType:            queueByType,
 		readyForReports:        concurrency.NewSignal(),
-		Schema:                 schema,
 		stopper:                concurrency.NewStopper(),
 		cron:                   cronScheduler,
 		concurrencySema:        semaphore.NewWeighted(int64(env.ReportExecutionMaxConcurrency.IntegerSetting())),

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -6,9 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/central/graphql/resolvers"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
@@ -61,7 +59,6 @@ type scheduler struct {
 	// Stores cancel functions for running reports, keyed by report ID.
 	// Used to cancel in-flight database queries and blob store writes when a user cancels a PREPARING report.
 	runningReportCancels map[string]context.CancelCauseFunc
-	Schema               *graphql.Schema
 
 	/* Concurrency and synchronization related fields */
 	// isStarted will make sure only one scheduling routine runs for an instance of scheduler
@@ -93,18 +90,13 @@ func New(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore rep
 
 	cronScheduler := cron.New()
 	cronScheduler.Start()
-	ourSchema, err := graphql.ParseSchema(resolvers.Schema(), resolvers.New())
-	if err != nil {
-		panic(err)
-	}
 	return newSchedulerImpl(reportConfigDatastore, reportSnapshotStore, collectionDatastore, notifierDatastore,
-		reportGenerator, validator, cronScheduler, ourSchema)
+		reportGenerator, validator, cronScheduler)
 }
 
 func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore reportSnapshotDS.DataStore,
 	collectionDatastore collectionDS.DataStore, notifierDatastore notifierDS.DataStore,
-	reportGenerator reportGen.ReportGenerator, validator *validation.Validator, cronScheduler *cron.Cron,
-	schema *graphql.Schema) *scheduler {
+	reportGenerator reportGen.ReportGenerator, validator *validation.Validator, cronScheduler *cron.Cron) *scheduler {
 	s := &scheduler{
 		reportConfigToEntryIDs: make(map[string]cron.EntryID),
 		reportConfigDatastore:  reportConfigDatastore,
@@ -117,7 +109,6 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		readyForReports:        concurrency.NewSignal(),
 		runningReportConfigs:   set.NewStringSet(),
 		runningReportCancels:   make(map[string]context.CancelCauseFunc),
-		Schema:                 schema,
 		stopper:                concurrency.NewStopper(),
 		cron:                   cronScheduler,
 		concurrencySema:        semaphore.NewWeighted(int64(env.ReportExecutionMaxConcurrency.IntegerSetting())),

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -283,6 +283,17 @@ func (s *scheduler) RemoveReportSchedule(reportConfigID string) {
 	}
 }
 
+func (s *scheduler) GetScheduledConfigIDs() []string {
+	s.cronJobsLock.Lock()
+	defer s.cronJobsLock.Unlock()
+
+	ids := make([]string, 0, len(s.reportConfigToEntryIDs))
+	for id := range s.reportConfigToEntryIDs {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 /* Functions to add/remove report jobs from queue */
 
 // CancelReportRequest cancels a report request. If the report is waiting in queue, it is removed

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -154,7 +154,7 @@ func TestQueueScheduledReportsSkipsEmptyResourceScope(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(mockReportConfigDS, nil, nil, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(mockReportConfigDS, nil, nil, nil, nil, nil, nil, cronScheduler)
 	s.queueScheduledReports()
 
 	// Only the two valid configs should have been scheduled
@@ -173,7 +173,7 @@ func TestCancelReportRequestCancelsRunningReport(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, nil, cronScheduler)
 	imageQueue := s.queues[0].queue
 
 	started := make(chan struct{})
@@ -221,7 +221,7 @@ func TestCancelReportRequestReturnsFalseForUnknownReport(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, nil, cronScheduler)
 
 	cancelled, err := s.CancelReportRequest(context.Background(), "nonexistent-id")
 	assert.NoError(t, err)
@@ -290,7 +290,7 @@ func TestQueuePendingReports(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, nil, cronScheduler)
 	s.isStarted.Store(true)
 	s.queuePendingReports()
 
@@ -305,7 +305,7 @@ func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(nil, mockSnapshotStore, nil, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(nil, mockSnapshotStore, nil, nil, nil, nil, nil, cronScheduler)
 	imageQueue := s.queues[0].queue
 
 	req := &reportGen.ReportRequest{

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -86,7 +86,6 @@ func main() {
 	waitForTerminationSignal()
 
 	log.Infof("central-worker shutting down")
-	cancel()
 
 	pruning.Singleton().Stop()
 	scheduler.Stop()

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -62,7 +62,7 @@ func main() {
 	log.Infof("Pruning GC started")
 
 	scheduler := vulnReportV2Scheduler.Singleton()
-	scheduler.Start()
+	scheduler.Start(globaldb.GetPostgres())
 	log.Infof("Vulnerability report scheduler started")
 
 	collectionDatastore, _ := collectionDS.Singleton()

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/central/globaldb"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
+	_ "github.com/stackrox/rox/central/notifiers/all"
 	"github.com/stackrox/rox/central/pruning"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	vulnReportV2Scheduler "github.com/stackrox/rox/central/reports/scheduler/v2"

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -12,6 +12,10 @@ import (
 
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/pruning"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
+	vulnReportV2Scheduler "github.com/stackrox/rox/central/reports/scheduler/v2"
+	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	"github.com/stackrox/rox/central/version"
 	vStore "github.com/stackrox/rox/central/version/store"
 	migratorLock "github.com/stackrox/rox/migrator/lock"
@@ -37,7 +41,8 @@ func main() {
 
 	log.Infof("Starting central-worker")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	poolVal := workerPoolSize.IntegerSetting()
 	if poolVal < 1 || poolVal > math.MaxInt32 {
@@ -56,13 +61,30 @@ func main() {
 	pruning.Singleton().Start()
 	log.Infof("Pruning GC started")
 
+	scheduler := vulnReportV2Scheduler.Singleton()
+	scheduler.Start()
+	log.Infof("Vulnerability report scheduler started")
+
+	collectionDatastore, _ := collectionDS.Singleton()
+	rl := newReportListener(
+		db,
+		scheduler,
+		reportConfigDS.Singleton(),
+		reportSnapshotDS.Singleton(),
+		collectionDatastore,
+	)
+	rl.start(ctx)
+	log.Infof("Report LISTEN/NOTIFY listener started")
+
 	log.Infof("central-worker is ready")
 
 	waitForTerminationSignal()
 
 	log.Infof("central-worker shutting down")
+	cancel()
 
 	pruning.Singleton().Stop()
+	scheduler.Stop()
 
 	globaldb.Close()
 }

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/globaldb"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
+	notifierProcessor "github.com/stackrox/rox/central/notifier/processor"
 	"github.com/stackrox/rox/central/pruning"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	vulnReportV2Scheduler "github.com/stackrox/rox/central/reports/scheduler/v2"
@@ -72,6 +74,8 @@ func main() {
 		reportConfigDS.Singleton(),
 		reportSnapshotDS.Singleton(),
 		collectionDatastore,
+		notifierDS.Singleton(),
+		notifierProcessor.Singleton(),
 	)
 	rl.start(ctx)
 	log.Infof("Report LISTEN/NOTIFY listener started")

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	collectionDatastore, _ := collectionDS.Singleton()
 	rl := newReportListener(
-		db,
+		globaldb.GetPostgres(),
 		scheduler,
 		reportConfigDS.Singleton(),
 		reportSnapshotDS.Singleton(),

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -12,6 +12,10 @@ import (
 
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/pruning"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
+	vulnReportV2Scheduler "github.com/stackrox/rox/central/reports/scheduler/v2"
+	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	"github.com/stackrox/rox/central/version"
 	vStore "github.com/stackrox/rox/central/version/store"
 	"github.com/stackrox/rox/pkg/dblock"
@@ -37,7 +41,8 @@ func main() {
 
 	log.Infof("Starting central-worker")
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	poolVal := workerPoolSize.IntegerSetting()
 	if poolVal < 1 || poolVal > math.MaxInt32 {
@@ -56,13 +61,30 @@ func main() {
 	pruning.Singleton().Start()
 	log.Infof("Pruning GC started")
 
+	scheduler := vulnReportV2Scheduler.Singleton()
+	scheduler.Start()
+	log.Infof("Vulnerability report scheduler started")
+
+	collectionDatastore, _ := collectionDS.Singleton()
+	rl := newReportListener(
+		db,
+		scheduler,
+		reportConfigDS.Singleton(),
+		reportSnapshotDS.Singleton(),
+		collectionDatastore,
+	)
+	rl.start(ctx)
+	log.Infof("Report LISTEN/NOTIFY listener started")
+
 	log.Infof("central-worker is ready")
 
 	waitForTerminationSignal()
 
 	log.Infof("central-worker shutting down")
+	cancel()
 
 	pruning.Singleton().Stop()
+	scheduler.Stop()
 
 	globaldb.Close()
 }

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -142,11 +142,7 @@ func (r *reportListener) handleRequestSubmitted(snapshotID string) {
 		ReportSnapshot: snap,
 		Collection:     collection,
 	}
-	if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
-		log.Errorf("Failed to submit report request for snapshot %s: %v", snapshotID, err)
-	} else {
-		r.trackReportID(snapshotID)
-	}
+	r.submitIfNew(snapshotID, req)
 }
 
 func (r *reportListener) handleRequestCancelled(snapshotID string) {
@@ -211,10 +207,6 @@ func (r *reportListener) resyncPendingRequests() {
 	}
 
 	for _, snap := range snapshots {
-		if r.isReportIDKnown(snap.GetReportId()) {
-			continue
-		}
-
 		var collection *storage.ResourceCollection
 		if collID := snap.GetCollection().GetId(); collID != "" {
 			var exists bool
@@ -229,22 +221,20 @@ func (r *reportListener) resyncPendingRequests() {
 			ReportSnapshot: snap,
 			Collection:     collection,
 		}
-		if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
-			log.Errorf("Error resyncing pending report %s: %v", snap.GetReportId(), err)
-		} else {
-			r.trackReportID(snap.GetReportId())
-		}
+		r.submitIfNew(snap.GetReportId(), req)
 	}
 }
 
-func (r *reportListener) trackReportID(id string) {
+func (r *reportListener) submitIfNew(reportID string, req *reportGen.ReportRequest) {
 	r.knownMu.Lock()
 	defer r.knownMu.Unlock()
-	r.knownReportIDs.Add(id)
-}
 
-func (r *reportListener) isReportIDKnown(id string) bool {
-	r.knownMu.Lock()
-	defer r.knownMu.Unlock()
-	return r.knownReportIDs.Contains(id)
+	if r.knownReportIDs.Contains(reportID) {
+		return
+	}
+	if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
+		log.Errorf("Failed to submit report request %s: %v", reportID, err)
+		return
+	}
+	r.knownReportIDs.Add(reportID)
 }

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -32,6 +32,7 @@ type reportListener struct {
 	collectionDatastore collectionDS.DataStore
 	notifierStore       notifierDS.DataStore
 	notifierProcessor   notifier.Processor
+	knownReportIDs      set.StringSet
 }
 
 func newReportListener(
@@ -51,6 +52,7 @@ func newReportListener(
 		collectionDatastore: collectionDatastore,
 		notifierStore:       notifierStore,
 		notifierProcessor:   notifierProcessor,
+		knownReportIDs:      set.NewStringSet(),
 	}
 }
 
@@ -140,6 +142,8 @@ func (r *reportListener) handleRequestSubmitted(snapshotID string) {
 	}
 	if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
 		log.Errorf("Failed to submit report request for snapshot %s: %v", snapshotID, err)
+	} else {
+		r.knownReportIDs.Add(snapshotID)
 	}
 }
 
@@ -205,6 +209,10 @@ func (r *reportListener) resyncPendingRequests() {
 	}
 
 	for _, snap := range snapshots {
+		if r.knownReportIDs.Contains(snap.GetReportId()) {
+			continue
+		}
+
 		var collection *storage.ResourceCollection
 		if collID := snap.GetCollection().GetId(); collID != "" {
 			var exists bool
@@ -221,7 +229,8 @@ func (r *reportListener) resyncPendingRequests() {
 		}
 		if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
 			log.Errorf("Error resyncing pending report %s: %v", snap.GetReportId(), err)
+		} else {
+			r.knownReportIDs.Add(snap.GetReportId())
 		}
 	}
-
 }

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 var listenerCtx = sac.WithAllAccess(context.Background())
@@ -32,6 +33,7 @@ type reportListener struct {
 	collectionDatastore collectionDS.DataStore
 	notifierStore       notifierDS.DataStore
 	notifierProcessor   notifier.Processor
+	knownMu             sync.Mutex
 	knownReportIDs      set.StringSet
 }
 
@@ -143,7 +145,7 @@ func (r *reportListener) handleRequestSubmitted(snapshotID string) {
 	if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
 		log.Errorf("Failed to submit report request for snapshot %s: %v", snapshotID, err)
 	} else {
-		r.knownReportIDs.Add(snapshotID)
+		r.trackReportID(snapshotID)
 	}
 }
 
@@ -209,7 +211,7 @@ func (r *reportListener) resyncPendingRequests() {
 	}
 
 	for _, snap := range snapshots {
-		if r.knownReportIDs.Contains(snap.GetReportId()) {
+		if r.isReportIDKnown(snap.GetReportId()) {
 			continue
 		}
 
@@ -230,7 +232,19 @@ func (r *reportListener) resyncPendingRequests() {
 		if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
 			log.Errorf("Error resyncing pending report %s: %v", snap.GetReportId(), err)
 		} else {
-			r.knownReportIDs.Add(snap.GetReportId())
+			r.trackReportID(snap.GetReportId())
 		}
 	}
+}
+
+func (r *reportListener) trackReportID(id string) {
+	r.knownMu.Lock()
+	defer r.knownMu.Unlock()
+	r.knownReportIDs.Add(id)
+}
+
+func (r *reportListener) isReportIDKnown(id string) bool {
+	r.knownMu.Lock()
+	defer r.knownMu.Unlock()
+	return r.knownReportIDs.Contains(id)
 }

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 )
 
-var workerResyncIntervalMinutes = env.RegisterIntegerSetting("ROX_WORKER_RESYNC_INTERVAL_MINUTES", 5)
 
 var listenerCtx = sac.WithAllAccess(context.Background())
 
@@ -152,7 +151,7 @@ func (r *reportListener) handleRequestCancelled(snapshotID string) {
 }
 
 func (r *reportListener) periodicResync(ctx context.Context) {
-	ticker := time.NewTicker(time.Duration(workerResyncIntervalMinutes.IntegerSetting()) * time.Minute)
+	ticker := time.NewTicker(time.Duration(env.CentralWorkerResyncIntervalMins.IntegerSetting()) * time.Minute)
 	defer ticker.Stop()
 	for {
 		select {

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -12,16 +12,15 @@ import (
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/notifier"
 	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres"
 	pgNotify "github.com/stackrox/rox/pkg/postgres/notify"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 )
-
 
 var listenerCtx = sac.WithAllAccess(context.Background())
 

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/central/reports/common"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
+	schedulerV2 "github.com/stackrox/rox/central/reports/scheduler/v2"
+	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
+	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+	pgNotify "github.com/stackrox/rox/pkg/postgres/notify"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+const configResyncInterval = 5 * time.Minute
+
+var listenerCtx = sac.WithAllAccess(context.Background())
+
+type reportListener struct {
+	db                  postgres.DB
+	scheduler           schedulerV2.Scheduler
+	reportConfigStore   reportConfigDS.DataStore
+	snapshotStore       reportSnapshotDS.DataStore
+	collectionDatastore collectionDS.DataStore
+}
+
+func newReportListener(
+	db postgres.DB,
+	scheduler schedulerV2.Scheduler,
+	reportConfigStore reportConfigDS.DataStore,
+	snapshotStore reportSnapshotDS.DataStore,
+	collectionDatastore collectionDS.DataStore,
+) *reportListener {
+	return &reportListener{
+		db:                  db,
+		scheduler:           scheduler,
+		reportConfigStore:   reportConfigStore,
+		snapshotStore:       snapshotStore,
+		collectionDatastore: collectionDatastore,
+	}
+}
+
+func (r *reportListener) start(ctx context.Context) {
+	listener := pgNotify.NewListener(r.db, r.handleNotification,
+		pgNotify.ReportConfigChanged,
+		pgNotify.ReportRequestSubmitted,
+		pgNotify.ReportRequestCancelled,
+	)
+	go listener.Listen(ctx)
+	go r.periodicResync(ctx)
+}
+
+func (r *reportListener) handleNotification(channel, payload string) {
+	switch channel {
+	case pgNotify.ReportConfigChanged:
+		r.handleConfigChanged(payload)
+	case pgNotify.ReportRequestSubmitted:
+		r.handleRequestSubmitted(payload)
+	case pgNotify.ReportRequestCancelled:
+		r.handleRequestCancelled(payload)
+	}
+}
+
+func (r *reportListener) handleConfigChanged(configID string) {
+	config, exists, err := r.reportConfigStore.GetReportConfiguration(listenerCtx, configID)
+	if err != nil {
+		log.Errorf("Failed to load report config %s: %v", configID, err)
+		return
+	}
+	if !exists {
+		r.scheduler.RemoveReportSchedule(configID)
+		return
+	}
+	if config.GetSchedule() != nil {
+		if err := r.scheduler.UpsertReportSchedule(config); err != nil {
+			log.Errorf("Failed to upsert schedule for config %s: %v", configID, err)
+		}
+	} else {
+		r.scheduler.RemoveReportSchedule(configID)
+	}
+}
+
+func (r *reportListener) handleRequestSubmitted(snapshotID string) {
+	snap, exists, err := r.snapshotStore.Get(listenerCtx, snapshotID)
+	if err != nil || !exists {
+		log.Errorf("Failed to load report snapshot %s: exists=%v err=%v", snapshotID, exists, err)
+		return
+	}
+	if snap.GetReportStatus().GetRunState() != storage.ReportStatus_WAITING {
+		return
+	}
+
+	var collection *storage.ResourceCollection
+	if snap.GetCollection().GetId() != "" {
+		collection, exists, err = r.collectionDatastore.Get(listenerCtx, snap.GetCollection().GetId())
+		if err != nil || !exists {
+			log.Errorf("Failed to load collection for snapshot %s: %v", snapshotID, err)
+			return
+		}
+	}
+
+	req := &reportGen.ReportRequest{
+		ReportSnapshot: snap,
+		Collection:     collection,
+	}
+	if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
+		log.Errorf("Failed to submit report request for snapshot %s: %v", snapshotID, err)
+	}
+}
+
+func (r *reportListener) handleRequestCancelled(snapshotID string) {
+	if _, err := r.scheduler.CancelReportRequest(listenerCtx, snapshotID); err != nil {
+		log.Errorf("Failed to cancel report request %s: %v", snapshotID, err)
+	}
+}
+
+func (r *reportListener) periodicResync(ctx context.Context) {
+	ticker := time.NewTicker(configResyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.resyncConfigs()
+		}
+	}
+}
+
+func (r *reportListener) resyncConfigs() {
+	query := search.NewQueryBuilder().
+		AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).
+		ProtoQuery()
+	configs, err := r.reportConfigStore.GetReportConfigurations(listenerCtx, query)
+	if err != nil {
+		log.Errorf("Error resyncing report configs: %v", err)
+		return
+	}
+	for _, rc := range configs {
+		if rc.GetSchedule() != nil && common.HasValidResourceScope(rc.GetResourceScope()) {
+			if err := r.scheduler.UpsertReportSchedule(rc); err != nil {
+				log.Errorf("Error resyncing schedule for config %s: %v", rc.GetId(), err)
+			}
+		}
+	}
+}

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -11,13 +11,15 @@ import (
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres"
 	pgNotify "github.com/stackrox/rox/pkg/postgres/notify"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
 )
 
-const configResyncInterval = 5 * time.Minute
+var workerResyncIntervalMinutes = env.RegisterIntegerSetting("ROX_WORKER_RESYNC_INTERVAL_MINUTES", 5)
 
 var listenerCtx = sac.WithAllAccess(context.Background())
 
@@ -120,7 +122,7 @@ func (r *reportListener) handleRequestCancelled(snapshotID string) {
 }
 
 func (r *reportListener) periodicResync(ctx context.Context) {
-	ticker := time.NewTicker(configResyncInterval)
+	ticker := time.NewTicker(time.Duration(workerResyncIntervalMinutes.IntegerSetting()) * time.Minute)
 	defer ticker.Stop()
 	for {
 		select {
@@ -135,18 +137,30 @@ func (r *reportListener) periodicResync(ctx context.Context) {
 
 func (r *reportListener) resyncConfigs() {
 	query := search.NewQueryBuilder().
-		AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).
+		AddExactMatches(search.ReportType,
+			storage.ReportConfiguration_VULNERABILITY.String(),
+			storage.ReportConfiguration_NODE_VULNERABILITY.String(),
+		).
 		ProtoQuery()
 	configs, err := r.reportConfigStore.GetReportConfigurations(listenerCtx, query)
 	if err != nil {
 		log.Errorf("Error resyncing report configs: %v", err)
 		return
 	}
+
+	activeConfigIDs := set.NewStringSet()
 	for _, rc := range configs {
 		if rc.GetSchedule() != nil && common.HasValidResourceScope(rc.GetResourceScope()) {
+			activeConfigIDs.Add(rc.GetId())
 			if err := r.scheduler.UpsertReportSchedule(rc); err != nil {
 				log.Errorf("Error resyncing schedule for config %s: %v", rc.GetId(), err)
 			}
+		}
+	}
+
+	for _, id := range r.scheduler.GetScheduledConfigIDs() {
+		if !activeConfigIDs.Contains(id) {
+			r.scheduler.RemoveReportSchedule(id)
 		}
 	}
 }

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	schedulerV2 "github.com/stackrox/rox/central/reports/scheduler/v2"
@@ -11,6 +12,8 @@ import (
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/notifier"
+	pkgNotifiers "github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/postgres"
 	pgNotify "github.com/stackrox/rox/pkg/postgres/notify"
@@ -29,6 +32,8 @@ type reportListener struct {
 	reportConfigStore   reportConfigDS.DataStore
 	snapshotStore       reportSnapshotDS.DataStore
 	collectionDatastore collectionDS.DataStore
+	notifierStore       notifierDS.DataStore
+	notifierProcessor   notifier.Processor
 }
 
 func newReportListener(
@@ -37,6 +42,8 @@ func newReportListener(
 	reportConfigStore reportConfigDS.DataStore,
 	snapshotStore reportSnapshotDS.DataStore,
 	collectionDatastore collectionDS.DataStore,
+	notifierStore notifierDS.DataStore,
+	notifierProcessor notifier.Processor,
 ) *reportListener {
 	return &reportListener{
 		db:                  db,
@@ -44,11 +51,14 @@ func newReportListener(
 		reportConfigStore:   reportConfigStore,
 		snapshotStore:       snapshotStore,
 		collectionDatastore: collectionDatastore,
+		notifierStore:       notifierStore,
+		notifierProcessor:   notifierProcessor,
 	}
 }
 
 func (r *reportListener) start(ctx context.Context) {
 	listener := pgNotify.NewListener(r.db, r.handleNotification,
+		pgNotify.NotifierChanged,
 		pgNotify.ReportConfigChanged,
 		pgNotify.ReportRequestSubmitted,
 		pgNotify.ReportRequestCancelled,
@@ -59,6 +69,8 @@ func (r *reportListener) start(ctx context.Context) {
 
 func (r *reportListener) handleNotification(channel, payload string) {
 	switch channel {
+	case pgNotify.NotifierChanged:
+		r.handleNotifierChanged(payload)
 	case pgNotify.ReportConfigChanged:
 		r.handleConfigChanged(payload)
 	case pgNotify.ReportRequestSubmitted:
@@ -66,6 +78,24 @@ func (r *reportListener) handleNotification(channel, payload string) {
 	case pgNotify.ReportRequestCancelled:
 		r.handleRequestCancelled(payload)
 	}
+}
+
+func (r *reportListener) handleNotifierChanged(notifierID string) {
+	protoNotifier, exists, err := r.notifierStore.GetNotifier(listenerCtx, notifierID)
+	if err != nil {
+		log.Errorf("Failed to load notifier %s: %v", notifierID, err)
+		return
+	}
+	if !exists {
+		r.notifierProcessor.RemoveNotifier(listenerCtx, notifierID)
+		return
+	}
+	n, err := pkgNotifiers.CreateNotifier(protoNotifier)
+	if err != nil {
+		log.Errorf("Failed to create notifier %s: %v", notifierID, err)
+		return
+	}
+	r.notifierProcessor.UpdateNotifier(listenerCtx, n)
 }
 
 func (r *reportListener) handleConfigChanged(configID string) {

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -128,6 +128,7 @@ func (r *reportListener) periodicResync(ctx context.Context) {
 			return
 		case <-ticker.C:
 			r.resyncConfigs()
+			r.resyncPendingRequests()
 		}
 	}
 }
@@ -148,4 +149,37 @@ func (r *reportListener) resyncConfigs() {
 			}
 		}
 	}
+}
+
+func (r *reportListener) resyncPendingRequests() {
+	query := search.NewQueryBuilder().
+		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String()).
+		WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.ReportQueuedTime))).
+		ProtoQuery()
+	snapshots, err := r.snapshotStore.SearchReportSnapshots(listenerCtx, query)
+	if err != nil {
+		log.Errorf("Error resyncing pending report requests: %v", err)
+		return
+	}
+
+	for _, snap := range snapshots {
+		var collection *storage.ResourceCollection
+		if collID := snap.GetCollection().GetId(); collID != "" {
+			var exists bool
+			collection, exists, err = r.collectionDatastore.Get(listenerCtx, collID)
+			if err != nil || !exists {
+				log.Errorf("Error loading collection for pending snapshot %s: %v", snap.GetReportId(), err)
+				continue
+			}
+		}
+
+		req := &reportGen.ReportRequest{
+			ReportSnapshot: snap,
+			Collection:     collection,
+		}
+		if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
+			log.Errorf("Error resyncing pending report %s: %v", snap.GetReportId(), err)
+		}
+	}
+
 }

--- a/pkg/env/central_worker.go
+++ b/pkg/env/central_worker.go
@@ -1,5 +1,6 @@
 package env
 
 var (
-	CentralWorkerEnabled = RegisterBooleanSetting("ROX_CENTRAL_WORKER_ENABLED", false)
+	CentralWorkerEnabled            = RegisterBooleanSetting("ROX_CENTRAL_WORKER_ENABLED", false)
+	CentralWorkerResyncIntervalMins = RegisterIntegerSetting("ROX_WORKER_RESYNC_INTERVAL_MINUTES", 5).WithMinimum(1)
 )

--- a/pkg/postgres/notify/channels.go
+++ b/pkg/postgres/notify/channels.go
@@ -1,6 +1,7 @@
 package notify
 
 const (
+	NotifierChanged        = "notifier_changed"
 	ReportConfigChanged    = "report_config_changed"
 	ReportRequestSubmitted = "report_request_submitted"
 	ReportRequestCancelled = "report_request_cancelled"


### PR DESCRIPTION
## Description

Adds report scheduler v2 and LISTEN/NOTIFY listener to the worker. Also removes the unused `graphql.Schema` field from the scheduler struct. This field was stored but never read, and its initialization in `New()` called `resolvers.New()` which pulls in Central's full singleton chain (JWT, API tokens, etc.), causing the central-worker pod to crash on startup.

### Report listener
- LISTENs on `report_config_changed`, `report_request_submitted`, `report_request_cancelled`
- On config change: reloads config from DB, calls `UpsertReportSchedule` or `RemoveReportSchedule`
- On request submitted: loads snapshot, submits to scheduler
- On request cancelled: forwards to scheduler
- 5-minute periodic re-sync as fallback for missed NOTIFYs

### GraphQL removal
- Removed `*graphql.Schema` field and parameter from `reportGeneratorImpl`, `New()`, and scheduler
- Removed `graphql.ParseSchema(resolvers.Schema(), resolvers.New())` calls from both singletons
- V1 reporting is dead code (not registered in `main.go`), so this is safe

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests

### How I validated my change

Both `./central/` and `./central/worker/` compile clean after GraphQL removal and reporting wiring.

Part 8 of 8 in the central-worker PR stack for ROX-32705.