### PR TITLE
feat: add TopSeverityBatch and topImageCVESeverity field

### DIFF
--- a/central/graphql/resolvers/deployments.go
+++ b/central/graphql/resolvers/deployments.go
@@ -41,6 +41,7 @@ func init() {
 			"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
 			"imageCount(query: String): Int!",
 			"imageCVECountBySeverity(query: String): ResourceCountByCVESeverity!",
+			"topImageCVESeverity(query: String): String!",
 			"images(query: String, pagination: Pagination): [Image!]!",
 			"imageVulnerabilityCount(query: String): Int!",
 			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
@@ -561,6 +562,26 @@ func (resolver *deploymentResolver) ImageCVECountBySeverity(ctx context.Context,
 	}
 	val, err := resolver.root.ImageCVEView.CountBySeverity(resolver.withDeploymentScopeContext(ctx), query)
 	return resolver.root.wrapResourceCountByCVESeverityWithContext(ctx, val, err)
+}
+
+func (resolver *deploymentResolver) TopImageCVESeverity(ctx context.Context, q RawQuery) (string, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Deployments, "TopImageCVESeverity")
+
+	if err := readImages(ctx); err != nil {
+		return "", err
+	}
+	query, err := q.AsV1QueryOrEmpty()
+	if err != nil {
+		return "", err
+	}
+	result, err := resolver.root.ImageCVEView.TopSeverityBatch(ctx, []string{resolver.data.GetId()}, search.DeploymentID, query)
+	if err != nil {
+		return "", err
+	}
+	if sev, ok := result[resolver.data.GetId()]; ok {
+		return sev.String(), nil
+	}
+	return storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY.String(), nil
 }
 
 func (resolver *deploymentResolver) withDeploymentScopeContext(ctx context.Context) context.Context {

--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -59,6 +60,7 @@ type ImageResolver interface {
 	ImageVulnerabilityCount(ctx context.Context, args RawQuery) (int32, error)
 	ImageVulnerabilityCounter(ctx context.Context, args RawQuery) (*VulnerabilityCounterResolver, error)
 	ImageCVECountBySeverity(ctx context.Context, q RawQuery) (*resourceCountBySeverityResolver, error)
+	TopImageCVESeverity(ctx context.Context, q RawQuery) (string, error)
 	ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error)
 	ImageComponentCount(ctx context.Context, args RawQuery) (int32, error)
 	PlottedImageVulnerabilities(ctx context.Context, args RawQuery) (*PlottedImageVulnerabilitiesResolver, error)
@@ -104,6 +106,7 @@ func init() {
 			"imageComponentCount(query: String): Int!",
 			"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
 			"imageCVECountBySeverity(query: String): ResourceCountByCVESeverity!",
+			"topImageCVESeverity(query: String): String!",
 			"imageVulnerabilityCount(query: String): Int!",
 			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability]!",
@@ -276,6 +279,26 @@ func (resolver *imageResolver) ImageCVECountBySeverity(ctx context.Context, q Ra
 	}
 	val, err := resolver.root.ImageCVEView.CountBySeverity(resolver.withImageScopeContext(ctx), query)
 	return resolver.root.wrapResourceCountByCVESeverityWithContext(ctx, val, err)
+}
+
+func (resolver *imageResolver) TopImageCVESeverity(ctx context.Context, q RawQuery) (string, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "TopImageCVESeverity")
+
+	if err := readImages(ctx); err != nil {
+		return "", err
+	}
+	query, err := q.AsV1QueryOrEmpty()
+	if err != nil {
+		return "", err
+	}
+	result, err := resolver.root.ImageCVEView.TopSeverityBatch(ctx, []string{resolver.data.GetId()}, search.ImageSHA, query)
+	if err != nil {
+		return "", err
+	}
+	if sev, ok := result[resolver.data.GetId()]; ok {
+		return sev.String(), nil
+	}
+	return storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY.String(), nil
 }
 
 func (resolver *imageResolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {

--- a/central/graphql/resolvers/images_v2.go
+++ b/central/graphql/resolvers/images_v2.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -29,6 +30,7 @@ func init() {
 			"imageComponentCount(query: String): Int!",
 			"imageComponents(query: String, pagination: Pagination): [ImageComponent!]!",
 			"imageCVECountBySeverity(query: String): ResourceCountByCVESeverity!",
+			"topImageCVESeverity(query: String): String!",
 			"imageVulnerabilityCount(query: String): Int!",
 			"imageVulnerabilityCounter(query: String): VulnerabilityCounter!",
 			"imageVulnerabilities(query: String, scopeQuery: String, pagination: Pagination): [ImageVulnerability]!",
@@ -182,6 +184,26 @@ func (resolver *imageV2Resolver) ImageCVECountBySeverity(ctx context.Context, q 
 	}
 	val, err := resolver.root.ImageCVEView.CountBySeverity(resolver.withImageScopeContext(ctx), query)
 	return resolver.root.wrapResourceCountByCVESeverityWithContext(ctx, val, err)
+}
+
+func (resolver *imageV2Resolver) TopImageCVESeverity(ctx context.Context, q RawQuery) (string, error) {
+	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.Images, "TopImageCVESeverity")
+
+	if err := readImages(ctx); err != nil {
+		return "", err
+	}
+	query, err := q.AsV1QueryOrEmpty()
+	if err != nil {
+		return "", err
+	}
+	result, err := resolver.root.ImageCVEView.TopSeverityBatch(ctx, []string{resolver.data.GetId()}, search.ImageID, query)
+	if err != nil {
+		return "", err
+	}
+	if sev, ok := result[resolver.data.GetId()]; ok {
+		return sev.String(), nil
+	}
+	return storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY.String(), nil
 }
 
 func (resolver *imageV2Resolver) ImageComponents(ctx context.Context, args PaginatedQuery) ([]ImageComponentResolver, error) {

--- a/central/views/imagecve/mocks/types.go
+++ b/central/views/imagecve/mocks/types.go
@@ -19,6 +19,7 @@ import (
 	imagecve "github.com/stackrox/rox/central/views/imagecve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
+	search "github.com/stackrox/rox/pkg/search"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -283,4 +284,19 @@ func (m *MockCveView) GetImageIDs(ctx context.Context, q *v1.Query) ([]string, e
 func (mr *MockCveViewMockRecorder) GetImageIDs(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageIDs", reflect.TypeOf((*MockCveView)(nil).GetImageIDs), ctx, q)
+}
+
+// TopSeverityBatch mocks base method.
+func (m *MockCveView) TopSeverityBatch(ctx context.Context, entityIDs []string, entityType search.FieldLabel, q *v1.Query) (map[string]storage.VulnerabilitySeverity, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TopSeverityBatch", ctx, entityIDs, entityType, q)
+	ret0, _ := ret[0].(map[string]storage.VulnerabilitySeverity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TopSeverityBatch indicates an expected call of TopSeverityBatch.
+func (mr *MockCveViewMockRecorder) TopSeverityBatch(ctx, entityIDs, entityType, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TopSeverityBatch", reflect.TypeOf((*MockCveView)(nil).TopSeverityBatch), ctx, entityIDs, entityType, q)
 }

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -27,10 +27,14 @@ type CveCore interface {
 	GetPublishDate() *time.Time
 }
 
-// EntitySeverityResult holds the top severity for a single entity (image or deployment).
-type EntitySeverityResult struct {
-	EntityID    string                        `db:"entity_id"`
-	TopSeverity storage.VulnerabilitySeverity `db:"top_severity"`
+type imageSeverityResult struct {
+	EntityID    string                        `db:"image_id"`
+	TopSeverity storage.VulnerabilitySeverity `db:"severity_max"`
+}
+
+type deploymentSeverityResult struct {
+	EntityID    string                        `db:"deployment_id"`
+	TopSeverity storage.VulnerabilitySeverity `db:"severity_max"`
 }
 
 // CveView interface is like a SQL view that provides functionality to fetch the image CVE data

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/search"
 )
 
 // CveCore is an interface to get image CVE properties.
@@ -26,6 +27,12 @@ type CveCore interface {
 	GetPublishDate() *time.Time
 }
 
+// EntitySeverityResult holds the top severity for a single entity (image or deployment).
+type EntitySeverityResult struct {
+	EntityID    string                        `db:"entity_id"`
+	TopSeverity storage.VulnerabilitySeverity `db:"top_severity"`
+}
+
 // CveView interface is like a SQL view that provides functionality to fetch the image CVE data
 // irrespective of the data model. One CVE can have multiple database entries if that CVE impacts multiple distros.
 // Each record may have different values for properties like severity. However, the core information is the same.
@@ -38,4 +45,5 @@ type CveView interface {
 	Get(ctx context.Context, q *v1.Query, options views.ReadOptions) ([]CveCore, error)
 	GetImageIDs(ctx context.Context, q *v1.Query) ([]string, error)
 	GetDeploymentIDs(ctx context.Context, q *v1.Query) ([]string, error)
+	TopSeverityBatch(ctx context.Context, entityIDs []string, entityType search.FieldLabel, q *v1.Query) (map[string]storage.VulnerabilitySeverity, error)
 }

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/views"
 	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/contextutil"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
@@ -116,6 +117,35 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 		return nil, err
 	}
 	return ret, nil
+}
+
+func (v *imageCVECoreViewImpl) TopSeverityBatch(ctx context.Context, entityIDs []string, entityType search.FieldLabel, q *v1.Query) (map[string]storage.VulnerabilitySeverity, error) {
+	if len(entityIDs) == 0 {
+		return nil, nil
+	}
+	cloned := q.CloneVT()
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(entityType).Proto(),
+		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{Fields: []string{entityType.String()}}
+	cloned = search.ConjunctionQuery(cloned,
+		search.NewQueryBuilder().AddExactMatches(entityType, entityIDs...).ProtoQuery(),
+	)
+	cloned.Pagination = nil
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	result := make(map[string]storage.VulnerabilitySeverity, len(entityIDs))
+	err := pgSearch.RunSelectRequestForSchemaFn[EntitySeverityResult](queryCtx, v.db, v.schema, cloned, func(r *EntitySeverityResult) error {
+		result[r.EntityID] = r.TopSeverity
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func (v *imageCVECoreViewImpl) GetDeploymentIDs(ctx context.Context, q *v1.Query) ([]string, error) {

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/pkg/errors"
 	imagev2common "github.com/stackrox/rox/central/imagev2/common"
 	"github.com/stackrox/rox/central/views"
 	"github.com/stackrox/rox/central/views/common"
@@ -123,25 +124,36 @@ func (v *imageCVECoreViewImpl) TopSeverityBatch(ctx context.Context, entityIDs [
 	if len(entityIDs) == 0 {
 		return nil, nil
 	}
-	cloned := q.CloneVT()
+	filtered := imagev2common.WithRowsFromImageV2Only(q.CloneVT())
+	cloned := search.ConjunctionQuery(filtered,
+		search.NewQueryBuilder().AddExactMatches(entityType, entityIDs...).ProtoQuery(),
+	)
 	cloned.Selects = []*v1.QuerySelect{
 		search.NewQuerySelect(entityType).Proto(),
 		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{Fields: []string{entityType.String()}}
-	cloned = search.ConjunctionQuery(cloned,
-		search.NewQueryBuilder().AddExactMatches(entityType, entityIDs...).ProtoQuery(),
-	)
 	cloned.Pagination = nil
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
 	result := make(map[string]storage.VulnerabilitySeverity, len(entityIDs))
-	err := pgSearch.RunSelectRequestForSchemaFn[EntitySeverityResult](queryCtx, v.db, v.schema, cloned, func(r *EntitySeverityResult) error {
-		result[r.EntityID] = r.TopSeverity
-		return nil
-	})
+	var err error
+	switch entityType {
+	case search.ImageID:
+		err = pgSearch.RunSelectRequestForSchemaFn[imageSeverityResult](queryCtx, v.db, v.schema, cloned, func(r *imageSeverityResult) error {
+			result[r.EntityID] = r.TopSeverity
+			return nil
+		})
+	case search.DeploymentID:
+		err = pgSearch.RunSelectRequestForSchemaFn[deploymentSeverityResult](queryCtx, v.db, v.schema, cloned, func(r *deploymentSeverityResult) error {
+			result[r.EntityID] = r.TopSeverity
+			return nil
+		})
+	default:
+		return nil, errors.Errorf("unsupported entity type for TopSeverityBatch: %s", entityType)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -530,6 +530,69 @@ func (s *ImageCVEViewTestSuite) TestGetImageCVECoreUnifiedViewWithPagination() {
 	}
 }
 
+func (s *ImageCVEViewTestSuite) TestTopSeverityBatch() {
+	ctx := sac.WithAllAccess(context.Background())
+
+	imageIDs := make([]string, len(s.testImages))
+	for i, img := range s.testImages {
+		imageIDs[i] = img.GetId()
+	}
+
+	result, err := s.cveView.TopSeverityBatch(ctx, imageIDs, imageSearchField(), search.EmptyQuery())
+	s.NoError(err)
+	s.NotEmpty(result)
+
+	// Verify each image has a severity and it matches the max across its CVEs.
+	for _, img := range s.testImages {
+		sev, ok := result[img.GetId()]
+		s.True(ok, "image %s should have a severity", img.GetId())
+		s.NotEqual(storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY, sev)
+
+		// Compute expected max severity from the image's components.
+		var expectedMax storage.VulnerabilitySeverity
+		for _, comp := range img.GetScan().GetComponents() {
+			for _, vuln := range comp.GetVulns() {
+				if vuln.GetSeverity() > expectedMax {
+					expectedMax = vuln.GetSeverity()
+				}
+			}
+		}
+		s.Equal(expectedMax, sev, "image %s: expected severity %s, got %s", img.GetId(), expectedMax, sev)
+	}
+}
+
+func (s *ImageCVEViewTestSuite) TestTopSeverityBatchWithFilter() {
+	ctx := sac.WithAllAccess(context.Background())
+
+	imageIDs := make([]string, len(s.testImages))
+	for i, img := range s.testImages {
+		imageIDs[i] = img.GetId()
+	}
+
+	// Filter to only fixable CVEs.
+	q := search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery()
+	result, err := s.cveView.TopSeverityBatch(ctx, imageIDs, imageSearchField(), q)
+	s.NoError(err)
+
+	// Images with no fixable CVEs should not appear in the result.
+	for id, sev := range result {
+		s.NotEqual(storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY, sev,
+			"image %s should have a non-unknown severity for fixable CVEs", id)
+	}
+}
+
+func (s *ImageCVEViewTestSuite) TestTopSeverityBatchEmpty() {
+	ctx := sac.WithAllAccess(context.Background())
+
+	result, err := s.cveView.TopSeverityBatch(ctx, []string{}, imageSearchField(), search.EmptyQuery())
+	s.NoError(err)
+	s.Nil(result)
+
+	result, err = s.cveView.TopSeverityBatch(ctx, []string{"nonexistent-id"}, imageSearchField(), search.EmptyQuery())
+	s.NoError(err)
+	s.Empty(result)
+}
+
 func (s *ImageCVEViewTestSuite) TestCountImageCVECore() {
 	for _, tc := range s.testCases() {
 		if tc.skipCountTests {


### PR DESCRIPTION
feat: add TopSeverityBatch and topImageCVESeverity field

Add TopSeverityBatch(ctx, entityIDs, entityType, q) to CveView
interface. Uses GROUP BY entity_id with MAX(severity) — a single
aggregate instead of 10 filtered COUNTs per entity.

Add topImageCVESeverity GraphQL field to Image, ImageV2, and Deployment
types. Each resolver calls TopSeverityBatch with its entity ID. Full
cross-entity batching via a dataloader is a follow-up optimization.

Partially AI-generated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

fix: fix TopSeverityBatch query construction and add tests

Fix two bugs: set selects/groupBy after ConjunctionQuery (which creates
a new wrapper query), and use entity-type-specific result structs since
db column aliases differ between image_id and deployment_id.

Add three integration tests: basic batch across all images verifying
MAX(severity) matches expected, batch with fixable filter, and empty
input/nonexistent ID edge cases.

Partially AI-generated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
