### PR TITLE
fix(test): Handle empty registry credentials in pull secret guard

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -434,9 +434,8 @@ class BaseSpecification extends Specification {
     }
 
     static addRedHatImagePullSecret(Kubernetes orchestrator, String ns = Constants.ORCHESTRATOR_NAMESPACE) {
-        if (!Env.IN_CI && (Env.get("REDHAT_USERNAME") == null ||
-                           Env.get("REDHAT_PASSWORD") == null)) {
-            LOG.warn "The REDHAT_USERNAME and/or REDHAT_PASSWORD env var is missing. " +
+        if (!Env.get("REDHAT_USERNAME") || !Env.get("REDHAT_PASSWORD")) {
+            LOG.warn "The REDHAT_USERNAME and/or REDHAT_PASSWORD env var is missing or empty. " +
                     "(this is ok if your test does not use images from registry.redhat.io)"
             return
         }
@@ -444,8 +443,8 @@ class BaseSpecification extends Specification {
         orchestrator.createImagePullSecret(new Secret(
                 name: "redhat-image-pull-secret",
                 server: "https://registry.redhat.io",
-                username: Env.mustGetInCI("REDHAT_USERNAME", "{}"),
-                password: Env.mustGetInCI("REDHAT_PASSWORD", "{}"),
+                username: Env.get("REDHAT_USERNAME"),
+                password: Env.get("REDHAT_PASSWORD"),
                 namespace: ns
         ))
 


### PR DESCRIPTION
## Description

The guard in `addRedHatImagePullSecret` only checked for null `REDHAT_USERNAME`/`REDHAT_PASSWORD`, not empty strings. On dependabot PRs, GitHub provides empty strings instead of null for secrets not in the dependabot secret store. This caused the method to create a pull secret with empty credentials, leading to 401 errors when pods tried to pull from `registry.redhat.io`. The fix uses Groovy truthiness to check for both null and empty, removes the `!Env.IN_CI` guard for consistent behavior across environments, and uses `Env.get` instead of `mustGetInCI` since the guard already handles early return.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Defensive guard fix in test infrastructure. The logic change is straightforward: Groovy falsy check covers both null and empty string. CI will validate that existing tests still pass with the updated guard.
