### PR TITLE
ROX-35370: Fix CVE-2026-99999

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1293,6 +1293,7 @@ jobs:
       (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
     permissions:
       id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -1306,6 +1307,12 @@ jobs:
             "stackrox-operator",
           ]
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Scan image vulnerabilities
         uses: stackrox/actions/release/scan-image-vulnerabilities@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/scan-image-vulnerabilities@v1
         id: scan-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1278,6 +1278,151 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
+  verify-cve-fix-scan:
+    name: "CVE scan: ${{ matrix.image }}:${{ needs.define-job-matrix.outputs.build-tag }}"
+    runs-on: ubuntu-latest
+    needs:
+      - define-job-matrix
+      - push-main-manifests
+      - push-scanner-manifests
+      - push-operator-manifests
+      - build-and-push-db
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.title, 'CVE-')
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          [
+            "central-db",
+            "main",
+            "roxctl",
+            "scanner-v4",
+            "scanner-v4-db",
+            "stackrox-operator",
+          ]
+    steps:
+      - name: Scan image vulnerabilities
+        uses: stackrox/actions/release/scan-image-vulnerabilities@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/scan-image-vulnerabilities@v1
+        id: scan-image
+        with:
+          image: rhacs-eng/${{ matrix.image }}
+          version: ${{ needs.define-job-matrix.outputs.build-tag }}
+          wait-limit: "1800"
+          summary-prefix: "CVE-fix-verify:"
+          quay-bearer-token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+          central-url: ${{ vars.ACS_DOGFOODING_CENTRAL_URL }}
+
+      - name: Upload scan result artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        with:
+          name: cve-verify_${{ matrix.image }}.json
+          path: ${{ steps.scan-image.outputs.result-path }}
+          retention-days: 7
+
+  verify-cve-fix:
+    name: "CVE fix verification"
+    runs-on: ubuntu-latest
+    needs:
+      - define-job-matrix
+      - verify-cve-fix-scan
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.title, 'CVE-')
+    permissions:
+      pull-requests: write
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Extract CVE IDs from PR title
+        id: extract-cves
+        run: |
+          cves="$(echo "$PR_TITLE" | grep -oiE 'CVE-[0-9]{4}-[0-9]+' | tr '[:lower:]' '[:upper:]' | sort -u | paste -sd ',' -)"
+          if [[ -z "$cves" ]]; then
+            echo "No CVE IDs found in PR title: $PR_TITLE" >&2
+            exit 1
+          fi
+          echo "cves=${cves}" >> "$GITHUB_OUTPUT"
+          echo "Found CVE IDs: ${cves}"
+
+      - name: Download all scan artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+        with:
+          pattern: cve-verify_*.json
+          path: scan-results
+          merge-multiple: false
+
+      - name: Flatten scan results
+        id: flatten
+        run: |
+          mkdir -p scan-results-flat
+          infra_failure=false
+          for dir in scan-results/cve-verify_*/; do
+            image_name="$(basename "$dir" | sed 's/^cve-verify_//' | sed 's/\.json$//')"
+            if [[ -f "${dir}scan-result.json" ]]; then
+              cp "${dir}scan-result.json" "scan-results-flat/${image_name}.json"
+            else
+              echo "::warning::No scan result for ${image_name}"
+              infra_failure=true
+            fi
+          done
+          # If no artifacts were downloaded at all, the directory won't exist
+          if [[ ! -d scan-results ]] || [[ -z "$(ls scan-results-flat/ 2>/dev/null)" ]]; then
+            infra_failure=true
+          fi
+          echo "infra-failure=${infra_failure}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify CVE fix
+        id: verify
+        run: |
+          set +e
+          comment_body="$(bash .github/workflows/scripts/verify-cve-fix.sh \
+            --cves "${{ steps.extract-cves.outputs.cves }}" \
+            --scan-dir scan-results-flat)"
+          exit_code=$?
+          set -e
+          {
+            echo "comment<<COMMENT_EOF"
+            echo "$comment_body"
+            echo "COMMENT_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ steps.flatten.outputs.infra-failure }}" == "true" && "${{ steps.verify.outputs.exit-code }}" != "1" ]]; then
+            gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'COMMENT_EOF'
+          **CVE Fix Verification: COULD NOT RUN** :warning:
+
+          The vulnerability scan could not complete due to an infrastructure error:
+
+          > One or more image scans failed to produce results.
+
+          **Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.
+          COMMENT_EOF
+          )"
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" \
+              --body "${{ steps.verify.outputs.comment }}"
+          fi
+
+      - name: Fail if CVE still present
+        if: steps.verify.outputs.exit-code == '1'
+        run: exit 1
+
   slack-on-build-failure:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1302,6 +1447,7 @@ jobs:
       - pre-build-ui
       - push-matching-collector-scanner
       - scan-go-binaries
