### PR TITLE
ROX-35252: Add collation version reconciliation

### DIFF
--- a/central/backgroundmigrations/runner/runner.go
+++ b/central/backgroundmigrations/runner/runner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/collation"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -190,6 +191,9 @@ func (r *Runner) runMigrations(ctx context.Context) error {
 		if err := schema.ApplyAllIndexes(ctx, r.db, env.BackgroundIndexTimeout.DurationSetting()); err != nil {
 			return errors.Wrap(err, "creating background indexes")
 		}
+		if err := r.reconcileCollation(ctx); err != nil {
+			return errors.Wrap(err, "reconciling collation")
+		}
 		bgMigrationCompleteGauge.Set(1)
 		return nil
 	}
@@ -235,11 +239,22 @@ func (r *Runner) runMigrations(ctx context.Context) error {
 	if err := schema.ApplyAllIndexes(ctx, r.db, env.BackgroundIndexTimeout.DurationSetting()); err != nil {
 		return errors.Wrap(err, "creating background indexes")
 	}
+	if err := r.reconcileCollation(ctx); err != nil {
+		return errors.Wrap(err, "reconciling collation")
+	}
 
 	bgMigrationCompleteGauge.Set(1)
 
 	log.Infof("background migrations and index reconciliation complete")
 	return nil
+}
+
+func (r *Runner) reconcileCollation(ctx context.Context) error {
+	if env.SkipCollationReconciliation.BooleanSetting() {
+		log.Infof("skipping collation reconciliation (%s=true)", env.SkipCollationReconciliation.EnvVar())
+		return nil
+	}
+	return collation.Reconcile(ctx, r.db, env.BackgroundIndexTimeout.DurationSetting())
 }
 
 func (r *Runner) readState(ctx context.Context) (int, string, error) {

--- a/pkg/env/background_migration.go
+++ b/pkg/env/background_migration.go
@@ -17,3 +17,7 @@ var SkipBackgroundMigrations = RegisterSetting("ROX_SKIP_BACKGROUND_MIGRATIONS")
 // BackgroundIndexTimeout is the per-statement timeout for CREATE INDEX CONCURRENTLY and
 // DROP INDEX CONCURRENTLY operations during background index reconciliation.
 var BackgroundIndexTimeout = registerDurationSetting("ROX_BACKGROUND_INDEX_TIMEOUT", 2*time.Hour)
+
+// SkipCollationReconciliation disables automatic collation version reconciliation
+// (REINDEX of affected indexes) during background migration.
+var SkipCollationReconciliation = RegisterBooleanSetting("ROX_SKIP_COLLATION_RECONCILIATION", false)

--- a/pkg/postgres/collation/reconcile.go
+++ b/pkg/postgres/collation/reconcile.go
@@ -1,0 +1,127 @@
+package collation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+var log = logging.LoggerForModule()
+
+// IndexInfo describes a BTREE index affected by a collation version change.
+type IndexInfo struct {
+	Name  string
+	Table string
+}
+
+// CheckMismatch queries the database for a collation version mismatch between
+// the recorded version (set at initdb time) and the version provided by the OS.
+func CheckMismatch(ctx context.Context, db postgres.DB) (recorded, actual string, mismatch bool, err error) {
+	const query = `
+		SELECT d.datcollversion,
+		       pg_catalog.pg_database_collation_actual_version(d.oid)
+		FROM pg_catalog.pg_database d
+		WHERE d.datname = current_database()`
+
+	var recordedVal, actualVal *string
+	if err := db.QueryRow(ctx, query).Scan(&recordedVal, &actualVal); err != nil {
+		return "", "", false, fmt.Errorf("querying collation version: %w", err)
+	}
+
+	// NULL datcollversion occurs with C locale databases that have no collation version.
+	if recordedVal == nil || actualVal == nil || *recordedVal == "" || *actualVal == "" {
+		return "", "", false, nil
+	}
+
+	return *recordedVal, *actualVal, *recordedVal != *actualVal, nil
+}
+
+// AffectedIndexes returns BTREE indexes in the public schema that use
+// locale-sensitive collation (indcollation OID != 0) and are therefore
+// affected by glibc/ICU version changes.
+func AffectedIndexes(ctx context.Context, db postgres.DB) ([]IndexInfo, error) {
+	const query = `
+		SELECT c.relname AS index_name, t.relname AS table_name
+		FROM pg_index i
+		JOIN pg_class c ON c.oid = i.indexrelid
+		JOIN pg_class t ON t.oid = i.indrelid
+		JOIN pg_am am ON am.oid = c.relam
+		WHERE am.amname = 'btree'
+		  AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+		  AND EXISTS (
+		      SELECT 1 FROM unnest(i.indcollation) AS colloid WHERE colloid != 0
+		  )
+		ORDER BY t.relname, c.relname`
+
+	rows, err := db.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("querying affected indexes: %w", err)
+	}
+	defer rows.Close()
+
+	var indexes []IndexInfo
+	for rows.Next() {
+		var idx IndexInfo
+		if err := rows.Scan(&idx.Name, &idx.Table); err != nil {
+			return nil, fmt.Errorf("scanning index row: %w", err)
+		}
+		indexes = append(indexes, idx)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading index rows: %w", err)
+	}
+	return indexes, nil
+}
+
+// Reconcile detects a collation version mismatch, reindexes all affected BTREE
+// indexes, and refreshes the recorded collation version. If no mismatch exists,
+// it returns nil immediately (one cheap query per startup).
+func Reconcile(ctx context.Context, db postgres.DB, perIndexTimeout time.Duration) error {
+	recorded, actual, mismatch, err := CheckMismatch(ctx, db)
+	if err != nil {
+		return fmt.Errorf("checking collation mismatch: %w", err)
+	}
+	if !mismatch {
+		return nil
+	}
+
+	log.Infof("Collation version mismatch detected (recorded=%s, actual=%s). Reindexing affected BTREE indexes.", recorded, actual)
+
+	indexes, err := AffectedIndexes(ctx, db)
+	if err != nil {
+		return fmt.Errorf("finding affected indexes: %w", err)
+	}
+
+	if len(indexes) == 0 {
+		log.Warnf("Collation mismatch detected but no affected indexes found")
+	} else {
+		log.Infof("Found %d collation-dependent indexes to reindex", len(indexes))
+		for i, idx := range indexes {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			log.Infof("Reindexing %d/%d: %s (table: %s)", i+1, len(indexes), idx.Name, idx.Table)
+			stmtCtx, cancel := context.WithTimeout(ctx, perIndexTimeout)
+			_, execErr := db.Exec(stmtCtx, "REINDEX INDEX CONCURRENTLY "+pq.QuoteIdentifier(idx.Name))
+			cancel()
+			if execErr != nil {
+				return fmt.Errorf("reindexing %s: %w", idx.Name, execErr)
+			}
+		}
+	}
+
+	var dbName string
+	if err := db.QueryRow(ctx, "SELECT current_database()").Scan(&dbName); err != nil {
+		return fmt.Errorf("querying database name: %w", err)
+	}
+	if _, err := db.Exec(ctx, "ALTER DATABASE "+pq.QuoteIdentifier(dbName)+" REFRESH COLLATION VERSION"); err != nil {
+		return fmt.Errorf("refreshing collation version: %w", err)
+	}
+
+	log.Infof("Collation reconciliation complete. Reindexed %d indexes, collation version updated from %s to %s.", len(indexes), recorded, actual)
+	return nil
+}

