### PR TITLE
ROX-35370: Fix CVE-2026-99999

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1293,6 +1293,7 @@ jobs:
       (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
     permissions:
       id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -1306,6 +1307,12 @@ jobs:
             "stackrox-operator",
           ]
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Scan image vulnerabilities
         uses: stackrox/actions/release/scan-image-vulnerabilities@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/scan-image-vulnerabilities@v1
         id: scan-image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1367,14 +1367,7 @@ jobs:
 
       - name: Extract CVE IDs from PR title
         id: extract-cves
-        run: |
-          cves="$(echo "$PR_TITLE" | grep -oiE 'CVE-[0-9]{4}-[0-9]+' | tr '[:lower:]' '[:upper:]' | sort -u | paste -sd ',' -)"
-          if [[ -z "$cves" ]]; then
-            echo "No CVE IDs found in PR title: $PR_TITLE" >&2
-            exit 1
-          fi
-          echo "cves=${cves}" >> "$GITHUB_OUTPUT"
-          echo "Found CVE IDs: ${cves}"
+        run: .github/workflows/scripts/extract-cve-ids.sh "$PR_TITLE"
 
       - name: Download all scan artifacts
         uses: ./.github/actions/download-artifact-with-retry
@@ -1384,73 +1377,29 @@ jobs:
 
       - name: Flatten scan results
         id: flatten
-        run: |
-          mkdir -p scan-results-flat
-          infra_failure=false
-          shopt -s nullglob
-          for dir in scan-results/cve-verify_*/; do
-            image_name="$(basename "$dir" | sed 's/^cve-verify_//' | sed 's/\.json$//')"
-            if [[ -f "${dir}scan-result.json" ]]; then
-              cp "${dir}scan-result.json" "scan-results-flat/${image_name}.json"
-            else
-              echo "::warning::No scan result for ${image_name}"
-              infra_failure=true
-            fi
-          done
-          shopt -u nullglob
-          # Verify every image verify-cve-fix-scan is expected to scan
-          # (kept in sync with that job's matrix) actually produced a
-          # result. A matrix leg that fails before reaching the scan step
-          # (e.g. a wait-for-image timeout or central-login flake) never
-          # uploads an artifact at all, so it wouldn't otherwise be
-          # detected by the loop above and could silently narrow the
-          # verdict to fewer than all 6 images.
-          expected_images=(central-db main roxctl scanner-v4 scanner-v4-db stackrox-operator)
-          for image in "${expected_images[@]}"; do
-            if [[ ! -f "scan-results-flat/${image}.json" ]]; then
-              echo "::warning::No scan result artifact was produced for ${image}"
-              infra_failure=true
-            fi
-          done
-          echo "infra-failure=${infra_failure}" >> "$GITHUB_OUTPUT"
+        run: >-
+          .github/workflows/scripts/flatten-cve-scan-results.sh
+          --source-dir scan-results
+          --dest-dir scan-results-flat
+          --expected-images central-db,main,roxctl,scanner-v4,scanner-v4-db,stackrox-operator
 
       - name: Verify CVE fix
         id: verify
-        run: |
-          set +e
-          comment_body="$(bash .github/workflows/scripts/verify-cve-fix.sh \
-            --cves "${{ steps.extract-cves.outputs.cves }}" \
-            --scan-dir scan-results-flat)"
-          exit_code=$?
-          set -e
-          delimiter="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
-          {
-            echo "comment<<${delimiter}"
-            echo "$comment_body"
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
-          echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"
+        run: >-
+          .github/workflows/scripts/run-cve-fix-verification.sh
+          --cves "${{ steps.extract-cves.outputs.cves }}"
+          --scan-dir scan-results-flat
 
       - name: Post PR comment
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: ${{ steps.verify.outputs.comment }}
-        run: |
-          if [[ "${{ steps.flatten.outputs.infra-failure }}" == "true" && "${{ steps.verify.outputs.exit-code }}" != "1" ]]; then
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'COMMENT_EOF'
-          **CVE Fix Verification: COULD NOT RUN** :warning:
-
-          The vulnerability scan could not complete due to an infrastructure error:
-
-          > One or more image scans failed to produce results.
-
-          **Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.
-          COMMENT_EOF
-          )"
-          else
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$COMMENT_BODY"
-          fi
+        run: >-
+          .github/workflows/scripts/post-cve-fix-comment.sh
+          --pr-number "${{ github.event.pull_request.number }}"
+          --infra-failure "${{ steps.flatten.outputs.infra-failure }}"
+          --exit-code "${{ steps.verify.outputs.exit-code }}"
 
       - name: Fail if CVE still present
         if: steps.verify.outputs.exit-code == '1'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1278,6 +1278,151 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
