### PR TITLE
fix(test): Handle empty REDHAT_* secrets and fail on empty vars

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/Env.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Env.groovy
@@ -89,7 +89,7 @@ class Env {
 
     protected String mustGetInternal(String key) {
         def value = envVars.get(key)
-        if (value == null) {
+        if (!value) {
             throw new RuntimeException("No value assigned for required key ${key}")
         }
         return value
@@ -97,7 +97,7 @@ class Env {
 
     protected String mustGetInCIInternal(String key, String defVal) {
         def value = envVars.get(key)
-        if (value == null) {
+        if (!value) {
             if (IN_CI) {
                 throw new RuntimeException("No value assigned for required key ${key}")
             }

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -434,9 +434,8 @@ class BaseSpecification extends Specification {
     }
 
     static addRedHatImagePullSecret(Kubernetes orchestrator, String ns = Constants.ORCHESTRATOR_NAMESPACE) {
-        if (!Env.IN_CI && (Env.get("REDHAT_USERNAME") == null ||
-                           Env.get("REDHAT_PASSWORD") == null)) {
-            LOG.warn "The REDHAT_USERNAME and/or REDHAT_PASSWORD env var is missing. " +
+        if (!Env.get("REDHAT_USERNAME") || !Env.get("REDHAT_PASSWORD")) {
+            LOG.warn "The REDHAT_USERNAME and/or REDHAT_PASSWORD env var is missing or empty. " +
                     "(this is ok if your test does not use images from registry.redhat.io)"
             return
         }
@@ -444,8 +443,8 @@ class BaseSpecification extends Specification {
         orchestrator.createImagePullSecret(new Secret(
                 name: "redhat-image-pull-secret",
                 server: "https://registry.redhat.io",
-                username: Env.mustGetInCI("REDHAT_USERNAME", "{}"),
-                password: Env.mustGetInCI("REDHAT_PASSWORD", "{}"),
+                username: Env.get("REDHAT_USERNAME"),
+                password: Env.get("REDHAT_PASSWORD"),
                 namespace: ns
         ))
 

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -371,8 +371,7 @@ class BaseSpecification extends Specification {
         // Add an image pull secret to the qa namespace and also the default service account so the qa namespace can
         // pull stackrox images from dockerhub
 
-        if (!Env.IN_CI && (Env.get("REGISTRY_USERNAME", null) == null ||
-                           Env.get("REGISTRY_PASSWORD", null) == null)) {
+        if (!Env.get("REGISTRY_USERNAME", null) || !Env.get("REGISTRY_PASSWORD", null)) {
             // Arguably this should be fatal but for tests that don't pull from docker.io/stackrox it is not strictly
             // necessary.
             LOG.warn "The REGISTRY_USERNAME and/or REGISTRY_PASSWORD env var is missing. " +
@@ -403,7 +402,7 @@ class BaseSpecification extends Specification {
     }
 
     static addGCRImagePullSecret(Kubernetes orchestrator, String ns = Constants.ORCHESTRATOR_NAMESPACE) {
-        if (!Env.IN_CI && Env.get("GOOGLE_CREDENTIALS_GCR_SCANNER_V2", null) == null) {
+        if (!Env.get("GOOGLE_CREDENTIALS_GCR_SCANNER_V2", null)) {
             // Arguably this should be fatal but for tests that don't pull from us.gcr.io it is not strictly necessary
             LOG.warn "The GOOGLE_CREDENTIALS_GCR_SCANNER_V2 env var is missing. "+
                     "(this is ok if your test does not use images on us.gcr.io)"

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -443,8 +443,8 @@ class BaseSpecification extends Specification {
         orchestrator.createImagePullSecret(new Secret(
                 name: "redhat-image-pull-secret",
                 server: "https://registry.redhat.io",
-                username: Env.get("REDHAT_USERNAME"),
-                password: Env.get("REDHAT_PASSWORD"),
+                username: Env.mustGetInCI("REDHAT_USERNAME", "{}"),
+                password: Env.mustGetInCI("REDHAT_PASSWORD", "{}"),
                 namespace: ns
         ))
 


### PR DESCRIPTION
## Description

A variation of https://github.com/stackrox/stackrox/pull/21600

Ref doc: https://groovy-lang.org/semantics.html#_strings

Context thread: https://redhat-internal.slack.com/archives/CELUQKESC/p1783415871588119

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change to actual tests.

### How I validated my change

1. Default CI.
2. Will trigger more prow things that rely on Groovy tests.