+      - verify-cve-fix
     permissions:
       actions: read
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1331,7 +1331,13 @@ jobs:
           central-url: ${{ vars.ACS_DOGFOODING_CENTRAL_URL }}
 
       - name: Upload scan result artifact
-        if: always()
+        # Skip (instead of erroring) when the scan step failed before it got
+        # far enough to set result-path (e.g. a wait-for-image timeout) -
+        # continue-on-error above means that failure wouldn't otherwise stop
+        # this step, and actions/upload-artifact hard-errors on an empty
+        # required `path` input. verify-cve-fix's own missing-image check
+        # still catches and reports this case non-blockingly.
+        if: always() && steps.scan-image.outputs.result-path != ''
         uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cve-verify_${{ matrix.image }}.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1289,7 +1289,8 @@ jobs:
       - build-and-push-db
     if: >-
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.title, 'CVE-')
+      contains(github.event.pull_request.title, 'CVE-') &&
+      (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
     permissions:
       id-token: write
     strategy:
@@ -1333,7 +1334,8 @@ jobs:
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.title, 'CVE-')
+      contains(github.event.pull_request.title, 'CVE-') &&
+      (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
     permissions:
       pull-requests: write
     env:
@@ -1368,6 +1370,7 @@ jobs:
         run: |
           mkdir -p scan-results-flat
           infra_failure=false
+          shopt -s nullglob
           for dir in scan-results/cve-verify_*/; do
             image_name="$(basename "$dir" | sed 's/^cve-verify_//' | sed 's/\.json$//')"
             if [[ -f "${dir}scan-result.json" ]]; then
@@ -1377,6 +1380,7 @@ jobs:
               infra_failure=true
             fi
           done
+          shopt -u nullglob
           # If no artifacts were downloaded at all, the directory won't exist
           if [[ ! -d scan-results ]] || [[ -z "$(ls scan-results-flat/ 2>/dev/null)" ]]; then
             infra_failure=true
@@ -1392,16 +1396,19 @@ jobs:
             --scan-dir scan-results-flat)"
           exit_code=$?
           set -e
+          delimiter="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
           {
-            echo "comment<<COMMENT_EOF"
+            echo "comment<<${delimiter}"
             echo "$comment_body"
-            echo "COMMENT_EOF"
+            echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
           echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: Post PR comment
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ steps.verify.outputs.comment }}
         run: |
           if [[ "${{ steps.flatten.outputs.infra-failure }}" == "true" && "${{ steps.verify.outputs.exit-code }}" != "1" ]]; then
             gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'COMMENT_EOF'
@@ -1415,8 +1422,7 @@ jobs:
           COMMENT_EOF
           )"
           else
-            gh pr comment "${{ github.event.pull_request.number }}" \
-              --body "${{ steps.verify.outputs.comment }}"
+            gh pr comment "${{ github.event.pull_request.number }}" --body "$COMMENT_BODY"
           fi
 
       - name: Fail if CVE still present

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1309,6 +1309,12 @@ jobs:
       - name: Scan image vulnerabilities
         uses: stackrox/actions/release/scan-image-vulnerabilities@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/scan-image-vulnerabilities@v1
         id: scan-image
+        # The composite action fails on ANY fixable CRITICAL/IMPORTANT CVE in
+        # the image, not just the CVE(s) this PR is verifying. The scan
+        # result artifact is still produced (uploaded via if: always() below)
+        # and is what verify-cve-fix.sh actually checks, so a red X here must
+        # not fail this job / block the PR on unrelated pre-existing CVEs.
+        continue-on-error: true
         with:
           image: rhacs-eng/${{ matrix.image }}
           version: ${{ needs.define-job-matrix.outputs.build-tag }}
