### PR TITLE
ROX-35307: retry severity policy enforcement in AC test case

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -108,42 +108,20 @@ class AdmissionControllerTest extends BaseSpecification {
 
         // Wait for policy propagation to sensor and admission controller
         // Verify by attempting to create a deployment that should be blocked
-        def latestTagDeployment = new Deployment()
-                .setName("setup-verification-latest")
+        def testDeployment = new Deployment()
+                .setName("setup-verification")
                 .setNamespace(TEST_NAMESPACE)
                 .setImage(BUSYBOX_LATEST_TAG_IMAGE)
                 .addLabel("app", "test")
 
         withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
-            def created = orchestrator.createDeploymentNoWait(latestTagDeployment)
+            def created = orchestrator.createDeploymentNoWait(testDeployment)
             assert !created // Should be blocked by latest tag policy
         }
 
         // Clean up if somehow it was created
         try {
-            orchestrator.deleteDeployment(latestTagDeployment)
-        } catch (Exception ignored) {
-            // Expected - deployment should not exist
-        }
-
-        // Wait for severity policy enforcement with cached scan data to propagate
-        // to the admission controller. The image was pre-scanned above, but the AC
-        // may not have fetched scan results from Central yet.
-        def severityDeployment = new Deployment()
-                .setName("setup-verification-severity")
-                .setNamespace(TEST_NAMESPACE)
-                .setImagePrefetcherAffinity()
-                .setImage(SCAN_INLINE_IMAGE_NAME_WITH_SHA)
-                .addLabel("app", "test")
-
-        withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
-            def created = orchestrator.createDeploymentNoWait(severityDeployment)
-            assert !created // Should be blocked by severity policy
-        }
-
-        // Clean up if somehow it was created
-        try {
-            orchestrator.deleteDeployment(severityDeployment)
+            orchestrator.deleteDeployment(testDeployment)
         } catch (Exception ignored) {
             // Expected - deployment should not exist
         }
@@ -163,7 +141,21 @@ class AdmissionControllerTest extends BaseSpecification {
     def "Verify admission controller enforcement on create: #desc"() {
         when:
         "Create a deployment that violates an enforced policy"
-        def created = orchestrator.createDeploymentNoWait(deployment)
+        // Retry to allow time for the admission controller to fetch scan data from
+        // Central. Policies that require image enrichment (e.g. severity) may not
+        // evaluate on the first attempt if the AC pod handling this request hasn't
+        // cached the scan results yet. The retry is harmless for fast-path policies
+        // (latest tag, bypass) since they pass on the first attempt.
+        def created
+        withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
+            created = orchestrator.createDeploymentNoWait(deployment)
+            if (created != launched) {
+                if (created) {
+                    deleteDeploymentWithCaution(deployment)
+                }
+                assert created == launched
+            }
+        }
 
         then:
         "Verify the admission controller allows or blocks based on policy and bypass annotation"


### PR DESCRIPTION
## Description

The `AdmissionControllerTest` "blocked by enforced severity policy (cached scan)" test case has been flaking ([ROX-35307](https://redhat.atlassian.net/browse/ROX-35307)). Prior fixes in #21457 and #21520 added scan data assertions and a `setupSpec` retry loop for severity enforcement. However, the `setupSpec` retry only warmed the cache of whichever admission controller pod handled that particular request. With 3 AC replicas, the actual test request could hit a different pod that hadn't yet fetched scan results from Central.

This PR removes the severity-specific retry from `setupSpec` and instead adds a retry loop directly in the test body (`"Verify admission controller enforcement on create"`). This way, whichever AC pod handles the test request gets time to fetch and cache scan results. The retry is harmless for fast-path policies (latest tag, bypass) since they pass on the first attempt.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

This is a test-only change in `qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy`. After #21520, the severity test case passed 7/7 merge jobs, but the edge case with multiple AC replicas remained. This change moves the retry into the test body itself so it covers whichever pod handles the request. Validation comes from CI runs on this PR.


[ROX-35307]: https://redhat.atlassian.net/browse/ROX-35307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