### PR TITLE
ROX-35267: ci(e2e): stream StackRox pod logs continuously during tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1354,6 +1354,43 @@ summarize_check_output() {
     echo "${output}"
 }
 
+# start_continuous_log_streaming starts a background process that continuously
+# streams logs from StackRox pods to files. This preserves logs across pod
+# replacements (deployment rollouts) and container restarts, where kubectl's
+# single-previous-container limitation would otherwise lose intermediate logs.
+# See ROX-35267.
+start_continuous_log_streaming() {
+    if [[ "$#" -lt 1 ]]; then
+        die "missing args. usage: start_continuous_log_streaming <output-dir> [namespace]"
+    fi
+
+    local dir="$1"
+    local ns="${2:-stackrox}"
+    mkdir -p "$dir"
+
+    info "Starting continuous log streaming for namespace $ns to $dir"
+
+    local labels=("app=central" "app=sensor" "app=scanner-v4-indexer" "app=scanner-v4-matcher")
+
+    for label in "${labels[@]}"; do
+        local app_name="${label#app=}"
+        local log_file="$dir/${app_name}-continuous.log"
+        (
+            while true; do
+                pod=$(kubectl -n "$ns" get pod -l "$label" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null) || { sleep 2; continue; }
+                [[ -n "$pod" ]] || { sleep 2; continue; }
+                echo "--- streaming from $pod ($(date -Iseconds)) ---" >> "$log_file"
+                kubectl -n "$ns" logs -f --timestamps "$pod" >> "$log_file" 2>/dev/null || true
+                echo "--- stream from $pod ended ($(date -Iseconds)) ---" >> "$log_file"
+                sleep 1
+            done
+        ) &
+    done
+
+    info "Continuous log streaming started for: ${labels[*]}"
+}
+
+
 collect_and_check_stackrox_logs() {
     if [[ "$#" -ne 2 ]]; then
         die "missing args. usage: collect_and_check_stackrox_logs <output-dir> <test_stage>"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -43,6 +43,10 @@ test_e2e() {
     deploy_optional_e2e_components
     deploy_stackrox
 
+    # Background streamers are not explicitly stopped. They die when the CI
+    # runner terminates, same as the port-forward processes in setup_proxy_tests.
+    start_continuous_log_streaming "$output_dir"
+
     rm -f FAIL
 
     prepare_for_endpoints_test

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -17,6 +17,8 @@ source "$ROOT/tests/scripts/setup-certs.sh"
 source "$ROOT/tests/e2e/lib.sh"
 
 test_e2e() {
+    local output_dir="${1:-/tmp/e2e-test-logs}"
+
     info "Starting e2e tests"
 
     require_environment "KUBECONFIG"
@@ -74,7 +76,7 @@ test_e2e() {
 
     cd "$ROOT"
 
-    collect_and_check_stackrox_logs "/tmp/e2e-test-logs" "initial_tests"
+    collect_and_check_stackrox_logs "$output_dir" "initial_tests"
 
     # Give some time for previous tests to finish up
     wait_for_api


### PR DESCRIPTION
## Description

When pods are replaced (deployment rollouts) or restart multiple times during e2e tests, `kubectl logs -p` only captures the last previous container's log. Earlier incarnations' logs are lost entirely, making failures impossible to debug when they coincide with a pod that no longer exists.

This was the case in ROX-35267: Central was scheduled 5 times during a test run, but the collected log only covered a later time span, so the `TestMetadataIsSetCorrectly` `DeadlineExceeded` failure could not be investigated.

This PR adds background log streaming that follows pod logs to files throughout the entire test run. When a pod is replaced, the stream reconnects to the new pod. Markers in the log file show exactly when each stream started and ended, enabling timestamp correlation with test failures.

Streams central, sensor, scanner-v4-indexer, and scanner-v4-matcher. The functions are in `lib.sh` so other e2e runners can adopt them.

This tries to implement @porridge's suggestion in the [ROX-35267](https://redhat.atlassian.net/browse/ROX-35267) Jira comments.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI-only change (test infrastructure). Validated syntax with `bash -n` and shellcheck. The streaming logic uses standard kubectl commands (`logs -f`, `get pod -l`). Will be validated by the next `gke-nongroovy-e2e-tests` run — the continuous log files should appear in the collected artifacts.

[ROX-35267]: https://redhat.atlassian.net/browse/ROX-35267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