### PR TITLE
chore(scanner): finish updater and scanner slog migration

### DIFF
--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -12,8 +12,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/quay/claircore/toolkit/log"
-	"github.com/quay/zlog/v2"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/continuousprofiling"
 	"github.com/stackrox/rox/pkg/env"
@@ -32,6 +30,7 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/config"
 	"github.com/stackrox/rox/scanner/indexer"
+	"github.com/stackrox/rox/scanner/internal/logging"
 	"github.com/stackrox/rox/scanner/internal/version"
 	"github.com/stackrox/rox/scanner/matcher"
 	"github.com/stackrox/rox/scanner/services"
@@ -79,7 +78,7 @@ func main() {
 	defer cancel()
 
 	// Initialize logging and setup context.
-	err = initializeLogging(cfg.LogLevel)
+	err = logging.Initialize(cfg.LogLevel)
 	if err != nil {
 		golog.Fatalf("failed to initialize logging: %v", err)
 	}
@@ -135,21 +134,6 @@ func main() {
 	signal.Notify(sigC, unix.SIGINT, unix.SIGTERM)
 	sig := <-sigC
 	slog.InfoContext(ctx, "signal received", "signal", sig.String())
-}
-
-func initializeLogging(logLevel slog.Level) error {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return err
-	}
-	h := zlog.NewHandler(os.Stdout, &zlog.Options{
-		Level:      logLevel,
-		ContextKey: log.AttrsKey,
-		LevelKey:   log.LevelKey,
-	})
-	logger := slog.New(h).With("host", hostname)
-	slog.SetDefault(logger)
-	return nil
 }
 
 // createGRPCService creates a ready-to-start gRPC API instance and register its services.

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	golog "log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -53,7 +52,7 @@ func init() {
 	// Set the http.DefaultTransport's Proxy function to one which reads from the proxy configuration file.
 	// Note: http.DefaultClient uses http.DefaultTransport.
 	if !proxy.UseWithDefaultTransport() {
-		golog.Println("Failed to use proxy transport with default HTTP transport. Some proxy features may not work.")
+		slog.Warn("failed to use proxy transport with default HTTP transport; some proxy features may not work")
 	}
 
 	memlimit.SetMemoryLimit()
@@ -70,7 +69,8 @@ func main() {
 	}
 	cfg, err := config.Read(*configPath)
 	if err != nil {
-		golog.Fatalf("failed to load configuration %q: %v", *configPath, err)
+		slog.Error("failed to load configuration", "path", *configPath, "reason", err)
+		os.Exit(1)
 	}
 
 	// Create cancellable context.