@@ -1319,11 +1325,10 @@ jobs:
 
       - name: Upload scan result artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cve-verify_${{ matrix.image }}.json
           path: ${{ steps.scan-image.outputs.result-path }}
-          retention-days: 7
 
   verify-cve-fix:
     name: "CVE fix verification"
@@ -1359,11 +1364,10 @@ jobs:
           echo "Found CVE IDs: ${cves}"
 
       - name: Download all scan artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+        uses: ./.github/actions/download-artifact-with-retry
         with:
           pattern: cve-verify_*.json
           path: scan-results
-          merge-multiple: false
 
       - name: Flatten scan results
         id: flatten
@@ -1381,10 +1385,20 @@ jobs:
             fi
           done
           shopt -u nullglob
-          # If no artifacts were downloaded at all, the directory won't exist
-          if [[ ! -d scan-results ]] || [[ -z "$(ls scan-results-flat/ 2>/dev/null)" ]]; then
-            infra_failure=true
-          fi
+          # Verify every image verify-cve-fix-scan is expected to scan
+          # (kept in sync with that job's matrix) actually produced a
+          # result. A matrix leg that fails before reaching the scan step
+          # (e.g. a wait-for-image timeout or central-login flake) never
+          # uploads an artifact at all, so it wouldn't otherwise be
+          # detected by the loop above and could silently narrow the
+          # verdict to fewer than all 6 images.
+          expected_images=(central-db main roxctl scanner-v4 scanner-v4-db stackrox-operator)
+          for image in "${expected_images[@]}"; do
+            if [[ ! -f "scan-results-flat/${image}.json" ]]; then
+              echo "::warning::No scan result artifact was produced for ${image}"
+              infra_failure=true
+            fi
+          done
           echo "infra-failure=${infra_failure}" >> "$GITHUB_OUTPUT"
 
       - name: Verify CVE fix

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -67,7 +67,7 @@ fi
 usable_scan_files=()
 unparseable_files=()
 for scan_file in "${SCAN_FILES[@]}"; do
-  if jq -e '(.result.vulnerabilities // empty) | type == "array"' "$scan_file" >/dev/null 2>&1; then
+  if jq -e '(.result // empty) as $r | ($r | type) == "object" and (($r.vulnerabilities // []) | type == "array")' "$scan_file" >/dev/null 2>&1; then
     usable_scan_files+=("$scan_file")
   else
     unparseable_files+=("$(basename "$scan_file")")

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -9,7 +9,10 @@
 #
 # Exit codes:
 #   0 - All target CVEs are absent from all scans (PASSED), or no scan
-#       result files were found (infrastructure failure, non-blocking)
+#       result files were found (infrastructure failure, non-blocking).
+#       If some (but not all) scan result files could not be parsed
+#       (invalid JSON or unexpected shape), a WARNING section listing
+#       them is appended to the output, but the exit code is unaffected.
 #   1 - At least one target CVE is still present (FAILED)
 #   2 - Invalid usage (bad or missing arguments)
 #
@@ -59,12 +62,12 @@ fi
 
 # Identify scan result files that are not valid JSON or do not match the
 # expected roxctl image scan shape (an object with a "result.vulnerabilities"
-# key). These are skipped when checking for CVEs below, but flagged in the
+# array). These are skipped when checking for CVEs below, but flagged in the
 # output so an unparseable scan is never mistaken for a clean one.
 usable_scan_files=()
 unparseable_files=()
 for scan_file in "${SCAN_FILES[@]}"; do
-  if jq -e '(.result // empty) | has("vulnerabilities")' "$scan_file" >/dev/null 2>&1; then
+  if jq -e '(.result.vulnerabilities // empty) | type == "array"' "$scan_file" >/dev/null 2>&1; then
     usable_scan_files+=("$scan_file")
   else
     unparseable_files+=("$(basename "$scan_file")")
