### PR TITLE
ROX-35502: Add protocol integration tests for Sensor <-> roxagent

### DIFF
--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -1,0 +1,366 @@
+package vsockclient
+
+import (
+	"net"
+	"testing"
+
+	roxagentvsock "github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/vsockframing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// protocolHarness drives a real Sensor client against a real roxagent handler
+// over net.Pipe(), validating the protocol contract end-to-end.
+type protocolHarness struct {
+	t       testing.TB
+	client  *Client
+	cache   *roxagentvsock.ReportCache
+	handler *roxagentvsock.Handler
+}
+
+type protocolHarnessOptions struct {
+	capabilities    []string
+	maxResponseSize int
+	agentVersion    string
+	seedReport      *v4.IndexReport
+	seedFacts       map[string]string
+}
+
+func newProtocolHarness(t testing.TB, opts protocolHarnessOptions) *protocolHarness {
+	t.Helper()
+
+	if opts.capabilities == nil {
+		opts.capabilities = []string{CapabilityReportV1}
+	}
+	if opts.maxResponseSize == 0 {
+		opts.maxResponseSize = 10 << 20
+	}
+	if opts.agentVersion == "" {
+		opts.agentVersion = "test-agent"
+	}
+
+	cache := &roxagentvsock.ReportCache{}
+	if opts.seedReport != nil {
+		cache.SetReport(opts.seedReport, opts.seedFacts)
+	}
+
+	return &protocolHarness{
+		t:       t,
+		client:  NewClient(opts.capabilities, opts.maxResponseSize),
+		cache:   cache,
+		handler: roxagentvsock.NewHandler(cache, opts.agentVersion),
+	}
+}
+
+func (h *protocolHarness) getReport(ifNewerThan uint32) (*GetReportResult, error) {
+	h.t.Helper()
+
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.handler.HandleConn(agentConn)
+	}()
+
+	result, err := h.client.GetReport(clientConn, ifNewerThan)
+	<-done
+	return result, err
+}
+
+func TestGetReportIntegration(t *testing.T) {
+	cases := map[string]struct {
+		// Arguments
+		seedReport   *v4.IndexReport
+		seedFacts    map[string]string
+		agentVersion string
+		ifNewerThan  uint32
+		// Expectations
+		wantErr     error
+		checkResult func(t *testing.T, result *GetReportResult)
+	}{
+		"should return not ready when cache is empty": {
+			wantErr: ErrNotReady,
+		},
+		"should return full report when cache has report": {
+			seedReport: &v4.IndexReport{HashId: "integration-test-hash"},
+			seedFacts:  map[string]string{"os": "rhel", "arch": "x86_64"},
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.False(t, result.Unchanged)
+				require.NotNil(t, result.IndexReport)
+				assert.Equal(t, "integration-test-hash", result.IndexReport.GetHashId())
+
+				require.NotNil(t, result.Meta)
+				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.NotNil(t, result.Meta.GetReportGeneratedAt())
+				assert.Contains(t, result.Meta.GetSupportedMethods(), "get_report")
+				assert.Equal(t, "rhel", result.Meta.GetFacts()["os"])
+				assert.Equal(t, "x86_64", result.Meta.GetFacts()["arch"])
+			},
+		},
+		"should return unchanged when generation matches": {
+			seedReport:  &v4.IndexReport{HashId: "unchanged-hash"},
+			ifNewerThan: 1,
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.True(t, result.Unchanged)
+				assert.Nil(t, result.IndexReport)
+				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+			},
+		},
+		"should return full report when sensor generation exceeds agent after restart": {
+			seedReport:  &v4.IndexReport{HashId: "post-restart-hash"},
+			ifNewerThan: 5,
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.False(t, result.Unchanged, "agent restarted (gen=1 < requested=5), must serve full report")
+				require.NotNil(t, result.IndexReport)
+				assert.Equal(t, "post-restart-hash", result.IndexReport.GetHashId())
+				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+			},
+		},
+		"should deliver all agent metadata to sensor": {
+			seedReport:   &v4.IndexReport{HashId: "meta-hash"},
+			seedFacts:    map[string]string{"os_id": "rhel", "kernel": "5.14.0", "instance_id": "i-abc123"},
+			agentVersion: "roxagent-0.3.1-deadbeef",
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				require.NotNil(t, result.Meta)
+				assert.Equal(t, "roxagent-0.3.1-deadbeef", result.Meta.GetAgentVersion())
+				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.NotNil(t, result.Meta.GetReportGeneratedAt())
+				assert.Contains(t, result.Meta.GetSupportedMethods(), "get_report")
+
+				facts := result.Meta.GetFacts()
+				assert.Equal(t, "rhel", facts["os_id"])
+				assert.Equal(t, "5.14.0", facts["kernel"])
+				assert.Equal(t, "i-abc123", facts["instance_id"])
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := newProtocolHarness(t, protocolHarnessOptions{
+				seedReport:   tc.seedReport,
+				seedFacts:    tc.seedFacts,
+				agentVersion: tc.agentVersion,
+			})
+
+			result, err := h.getReport(tc.ifNewerThan)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tc.checkResult != nil {
+				tc.checkResult(t, result)
+			}
+		})
+	}
+}
+
+// --- Compatibility persona helpers ---
+
+// exchangeWithResponder runs a single GetReport exchange using a fake agent
+// responder instead of the real handler. This allows testing protocol
+// compatibility with simulated older or future agent behavior.
+func exchangeWithResponder(t *testing.T, client *Client, ifNewerThan uint32, responder func(net.Conn)) (*GetReportResult, error) {
+	t.Helper()
+
+	clientConn, agentConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		responder(agentConn)
+	}()
+
+	result, err := client.GetReport(clientConn, ifNewerThan)
+	<-done
+	return result, err
+}
+
+// oldAgentResponder models a plausible older roxagent that:
+//   - supports only get_report
+//   - does not advertise supported_methods
+//   - does not include facts or report_generated_at
+//   - always returns the full report (ignores if_newer_than_generation)
+//   - returns UNKNOWN_METHOD for anything else
+func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
+	return func(conn net.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		reqData, err := vsockframing.ReadFrame(conn, 1<<20)
+		if err != nil {
+			return
+		}
+		var req pb.VMServiceRequest
+		if err := proto.Unmarshal(reqData, &req); err != nil {
+			return
+		}
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{
+				AgentVersion:     "roxagent-0.1.0",
+				ReportGeneration: generation,
+			},
+		}
+
+		if req.GetGetReport() != nil {
+			resp.Result = &pb.VMServiceResponse_GetReport{
+				GetReport: &pb.GetReportResponse{IndexReport: report},
+			}
+		} else {
+			resp.Result = &pb.VMServiceResponse_Error{
+				Error: &pb.ErrorResponse{
+					Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
+					Message: "unsupported method",
+				},
+			}
+		}
+
+		respData, err := proto.Marshal(resp)
+		if err != nil {
+			return
+		}
+		_ = vsockframing.WriteFrame(conn, respData)
+	}
+}
+
+// futureAgentResponder models a plausible future roxagent that:
+//   - advertises extra supported_methods beyond get_report
+//   - still handles get_report correctly
+//   - includes richer metadata (facts, supported_methods)
+//   - supports if_newer_than_generation (unchanged semantics)
+//   - returns UNKNOWN_METHOD for methods it doesn't recognize
+func futureAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
+	return func(conn net.Conn) {
+		defer func() { _ = conn.Close() }()
+
+		reqData, err := vsockframing.ReadFrame(conn, 1<<20)
+		if err != nil {
+			return
+		}
+		var req pb.VMServiceRequest
+		if err := proto.Unmarshal(reqData, &req); err != nil {
+			return
+		}
+
+		resp := &pb.VMServiceResponse{
+			Meta: &pb.ResponseMeta{
+				AgentVersion:     "roxagent-2.0.0-future",
+				ReportGeneration: generation,
+				SupportedMethods: []string{"get_report", "get_config", "submit_event"},
+				Facts:            map[string]string{"os_id": "rhel", "protocol_version": "2"},
+			},
+		}
+
+		switch {
+		case req.GetGetReport() != nil:
+			if req.GetGetReport().GetIfNewerThanGeneration() == generation {
+				resp.Result = &pb.VMServiceResponse_GetReport{
+					GetReport: &pb.GetReportResponse{Unchanged: true},
+				}
+			} else {
+				resp.Result = &pb.VMServiceResponse_GetReport{
+					GetReport: &pb.GetReportResponse{IndexReport: report},
+				}
+			}
+		default:
+			resp.Result = &pb.VMServiceResponse_Error{
+				Error: &pb.ErrorResponse{
+					Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
+					Message: "unsupported method",
+				},
+			}
+		}
+
+		respData, err := proto.Marshal(resp)
+		if err != nil {
+			return
+		}
+		_ = vsockframing.WriteFrame(conn, respData)
+	}
+}
+
+func TestGetReportCompatibility(t *testing.T) {
+	report := &v4.IndexReport{HashId: "compat-hash"}
+	client := NewClient([]string{CapabilityReportV1}, 10<<20)
+
+	cases := map[string]struct {
+		// Arguments
+		responder   func(net.Conn)
+		ifNewerThan uint32
+		// Expectations
+		checkResult func(t *testing.T, result *GetReportResult)
+	}{
+		"old agent should serve get_report to current sensor": {
+			responder: oldAgentResponder(report, 1),
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.False(t, result.Unchanged)
+				require.NotNil(t, result.IndexReport)
+				assert.Equal(t, "compat-hash", result.IndexReport.GetHashId())
+				assert.Equal(t, "roxagent-0.1.0", result.Meta.GetAgentVersion())
+				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.Empty(t, result.Meta.GetSupportedMethods())
+				assert.Empty(t, result.Meta.GetFacts())
+			},
+		},
+		"old agent should always return full report ignoring if_newer_than": {
+			responder:   oldAgentResponder(report, 1),
+			ifNewerThan: 1,
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.False(t, result.Unchanged, "old agent does not support unchanged optimization")
+				require.NotNil(t, result.IndexReport)
+			},
+		},
+		"future agent should serve get_report to current sensor": {
+			responder: futureAgentResponder(report, 1),
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.False(t, result.Unchanged)
+				require.NotNil(t, result.IndexReport)
+				assert.Equal(t, "compat-hash", result.IndexReport.GetHashId())
+				assert.Equal(t, "roxagent-2.0.0-future", result.Meta.GetAgentVersion())
+				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.Equal(t, []string{"get_report", "get_config", "submit_event"}, result.Meta.GetSupportedMethods())
+				assert.Equal(t, "rhel", result.Meta.GetFacts()["os_id"])
+				assert.Equal(t, "2", result.Meta.GetFacts()["protocol_version"])
+			},
+		},
+		"future agent should return unchanged when generation matches": {
+			responder:   futureAgentResponder(report, 3),
+			ifNewerThan: 3,
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.True(t, result.Unchanged)
+				assert.Nil(t, result.IndexReport)
+				assert.Equal(t, uint32(3), result.Meta.GetReportGeneration())
+			},
+		},
+		"future agent extra supported_methods are discoverable by sensor": {
+			responder: futureAgentResponder(report, 1),
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				methods := result.Meta.GetSupportedMethods()
+				assert.Contains(t, methods, "get_report")
+				assert.Contains(t, methods, "get_config")
+				assert.Contains(t, methods, "submit_event")
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result, err := exchangeWithResponder(t, client, tc.ifNewerThan, tc.responder)
+
+			require.NoError(t, err)
+			if tc.checkResult != nil {
+				tc.checkResult(t, result)
+			}
+		})
+	}
+}

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -2,8 +2,11 @@ package vsockclient
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	roxagentvsock "github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -14,10 +17,16 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// exchangeTimeout bounds a single client/handler exchange. Under synctest the
+// fake clock advances this duration instantly once every goroutine is durably
+// blocked (e.g. a protocol deadlock on net.Pipe), so GetReport's context
+// cancel closes the stream via AfterFunc and the test fails fast instead of
+// hanging the package.
+const exchangeTimeout = 5 * time.Second
+
 // protocolHarness drives a real Sensor client against a real roxagent handler
 // over net.Pipe(), validating the protocol contract end-to-end.
 type protocolHarness struct {
-	t       testing.TB
 	client  *Client
 	cache   *roxagentvsock.ReportCache
 	handler *roxagentvsock.Handler
@@ -31,7 +40,7 @@ type protocolHarnessOptions struct {
 	seedFacts       map[string]string
 }
 
-func newProtocolHarness(t testing.TB, opts protocolHarnessOptions) *protocolHarness {
+func newProtocolHarness(t *testing.T, opts protocolHarnessOptions) *protocolHarness {
 	t.Helper()
 
 	if opts.capabilities == nil {
@@ -50,27 +59,50 @@ func newProtocolHarness(t testing.TB, opts protocolHarnessOptions) *protocolHarn
 	}
 
 	return &protocolHarness{
-		t:       t,
 		client:  NewClient(opts.capabilities, opts.maxResponseSize),
 		cache:   cache,
 		handler: roxagentvsock.NewHandler(cache, opts.agentVersion),
 	}
 }
 
-func (h *protocolHarness) getReport(ifNewerThan, knownEpoch uint32) (*GetReportResult, error) {
-	h.t.Helper()
+func (h *protocolHarness) getReport(t *testing.T, ifNewerThan, knownEpoch uint32) (*GetReportResult, error) {
+	t.Helper()
+	return exchangeOnce(t, h.client, ifNewerThan, knownEpoch, h.handler.HandleConn)
+}
 
-	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
+// exchangeOnce runs a single GetReport against responder over net.Pipe()
+// inside a synctest bubble. A stuck peer makes the exchange timeout fire on
+// the fake clock (via GetReport's AfterFunc stream close) instead of hanging
+// the package on wall time.
+func exchangeOnce(t *testing.T, client *Client, ifNewerThan, knownEpoch uint32, responder func(net.Conn)) (*GetReportResult, error) {
+	t.Helper()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		h.handler.HandleConn(agentConn)
-	}()
+	var result *GetReportResult
+	var err error
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), exchangeTimeout)
+		defer cancel()
 
-	result, err := h.client.GetReport(context.Background(), clientConn, ifNewerThan, knownEpoch)
-	<-done
+		clientConn, agentConn := net.Pipe()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			responder(agentConn)
+		}()
+
+		result, err = client.GetReport(ctx, clientConn, ifNewerThan, knownEpoch)
+		// Close the client end before waiting so a responder blocked in WriteFrame
+		// (or similar) is unblocked even when GetReport already returned.
+		_ = clientConn.Close()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			if err == nil {
+				err = fmt.Errorf("waiting for responder: %w", ctx.Err())
+			}
+		}
+	})
 	return result, err
 }
 
