### PR TITLE
chore(ci): Iterate on test cluster teardown

### DIFF
--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -192,6 +192,7 @@ jobs:
         fi
         if ! scripts/ci/gke.sh teardown_gke_cluster false; then
           echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+          exit 6
         fi
 
     - name: Publish test summary

--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -72,7 +72,6 @@ jobs:
         install_components: "gke-gcloud-auth-plugin,beta"
 
     - name: Create GKE cluster
-      id: create-cluster
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
@@ -184,14 +183,16 @@ jobs:
         FinalPost(store_qa_tests_data=False).run()
 
     - name: Teardown GKE cluster
-      if: always() && steps.create-cluster.outcome == 'success'
+      if: always()
       continue-on-error: true
       run: |
         if [[ -z "${CLUSTER_NAME:-}" ]]; then
           echo "No cluster to teardown"
           exit 0
         fi
-        scripts/ci/gke.sh teardown_gke_cluster false
+        if ! scripts/ci/gke.sh teardown_gke_cluster false; then
+          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+        fi
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -144,6 +144,7 @@ jobs:
         fi
         if ! scripts/ci/gke.sh teardown_gke_cluster false; then
           echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+          exit 6
         fi
 
     - name: Publish test summary

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -58,7 +58,6 @@ jobs:
         install_components: "gke-gcloud-auth-plugin,beta"
 
     - name: Create GKE cluster
-      id: create-cluster
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
@@ -136,14 +135,16 @@ jobs:
         FinalPost(store_qa_tests_data=False).run()
 
     - name: Teardown GKE cluster
-      if: always() && steps.create-cluster.outcome == 'success'
+      if: always()
       continue-on-error: true
       run: |
         if [[ -z "${CLUSTER_NAME:-}" ]]; then
           echo "No cluster to teardown"
           exit 0
         fi
-        scripts/ci/gke.sh teardown_gke_cluster false
+        if ! scripts/ci/gke.sh teardown_gke_cluster false; then
+          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+        fi
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -60,7 +60,6 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Trigger test cluster creation
-      id: create-cluster
       uses: stackrox/actions/infra/create-cluster@79f8a64e6701be953c23ef1718fcc186a2fb0d0d # ratchet:stackrox/actions/infra/create-cluster@v1
       with:
         token: ${{ secrets.INFRA_TOKEN }}
@@ -151,10 +150,13 @@ jobs:
         from post_tests import FinalPost
         FinalPost(store_qa_tests_data=True).run()
 
-    - name: Delete cluster
-      if: always() && steps.create-cluster.outcome == 'success'
+    - name: Teardown cluster
+      if: always()
       continue-on-error: true
-      run: infractl delete "${CLUSTER_NAME}"
+      run: |
+        if ! infractl delete "${CLUSTER_NAME}"; then
+          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+        fi
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
@@ -206,7 +208,6 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Trigger test cluster creation
-      id: create-cluster
       uses: stackrox/actions/infra/create-cluster@79f8a64e6701be953c23ef1718fcc186a2fb0d0d # ratchet:stackrox/actions/infra/create-cluster@v1
       with:
         token: ${{ secrets.INFRA_TOKEN }}
@@ -296,10 +297,13 @@ jobs:
         from post_tests import FinalPost
         FinalPost(store_qa_tests_data=True).run()
 
-    - name: Delete cluster
-      if: always() && steps.create-cluster.outcome == 'success'
+    - name: Teardown cluster
+      if: always()
       continue-on-error: true
-      run: infractl delete "${CLUSTER_NAME}"
+      run: |
+        if ! infractl delete "${CLUSTER_NAME}"; then
+          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+        fi
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
@@ -351,7 +355,6 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Trigger test cluster creation
-      id: create-cluster
       uses: stackrox/actions/infra/create-cluster@79f8a64e6701be953c23ef1718fcc186a2fb0d0d # ratchet:stackrox/actions/infra/create-cluster@v1
       with:
         token: ${{ secrets.INFRA_TOKEN }}
@@ -428,10 +431,13 @@ jobs:
         from post_tests import FinalPost
         FinalPost(store_qa_tests_data=False).run()
 
-    - name: Delete cluster
-      if: always() && steps.create-cluster.outcome == 'success'
+    - name: Teardown cluster
+      if: always()
       continue-on-error: true
-      run: infractl delete "${CLUSTER_NAME}"
+      run: |
+        if ! infractl delete "${CLUSTER_NAME}"; then
+          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+        fi
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -156,6 +156,7 @@ jobs:
       run: |
         if ! infractl delete "${CLUSTER_NAME}"; then
           echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+          exit 6
         fi
 
     - name: Publish test summary
@@ -303,6 +304,7 @@ jobs:
       run: |
         if ! infractl delete "${CLUSTER_NAME}"; then
           echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+          exit 6
         fi
 
     - name: Publish test summary
@@ -437,6 +439,7 @@ jobs:
       run: |
         if ! infractl delete "${CLUSTER_NAME}"; then
           echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+          exit 6
         fi
 
     - name: Publish test summary

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -178,6 +178,7 @@ jobs:
         fi
         if ! scripts/ci/gke.sh teardown_gke_cluster false; then
           echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+          exit 6
         fi
 
     - name: Publish test summary

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -72,7 +72,6 @@ jobs:
         install_components: "gke-gcloud-auth-plugin,beta"
 
     - name: Create GKE cluster
-      id: create-cluster
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
@@ -170,14 +169,16 @@ jobs:
         FinalPost(store_qa_tests_data=False).run()
 
     - name: Teardown GKE cluster
-      if: always() && steps.create-cluster.outcome == 'success'
+      if: always()
       continue-on-error: true
       run: |
         if [[ -z "${CLUSTER_NAME:-}" ]]; then
           echo "No cluster to teardown"
           exit 0
         fi
-        scripts/ci/gke.sh teardown_gke_cluster false
+        if ! scripts/ci/gke.sh teardown_gke_cluster false; then
+          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
+        fi
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2


### PR DESCRIPTION
## Description

This continues on top of https://github.com/stackrox/stackrox/pull/21604. It started out as test PR and through testing I noticed two things:

1. If a cluster wasn't created, the deletion does not fail. See <https://github.com/stackrox/stackrox/actions/runs/28998917726/job/86055754351?pr=21617#step:16:37>. It just says `No cluster to teardown`. So there's no reason to try be smart and do `always() && steps.create-cluster.outcome == 'success'`, just `always()` is good and simple.

2. When the deletion would actually fail, as simulated here <https://github.com/stackrox/stackrox/actions/runs/28975552099/job/85983280827?pr=21617#step:15:81>, GHA still renders the step as succeeded, no warning icon as I expected.
There's an annotation in the summary page but it does not explain much.\
<img width="424" height="57" alt="image" src="https://github.com/user-attachments/assets/5281c2c8-e87a-49bf-a613-d1b50eb56985" />

Therefore, I decided to at least add an extra annotation for this case.

## Validation

This is how it looks. Not ideal but better than nothing.

https://github.com/stackrox/stackrox/actions/runs/29009522120/job/86090873445?pr=21617#step:15:29

<img width="999" height="155" alt="image" src="https://github.com/user-attachments/assets/0f763b3c-19d8-48a1-aff9-35868f925a1c" />

<img width="781" height="205" alt="image" src="https://github.com/user-attachments/assets/a6e41dd3-e7a7-439b-82ae-70ffc3ef7d83" />

