### PR TITLE
ROX-35668: Add lock on init to avoid race

### DIFF
--- a/central/networkgraph/entity/networktree/manager_impl.go
+++ b/central/networkgraph/entity/networktree/manager_impl.go
@@ -30,6 +30,9 @@ type managerImpl struct {
 func (f *managerImpl) Initialize(entitiesByCluster map[string][]*storage.NetworkEntityInfo) error {
 	defer f.initializedSig.Signal()
 
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
 	for cluster, entities := range entitiesByCluster {
 		if _, err := f.createNoLock(cluster, entities...); err != nil {
 			return err


### PR DESCRIPTION
## Description

**Fix comes from CI Fixing Factory**

The bug: `managerImpl.Initialize()` accesses the trees map without holding any lock, but it runs in a background goroutine.

Here's the chain:

1. When a `networkEntityDataStore` is created (`datastore_impl.go:75`), it spawns `go ds.initNetworkTrees(...)`, which eventually calls `manager.Initialize()`.
2. `Initialize()` iterates over clusters and calls `createNoLock()`, which reads and writes `f.trees` - a plain `map[string]tree.NetworkTree`.
3. Meanwhile, test teardown (or any other caller) can invoke `DeleteNetworkTree()` or `GetNetworkTree()`. Those methods do acquire the lock — but they only wait for `initializedSig` first. In a test suite using the singleton manager, `initializedSig` may already be signaled from a previous test's init, so they proceed immediately and access the same map concurrently.

The race detector caught two specific conflicts:
- Race 1: createNoLock reading f.trees[clusterID] (line 84) vs DeleteNetworkTree deleting from f.trees (line 110)
- Race 2: createNoLock writing f.trees[clusterID] = t (line 97) vs GetNetworkTree reading f.trees[clusterID] (line 50)

The fix adds `f.lock.Lock() / defer f.lock.Unlock()` at the top of `Initialize()`, so the map mutations in createNoLock are synchronized with every other method that touches f.trees. The defer order matters - Go defers are LIFO, so `Unlock()` runs before `Signal()`, which means the lock is released before any waiter on `initializedSig` wakes up and tries to acquire it.

**Author Note**
- this PR changes production code. Change is reasonable - but with current implementation and how manager is used (always singleton) - it is not relevant for production code.
- in tests where singleton is re-initialized and used across tests, this change is important.
- better solution would be larger refactoring of all tests that use manager and always create new manager per test/suite, instead of using singleton. In that way, we would have better isolation.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] no test changes

### How I validated my change

- [x] run tests locally
- [x] run tests in CI