@@ -151,7 +183,7 @@ func TestGetReportIntegration(t *testing.T) {
 				agentVersion: tc.agentVersion,
 			})
 
-			result, err := h.getReport(tc.ifNewerThan, tc.knownEpoch)
+			result, err := h.getReport(t, tc.ifNewerThan, tc.knownEpoch)
 
 			if tc.wantErr != nil {
 				require.Error(t, err)
@@ -167,41 +199,41 @@ func TestGetReportIntegration(t *testing.T) {
 }
 
 // TestGetReportIntegration_KnownEpochSingleRoundTrip drives a real Client
-// against a real roxagent Handler to verify the single-round-trip contract:
+// against a real roxagent Handler to verify the single-round-trip contract.
 // report_generation resets to 1 on every roxagent restart, so a restarted
 // agent can coincidentally match a generation Sensor already has cached.
-// Before known_epoch, Sensor could only detect this from the response epoch
-// and had to make a second, forced request. Now the agent resolves it
-// itself, in the same response, using the epoch Sensor reports knowing.
+// known_epoch lets the agent detect that restart itself, in a single round
+// trip, by comparing Sensor's last-seen epoch against its current one.
 func TestGetReportIntegration_KnownEpochSingleRoundTrip(t *testing.T) {
 	h := newProtocolHarness(t, protocolHarnessOptions{
 		seedReport: &v4.IndexReport{HashId: "epoch-test-hash"},
 	})
 
 	// First-ever request for this VM: Sensor has no cached epoch yet.
-	first, err := h.getReport(0, 0)
+	first, err := h.getReport(t, 0, 0)
 	require.NoError(t, err)
 	require.False(t, first.Unchanged)
 	epoch := first.Meta.GetEpoch()
 	require.NotZero(t, epoch, "agent should seed a non-zero epoch")
 
 	t.Run("unchanged in a single round trip when known epoch matches", func(t *testing.T) {
-		result, err := h.getReport(1, epoch)
+		result, err := h.getReport(t, 1, epoch)
 		require.NoError(t, err)
 		assert.True(t, result.Unchanged)
 		assert.Nil(t, result.IndexReport)
 	})
 
 	t.Run("full report in a single round trip when known epoch mismatches despite matching generation", func(t *testing.T) {
-		result, err := h.getReport(1, epoch+1)
+		result, err := h.getReport(t, 1, epoch+1)
 		require.NoError(t, err)
 		assert.False(t, result.Unchanged, "epoch mismatch must be resolved in this same response, not a second dial")
 		require.NotNil(t, result.IndexReport)
 		assert.Equal(t, "epoch-test-hash", result.IndexReport.GetHashId())
+		assert.Equal(t, epoch, result.Meta.GetEpoch(), "response must carry the agent's current epoch")
 	})
 
 	t.Run("unchanged when known epoch is zero (backward compat: falls back to generation-only)", func(t *testing.T) {
-		result, err := h.getReport(1, 0)
+		result, err := h.getReport(t, 1, 0)
 		require.NoError(t, err)
 		assert.True(t, result.Unchanged)
 	})
@@ -209,70 +241,57 @@ func TestGetReportIntegration_KnownEpochSingleRoundTrip(t *testing.T) {
 
 // --- Compatibility persona helpers ---
 
-// exchangeWithResponder runs a single GetReport exchange using a fake agent
-// responder instead of the real handler. This allows testing protocol
-// compatibility with simulated older or future agent behavior.
-func exchangeWithResponder(t *testing.T, client *Client, ifNewerThan uint32, responder func(net.Conn)) (*GetReportResult, error) {
-	t.Helper()
+// respondOnce reads one framed VMServiceRequest, builds a response, and writes
+// it back. Used by fake agent personas that only differ in response content.
+func respondOnce(conn net.Conn, build func(*pb.VMServiceRequest) *pb.VMServiceResponse) {
+	defer func() { _ = conn.Close() }()
 
-	clientConn, agentConn := net.Pipe()
-	defer func() { _ = clientConn.Close() }()
+	reqData, err := vsockframing.ReadFrame(conn, 1<<20)
+	if err != nil {
+		return
+	}
+	var req pb.VMServiceRequest
+	if err := proto.Unmarshal(reqData, &req); err != nil {
+		return
+	}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		responder(agentConn)
-	}()
-
-	result, err := client.GetReport(context.Background(), clientConn, ifNewerThan, 0)
-	<-done
-	return result, err
+	resp := build(&req)
+	respData, err := proto.Marshal(resp)
+	if err != nil {
+		return
+	}
+	_ = vsockframing.WriteFrame(conn, respData)
 }
 
 // oldAgentResponder models a plausible older roxagent that:
 //   - supports only get_report
 //   - does not advertise supported_methods
-//   - does not include facts or report_generated_at
-//   - always returns the full report (ignores last_known_generation)
+//   - does not include facts, report_generated_at, or epoch
+//   - always returns the full report (ignores last_known_generation and known_epoch)
 //   - returns UNKNOWN_METHOD for anything else
 func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
 	return func(conn net.Conn) {
-		defer func() { _ = conn.Close() }()
-
-		reqData, err := vsockframing.ReadFrame(conn, 1<<20)
-		if err != nil {
-			return
-		}
-		var req pb.VMServiceRequest
-		if err := proto.Unmarshal(reqData, &req); err != nil {
-			return
-		}
-
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{
-				AgentVersion:     "roxagent-0.1.0",
-				ReportGeneration: generation,
-			},
-		}
-
-		if req.GetGetReport() != nil {
-			resp.Result = &pb.VMServiceResponse_GetReport{
-				GetReport: &pb.GetReportResponse{IndexReport: report},
-			}
-		} else {
-			resp.Result = &pb.VMServiceResponse_Error{
-				Error: &pb.ErrorResponse{
-					Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
-					Message: "unsupported method",
+		respondOnce(conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
+			resp := &pb.VMServiceResponse{
+				Meta: &pb.ResponseMeta{
+					AgentVersion:     "roxagent-0.1.0",
+					ReportGeneration: generation,
 				},
 			}
-		}
-
-		respData, err := proto.Marshal(resp)
-		if err != nil {
-			return
-		}
-		_ = vsockframing.WriteFrame(conn, respData)
+			if req.GetGetReport() != nil {
+				resp.Result = &pb.VMServiceResponse_GetReport{
+					GetReport: &pb.GetReportResponse{IndexReport: report},
+				}
+			} else {
+				resp.Result = &pb.VMServiceResponse_Error{
+					Error: &pb.ErrorResponse{
+						Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
+						Message: "unsupported method",
+					},
+				}
+			}
+			return resp
+		})
 	}
 }
 
@@ -284,51 +303,36 @@ func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn)
 //   - returns UNKNOWN_METHOD for methods it doesn't recognize
 func futureAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
 	return func(conn net.Conn) {
-		defer func() { _ = conn.Close() }()
-
-		reqData, err := vsockframing.ReadFrame(conn, 1<<20)
-		if err != nil {
-			return
-		}
-		var req pb.VMServiceRequest
-		if err := proto.Unmarshal(reqData, &req); err != nil {
-			return
-		}
-
-		resp := &pb.VMServiceResponse{
-			Meta: &pb.ResponseMeta{
-				AgentVersion:     "roxagent-2.0.0-future",
-				ReportGeneration: generation,
-				SupportedMethods: []string{"get_report", "get_config", "submit_event"},
-				Facts:            map[string]string{"os_id": "rhel", "protocol_version": "2"},
-			},
-		}
-
-		switch {
-		case req.GetGetReport() != nil:
-			if req.GetGetReport().GetLastKnownGeneration() == generation {
-				resp.Result = &pb.VMServiceResponse_GetReport{
-					GetReport: &pb.GetReportResponse{Unchanged: true},
-				}
-			} else {
-				resp.Result = &pb.VMServiceResponse_GetReport{
-					GetReport: &pb.GetReportResponse{IndexReport: report},
-				}
-			}
-		default:
-			resp.Result = &pb.VMServiceResponse_Error{
-				Error: &pb.ErrorResponse{
-					Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
-					Message: "unsupported method",
+		respondOnce(conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
+			resp := &pb.VMServiceResponse{
+				Meta: &pb.ResponseMeta{
+					AgentVersion:     "roxagent-2.0.0-future",
+					ReportGeneration: generation,
+					SupportedMethods: []string{"get_report", "get_config", "submit_event"},
+					Facts:            map[string]string{"os_id": "rhel", "protocol_version": "2"},
 				},
 			}
-		}
-
-		respData, err := proto.Marshal(resp)
-		if err != nil {
-			return
-		}
-		_ = vsockframing.WriteFrame(conn, respData)
+			switch {
+			case req.GetGetReport() != nil:
+				if req.GetGetReport().GetLastKnownGeneration() == generation {
+					resp.Result = &pb.VMServiceResponse_GetReport{
+						GetReport: &pb.GetReportResponse{Unchanged: true},
+					}
+				} else {
+					resp.Result = &pb.VMServiceResponse_GetReport{
+						GetReport: &pb.GetReportResponse{IndexReport: report},
+					}
+				}
+			default:
+				resp.Result = &pb.VMServiceResponse_Error{
+					Error: &pb.ErrorResponse{
+						Code:    pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD,
+						Message: "unsupported method",
+					},
+				}
+			}
+			return resp
+		})
 	}
 }
 
@@ -340,6 +344,7 @@ func TestGetReportCompatibility(t *testing.T) {
 		// Arguments
 		responder   func(net.Conn)
 		ifNewerThan uint32
+		knownEpoch  uint32
 		// Expectations
 		checkResult func(t *testing.T, result *GetReportResult)
 	}{
@@ -361,6 +366,16 @@ func TestGetReportCompatibility(t *testing.T) {
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged, "old agent does not support unchanged optimization")
 				require.NotNil(t, result.IndexReport)
+			},
+		},
+		"old agent should tolerate non-zero known_epoch and omit epoch in response": {
+			responder:   oldAgentResponder(report, 1),
+			ifNewerThan: 1,
+			knownEpoch:  42,
+			checkResult: func(t *testing.T, result *GetReportResult) {
+				assert.False(t, result.Unchanged)
+				require.NotNil(t, result.IndexReport)
+				assert.Zero(t, result.Meta.GetEpoch(), "old agent does not populate epoch")
 			},
 		},
 		"future agent should serve get_report to current sensor": {
@@ -398,7 +413,7 @@ func TestGetReportCompatibility(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result, err := exchangeWithResponder(t, client, tc.ifNewerThan, tc.responder)
+			result, err := exchangeOnce(t, client, tc.ifNewerThan, tc.knownEpoch, tc.responder)
 
 			require.NoError(t, err)
 			if tc.checkResult != nil {

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -1,6 +1,7 @@
 package vsockclient
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -68,7 +69,7 @@ func (h *protocolHarness) getReport(ifNewerThan, knownEpoch uint32) (*GetReportR
 		h.handler.HandleConn(agentConn)
 	}()
 
-	result, err := h.client.GetReport(clientConn, ifNewerThan, knownEpoch)
+	result, err := h.client.GetReport(context.Background(), clientConn, ifNewerThan, knownEpoch)
 	<-done
 	return result, err
 }
@@ -223,7 +224,7 @@ func exchangeWithResponder(t *testing.T, client *Client, ifNewerThan uint32, res
 		responder(agentConn)
 	}()
 
-	result, err := client.GetReport(clientConn, ifNewerThan, 0)
+	result, err := client.GetReport(context.Background(), clientConn, ifNewerThan, 0)
 	<-done
 	return result, err
 }

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -122,14 +122,16 @@ func TestGetReportIntegration(t *testing.T) {
 			wantErr: ErrNotReady,
 		},
 		"should return full report when cache has report": {
-			seedReport: &v4.IndexReport{HashId: "integration-test-hash"},
-			seedFacts:  map[string]string{"os": "rhel", "arch": "x86_64"},
+			seedReport:   &v4.IndexReport{HashId: "integration-test-hash"},
+			seedFacts:    map[string]string{"os": "rhel", "arch": "x86_64"},
+			agentVersion: "roxagent-0.3.1-deadbeef",
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged)
 				require.NotNil(t, result.IndexReport)
 				assert.Equal(t, "integration-test-hash", result.IndexReport.GetHashId())
 
 				require.NotNil(t, result.Meta)
+				assert.Equal(t, "roxagent-0.3.1-deadbeef", result.Meta.GetAgentVersion())
 				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
 				assert.NotNil(t, result.Meta.GetReportGeneratedAt())
 				assert.Contains(t, result.Meta.GetSupportedMethods(), "get_report")
@@ -154,23 +156,8 @@ func TestGetReportIntegration(t *testing.T) {
 				require.NotNil(t, result.IndexReport)
 				assert.Equal(t, "post-restart-hash", result.IndexReport.GetHashId())
 				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
-			},
-		},
-		"should deliver all agent metadata to sensor": {
-			seedReport:   &v4.IndexReport{HashId: "meta-hash"},
-			seedFacts:    map[string]string{"os_id": "rhel", "kernel": "5.14.0", "instance_id": "i-abc123"},
-			agentVersion: "roxagent-0.3.1-deadbeef",
-			checkResult: func(t *testing.T, result *GetReportResult) {
-				require.NotNil(t, result.Meta)
-				assert.Equal(t, "roxagent-0.3.1-deadbeef", result.Meta.GetAgentVersion())
-				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
 				assert.NotNil(t, result.Meta.GetReportGeneratedAt())
 				assert.Contains(t, result.Meta.GetSupportedMethods(), "get_report")
-
-				facts := result.Meta.GetFacts()
-				assert.Equal(t, "rhel", facts["os_id"])
-				assert.Equal(t, "5.14.0", facts["kernel"])
-				assert.Equal(t, "i-abc123", facts["instance_id"])
 			},
 		},
 	}
