### PR TITLE
ROX-35619: Prune app.k8s.io/Application when API is gone

### DIFF
--- a/operator/internal/common/extensions/mapkubeapis.go
+++ b/operator/internal/common/extensions/mapkubeapis.go
@@ -38,6 +38,11 @@ func AddMapKubeAPIsExtensionIfMapFileExists(opts []pkgReconciler.Option, mapper 
 				Version: "v1alpha3",
 				Kind:    "DestinationRule",
 			},
+			{
+				Group:   "app.k8s.io",
+				Version: "v1beta1",
+				Kind:    "Application",
+			},
 		},
 	}
 	extension := MapKubeAPIsExtension(config)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When the [app.k8s.io](http://app.k8s.io/)/v1beta1/Application API disappears (due to CRD removal) the ACS operator will start failing with errors such as:

```
	//   unable to build kubernetes objects from current release manifest: [resource mapping not found for name:
	//   "stackrox" namespace: "stackrox" from "": no matches for kind "Application"
	//   in version "app.k8s.io/v1beta1" ensure CRDs are installed first,
```

see https://issues.redhat.com/browse/ROX-19315 for a similar istio exercise last year.

Since RH ACM (the main/only provider of the above API in OpenShift ecosystem) has deprecated the related APIs a while ago, and might drop it soon, we need to backport this to older ACS releases to stay afloat.

- see also https://github.com/stackrox/stackrox/pull/21585 which stops shipping the `Application` resource

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] not modified existing tests, this is rather hard to test automatically

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] manual test:
   - [x] install ACM, create a `MultiClusterEngine CR`
   - [x] make sure the API is there,
   - [x] install ACS,
   - [x] make sure the resource is applied,
   - [x] remove ACM and the `MCE` CR (this does not prune the application CRD)
   - [x] remove the CRD
   - [x] make sure ACS operator still reconciles - it actually seems to have the API cached, and does not realize anything might be wrong
   - [x] bounce the ACS operator pod and make sure ACS operator still reconciles