### PR TITLE
ci(e2e): use passed output dir argument in run.sh

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -17,6 +17,8 @@ source "$ROOT/tests/scripts/setup-certs.sh"
 source "$ROOT/tests/e2e/lib.sh"
 
 test_e2e() {
+    local output_dir="${1:-/tmp/e2e-test-logs}"
+
     info "Starting e2e tests"
 
     require_environment "KUBECONFIG"
@@ -74,7 +76,7 @@ test_e2e() {
 
     cd "$ROOT"
 
-    collect_and_check_stackrox_logs "/tmp/e2e-test-logs" "initial_tests"
+    collect_and_check_stackrox_logs "$output_dir" "initial_tests"
 
     # Give some time for previous tests to finish up
     wait_for_api


### PR DESCRIPTION
## Description

Both callers of `tests/e2e/run.sh` (GitHub Actions workflow and OpenShift CI `ci_tests.py`) pass `/tmp/e2e-test-logs` as `$1`, but `test_e2e` ignored the argument and hardcoded the same path. This makes it look like the argument matters when it is actually dead.

Use the argument with the same default, matching the pattern in `run-vm-scanning.sh` (`local output_dir="${1:-...}"`).

Prep for ROX-35267 continuous log streaming PR which adds another use of the output dir.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

No behavioral change — both callers already pass the same value that was hardcoded. Validated with `bash -n`.