### PR TITLE
ROX-32912: Bump v2 vulnerability bundle to release-4.11

### DIFF
--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -5,4 +5,4 @@
 # Each vulnerability bundle version serves the Scanner V4 requesting it, which is, by default, based on the version specified in scanner/VULNERABILITY_VERSION in the related Scanner V4 tag.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
-v2 tags/4.11.1
+v2 heads/2859e843d618d59df8b68bb751507bcd815c890e

--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -5,4 +5,4 @@
 # Each vulnerability bundle version serves the Scanner V4 requesting it, which is, by default, based on the version specified in scanner/VULNERABILITY_VERSION in the related Scanner V4 tag.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
-v2 tags/4.9.8-rc.2
+v2 tags/4.11.1


### PR DESCRIPTION
## Description

Updates the v2 vulnerability bundle stream reference from `tags/4.9.8-rc.2` to `heads/2859e843d6` (release-4.11 tip), which includes the claircore bump from #21598 (quay/claircore#1942) fixing a hard-fail on unparseable VEX entries.

Bundles generated from this ref contain `Self`, `Aliases`, and `Invert` fields on vulnerabilities, enabling VEX `known_not_affected` filtering on 4.11+ deployments.

Backward compatibility was validated on three GKE clusters using an RC bundle built from the release-4.11 tip:

| Version | Bundle import | Errors | CVE-2024-24786 | Vulns |
|---------|--------------|--------|----------------|-------|
| 4.9.8   | 13/13        | 0      | Present        | 2,085 |
| 4.10.4  | 13/13        | 0      | Present        | 2,085 |
| 4.11    | 13/13        | 0      | Suppressed     | 984   |

The new JSON fields are silently ignored by 4.9 and 4.10 (Go's JSON decoder skips unknown fields). 4.11 imports alias data and suppresses CVE-2024-24786 via VEX. Zero VersionRange encoding errors on any version.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

See validation table above. RC bundle hosted at https://github.com/jvdm/quay-claircore/releases/tag/v0-rc-bundle-test. Each cluster deployed with dev images from the corresponding release tag, matcher configured with `SCANNER_V4_MATCHER_VULNERABILITIES_URL` pointing to the RC bundle. All 13 bundles imported without errors on all three versions. Scan of `registry.redhat.io/mta/mta-rhel8-operator@sha256:1719cafe...` confirmed VEX suppression on 4.11 and no impact on 4.9/4.10.