### PR TITLE
refactor(ui): move buildNestedRawQueryParams to searchUtils

### DIFF
--- a/ui/apps/platform/src/services/ComplianceCommon.ts
+++ b/ui/apps/platform/src/services/ComplianceCommon.ts
@@ -1,8 +1,3 @@
-import qs from 'qs';
-
-import type { SearchQueryOptions } from 'types/search';
-import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-
 export const complianceV2Url = '/v2/compliance';
 
 export const ComplianceCheckStatusValues = [
@@ -87,26 +82,3 @@ export type ComplianceProfileSummary = {
     standards: ComplianceBenchmark[];
     operatorKind?: ComplianceProfileOperatorKind;
 };
-
-/*
- * Builds query parameters for nested RawQuery in compliance API requests
- *
- * This is used when the RawQuery is nested within the request parameter,
- * not when it's the sole parameter.
- */
-export function buildNestedRawQueryParams({
-    page,
-    perPage,
-    sortOption,
-    searchFilter = {},
-}: SearchQueryOptions): string {
-    const query = getRequestQueryStringForSearchFilter(searchFilter);
-    const pagination = getPaginationParams({ page, perPage, sortOption });
-    const queryParameters = {
-        query: {
-            query,
-            pagination,
-        },
-    };
-    return qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
-}

--- a/ui/apps/platform/src/services/ComplianceResultsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsService.ts
@@ -1,7 +1,8 @@
 import axios from 'services/instance';
 import type { SearchQueryOptions } from 'types/search';
 
-import { buildNestedRawQueryParams, complianceV2Url } from './ComplianceCommon';
+import { buildNestedRawQueryParams } from 'utils/searchUtils';
+import { complianceV2Url } from './ComplianceCommon';
 import type {
     ComplianceCheckStatus,
     ComplianceControl,

--- a/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
+++ b/ui/apps/platform/src/services/ComplianceResultsStatsService.ts
@@ -2,9 +2,9 @@ import axios from 'services/instance';
 import type { SearchFilter, SearchQueryOptions } from 'types/search';
 import qs from 'qs';
 
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { buildNestedRawQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 
-import { buildNestedRawQueryParams, complianceV2Url } from './ComplianceCommon';
+import { complianceV2Url } from './ComplianceCommon';
 import type {
     ComplianceCheckResultStatusCount,
     ComplianceCheckStatusCount,

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -14,7 +14,7 @@ import type {
     ViewBasedReportSnapshot,
 } from 'services/ReportsService.types';
 import type { ApiSortOption, SearchFilter } from 'types/search';
-import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import { buildNestedRawQueryParams, getPaginationParams } from 'utils/searchUtils';
 import type { ReportNotificationMethod, ReportStatus } from 'types/reportJob';
 import { sanitizeFilename } from 'utils/fileUtils';
 
@@ -144,14 +144,9 @@ export function fetchViewBasedReportHistory({
     sortOption,
     showMyHistory,
 }: FetchViewBasedReportHistoryServiceParams): Promise<ViewBasedReportSnapshot[]> {
-    const params = queryString.stringify(
-        {
-            reportParamQuery: {
-                query: getRequestQueryStringForSearchFilter(searchFilter),
-                pagination: getPaginationParams({ page, perPage, sortOption }),
-            },
-        },
-        { arrayFormat: 'repeat', allowDots: true }
+    const params = buildNestedRawQueryParams(
+        { searchFilter, page, perPage, sortOption },
+        'reportParamQuery'
     );
 
     const endpoint = showMyHistory

--- a/ui/apps/platform/src/services/SecretsService.ts
+++ b/ui/apps/platform/src/services/SecretsService.ts
@@ -1,9 +1,7 @@
 import queryString from 'qs';
 
 import type { SearchFilter, SearchQueryOptions } from 'types/search';
-import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-// TODO: Move buildNestedRawQueryParams to searchUtils as a shared helper
-import { buildNestedRawQueryParams } from './ComplianceCommon';
+import { buildNestedRawQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import axios from './instance';
 import { makeCancellableAxiosRequest } from './cancellationUtils';
 import type { CancellableRequest } from './cancellationUtils';

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -2,9 +2,7 @@ import axios from 'services/instance';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { ScanComponent, SourceType } from 'types/scanComponent.proto';
 import type { SearchQueryOptions } from 'types/search';
-import { applyRegexSearchModifiers } from 'utils/searchUtils';
-
-import { buildNestedRawQueryParams } from './ComplianceCommon';
+import { applyRegexSearchModifiers, buildNestedRawQueryParams } from 'utils/searchUtils';
 
 // Legacy API (v2/virtualmachines)
 

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -8,6 +8,7 @@ import type {
     ApiSortOptionSingle,
     GraphQLSortOption,
     SearchFilter,
+    SearchQueryOptions,
 } from 'types/search';
 import { nodeAttributes } from 'Components/CompoundSearchFilter/attributes/node';
 import { imageAttributes } from 'Components/CompoundSearchFilter/attributes/image';
@@ -237,6 +238,34 @@ export function getListQueryParams({
         },
         { allowDots: true }
     );
+}
+
+/**
+ * Builds query parameters for API endpoints where RawQuery is nested within
+ * the request message (e.g. `{ query: { query, pagination } }`), rather than
+ * being the top-level request parameter.
+ *
+ * @param options - Search query options (page, perPage, sortOption, searchFilter)
+ * @param paramName - The name of the nested parameter (defaults to 'query').
+ *                    Use 'reportParamQuery' for report history endpoints.
+ * @param additionalParams - Additional top-level parameters to include alongside the nested query
+ *                          (e.g., { includeRelationships: true })
+ */
+export function buildNestedRawQueryParams(
+    { page, perPage, sortOption, searchFilter = {} }: SearchQueryOptions,
+    paramName = 'query',
+    additionalParams: Record<string, unknown> = {}
+): string {
+    const query = getRequestQueryStringForSearchFilter(searchFilter);
+    const pagination = getPaginationParams({ page, perPage, sortOption });
+    const queryParameters = {
+        [paramName]: {
+            query,
+            pagination,
+        },
+        ...additionalParams,
+    };
+    return qs.stringify(queryParameters, { arrayFormat: 'repeat', allowDots: true });
 }
 
 /**


### PR DESCRIPTION
## Description

Small refactor to move `buildNestedRawQueryParams` out of Compliance, and make it usable for other pages.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI