### PR TITLE
ROX-29681: Scanner V4 KEV support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Added Features
 - ROX-34997: The Central CR now supports `spec.central.rolloutStrategy` (`Recreate` or `RollingUpdate`) to configure the central deployment rollout strategy. Default remains `Recreate`.
+
 - ROX-35181: Administrative events are now exposed as configurable custom Prometheus metrics (`rox_central_admin_event_*`), aggregated by Type, Level, Domain, ResourceType, and ResourceName. Requires permission to read Administration resource, globally scoped.
-- ROX-29681: StackRox now supports CISA KEV data when using Scanner V4. To enable it, set `ROX_CISA_KEV=true` in both Central and Scanner V4 Matcher.
 
 ### Removed Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Added Features
 - ROX-34997: The Central CR now supports `spec.central.rolloutStrategy` (`Recreate` or `RollingUpdate`) to configure the central deployment rollout strategy. Default remains `Recreate`.
-
 - ROX-35181: Administrative events are now exposed as configurable custom Prometheus metrics (`rox_central_admin_event_*`), aggregated by Type, Level, Domain, ResourceType, and ResourceName. Requires permission to read Administration resource, globally scoped.
+- ROX-29681: StackRox now supports CISA KEV data when using Scanner V4. To enable it, set `ROX_CISA_KEV=true` in both Central and Scanner V4 Matcher.
 
 ### Removed Features
 

--- a/generated/internalapi/scanner/v4/vulnerability_report.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report.pb.go
@@ -182,7 +182,7 @@ func (VulnerabilityReport_Vulnerability_CVSS_Source) EnumDescriptor() ([]byte, [
 	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 2, 0, 0}
 }
 
-// Next tag: 19
+// Next tag: 20
 type VulnerabilityReport struct {
 	state                  protoimpl.MessageState                        `protogen:"open.v1"`
 	HashId                 string                                        `protobuf:"bytes,1,opt,name=hash_id,json=hashId,proto3" json:"hash_id,omitempty"`
@@ -433,12 +433,13 @@ type VulnerabilityReport_Vulnerability struct {
 	RepositoryId       string                                     `protobuf:"bytes,10,opt,name=repository_id,json=repositoryId,proto3" json:"repository_id,omitempty"`
 	FixedInVersion     string                                     `protobuf:"bytes,11,opt,name=fixed_in_version,json=fixedInVersion,proto3" json:"fixed_in_version,omitempty"`
 	// Deprecated: Marked as deprecated in internalapi/scanner/v4/vulnerability_report.proto.
-	Cvss          *VulnerabilityReport_Vulnerability_CVSS   `protobuf:"bytes,12,opt,name=cvss,proto3" json:"cvss,omitempty"` // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
-	CvssMetrics   []*VulnerabilityReport_Vulnerability_CVSS `protobuf:"bytes,13,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
-	EpssMetrics   *VulnerabilityReport_Vulnerability_EPSS   `protobuf:"bytes,14,opt,name=epss_metrics,json=epssMetrics,proto3" json:"epss_metrics,omitempty"`
-	Updater       string                                    `protobuf:"bytes,16,opt,name=updater,proto3" json:"updater,omitempty"`
-	FixedDate     *timestamppb.Timestamp                    `protobuf:"bytes,17,opt,name=fixed_date,json=fixedDate,proto3" json:"fixed_date,omitempty"` // will not be avail from all vuln sources
-	Aliases       []*VulnerabilityReport_Alias              `protobuf:"bytes,18,rep,name=aliases,proto3" json:"aliases,omitempty"`
+	Cvss          *VulnerabilityReport_Vulnerability_CVSS        `protobuf:"bytes,12,opt,name=cvss,proto3" json:"cvss,omitempty"` // value of cvss field is included in cvss_metrics field, the exact deprecation date is undecided
+	CvssMetrics   []*VulnerabilityReport_Vulnerability_CVSS      `protobuf:"bytes,13,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
+	EpssMetrics   *VulnerabilityReport_Vulnerability_EPSS        `protobuf:"bytes,14,opt,name=epss_metrics,json=epssMetrics,proto3" json:"epss_metrics,omitempty"`
+	Updater       string                                         `protobuf:"bytes,16,opt,name=updater,proto3" json:"updater,omitempty"`
+	FixedDate     *timestamppb.Timestamp                         `protobuf:"bytes,17,opt,name=fixed_date,json=fixedDate,proto3" json:"fixed_date,omitempty"` // will not be avail from all vuln sources
+	Aliases       []*VulnerabilityReport_Alias                   `protobuf:"bytes,18,rep,name=aliases,proto3" json:"aliases,omitempty"`
+	Exploit       *VulnerabilityReport_Vulnerability_CISAExploit `protobuf:"bytes,19,opt,name=exploit,proto3" json:"exploit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -601,6 +602,13 @@ func (x *VulnerabilityReport_Vulnerability) GetAliases() []*VulnerabilityReport_
 	return nil
 }
 
+func (x *VulnerabilityReport_Vulnerability) GetExploit() *VulnerabilityReport_Vulnerability_CISAExploit {
+	if x != nil {
+		return x.Exploit
+	}
+	return nil
+}
+
 type VulnerabilityReport_Vulnerability_CVSS struct {
 	state         protoimpl.MessageState                        `protogen:"open.v1"`
 	V2            *VulnerabilityReport_Vulnerability_CVSS_V2    `protobuf:"bytes,1,opt,name=v2,proto3" json:"v2,omitempty"`
@@ -737,6 +745,90 @@ func (x *VulnerabilityReport_Vulnerability_EPSS) GetPercentile() float32 {
 	return 0
 }
 
+type VulnerabilityReport_Vulnerability_CISAExploit struct {
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	CatalogVersion             string                 `protobuf:"bytes,1,opt,name=catalog_version,json=catalogVersion,proto3" json:"catalog_version,omitempty"`
+	DateAdded                  string                 `protobuf:"bytes,2,opt,name=date_added,json=dateAdded,proto3" json:"date_added,omitempty"`
+	ShortDescription           string                 `protobuf:"bytes,3,opt,name=short_description,json=shortDescription,proto3" json:"short_description,omitempty"`
+	RequiredAction             string                 `protobuf:"bytes,4,opt,name=required_action,json=requiredAction,proto3" json:"required_action,omitempty"`
+	DueDate                    string                 `protobuf:"bytes,5,opt,name=due_date,json=dueDate,proto3" json:"due_date,omitempty"`
+	KnownRansomwareCampaignUse string                 `protobuf:"bytes,6,opt,name=known_ransomware_campaign_use,json=knownRansomwareCampaignUse,proto3" json:"known_ransomware_campaign_use,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) Reset() {
+	*x = VulnerabilityReport_Vulnerability_CISAExploit{}
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VulnerabilityReport_Vulnerability_CISAExploit) ProtoMessage() {}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VulnerabilityReport_Vulnerability_CISAExploit.ProtoReflect.Descriptor instead.
+func (*VulnerabilityReport_Vulnerability_CISAExploit) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP(), []int{0, 2, 2}
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetCatalogVersion() string {
+	if x != nil {
+		return x.CatalogVersion
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetDateAdded() string {
+	if x != nil {
+		return x.DateAdded
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetShortDescription() string {
+	if x != nil {
+		return x.ShortDescription
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetRequiredAction() string {
+	if x != nil {
+		return x.RequiredAction
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetDueDate() string {
+	if x != nil {
+		return x.DueDate
+	}
+	return ""
+}
+
+func (x *VulnerabilityReport_Vulnerability_CISAExploit) GetKnownRansomwareCampaignUse() string {
+	if x != nil {
+		return x.KnownRansomwareCampaignUse
+	}
+	return ""
+}
+
 type VulnerabilityReport_Vulnerability_CVSS_V2 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	BaseScore     float32                `protobuf:"fixed32,1,opt,name=base_score,json=baseScore,proto3" json:"base_score,omitempty"`
@@ -747,7 +839,7 @@ type VulnerabilityReport_Vulnerability_CVSS_V2 struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS_V2{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[10]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -759,7 +851,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V2) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS_V2) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V2) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[10]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -799,7 +891,7 @@ type VulnerabilityReport_Vulnerability_CVSS_V3 struct {
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) Reset() {
 	*x = VulnerabilityReport_Vulnerability_CVSS_V3{}
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[11]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -811,7 +903,7 @@ func (x *VulnerabilityReport_Vulnerability_CVSS_V3) String() string {
 func (*VulnerabilityReport_Vulnerability_CVSS_V3) ProtoMessage() {}
 
 func (x *VulnerabilityReport_Vulnerability_CVSS_V3) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[11]
+	mi := &file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -846,7 +938,7 @@ var File_internalapi_scanner_v4_vulnerability_report_proto protoreflect.FileDesc
 const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\n" +
 	"1internalapi/scanner/v4/vulnerability_report.proto\x12\n" +
-	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\xad\x14\n" +
+	"scanner.v4\x1a\x1fgoogle/protobuf/timestamp.proto\x1a#internalapi/scanner/v4/common.proto\"\x8e\x17\n" +
 	"\x13VulnerabilityReport\x12\x17\n" +
 	"\ahash_id\x18\x01 \x01(\tR\x06hashId\x12^\n" +
 	"\x0fvulnerabilities\x18\x02 \x03(\v24.scanner.v4.VulnerabilityReport.VulnerabilitiesEntryR\x0fvulnerabilities\x12t\n" +
@@ -859,7 +951,7 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\x04link\x18\x02 \x01(\tR\x04link\x1a1\n" +
 	"\x05Alias\x12\x14\n" +
 	"\x05space\x18\x01 \x01(\tR\x05space\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x1a\xdd\f\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x1a\xbe\x0f\n" +
 	"\rVulnerability\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12D\n" +
@@ -881,7 +973,8 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\aupdater\x18\x10 \x01(\tR\aupdater\x129\n" +
 	"\n" +
 	"fixed_date\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\tfixedDate\x12?\n" +
-	"\aaliases\x18\x12 \x03(\v2%.scanner.v4.VulnerabilityReport.AliasR\aaliases\x1a\xc5\x03\n" +
+	"\aaliases\x18\x12 \x03(\v2%.scanner.v4.VulnerabilityReport.AliasR\aaliases\x12S\n" +
+	"\aexploit\x18\x13 \x01(\v29.scanner.v4.VulnerabilityReport.Vulnerability.CISAExploitR\aexploit\x1a\xc5\x03\n" +
 	"\x04CVSS\x12E\n" +
 	"\x02v2\x18\x01 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2R\x02v2\x12E\n" +
 	"\x02v3\x18\x02 \x01(\v25.scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3R\x02v3\x12Q\n" +
@@ -908,7 +1001,15 @@ const file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc = "" +
 	"\vprobability\x18\x03 \x01(\x02R\vprobability\x12\x1e\n" +
 	"\n" +
 	"percentile\x18\x04 \x01(\x02R\n" +
-	"percentile\"|\n" +
+	"percentile\x1a\x89\x02\n" +
+	"\vCISAExploit\x12'\n" +
+	"\x0fcatalog_version\x18\x01 \x01(\tR\x0ecatalogVersion\x12\x1d\n" +
+	"\n" +
+	"date_added\x18\x02 \x01(\tR\tdateAdded\x12+\n" +
+	"\x11short_description\x18\x03 \x01(\tR\x10shortDescription\x12'\n" +
+	"\x0frequired_action\x18\x04 \x01(\tR\x0erequiredAction\x12\x19\n" +
+	"\bdue_date\x18\x05 \x01(\tR\adueDate\x12A\n" +
+	"\x1dknown_ransomware_campaign_use\x18\x06 \x01(\tR\x1aknownRansomwareCampaignUse\"|\n" +
 	"\bSeverity\x12\x18\n" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fSEVERITY_LOW\x10\x01\x12\x15\n" +
@@ -945,7 +1046,7 @@ func file_internalapi_scanner_v4_vulnerability_report_proto_rawDescGZIP() []byte
 }
 
 var file_internalapi_scanner_v4_vulnerability_report_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_internalapi_scanner_v4_vulnerability_report_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_internalapi_scanner_v4_vulnerability_report_proto_goTypes = []any{
 	(VulnerabilityReport_Note)(0),                      // 0: scanner.v4.VulnerabilityReport.Note
 	(VulnerabilityReport_Vulnerability_Severity)(0),    // 1: scanner.v4.VulnerabilityReport.Vulnerability.Severity
@@ -958,38 +1059,40 @@ var file_internalapi_scanner_v4_vulnerability_report_proto_goTypes = []any{
 	nil, // 8: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
 	nil, // 9: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
 	nil, // 10: scanner.v4.VulnerabilityReport.PackageNotVulnerableEntry
-	(*VulnerabilityReport_Vulnerability_CVSS)(nil),    // 11: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
-	(*VulnerabilityReport_Vulnerability_EPSS)(nil),    // 12: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil), // 13: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil), // 14: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
-	(*Contents)(nil),              // 15: scanner.v4.Contents
-	(*timestamppb.Timestamp)(nil), // 16: google.protobuf.Timestamp
+	(*VulnerabilityReport_Vulnerability_CVSS)(nil),        // 11: scanner.v4.VulnerabilityReport.Vulnerability.CVSS
+	(*VulnerabilityReport_Vulnerability_EPSS)(nil),        // 12: scanner.v4.VulnerabilityReport.Vulnerability.EPSS
+	(*VulnerabilityReport_Vulnerability_CISAExploit)(nil), // 13: scanner.v4.VulnerabilityReport.Vulnerability.CISAExploit
+	(*VulnerabilityReport_Vulnerability_CVSS_V2)(nil),     // 14: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	(*VulnerabilityReport_Vulnerability_CVSS_V3)(nil),     // 15: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	(*Contents)(nil),              // 16: scanner.v4.Contents
+	(*timestamppb.Timestamp)(nil), // 17: google.protobuf.Timestamp
 }
 var file_internalapi_scanner_v4_vulnerability_report_proto_depIdxs = []int32{
 	8,  // 0: scanner.v4.VulnerabilityReport.vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.VulnerabilitiesEntry
 	9,  // 1: scanner.v4.VulnerabilityReport.package_vulnerabilities:type_name -> scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry
-	15, // 2: scanner.v4.VulnerabilityReport.contents:type_name -> scanner.v4.Contents
+	16, // 2: scanner.v4.VulnerabilityReport.contents:type_name -> scanner.v4.Contents
 	0,  // 3: scanner.v4.VulnerabilityReport.notes:type_name -> scanner.v4.VulnerabilityReport.Note
 	10, // 4: scanner.v4.VulnerabilityReport.package_not_vulnerable:type_name -> scanner.v4.VulnerabilityReport.PackageNotVulnerableEntry
 	5,  // 5: scanner.v4.VulnerabilityReport.Vulnerability.advisory:type_name -> scanner.v4.VulnerabilityReport.Advisory
-	16, // 6: scanner.v4.VulnerabilityReport.Vulnerability.issued:type_name -> google.protobuf.Timestamp
+	17, // 6: scanner.v4.VulnerabilityReport.Vulnerability.issued:type_name -> google.protobuf.Timestamp
 	1,  // 7: scanner.v4.VulnerabilityReport.Vulnerability.normalized_severity:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.Severity
 	11, // 8: scanner.v4.VulnerabilityReport.Vulnerability.cvss:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	11, // 9: scanner.v4.VulnerabilityReport.Vulnerability.cvss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS
 	12, // 10: scanner.v4.VulnerabilityReport.Vulnerability.epss_metrics:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.EPSS
-	16, // 11: scanner.v4.VulnerabilityReport.Vulnerability.fixed_date:type_name -> google.protobuf.Timestamp
+	17, // 11: scanner.v4.VulnerabilityReport.Vulnerability.fixed_date:type_name -> google.protobuf.Timestamp
 	6,  // 12: scanner.v4.VulnerabilityReport.Vulnerability.aliases:type_name -> scanner.v4.VulnerabilityReport.Alias
-	7,  // 13: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
-	4,  // 14: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
-	4,  // 15: scanner.v4.VulnerabilityReport.PackageNotVulnerableEntry.value:type_name -> scanner.v4.StringList
-	13, // 16: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
-	14, // 17: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v3:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
-	2,  // 18: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.source:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	13, // 13: scanner.v4.VulnerabilityReport.Vulnerability.exploit:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CISAExploit
+	7,  // 14: scanner.v4.VulnerabilityReport.VulnerabilitiesEntry.value:type_name -> scanner.v4.VulnerabilityReport.Vulnerability
+	4,  // 15: scanner.v4.VulnerabilityReport.PackageVulnerabilitiesEntry.value:type_name -> scanner.v4.StringList
+	4,  // 16: scanner.v4.VulnerabilityReport.PackageNotVulnerableEntry.value:type_name -> scanner.v4.StringList
+	14, // 17: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v2:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V2
+	15, // 18: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.v3:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.V3
+	2,  // 19: scanner.v4.VulnerabilityReport.Vulnerability.CVSS.source:type_name -> scanner.v4.VulnerabilityReport.Vulnerability.CVSS.Source
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_scanner_v4_vulnerability_report_proto_init() }
@@ -1004,7 +1107,7 @@ func file_internalapi_scanner_v4_vulnerability_report_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc), len(file_internalapi_scanner_v4_vulnerability_report_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/vulnerability_report_vtproto.pb.go
@@ -136,6 +136,28 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) CloneMessageVT() proto.Message 
 	return m.CloneVT()
 }
 
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) CloneVT() *VulnerabilityReport_Vulnerability_CISAExploit {
+	if m == nil {
+		return (*VulnerabilityReport_Vulnerability_CISAExploit)(nil)
+	}
+	r := new(VulnerabilityReport_Vulnerability_CISAExploit)
+	r.CatalogVersion = m.CatalogVersion
+	r.DateAdded = m.DateAdded
+	r.ShortDescription = m.ShortDescription
+	r.RequiredAction = m.RequiredAction
+	r.DueDate = m.DueDate
+	r.KnownRansomwareCampaignUse = m.KnownRansomwareCampaignUse
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *VulnerabilityReport_Vulnerability) CloneVT() *VulnerabilityReport_Vulnerability {
 	if m == nil {
 		return (*VulnerabilityReport_Vulnerability)(nil)
@@ -157,6 +179,7 @@ func (m *VulnerabilityReport_Vulnerability) CloneVT() *VulnerabilityReport_Vulne
 	r.EpssMetrics = m.EpssMetrics.CloneVT()
 	r.Updater = m.Updater
 	r.FixedDate = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.FixedDate).CloneVT())
+	r.Exploit = m.Exploit.CloneVT()
 	if rhs := m.CvssMetrics; rhs != nil {
 		tmpContainer := make([]*VulnerabilityReport_Vulnerability_CVSS, len(rhs))
 		for k, v := range rhs {
@@ -391,6 +414,40 @@ func (this *VulnerabilityReport_Vulnerability_EPSS) EqualMessageVT(thatMsg proto
 	}
 	return this.EqualVT(that)
 }
+func (this *VulnerabilityReport_Vulnerability_CISAExploit) EqualVT(that *VulnerabilityReport_Vulnerability_CISAExploit) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.CatalogVersion != that.CatalogVersion {
+		return false
+	}
+	if this.DateAdded != that.DateAdded {
+		return false
+	}
+	if this.ShortDescription != that.ShortDescription {
+		return false
+	}
+	if this.RequiredAction != that.RequiredAction {
+		return false
+	}
+	if this.DueDate != that.DueDate {
+		return false
+	}
+	if this.KnownRansomwareCampaignUse != that.KnownRansomwareCampaignUse {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *VulnerabilityReport_Vulnerability_CISAExploit) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*VulnerabilityReport_Vulnerability_CISAExploit)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *VulnerabilityReport_Vulnerability) EqualVT(that *VulnerabilityReport_Vulnerability) bool {
 	if this == that {
 		return true
@@ -478,6 +535,9 @@ func (this *VulnerabilityReport_Vulnerability) EqualVT(that *VulnerabilityReport
 				return false
 			}
 		}
+	}
+	if !this.Exploit.EqualVT(that.Exploit) {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -915,6 +975,81 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) MarshalToSizedBufferVT(dAtA []b
 	return len(dAtA) - i, nil
 }
 
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.KnownRansomwareCampaignUse) > 0 {
+		i -= len(m.KnownRansomwareCampaignUse)
+		copy(dAtA[i:], m.KnownRansomwareCampaignUse)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.KnownRansomwareCampaignUse)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.DueDate) > 0 {
+		i -= len(m.DueDate)
+		copy(dAtA[i:], m.DueDate)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DueDate)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.RequiredAction) > 0 {
+		i -= len(m.RequiredAction)
+		copy(dAtA[i:], m.RequiredAction)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RequiredAction)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.ShortDescription) > 0 {
+		i -= len(m.ShortDescription)
+		copy(dAtA[i:], m.ShortDescription)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ShortDescription)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.DateAdded) > 0 {
+		i -= len(m.DateAdded)
+		copy(dAtA[i:], m.DateAdded)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DateAdded)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.CatalogVersion) > 0 {
+		i -= len(m.CatalogVersion)
+		copy(dAtA[i:], m.CatalogVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CatalogVersion)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *VulnerabilityReport_Vulnerability) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -944,6 +1079,18 @@ func (m *VulnerabilityReport_Vulnerability) MarshalToSizedBufferVT(dAtA []byte) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Exploit != nil {
+		size, err := m.Exploit.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
 	}
 	if len(m.Aliases) > 0 {
 		for iNdEx := len(m.Aliases) - 1; iNdEx >= 0; iNdEx-- {
@@ -1401,6 +1548,40 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) SizeVT() (n int) {
 	return n
 }
 
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.CatalogVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DateAdded)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ShortDescription)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.RequiredAction)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DueDate)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.KnownRansomwareCampaignUse)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *VulnerabilityReport_Vulnerability) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1481,6 +1662,10 @@ func (m *VulnerabilityReport_Vulnerability) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.Exploit != nil {
+		l = m.Exploit.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2295,6 +2480,249 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) UnmarshalVT(dAtA []byte) error 
 	}
 	return nil
 }
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CatalogVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CatalogVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DateAdded", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DateAdded = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShortDescription", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ShortDescription = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredAction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RequiredAction = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DueDate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DueDate = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownRansomwareCampaignUse", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KnownRansomwareCampaignUse = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2908,6 +3336,42 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Aliases = append(m.Aliases, &VulnerabilityReport_Alias{})
 			if err := m.Aliases[len(m.Aliases)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &VulnerabilityReport_Vulnerability_CISAExploit{}
+			}
+			if err := m.Exploit.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -4356,6 +4820,273 @@ func (m *VulnerabilityReport_Vulnerability_EPSS) UnmarshalVTUnsafe(dAtA []byte) 
 	}
 	return nil
 }
+func (m *VulnerabilityReport_Vulnerability_CISAExploit) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VulnerabilityReport_Vulnerability_CISAExploit: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CatalogVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CatalogVersion = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DateAdded", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DateAdded = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShortDescription", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ShortDescription = stringValue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredAction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.RequiredAction = stringValue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DueDate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DueDate = stringValue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownRansomwareCampaignUse", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.KnownRansomwareCampaignUse = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5009,6 +5740,42 @@ func (m *VulnerabilityReport_Vulnerability) UnmarshalVTUnsafe(dAtA []byte) error
 			}
 			m.Aliases = append(m.Aliases, &VulnerabilityReport_Alias{})
 			if err := m.Aliases[len(m.Aliases)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &VulnerabilityReport_Vulnerability_CISAExploit{}
+			}
+			if err := m.Exploit.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/facebookincubator/nvdtools/cvss3"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/rhel/rhcc"
 	"github.com/quay/claircore/rhel/vex"
 	"github.com/quay/claircore/toolkit/types"
@@ -134,7 +135,11 @@ func ToProtoV4VulnerabilityReport(ctx context.Context, r *claircore.Vulnerabilit
 	if err != nil {
 		return nil, fmt.Errorf("internal error: parsing Red Hat CSAF advisories: %w", err)
 	}
-	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, nvdVulns, epssItems, csafAdvisories)
+	kevEntries, err := cveKEV(ctx, r.Enrichments)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: parsing CISA KEV exploits: %w", err)
+	}
+	vulnerabilities, err := toProtoV4VulnerabilitiesMap(ctx, r.Vulnerabilities, nvdVulns, epssItems, csafAdvisories, kevEntries)
 	if err != nil {
 		return nil, fmt.Errorf("internal error: %w", err)
 	}
@@ -582,6 +587,7 @@ func toProtoV4VulnerabilitiesMap(
 	nvdVulns map[string]map[string]*nvdschema.CVEAPIJSON20CVEItem,
 	epssItems map[string]map[string]*epss.EPSSItem,
 	csafAdvisories map[string]csaf.Advisory,
+	kevEntries map[string]map[string]*kev.Entry,
 ) (map[string]*v4.VulnerabilityReport_Vulnerability, error) {
 	if vulns == nil {
 		return nil, nil
@@ -622,10 +628,8 @@ func toProtoV4VulnerabilitiesMap(
 		// Find the related NVD vuln for this vulnerability name, let it be empty if no
 		// NVD vuln for that name was found.
 		var nvdVuln nvdschema.CVEAPIJSON20CVEItem
-		if nvdCVEs, ok := nvdVulns[v.ID]; ok {
-			if v, ok := nvdCVEs[cve]; foundCVE && ok {
-				nvdVuln = *v
-			}
+		if item := lookupByCVE(nvdVulns, v.ID, cve, foundCVE); item != nil {
+			nvdVuln = *item
 		}
 		metrics, err := cvssMetrics(ctx, v, name, &nvdVuln, csafAdvisory)
 		if err != nil {
@@ -674,16 +678,12 @@ func toProtoV4VulnerabilitiesMap(
 
 		fixed := fixedTime(csafAdvisory)
 
-		var vulnEPSS *epss.EPSSItem
-		if epssVulnItem, ok := epssItems[v.ID]; ok {
-			if v, ok := epssVulnItem[cve]; foundCVE && ok {
-				vulnEPSS = v
-			}
-		}
+		vulnEPSS := lookupByCVE(epssItems, v.ID, cve, foundCVE)
 		// overwrite with RHSA EPSS score if it exists
 		if rhelEPSS, ok := rhelEPSSDetails[name]; ok {
 			vulnEPSS = &rhelEPSS
 		}
+		vulnKEV := lookupByCVE(kevEntries, v.ID, cve, foundCVE)
 
 		if vulnerabilities == nil {
 			vulnerabilities = make(map[string]*v4.VulnerabilityReport_Vulnerability, len(vulns))
@@ -713,6 +713,16 @@ func toProtoV4VulnerabilitiesMap(
 				Date:         vulnEPSS.Date,
 				Probability:  float32(vulnEPSS.EPSS),
 				Percentile:   float32(vulnEPSS.Percentile),
+			}
+		}
+		if vulnKEV != nil {
+			vulnerabilities[k].Exploit = &v4.VulnerabilityReport_Vulnerability_CISAExploit{
+				CatalogVersion:             vulnKEV.CatalogVersion,
+				DateAdded:                  vulnKEV.DateAdded,
+				ShortDescription:           vulnKEV.ShortDescription,
+				RequiredAction:             vulnKEV.RequiredAction,
+				DueDate:                    vulnKEV.DueDate,
+				KnownRansomwareCampaignUse: vulnKEV.KnownRansomwareCampaignUse,
 			}
 		}
 	}
@@ -1071,6 +1081,48 @@ func redhatCSAFAdvisories(ctx context.Context, enrichments map[string][]json.Raw
 			continue
 		}
 		ret[id] = records[0]
+	}
+	return ret, nil
+}
+
+// lookupByCVE fetches the entry for the given vulnerability ID and CVE from a
+// CVE-keyed enrichment map, or nil if there is none.
+func lookupByCVE[T any](m map[string]map[string]*T, vulnID, cve string, foundCVE bool) *T {
+	if !foundCVE {
+		return nil
+	}
+	return m[vulnID][cve]
+}
+
+// cveKEV unmarshals and returns the KEV enrichment, if it exists.
+func cveKEV(_ context.Context, enrichments map[string][]json.RawMessage) (map[string]map[string]*kev.Entry, error) {
+	enrichmentsList := enrichments[kev.Type]
+	if len(enrichmentsList) == 0 {
+		return nil, nil
+	}
+	var items map[string][]kev.Entry
+	// The CISA KEV enrichment always contains only one element.
+	err := json.Unmarshal(enrichmentsList[0], &items)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	// Returns a map of maps keyed by CVE ID due to enrichment matching on multiple
+	// vulnerability fields, potentially including unrelated records--we assume the
+	// caller will know how to filter what is relevant.
+	ret := make(map[string]map[string]*kev.Entry)
+	for ccVulnID, list := range items {
+		if len(list) == 0 {
+			continue
+		}
+		m := make(map[string]*kev.Entry)
+		for idx := range list {
+			vulnData := list[idx]
+			m[vulnData.CVE] = &vulnData
+		}
+		ret[ccVulnID] = m
 	}
 	return ret, nil
 }

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -1,6 +1,7 @@
 package mappers
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	nvdschema "github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/toolkit/types"
 	"github.com/quay/claircore/toolkit/types/cpe"
@@ -1583,9 +1585,141 @@ func Test_toProtoV4VulnerabilitiesMapWithEPSS(t *testing.T) {
 			ctx := test.Logging(t)
 			enableRedHatCVEs := "false"
 			t.Setenv(features.ScannerV4RedHatCVEs.EnvVar(), enableRedHatCVEs)
-			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, tt.epssItems, nil)
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, tt.epssItems, nil, nil)
 			assert.NoError(t, err)
 			protoassert.MapEqual(t, tt.want, got)
+		})
+	}
+}
+
+func Test_toProtoV4VulnerabilitiesMapWithExploit(t *testing.T) {
+	now := time.Now()
+	protoNow, err := protocompat.ConvertTimeToTimestampOrError(now)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		ccVulnerabilities map[string]*claircore.Vulnerability
+		exploits          map[string]map[string]*kev.Entry
+		want              map[string]*v4.VulnerabilityReport_Vulnerability
+	}{
+		"basic": {
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"foo": {
+					ID:     "foo",
+					Name:   "CVE-1234-567",
+					Issued: now,
+				},
+				"bar": {
+					ID:     "bar",
+					Name:   "CVE-1234-568",
+					Issued: now,
+				},
+			},
+			exploits: map[string]map[string]*kev.Entry{
+				"foo": {
+					"CVE-1234-567": &kev.Entry{
+						CVE:                        "CVE-1234-567",
+						VulnerabilityName:          "bad news",
+						CatalogVersion:             "2025.10.01",
+						DateAdded:                  "2025-09-20",
+						ShortDescription:           "This is a bad vulnerability",
+						RequiredAction:             "hide",
+						DueDate:                    "2025-10-12",
+						KnownRansomwareCampaignUse: "Known",
+					},
+				},
+			},
+			want: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"foo": {
+					Id:     "foo",
+					Issued: protoNow,
+					Name:   "CVE-1234-567",
+					Exploit: &v4.VulnerabilityReport_Vulnerability_CISAExploit{
+						CatalogVersion:             "2025.10.01",
+						DateAdded:                  "2025-09-20",
+						ShortDescription:           "This is a bad vulnerability",
+						RequiredAction:             "hide",
+						DueDate:                    "2025-10-12",
+						KnownRansomwareCampaignUse: "Known",
+					},
+				},
+				"bar": {
+					Id:     "bar",
+					Issued: protoNow,
+					Name:   "CVE-1234-568",
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, nil, nil, nil, tt.exploits)
+			assert.NoError(t, err)
+			protoassert.MapEqual(t, tt.want, got)
+		})
+	}
+}
+
+func Test_cveKEVExploits(t *testing.T) {
+	entryJSON := func(vulnToEntries map[string][]kev.Entry) json.RawMessage {
+		data, err := json.Marshal(vulnToEntries)
+		require.NoError(t, err)
+		return data
+	}
+	tests := map[string]struct {
+		enrichments map[string][]json.RawMessage
+		want        map[string]map[string]*kev.Entry
+		wantErr     bool
+	}{
+		"nil enrichments": {
+			enrichments: nil,
+		},
+		"no kev enrichment": {
+			enrichments: map[string][]json.RawMessage{
+				"other": {json.RawMessage(`{}`)},
+			},
+		},
+		"malformed payload": {
+			enrichments: map[string][]json.RawMessage{
+				kev.Type: {json.RawMessage(`malformed`)},
+			},
+			wantErr: true,
+		},
+		"empty items": {
+			enrichments: map[string][]json.RawMessage{
+				kev.Type: {json.RawMessage(`{}`)},
+			},
+		},
+		"multiple entries per vulnerability": {
+			enrichments: map[string][]json.RawMessage{
+				kev.Type: {entryJSON(map[string][]kev.Entry{
+					"foo": {
+						{CVE: "CVE-1234-567", DateAdded: "2025-09-20"},
+						{CVE: "CVE-1234-568", DateAdded: "2025-09-21"},
+					},
+					"bar": {},
+				})},
+			},
+			want: map[string]map[string]*kev.Entry{
+				"foo": {
+					"CVE-1234-567": {CVE: "CVE-1234-567", DateAdded: "2025-09-20"},
+					"CVE-1234-568": {CVE: "CVE-1234-568", DateAdded: "2025-09-21"},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
+			got, err := cveKEV(ctx, tt.enrichments)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -2396,7 +2530,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			}
 			t.Setenv(features.ScannerV4RedHatCVEs.EnvVar(), enableRedHatCVEs)
 			// EPSS scores are intentionally not covered here
-			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, nil, tt.advisories)
+			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, nil, tt.advisories, nil)
 			assert.NoError(t, err)
 			protoassert.MapEqual(t, tt.want, got)
 		})

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -1662,7 +1662,7 @@ func Test_toProtoV4VulnerabilitiesMapWithExploit(t *testing.T) {
 	}
 }
 
