### PR TITLE
ROX-35414: Add secrets list page with table, pagination, and sorting

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/secrets.test.ts
+++ b/ui/apps/platform/cypress/integration/risk/secrets.test.ts
@@ -1,7 +1,30 @@
 import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
+import { interceptAndWatchRequests } from '../../helpers/request';
+import { sortByTableHeader } from '../../helpers/tableHelpers';
 import { assertCannotFindThePage, visit } from '../../helpers/visit';
 import navSelectors from '../../selectors/navigation';
+
+const listSecretsAlias = 'listSecrets';
+const secretsCountAlias = 'secretsCount';
+
+const routeMatcherMapForSecrets = {
+    [listSecretsAlias]: {
+        method: 'GET' as const,
+        url: '/v1/secretsextended?*',
+    },
+    [secretsCountAlias]: {
+        method: 'GET' as const,
+        url: '/v1/secretscount?*',
+    },
+};
+
+function visitSecretsPage(
+    routeMatcherMap?: Record<string, { method: string; url: string }>,
+    staticResponseMap?: Record<string, { body?: unknown; fixture?: string }>
+) {
+    return visit('/main/risk/secrets', routeMatcherMap, staticResponseMap);
+}
 
 describe('Risk - Secrets page', () => {
     withAuth();
@@ -13,14 +36,10 @@ describe('Risk - Secrets page', () => {
             }
         });
 
-        it('should render the Secrets page with the correct heading', () => {
-            visit('/main/risk/secrets');
+        it('should render the heading and nav structure', () => {
+            visitSecretsPage(routeMatcherMapForSecrets);
 
-            cy.get('h1:contains("Secrets")');
-        });
-
-        it('should show Risk as an expandable nav section with Workloads and Secrets children', () => {
-            visit('/main/risk/secrets');
+            cy.get('h1').contains('Secrets Risk');
 
             cy.get(`${navSelectors.navExpandable}:contains("Risk")`);
             cy.get(`${navSelectors.nestedNavLinks}:contains("Workloads")`);
@@ -28,6 +47,42 @@ describe('Risk - Secrets page', () => {
                 'have.class',
                 'pf-m-current'
             );
+        });
+
+        it('should sort by table columns', () => {
+            interceptAndWatchRequests(routeMatcherMapForSecrets).then(({ waitForRequests }) => {
+                visitSecretsPage();
+                waitForRequests();
+
+                sortByTableHeader('Secret');
+                cy.wait(`@${listSecretsAlias}`).then((interception) => {
+                    expect(interception.request.url).to.include('Secret');
+                });
+
+                sortByTableHeader('Cluster');
+                cy.wait(`@${listSecretsAlias}`).then((interception) => {
+                    expect(interception.request.url).to.include('Cluster');
+                });
+
+                sortByTableHeader('Namespace');
+                cy.wait(`@${listSecretsAlias}`).then((interception) => {
+                    expect(interception.request.url).to.include('Namespace');
+                });
+
+                sortByTableHeader('Created');
+                cy.wait(`@${listSecretsAlias}`).then((interception) => {
+                    expect(interception.request.url).to.include('Created%20Time');
+                });
+            });
+        });
+
+        it('should display an empty state when no secrets are returned', () => {
+            visitSecretsPage(routeMatcherMapForSecrets, {
+                [listSecretsAlias]: { body: { secrets: [] } },
+                [secretsCountAlias]: { body: { count: 0 } },
+            });
+
+            cy.get('tbody').contains('No results found');
         });
     });
 

--- a/ui/apps/platform/src/Containers/Risk/Secrets/SecretsPage.tsx
+++ b/ui/apps/platform/src/Containers/Risk/Secrets/SecretsPage.tsx
@@ -1,15 +1,116 @@
-import { Flex, PageSection, Title } from '@patternfly/react-core';
+import { useCallback } from 'react';
+import {
+    PageSection,
+    Pagination,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import PageTitle from 'Components/PageTitle';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useURLPagination from 'hooks/useURLPagination';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLSort from 'hooks/useURLSort';
+import type { SortOption } from 'types/table';
+import { secretTypeLabels } from './secrets.utils';
+import { fetchSecretCount, fetchSecrets } from 'services/SecretsService';
+import { getTableUIState } from 'utils/getTableUIState';
+import { getDateTime } from 'utils/dateUtils';
+
+const sortFields = ['Secret', 'Namespace', 'Cluster', 'Created Time'];
+
+const defaultSortOption: SortOption = {
+    field: 'Secret',
+    direction: 'asc',
+};
 
 function SecretsPage() {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(20);
+    const { sortOption, getSortParams } = useURLSort({ sortFields, defaultSortOption });
+
+    const fetchSecretsCallback = useCallback(
+        () => fetchSecrets({ searchFilter: {}, sortOption, page, perPage }),
+        [sortOption, page, perPage]
+    );
+    const secretsQuery = useRestQuery(fetchSecretsCallback);
+
+    const fetchCountCallback = useCallback(() => fetchSecretCount({}), []);
+    const countQuery = useRestQuery(fetchCountCallback);
+
+    const tableState = getTableUIState({
+        isLoading: secretsQuery.isLoading,
+        data: secretsQuery.data,
+        error: secretsQuery.error,
+        searchFilter: {},
+    });
+
     return (
         <>
             <PageTitle title="Risk - Secrets" />
             <PageSection>
-                <Flex direction={{ default: 'column' }}>
-                    <Title headingLevel="h1">Secrets</Title>
-                </Flex>
+                <Title headingLevel="h1">Secrets Risk</Title>
+            </PageSection>
+            <PageSection>
+                <Toolbar>
+                    <ToolbarContent>
+                        <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
+                            <Pagination
+                                itemCount={countQuery.data ?? 0}
+                                page={page}
+                                perPage={perPage}
+                                onSetPage={(_, newPage) => setPage(newPage)}
+                                onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                            />
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+                <Table variant="compact">
+                    <Thead>
+                        <Tr>
+                            <Th modifier="nowrap" sort={getSortParams('Secret')}>
+                                Secret
+                            </Th>
+                            <Th modifier="nowrap">Types</Th>
+                            <Th modifier="nowrap" sort={getSortParams('Created Time')}>
+                                Created
+                            </Th>
+                            <Th modifier="nowrap" sort={getSortParams('Cluster')}>
+                                Cluster
+                            </Th>
+                            <Th modifier="nowrap" sort={getSortParams('Namespace')}>
+                                Namespace
+                            </Th>
+                        </Tr>
+                    </Thead>
+                    <TbodyUnified
+                        tableState={tableState}
+                        colSpan={5}
+                        renderer={({ data }) => (
+                            <Tbody>
+                                {data.map(
+                                    ({ id, name, namespace, clusterName, types, createdAt }) => (
+                                        <Tr key={id}>
+                                            <Td dataLabel="Secret">{name}</Td>
+                                            <Td dataLabel="Types">
+                                                {types
+                                                    .map((type) => secretTypeLabels[type] ?? type)
+                                                    .join(', ')}
+                                            </Td>
+                                            <Td dataLabel="Created">
+                                                {createdAt ? getDateTime(createdAt) : '-'}
+                                            </Td>
+                                            <Td dataLabel="Cluster">{clusterName}</Td>
+                                            <Td dataLabel="Namespace">{namespace}</Td>
+                                        </Tr>
+                                    )
+                                )}
+                            </Tbody>
+                        )}
+                    />
+                </Table>
             </PageSection>
         </>
     );

--- a/ui/apps/platform/src/Containers/Risk/Secrets/secrets.utils.ts
+++ b/ui/apps/platform/src/Containers/Risk/Secrets/secrets.utils.ts
@@ -1,0 +1,16 @@
+import type { SecretType } from 'services/SecretsService';
+
+export const secretTypeLabels: Record<SecretType, string> = Object.freeze({
+    UNDETERMINED: 'Undetermined',
+    PUBLIC_CERTIFICATE: 'Public certificate',
+    CERTIFICATE_REQUEST: 'Certificate request',
+    PRIVACY_ENHANCED_MESSAGE: 'Privacy enhanced message',
+    OPENSSH_PRIVATE_KEY: 'OpenSSH private key',
+    PGP_PRIVATE_KEY: 'PGP private key',
+    EC_PRIVATE_KEY: 'EC private key',
+    RSA_PRIVATE_KEY: 'RSA private key',
+    DSA_PRIVATE_KEY: 'DSA private key',
+    CERT_PRIVATE_KEY: 'Certificate private key',
+    ENCRYPTED_PRIVATE_KEY: 'Encrypted private key',
+    IMAGE_PULL_SECRET: 'Image pull secret',
+});

--- a/ui/apps/platform/src/services/SecretsService.ts
+++ b/ui/apps/platform/src/services/SecretsService.ts
@@ -1,0 +1,65 @@
+import queryString from 'qs';
+
+import type { SearchFilter, SearchQueryOptions } from 'types/search';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+// TODO: Move buildNestedRawQueryParams to searchUtils as a shared helper
+import { buildNestedRawQueryParams } from './ComplianceCommon';
+import axios from './instance';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
+
+const baseUrl = '/v1/secretsextended';
+const baseCountUrl = '/v1/secretscount';
+
+export const secretTypes = [
+    'UNDETERMINED',
+    'PUBLIC_CERTIFICATE',
+    'CERTIFICATE_REQUEST',
+    'PRIVACY_ENHANCED_MESSAGE',
+    'OPENSSH_PRIVATE_KEY',
+    'PGP_PRIVATE_KEY',
+    'EC_PRIVATE_KEY',
+    'RSA_PRIVATE_KEY',
+    'DSA_PRIVATE_KEY',
+    'CERT_PRIVATE_KEY',
+    'ENCRYPTED_PRIVATE_KEY',
+    'IMAGE_PULL_SECRET',
+] as const;
+
+export type SecretType = (typeof secretTypes)[number];
+
+export type ListSecret = {
+    id: string;
+    name: string;
+    clusterId: string;
+    clusterName: string;
+    namespace: string;
+    types: SecretType[];
+    createdAt: string; // ISO 8601 string
+};
+
+export function fetchSecrets({
+    searchFilter,
+    sortOption,
+    page,
+    perPage,
+}: SearchQueryOptions): CancellableRequest<ListSecret[]> {
+    const params = buildNestedRawQueryParams({ searchFilter, sortOption, page, perPage });
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{ secrets: ListSecret[] }>(`${baseUrl}?${params}`, { signal })
+            .then((response) => response?.data?.secrets ?? [])
+    );
+}
+
+export function fetchSecretCount(searchFilter: SearchFilter): CancellableRequest<number> {
+    const params = queryString.stringify(
+        { query: getRequestQueryStringForSearchFilter(searchFilter) },
+        { arrayFormat: 'repeat' }
+    );
+    return makeCancellableAxiosRequest((signal) =>
+        axios
+            .get<{ count: number }>(`${baseCountUrl}?${params}`, { signal })
+            .then((response) => response?.data?.count ?? 0)
+    );
+}


### PR DESCRIPTION
## Description

Implemented a secrets list page under Risk showing secrets across all clusters with sorting and pagination. Uses the new `/v1/secretsextended` endpoint with nested `RawQuery` serialization.

Part of epic ROX-35386.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Test populated Secrets page in UI:
<img width="1637" height="883" alt="image" src="https://github.com/user-attachments/assets/67574fce-4a0a-423d-a142-c6bd9627f5f4" />

Verify passing e2e tests.