+  verify-cve-fix-scan:
+    name: "CVE scan: ${{ matrix.image }}:${{ needs.define-job-matrix.outputs.build-tag }}"
+    runs-on: ubuntu-latest
+    needs:
+      - define-job-matrix
+      - push-main-manifests
+      - push-scanner-manifests
+      - push-operator-manifests
+      - build-and-push-db
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.title, 'CVE-')
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          [
+            "central-db",
+            "main",
+            "roxctl",
+            "scanner-v4",
+            "scanner-v4-db",
+            "stackrox-operator",
+          ]
+    steps:
+      - name: Scan image vulnerabilities
+        uses: stackrox/actions/release/scan-image-vulnerabilities@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/scan-image-vulnerabilities@v1
+        id: scan-image
+        with:
+          image: rhacs-eng/${{ matrix.image }}
+          version: ${{ needs.define-job-matrix.outputs.build-tag }}
+          wait-limit: "1800"
+          summary-prefix: "CVE-fix-verify:"
+          quay-bearer-token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+          central-url: ${{ vars.ACS_DOGFOODING_CENTRAL_URL }}
+
+      - name: Upload scan result artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        with:
+          name: cve-verify_${{ matrix.image }}.json
+          path: ${{ steps.scan-image.outputs.result-path }}
+          retention-days: 7
+
+  verify-cve-fix:
+    name: "CVE fix verification"
+    runs-on: ubuntu-latest
+    needs:
+      - define-job-matrix
+      - verify-cve-fix-scan
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.title, 'CVE-')
+    permissions:
+      pull-requests: write
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Extract CVE IDs from PR title
+        id: extract-cves
+        run: |
+          cves="$(echo "$PR_TITLE" | grep -oiE 'CVE-[0-9]{4}-[0-9]+' | tr '[:lower:]' '[:upper:]' | sort -u | paste -sd ',' -)"
+          if [[ -z "$cves" ]]; then
+            echo "No CVE IDs found in PR title: $PR_TITLE" >&2
+            exit 1
+          fi
+          echo "cves=${cves}" >> "$GITHUB_OUTPUT"
+          echo "Found CVE IDs: ${cves}"
+
+      - name: Download all scan artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+        with:
+          pattern: cve-verify_*.json
+          path: scan-results
+          merge-multiple: false
+
+      - name: Flatten scan results
+        id: flatten
+        run: |
+          mkdir -p scan-results-flat
+          infra_failure=false
+          for dir in scan-results/cve-verify_*/; do
+            image_name="$(basename "$dir" | sed 's/^cve-verify_//' | sed 's/\.json$//')"
+            if [[ -f "${dir}scan-result.json" ]]; then
+              cp "${dir}scan-result.json" "scan-results-flat/${image_name}.json"
+            else
+              echo "::warning::No scan result for ${image_name}"
+              infra_failure=true
+            fi
+          done
+          # If no artifacts were downloaded at all, the directory won't exist
+          if [[ ! -d scan-results ]] || [[ -z "$(ls scan-results-flat/ 2>/dev/null)" ]]; then
+            infra_failure=true
+          fi
+          echo "infra-failure=${infra_failure}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify CVE fix
+        id: verify
+        run: |
+          set +e
+          comment_body="$(bash .github/workflows/scripts/verify-cve-fix.sh \
+            --cves "${{ steps.extract-cves.outputs.cves }}" \
+            --scan-dir scan-results-flat)"
+          exit_code=$?
+          set -e
+          {
+            echo "comment<<COMMENT_EOF"
+            echo "$comment_body"
+            echo "COMMENT_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ steps.flatten.outputs.infra-failure }}" == "true" && "${{ steps.verify.outputs.exit-code }}" != "1" ]]; then
+            gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'COMMENT_EOF'
+          **CVE Fix Verification: COULD NOT RUN** :warning:
+
+          The vulnerability scan could not complete due to an infrastructure error:
+
+          > One or more image scans failed to produce results.
+
+          **Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.
+          COMMENT_EOF
+          )"
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" \
+              --body "${{ steps.verify.outputs.comment }}"
+          fi
+
+      - name: Fail if CVE still present
+        if: steps.verify.outputs.exit-code == '1'
+        run: exit 1
+
   slack-on-build-failure:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1302,6 +1447,7 @@ jobs:
       - pre-build-ui
       - push-matching-collector-scanner
       - scan-go-binaries
+      - verify-cve-fix
     permissions:
       actions: read
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1331,7 +1331,13 @@ jobs:
           central-url: ${{ vars.ACS_DOGFOODING_CENTRAL_URL }}
 
       - name: Upload scan result artifact