@@ -243,24 +230,33 @@ func TestGetReportIntegration_KnownEpochSingleRoundTrip(t *testing.T) {
 
 // respondOnce reads one framed VMServiceRequest, builds a response, and writes
 // it back. Used by fake agent personas that only differ in response content.
-func respondOnce(conn net.Conn, build func(*pb.VMServiceRequest) *pb.VMServiceResponse) {
+// Framing/protobuf failures here mean the harness itself is broken rather
+// than the protocol under test, so they're logged (not asserted) to help
+// triage without failing the test on the wrong line.
+func respondOnce(t testing.TB, conn net.Conn, build func(*pb.VMServiceRequest) *pb.VMServiceResponse) {
+	t.Helper()
 	defer func() { _ = conn.Close() }()
 
 	reqData, err := vsockframing.ReadFrame(conn, 1<<20)
 	if err != nil {
+		t.Logf("respondOnce: reading request frame: %v", err)
 		return
 	}
 	var req pb.VMServiceRequest
 	if err := proto.Unmarshal(reqData, &req); err != nil {
+		t.Logf("respondOnce: unmarshalling request: %v", err)
 		return
 	}
 
 	resp := build(&req)
 	respData, err := proto.Marshal(resp)
 	if err != nil {
+		t.Logf("respondOnce: marshalling response: %v", err)
 		return
 	}
-	_ = vsockframing.WriteFrame(conn, respData)
+	if err := vsockframing.WriteFrame(conn, respData); err != nil {
+		t.Logf("respondOnce: writing response frame: %v", err)
+	}
 }
 
 // oldAgentResponder models a plausible older roxagent that:
@@ -269,9 +265,9 @@ func respondOnce(conn net.Conn, build func(*pb.VMServiceRequest) *pb.VMServiceRe
 //   - does not include facts, report_generated_at, or epoch
 //   - always returns the full report (ignores last_known_generation and known_epoch)
 //   - returns UNKNOWN_METHOD for anything else
-func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
+func oldAgentResponder(t testing.TB, report *v4.IndexReport, generation uint32) func(net.Conn) {
 	return func(conn net.Conn) {
-		respondOnce(conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
+		respondOnce(t, conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
 			resp := &pb.VMServiceResponse{
 				Meta: &pb.ResponseMeta{
 					AgentVersion:     "roxagent-0.1.0",
@@ -301,9 +297,9 @@ func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn)
 //   - includes richer metadata (facts, supported_methods)
 //   - supports last_known_generation (unchanged semantics)
 //   - returns UNKNOWN_METHOD for methods it doesn't recognize
-func futureAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
+func futureAgentResponder(t testing.TB, report *v4.IndexReport, generation uint32) func(net.Conn) {
 	return func(conn net.Conn) {
-		respondOnce(conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
+		respondOnce(t, conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
 			resp := &pb.VMServiceResponse{
 				Meta: &pb.ResponseMeta{
 					AgentVersion:     "roxagent-2.0.0-future",
@@ -336,50 +332,59 @@ func futureAgentResponder(report *v4.IndexReport, generation uint32) func(net.Co
 	}
 }
 
+// assertOldAgentReport checks the properties every old-agent compatibility
+// case expects regardless of the request that triggered them: an old agent
+// always serves the full report under its fixed identity and never
+// advertises newer protocol metadata.
+func assertOldAgentReport(t *testing.T, result *GetReportResult) {
+	t.Helper()
+	require.NotNil(t, result.IndexReport)
+	assert.Equal(t, "compat-hash", result.IndexReport.GetHashId())
+	assert.Equal(t, "roxagent-0.1.0", result.Meta.GetAgentVersion())
+	assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+	assert.Empty(t, result.Meta.GetSupportedMethods())
+	assert.Empty(t, result.Meta.GetFacts())
+}
+
 func TestGetReportCompatibility(t *testing.T) {
 	report := &v4.IndexReport{HashId: "compat-hash"}
 	client := NewClient([]string{CapabilityReportV1}, 10<<20)
 
 	cases := map[string]struct {
 		// Arguments
-		responder   func(net.Conn)
-		ifNewerThan uint32
-		knownEpoch  uint32
+		makeResponderFunc func(t testing.TB) func(net.Conn)
+		ifNewerThan       uint32
+		knownEpoch        uint32
 		// Expectations
 		checkResult func(t *testing.T, result *GetReportResult)
 	}{
 		"old agent should serve get_report to current sensor": {
-			responder: oldAgentResponder(report, 1),
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report, 1) },
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged)
-				require.NotNil(t, result.IndexReport)
-				assert.Equal(t, "compat-hash", result.IndexReport.GetHashId())
-				assert.Equal(t, "roxagent-0.1.0", result.Meta.GetAgentVersion())
-				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
-				assert.Empty(t, result.Meta.GetSupportedMethods())
-				assert.Empty(t, result.Meta.GetFacts())
+				assertOldAgentReport(t, result)
 			},
 		},
 		"old agent should always return full report ignoring last_known_generation": {
-			responder:   oldAgentResponder(report, 1),
-			ifNewerThan: 1,
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report, 1) },
+			ifNewerThan:       1,
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged, "old agent does not support unchanged optimization")
-				require.NotNil(t, result.IndexReport)
+				assertOldAgentReport(t, result)
 			},
 		},
 		"old agent should tolerate non-zero known_epoch and omit epoch in response": {
-			responder:   oldAgentResponder(report, 1),
-			ifNewerThan: 1,
-			knownEpoch:  42,
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report, 1) },
+			ifNewerThan:       1,
+			knownEpoch:        42,
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged)
-				require.NotNil(t, result.IndexReport)
+				assertOldAgentReport(t, result)
 				assert.Zero(t, result.Meta.GetEpoch(), "old agent does not populate epoch")
 			},
 		},
 		"future agent should serve get_report to current sensor": {
-			responder: futureAgentResponder(report, 1),
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return futureAgentResponder(t, report, 1) },
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged)
 				require.NotNil(t, result.IndexReport)
@@ -392,28 +397,19 @@ func TestGetReportCompatibility(t *testing.T) {
 			},
 		},
 		"future agent should return unchanged when generation matches": {
-			responder:   futureAgentResponder(report, 3),
-			ifNewerThan: 3,
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return futureAgentResponder(t, report, 3) },
+			ifNewerThan:       3,
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.True(t, result.Unchanged)
 				assert.Nil(t, result.IndexReport)
 				assert.Equal(t, uint32(3), result.Meta.GetReportGeneration())
 			},
 		},