@@ -80,7 +80,8 @@ func main() {
 	// Initialize logging and setup context.
 	err = logging.Initialize(cfg.LogLevel)
 	if err != nil {
-		golog.Fatalf("failed to initialize logging: %v", err)
+		slog.Error("failed to initialize logging", "reason", err)
+		os.Exit(1)
 	}
 
 	if err := continuousprofiling.SetupClient(continuousprofiling.DefaultConfig()); err != nil {

--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -4,16 +4,46 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
+	"os"
 	"time"
 
+	"github.com/quay/claircore/toolkit/log"
+	"github.com/quay/zlog/v2"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/scanner/internal/version"
 	"github.com/stackrox/rox/scanner/updater"
 )
 
 const DefaultURL = "https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/manual/vulns.yaml"
+
+const logLevelEnvVar = "STACKROX_SCANNER_V4_UPDATER_LOG_LEVEL"
+
+func initializeLogging() error {
+	level := slog.LevelInfo
+	var levelErr error
+	if v := os.Getenv(logLevelEnvVar); v != "" {
+		if err := level.UnmarshalText([]byte(v)); err != nil {
+			level = slog.LevelInfo
+			levelErr = err
+		}
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	h := zlog.NewHandler(os.Stdout, &zlog.Options{
+		Level:      level,
+		ContextKey: log.AttrsKey,
+		LevelKey:   log.LevelKey,
+	})
+	logger := slog.New(h).With("host", hostname)
+	slog.SetDefault(logger)
+	if levelErr != nil {
+		slog.Warn("invalid log level, using info", "var", logLevelEnvVar, "reason", levelErr)
+	}
+	return nil
+}
 
 func tryExport(ctx context.Context, outputDir string, opts *updater.ExportOptions) error {
 	const timeout = 3 * time.Hour
@@ -27,13 +57,19 @@ func tryExport(ctx context.Context, outputDir string, opts *updater.ExportOption
 }
 
 func main() {
+	if err := initializeLogging(); err != nil {
+		slog.Error("failed to initialize logging", "reason", err)
+		os.Exit(1)
+	}
+
 	var ctx = context.Background()
 
 	var rootCmd = &cobra.Command{
-		Use:          "updater",
-		Version:      version.Version,
-		SilenceUsage: true,
-		Short:        "StackRox Scanner vulnerability updater",
+		Use:           "updater",
+		Version:       version.Version,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Short:         "StackRox Scanner vulnerability updater",
 	}
 
 	var exportCmd = &cobra.Command{
@@ -91,6 +127,7 @@ func main() {
 	rootCmd.AddCommand(exportCmd, importCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		slog.Error("updater failed", "reason", err)
+		os.Exit(1)
 	}
 }

--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -8,9 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/quay/claircore/toolkit/log"
-	"github.com/quay/zlog/v2"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/scanner/internal/logging"
 	"github.com/stackrox/rox/scanner/internal/version"
 	"github.com/stackrox/rox/scanner/updater"
 )
@@ -28,17 +27,9 @@ func initializeLogging() error {
 			levelErr = err
 		}
 	}
-	hostname, err := os.Hostname()
-	if err != nil {
+	if err := logging.Initialize(level); err != nil {
 		return err
 	}
-	h := zlog.NewHandler(os.Stdout, &zlog.Options{
-		Level:      level,
-		ContextKey: log.AttrsKey,
-		LevelKey:   log.LevelKey,
-	})
-	logger := slog.New(h).With("host", hostname)
-	slog.SetDefault(logger)
 	if levelErr != nil {
 		slog.Warn("invalid log level, using info", "var", logLevelEnvVar, "reason", levelErr)
 	}

--- a/scanner/internal/logging/logging.go
+++ b/scanner/internal/logging/logging.go
@@ -1,0 +1,27 @@
+// Package logging provides common slog initialization for scanner binaries.
+package logging
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/quay/claircore/toolkit/log"
+	"github.com/quay/zlog/v2"
+)
+
+// Initialize configures a zlog/v2 [slog.Handler] that writes to stdout as the
+// default [slog.Logger], tagged with the host name.
+func Initialize(level slog.Level) error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	h := zlog.NewHandler(os.Stdout, &zlog.Options{
+		Level:      level,
+		ContextKey: log.AttrsKey,
+		LevelKey:   log.LevelKey,
+	})
+	logger := slog.New(h).With("host", hostname)
+	slog.SetDefault(logger)
+	return nil
+}

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	stdlog "log"
 	"log/slog"
 	"net/http"
 	"os"
@@ -89,9 +88,11 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 		parsedInterval, err := time.ParseDuration(configuredInterval)
 		switch {
 		case err != nil:
-			stdlog.Printf("invalid interval, using default (%v): %v", interval, err)
+			slog.WarnContext(ctx, "invalid interval, using default",
+				"default", interval, "reason", err)
 		case parsedInterval < interval:
-			stdlog.Printf("interval is too small (%v): using default (%v)", parsedInterval, interval)
+			slog.WarnContext(ctx, "interval is too small, using default",
+				"interval", parsedInterval, "default", interval)
 		default:
 			interval = parsedInterval
 		}


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/20259 left the updater's logging half-migrated and a couple of stdlib log lines in scanner. These changes align the scanner and updater binaries to use the same logging structure.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

N/A

### How I validated my change

CI logs: https://github.com/stackrox/stackrox/actions/runs/28982227233/job/86003469890