### PR TITLE
ROX-35583: switch UnmarshalVTUnsafe to UnmarshalVT

### DIFF
--- a/central/apitoken/datastore/internal/schedulestore/postgres/store.go
+++ b/central/apitoken/datastore/internal/schedulestore/postgres/store.go
@@ -128,7 +128,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.NotificationSche
 	}
 
 	var msg storage.NotificationSchedule
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/config/store/postgres/store.go
+++ b/central/config/store/postgres/store.go
@@ -128,7 +128,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.Config, bool, er
 	}
 
 	var msg storage.Config
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/cve/cluster/datastore/store/postgres/full_store.go
+++ b/central/cve/cluster/datastore/store/postgres/full_store.go
@@ -288,7 +288,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 			return nil, err
 		}
 		msg := &storage.ClusterCVE{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
+		if err := pgutils.UnmarshalVTMessage(msg, data); err != nil {
 			return nil, err
 		}
 		idToCVEMap[msg.GetId()] = msg

--- a/central/delegatedregistryconfig/store/postgres/store.go
+++ b/central/delegatedregistryconfig/store/postgres/store.go
@@ -128,7 +128,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.DelegatedRegistr
 	}
 
 	var msg storage.DelegatedRegistryConfig
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/globaldb/v2backuprestore/service/http_handlers.go
+++ b/central/globaldb/v2backuprestore/service/http_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/ioutils"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -51,7 +52,7 @@ func (s *service) handleRestore(req *http.Request) error {
 	}
 
 	var header v1.DBRestoreRequestHeader
-	if err := header.UnmarshalVTUnsafe(headerBytes); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&header, headerBytes); err != nil {
 		return errors.Wrapf(errox.InvalidArgs, "could not parse restore request header: %v", err)
 	}
 

--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -607,7 +607,7 @@ func (s *storeImpl) getFullImage(ctx context.Context, tx *postgres.Tx, imageID s
 	}
 
 	var image storage.Image
-	if err := image.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&image, data); err != nil {
 		return nil, false, err
 	}
 