-        if: always()
+        # Skip (instead of erroring) when the scan step failed before it got
+        # far enough to set result-path (e.g. a wait-for-image timeout) -
+        # continue-on-error above means that failure wouldn't otherwise stop
+        # this step, and actions/upload-artifact hard-errors on an empty
+        # required `path` input. verify-cve-fix's own missing-image check
+        # still catches and reports this case non-blockingly.
+        if: always() && steps.scan-image.outputs.result-path != ''
         uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cve-verify_${{ matrix.image }}.json

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1289,7 +1289,8 @@ jobs:
       - build-and-push-db
     if: >-
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.title, 'CVE-')
+      contains(github.event.pull_request.title, 'CVE-') &&
+      (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
     permissions:
       id-token: write
     strategy:
@@ -1333,7 +1334,8 @@ jobs:
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.title, 'CVE-')
+      contains(github.event.pull_request.title, 'CVE-') &&
+      (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
     permissions:
       pull-requests: write
     env:
@@ -1368,6 +1370,7 @@ jobs:
         run: |
           mkdir -p scan-results-flat
           infra_failure=false
+          shopt -s nullglob
           for dir in scan-results/cve-verify_*/; do
             image_name="$(basename "$dir" | sed 's/^cve-verify_//' | sed 's/\.json$//')"
             if [[ -f "${dir}scan-result.json" ]]; then
@@ -1377,6 +1380,7 @@ jobs:
               infra_failure=true
             fi
           done
+          shopt -u nullglob
           # If no artifacts were downloaded at all, the directory won't exist
           if [[ ! -d scan-results ]] || [[ -z "$(ls scan-results-flat/ 2>/dev/null)" ]]; then
             infra_failure=true
@@ -1392,16 +1396,19 @@ jobs:
             --scan-dir scan-results-flat)"
           exit_code=$?
           set -e
+          delimiter="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
           {
-            echo "comment<<COMMENT_EOF"
+            echo "comment<<${delimiter}"
             echo "$comment_body"
-            echo "COMMENT_EOF"
+            echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
           echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"
 
       - name: Post PR comment
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ steps.verify.outputs.comment }}
         run: |
           if [[ "${{ steps.flatten.outputs.infra-failure }}" == "true" && "${{ steps.verify.outputs.exit-code }}" != "1" ]]; then
             gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'COMMENT_EOF'
@@ -1415,8 +1422,7 @@ jobs:
           COMMENT_EOF
           )"
           else
-            gh pr comment "${{ github.event.pull_request.number }}" \
-              --body "${{ steps.verify.outputs.comment }}"
+            gh pr comment "${{ github.event.pull_request.number }}" --body "$COMMENT_BODY"
           fi
 
       - name: Fail if CVE still present

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1309,6 +1309,12 @@ jobs:
       - name: Scan image vulnerabilities
         uses: stackrox/actions/release/scan-image-vulnerabilities@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/scan-image-vulnerabilities@v1
         id: scan-image
+        # The composite action fails on ANY fixable CRITICAL/IMPORTANT CVE in
+        # the image, not just the CVE(s) this PR is verifying. The scan
+        # result artifact is still produced (uploaded via if: always() below)
+        # and is what verify-cve-fix.sh actually checks, so a red X here must
+        # not fail this job / block the PR on unrelated pre-existing CVEs.
+        continue-on-error: true
         with:
           image: rhacs-eng/${{ matrix.image }}
           version: ${{ needs.define-job-matrix.outputs.build-tag }}
@@ -1319,11 +1325,10 @@ jobs:
 
       - name: Upload scan result artifact
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cve-verify_${{ matrix.image }}.json
           path: ${{ steps.scan-image.outputs.result-path }}
-          retention-days: 7
 
   verify-cve-fix:
     name: "CVE fix verification"
@@ -1359,11 +1364,10 @@ jobs:
           echo "Found CVE IDs: ${cves}"
 
       - name: Download all scan artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+        uses: ./.github/actions/download-artifact-with-retry
         with:
           pattern: cve-verify_*.json
           path: scan-results
-          merge-multiple: false
 
       - name: Flatten scan results
         id: flatten
@@ -1381,10 +1385,20 @@ jobs:
             fi
           done
           shopt -u nullglob
-          # If no artifacts were downloaded at all, the directory won't exist
-          if [[ ! -d scan-results ]] || [[ -z "$(ls scan-results-flat/ 2>/dev/null)" ]]; then
-            infra_failure=true
-          fi
+          # Verify every image verify-cve-fix-scan is expected to scan
+          # (kept in sync with that job's matrix) actually produced a
+          # result. A matrix leg that fails before reaching the scan step
+          # (e.g. a wait-for-image timeout or central-login flake) never
+          # uploads an artifact at all, so it wouldn't otherwise be
+          # detected by the loop above and could silently narrow the
+          # verdict to fewer than all 6 images.
+          expected_images=(central-db main roxctl scanner-v4 scanner-v4-db stackrox-operator)
+          for image in "${expected_images[@]}"; do
+            if [[ ! -f "scan-results-flat/${image}.json" ]]; then
+              echo "::warning::No scan result artifact was produced for ${image}"
+              infra_failure=true
+            fi
+          done
           echo "infra-failure=${infra_failure}" >> "$GITHUB_OUTPUT"
 
       - name: Verify CVE fix

