### PR TITLE
ROX-33377: add source filtering to vulnerability updater

### DIFF
--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -6,23 +6,32 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/scanner/config"
 	"github.com/stackrox/rox/scanner/internal/logging"
 	"github.com/stackrox/rox/scanner/internal/version"
 	"github.com/stackrox/rox/scanner/updater"
 )
 
-const DefaultURL = "https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/manual/vulns.yaml"
+const (
+	defaultManualURL = "https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/manual/vulns.yaml"
+	logLevelEnvVar   = "STACKROX_SCANNER_V4_UPDATER_LOG_LEVEL"
+	sourcesEnvVar    = "STACKROX_SCANNER_V4_UPDATER_SOURCES"
+)
 
-const logLevelEnvVar = "STACKROX_SCANNER_V4_UPDATER_LOG_LEVEL"
+var (
+	logLevelRaw = os.Getenv(logLevelEnvVar)
+	sourcesRaw  = os.Getenv(sourcesEnvVar)
+)
 
 func initializeLogging() error {
 	level := slog.LevelInfo
 	var levelErr error
-	if v := os.Getenv(logLevelEnvVar); v != "" {
-		if err := level.UnmarshalText([]byte(v)); err != nil {
+	if logLevelRaw != "" {
+		if err := level.UnmarshalText([]byte(logLevelRaw)); err != nil {
 			level = slog.LevelInfo
 			levelErr = err
 		}
@@ -40,16 +49,18 @@ func tryExport(ctx context.Context, outputDir string, opts *updater.ExportOption
 	const timeout = 3 * time.Hour
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	err := updater.Export(ctx, outputDir, opts)
-	if err != nil {
-		return err
-	}
-	return nil
+	return updater.Export(ctx, outputDir, opts)
 }
 
 func main() {
 	if err := initializeLogging(); err != nil {
 		slog.Error("failed to initialize logging", "reason", err)
+		os.Exit(1)
+	}
+
+	sources := config.NormalizeStringList(strings.Split(sourcesRaw, ","))
+	if len(sourcesRaw) > 0 && len(sources) == 0 {
+		slog.Error("unable to parse sources", "raw_sources", sourcesRaw)
 		os.Exit(1)
 	}
 
@@ -79,7 +90,10 @@ func main() {
 					"attempt", attempt,
 					"manual_vulns_url", manualURL,
 					"output_directory", outputDir)
-				err := tryExport(ctx, outputDir, &updater.ExportOptions{ManualVulnURL: manualURL})
+				err := tryExport(ctx, outputDir, &updater.ExportOptions{
+					ManualVulnURL: manualURL,
+					Sources:       sources,
+				})
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) {
 						slog.WarnContext(ctx, "export failed; will retry if within retry limits",
@@ -95,7 +109,7 @@ func main() {
 			return errors.New("data export failed: max retries exceeded")
 		},
 	}
-	exportCmd.Flags().String("manual-url", DefaultURL, "URL to the manual vulnerability data.")
+	exportCmd.Flags().String("manual-url", defaultManualURL, "URL to the manual vulnerability data.")
 
 	var importCmd = &cobra.Command{
 		Use:   "import",

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -270,7 +270,23 @@ func (c *MatcherConfig) validate() error {
 		return fmt.Errorf("readiness: invalid readiness type %q", c.Readiness)
 	}
 
+	c.VulnBundleAllowlist = NormalizeStringList(c.VulnBundleAllowlist)
+
 	return nil
+}
+
+// NormalizeStringList trims whitespace from each entry and drops empty strings.
+func NormalizeStringList(entries []string) []string {
+	if entries == nil {
+		return nil
+	}
+	result := make([]string, 0, len(entries))
+	for _, s := range entries {
+		if t := strings.TrimSpace(s); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
 }
 
 // Database provides database configuration for scanner backends.

--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -405,3 +405,38 @@ func Test_ProxyConfig_validate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestNormalizeStringList(t *testing.T) {
+	tests := map[string]struct {
+		input []string
+		want  []string
+	}{
+		"nil returns nil": {
+			input: nil,
+			want:  nil,
+		},
+		"empty slice returns empty": {
+			input: []string{},
+			want:  []string{},
+		},
+		"trims whitespace": {
+			input: []string{" a ", " b "},
+			want:  []string{"a", "b"},
+		},
+		"drops empties": {
+			input: []string{"a", "", " ", "b"},
+			want:  []string{"a", "b"},
+		},
+		"no changes needed": {
+			input: []string{"a", "b"},
+			want:  []string{"a", "b"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NormalizeStringList(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -152,7 +152,7 @@ func New(ctx context.Context, opts Opts) (*Updater, error) {
 	}
 	u.iterateFunc = jsonblob.Iterate
 
-	u.vulnBundleAllowlist = set.NewFrozenSet(normalizeAllowlist(opts.VulnBundleAllowlist)...)
+	u.vulnBundleAllowlist = set.NewFrozenSet(opts.VulnBundleAllowlist...)
 
 	u.tryRemoveExiting()
 
@@ -628,19 +628,6 @@ func isRetryableDialError(err error) bool {
 		return false
 	}
 	return errors.Is(err, syscall.ECONNREFUSED) || opErr.Timeout()
-}
-
-// normalizeAllowlist trims whitespace from each entry and drops empty strings.
-// This handles cases the allowed names are configured with surrounding spaces,
-// e.g. from a comma-separated environment variable or YAML value.
-func normalizeAllowlist(entries []string) []string {
-	result := make([]string, 0, len(entries))
-	for _, s := range entries {
-		if t := strings.TrimSpace(s); t != "" {
-			result = append(result, t)
-		}
-	}
-	return result
 }
 
 // isBundleAllowed reports whether the named bundle file should be imported.

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -387,23 +387,6 @@ func TestUpdater_Initialized(t *testing.T) {
 	})
 }
 
-func TestNormalizeAllowlist(t *testing.T) {
-	// Simulates an allowlist with only whitespace.
-	input := []string{" ", "  ", "  \t   ", ""}
-	u := &Updater{vulnBundleAllowlist: set.NewFrozenSet(normalizeAllowlist(input)...)}
-	assert.True(t, u.isBundleAllowed("bundles/epss.json.zst"), "everything allowed when list empty")
-	assert.True(t, u.isBundleAllowed("hello-world"), "everything allowed when list empty")
-
-	// Simulates an allowlist with surrounding whitespace.
-	input = []string{" epss", " nvd ", "rhel-vex", "", "  "}
-	u = &Updater{vulnBundleAllowlist: set.NewFrozenSet(normalizeAllowlist(input)...)}
-	assert.True(t, u.isBundleAllowed("bundles/epss.json.zst"), "leading-space entry should match")
-	assert.True(t, u.isBundleAllowed("bundles/nvd.json.zst"), "surrounding-space entry should match")
-	assert.True(t, u.isBundleAllowed("bundles/rhel-vex.json.zst"), "clean entry should match")
-	assert.False(t, u.isBundleAllowed("bundles/alpine.json.zst"), "non-listed bundle should not match")
-	assert.Equal(t, 3, u.vulnBundleAllowlist.Cardinality(), "empty/whitespace-only entries should be dropped")
-}
-
 func TestIsBundleAllowed(t *testing.T) {
 	tests := map[string]struct {
 		allowlist set.FrozenSet[string]

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -79,6 +80,15 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 			managerOpts = rhelVexOpts()
 		}
 		bundles[uSet] = managerOpts
+	}
+
+	if filter := os.Getenv("STACKROX_UPDATER_SOURCES"); filter != "" {
+		filtered, err := filterSources(bundles, filter)
+		if err != nil {
+			return err
+		}
+		stdlog.Printf("source filter active: running %d/%d sources: %v", len(filtered), len(bundles), strings.Split(filter, ","))
+		bundles = filtered
 	}
 
 	// Rate limit to ~16 requests/second by default.
@@ -225,6 +235,20 @@ func redhatCSAFOpts() []updates.ManagerOption {
 			"stackrox.rhel-csaf": csaf.NewFactory(),
 		}),
 	}
+}
+
+func filterSources(bundles map[string][]updates.ManagerOption, filter string) (map[string][]updates.ManagerOption, error) {
+	selected := strings.Split(filter, ",")
+	filtered := make(map[string][]updates.ManagerOption, len(selected))
+	for _, s := range selected {
+		s = strings.TrimSpace(s)
+		if o, ok := bundles[s]; ok {
+			filtered[s] = o
+		} else {
+			return nil, fmt.Errorf("unknown source: %q", s)
+		}
+	}
+	return filtered, nil
 }
 
 func zstdWriter(filename string) (io.WriteCloser, error) {

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -50,6 +49,9 @@ var (
 
 type ExportOptions struct {
 	ManualVulnURL string
+	// Sources restricts which updaters run. When nil or empty, all updaters run.
+	// Values must be pre-normalized (trimmed, no empty entries).
+	Sources []string
 }
 
 // Export is responsible for triggering the updaters to download Common Vulnerabilities and Exposures (CVEs) data.
@@ -82,12 +84,12 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 		bundles[uSet] = managerOpts
 	}
 
-	if filter := os.Getenv("STACKROX_UPDATER_SOURCES"); filter != "" {
-		filtered, err := filterSources(bundles, filter)
+	if len(opts.Sources) > 0 {
+		filtered, err := filterSources(bundles, opts.Sources)
 		if err != nil {
-			return err
+			return fmt.Errorf("filtering sources: %w", err)
 		}
-		stdlog.Printf("source filter active: running %d/%d sources: %v", len(filtered), len(bundles), strings.Split(filter, ","))
+		slog.InfoContext(ctx, "source filter active", "running", len(filtered), "total", len(bundles), "sources", opts.Sources)
 		bundles = filtered
 	}
 
@@ -237,11 +239,9 @@ func redhatCSAFOpts() []updates.ManagerOption {
 	}
 }
 
-func filterSources(bundles map[string][]updates.ManagerOption, filter string) (map[string][]updates.ManagerOption, error) {
-	selected := strings.Split(filter, ",")
+func filterSources(bundles map[string][]updates.ManagerOption, selected []string) (map[string][]updates.ManagerOption, error) {
 	filtered := make(map[string][]updates.ManagerOption, len(selected))
 	for _, s := range selected {
-		s = strings.TrimSpace(s)
 		if o, ok := bundles[s]; ok {
 			filtered[s] = o
 		} else {

--- a/scanner/updater/export_test.go
+++ b/scanner/updater/export_test.go
@@ -1,0 +1,70 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/quay/claircore/libvuln/updates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSources(t *testing.T) {
+	allSources := map[string][]updates.ManagerOption{
+		"alpine":             nil,
+		"aws":                nil,
+		"debian":             nil,
+		"epss":               nil,
+		"manual":             nil,
+		"nvd":                nil,
+		"oracle":             nil,
+		"osv":                nil,
+		"photon":             nil,
+		"rhel-vex":           nil,
+		"stackrox-rhel-csaf": nil,
+		"suse":               nil,
+		"ubuntu":             nil,
+	}
+
+	tests := map[string]struct {
+		filter    string
+		wantKeys  []string
+		wantError string
+	}{
+		"single source": {
+			filter:   "alpine",
+			wantKeys: []string{"alpine"},
+		},
+		"multiple sources": {
+			filter:   "alpine,nvd,osv",
+			wantKeys: []string{"alpine", "nvd", "osv"},
+		},
+		"whitespace trimming": {
+			filter:   " alpine , nvd ",
+			wantKeys: []string{"alpine", "nvd"},
+		},
+		"unknown source": {
+			filter:    "alpine,bogus",
+			wantError: `unknown source: "bogus"`,
+		},
+		"all sources": {
+			filter:   "alpine,aws,debian,epss,manual,nvd,oracle,osv,photon,rhel-vex,stackrox-rhel-csaf,suse,ubuntu",
+			wantKeys: []string{"alpine", "aws", "debian", "epss", "manual", "nvd", "oracle", "osv", "photon", "rhel-vex", "stackrox-rhel-csaf", "suse", "ubuntu"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := filterSources(allSources, tc.filter)
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			var gotKeys []string
+			for k := range result {
+				gotKeys = append(gotKeys, k)
+			}
+			assert.ElementsMatch(t, tc.wantKeys, gotKeys)
+		})
+	}
+}

--- a/scanner/updater/export_test.go
+++ b/scanner/updater/export_test.go
@@ -1,6 +1,8 @@
 package updater
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/quay/claircore/libvuln/updates"
@@ -9,62 +11,44 @@ import (
 )
 
 func TestFilterSources(t *testing.T) {
-	allSources := map[string][]updates.ManagerOption{
-		"alpine":             nil,
-		"aws":                nil,
-		"debian":             nil,
-		"epss":               nil,
-		"manual":             nil,
-		"nvd":                nil,
-		"oracle":             nil,
-		"osv":                nil,
-		"photon":             nil,
-		"rhel-vex":           nil,
-		"stackrox-rhel-csaf": nil,
-		"suse":               nil,
-		"ubuntu":             nil,
+	bundles := map[string][]updates.ManagerOption{
+		"alpha":   nil,
+		"bravo":   nil,
+		"charlie": nil,
 	}
 
 	tests := map[string]struct {
-		filter    string
+		selected  []string
 		wantKeys  []string
 		wantError string
 	}{
 		"single source": {
-			filter:   "alpine",
-			wantKeys: []string{"alpine"},
+			selected: []string{"alpha"},
+			wantKeys: []string{"alpha"},
 		},
 		"multiple sources": {
-			filter:   "alpine,nvd,osv",
-			wantKeys: []string{"alpine", "nvd", "osv"},
-		},
-		"whitespace trimming": {
-			filter:   " alpine , nvd ",
-			wantKeys: []string{"alpine", "nvd"},
+			selected: []string{"alpha", "charlie"},
+			wantKeys: []string{"alpha", "charlie"},
 		},
 		"unknown source": {
-			filter:    "alpine,bogus",
+			selected:  []string{"alpha", "bogus"},
 			wantError: `unknown source: "bogus"`,
 		},
 		"all sources": {
-			filter:   "alpine,aws,debian,epss,manual,nvd,oracle,osv,photon,rhel-vex,stackrox-rhel-csaf,suse,ubuntu",
-			wantKeys: []string{"alpine", "aws", "debian", "epss", "manual", "nvd", "oracle", "osv", "photon", "rhel-vex", "stackrox-rhel-csaf", "suse", "ubuntu"},
+			selected: []string{"alpha", "bravo", "charlie"},
+			wantKeys: []string{"alpha", "bravo", "charlie"},
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result, err := filterSources(allSources, tc.filter)
+			result, err := filterSources(bundles, tc.selected)
 			if tc.wantError != "" {
 				require.ErrorContains(t, err, tc.wantError)
 				return
 			}
 			require.NoError(t, err)
-			var gotKeys []string
-			for k := range result {
-				gotKeys = append(gotKeys, k)
-			}
-			assert.ElementsMatch(t, tc.wantKeys, gotKeys)
+			assert.ElementsMatch(t, tc.wantKeys, slices.Collect(maps.Keys(result)))
 		})
 	}
 }


### PR DESCRIPTION
## Description

The vulnerability updater binary always runs all 13 data sources. This makes it impossible to run sources independently in CI with separate schedules, retry policies, and failure isolation.

This adds a `STACKROX_SCANNER_V4_UPDATER_SOURCES` environment variable that filters which sources `Export()` runs. When set (e.g., `STACKROX_SCANNER_V4_UPDATER_SOURCES=alpine,nvd`), only the named sources execute. When unset, all sources run as before.

This is the Go-side enabler for splitting the monolithic CI vulnerability update workflow into per-source jobs, so that a failure in one source no longer blocks all others from publishing.

Some refactoring was used to reuse `NormalizeStringList`. I moved it from inside the Matcher to not make that part of its interface, and blocked invalid input at the configuration level.

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed
- [x] documentation PR is created and is linked above OR is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests

### How I validated my change

Ran the updater locally with `STACKROX_UPDATER_SOURCES=manual` and verified only `manual.json.zst` was produced (24 vulnerabilities, 1.7K). Log confirms `source filter active: running 1/13 sources: [manual]`.