### PR TITLE
ROX-35254: fix missing image prefetch for BYODB GHA job

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -625,7 +625,7 @@ _image_prefetcher_prebuilt_start() {
     # _image_prefetcher_prebuilt_await
 
     case "$CI_JOB_NAME" in
-    *qa-e2e-tests)
+    *qa-e2e-tests|*byodb*)
         image_prefetcher_start_set qa-e2e
         _set_quay_pull_policy
         ;;
@@ -794,7 +794,7 @@ _image_prefetcher_prebuilt_await() {
     # at the last moment before any of the prebuilt images is used. (See other existing examples.)
     # This way we save time since prefetching can happen in parallel with whatever other setup the test job needs.
 
-    *qa-e2e-tests)
+    *qa-e2e-tests|*byodb*)
         image_prefetcher_await_set qa-e2e
         ;;
     *nongroovy-e2e-tests)


### PR DESCRIPTION
## Description

The `gke-byodb-test` GHA workflow (added in b8fed2a601) sets `CI_JOB_NAME=gke-byodb-test`, which does not match any case in the image prefetcher dispatch in `scripts/ci/lib.sh`. As a result, test images (notably `quay.io/rhacs-eng/qa:splunk-ta-test-latest` for the Splunk TA integration test) are not prefetched on the GKE nodes, and `IMAGE_PULL_POLICY_FOR_QUAY_IO` is not set.

This causes `IntegrationsSplunkViolationsTest` to fail during `setupSpec()` with either:
- **Deployment timeout**: the Splunk image is not pre-pulled, so the 3-minute deployment timeout (`Timer(60, 3)`) is exceeded during a cold pull.
- **SSLHandshakeException**: the image pull succeeds late, but Splunk is still booting when the TLS retry window expires.

Previously, this test ran under the Prow job `*-merge-qa-e2e-tests`, which matched the `*qa-e2e-tests` prefetch case. The migration to GHA broke this because the new job name does not match any existing case.

**Fix**: add `*byodb*` to the `qa-e2e` prefetch case in both `_image_prefetcher_prebuilt_start` and `_image_prefetcher_prebuilt_await`, so the BYODB job gets the same image prefetching and quay pull policy as the original Prow job.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

The fix will be validated by the next `gke-byodb-test` run on master after merge. No new tests needed: the existing `IntegrationsSplunkViolationsTest` is itself the regression test.

### How I validated my change

Verified via bash `case` pattern matching that `gke-byodb-test` matches `*byodb*` and correctly routes to the `qa-e2e` prefetch set, while not affecting any other existing job name patterns (`*nongroovy-e2e-tests`, `*compatibility-tests`, etc.).