### PR TITLE
feat: add TopSeverity and TopEPSS fields, single-phase query path

### DIFF
--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -41,6 +41,8 @@ func init() {
 				"exceptionCount(requestStatus: [String]): Int!",
 				"images(pagination: Pagination): [Image!]!",
 				"topCVSS: Float!",
+				"topEpssProbability: Float!",
+				"topSeverity: String!",
 				"publishedOn: Time",
 				"topNvdCVSS: Float!",
 			}),
@@ -295,6 +297,14 @@ func (resolver *imageCVECoreResolver) Images(ctx context.Context, args struct{ P
 
 func (resolver *imageCVECoreResolver) TopCVSS(_ context.Context) float64 {
 	return float64(resolver.data.GetTopCVSS())
+}
+
+func (resolver *imageCVECoreResolver) TopEpssProbability(_ context.Context) float64 {
+	return float64(resolver.data.GetEPSSProbability())
+}
+
+func (resolver *imageCVECoreResolver) TopSeverity(_ context.Context) string {
+	return resolver.data.GetTopSeverity().String()
 }
 
 func (resolver *imageCVECoreResolver) TopNVDCVSS(_ context.Context) float64 {

--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -40,6 +40,8 @@ func init() {
 				"exceptionCount(requestStatus: [String]): Int!",
 				"images(pagination: Pagination): [Image!]!",
 				"topCVSS: Float!",
+				"topEpssProbability: Float!",
+				"topSeverity: String!",
 				"publishedOn: Time",
 				"topNvdCVSS: Float!",
 			}),
@@ -294,6 +296,14 @@ func (resolver *imageCVECoreResolver) Images(ctx context.Context, args struct{ P
 
 func (resolver *imageCVECoreResolver) TopCVSS(_ context.Context) float64 {
 	return float64(resolver.data.GetTopCVSS())
+}
+
+func (resolver *imageCVECoreResolver) TopEpssProbability(_ context.Context) float64 {
+	return float64(resolver.data.GetEPSSProbability())
+}
+
+func (resolver *imageCVECoreResolver) TopSeverity(_ context.Context) string {
+	return resolver.data.GetTopSeverity().String()
 }
 
 func (resolver *imageCVECoreResolver) TopNVDCVSS(_ context.Context) float64 {

--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -112,7 +112,11 @@ func (resolver *Resolver) ImageCVEs(ctx context.Context, q PaginatedQuery) ([]*i
 		return nil, err
 	}
 
-	cves, err := resolver.ImageCVEView.Get(ctx, query, views.ReadOptions{})
+	readOpts := views.ReadOptions{}
+	if features.VulnMgmtUnifiedCVEView.Enabled() {
+		readOpts.SkipGetImagesBySeverity = true
+	}
+	cves, err := resolver.ImageCVEView.Get(ctx, query, readOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -113,7 +113,11 @@ func (resolver *Resolver) ImageCVEs(ctx context.Context, q PaginatedQuery) ([]*i
 		return nil, err
 	}
 
-	cves, err := resolver.ImageCVEView.Get(ctx, query, views.ReadOptions{})
+	readOpts := views.ReadOptions{}
+	if features.VulnMgmtUnifiedCVEView.Enabled() {
+		readOpts.SkipGetImagesBySeverity = true
+	}
+	cves, err := resolver.ImageCVEView.Get(ctx, query, readOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/central/graphql/resolvers/image_cve_v2_core_test.go
+++ b/central/graphql/resolvers/image_cve_v2_core_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stackrox/rox/central/views"
 	"github.com/stackrox/rox/central/views/imagecve"
 	imageCVEViewMock "github.com/stackrox/rox/central/views/imagecve/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	"github.com/stretchr/testify/suite"
@@ -148,6 +150,29 @@ func (s *ImageCVEV2CoreResolverTestSuite) TestImageCVECountWithQuery() {
 	response, err := s.resolver.ImageCVECount(s.ctx, *q)
 	s.NoError(err)
 	s.Equal(response, int32(3))
+}
+
+func (s *ImageCVEV2CoreResolverTestSuite) TestImageCVEResolverFields() {
+	q := &PaginatedQuery{}
+	expectedQ, err := q.AsV1QueryOrEmpty()
+	s.Require().NoError(err)
+
+	mockCore := imageCVEViewMock.NewMockCveCore(s.mockCtrl)
+	mockCore.EXPECT().GetTopSeverity().Return(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY).AnyTimes()
+	mockCore.EXPECT().GetEPSSProbability().Return(float32(0.95)).AnyTimes()
+	mockCore.EXPECT().GetTopCVSS().Return(float32(9.8)).AnyTimes()
+	mockCore.EXPECT().GetTopNVDCVSS().Return(float32(9.5)).AnyTimes()
+
+	s.imageCVEView.EXPECT().Get(s.ctx, expectedQ, views.ReadOptions{}).Return([]imagecve.CveCore{mockCore}, nil)
+	response, err := s.resolver.ImageCVEs(s.ctx, *q)
+	s.NoError(err)
+	s.Require().Len(response, 1)
+
+	r := response[0]
+	s.Equal("CRITICAL_VULNERABILITY_SEVERITY", r.TopSeverity(s.ctx))
+	s.InDelta(0.95, r.TopEpssProbability(s.ctx), 0.001)
+	s.InDelta(9.8, r.TopCVSS(s.ctx), 0.001)
+	s.InDelta(9.5, r.TopNVDCVSS(s.ctx), 0.001)
 }
 
 func (s *ImageCVEV2CoreResolverTestSuite) TestGetImageCVEMalformed() {

--- a/central/graphql/resolvers/image_cve_v2_core_test.go
+++ b/central/graphql/resolvers/image_cve_v2_core_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/central/views/imagecve"
 	imageCVEViewMock "github.com/stackrox/rox/central/views/imagecve/mocks"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
 	"github.com/stretchr/testify/suite"

--- a/central/graphql/resolvers/image_cve_v2_core_test.go
+++ b/central/graphql/resolvers/image_cve_v2_core_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/central/views"
 	"github.com/stackrox/rox/central/views/imagecve"
 	imageCVEViewMock "github.com/stackrox/rox/central/views/imagecve/mocks"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
@@ -149,6 +150,29 @@ func (s *ImageCVEV2CoreResolverTestSuite) TestImageCVECountWithQuery() {
 	response, err := s.resolver.ImageCVECount(s.ctx, *q)
 	s.NoError(err)
 	s.Equal(response, int32(3))
+}
+
+func (s *ImageCVEV2CoreResolverTestSuite) TestImageCVEResolverFields() {
+	q := &PaginatedQuery{}
+	expectedQ, err := q.AsV1QueryOrEmpty()
+	s.Require().NoError(err)
+
+	mockCore := imageCVEViewMock.NewMockCveCore(s.mockCtrl)
+	mockCore.EXPECT().GetTopSeverity().Return(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY).AnyTimes()
+	mockCore.EXPECT().GetEPSSProbability().Return(float32(0.95)).AnyTimes()
+	mockCore.EXPECT().GetTopCVSS().Return(float32(9.8)).AnyTimes()
+	mockCore.EXPECT().GetTopNVDCVSS().Return(float32(9.5)).AnyTimes()
+
+	s.imageCVEView.EXPECT().Get(s.ctx, expectedQ, views.ReadOptions{}).Return([]imagecve.CveCore{mockCore}, nil)
+	response, err := s.resolver.ImageCVEs(s.ctx, *q)
+	s.NoError(err)
+	s.Require().Len(response, 1)
+
+	r := response[0]
+	s.Equal("CRITICAL_VULNERABILITY_SEVERITY", r.TopSeverity(s.ctx))
+	s.InDelta(0.95, r.TopEpssProbability(s.ctx), 0.001)
+	s.InDelta(9.8, r.TopCVSS(s.ctx), 0.001)
+	s.InDelta(9.5, r.TopNVDCVSS(s.ctx), 0.001)
 }
 
 func (s *ImageCVEV2CoreResolverTestSuite) TestGetImageCVEMalformed() {

--- a/central/views/imagecve/db_response.go
+++ b/central/views/imagecve/db_response.go
@@ -4,28 +4,31 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/views/common"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 )
 
 type imageCVECoreResponse struct {
-	CVE                                string     `db:"cve"`
-	CVEIDs                             []string   `db:"cve_id"`
-	ImagesWithCriticalSeverity         int        `db:"critical_severity_count"`
-	FixableImagesWithCriticalSeverity  int        `db:"fixable_critical_severity_count"`
-	ImagesWithImportantSeverity        int        `db:"important_severity_count"`
-	FixableImagesWithImportantSeverity int        `db:"fixable_important_severity_count"`
-	ImagesWithModerateSeverity         int        `db:"moderate_severity_count"`
-	FixableImagesWithModerateSeverity  int        `db:"fixable_moderate_severity_count"`
-	ImagesWithLowSeverity              int        `db:"low_severity_count"`
-	FixableImagesWithLowSeverity       int        `db:"fixable_low_severity_count"`
-	ImagesWithUnknownSeverity          int        `db:"unknown_severity_count"`
-	FixableImagesWithUnknownSeverity   int        `db:"fixable_unknown_severity_count"`
-	TopCVSS                            *float32   `db:"cvss_max"`
-	AffectedImageCount                 int        `db:"image_sha_count"`
-	FirstDiscoveredInSystem            *time.Time `db:"cve_created_time_min"`
-	Published                          *time.Time `db:"cve_published_on_min"`
-	TopNVDCVSS                         *float32   `db:"nvd_cvss_max"`
-	AffectedImageCountV2               int        `db:"image_id_count"`
+	CVE                                string                         `db:"cve"`
+	CVEIDs                             []string                       `db:"cve_id"`
+	ImagesWithCriticalSeverity         int                            `db:"critical_severity_count"`
+	FixableImagesWithCriticalSeverity  int                            `db:"fixable_critical_severity_count"`
+	ImagesWithImportantSeverity        int                            `db:"important_severity_count"`
+	FixableImagesWithImportantSeverity int                            `db:"fixable_important_severity_count"`
+	ImagesWithModerateSeverity         int                            `db:"moderate_severity_count"`
+	FixableImagesWithModerateSeverity  int                            `db:"fixable_moderate_severity_count"`
+	ImagesWithLowSeverity              int                            `db:"low_severity_count"`
+	FixableImagesWithLowSeverity       int                            `db:"fixable_low_severity_count"`
+	ImagesWithUnknownSeverity          int                            `db:"unknown_severity_count"`
+	FixableImagesWithUnknownSeverity   int                            `db:"fixable_unknown_severity_count"`
+	TopSeverity                        *storage.VulnerabilitySeverity `db:"severity_max"`
+	EpssProbability                    *float32                       `db:"epss_probability_max"`
+	TopCVSS                            *float32                       `db:"cvss_max"`
+	AffectedImageCount                 int                            `db:"image_sha_count"`
+	FirstDiscoveredInSystem            *time.Time                     `db:"cve_created_time_min"`
+	Published                          *time.Time                     `db:"cve_published_on_min"`
+	TopNVDCVSS                         *float32                       `db:"nvd_cvss_max"`
+	AffectedImageCountV2               int                            `db:"image_id_count"`
 }
 
 func (c *imageCVECoreResponse) GetCVE() string {
@@ -78,6 +81,20 @@ func (c *imageCVECoreResponse) GetFirstDiscoveredInSystem() *time.Time {
 
 func (c *imageCVECoreResponse) GetPublishDate() *time.Time {
 	return c.Published
+}
+
+func (c *imageCVECoreResponse) GetTopSeverity() storage.VulnerabilitySeverity {
+	if c.TopSeverity == nil {
+		return storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	}
+	return *c.TopSeverity
+}
+
+func (c *imageCVECoreResponse) GetEPSSProbability() float32 {
+	if c.EpssProbability == nil {
+		return 0.0
+	}
+	return *c.EpssProbability
 }
 
 type imageResponse struct {

--- a/central/views/imagecve/mocks/types.go
+++ b/central/views/imagecve/mocks/types.go
@@ -18,6 +18,7 @@ import (
 	common "github.com/stackrox/rox/central/views/common"
 	imagecve "github.com/stackrox/rox/central/views/imagecve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	storage "github.com/stackrox/rox/generated/storage"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -85,6 +86,20 @@ func (m *MockCveCore) GetCVEIDs() []string {
 func (mr *MockCveCoreMockRecorder) GetCVEIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEIDs", reflect.TypeOf((*MockCveCore)(nil).GetCVEIDs))
+}
+
+// GetEPSSProbability mocks base method.
+func (m *MockCveCore) GetEPSSProbability() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEPSSProbability")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetEPSSProbability indicates an expected call of GetEPSSProbability.
+func (mr *MockCveCoreMockRecorder) GetEPSSProbability() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEPSSProbability", reflect.TypeOf((*MockCveCore)(nil).GetEPSSProbability))
 }
 
 // GetFirstDiscoveredInSystem mocks base method.
@@ -155,6 +170,20 @@ func (m *MockCveCore) GetTopNVDCVSS() float32 {
 func (mr *MockCveCoreMockRecorder) GetTopNVDCVSS() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopNVDCVSS", reflect.TypeOf((*MockCveCore)(nil).GetTopNVDCVSS))
+}
+
+// GetTopSeverity mocks base method.
+func (m *MockCveCore) GetTopSeverity() storage.VulnerabilitySeverity {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTopSeverity")
+	ret0, _ := ret[0].(storage.VulnerabilitySeverity)
+	return ret0
+}
+
+// GetTopSeverity indicates an expected call of GetTopSeverity.
+func (mr *MockCveCoreMockRecorder) GetTopSeverity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopSeverity", reflect.TypeOf((*MockCveCore)(nil).GetTopSeverity))
 }
 
 // MockCveView is a mock of CveView interface.

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/views"
 	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 )
 
 // CveCore is an interface to get image CVE properties.
@@ -18,6 +19,8 @@ type CveCore interface {
 	GetImagesBySeverity() common.ResourceCountByCVESeverity
 	GetTopCVSS() float32
 	GetTopNVDCVSS() float32
+	GetTopSeverity() storage.VulnerabilitySeverity
+	GetEPSSProbability() float32
 	GetAffectedImageCount() int
 	GetFirstDiscoveredInSystem() *time.Time
 	GetPublishDate() *time.Time

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -86,10 +86,10 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	// Update the sort options to use aggregations if necessary as we are grouping by CVEs
 	cloned = common.UpdateSortAggs(cloned)
 
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 	var err error
 	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
-		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
+		cvesToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +104,7 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	defer cancel()
 
 	ret := make([]CveCore, 0, paginated.GetLimit(q.GetPagination().GetLimit(), 100))
-	err = pgSearch.RunSelectRequestForSchemaFn[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVECoreResponseQuery(cloned, cveIDsToFilter, options), func(r *imageCVECoreResponse) error {
+	err = pgSearch.RunSelectRequestForSchemaFn[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVECoreResponseQuery(cloned, cvesToFilter, options), func(r *imageCVECoreResponse) error {
 		// For each record, sort the IDs so that result looks consistent.
 		sort.SliceStable(r.CVEIDs, func(i, j int) bool {
 			return r.CVEIDs[i] < r.CVEIDs[j]
@@ -181,7 +181,7 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	}
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{
-		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
+		search.NewQuerySelect(search.CVE).Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
 		Fields: []string{search.CVE.String()},
@@ -203,10 +203,10 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	return cloned
 }
 
-func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, options views.ReadOptions) *v1.Query {
+func withSelectCVECoreResponseQuery(q *v1.Query, cvesToFilter []string, options views.ReadOptions) *v1.Query {
 	cloned := q.CloneVT()
-	if len(cveIDsToFilter) > 0 {
-		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddDocIDs(cveIDsToFilter...).ProtoQuery())
+	if len(cvesToFilter) > 0 {
+		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddExactMatches(search.CVE, cvesToFilter...).ProtoQuery())
 		cloned.Pagination = q.GetPagination()
 	}
 	searchField := search.ImageSHA
@@ -246,22 +246,23 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	return cloned
 }
 
+type cveNameResponse struct {
+	CVE string `db:"cve"`
+}
+
 func (v *imageCVECoreViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
-	// TODO(@charmik) : Update the SQL query generator to not include 'ORDER BY' and 'GROUP BY' fields in the select clause (before where).
-	//  SQL syntax does not need those fields in the select clause. The below query for example would work fine
-	//  "SELECT JSONB_AGG(DISTINCT(image_cves.Id)) AS cve_id FROM image_cves GROUP BY image_cves.CveBaseInfo_Cve ORDER BY MAX(image_cves.Cvss) DESC LIMIT 20;"
-	err := pgSearch.RunSelectRequestForSchemaFn[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *imageCVECoreResponse) error {
-		cveIDsToFilter = append(cveIDsToFilter, r.CVEIDs...)
+	err := pgSearch.RunSelectRequestForSchemaFn[cveNameResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *cveNameResponse) error {
+		cvesToFilter = append(cvesToFilter, r.CVE)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return cveIDsToFilter, nil
+	return cvesToFilter, nil
 }

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -88,7 +88,10 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 
 	var cveIDsToFilter []string
 	var err error
-	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
+	// When unified CVE view is enabled, severity counts are replaced with
+	// MAX(severity). This eliminates the need for a two-phase query because
+	// ORDER BY MAX(severity) DESC + LIMIT works in a single pass.
+	if !features.VulnMgmtUnifiedCVEView.Enabled() && (cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0) {
 		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			return nil, err
@@ -194,7 +197,7 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	// TODO(ROX-26310): Update the search framework to inject required select.
 	// Add the severity selects if severity is a sort option to ensure we have the filtered
 	// list of CVEs ordered appropriately.
-	if common.IsSortBySeverityCounts(cloned) {
+	if !features.VulnMgmtUnifiedCVEView.Enabled() && common.IsSortBySeverityCounts(cloned) {
 		cloned.Selects = append(cloned.Selects,
 			common.WithCountBySeverityAndFixabilityQuery(q, searchField).GetSelects()...,
 		)
@@ -216,8 +219,10 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	cloned.Selects = []*v1.QuerySelect{
 		search.NewQuerySelect(search.CVE).Proto(),
 		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
+		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.EPSSProbablity).AggrFunc(aggregatefunc.Max).Proto(),
 	}
-	if !options.SkipGetImagesBySeverity {
+	if !options.SkipGetImagesBySeverity && !features.VulnMgmtUnifiedCVEView.Enabled() {
 		cloned.Selects = append(cloned.Selects,
 			common.WithCountBySeverityAndFixabilityQuery(q, searchField).GetSelects()...,
 		)

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -88,10 +88,10 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 
 	var cveIDsToFilter []string
 	var err error
-	// When unified CVE view is enabled, severity counts are replaced with
-	// MAX(severity). This eliminates the need for a two-phase query because
-	// ORDER BY MAX(severity) DESC + LIMIT works in a single pass.
-	if !features.VulnMgmtUnifiedCVEView.Enabled() && (cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0) {
+	// When SkipGetImagesBySeverity is set, severity counts are not included
+	// and the two-phase query is unnecessary since MAX(severity) sort works
+	// in a single pass.
+	if !options.SkipGetImagesBySeverity && (cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0) {
 		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			return nil, err
@@ -197,7 +197,7 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	// TODO(ROX-26310): Update the search framework to inject required select.
 	// Add the severity selects if severity is a sort option to ensure we have the filtered
 	// list of CVEs ordered appropriately.
-	if !features.VulnMgmtUnifiedCVEView.Enabled() && common.IsSortBySeverityCounts(cloned) {
+	if common.IsSortBySeverityCounts(cloned) {
 		cloned.Selects = append(cloned.Selects,
 			common.WithCountBySeverityAndFixabilityQuery(q, searchField).GetSelects()...,
 		)
@@ -222,7 +222,7 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
 		search.NewQuerySelect(search.EPSSProbablity).AggrFunc(aggregatefunc.Max).Proto(),
 	}
-	if !options.SkipGetImagesBySeverity && !features.VulnMgmtUnifiedCVEView.Enabled() {
+	if !options.SkipGetImagesBySeverity {
 		cloned.Selects = append(cloned.Selects,
 			common.WithCountBySeverityAndFixabilityQuery(q, searchField).GetSelects()...,
 		)

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -88,10 +88,7 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 
 	var cveIDsToFilter []string
 	var err error
-	// When SkipGetImagesBySeverity is set, severity counts are not included
-	// and the two-phase query is unnecessary since MAX(severity) sort works
-	// in a single pass.
-	if !options.SkipGetImagesBySeverity && (cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0) {
+	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
 		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			return nil, err

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -50,15 +50,16 @@ type testImage interface {
 }
 
 type testCase struct {
-	desc           string
-	ctx            context.Context
-	q              *v1.Query
-	matchFilter    *filterImpl
-	less           lessFunc
-	readOptions    views.ReadOptions
-	expectedErr    string
-	skipCountTests bool
-	testOrder      bool
+	desc                 string
+	ctx                  context.Context
+	q                    *v1.Query
+	matchFilter          *filterImpl
+	less                 lessFunc
+	readOptions          views.ReadOptions
+	expectedErr          string
+	skipCountTests       bool
+	testOrder            bool
+	sortsBySeverityCount bool
 }
 
 type imageIDsPaginationTestCase struct {
@@ -439,6 +440,97 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECoreWithPagination() {
 	}
 }
 
+func (s *ImageCVEViewTestSuite) TestGetImageCVECoreUnifiedView() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, tc := range s.testCases() {
+		if tc.sortsBySeverityCount {
+			continue
+		}
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+			if tc.expectedErr != "" {
+				s.ErrorContains(err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+
+			// With unified view, severity counts are skipped — zero them in expected.
+			for _, entry := range expected {
+				if resp, ok := entry.(*imageCVECoreResponse); ok {
+					resp.ImagesWithCriticalSeverity = 0
+					resp.FixableImagesWithCriticalSeverity = 0
+					resp.ImagesWithImportantSeverity = 0
+					resp.FixableImagesWithImportantSeverity = 0
+					resp.ImagesWithModerateSeverity = 0
+					resp.FixableImagesWithModerateSeverity = 0
+					resp.ImagesWithLowSeverity = 0
+					resp.FixableImagesWithLowSeverity = 0
+					resp.ImagesWithUnknownSeverity = 0
+					resp.FixableImagesWithUnknownSeverity = 0
+				}
+			}
+
+			assertResponsesAreEqual(t, expected, actual, tc.testOrder)
+
+			// Verify TopSeverity and EPSS are populated.
+			for _, record := range actual {
+				assert.NotEqual(t, storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY, record.GetTopSeverity(),
+					"TopSeverity should be populated for CVE %s", record.GetCVE())
+			}
+		})
+	}
+}
+
+func (s *ImageCVEViewTestSuite) TestGetImageCVECoreUnifiedViewWithPagination() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, paginationTestCase := range s.paginationTestCases() {
+		baseTestCases := s.testCases()
+		for idx := range baseTestCases {
+			tc := &baseTestCases[idx]
+			if !tc.readOptions.IsDefault() || tc.sortsBySeverityCount {
+				continue
+			}
+			applyPaginationProps(tc, paginationTestCase)
+
+			s.T().Run(tc.desc, func(t *testing.T) {
+				actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+				if tc.expectedErr != "" {
+					s.ErrorContains(err, tc.expectedErr)
+					return
+				}
+				assert.NoError(t, err)
+
+				expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+				for _, entry := range expected {
+					if resp, ok := entry.(*imageCVECoreResponse); ok {
+						resp.ImagesWithCriticalSeverity = 0
+						resp.FixableImagesWithCriticalSeverity = 0
+						resp.ImagesWithImportantSeverity = 0
+						resp.FixableImagesWithImportantSeverity = 0
+						resp.ImagesWithModerateSeverity = 0
+						resp.FixableImagesWithModerateSeverity = 0
+						resp.ImagesWithLowSeverity = 0
+						resp.FixableImagesWithLowSeverity = 0
+						resp.ImagesWithUnknownSeverity = 0
+						resp.FixableImagesWithUnknownSeverity = 0
+					}
+				}
+				assertResponsesAreEqual(t, expected, actual, tc.testOrder)
+			})
+		}
+	}
+}
+
 func (s *ImageCVEViewTestSuite) TestCountImageCVECore() {
 	for _, tc := range s.testCases() {
 		if tc.skipCountTests {
@@ -724,12 +816,13 @@ func (s *ImageCVEViewTestSuite) testCases() []testCase {
 				}),
 		},
 		{
-			desc:           "search all sort by critical severity most first",
-			ctx:            context.Background(),
-			q:              search.NewQueryBuilder().WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.CriticalSeverityCount).Reversed(true)).AddSortOption(search.NewSortOption(search.CVE))).ProtoQuery(),
-			matchFilter:    matchAllFilter(),
-			skipCountTests: true,
-			testOrder:      true,
+			desc:                 "search all sort by critical severity most first",
+			ctx:                  context.Background(),
+			q:                    search.NewQueryBuilder().WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.CriticalSeverityCount).Reversed(true)).AddSortOption(search.NewSortOption(search.CVE))).ProtoQuery(),
+			matchFilter:          matchAllFilter(),
+			skipCountTests:       true,
+			testOrder:            true,
+			sortsBySeverityCount: true,
 			less: func(records []*imageCVECoreResponse) func(i, j int) bool {
 				return func(i, j int) bool {
 					if records[i].ImagesWithCriticalSeverity == records[j].ImagesWithCriticalSeverity {
@@ -1068,6 +1161,14 @@ func (s *ImageCVEViewTestSuite) compileExpected(images []testImage, filter *filt
 				}
 
 				val.TopCVSS = pointers.Float32(max(val.GetTopCVSS(), vuln.GetCvss()))
+				if val.TopSeverity == nil || vuln.GetSeverity() > *val.TopSeverity {
+					sev := vuln.GetSeverity()
+					val.TopSeverity = &sev
+				}
+				epss := vuln.GetCveBaseInfo().GetEpss().GetEpssProbability()
+				if val.EpssProbability == nil || epss > *val.EpssProbability {
+					val.EpssProbability = pointers.Float32(epss)
+				}
 
 				if val.GetFirstDiscoveredInSystem().After(vulnTime) {
 					val.FirstDiscoveredInSystem = &vulnTime
@@ -1464,6 +1565,8 @@ func assertResponsesAreEqual(t *testing.T, expected []CveCore, actual []CveCore,
 		assert.Equal(t, expected[i].GetCVE(), flatCVE.GetCVE())
 		assert.Equal(t, expected[i].GetTopCVSS(), flatCVE.GetTopCVSS())
 		assert.Equal(t, expected[i].GetTopNVDCVSS(), flatCVE.GetTopNVDCVSS())
+		assert.Equal(t, expected[i].GetTopSeverity(), flatCVE.GetTopSeverity())
+		assert.Equal(t, expected[i].GetEPSSProbability(), flatCVE.GetEPSSProbability())
 		assert.Equal(t, expected[i].GetAffectedImageCount(), flatCVE.GetAffectedImageCount())
 		assert.Equal(t, expected[i].GetFirstDiscoveredInSystem(), flatCVE.GetFirstDiscoveredInSystem())
 		assert.Equal(t, expected[i].GetPublishDate(), flatCVE.GetPublishDate())

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1159,14 +1159,14 @@ func (s *ImageCVEViewTestSuite) compileExpected(images []testImage, filter *filt
 					val.CVEIDs = append(val.CVEIDs, id)
 				}
 
-				val.TopCVSS = pointers.Float32(max(val.GetTopCVSS(), vuln.GetCvss()))
+				val.TopCVSS = new(max(val.GetTopCVSS(), vuln.GetCvss()))
 				if val.TopSeverity == nil || vuln.GetSeverity() > *val.TopSeverity {
 					sev := vuln.GetSeverity()
 					val.TopSeverity = &sev
 				}
 				epss := vuln.GetCveBaseInfo().GetEpss().GetEpssProbability()
 				if val.EpssProbability == nil || epss > *val.EpssProbability {
-					val.EpssProbability = pointers.Float32(epss)
+					val.EpssProbability = new(epss)
 				}
 
 				if val.GetFirstDiscoveredInSystem().After(vulnTime) {

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -49,15 +49,16 @@ type testImage interface {
 }
 
 type testCase struct {
-	desc           string
-	ctx            context.Context
-	q              *v1.Query
-	matchFilter    *filterImpl
-	less           lessFunc
-	readOptions    views.ReadOptions
-	expectedErr    string
-	skipCountTests bool
-	testOrder      bool
+	desc                 string
+	ctx                  context.Context
+	q                    *v1.Query
+	matchFilter          *filterImpl
+	less                 lessFunc
+	readOptions          views.ReadOptions
+	expectedErr          string
+	skipCountTests       bool
+	testOrder            bool
+	sortsBySeverityCount bool
 }
 
 type imageIDsPaginationTestCase struct {
@@ -438,6 +439,97 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECoreWithPagination() {
 	}
 }
 
+func (s *ImageCVEViewTestSuite) TestGetImageCVECoreUnifiedView() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, tc := range s.testCases() {
+		if tc.sortsBySeverityCount {
+			continue
+		}
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+			if tc.expectedErr != "" {
+				s.ErrorContains(err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+
+			// With unified view, severity counts are skipped — zero them in expected.
+			for _, entry := range expected {
+				if resp, ok := entry.(*imageCVECoreResponse); ok {
+					resp.ImagesWithCriticalSeverity = 0
+					resp.FixableImagesWithCriticalSeverity = 0
+					resp.ImagesWithImportantSeverity = 0
+					resp.FixableImagesWithImportantSeverity = 0
+					resp.ImagesWithModerateSeverity = 0
+					resp.FixableImagesWithModerateSeverity = 0
+					resp.ImagesWithLowSeverity = 0
+					resp.FixableImagesWithLowSeverity = 0
+					resp.ImagesWithUnknownSeverity = 0
+					resp.FixableImagesWithUnknownSeverity = 0
+				}
+			}
+
+			assertResponsesAreEqual(t, expected, actual, tc.testOrder)
+
+			// Verify TopSeverity and EPSS are populated.
+			for _, record := range actual {
+				assert.NotEqual(t, storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY, record.GetTopSeverity(),
+					"TopSeverity should be populated for CVE %s", record.GetCVE())
+			}
+		})
+	}
+}
+
+func (s *ImageCVEViewTestSuite) TestGetImageCVECoreUnifiedViewWithPagination() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, paginationTestCase := range s.paginationTestCases() {
+		baseTestCases := s.testCases()
+		for idx := range baseTestCases {
+			tc := &baseTestCases[idx]
+			if !tc.readOptions.IsDefault() || tc.sortsBySeverityCount {
+				continue
+			}
+			applyPaginationProps(tc, paginationTestCase)
+
+			s.T().Run(tc.desc, func(t *testing.T) {
+				actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+				if tc.expectedErr != "" {
+					s.ErrorContains(err, tc.expectedErr)
+					return
+				}
+				assert.NoError(t, err)
+
+				expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+				for _, entry := range expected {
+					if resp, ok := entry.(*imageCVECoreResponse); ok {
+						resp.ImagesWithCriticalSeverity = 0
+						resp.FixableImagesWithCriticalSeverity = 0
+						resp.ImagesWithImportantSeverity = 0
+						resp.FixableImagesWithImportantSeverity = 0
+						resp.ImagesWithModerateSeverity = 0
+						resp.FixableImagesWithModerateSeverity = 0
+						resp.ImagesWithLowSeverity = 0
+						resp.FixableImagesWithLowSeverity = 0
+						resp.ImagesWithUnknownSeverity = 0
+						resp.FixableImagesWithUnknownSeverity = 0
+					}
+				}
+				assertResponsesAreEqual(t, expected, actual, tc.testOrder)
+			})
+		}
+	}
+}
+
 func (s *ImageCVEViewTestSuite) TestCountImageCVECore() {
 	for _, tc := range s.testCases() {
 		if tc.skipCountTests {
@@ -723,12 +815,13 @@ func (s *ImageCVEViewTestSuite) testCases() []testCase {
 				}),
 		},
 		{
-			desc:           "search all sort by critical severity most first",
-			ctx:            context.Background(),
-			q:              search.NewQueryBuilder().WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.CriticalSeverityCount).Reversed(true)).AddSortOption(search.NewSortOption(search.CVE))).ProtoQuery(),
-			matchFilter:    matchAllFilter(),
-			skipCountTests: true,
-			testOrder:      true,
+			desc:                 "search all sort by critical severity most first",
+			ctx:                  context.Background(),
+			q:                    search.NewQueryBuilder().WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.CriticalSeverityCount).Reversed(true)).AddSortOption(search.NewSortOption(search.CVE))).ProtoQuery(),
+			matchFilter:          matchAllFilter(),
+			skipCountTests:       true,
+			testOrder:            true,
+			sortsBySeverityCount: true,
 			less: func(records []*imageCVECoreResponse) func(i, j int) bool {
 				return func(i, j int) bool {
 					if records[i].ImagesWithCriticalSeverity == records[j].ImagesWithCriticalSeverity {
@@ -1066,7 +1159,15 @@ func (s *ImageCVEViewTestSuite) compileExpected(images []testImage, filter *filt
 					val.CVEIDs = append(val.CVEIDs, id)
 				}
 
-				val.TopCVSS = new(max(val.GetTopCVSS(), vuln.GetCvss()))
+				val.TopCVSS = pointers.Float32(max(val.GetTopCVSS(), vuln.GetCvss()))
+				if val.TopSeverity == nil || vuln.GetSeverity() > *val.TopSeverity {
+					sev := vuln.GetSeverity()
+					val.TopSeverity = &sev
+				}
+				epss := vuln.GetCveBaseInfo().GetEpss().GetEpssProbability()
+				if val.EpssProbability == nil || epss > *val.EpssProbability {
+					val.EpssProbability = pointers.Float32(epss)
+				}
 
 				if val.GetFirstDiscoveredInSystem().After(vulnTime) {
 					val.FirstDiscoveredInSystem = &vulnTime
@@ -1463,6 +1564,8 @@ func assertResponsesAreEqual(t *testing.T, expected []CveCore, actual []CveCore,
 		assert.Equal(t, expected[i].GetCVE(), flatCVE.GetCVE())
 		assert.Equal(t, expected[i].GetTopCVSS(), flatCVE.GetTopCVSS())
 		assert.Equal(t, expected[i].GetTopNVDCVSS(), flatCVE.GetTopNVDCVSS())
+		assert.Equal(t, expected[i].GetTopSeverity(), flatCVE.GetTopSeverity())
+		assert.Equal(t, expected[i].GetEPSSProbability(), flatCVE.GetEPSSProbability())
 		assert.Equal(t, expected[i].GetAffectedImageCount(), flatCVE.GetAffectedImageCount())
 		assert.Equal(t, expected[i].GetFirstDiscoveredInSystem(), flatCVE.GetFirstDiscoveredInSystem())
 		assert.Equal(t, expected[i].GetPublishDate(), flatCVE.GetPublishDate())

--- a/central/views/imagecveflat/view_impl.go
+++ b/central/views/imagecveflat/view_impl.go
@@ -52,12 +52,9 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	// Update the sort options to use aggregations if necessary as we are grouping by CVEs
 	cloned = common.UpdateSortAggs(cloned)
 
-	// Performance improvements to narrow aggregations performed.
-	// When unified CVE view is enabled, severity counts are replaced with
-	// MAX(severity), allowing a single-phase query with ORDER BY + LIMIT.
 	var cveIDsToFilter []string
 	var err error
-	if !features.VulnMgmtUnifiedCVEView.Enabled() && (cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0) {
+	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
 		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			log.Error(err)

--- a/central/views/imagecveflat/view_impl.go
+++ b/central/views/imagecveflat/view_impl.go
@@ -52,10 +52,10 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	// Update the sort options to use aggregations if necessary as we are grouping by CVEs
 	cloned = common.UpdateSortAggs(cloned)
 
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 	var err error
 	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
-		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
+		cvesToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			log.Error(err)
 			return nil, err
@@ -72,7 +72,7 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	defer cancel()
 
 	var ret []CveFlat
-	err = pgSearch.RunSelectRequestForSchemaFn[imageCVEFlatResponse](queryCtx, v.db, v.schema, withSelectCVEFlatResponseQuery(cloned, cveIDsToFilter, options), func(r *imageCVEFlatResponse) error {
+	err = pgSearch.RunSelectRequestForSchemaFn[imageCVEFlatResponse](queryCtx, v.db, v.schema, withSelectCVEFlatResponseQuery(cloned, cvesToFilter, options), func(r *imageCVEFlatResponse) error {
 		// For each record, sort the IDs so that result looks consistent.
 		sort.SliceStable(r.CVEIDs, func(i, j int) bool {
 			return r.CVEIDs[i] < r.CVEIDs[j]
@@ -90,7 +90,7 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{
-		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
+		search.NewQuerySelect(search.CVE).Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
 		Fields: []string{search.CVE.String()},
@@ -99,10 +99,10 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	return cloned
 }
 
-func withSelectCVEFlatResponseQuery(q *v1.Query, cveIDsToFilter []string, options views.ReadOptions) *v1.Query {
+func withSelectCVEFlatResponseQuery(q *v1.Query, cvesToFilter []string, options views.ReadOptions) *v1.Query {
 	cloned := q.CloneVT()
-	if len(cveIDsToFilter) > 0 {
-		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddDocIDs(cveIDsToFilter...).ProtoQuery())
+	if len(cvesToFilter) > 0 {
+		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddExactMatches(search.CVE, cvesToFilter...).ProtoQuery())
 		cloned.Pagination = q.GetPagination()
 	}
 
@@ -144,17 +144,18 @@ func withSelectCVEFlatResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	return cloned
 }
 
+type cveNameResponse struct {
+	CVE string `db:"cve"`
+}
+
 func (v *imageCVEFlatViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
-	// TODO(@charmik) : Update the SQL query generator to not include 'ORDER BY' and 'GROUP BY' fields in the select clause (before where).
-	//  SQL syntax does not need those fields in the select clause. The below query for example would work fine
-	//  "SELECT JSONB_AGG(DISTINCT(image_cves.Id)) AS cve_id FROM image_cves GROUP BY image_cves.CveBaseInfo_Cve ORDER BY MAX(image_cves.Cvss) DESC LIMIT 20;"
-	err := pgSearch.RunSelectRequestForSchemaFn[imageCVEFlatResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *imageCVEFlatResponse) error {
-		cveIDsToFilter = append(cveIDsToFilter, r.CVEIDs...)
+	err := pgSearch.RunSelectRequestForSchemaFn[cveNameResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *cveNameResponse) error {
+		cvesToFilter = append(cvesToFilter, r.CVE)
 		return nil
 	})
 	if err != nil {
@@ -162,5 +163,5 @@ func (v *imageCVEFlatViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query)
 		return nil, err
 	}
 
-	return cveIDsToFilter, nil
+	return cvesToFilter, nil
 }

--- a/central/views/imagecveflat/view_impl.go
+++ b/central/views/imagecveflat/view_impl.go
@@ -52,10 +52,12 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	// Update the sort options to use aggregations if necessary as we are grouping by CVEs
 	cloned = common.UpdateSortAggs(cloned)
 
-	// Performance improvements to narrow aggregations performed
+	// Performance improvements to narrow aggregations performed.
+	// When unified CVE view is enabled, severity counts are replaced with
+	// MAX(severity), allowing a single-phase query with ORDER BY + LIMIT.
 	var cveIDsToFilter []string
 	var err error
-	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
+	if !features.VulnMgmtUnifiedCVEView.Enabled() && (cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0) {
 		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			log.Error(err)

--- a/central/views/imagecveflat/view_test.go
+++ b/central/views/imagecveflat/view_test.go
@@ -340,6 +340,59 @@ func (s *ImageCVEFlatViewTestSuite) TestGetImageCVEFlatWithPagination() {
 	}
 }
 
+func (s *ImageCVEFlatViewTestSuite) TestGetImageCVEFlatUnifiedView() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, tc := range s.testCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+			if tc.expectedErr != "" {
+				s.ErrorContains(err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+			assert.Equal(t, len(expected), len(actual))
+			assertResponsesAreEqual(t, expected, actual, tc.testOrder)
+		})
+	}
+}
+
+func (s *ImageCVEFlatViewTestSuite) TestGetImageCVEFlatUnifiedViewWithPagination() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, paginationTestCase := range s.paginationTestCases() {
+		baseTestCases := s.testCases()
+		for idx := range baseTestCases {
+			tc := &baseTestCases[idx]
+			if !tc.readOptions.IsDefault() {
+				continue
+			}
+			applyPaginationProps(tc, paginationTestCase)
+
+			s.T().Run(tc.desc, func(t *testing.T) {
+				actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+				if tc.expectedErr != "" {
+					s.ErrorContains(err, tc.expectedErr)
+					return
+				}
+				assert.NoError(t, err)
+
+				expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+				assert.Equal(t, len(expected), len(actual))
+				assertResponsesAreEqual(t, expected, actual, true)
+			})
+		}
+	}
+}
+
 func (s *ImageCVEFlatViewTestSuite) TestCountImageCVEFlat() {
 	for _, tc := range s.testCases() {
 		if tc.skipCountTests {

--- a/central/views/imagecveflat/view_test.go
+++ b/central/views/imagecveflat/view_test.go
@@ -341,6 +341,59 @@ func (s *ImageCVEFlatViewTestSuite) TestGetImageCVEFlatWithPagination() {
 	}
 }
 
+func (s *ImageCVEFlatViewTestSuite) TestGetImageCVEFlatUnifiedView() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, tc := range s.testCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+			if tc.expectedErr != "" {
+				s.ErrorContains(err, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+			assert.Equal(t, len(expected), len(actual))
+			assertResponsesAreEqual(t, expected, actual, tc.testOrder)
+		})
+	}
+}
+
+func (s *ImageCVEFlatViewTestSuite) TestGetImageCVEFlatUnifiedViewWithPagination() {
+	s.T().Setenv(features.VulnMgmtUnifiedCVEView.EnvVar(), "true")
+	if !features.VulnMgmtUnifiedCVEView.Enabled() {
+		s.T().Skip("Cannot enable VulnMgmtUnifiedCVEView")
+	}
+
+	for _, paginationTestCase := range s.paginationTestCases() {
+		baseTestCases := s.testCases()
+		for idx := range baseTestCases {
+			tc := &baseTestCases[idx]
+			if !tc.readOptions.IsDefault() {
+				continue
+			}
+			applyPaginationProps(tc, paginationTestCase)
+
+			s.T().Run(tc.desc, func(t *testing.T) {
+				actual, err := s.cveView.Get(sac.WithAllAccess(tc.ctx), tc.q, tc.readOptions)
+				if tc.expectedErr != "" {
+					s.ErrorContains(err, tc.expectedErr)
+					return
+				}
+				assert.NoError(t, err)
+
+				expected := s.compileExpected(s.testImages, tc.matchFilter, tc.readOptions, tc.less)
+				assert.Equal(t, len(expected), len(actual))
+				assertResponsesAreEqual(t, expected, actual, true)
+			})
+		}
+	}
+}
+
 func (s *ImageCVEFlatViewTestSuite) TestCountImageCVEFlat() {
 	for _, tc := range s.testCases() {
 		if tc.skipCountTests {

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -21,6 +21,7 @@ central/reports/service/v2/service_impl_test.go
 central/sensor/service/connection/sensor-central-data-flow.excalidraw.svg
 central/splunk/violations_test.go
 central/testutils/testdata/imgdata.json.gz
+central/views/imagecve/view_test.go
 central/vulnmgmt/vulnerabilityrequest/datastore/datastore_impl_postgres_test.go
 compliance/node/index/testdata/usr/share/rpm/rpmdb.sqlite
 deploy/charts/monitoring/dashboards/*.json


### PR DESCRIPTION
Add GetTopSeverity() and GetEPSSProbability() to the CveCore interface
and expose them as topSeverity and topEpssProbability on the ImageCVECore
GraphQL type. Both views (imagecve and imagecveflat) now always include
MAX(severity) and MAX(epss_probability) selects.

When ROX_VULN_MGMT_UNIFIED_CVE_VIEW is enabled, severity count selects
(10 filtered COUNTs) and the two-phase pagination query are skipped.
MAX(severity) as the sort key allows a single-phase GROUP BY + ORDER BY
+ LIMIT query.

Partially AI-generated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