--- a/.github/workflows/scripts/extract-cve-ids.sh
+++ b/.github/workflows/scripts/extract-cve-ids.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Extracts CVE IDs from a PR title and writes them to $GITHUB_OUTPUT.
+#
+# Usage: extract-cve-ids.sh <pr-title>
+#
+# Exit codes:
+#   0 - At least one CVE ID was found; written to $GITHUB_OUTPUT as `cves`
+#       (comma-separated, upper-cased, deduplicated).
+#   1 - No CVE IDs found in the given title.
+#
+set -euo pipefail
+
+PR_TITLE="${1:-}"
+
+cves="$(echo "$PR_TITLE" | grep -oiE 'CVE-[0-9]{4}-[0-9]+' | tr '[:lower:]' '[:upper:]' | sort -u | paste -sd ',' -)"
+if [[ -z "$cves" ]]; then
+  echo "No CVE IDs found in PR title: $PR_TITLE" >&2
+  exit 1
+fi
+echo "cves=${cves}" >> "$GITHUB_OUTPUT"
+echo "Found CVE IDs: ${cves}"

--- a/.github/workflows/scripts/flatten-cve-scan-results.sh
+++ b/.github/workflows/scripts/flatten-cve-scan-results.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Flattens per-image CVE scan result artifacts (as downloaded by
+# download-artifact-with-retry from the verify-cve-fix-scan matrix job) into
+# a single directory, and checks that every expected image produced a
+# result.
+#
+# Usage: flatten-cve-scan-results.sh --source-dir <dir> --dest-dir <dir> \
+#          --expected-images <img1,img2,...>
+#
+# The source directory is expected to contain one subdirectory per image,
+# named cve-verify_<image>.json/, each containing a scan-result.json file
+# (as uploaded by the "Upload scan result artifact" step). Each found
+# scan-result.json is copied to <dest-dir>/<image>.json.
+#
+# --expected-images should be kept in sync with the verify-cve-fix-scan
+# job's matrix: a matrix leg that fails before reaching the scan step (e.g.
+# a wait-for-image timeout or central-login flake) never uploads an
+# artifact at all, so it wouldn't otherwise be detected by the copy loop
+# and could silently narrow the verdict to fewer than all expected images.
+#
+# Writes `infra-failure=true|false` to $GITHUB_OUTPUT.
+#
+set -euo pipefail
+
+SOURCE_DIR=""
+DEST_DIR=""
+EXPECTED_IMAGES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-dir)
+      SOURCE_DIR="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    --dest-dir)
+      DEST_DIR="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    --expected-images)
+      EXPECTED_IMAGES="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$SOURCE_DIR" || -z "$DEST_DIR" || -z "$EXPECTED_IMAGES" ]]; then
+  echo "Usage: flatten-cve-scan-results.sh --source-dir <dir> --dest-dir <dir> --expected-images <img1,img2,...>" >&2
+  exit 2
+fi
+
+mkdir -p "$DEST_DIR"
+infra_failure=false
+shopt -s nullglob
+for dir in "${SOURCE_DIR}"/cve-verify_*/; do
+  image_name="$(basename "$dir" | sed 's/^cve-verify_//' | sed 's/\.json$//')"
+  if [[ -f "${dir}scan-result.json" ]]; then
+    cp "${dir}scan-result.json" "${DEST_DIR}/${image_name}.json"
+  else
+    echo "::warning::No scan result for ${image_name}"
+    infra_failure=true
+  fi
+done
+shopt -u nullglob
+
+IFS=',' read -ra expected_images_arr <<< "$EXPECTED_IMAGES"
+for image in "${expected_images_arr[@]}"; do
+  if [[ ! -f "${DEST_DIR}/${image}.json" ]]; then
+    echo "::warning::No scan result artifact was produced for ${image}"
+    infra_failure=true
+  fi
+done
+echo "infra-failure=${infra_failure}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/flatten-cve-scan-results.sh
+++ b/.github/workflows/scripts/flatten-cve-scan-results.sh
@@ -21,6 +21,11 @@
 #
 # Writes `infra-failure=true|false` to $GITHUB_OUTPUT.
 #
+# Exit codes:
+#   0 - Ran to completion; `infra-failure` output indicates whether any
+#       expected image was missing a scan result.
+#   2 - Invalid usage (bad or missing arguments)
+#
 set -euo pipefail
 
 SOURCE_DIR=""

--- a/.github/workflows/scripts/post-cve-fix-comment.sh
+++ b/.github/workflows/scripts/post-cve-fix-comment.sh
@@ -12,6 +12,10 @@
 #                   there was no infra failure (or the CVE(s) are still
 #                   present, i.e. exit-code 1).
 #