--- a/central/installation/store/postgres/store.go
+++ b/central/installation/store/postgres/store.go
@@ -128,7 +128,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.InstallationInfo
 	}
 
 	var msg storage.InstallationInfo
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -505,7 +505,7 @@ func markOrphanedNodeCVEs(ctx context.Context, tx *postgres.Tx) error {
 			return err
 		}
 		msg := &storage.NodeCVE{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
+		if err := pgutils.UnmarshalVTMessage(msg, data); err != nil {
 			return err
 		}
 		if ids.Add(msg.GetId()) {
@@ -711,7 +711,7 @@ func (s *storeImpl) getFullNode(ctx context.Context, tx *postgres.Tx, nodeID str
 	}
 
 	var node storage.Node
-	if err := node.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&node, data); err != nil {
 		return nil, false, err
 	}
 	if err := s.populateNode(ctx, tx, &node); err != nil {
@@ -735,7 +735,7 @@ func getNodeComponentEdges(ctx context.Context, tx *postgres.Tx, nodeID string) 
 			return nil, err
 		}
 		msg := &storage.NodeComponentEdge{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
+		if err := pgutils.UnmarshalVTMessage(msg, data); err != nil {
 			return nil, err
 		}
 		componentIDToEdgeMap[msg.GetNodeComponentId()] = msg
@@ -758,7 +758,7 @@ func getNodeComponents(ctx context.Context, tx *postgres.Tx, componentIDs []stri
 			return nil, err
 		}
 		msg := &storage.NodeComponent{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
+		if err := pgutils.UnmarshalVTMessage(msg, data); err != nil {
 			return nil, err
 		}
 		idToComponentMap[msg.GetId()] = msg
@@ -781,7 +781,7 @@ func getComponentCVEEdges(ctx context.Context, tx *postgres.Tx, componentIDs []s
 			return nil, err
 		}
 		msg := &storage.NodeComponentCVEEdge{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
+		if err := pgutils.UnmarshalVTMessage(msg, data); err != nil {
 			return nil, err
 		}
 		componentIDToEdgesMap[msg.GetNodeComponentId()] = append(componentIDToEdgesMap[msg.GetNodeComponentId()], msg)
@@ -924,7 +924,7 @@ func (s *storeImpl) retryableGetNodeMetadata(ctx context.Context, id string) (*s
 	}
 
 	var msg storage.Node
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil
@@ -1007,7 +1007,7 @@ func getCVEs(ctx context.Context, tx *postgres.Tx, cveIDs []string) (map[string]
 			return nil, err
 		}
 		msg := &storage.NodeCVE{}
-		if err := msg.UnmarshalVTUnsafe(data); err != nil {
+		if err := pgutils.UnmarshalVTMessage(msg, data); err != nil {
 			return nil, err
 		}
 		idToCVEMap[msg.GetId()] = msg

--- a/central/notifier/encconfig/datastore/store/postgres/store.go
+++ b/central/notifier/encconfig/datastore/store/postgres/store.go
@@ -128,7 +128,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.NotifierEncConfi
 	}
 
 	var msg storage.NotifierEncConfig
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/notifiers/awssh/notifier.go
+++ b/central/notifiers/awssh/notifier.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/notifiers"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
@@ -170,7 +171,7 @@ func (c *configuration) getCredentials() (string, string, error) {
 		return "", "", errors.Errorf("Error decrypting notifier secret for notifier '%s'", c.descriptor.GetName())
 	}
 	creds := &storage.AWSSecurityHub_Credentials{}
-	err = creds.UnmarshalVTUnsafe([]byte(decCredsStr))
+	err = pgutils.UnmarshalVTMessage(creds, []byte(decCredsStr))
 	if err != nil {
 		return "", "", errors.Errorf("Error unmarshalling notifier credentials for notifier '%s'", c.descriptor.GetName())
 	}

--- a/central/probeupload/service/service_impl.go
+++ b/central/probeupload/service/service_impl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/routes"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/probeupload"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/utils"
@@ -118,7 +119,7 @@ func (s *service) doHandleProbeUpload(req *http.Request) error {
 	}
 
 	var manifest v1.ProbeUploadManifest
-	if err := manifest.UnmarshalVTUnsafe(manifestBytes); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&manifest, manifestBytes); err != nil {
 		return errors.Wrap(err, "failed to unmarshal manifest")
 	}
 

--- a/central/processlisteningonport/datastore/datastore_impl.go
+++ b/central/processlisteningonport/datastore/datastore_impl.go
@@ -628,7 +628,7 @@ func (ds *datastoreImpl) readRowsToFindPLOPsWithNoProcessInformation(rows pgx.Ro
 		}
 
 		var msg storage.ProcessListeningOnPortStorage
-		if err := msg.UnmarshalVTUnsafe(serialized); err != nil {
+		if err := pgutils.UnmarshalVTMessage(&msg, serialized); err != nil {
 			return nil, err
 		}
 

--- a/central/processlisteningonport/store/postgres/full_store.go
+++ b/central/processlisteningonport/store/postgres/full_store.go
@@ -212,13 +212,13 @@ func (s *fullStoreImpl) readRows(
 		}
 
 		var msg storage.ProcessListeningOnPortStorage
-		if err := msg.UnmarshalVTUnsafe(serialized); err != nil {
+		if err := pgutils.UnmarshalVTMessage(&msg, serialized); err != nil {
 			return nil, err
 		}
 
 		var procMsg storage.ProcessIndicator
 		if procSerialized != nil {
-			if err := procMsg.UnmarshalVTUnsafe(procSerialized); err != nil {
+			if err := pgutils.UnmarshalVTMessage(&procMsg, procSerialized); err != nil {
 				return nil, err
 			}
 		}

--- a/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
+++ b/central/sensorupgradeconfig/datastore/internal/store/postgres/store.go
@@ -128,7 +128,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*storage.SensorUpgradeCon
 	}
 
 	var msg storage.SensorUpgradeConfig
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/systeminfo/store/postgres/store.go
+++ b/central/systeminfo/store/postgres/store.go
@@ -74,7 +74,7 @@ func (s *storeImpl) get(ctx context.Context) (*storage.SystemInfo, bool, error) 
 	}
 
 	var msg storage.SystemInfo
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil

--- a/central/virtualmachine/v2/datastore/store/postgres/store.go
+++ b/central/virtualmachine/v2/datastore/store/postgres/store.go
@@ -212,7 +212,7 @@ func (s *storeImpl) getVirtualMachine(ctx context.Context, tx *postgres.Tx, id s
 		return nil, pgutils.ErrNilIfNoRows(err)
 	}
 	var vm storage.VirtualMachineV2
-	if err := vm.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&vm, data); err != nil {
 		return nil, err
 	}
 	return &vm, nil
@@ -324,7 +324,7 @@ func (s *storeImpl) getScanForVM(ctx context.Context, tx *postgres.Tx, vmID stri
 		return nil, pgutils.ErrNilIfNoRows(err)
 	}
 	var scan storage.VirtualMachineScanV2
-	if err := scan.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&scan, data); err != nil {
 		return nil, err
 	}
 	return &scan, nil

--- a/migrator/migrations/m_212_to_m_213_add_container_start_column_to_indicators/schema/convert_process_indicators.go
+++ b/migrator/migrations/m_212_to_m_213_add_container_start_column_to_indicators/schema/convert_process_indicators.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 )
 
@@ -35,7 +36,7 @@ func ConvertProcessIndicatorFromProto(obj *storage.ProcessIndicator) (*ProcessIn
 // ConvertProcessIndicatorToProto converts Gorm model `ProcessIndicators` to its protobuf type object
 func ConvertProcessIndicatorToProto(m *ProcessIndicators) (*storage.ProcessIndicator, error) {
 	var msg storage.ProcessIndicator
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_images.go
+++ b/migrator/migrations/postgreshelper/schema/convert_images.go
@@ -4,6 +4,7 @@ package schema
 import (
 	"github.com/lib/pq"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 )
 
@@ -54,7 +55,7 @@ func ConvertImageLayerFromProto(obj *storage.ImageLayer, idx int, images_Id stri
 // ConvertImageToProto converts Gorm model `Images` to its protobuf type object
 func ConvertImageToProto(m *Images) (*storage.Image, error) {
 	var msg storage.Image
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_child1.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestChild1FromProto converts a `*storage.TestChild1` to Gorm model
@@ -22,7 +23,7 @@ func ConvertTestChild1FromProto(obj *storage.TestChild1) (*TestChild1, error) {
 // ConvertTestChild1ToProto converts Gorm model `TestChild1` to its protobuf type object
 func ConvertTestChild1ToProto(m *TestChild1) (*storage.TestChild1, error) {
 	var msg storage.TestChild1
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_child1_p4.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_child1_p4.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestChild1P4FromProto converts a `*storage.TestChild1P4` to Gorm model
@@ -23,7 +24,7 @@ func ConvertTestChild1P4FromProto(obj *storage.TestChild1P4) (*TestChild1P4, err
 // ConvertTestChild1P4ToProto converts Gorm model `TestChild1P4` to its protobuf type object
 func ConvertTestChild1P4ToProto(m *TestChild1P4) (*storage.TestChild1P4, error) {
 	var msg storage.TestChild1P4
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_child2.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_child2.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestChild2FromProto converts a `*storage.TestChild2` to Gorm model
@@ -24,7 +25,7 @@ func ConvertTestChild2FromProto(obj *storage.TestChild2) (*TestChild2, error) {
 // ConvertTestChild2ToProto converts Gorm model `TestChild2` to its protobuf type object
 func ConvertTestChild2ToProto(m *TestChild2) (*storage.TestChild2, error) {
 	var msg storage.TestChild2
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_g2_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_g2_grand_child1.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestG2GrandChild1FromProto converts a `*storage.TestG2GrandChild1` to Gorm model
@@ -24,7 +25,7 @@ func ConvertTestG2GrandChild1FromProto(obj *storage.TestG2GrandChild1) (*TestG2G
 // ConvertTestG2GrandChild1ToProto converts Gorm model `TestG2GrandChild1` to its protobuf type object
 func ConvertTestG2GrandChild1ToProto(m *TestG2GrandChild1) (*storage.TestG2GrandChild1, error) {
 	var msg storage.TestG2GrandChild1
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_g3_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_g3_grand_child1.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestG3GrandChild1FromProto converts a `*storage.TestG3GrandChild1` to Gorm model
@@ -22,7 +23,7 @@ func ConvertTestG3GrandChild1FromProto(obj *storage.TestG3GrandChild1) (*TestG3G
 // ConvertTestG3GrandChild1ToProto converts Gorm model `TestG3GrandChild1` to its protobuf type object
 func ConvertTestG3GrandChild1ToProto(m *TestG3GrandChild1) (*storage.TestG3GrandChild1, error) {
 	var msg storage.TestG3GrandChild1
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_g_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_g_grand_child1.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestGGrandChild1FromProto converts a `*storage.TestGGrandChild1` to Gorm model
@@ -22,7 +23,7 @@ func ConvertTestGGrandChild1FromProto(obj *storage.TestGGrandChild1) (*TestGGran
 // ConvertTestGGrandChild1ToProto converts Gorm model `TestGGrandChild1` to its protobuf type object
 func ConvertTestGGrandChild1ToProto(m *TestGGrandChild1) (*storage.TestGGrandChild1, error) {
 	var msg storage.TestGGrandChild1
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_grand_child1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_grand_child1.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestGrandChild1FromProto converts a `*storage.TestGrandChild1` to Gorm model
@@ -24,7 +25,7 @@ func ConvertTestGrandChild1FromProto(obj *storage.TestGrandChild1) (*TestGrandCh
 // ConvertTestGrandChild1ToProto converts Gorm model `TestGrandChild1` to its protobuf type object
 func ConvertTestGrandChild1ToProto(m *TestGrandChild1) (*storage.TestGrandChild1, error) {
 	var msg storage.TestGrandChild1
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_grandparents.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestGrandparentFromProto converts a `*storage.TestGrandparent` to Gorm model
@@ -45,7 +46,7 @@ func ConvertTestGrandparent_Embedded_Embedded2FromProto(obj *storage.TestGrandpa
 // ConvertTestGrandparentToProto converts Gorm model `TestGrandparents` to its protobuf type object
 func ConvertTestGrandparentToProto(m *TestGrandparents) (*storage.TestGrandparent, error) {
 	var msg storage.TestGrandparent
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent1.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent1.go
@@ -4,6 +4,7 @@ package schema
 import (
 	"github.com/lib/pq"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestParent1FromProto converts a `*storage.TestParent1` to Gorm model
@@ -35,7 +36,7 @@ func ConvertTestParent1_Child1RefFromProto(obj *storage.TestParent1_Child1Ref, i
 // ConvertTestParent1ToProto converts Gorm model `TestParent1` to its protobuf type object
 func ConvertTestParent1ToProto(m *TestParent1) (*storage.TestParent1, error) {
 	var msg storage.TestParent1
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent2.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent2.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestParent2FromProto converts a `*storage.TestParent2` to Gorm model
@@ -23,7 +24,7 @@ func ConvertTestParent2FromProto(obj *storage.TestParent2) (*TestParent2, error)
 // ConvertTestParent2ToProto converts Gorm model `TestParent2` to its protobuf type object
 func ConvertTestParent2ToProto(m *TestParent2) (*storage.TestParent2, error) {
 	var msg storage.TestParent2
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent3.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent3.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestParent3FromProto converts a `*storage.TestParent3` to Gorm model
@@ -23,7 +24,7 @@ func ConvertTestParent3FromProto(obj *storage.TestParent3) (*TestParent3, error)
 // ConvertTestParent3ToProto converts Gorm model `TestParent3` to its protobuf type object
 func ConvertTestParent3ToProto(m *TestParent3) (*storage.TestParent3, error) {
 	var msg storage.TestParent3
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_parent4.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_parent4.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestParent4FromProto converts a `*storage.TestParent4` to Gorm model
@@ -23,7 +24,7 @@ func ConvertTestParent4FromProto(obj *storage.TestParent4) (*TestParent4, error)
 // ConvertTestParent4ToProto converts Gorm model `TestParent4` to its protobuf type object
 func ConvertTestParent4ToProto(m *TestParent4) (*storage.TestParent4, error) {
 	var msg storage.TestParent4
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_short_circuits.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_short_circuits.go
@@ -3,6 +3,7 @@ package schema
 
 import (
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 // ConvertTestShortCircuitFromProto converts a `*storage.TestShortCircuit` to Gorm model
@@ -23,7 +24,7 @@ func ConvertTestShortCircuitFromProto(obj *storage.TestShortCircuit) (*TestShort
 // ConvertTestShortCircuitToProto converts Gorm model `TestShortCircuits` to its protobuf type object
 func ConvertTestShortCircuitToProto(m *TestShortCircuits) (*storage.TestShortCircuit, error) {
 	var msg storage.TestShortCircuit
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_single_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_single_key_structs.go
@@ -35,7 +35,7 @@ func ConvertTestSingleKeyStructFromProto(obj *storage.TestSingleKeyStruct) (*Tes
 // ConvertTestSingleKeyStructToProto converts Gorm model `TestSingleKeyStructs` to its protobuf type object
 func ConvertTestSingleKeyStructToProto(m *TestSingleKeyStructs) (*storage.TestSingleKeyStruct, error) {
 	var msg storage.TestSingleKeyStruct
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_single_uuid_key_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_single_uuid_key_structs.go
@@ -35,7 +35,7 @@ func ConvertTestSingleUUIDKeyStructFromProto(obj *storage.TestSingleUUIDKeyStruc
 // ConvertTestSingleUUIDKeyStructToProto converts Gorm model `TestSingleUUIDKeyStructs` to its protobuf type object
 func ConvertTestSingleUUIDKeyStructToProto(m *TestSingleUUIDKeyStructs) (*storage.TestSingleUUIDKeyStruct, error) {
 	var msg storage.TestSingleUUIDKeyStruct
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/migrations/postgreshelper/schema/convert_test_structs.go
+++ b/migrator/migrations/postgreshelper/schema/convert_test_structs.go
@@ -53,7 +53,7 @@ func ConvertTestStruct_NestedFromProto(obj *storage.TestStruct_Nested, idx int, 
 // ConvertTestStructToProto converts Gorm model `TestStructs` to its protobuf type object
 func ConvertTestStructToProto(m *TestStructs) (*storage.TestStruct, error) {
 	var msg storage.TestStruct
-	if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 		return nil, err
 	}
 	return &msg, nil

--- a/migrator/version/convert_versions.go
+++ b/migrator/version/convert_versions.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv"
@@ -28,7 +29,7 @@ func ConvertVersionToProto(m *schema.Versions) (*storage.Version, error) {
 	// During the transition to not use serialized, we may be coming from a database
 	// that uses it.  So if serialized is not nil, we will need to use that
 	if m.Serialized != nil {
-		if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+		if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
 			return nil, err
 		}
 		return &msg, nil

--- a/pkg/env/unmarshal.go
+++ b/pkg/env/unmarshal.go
@@ -1,0 +1,3 @@
+package env
+
+var UseUnsafeUnmarshal = RegisterBooleanSetting("ROX_USE_UNSAFE_UNMARSHAL", false)

--- a/pkg/grpc/common/authn/servicecerttoken/token.go
+++ b/pkg/grpc/common/authn/servicecerttoken/token.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/cryptoutils"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 )
 
@@ -32,7 +33,7 @@ func ParseToken(token string, maxLeeway time.Duration) (*x509.Certificate, error
 	}
 
 	var auth central.ServiceCertAuth
-	if err := auth.UnmarshalVTUnsafe(authBytes); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&auth, authBytes); err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal service cert auth structure")
 	}
 

--- a/pkg/postgres/pgutils/scan.go
+++ b/pkg/postgres/pgutils/scan.go
@@ -7,7 +7,7 @@ import (
 
 // Unmarshaler is a generic interface type wrapping around types that implement protobuf Unmarshaler.
 type Unmarshaler[T any] interface {
-	UnmarshalVTUnsafe(dAtA []byte) error
+	VTUnmarshaler
 	*T
 }
 
@@ -40,7 +40,7 @@ func Unmarshal[T any, PT Unmarshaler[T]](row pgx.Row) (*T, error) {
 		return nil, err
 	}
 	msg := new(T)
-	if err := PT(msg).UnmarshalVTUnsafe(data); err != nil {
+	if err := UnmarshalVTMessage(PT(msg), data); err != nil {
 		return nil, err
 	}
 	return msg, nil

--- a/pkg/postgres/pgutils/unmarshal.go
+++ b/pkg/postgres/pgutils/unmarshal.go
@@ -1,0 +1,17 @@
+package pgutils
+
+import "github.com/stackrox/rox/pkg/env"
+
+// VTUnmarshaler is implemented by all vtprotobuf-generated message types.
+type VTUnmarshaler interface {
+	UnmarshalVT([]byte) error
+	UnmarshalVTUnsafe([]byte) error
+}
+
+//go:fix inline
+func UnmarshalVTMessage(msg VTUnmarshaler, data []byte) error {
+	if env.UseUnsafeUnmarshal.BooleanSetting() {
+		return msg.UnmarshalVTUnsafe(data)
+	}
+	return msg.UnmarshalVT(data)
+}

--- a/pkg/postgres/pgutils/unmarshal.go
+++ b/pkg/postgres/pgutils/unmarshal.go
@@ -10,7 +10,6 @@ type VTUnmarshaler interface {
 	UnmarshalVTUnsafe([]byte) error
 }
 
-//go:fix inline
 func UnmarshalVTMessage(msg VTUnmarshaler, data []byte) error {
 	if useUnsafe {
 		return msg.UnmarshalVTUnsafe(data)

--- a/pkg/postgres/pgutils/unmarshal.go
+++ b/pkg/postgres/pgutils/unmarshal.go
@@ -2,6 +2,8 @@ package pgutils
 
 import "github.com/stackrox/rox/pkg/env"
 
+var useUnsafe = env.UseUnsafeUnmarshal.BooleanSetting()
+
 // VTUnmarshaler is implemented by all vtprotobuf-generated message types.
 type VTUnmarshaler interface {
 	UnmarshalVT([]byte) error
@@ -10,7 +12,7 @@ type VTUnmarshaler interface {
 
 //go:fix inline
 func UnmarshalVTMessage(msg VTUnmarshaler, data []byte) error {
-	if env.UseUnsafeUnmarshal.BooleanSetting() {
+	if useUnsafe {
 		return msg.UnmarshalVTUnsafe(data)
 	}
 	return msg.UnmarshalVT(data)

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1149,7 +1149,7 @@ func handleRowsWithCallback[T any, PT pgutils.Unmarshaler[T]](ctx context.Contex
 		}
 
 		msg := new(T)
-		if errUnmarshal := PT(msg).UnmarshalVTUnsafe(data); errUnmarshal != nil {
+		if errUnmarshal := pgutils.UnmarshalVTMessage(PT(msg), data); errUnmarshal != nil {
 			return errUnmarshal
 		}
 		return callback(msg)

--- a/sensor/admission-control/settingswatch/common.go
+++ b/sensor/admission-control/settingswatch/common.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/gziputil"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 )
 
 func getPoliciesFromFile(file string) (*storage.PolicyList, error) {
@@ -24,7 +25,7 @@ func decompressAndUnmarshalPolicies(data []byte) (*storage.PolicyList, error) {
 	}
 
 	var policyList storage.PolicyList
-	if err := policyList.UnmarshalVTUnsafe(runTimePoliciesData); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&policyList, runTimePoliciesData); err != nil {
 		return nil, errors.Wrap(err, "unmarshaling decompressed policies data")
 	}
 	return &policyList, nil

--- a/sensor/admission-control/settingswatch/k8s.go
+++ b/sensor/admission-control/settingswatch/k8s.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/gziputil"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,7 +104,7 @@ func parseSettings(cm *v1.ConfigMap) (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var config storage.DynamicClusterConfig
-	if err := config.UnmarshalVTUnsafe(configData); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&config, configData); err != nil {
 		return nil, errors.Wrap(err, "could not parse protobuf-encoded config data from configmap")
 	}
 

--- a/sensor/admission-control/settingswatch/mount.go
+++ b/sensor/admission-control/settingswatch/mount.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/gziputil"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 )
 
@@ -61,7 +62,7 @@ func (m *mountSettingsWatch) OnChange(dir string) (interface{}, error) {
 	}
 
 	var clusterConfig storage.DynamicClusterConfig
-	if err := clusterConfig.UnmarshalVTUnsafe(configData); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&clusterConfig, configData); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling decompressed cluster config data from file %s", configPath)
 	}
 

--- a/sensor/admission-control/settingswatch/persist.go
+++ b/sensor/admission-control/settingswatch/persist.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/sensor/admission-control/common"
 	"github.com/stackrox/rox/sensor/admission-control/manager"
 )
@@ -80,7 +81,7 @@ func (p *persister) loadExisting() (*sensor.AdmissionControlSettings, error) {
 	}
 
 	var settings sensor.AdmissionControlSettings
-	if err := settings.UnmarshalVTUnsafe(bytes); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&settings, bytes); err != nil {
 		return nil, errors.Wrapf(err, "unmarshaling initial admission control settings from %s", settingsPath)
 	}
 

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/x509utils"
 )
@@ -217,7 +218,7 @@ func issuedByStackRoxCA(proxyCert *x509.Certificate) bool {
 
 func (c *Client) parseTLSChallengeResponse(challenge *v1.TLSChallengeResponse) (*v1.TrustInfo, error) {
 	var trustInfo v1.TrustInfo
-	err := trustInfo.UnmarshalVTUnsafe(challenge.GetTrustInfoSerialized())
+	err := pgutils.UnmarshalVTMessage(&trustInfo, challenge.GetTrustInfoSerialized())
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing TrustInfo proto")
 	}

--- a/tools/generate-helpers/pg-table-bindings/migration_tool.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/migration_tool.go.tpl
@@ -39,7 +39,7 @@
     // Convert{{$schema.TypeName}}ToProto converts Gorm model `{{$schema.Table|upperCamelCase}}` to its protobuf type object
     func Convert{{$schema.TypeName}}ToProto(m *{{$schema.Table|upperCamelCase}}) ({{$schema.Type}}, error) {
         var msg storage.{{$schema.TypeName}}
-        if err := msg.UnmarshalVTUnsafe(m.Serialized); err != nil {
+        if err := pgutils.UnmarshalVTMessage(&msg, m.Serialized); err != nil {
             return nil, err
         }
         return &msg, nil

--- a/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/singleton.go.tpl
@@ -154,7 +154,7 @@ func (s *storeImpl) retryableGet(ctx context.Context) (*{{.Type}}, bool, error) 
 	}
 
 	var msg {{.Type}}
-	if err := msg.UnmarshalVTUnsafe(data); err != nil {
+	if err := pgutils.UnmarshalVTMessage(&msg, data); err != nil {
 		return nil, false, err
 	}
 	return &msg, true, nil


### PR DESCRIPTION
## Description

`UnmarshalVTUnsafe` creates zero-copy strings via `unsafe.Pointer` that reference the underlying pgx scan `[]byte` buffer. Any string stored long-term (map key, cache entry) pins the entire serialized proto blob, causing 69x memory amplification in production (~10.8 GB retained heap from ~160 MB of actual data).

**Root cause:** pgx `Scan()` copies bytes (`make([]byte, len(src)); copy(...)`) so the "unsafe" optimization provides zero benefit — strings already reference a copy, not the wire buffer. But since the copy is shared across all fields of a single row, one long-lived string pins the entire row's serialized data.

**Fix:** Introduce a runtime toggle `ROX_USE_UNSAFE_UNMARSHAL` (default: `false`) via `pkg/env` and route all postgres unmarshal call sites through `pgutils.UnmarshalVTMessage`. This centralizes the branching logic so operators can opt back into unsafe mode if they prefer the performance trade-off.

**Why not a hard switch?** A toggle lets us validate the safe path in staging without committing to it permanently. Operators who benchmarked and accepted the memory trade-off can re-enable unsafe.

**Why `pkg/env` instead of `pkg/features`?** Feature flags (`pkg/features`) are exposed via `/v1/featureflags` API, telemetry, and UI. This is an internal operational toggle that should not appear in customer-facing surfaces.

**gRPC codec excluded:** `pkg/grpc/codec.go` uses a buffer pool (`buf.Free()` returns data to pool). `UnmarshalVTUnsafe` would alias freed memory — a use-after-free. The codec must always use safe `UnmarshalVT`.

Refs:
- https://github.com/planetscale/vtprotobuf/issues/167

Generated with AI assistance.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests — the toggle routes between two existing vtprotobuf methods with identical signatures. Existing unit and integration tests cover all affected unmarshal paths. The env var defaults to `false` (safe), matching the pre-toggle behavior tested in CI.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Heap-profiled a demo instance comparing master baseline vs this PR with `ROX_USE_UNSAFE_UNMARSHAL=false` (default). Same workload applied to both (30 iterations of deployments/images/alerts API calls), heap snapshots taken via `/debug/heap?gc=1`.

**Heap totals:**

| Commit | Heap in-use |
|--------|-------------|
| master baseline | 80.56 MB |
| this PR (safe) | 72.75 MB |
| **Delta** | **-7.81 MB (-9.7%)** |

The pgx scan buffer reduction (-7.51 MB) confirms that strings no longer pin serialized row data. The 69x amplification effect scales with  cached object count — full benefit requires a production-scale dataset (~10.8 GB retained heap reduction observed in production profiling  that motivated ROX-35583).

Refs: 
- #12494
- #12507
- #12508
- #12509
- #12510
- #12511
- #12512
- #12706
