### PR TITLE
ROX-35704: Revert Adding hummingbird as a known distro

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -267,19 +267,6 @@ func v4Package(p *claircore.Package) (*v4.Package, error) {
 	}, nil
 }
 
-// versionAgnosticDIDs lists distribution IDs whose vulnerability data is not
-// partitioned by version. A scanned image matching any of these DIDs is
-// considered supported regardless of its reported version.
-var versionAgnosticDIDs = map[string]bool{
-	"hummingbird": true,
-}
-
-// IsVersionAgnostic reports whether the given distribution ID uses
-// version-agnostic vulnerability matching.
-func IsVersionAgnostic(did string) bool {
-	return versionAgnosticDIDs[did]
-}
-
 // VersionID returns the distribution version ID.
 func VersionID(d *claircore.Distribution) string {
 	vID := d.VersionID

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -2647,31 +2647,6 @@ func Test_versionID(t *testing.T) {
 	}
 }
 
-func TestIsVersionAgnostic(t *testing.T) {
-	tests := map[string]struct {
-		did  string
-		want bool
-	}{
-		"hummingbird is version-agnostic": {
-			did:  "hummingbird",
-			want: true,
-		},
-		"rhel is not version-agnostic": {
-			did:  "rhel",
-			want: false,
-		},
-		"empty DID is not version-agnostic": {
-			did:  "",
-			want: false,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tt.want, IsVersionAgnostic(tt.did))
-		})
-	}
-}
-
 func Test_sortByNVDCVSS(t *testing.T) {
 	type args struct {
 		ids             []string

--- a/scanner/datastore/postgres/distributions.go
+++ b/scanner/datastore/postgres/distributions.go
@@ -13,8 +13,6 @@ import (
 // The purpose of this is to identify the major version represented by this CPE.
 var rhelCPE = regexp.MustCompile(`^cpe:2\.3:o:redhat:enterprise_linux:(\d+)(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*$`)
 
-var hummingbirdCPE = regexp.MustCompile(`^cpe:2\.3:a:redhat:hummingbird:\d+(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*$`)
-
 // Distributions retrieves the currently known distributions from the database.
 //
 // A distribution is considered known if there exists at least one row in the vuln table which references it.
@@ -23,8 +21,7 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 	// As of ClairCore v1.5.29, all distributions may be identified by dist_id, dist_version_id, and dist_version except for RHEL.
 	// As of this version of ClairCore, RHEL vulnerabilities are not associated with a specific RHEL version, but rather just the CPE(s).
 	// So, to capture all RHEL distributions, we must also search for rows with column repo_name matching the expected RHEL-major-version-identifying CPE.
-	// Hummingbird is a Red Hat product whose vulns also use CPE-based matching with no dist_* fields populated.
-	const selectDists = `SELECT DISTINCT dist_id, dist_version_id, dist_version, repo_name FROM vuln WHERE repo_name = '' OR repo_name LIKE 'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*' OR repo_name LIKE 'cpe:2.3:a:redhat:hummingbird:%:*:*:*:*:*:*:*'`
+	const selectDists = `SELECT DISTINCT dist_id, dist_version_id, dist_version, repo_name FROM vuln WHERE repo_name = '' OR repo_name LIKE 'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*'`
 
 	rows, err := m.pool.Query(ctx, selectDists)
 	if err != nil {
@@ -50,14 +47,7 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 			Version:   version,
 		}
 		if repoName != "" {
-			switch {
-			case rhelCPE.MatchString(repoName):
-				dist, err = rhelDist(repoName)
-			case hummingbirdCPE.MatchString(repoName):
-				dist, err = hummingbirdDist()
-			default:
-				err = fmt.Errorf("unexpected repo name: %s", repoName)
-			}
+			dist, err = rhelDist(repoName)
 			if err != nil {
 				slog.WarnContext(ctx, "failed to parse repo_name; skipping...", "reason", err)
 				continue
@@ -76,12 +66,6 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 	}
 
 	return dists, nil
-}
-
-func hummingbirdDist() (claircore.Distribution, error) {
-	return claircore.Distribution{
-		DID: "hummingbird",
-	}, nil
 }
 
 func rhelDist(repoName string) (claircore.Distribution, error) {

--- a/scanner/datastore/postgres/distributions_test.go
+++ b/scanner/datastore/postgres/distributions_test.go
@@ -48,9 +48,6 @@ func TestDistributions(t *testing.T) {
 			VersionID: "",
 			Version:   "3.18",
 		},
-		{
-			DID: "hummingbird",
-		},
 	}
 	const insertDists = `
 INSERT INTO vuln (hash_kind, hash, dist_id, dist_version_id, dist_version, repo_name) VALUES
@@ -61,37 +58,13 @@ INSERT INTO vuln (hash_kind, hash, dist_id, dist_version_id, dist_version, repo_
     ('md5', 'fake5', 'alpine', '',      '3.18',          ''),
     ('md5', 'fake6', 'debian', '10',    '10 (buster)',   ''),
     ('md5', 'fake7', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*'),
-    ('md5', 'fake8', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10.1:*:*:*:*:*:*:*'),
-    ('md5', 'fake9', '',       '',      '',              'cpe:2.3:a:redhat:hummingbird:1:*:*:*:*:*:*:*')`
+    ('md5', 'fake8', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10.1:*:*:*:*:*:*:*')`
 	_, err = pool.Exec(ctx, insertDists)
 	require.NoError(t, err)
 
 	dists, err := store.Distributions(ctx)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expected, dists)
-}
-
-func TestHummingbirdDist(t *testing.T) {
-	dist, err := hummingbirdDist()
-	require.NoError(t, err)
-	assert.Equal(t, claircore.Distribution{DID: "hummingbird"}, dist)
-}
-
-func TestHummingbirdCPE(t *testing.T) {
-	for _, tc := range []struct {
-		repoName string
-		match    bool
-	}{
-		{"cpe:2.3:a:redhat:hummingbird:1:*:*:*:*:*:*:*", true},
-		{"cpe:2.3:a:redhat:hummingbird:2:*:*:*:*:*:*:*", true},
-		{"cpe:2.3:a:redhat:hummingbird:1.0:*:*:*:*:*:*:*", true},
-		{"cpe:2.3:o:redhat:enterprise_linux:9:*:*:*:*:*:*:*", false},
-		{"cpe:2.3:a:redhat:other_product:1:*:*:*:*:*:*:*", false},
-	} {
-		t.Run(tc.repoName, func(t *testing.T) {
-			assert.Equal(t, tc.match, hummingbirdCPE.MatchString(tc.repoName))
-		})
-	}
 }
 
 func TestRHELDist(t *testing.T) {

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -161,7 +161,7 @@ func (s *matcherService) notes(ctx context.Context, vr *v4.VulnerabilityReport) 
 	knownDists := s.matcher.GetKnownDistributions(ctx)
 	known := slices.ContainsFunc(knownDists, func(dist claircore.Distribution) bool {
 		vID := mappers.VersionID(&dist)
-		return distID == dist.DID && (mappers.IsVersionAgnostic(dist.DID) || versionID == vID)
+		return distID == dist.DID && versionID == vID
 	})
 	if !known {
 		return []v4.VulnerabilityReport_Note{v4.VulnerabilityReport_NOTE_OS_UNSUPPORTED}

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -243,9 +243,6 @@ func (s *matcherServiceTestSuite) Test_matcherService_notes() {
 			VersionID: "3.19",
 			Version:   "",
 		},
-		{
-			DID: "hummingbird",
-		},
 	}
 
 	srv := NewMatcherService(s.matcherMock, nil)
@@ -261,23 +258,6 @@ func (s *matcherServiceTestSuite) Test_matcherService_notes() {
 				"0": {
 					Did:       "alpine",
 					VersionId: "3.18",
-				},
-			},
-		},
-	})
-	s.Empty(notes)
-
-	// Hummingbird supported via DID-only match (no VersionID in known dist).
-	s.matcherMock.
-		EXPECT().
-		GetKnownDistributions(gomock.Any()).
-		Return(dists)
-	notes = srv.notes(s.ctx, &v4.VulnerabilityReport{
-		Contents: &v4.Contents{
-			Distributions: map[string]*v4.Distribution{
-				"0": {
-					Did:       "hummingbird",
-					VersionId: "20251124",
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Reverts https://github.com/stackrox/stackrox/pull/21326 (commit 413ec7fbabf0662ad08a774b0425363d9519274a)

We want to continue to indicate the OS is unknown until relevant data is ready for consumption.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Tests removed

### How I validated my change

CI + manually:

- Deployed 4.11.1
- Scanned a hummingbird image -> no error banner
- Replaced matcher image with the one from this PR
- Re-scanned same image -> error banner present

<img width="905" height="275" alt="image" src="https://github.com/user-attachments/assets/5444363f-dade-4c8f-99dc-8cfd59e81249" />
