### PR TITLE
ROX-35604: Wait for free advisory lock

### DIFF
--- a/central/backgroundmigrations/runner/runner_test.go
+++ b/central/backgroundmigrations/runner/runner_test.go
@@ -86,7 +86,7 @@ func (s *RunnerTestSuite) SetupSuite() {
 // due to connection pool timing, causing the next test to fail with
 // "advisory lock held by another instance".
 func (s *RunnerTestSuite) waitForAdvisoryUnlock() {
-	assert.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
 		dbConn, err := s.db.Acquire(s.ctx)
 		require.NoError(t, err)
 		require.NotNil(t, dbConn)

--- a/central/backgroundmigrations/runner/runner_test.go
+++ b/central/backgroundmigrations/runner/runner_test.go
@@ -81,8 +81,31 @@ func (s *RunnerTestSuite) SetupSuite() {
 	schema.ApplyAllSchemas(s.ctx, gormDB)
 }
 
+// waitForAdvisoryUnlock ensures no pool connection holds the background migration
+// advisory lock. Tests that use Start()/Stop() may leave the lock briefly held
+// due to connection pool timing, causing the next test to fail with
+// "advisory lock held by another instance".
+func (s *RunnerTestSuite) waitForAdvisoryUnlock() {
+	assert.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		dbConn, err := s.db.Acquire(s.ctx)
+		require.NoError(t, err)
+		require.NotNil(t, dbConn)
+
+		defer dbConn.Release()
+		var acquired bool
+		err = dbConn.QueryRow(s.ctx, "SELECT pg_try_advisory_lock($1)", bgMigrationAdvisoryLockID).Scan(&acquired)
+		require.NoError(t, err)
+		require.True(t, acquired)
+
+		_, err = dbConn.Exec(s.ctx, "SELECT pg_advisory_unlock($1)", bgMigrationAdvisoryLockID)
+		assert.NoError(t, err)
+	}, time.Second, 50*time.Millisecond, "advisory lock still held")
+}
+
 func (s *RunnerTestSuite) SetupTest() {
 	migrations.ResetRegistryForTesting(s.T())
+
+	s.waitForAdvisoryUnlock()
 
 	_, err := s.db.Exec(s.ctx,
 		"DELETE FROM "+schema.BackgroundMigrationVersionsTableName)


### PR DESCRIPTION
## Description

Fix comes from CI Fixing Factory.

**Analysis and Fix**

**The setup:** PostgreSQL advisory locks are process-level mutex locks used by the background migrations runner to ensure only one instance runs migrations at a time. The production code acquires the lock via `pg_try_advisory_lock(2846193750482637519)` before running migrations and releases it when done.

**The test suite:** `TestRunnerSuite` in `runner_test.go` runs ~20 subtests sequentially. Between each subtest, `SetupTest()` resets the database state (clears the versions table, re-seeds it) but does not release the advisory lock.

**The trigger:** PR #21125 (ROX-33507, merged July 2) refactored most subtests from the async pattern (`runner.Start() / runner.Stop()`) to synchronous `runOnce()`. But it left one test - `TestRetryStopsOnShutdown` - using the async `Start()/Stop()` pattern because that test specifically validates shutdown behavior.

**The race:**
1. `TestRetryStopsOnShutdown` calls `runner.Start()`, which spawns a background goroutine that acquires the advisory lock
2. The test calls `runner.Stop()`, which signals the goroutine to stop
3. `Stop()` returns as soon as the goroutine acknowledges the signal - but the goroutine hasn't released the advisory lock yet (the `defer` in `runOnce()` hasn't executed)
4. The test framework immediately runs `SetupTest()` for the next subtest
5. The next subtest (e.g. `TestRunsOnlyNewMigrations`, which runs alphabetically after `TestRetryStopsOnShutdown`) calls `runOnce()`, which tries `pg_try_advisory_lock` - and fails because the previous goroutine still holds it
6. Result: "advisory lock held by another instance"

**The fix** (in `fix-bg-migration-advisory-lock-race.patch`): Add a `waitForAdvisoryUnlock()` helper called from `SetupTest()` that polls `pg_try_advisory_lock / pg_advisory_unlock` in a loop (up to 1s) to ensure the lock is free before each subtest starts. This is a test-only change - production code is correct.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] run under stress in VM:
```
CI=true GOMAXPROCS=1 go test -tags sql_integration -count=100 -run TestRunnerSuite ./central/backgroundmigrations/runner/ -p 1
```
The advisory lock race between `TestRetryStopsOnShutdown` and the next subtest typically surfaces within 10-30 runs.
- [x] run under stress in VM with the fix
- [x] run tests in CI