@@ -109,6 +112,7 @@ if [[ ${#unparseable_files[@]} -gt 0 ]]; then
   for unparseable_file in "${unparseable_files[@]}"; do
     comment_body+="- ${unparseable_file}"$'\n'
   done
+  comment_body+=$'\n'
   comment_body+="**Action required:** Please verify manually that these images are free of the target CVE(s), since they could not be automatically checked."$'\n\n'
 fi
 

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Verifies that target CVE(s) are absent from image scan results.
+#
+# Usage: verify-cve-fix.sh --cves <comma-separated-cve-ids> --scan-dir <directory>
+#
+# The scan directory should contain JSON files from roxctl image scan.
+# Each file should be named like: <image-name>.json
+#
+# Exit codes:
+#   0 - All target CVEs are absent from all scans (PASSED)
+#   1 - At least one target CVE is still present (FAILED)
+#   2 - No scan results found (infrastructure failure)
+#
+set -euo pipefail
+
+CVES=""
+SCAN_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cves) CVES="$2"; shift 2 ;;
+    --scan-dir) SCAN_DIR="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$CVES" || -z "$SCAN_DIR" ]]; then
+  echo "Usage: verify-cve-fix.sh --cves <cve1,cve2,...> --scan-dir <dir>" >&2
+  exit 2
+fi
+
+IFS=',' read -ra CVE_LIST <<< "$CVES"
+
+# Check that scan results exist
+shopt -s nullglob
+SCAN_FILES=("${SCAN_DIR}"/*.json)
+shopt -u nullglob
+
+if [[ ${#SCAN_FILES[@]} -eq 0 ]]; then
+  cat <<'INFRA_EOF'
+**CVE Fix Verification: COULD NOT RUN** :warning:
+
+The vulnerability scan could not complete due to an infrastructure error:
+
+> No scan result files found.
+
+**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.
+INFRA_EOF
+  exit 0
+fi
+
+overall_failed=false
+comment_body=""
+
+for cve in "${CVE_LIST[@]}"; do
+  findings=""
+  for scan_file in "${SCAN_FILES[@]}"; do
+    image_name="$(basename "$scan_file" .json)"
+    matches="$(jq -r --arg cve "$cve" '
+      [.result.vulnerabilities // [] | .[] | select(.cveId == $cve)] |
+      .[] | [.componentName, .componentVersion, .componentFixedVersion] | @tsv
+    ' "$scan_file" 2>/dev/null || true)"
+
+    if [[ -n "$matches" ]]; then
+      while IFS=$'\t' read -r component version fixed_version; do
+        findings+="| ${image_name} | ${component} | ${version} | ${fixed_version:-N/A} |"$'\n'
+      done <<< "$matches"
+    fi
+  done
+
+  if [[ -n "$findings" ]]; then
+    overall_failed=true
+    comment_body+="**CVE Fix Verification: FAILED** :x:"$'\n\n'
+    comment_body+="${cve} is still present in the following images:"$'\n\n'
+    comment_body+="| Image | Component | Version | Fixed Version |"$'\n'
+    comment_body+="| --- | --- | --- | --- |"$'\n'
+    comment_body+="${findings}"$'\n'
+  else
+    comment_body+="**CVE Fix Verification: PASSED** :white_check_mark:"$'\n\n'
+    comment_body+="${cve} was not found in any scanned image."$'\n\n'
+  fi
+done
+
+echo "$comment_body"
+
+if [[ "$overall_failed" == "true" ]]; then
+  exit 1
+fi

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -8,11 +8,13 @@
 # Each file should be named like: <image-name>.json
 #
 # Exit codes:
-#   0 - All target CVEs are absent from all scans (PASSED), or no scan
-#       result files were found (infrastructure failure, non-blocking).
-#       If some (but not all) scan result files could not be parsed
-#       (invalid JSON or unexpected shape), a WARNING section listing
-#       them is appended to the output, but the exit code is unaffected.
+#   0 - All target CVEs are absent from all scans (PASSED); or no scan
+#       result files were found, or every scan result file found was
+#       unparseable (both cases are treated as an infrastructure
+#       failure: COULD NOT RUN, non-blocking). If some (but not all)
+#       scan result files were unparseable, a WARNING section listing
+#       them is appended to the PASSED/FAILED output instead, and the
+#       exit code is unaffected.
 #   1 - At least one target CVE is still present (FAILED)
 #   2 - Invalid usage (bad or missing arguments)
 #
@@ -73,6 +75,23 @@ for scan_file in "${SCAN_FILES[@]}"; do
     unparseable_files+=("$(basename "$scan_file")")
   fi
 done
+
+# If every scan result file was unparseable, there is nothing usable to check
+# CVEs against. Treat this the same as "no scan result files found" rather
+# than reporting a misleading PASSED verdict.
+if [[ ${#usable_scan_files[@]} -eq 0 ]]; then
+  comment_body="**CVE Fix Verification: COULD NOT RUN** :warning:"$'\n\n'
+  comment_body+="The vulnerability scan could not complete due to an infrastructure error:"$'\n\n'
+  comment_body+="> ${#unparseable_files[@]} scan result file(s) were found, but none of them could be parsed (invalid JSON or unexpected shape):"$'\n\n'
+  for unparseable_file in "${unparseable_files[@]}"; do
+    comment_body+="- ${unparseable_file}"$'\n'
+  done
+  comment_body+=$'\n'
+  # shellcheck disable=SC2016
+  comment_body+='**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.'$'\n'
+  echo "$comment_body"
+  exit 0
+fi
 
 overall_failed=false
 comment_body=""

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -8,9 +8,10 @@
 # Each file should be named like: <image-name>.json
 #
 # Exit codes:
-#   0 - All target CVEs are absent from all scans (PASSED)
+#   0 - All target CVEs are absent from all scans (PASSED), or no scan
+#       result files were found (infrastructure failure, non-blocking)
 #   1 - At least one target CVE is still present (FAILED)
-#   2 - No scan results found (infrastructure failure)
+#   2 - Invalid usage (bad or missing arguments)
 #
 set -euo pipefail
 
@@ -19,8 +20,14 @@ SCAN_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --cves) CVES="$2"; shift 2 ;;
-    --scan-dir) SCAN_DIR="$2"; shift 2 ;;
+    --cves)
+      CVES="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    --scan-dir)
+      SCAN_DIR="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -50,12 +57,26 @@ INFRA_EOF
   exit 0
 fi
 
+# Identify scan result files that are not valid JSON or do not match the
+# expected roxctl image scan shape (an object with a "result.vulnerabilities"
+# key). These are skipped when checking for CVEs below, but flagged in the
+# output so an unparseable scan is never mistaken for a clean one.
+usable_scan_files=()
+unparseable_files=()
+for scan_file in "${SCAN_FILES[@]}"; do
+  if jq -e '(.result // empty) | has("vulnerabilities")' "$scan_file" >/dev/null 2>&1; then
+    usable_scan_files+=("$scan_file")
+  else
+    unparseable_files+=("$(basename "$scan_file")")
+  fi
+done
+
 overall_failed=false
 comment_body=""
 
 for cve in "${CVE_LIST[@]}"; do
   findings=""
-  for scan_file in "${SCAN_FILES[@]}"; do
+  for scan_file in "${usable_scan_files[@]}"; do
     image_name="$(basename "$scan_file" .json)"
     matches="$(jq -r --arg cve "$cve" '
       [.result.vulnerabilities // [] | .[] | select(.cveId == $cve)] |
@@ -81,6 +102,15 @@ for cve in "${CVE_LIST[@]}"; do
     comment_body+="${cve} was not found in any scanned image."$'\n\n'
   fi
 done
+
+if [[ ${#unparseable_files[@]} -gt 0 ]]; then
+  comment_body+="**CVE Fix Verification: WARNING** :warning:"$'\n\n'
+  comment_body+="The following scan result file(s) could not be parsed and were skipped:"$'\n\n'
+  for unparseable_file in "${unparseable_files[@]}"; do
+    comment_body+="- ${unparseable_file}"$'\n'
+  done
+  comment_body+="**Action required:** Please verify manually that these images are free of the target CVE(s), since they could not be automatically checked."$'\n\n'
+fi
 
 echo "$comment_body"
 


### PR DESCRIPTION
Fourth throwaway test PR to re-validate the CVE fix verification workflow (ROX-35370) after fixing the upload-guard gap. Confirms the overall build run now completes with conclusion=success even when a scan leg hits an infra timeout. Will be closed without merging.