-func Test_cveKEVExploits(t *testing.T) {
+func Test_cveKEV(t *testing.T) {
 	entryJSON := func(vulnToEntries map[string][]kev.Entry) json.RawMessage {
 		data, err := json.Marshal(vulnToEntries)
 		require.NoError(t, err)

--- a/proto/internalapi/scanner/v4/vulnerability_report.proto
+++ b/proto/internalapi/scanner/v4/vulnerability_report.proto
@@ -11,7 +11,7 @@ import "internalapi/scanner/v4/common.proto";
 
 option go_package = "./internalapi/scanner/v4;v4";
 
-// Next tag: 19
+// Next tag: 20
 message VulnerabilityReport {
   message Advisory {
     string name = 1;
@@ -56,6 +56,14 @@ message VulnerabilityReport {
       float probability = 3;
       float percentile = 4;
     }
+    message CISAExploit {
+      string catalog_version = 1;
+      string date_added = 2;
+      string short_description = 3;
+      string required_action = 4;
+      string due_date = 5;
+      string known_ransomware_campaign_use = 6;
+    }
     string id = 1;
     string name = 2;
     Advisory advisory = 15;
@@ -74,6 +82,7 @@ message VulnerabilityReport {
     string updater = 16;
     google.protobuf.Timestamp fixed_date = 17; // will not be avail from all vuln sources
     repeated Alias aliases = 18;
+    CISAExploit exploit = 19;
   }
   enum Note {
     NOTE_UNSPECIFIED = 0;

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/quay/claircore/aws"
 	"github.com/quay/claircore/debian"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/gobin"
 	"github.com/quay/claircore/java"
 	"github.com/quay/claircore/libvuln"
@@ -46,24 +47,67 @@ import (
 	"github.com/stackrox/rox/scanner/sbom"
 )
 
-// matcherNames specifies the ClairCore matchers to use.
-//
-// Note: Do NOT hardcode the names. It's very easy to mess up...
-var matcherNames = []string{
-	(*alpine.Matcher)(nil).Name(),
-	(*aws.Matcher)(nil).Name(),
-	(*debian.Matcher)(nil).Name(),
-	(*gobin.Matcher)(nil).Name(),
-	(*java.Matcher)(nil).Name(),
-	(*oracle.Matcher)(nil).Name(),
-	(*photon.Matcher)(nil).Name(),
-	(*python.Matcher)(nil).Name(),
-	rhcc.Matcher.Name(),
-	(*rhel.Matcher)(nil).Name(),
-	(*ruby.Matcher)(nil).Name(),
-	(*suse.Matcher)(nil).Name(),
-	(*ubuntu.Matcher)(nil).Name(),
-}
+var (
+	// matcherNames specifies the Claircore matchers to use.
+	//
+	// Note: Do NOT hardcode the names. It's very easy to mess up...
+	matcherNames = []string{
+		(*alpine.Matcher)(nil).Name(),
+		(*aws.Matcher)(nil).Name(),
+		(*debian.Matcher)(nil).Name(),
+		(*gobin.Matcher)(nil).Name(),
+		(*java.Matcher)(nil).Name(),
+		(*oracle.Matcher)(nil).Name(),
+		(*photon.Matcher)(nil).Name(),
+		(*python.Matcher)(nil).Name(),
+		rhcc.Matcher.Name(),
+		(*rhel.Matcher)(nil).Name(),
+		(*ruby.Matcher)(nil).Name(),
+		(*suse.Matcher)(nil).Name(),
+		(*ubuntu.Matcher)(nil).Name(),
+	}
+
+	// enrichers specifies the Claircore enrichers to use.
+	// A nil flag means the enricher is always enabled.
+	enrichers = []struct {
+		name string
+		flag features.FeatureFlag
+		init func() driver.Enricher
+	}{
+		{
+			name: "fixedby",
+			init: func() driver.Enricher {
+				return &fixedby.Enricher{}
+			},
+		},
+		{
+			name: "nvd",
+			init: func() driver.Enricher {
+				return &nvd.Enricher{}
+			},
+		},
+		{
+			name: "epss",
+			init: func() driver.Enricher {
+				return &epss.Enricher{}
+			},
+		},
+		{
+			name: "csaf",
+			flag: features.ScannerV4RedHatCSAF,
+			init: func() driver.Enricher {
+				return &csaf.Enricher{}
+			},
+		},
+		{
+			name: "kev",
+			flag: features.KnownExploitedVulnerabilities,
+			init: func() driver.Enricher {
+				return &kev.Enricher{}
+			},
+		},
+	}
+)
 
 func init() {
 	// ClairCore does not register the Node.js factory by default.
@@ -140,22 +184,20 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig, reportProvider in
 		Transport: httputil.DenyTransport,
 	}
 
-	enrichers := []driver.Enricher{
-		&fixedby.Enricher{},
-		&nvd.Enricher{},
-		&epss.Enricher{},
+	enabledEnrichers := make([]driver.Enricher, 0, len(enrichers))
+	for _, e := range enrichers {
+		enabled := e.flag == nil || e.flag.Enabled()
+		slog.InfoContext(ctx, "enricher", "name", e.name, "enabled", enabled)
+		if !enabled {
+			continue
+		}
+		enabledEnrichers = append(enabledEnrichers, e.init())
 	}
-	var csafEnabled bool
-	if features.ScannerV4RedHatCSAF.Enabled() {
-		csafEnabled = true
-		enrichers = append(enrichers, &csaf.Enricher{})
-	}
-	slog.InfoContext(ctx, "CSAF enrichment", "enabled", csafEnabled)
 	libVuln, err := libvuln.New(ctx, &libvuln.Options{
 		Store:                    store,
 		Locker:                   locker,
 		MatcherNames:             matcherNames,
-		Enrichers:                enrichers,
+		Enrichers:                enabledEnrichers,
 		UpdateRetention:          libvuln.DefaultUpdateRetention,
 		DisableBackgroundUpdates: true,
 		Client:                   ccClient,

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/enricher/kev"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/libvuln/jsonblob"
 	"github.com/quay/claircore/libvuln/updates"
@@ -74,6 +75,7 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 	bundles["nvd"] = nvdOpts()
 	bundles["epss"] = epssOpts()
 	bundles["stackrox-rhel-csaf"] = redhatCSAFOpts()
+	bundles["cisa-kev"] = kevOpts()
 
 	// Claircore Updaters.
 	for _, uSet := range ccUpdaterSets {
@@ -235,6 +237,16 @@ func redhatCSAFOpts() []updates.ManagerOption {
 		updates.WithEnabled([]string{}),
 		updates.WithFactories(map[string]driver.UpdaterSetFactory{
 			"stackrox.rhel-csaf": csaf.NewFactory(),
+		}),
+	}
+}
+
+func kevOpts() []updates.ManagerOption {
+	return []updates.ManagerOption{
+		// This is required to prevent default updaters from running.
+		updates.WithEnabled([]string{}),
+		updates.WithFactories(map[string]driver.UpdaterSetFactory{
+			"clair.kev": kev.NewFactory(),
 		}),
 	}
 }


### PR DESCRIPTION
## Description

Scanner V4-side implementation of CISA KEV support. These changes are largely based on Ross's work from https://github.com/stackrox/stackrox/pull/16868.

The `ROX_CISA_KEV` feature flag was added as part of https://github.com/stackrox/stackrox/pull/17616.

See https://github.com/quay/claircore/pull/1563 for the Claircore-side.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed stackrox locally with the `4.12.x-406-g44b422da20` image tag

Set the `SCANNER_V4_MATCHER_VULNERABILITIES_URL` variable to the GCS bucket where this PR uploaded its vulnerability bundle:
```
❯ k set env \
    deploy/scanner-v4-matcher \
    SCANNER_V4_MATCHER_VULNERABILITIES_URL=https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/blugo-ROX-29681-CISA-KEV/vulnerabilities.zip
```

And the CISA KEV feature flag:
```
❯ k set env deploy/scanner-v4-matcher ROX_CISA_KEV=true
```

Observed the KEV bundle was consumed:
```
❯ k logs scanner-v4-matcher-5c9dfb864b-4dl74 | rg -i kev
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher.NewMatcher","time":"2026-07-09T07:59:47.385107559Z","msg":"enricher","host":"scanner-v4-matcher-5c9dfb864b-4dl74","name":"kev","enabled":true}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).fetchFromURL","time":"2026-07-09T08:00:34.516914099Z","msg":"fetching vuln update","host":"scanner-v4-matcher-5c9dfb864b-4dl74","url":"https://storage.googleapis.com/scanner-v4-test/vulnerability-bundles/blugo-ROX-29681-CISA-KEV/vulnerabilities.zip","attempt":1}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).runMultiBundleUpdate","time":"2026-07-09T08:01:04.669306907Z","msg":"starting bundle update","host":"scanner-v4-matcher-5c9dfb864b-4dl74","bundle":"bundles/cisa-kev.json.zst"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Import.func1","time":"2026-07-09T08:01:04.672775915Z","msg":"importing update","host":"scanner-v4-matcher-5c9dfb864b-4dl74","bundle":"bundles/cisa-kev.json.zst","updater":"clair.kev","kind":"enrichment"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Import.func1","time":"2026-07-09T08:01:18.019219417Z","msg":"update imported","host":"scanner-v4-matcher-5c9dfb864b-4dl74","bundle":"bundles/cisa-kev.json.zst","updater":"clair.kev","kind":"enrichment","ref":"8e8f76a7-ca02-4d18-b668-d770bac04d64","count":1635}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).runMultiBundleUpdate","time":"2026-07-09T08:01:18.021861733Z","msg":"completed bundle update","host":"scanner-v4-matcher-5c9dfb864b-4dl74","bundle":"bundles/cisa-kev.json.zst"}
```

Sample results:
```
❯ k port-forward svc/scanner-v4-matcher 8443 &
❯ grpcurl -insecure \
    -import-path proto \
    -proto internalapi/scanner/v4/matcher_service.proto \
    -d '{"hash_id": "/v4/containerimage/sha256:4a6db3167f84c9010f9e0ffb205775d816174b7a7cd4035e471f506a4f261898"}' \
    localhost:8443 scanner.v4.Matcher/GetVulnerabilities \
    | tee ubi8-kev.json \
    | jq '[.vulnerabilities[] | select(.exploit) | {name, exploit}] | first'
{
  "name": "CVE-2023-4911",
  "exploit": {
    "catalogVersion": "2026.07.07",
    "dateAdded": "2023-11-21",
    "shortDescription": "GNU C Library's dynamic loader ld.so contains a buffer overflow vulnerability when processing the GLIBC_TUNABLES environment variable, allowing a local attacker to execute code with elevated privileges.",
    "requiredAction": "Apply mitigations per vendor instructions or discontinue use of the product if mitigations are unavailable.",
    "dueDate": "2023-12-12",
    "knownRansomwareCampaignUse": "Unknown"
  }
}
```