### PR TITLE
perf: batch exception count queries in CVE resolvers

### DIFF
--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -58,7 +58,9 @@ type imageCVECoreResolver struct {
 	root *Resolver
 	data imagecve.CveCore
 
-	subFieldQuery *v1.Query
+	subFieldQuery              *v1.Query
+	preloadedExceptionCount    int32
+	hasPreloadedExceptionCount bool
 }
 
 func (resolver *Resolver) wrapImageCVECoreWithContext(ctx context.Context, value imagecve.CveCore, err error) (*imageCVECoreResolver, error) {
@@ -125,8 +127,25 @@ func (resolver *Resolver) ImageCVEs(ctx context.Context, q PaginatedQuery) ([]*i
 	if err != nil {
 		return nil, err
 	}
+
 	for _, r := range ret {
 		r.subFieldQuery = query
+	}
+
+	if resolver.vulnReqStore != nil {
+		cveNames := make([]string, len(ret))
+		for i, r := range ret {
+			cveNames[i] = r.data.GetCVE()
+		}
+		exceptionCounts, batchErr := batchExceptionCounts(ctx, resolver.vulnReqStore, cveNames)
+		if batchErr != nil {
+			log.Warnf("batch exception count failed, falling back to per-CVE: %v", batchErr)
+		} else {
+			for _, r := range ret {
+				r.preloadedExceptionCount = exceptionCounts[r.data.GetCVE()]
+				r.hasPreloadedExceptionCount = true
+			}
+		}
 	}
 
 	return ret, nil
@@ -227,6 +246,10 @@ func (resolver *imageCVECoreResolver) PublishedOn(_ context.Context) *graphql.Ti
 
 func (resolver *imageCVECoreResolver) ExceptionCount(ctx context.Context, args struct{ RequestStatus *[]*string }) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "ExceptionCount")
+
+	if resolver.hasPreloadedExceptionCount {
+		return resolver.preloadedExceptionCount, nil
+	}
 
 	if resolver.ctx == nil {
 		resolver.ctx = ctx

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -193,6 +193,22 @@ func (resolver *Resolver) ImageVulnerabilities(ctx context.Context, q PaginatedQ
 		return nil, err
 	}
 
+	if resolver.vulnReqStore != nil {
+		cveNames := make([]string, len(cveResolvers))
+		for i, r := range cveResolvers {
+			cveNames[i] = r.data.GetCveBaseInfo().GetCve()
+		}
+		exceptionCounts, batchErr := batchExceptionCounts(ctx, resolver.vulnReqStore, cveNames)
+		if batchErr != nil {
+			log.Warnf("batch exception count failed, falling back to per-CVE: %v", batchErr)
+		} else {
+			for _, r := range cveResolvers {
+				r.preloadedExceptionCount = exceptionCounts[r.data.GetCveBaseInfo().GetCve()]
+				r.hasPreloadedExceptionCount = true
+			}
+		}
+	}
+
 	// cast as return type
 	ret := make([]ImageVulnerabilityResolver, 0, len(cveResolvers))
 	for _, res := range cveResolvers {
@@ -622,6 +638,10 @@ func (resolver *imageCVEV2Resolver) UnusedVarSink(_ context.Context, _ RawQuery)
 
 func (resolver *imageCVEV2Resolver) ExceptionCount(ctx context.Context, args struct{ RequestStatus *[]*string }) (int32, error) {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.ImageCVEs, "ExceptionCount")
+
+	if resolver.hasPreloadedExceptionCount {
+		return resolver.preloadedExceptionCount, nil
+	}
 
 	if resolver.ctx == nil {
 		resolver.ctx = ctx

--- a/central/graphql/resolvers/image_vulnerabilities_utilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities_utilities.go
@@ -14,7 +14,9 @@ type imageCVEV2Resolver struct {
 	root *Resolver
 	data *storage.ImageCVEV2
 
-	flatData imagecveflat.CveFlat
+	flatData                   imagecveflat.CveFlat
+	preloadedExceptionCount    int32
+	hasPreloadedExceptionCount bool
 }
 
 func (resolver *Resolver) wrapImageCVEV2WithContext(ctx context.Context, value *storage.ImageCVEV2, ok bool, err error) (*imageCVEV2Resolver, error) {

--- a/central/graphql/resolvers/vulnerability_requests.go
+++ b/central/graphql/resolvers/vulnerability_requests.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
 	"github.com/stackrox/rox/central/metrics"
 	"github.com/stackrox/rox/central/vulnmgmt/vulnerabilityrequest/common"
+	vulnReqDataStore "github.com/stackrox/rox/central/vulnmgmt/vulnerabilityrequest/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
@@ -21,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/search/scoped"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -455,6 +457,32 @@ func (dr *DeferralRequestResolver) ExpiresOn(_ context.Context) (*graphql.Time, 
 // ExpiresWhenFixed returns true if the deferral request expires when vulnerability is fixable.
 func (dr *DeferralRequestResolver) ExpiresWhenFixed(_ context.Context) bool {
 	return dr.data.GetExpiry().GetExpiresWhenFixed()
+}
+
+// batchExceptionCounts returns unexpired exception counts grouped by CVE name
+// in a single query, replacing N individual Count() calls.
+func batchExceptionCounts(ctx context.Context, store vulnReqDataStore.DataStore, cves []string) (map[string]int32, error) {
+	if len(cves) == 0 {
+		return nil, nil
+	}
+	cveSet := set.NewStringSet(cves...)
+	q := search.NewQueryBuilder().
+		AddBools(search.ExpiredRequest, false).
+		AddExactMatches(search.CVE, cves...).
+		ProtoQuery()
+	requests, err := store.SearchRawRequests(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int32, len(cves))
+	for _, req := range requests {
+		for _, cve := range req.GetCves().GetCves() {
+			if cveSet.Contains(cve) {
+				counts[cve]++
+			}
+		}
+	}
+	return counts, nil
 }
 
 type exceptionQueryFilters struct {


### PR DESCRIPTION
Replace N per-CVE vulnReqStore.Count() calls with a single
SearchRawRequests query for all CVEs on the page. Results are
preloaded onto the resolver structs; ExceptionCount() returns the
preloaded value when available, falling back to individual queries
if batching fails.

Applies to both ImageCVEs (imageCVECoreResolver) and
ImageVulnerabilities (imageCVEV2Resolver) code paths.

Partially AI-generated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