--- a/pkg/postgres/collation/reconcile.go
+++ b/pkg/postgres/collation/reconcile.go
@@ -51,6 +51,7 @@ func AffectedIndexes(ctx context.Context, db postgres.DB) ([]IndexInfo, error) {
 		JOIN pg_class t ON t.oid = i.indrelid
 		JOIN pg_am am ON am.oid = c.relam
 		WHERE am.amname = 'btree'
+		  AND i.indisvalid
 		  AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
 		  AND EXISTS (
 		      SELECT 1 FROM unnest(i.indcollation) AS colloid WHERE colloid != 0

--- a/pkg/postgres/collation/reconcile_test.go
+++ b/pkg/postgres/collation/reconcile_test.go
@@ -85,19 +85,13 @@ func (s *CollationSuite) TestAffectedIndexes_FiltersCorrectly() {
 	s.False(foundTextHash, "HASH index on text column should be excluded")
 }
 
+// TestReconcile_NoMismatch_Noop verifies Reconcile returns nil immediately on a
+// healthy database and leaves the collation state unchanged. Full mismatch
+// testing (actual reindex + refresh) requires a multi-glibc environment.
 func (s *CollationSuite) TestReconcile_NoMismatch_Noop() {
 	err := Reconcile(s.ctx, s.testDB.DB, 30*time.Second)
 	s.NoError(err, "Reconcile should be a no-op when no mismatch exists")
-}
 
-// TestReconcile_ReindexesAndRefreshes verifies Reconcile executes without error
-// on a healthy database. Full mismatch testing requires a multi-glibc environment
-// (e.g., initdb under glibc 2.28, then run under glibc 2.34).
-func (s *CollationSuite) TestReconcile_ReindexesAndRefreshes() {
-	err := Reconcile(s.ctx, s.testDB.DB, 30*time.Second)
-	s.NoError(err)
-
-	// Verify no mismatch after reconcile.
 	_, _, mismatch, err := CheckMismatch(s.ctx, s.testDB.DB)
 	s.NoError(err)
 	s.False(mismatch)

--- a/pkg/postgres/collation/reconcile_test.go
+++ b/pkg/postgres/collation/reconcile_test.go
@@ -1,0 +1,104 @@
+//go:build sql_integration
+
+package collation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestCollationReconciliation(t *testing.T) {
+	suite.Run(t, new(CollationSuite))
+}
+
+type CollationSuite struct {
+	suite.Suite
+	testDB *pgtest.TestPostgres
+	ctx    context.Context
+}
+
+func (s *CollationSuite) SetupSuite() {
+	s.testDB = pgtest.ForT(s.T())
+	s.ctx = sac.WithAllAccess(context.Background())
+}
+
+func (s *CollationSuite) TestCheckMismatch_NoMismatch() {
+	recorded, actual, mismatch, err := CheckMismatch(s.ctx, s.testDB.DB)
+	s.NoError(err)
+	s.False(mismatch, "fresh database should not have a collation mismatch")
+	// On a healthy database both versions should be non-empty and equal.
+	if recorded != "" {
+		s.Equal(recorded, actual)
+	}
+}
+
+func (s *CollationSuite) TestAffectedIndexes_FiltersCorrectly() {
+	db := s.testDB.DB
+
+	// Create a test table with columns of different types.
+	_, err := db.Exec(s.ctx, `CREATE TABLE IF NOT EXISTS collation_test (
+		id serial PRIMARY KEY,
+		name text NOT NULL,
+		count integer NOT NULL
+	)`)
+	s.Require().NoError(err)
+
+	// BTREE index on text column — should be included.
+	_, err = db.Exec(s.ctx, `CREATE INDEX IF NOT EXISTS collation_test_name_idx ON collation_test (name)`)
+	s.Require().NoError(err)
+
+	// BTREE index on integer column — should be excluded (indcollation = 0).
+	_, err = db.Exec(s.ctx, `CREATE INDEX IF NOT EXISTS collation_test_count_idx ON collation_test (count)`)
+	s.Require().NoError(err)
+
+	// HASH index on text column — should be excluded (not BTREE).
+	_, err = db.Exec(s.ctx, `CREATE INDEX IF NOT EXISTS collation_test_name_hash ON collation_test USING hash (name)`)
+	s.Require().NoError(err)
+
+	s.T().Cleanup(func() {
+		_, _ = db.Exec(s.ctx, `DROP TABLE IF EXISTS collation_test CASCADE`)
+	})
+
+	indexes, err := AffectedIndexes(s.ctx, db)
+	s.Require().NoError(err)
+
+	// Find our test indexes in the results.
+	var foundTextBtree, foundIntBtree, foundTextHash bool
+	for _, idx := range indexes {
+		switch idx.Name {
+		case "collation_test_name_idx":
+			foundTextBtree = true
+		case "collation_test_count_idx":
+			foundIntBtree = true
+		case "collation_test_name_hash":
+			foundTextHash = true
+		}
+	}
+
+	s.True(foundTextBtree, "BTREE index on text column should be included")
+	s.False(foundIntBtree, "BTREE index on integer column should be excluded")
+	s.False(foundTextHash, "HASH index on text column should be excluded")
+}
+
+func (s *CollationSuite) TestReconcile_NoMismatch_Noop() {
+	err := Reconcile(s.ctx, s.testDB.DB, 30*time.Second)
+	s.NoError(err, "Reconcile should be a no-op when no mismatch exists")
+}
+
+// TestReconcile_ReindexesAndRefreshes verifies Reconcile executes without error
+// on a healthy database. Full mismatch testing requires a multi-glibc environment
+// (e.g., initdb under glibc 2.28, then run under glibc 2.34).
+func (s *CollationSuite) TestReconcile_ReindexesAndRefreshes() {
+	err := Reconcile(s.ctx, s.testDB.DB, 30*time.Second)
+	s.NoError(err)
+
+	// Verify no mismatch after reconcile.
+	_, _, mismatch, err := CheckMismatch(s.ctx, s.testDB.DB)
+	s.NoError(err)
+	s.False(mismatch)
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

After glibc upgrades (e.g. RHEL 8→9 base image), PostgreSQL detects a
collation version mismatch that can affect BTREE index sort order on
text columns. This adds a self-healing reconciliation that runs on every
Central startup: detect mismatch, REINDEX affected indexes, REFRESH
collation version. Skippable via ROX_SKIP_COLLATION_RECONCILIATION.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

upgrade of a long running cluster.