+# Exit codes:
+#   0 - Comment posted successfully
+#   2 - Invalid usage (bad or missing arguments)
+#
 set -euo pipefail
 
 PR_NUMBER=""

--- a/.github/workflows/scripts/post-cve-fix-comment.sh
+++ b/.github/workflows/scripts/post-cve-fix-comment.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Posts the CVE fix verification result as a PR comment: either a generic
+# "COULD NOT RUN" infra-failure message, or the actual verification comment
+# body, depending on whether the scan step hit an infrastructure failure.
+#
+# Usage: post-cve-fix-comment.sh --pr-number <n> --infra-failure <true|false> --exit-code <n>
+#
+# Reads from the environment:
+#   GH_TOKEN      - token used by `gh pr comment`.
+#   COMMENT_BODY  - the verification comment body to post, used whenever
+#                   there was no infra failure (or the CVE(s) are still
+#                   present, i.e. exit-code 1).
+#
+set -euo pipefail
+
+PR_NUMBER=""
+INFRA_FAILURE=""
+EXIT_CODE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr-number)
+      PR_NUMBER="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    --infra-failure)
+      INFRA_FAILURE="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    --exit-code)
+      EXIT_CODE="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PR_NUMBER" || -z "$INFRA_FAILURE" || -z "$EXIT_CODE" ]]; then
+  echo "Usage: post-cve-fix-comment.sh --pr-number <n> --infra-failure <true|false> --exit-code <n>" >&2
+  exit 2
+fi
+
+if [[ "$INFRA_FAILURE" == "true" && "$EXIT_CODE" != "1" ]]; then
+  gh pr comment "$PR_NUMBER" --body "$(cat <<'COMMENT_EOF'
+**CVE Fix Verification: COULD NOT RUN** :warning:
+
+The vulnerability scan could not complete due to an infrastructure error:
+
+> One or more image scans failed to produce results.
+
+**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.
+COMMENT_EOF
+)"
+else
+  gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+fi

