### PR TITLE
ROX-35267: Stream Central logs during e2e tests

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -41,6 +41,17 @@ test_e2e() {
     deploy_optional_e2e_components
     deploy_stackrox
 
+    # Stream Central logs and namespace events in background to preserve data
+    # across pod reschedulings. Point-in-time log collection loses logs from
+    # pods that are deleted before collection runs (ROX-35267).
+    local streaming_log_dir="/tmp/e2e-test-logs/streaming"
+    mkdir -p "$streaming_log_dir"
+    (while true; do
+        kubectl logs -f -l app=central -n stackrox --all-containers --prefix --timestamps 2>&1 || true
+        sleep 2
+    done) >> "$streaming_log_dir/central.log" 2>&1 &
+    kubectl get events -n stackrox --watch -o wide >> "$streaming_log_dir/events.log" 2>&1 &
+
     rm -f FAIL
 
     prepare_for_endpoints_test

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -50,7 +50,13 @@ test_e2e() {
         kubectl logs -f -l app=central -n stackrox --all-containers --prefix --timestamps 2>&1 || true
         sleep 2
     done) >> "$streaming_log_dir/central.log" 2>&1 &
-    kubectl get events -n stackrox --watch -o wide >> "$streaming_log_dir/events.log" 2>&1 &
+    local central_stream_pid=$!
+    (while true; do
+        kubectl get events -n stackrox --watch -o wide 2>&1 || true
+        sleep 2
+    done) >> "$streaming_log_dir/events.log" 2>&1 &
+    local events_stream_pid=$!
+    trap 'kill $central_stream_pid $events_stream_pid 2>/dev/null || true' EXIT
 
     rm -f FAIL
 


### PR DESCRIPTION
## Description

When Central pods are rescheduled mid-test, point-in-time log collection (`collect-service-logs.sh`) loses logs from pods deleted before collection runs. This makes failures like `TestMetadataIsSetCorrectly` (gRPC `DeadlineExceeded` due to Central unavailability) impossible to root-cause — the collected Central logs don't cover the failure window.

This adds background log streaming right after `deploy_stackrox` in the nongroovy e2e test runner:
- A loop that follows Central pod logs (`kubectl logs -f -l app=central`) across pod restarts, reconnecting after each rescheduling
- A `kubectl get events --watch` to capture namespace events (scheduling, OOM, probe failures) as they happen

Both append to `/tmp/e2e-test-logs/streaming/` where post-test steps collect artifacts from. This complements (does not replace) the existing point-in-time collection.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI infrastructure change — validated by reading the script flow and confirming the streaming directory is under the artifact collection path. The change is additive (background processes that append to new files) and cannot break existing test execution. Full validation will come from the next `gke-nongroovy-e2e-tests` run where Central gets rescheduled — the streaming logs should then contain the data that was previously lost.