-		"future agent extra supported_methods are discoverable by sensor": {
-			responder: futureAgentResponder(report, 1),
-			checkResult: func(t *testing.T, result *GetReportResult) {
-				methods := result.Meta.GetSupportedMethods()
-				assert.Contains(t, methods, "get_report")
-				assert.Contains(t, methods, "get_config")
-				assert.Contains(t, methods, "submit_event")
-			},
-		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result, err := exchangeOnce(t, client, tc.ifNewerThan, tc.knownEpoch, tc.responder)
+			result, err := exchangeOnce(t, client, tc.ifNewerThan, tc.knownEpoch, tc.makeResponderFunc(t))
 
 			require.NoError(t, err)
 			if tc.checkResult != nil {

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -56,7 +56,7 @@ func newProtocolHarness(t testing.TB, opts protocolHarnessOptions) *protocolHarn
 	}
 }
 
-func (h *protocolHarness) getReport(ifNewerThan uint32) (*GetReportResult, error) {
+func (h *protocolHarness) getReport(ifNewerThan, knownEpoch uint32) (*GetReportResult, error) {
 	h.t.Helper()
 
 	clientConn, agentConn := net.Pipe()
@@ -68,7 +68,7 @@ func (h *protocolHarness) getReport(ifNewerThan uint32) (*GetReportResult, error
 		h.handler.HandleConn(agentConn)
 	}()
 
-	result, err := h.client.GetReport(clientConn, ifNewerThan)
+	result, err := h.client.GetReport(clientConn, ifNewerThan, knownEpoch)
 	<-done
 	return result, err
 }
@@ -80,6 +80,7 @@ func TestGetReportIntegration(t *testing.T) {
 		seedFacts    map[string]string
 		agentVersion string
 		ifNewerThan  uint32
+		knownEpoch   uint32
 		// Expectations
 		wantErr     error
 		checkResult func(t *testing.T, result *GetReportResult)
@@ -149,7 +150,7 @@ func TestGetReportIntegration(t *testing.T) {
 				agentVersion: tc.agentVersion,
 			})
 
-			result, err := h.getReport(tc.ifNewerThan)
+			result, err := h.getReport(tc.ifNewerThan, tc.knownEpoch)
 
 			if tc.wantErr != nil {
 				require.Error(t, err)
@@ -162,6 +163,47 @@ func TestGetReportIntegration(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetReportIntegration_KnownEpochSingleRoundTrip drives a real Client
+// against a real roxagent Handler to verify the single-round-trip contract:
+// report_generation resets to 1 on every roxagent restart, so a restarted
+// agent can coincidentally match a generation Sensor already has cached.
+// Before known_epoch, Sensor could only detect this from the response epoch
+// and had to make a second, forced request. Now the agent resolves it
+// itself, in the same response, using the epoch Sensor reports knowing.
+func TestGetReportIntegration_KnownEpochSingleRoundTrip(t *testing.T) {
+	h := newProtocolHarness(t, protocolHarnessOptions{
+		seedReport: &v4.IndexReport{HashId: "epoch-test-hash"},
+	})
+
+	// First-ever request for this VM: Sensor has no cached epoch yet.
+	first, err := h.getReport(0, 0)
+	require.NoError(t, err)
+	require.False(t, first.Unchanged)
+	epoch := first.Meta.GetEpoch()
+	require.NotZero(t, epoch, "agent should seed a non-zero epoch")
+
+	t.Run("unchanged in a single round trip when known epoch matches", func(t *testing.T) {
+		result, err := h.getReport(1, epoch)
+		require.NoError(t, err)
+		assert.True(t, result.Unchanged)
+		assert.Nil(t, result.IndexReport)
+	})
+
+	t.Run("full report in a single round trip when known epoch mismatches despite matching generation", func(t *testing.T) {
+		result, err := h.getReport(1, epoch+1)
+		require.NoError(t, err)
+		assert.False(t, result.Unchanged, "epoch mismatch must be resolved in this same response, not a second dial")
+		require.NotNil(t, result.IndexReport)
+		assert.Equal(t, "epoch-test-hash", result.IndexReport.GetHashId())
+	})
+
+	t.Run("unchanged when known epoch is zero (backward compat: falls back to generation-only)", func(t *testing.T) {
+		result, err := h.getReport(1, 0)
+		require.NoError(t, err)
+		assert.True(t, result.Unchanged)
+	})
 }
 
 // --- Compatibility persona helpers ---
@@ -181,7 +223,7 @@ func exchangeWithResponder(t *testing.T, client *Client, ifNewerThan uint32, res
 		responder(agentConn)
 	}()
 
-	result, err := client.GetReport(clientConn, ifNewerThan)
+	result, err := client.GetReport(clientConn, ifNewerThan, 0)
 	<-done
 	return result, err
 }
@@ -190,7 +232,7 @@ func exchangeWithResponder(t *testing.T, client *Client, ifNewerThan uint32, res
 //   - supports only get_report
 //   - does not advertise supported_methods
 //   - does not include facts or report_generated_at
-//   - always returns the full report (ignores if_newer_than_generation)
+//   - always returns the full report (ignores last_known_generation)
 //   - returns UNKNOWN_METHOD for anything else
 func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
 	return func(conn net.Conn) {
@@ -237,7 +279,7 @@ func oldAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn)
 //   - advertises extra supported_methods beyond get_report
 //   - still handles get_report correctly
 //   - includes richer metadata (facts, supported_methods)
-//   - supports if_newer_than_generation (unchanged semantics)
+//   - supports last_known_generation (unchanged semantics)
 //   - returns UNKNOWN_METHOD for methods it doesn't recognize
 func futureAgentResponder(report *v4.IndexReport, generation uint32) func(net.Conn) {
 	return func(conn net.Conn) {
@@ -263,7 +305,7 @@ func futureAgentResponder(report *v4.IndexReport, generation uint32) func(net.Co
 
 		switch {
 		case req.GetGetReport() != nil:
-			if req.GetGetReport().GetIfNewerThanGeneration() == generation {
+			if req.GetGetReport().GetLastKnownGeneration() == generation {
 				resp.Result = &pb.VMServiceResponse_GetReport{
 					GetReport: &pb.GetReportResponse{Unchanged: true},
 				}
@@ -312,7 +354,7 @@ func TestGetReportCompatibility(t *testing.T) {
 				assert.Empty(t, result.Meta.GetFacts())
 			},
 		},
-		"old agent should always return full report ignoring if_newer_than": {
+		"old agent should always return full report ignoring last_known_generation": {
 			responder:   oldAgentResponder(report, 1),
 			ifNewerThan: 1,
 			checkResult: func(t *testing.T, result *GetReportResult) {

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -368,6 +368,13 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 	if validImportRoot == "sensor/common" {
 		// Need this for unit tests.
 		allowedPackages = appendPackageWithChildren(allowedPackages, "sensor/debugger")
+		if isTestFile {
+			// vsockclient's integration test drives a real roxagent vsockserver
+			// handler over net.Pipe() to validate the wire protocol contract.
+			// roxagent ships as a separate binary from Sensor, so this exception
+			// is scoped to test files only.
+			allowedPackages = appendPackageWithoutChildren(allowedPackages, "compliance/virtualmachines/roxagent/vsockserver")
+		}
 	}
 
 	if validImportRoot == "central" {


### PR DESCRIPTION
## Description

Adds an end-to-end integration test suite (`sensor/common/virtualmachine/vsockclient/client_integration_test.go`) that drives a real Sensor `vsockclient.Client` against a real roxagent `vsockserver.Handler` over `net.Pipe()`.
It validates the VSOCK pull-mode wire protocol contract:

- initial/full report delivery and "not ready" behavior while the agent's first scan is still in progress
- unchanged-report short-circuiting when the report generation matches
- single-round-trip epoch handling (agent-restart detection without an extra round trip, and backward compatibility when the epoch is unknown/zero)
- agent metadata (version, capabilities) delivered alongside the report

Also scopes a `roxvet` `validateimports` exception so that only **test** files under `sensor/common` may import `compliance/virtualmachines/roxagent/vsockserver`.
Production code under `sensor/common` remains disallowed from importing roxagent packages.

Sensor-side (`vsockclient`) and roxagent-side (`vsockserver`) protocol code are developed and reviewed as independent branches/PRs (git-spice can't represent a fork/diamond dependency in a linear stack), but the wire protocol contract between them needs a test that exercises both sides together.
This PR carries that cross-cutting coverage on its own branch, now based on `master` after #21434 and #21435 merged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

This PR *is* the automated test coverage: it adds new integration tests, with no production code changes.

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [x] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- CI