--- a/.github/workflows/scripts/run-cve-fix-verification.sh
+++ b/.github/workflows/scripts/run-cve-fix-verification.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Thin wrapper around verify-cve-fix.sh for use as a GitHub Actions step: it
+# forwards all arguments to verify-cve-fix.sh, then writes its captured
+# stdout and exit code to $GITHUB_OUTPUT as `comment` and `exit-code`
+# respectively, so a later workflow step can inspect them.
+#
+# Usage: run-cve-fix-verification.sh <args to pass to verify-cve-fix.sh>
+#
+# Unlike verify-cve-fix.sh, this wrapper always exits 0 itself, regardless
+# of verify-cve-fix.sh's exit code - callers must check the `exit-code`
+# output instead of this step's own exit status.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set +e
+comment_body="$("${SCRIPT_DIR}/verify-cve-fix.sh" "$@")"
+exit_code=$?
+set -e
+
+delimiter="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
+{
+  echo "comment<<${delimiter}"
+  echo "$comment_body"
+  echo "${delimiter}"
+} >> "$GITHUB_OUTPUT"
+echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -80,15 +80,19 @@ done
 # CVEs against. Treat this the same as "no scan result files found" rather
 # than reporting a misleading PASSED verdict.
 if [[ ${#usable_scan_files[@]} -eq 0 ]]; then
-  comment_body="**CVE Fix Verification: COULD NOT RUN** :warning:"$'\n\n'
-  comment_body+="The vulnerability scan could not complete due to an infrastructure error:"$'\n\n'
-  comment_body+="> ${#unparseable_files[@]} scan result file(s) were found, but none of them could be parsed (invalid JSON or unexpected shape):"$'\n\n'
-  for unparseable_file in "${unparseable_files[@]}"; do
-    comment_body+="- ${unparseable_file}"$'\n'
-  done
-  comment_body+=$'\n'
-  # shellcheck disable=SC2016
-  comment_body+='**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.'$'\n'
+  file_list="$(printf -- '- %s\n' "${unparseable_files[@]}")"
+  comment_body="$(cat <<EOF
+**CVE Fix Verification: COULD NOT RUN** :warning:
+
+The vulnerability scan could not complete due to an infrastructure error:
+
+> ${#unparseable_files[@]} scan result file(s) were found, but none of them could be parsed (invalid JSON or unexpected shape):
+
+${file_list}
+
+**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running \`roxctl image scan\` locally against the built images, or by re-running this workflow.
+EOF
+)"$'\n'
   echo "$comment_body"
   exit 0
 fi
@@ -114,25 +118,38 @@ for cve in "${CVE_LIST[@]}"; do
 
   if [[ -n "$findings" ]]; then
     overall_failed=true
-    comment_body+="**CVE Fix Verification: FAILED** :x:"$'\n\n'
-    comment_body+="${cve} is still present in the following images:"$'\n\n'
-    comment_body+="| Image | Component | Version | Fixed Version |"$'\n'
-    comment_body+="| --- | --- | --- | --- |"$'\n'
-    comment_body+="${findings}"$'\n'
+    comment_body+="$(cat <<EOF
+**CVE Fix Verification: FAILED** :x:
+
+${cve} is still present in the following images:
+
+| Image | Component | Version | Fixed Version |
+| --- | --- | --- | --- |
+${findings}
+EOF
+)"$'\n\n'
   else
-    comment_body+="**CVE Fix Verification: PASSED** :white_check_mark:"$'\n\n'
-    comment_body+="${cve} was not found in any scanned image."$'\n\n'
+    comment_body+="$(cat <<EOF
+**CVE Fix Verification: PASSED** :white_check_mark:
+
+${cve} was not found in any scanned image.
+EOF
+)"$'\n\n'
   fi
 done
 
 if [[ ${#unparseable_files[@]} -gt 0 ]]; then
-  comment_body+="**CVE Fix Verification: WARNING** :warning:"$'\n\n'
-  comment_body+="The following scan result file(s) could not be parsed and were skipped:"$'\n\n'
-  for unparseable_file in "${unparseable_files[@]}"; do
-    comment_body+="- ${unparseable_file}"$'\n'
-  done
-  comment_body+=$'\n'
-  comment_body+="**Action required:** Please verify manually that these images are free of the target CVE(s), since they could not be automatically checked."$'\n\n'
+  file_list="$(printf -- '- %s\n' "${unparseable_files[@]}")"
+  comment_body+="$(cat <<EOF
+**CVE Fix Verification: WARNING** :warning:
+
+The following scan result file(s) could not be parsed and were skipped:
+
+${file_list}
+
+**Action required:** Please verify manually that these images are free of the target CVE(s), since they could not be automatically checked.
+EOF
+)"$'\n\n'
 fi
 
 echo "$comment_body"

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -76,11 +76,17 @@ for scan_file in "${SCAN_FILES[@]}"; do
   fi
 done
 
+# Pre-render the unparseable-files bullet list once; it's referenced from both
+# the all-unparseable COULD-NOT-RUN block and the WARNING block below.
+# printf's trailing newline is stripped by $(...); the heredoc's own newline
+# after ${file_list} supplies the single blank-line separator before the next
+# paragraph in each of those blocks - do not add a trailing newline here.
+file_list="$(printf -- '- %s\n' "${unparseable_files[@]}")"
+
 # If every scan result file was unparseable, there is nothing usable to check
 # CVEs against. Treat this the same as "no scan result files found" rather
 # than reporting a misleading PASSED verdict.
 if [[ ${#usable_scan_files[@]} -eq 0 ]]; then
-  file_list="$(printf -- '- %s\n' "${unparseable_files[@]}")"
   comment_body="$(cat <<EOF
 **CVE Fix Verification: COULD NOT RUN** :warning:
 
@@ -139,7 +145,6 @@ EOF
 done
 
 if [[ ${#unparseable_files[@]} -gt 0 ]]; then
-  file_list="$(printf -- '- %s\n' "${unparseable_files[@]}")"
   comment_body+="$(cat <<EOF
 **CVE Fix Verification: WARNING** :warning:
 

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -67,7 +67,7 @@ fi
 usable_scan_files=()
 unparseable_files=()
 for scan_file in "${SCAN_FILES[@]}"; do
-  if jq -e '(.result.vulnerabilities // empty) | type == "array"' "$scan_file" >/dev/null 2>&1; then
+  if jq -e '(.result // empty) as $r | ($r | type) == "object" and (($r.vulnerabilities // []) | type == "array")' "$scan_file" >/dev/null 2>&1; then
     usable_scan_files+=("$scan_file")
   else
     unparseable_files+=("$(basename "$scan_file")")

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -9,7 +9,10 @@
 #
 # Exit codes:
 #   0 - All target CVEs are absent from all scans (PASSED), or no scan
-#       result files were found (infrastructure failure, non-blocking)
+#       result files were found (infrastructure failure, non-blocking).
+#       If some (but not all) scan result files could not be parsed
+#       (invalid JSON or unexpected shape), a WARNING section listing
+#       them is appended to the output, but the exit code is unaffected.
 #   1 - At least one target CVE is still present (FAILED)
 #   2 - Invalid usage (bad or missing arguments)
 #
@@ -59,12 +62,12 @@ fi
 
 # Identify scan result files that are not valid JSON or do not match the
 # expected roxctl image scan shape (an object with a "result.vulnerabilities"
-# key). These are skipped when checking for CVEs below, but flagged in the
+# array). These are skipped when checking for CVEs below, but flagged in the
 # output so an unparseable scan is never mistaken for a clean one.
 usable_scan_files=()
 unparseable_files=()
 for scan_file in "${SCAN_FILES[@]}"; do
-  if jq -e '(.result // empty) | has("vulnerabilities")' "$scan_file" >/dev/null 2>&1; then
+  if jq -e '(.result.vulnerabilities // empty) | type == "array"' "$scan_file" >/dev/null 2>&1; then
     usable_scan_files+=("$scan_file")
   else
     unparseable_files+=("$(basename "$scan_file")")
@@ -109,6 +112,7 @@ if [[ ${#unparseable_files[@]} -gt 0 ]]; then
   for unparseable_file in "${unparseable_files[@]}"; do
     comment_body+="- ${unparseable_file}"$'\n'
   done
+  comment_body+=$'\n'
   comment_body+="**Action required:** Please verify manually that these images are free of the target CVE(s), since they could not be automatically checked."$'\n\n'
 fi
 

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Verifies that target CVE(s) are absent from image scan results.
+#
+# Usage: verify-cve-fix.sh --cves <comma-separated-cve-ids> --scan-dir <directory>
+#
+# The scan directory should contain JSON files from roxctl image scan.
+# Each file should be named like: <image-name>.json
+#
+# Exit codes:
+#   0 - All target CVEs are absent from all scans (PASSED)
+#   1 - At least one target CVE is still present (FAILED)
+#   2 - No scan results found (infrastructure failure)
+#
+set -euo pipefail
+
+CVES=""
+SCAN_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cves) CVES="$2"; shift 2 ;;
+    --scan-dir) SCAN_DIR="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$CVES" || -z "$SCAN_DIR" ]]; then
+  echo "Usage: verify-cve-fix.sh --cves <cve1,cve2,...> --scan-dir <dir>" >&2
+  exit 2
+fi
+
+IFS=',' read -ra CVE_LIST <<< "$CVES"
+
+# Check that scan results exist
+shopt -s nullglob
+SCAN_FILES=("${SCAN_DIR}"/*.json)
+shopt -u nullglob
+
+if [[ ${#SCAN_FILES[@]} -eq 0 ]]; then
+  cat <<'INFRA_EOF'
+**CVE Fix Verification: COULD NOT RUN** :warning:
+
+The vulnerability scan could not complete due to an infrastructure error:
+
+> No scan result files found.
+
+**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.
+INFRA_EOF
+  exit 0
+fi
+
+overall_failed=false
+comment_body=""
+
+for cve in "${CVE_LIST[@]}"; do
+  findings=""
+  for scan_file in "${SCAN_FILES[@]}"; do
+    image_name="$(basename "$scan_file" .json)"
+    matches="$(jq -r --arg cve "$cve" '
+      [.result.vulnerabilities // [] | .[] | select(.cveId == $cve)] |
+      .[] | [.componentName, .componentVersion, .componentFixedVersion] | @tsv
+    ' "$scan_file" 2>/dev/null || true)"
+
+    if [[ -n "$matches" ]]; then
+      while IFS=$'\t' read -r component version fixed_version; do
+        findings+="| ${image_name} | ${component} | ${version} | ${fixed_version:-N/A} |"$'\n'
+      done <<< "$matches"
+    fi
+  done
+
+  if [[ -n "$findings" ]]; then
+    overall_failed=true
+    comment_body+="**CVE Fix Verification: FAILED** :x:"$'\n\n'
+    comment_body+="${cve} is still present in the following images:"$'\n\n'
+    comment_body+="| Image | Component | Version | Fixed Version |"$'\n'
+    comment_body+="| --- | --- | --- | --- |"$'\n'
+    comment_body+="${findings}"$'\n'
+  else
+    comment_body+="**CVE Fix Verification: PASSED** :white_check_mark:"$'\n\n'
+    comment_body+="${cve} was not found in any scanned image."$'\n\n'
+  fi
+done
+
+echo "$comment_body"
+
+if [[ "$overall_failed" == "true" ]]; then
+  exit 1
+fi

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -8,11 +8,13 @@
 # Each file should be named like: <image-name>.json
 #
 # Exit codes:
-#   0 - All target CVEs are absent from all scans (PASSED), or no scan
-#       result files were found (infrastructure failure, non-blocking).
-#       If some (but not all) scan result files could not be parsed
-#       (invalid JSON or unexpected shape), a WARNING section listing
-#       them is appended to the output, but the exit code is unaffected.
+#   0 - All target CVEs are absent from all scans (PASSED); or no scan
+#       result files were found, or every scan result file found was
+#       unparseable (both cases are treated as an infrastructure
+#       failure: COULD NOT RUN, non-blocking). If some (but not all)
+#       scan result files were unparseable, a WARNING section listing
+#       them is appended to the PASSED/FAILED output instead, and the
+#       exit code is unaffected.
 #   1 - At least one target CVE is still present (FAILED)
 #   2 - Invalid usage (bad or missing arguments)
 #
@@ -73,6 +75,23 @@ for scan_file in "${SCAN_FILES[@]}"; do
     unparseable_files+=("$(basename "$scan_file")")
   fi
 done
+
+# If every scan result file was unparseable, there is nothing usable to check
+# CVEs against. Treat this the same as "no scan result files found" rather
+# than reporting a misleading PASSED verdict.
+if [[ ${#usable_scan_files[@]} -eq 0 ]]; then
+  comment_body="**CVE Fix Verification: COULD NOT RUN** :warning:"$'\n\n'
+  comment_body+="The vulnerability scan could not complete due to an infrastructure error:"$'\n\n'
+  comment_body+="> ${#unparseable_files[@]} scan result file(s) were found, but none of them could be parsed (invalid JSON or unexpected shape):"$'\n\n'
+  for unparseable_file in "${unparseable_files[@]}"; do
+    comment_body+="- ${unparseable_file}"$'\n'
+  done
+  comment_body+=$'\n'
+  # shellcheck disable=SC2016
+  comment_body+='**Action required:** Please verify manually that your CVE fix is effective before merging this PR. You can do this by running `roxctl image scan` locally against the built images, or by re-running this workflow.'$'\n'
+  echo "$comment_body"
+  exit 0
+fi
 
 overall_failed=false
 comment_body=""

--- a/.github/workflows/scripts/verify-cve-fix.sh
+++ b/.github/workflows/scripts/verify-cve-fix.sh
@@ -8,9 +8,10 @@
 # Each file should be named like: <image-name>.json
 #
 # Exit codes:
-#   0 - All target CVEs are absent from all scans (PASSED)
+#   0 - All target CVEs are absent from all scans (PASSED), or no scan
+#       result files were found (infrastructure failure, non-blocking)
 #   1 - At least one target CVE is still present (FAILED)
-#   2 - No scan results found (infrastructure failure)
+#   2 - Invalid usage (bad or missing arguments)
 #
 set -euo pipefail
 
@@ -19,8 +20,14 @@ SCAN_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --cves) CVES="$2"; shift 2 ;;
-    --scan-dir) SCAN_DIR="$2"; shift 2 ;;
+    --cves)
+      CVES="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
+    --scan-dir)
+      SCAN_DIR="${2:-}"
+      if [[ $# -ge 2 ]]; then shift 2; else shift; fi
+      ;;
     *) echo "Unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -50,12 +57,26 @@ INFRA_EOF
   exit 0
 fi
 
+# Identify scan result files that are not valid JSON or do not match the
+# expected roxctl image scan shape (an object with a "result.vulnerabilities"
+# key). These are skipped when checking for CVEs below, but flagged in the
+# output so an unparseable scan is never mistaken for a clean one.
+usable_scan_files=()
+unparseable_files=()
+for scan_file in "${SCAN_FILES[@]}"; do
+  if jq -e '(.result // empty) | has("vulnerabilities")' "$scan_file" >/dev/null 2>&1; then
+    usable_scan_files+=("$scan_file")
+  else
+    unparseable_files+=("$(basename "$scan_file")")
+  fi
+done
+
 overall_failed=false
 comment_body=""
 
 for cve in "${CVE_LIST[@]}"; do
   findings=""
-  for scan_file in "${SCAN_FILES[@]}"; do
+  for scan_file in "${usable_scan_files[@]}"; do
     image_name="$(basename "$scan_file" .json)"
     matches="$(jq -r --arg cve "$cve" '
       [.result.vulnerabilities // [] | .[] | select(.cveId == $cve)] |
@@ -81,6 +102,15 @@ for cve in "${CVE_LIST[@]}"; do
     comment_body+="${cve} was not found in any scanned image."$'\n\n'
   fi
 done
+
+if [[ ${#unparseable_files[@]} -gt 0 ]]; then
+  comment_body+="**CVE Fix Verification: WARNING** :warning:"$'\n\n'
+  comment_body+="The following scan result file(s) could not be parsed and were skipped:"$'\n\n'
+  for unparseable_file in "${unparseable_files[@]}"; do
+    comment_body+="- ${unparseable_file}"$'\n'
+  done
+  comment_body+="**Action required:** Please verify manually that these images are free of the target CVE(s), since they could not be automatically checked."$'\n\n'
+fi
 
 echo "$comment_body"
 


### PR DESCRIPTION
Fifth throwaway test PR to re-validate the CVE fix verification workflow (ROX-35370) after extracting inline shell in build.yaml into dedicated scripts and heredoc-ifying verify-cve-fix.sh. Confirms the refactored scripts execute correctly in the real GitHub Actions runner environment. Will be closed without merging.