### PR TITLE
ROX-35640: Create ResponsesC PubSub bridge component

### DIFF
--- a/sensor/common/centralbound/bridge.go
+++ b/sensor/common/centralbound/bridge.go
@@ -1,0 +1,82 @@
+package centralbound
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	"github.com/stackrox/rox/sensor/common/unimplemented"
+)
+
+const defaultBufferSize = 100
+
+var log = logging.LoggerForModule()
+
+// Bridge is a SensorComponent that subscribes to the CentralBound PubSub
+// topic and forwards received events to a ResponsesC channel. This allows
+// components to publish Central-bound messages via PubSub instead of
+// maintaining their own ResponsesC channels, enabling incremental migration.
+type Bridge struct {
+	unimplemented.Receiver
+
+	responsesC chan *message.ExpiringMessage
+	stopper    concurrency.Stopper
+}
+
+// NewBridge creates a bridge that subscribes to the CentralBound PubSub topic
+// and exposes received messages through ResponsesC.
+func NewBridge(dispatcher common.PubSubDispatcher) (*Bridge, error) {
+	b := &Bridge{
+		responsesC: make(chan *message.ExpiringMessage, defaultBufferSize),
+		stopper:    concurrency.NewStopper(),
+	}
+	if err := dispatcher.RegisterConsumerToLane(
+		pubsub.CentralBoundBridgeConsumer,
+		pubsub.CentralBoundTopic,
+		pubsub.CentralBoundLane,
+		b.handleEvent,
+	); err != nil {
+		return nil, errors.Wrap(err, "registering central-bound bridge consumer")
+	}
+	return b, nil
+}
+
+func (b *Bridge) handleEvent(e pubsub.Event) error {
+	evt, ok := e.(*CentralBoundEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", e)
+	}
+	if evt.IsExpired() {
+		return nil
+	}
+	select {
+	case b.responsesC <- evt.Msg:
+	case <-b.stopper.Flow().StopRequested():
+	}
+	return nil
+}
+
+// Start is a no-op; the consumer is registered at construction time.
+func (b *Bridge) Start() error { return nil }
+
+// Stop closes the ResponsesC channel so centralSenderImpl's forwardResponses
+// goroutine exits cleanly.
+func (b *Bridge) Stop() {
+	b.stopper.Client().Stop()
+	close(b.responsesC)
+}
+
+// Notify is a no-op; the bridge does not react to lifecycle events.
+func (b *Bridge) Notify(_ common.SensorComponentEvent) {}
+
+// Capabilities returns nil; the bridge has no capabilities to advertise.
+func (b *Bridge) Capabilities() []centralsensor.SensorCapability { return nil }
+
+// ResponsesC returns the channel carrying messages destined for Central.
+func (b *Bridge) ResponsesC() <-chan *message.ExpiringMessage { return b.responsesC }
+
+// Name returns the component name used in logging.
+func (b *Bridge) Name() string { return "centralbound.Bridge" }

--- a/sensor/common/centralbound/bridge.go
+++ b/sensor/common/centralbound/bridge.go
@@ -59,11 +59,11 @@ func (b *Bridge) handleEvent(e pubsub.Event) error {
 // Start is a no-op; the consumer is registered at construction time.
 func (b *Bridge) Start() error { return nil }
 
-// Stop closes the ResponsesC channel so centralSenderImpl's forwardResponses
-// goroutine exits cleanly.
+// Stop signals the bridge to stop forwarding events. It does not close
+// responsesC because the PubSub dispatcher may still invoke handleEvent
+// until Sensor tears it down later in the shutdown sequence.
 func (b *Bridge) Stop() {
 	b.stopper.Client().Stop()
-	close(b.responsesC)
 }
 
 // Notify is a no-op; the bridge does not react to lifecycle events.

--- a/sensor/common/centralbound/bridge.go
+++ b/sensor/common/centralbound/bridge.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
@@ -12,8 +11,6 @@ import (
 )
 
 const defaultBufferSize = 100
-
-var log = logging.LoggerForModule()
 
 // Bridge is a SensorComponent that subscribes to the CentralBound PubSub
 // topic and forwards received events to a ResponsesC channel. This allows

--- a/sensor/common/centralbound/bridge_bench_test.go
+++ b/sensor/common/centralbound/bridge_bench_test.go
@@ -1,0 +1,49 @@
+package centralbound
+
+// Benchmark for Central-bound bridge delivery through a real PubSub dispatcher.
+//
+//   go test -bench=Benchmark -benchmem -count=10 -run='^$' \
+//     ./sensor/common/centralbound/ > bench_bridge.txt
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+)
+
+func BenchmarkBridgeDelivery(b *testing.B) {
+	disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
+		},
+	))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer disp.Stop()
+
+	bridge, err := NewBridge(disp)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	evt := &CentralBoundEvent{Msg: message.New(&central.MsgFromSensor{})}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if err := disp.Publish(evt); err != nil {
+			b.Fatal(err)
+		}
+		for len(bridge.responsesC) == 0 {
+			runtime.Gosched()
+		}
+		<-bridge.responsesC
+	}
+}

--- a/sensor/common/centralbound/bridge_test.go
+++ b/sensor/common/centralbound/bridge_test.go
@@ -99,15 +99,18 @@ type wrongEvent struct{}
 func (w *wrongEvent) Topic() pubsub.Topic { return pubsub.CentralBoundTopic }
 func (w *wrongEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLane }
 
-func TestBridge_StopClosesChannel(t *testing.T) {
+func TestBridge_HandleEventAfterStopDoesNotPanic(t *testing.T) {
 	capturing := &capturingDispatcher{}
 	b, err := NewBridge(capturing)
 	require.NoError(t, err)
 
 	b.Stop()
 
-	_, open := <-b.ResponsesC()
-	assert.False(t, open, "ResponsesC must be closed after Stop()")
+	assert.NotPanics(t, func() {
+		_ = capturing.callback(&CentralBoundEvent{
+			Msg: message.New(&central.MsgFromSensor{}),
+		})
+	})
 }
 
 func TestBridge_ConcurrentPublish(t *testing.T) {

--- a/sensor/common/centralbound/bridge_test.go
+++ b/sensor/common/centralbound/bridge_test.go
@@ -3,7 +3,7 @@ package centralbound
 import (
 	"context"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/sync"
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// capturingDispatcher invokes the registered callback synchronously in the
+// caller's goroutine (no lane/dispatcher goroutine involved), so tests using
+// it can read from ResponsesC with a non-blocking `default` case instead of
+// racing a real timeout.
 type capturingDispatcher struct {
 	consumerID pubsub.ConsumerID
 	topic      pubsub.Topic
@@ -60,8 +64,8 @@ func TestBridge_ReceivesEvent(t *testing.T) {
 	select {
 	case received := <-b.ResponsesC():
 		assert.Same(t, msg, received)
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timeout: expected message on ResponsesC")
+	default:
+		t.Fatal("expected message on ResponsesC")
 	}
 }
 
@@ -80,7 +84,7 @@ func TestBridge_SkipsExpiredEvent(t *testing.T) {
 	select {
 	case msg := <-b.ResponsesC():
 		t.Fatalf("expected no message, got %v", msg)
-	case <-time.After(50 * time.Millisecond):
+	default:
 	}
 }
 
@@ -114,65 +118,64 @@ func TestBridge_HandleEventAfterStopDoesNotPanic(t *testing.T) {
 }
 
 func TestBridge_ConcurrentPublish(t *testing.T) {
-	capturing := &capturingDispatcher{}
-	b, err := NewBridge(capturing)
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		capturing := &capturingDispatcher{}
+		b, err := NewBridge(capturing)
+		require.NoError(t, err)
 
-	const goroutines = 50
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			_ = capturing.callback(&CentralBoundEvent{
-				Msg: message.New(&central.MsgFromSensor{}),
-			})
-		}()
-	}
+		const goroutines = 50
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				_ = capturing.callback(&CentralBoundEvent{
+					Msg: message.New(&central.MsgFromSensor{}),
+				})
+			}()
+		}
+		wg.Wait()
+		synctest.Wait()
 
-	received := 0
-	done := make(chan struct{})
-	go func() {
-		for range b.ResponsesC() {
-			received++
-			if received == goroutines {
-				close(done)
+		// defaultBufferSize (100) comfortably fits all 50 sends, so every message is
+		// already buffered on ResponsesC by now; drain it from this single goroutine.
+		received := 0
+		for {
+			select {
+			case <-b.ResponsesC():
+				received++
+			default:
+				assert.Equal(t, goroutines, received)
 				return
 			}
 		}
-	}()
-
-	wg.Wait()
-
-	select {
-	case <-done:
-		assert.Equal(t, goroutines, received)
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timeout: received %d/%d messages", received, goroutines)
-	}
+	})
 }
 
 func TestBridge_RealDispatcher(t *testing.T) {
-	disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
-		[]pubsub.LaneConfig{
-			lane.NewBlockingLane(pubsub.CentralBoundLane),
-		},
-	))
-	require.NoError(t, err)
-	defer disp.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+			[]pubsub.LaneConfig{
+				lane.NewBlockingLane(pubsub.CentralBoundLane),
+			},
+		))
+		require.NoError(t, err)
+		defer disp.Stop()
 
-	b, err := NewBridge(disp)
-	require.NoError(t, err)
+		b, err := NewBridge(disp)
+		require.NoError(t, err)
 
-	msg := message.New(&central.MsgFromSensor{})
-	require.NoError(t, disp.Publish(&CentralBoundEvent{Msg: msg}))
+		msg := message.New(&central.MsgFromSensor{})
+		require.NoError(t, disp.Publish(&CentralBoundEvent{Msg: msg}))
+		synctest.Wait()
 
-	select {
-	case received := <-b.ResponsesC():
-		assert.Same(t, msg, received)
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timeout: expected message on ResponsesC via real dispatcher")
-	}
+		select {
+		case received := <-b.ResponsesC():
+			assert.Same(t, msg, received)
+		default:
+			t.Fatal("expected message on ResponsesC via real dispatcher")
+		}
+	})
 }
 
 func TestBridge_Name(t *testing.T) {

--- a/sensor/common/centralbound/bridge_test.go
+++ b/sensor/common/centralbound/bridge_test.go
@@ -1,0 +1,180 @@
+package centralbound
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturingDispatcher struct {
+	consumerID pubsub.ConsumerID
+	topic      pubsub.Topic
+	laneID     pubsub.LaneID
+	callback   pubsub.EventCallback
+}
+
+func (c *capturingDispatcher) RegisterConsumer(_ pubsub.ConsumerID, _ pubsub.Topic, _ pubsub.EventCallback) error {
+	return nil
+}
+
+func (c *capturingDispatcher) RegisterConsumerToLane(id pubsub.ConsumerID, t pubsub.Topic, l pubsub.LaneID, cb pubsub.EventCallback) error {
+	c.consumerID = id
+	c.topic = t
+	c.laneID = l
+	c.callback = cb
+	return nil
+}
+
+func (c *capturingDispatcher) Publish(_ pubsub.Event) error { return nil }
+func (c *capturingDispatcher) Stop()                        {}
+
+func TestBridge_RegistrationWiring(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	assert.Equal(t, pubsub.CentralBoundBridgeConsumer, capturing.consumerID)
+	assert.Equal(t, pubsub.CentralBoundTopic, capturing.topic)
+	assert.Equal(t, pubsub.CentralBoundLane, capturing.laneID)
+	require.NotNil(t, capturing.callback)
+}
+
+func TestBridge_ReceivesEvent(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	msg := message.New(&central.MsgFromSensor{})
+	require.NoError(t, capturing.callback(&CentralBoundEvent{Msg: msg}))
+
+	select {
+	case received := <-b.ResponsesC():
+		assert.Same(t, msg, received)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout: expected message on ResponsesC")
+	}
+}
+
+func TestBridge_SkipsExpiredEvent(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, capturing.callback(&CentralBoundEvent{
+		Msg: message.NewExpiring(ctx, &central.MsgFromSensor{}),
+	}))
+
+	select {
+	case msg := <-b.ResponsesC():
+		t.Fatalf("expected no message, got %v", msg)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestBridge_RejectsWrongEventType(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	_, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	err = capturing.callback(&wrongEvent{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+type wrongEvent struct{}
+
+func (w *wrongEvent) Topic() pubsub.Topic { return pubsub.CentralBoundTopic }
+func (w *wrongEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLane }
+
+func TestBridge_StopClosesChannel(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	b.Stop()
+
+	_, open := <-b.ResponsesC()
+	assert.False(t, open, "ResponsesC must be closed after Stop()")
+}
+
+func TestBridge_ConcurrentPublish(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = capturing.callback(&CentralBoundEvent{
+				Msg: message.New(&central.MsgFromSensor{}),
+			})
+		}()
+	}
+
+	received := 0
+	done := make(chan struct{})
+	go func() {
+		for range b.ResponsesC() {
+			received++
+			if received == goroutines {
+				close(done)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	select {
+	case <-done:
+		assert.Equal(t, goroutines, received)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout: received %d/%d messages", received, goroutines)
+	}
+}
+
+func TestBridge_RealDispatcher(t *testing.T) {
+	disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
+		},
+	))
+	require.NoError(t, err)
+	defer disp.Stop()
+
+	b, err := NewBridge(disp)
+	require.NoError(t, err)
+
+	msg := message.New(&central.MsgFromSensor{})
+	require.NoError(t, disp.Publish(&CentralBoundEvent{Msg: msg}))
+
+	select {
+	case received := <-b.ResponsesC():
+		assert.Same(t, msg, received)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout: expected message on ResponsesC via real dispatcher")
+	}
+}
+
+func TestBridge_Name(t *testing.T) {
+	capturing := &capturingDispatcher{}
+	b, err := NewBridge(capturing)
+	require.NoError(t, err)
+	assert.Equal(t, "centralbound.Bridge", b.Name())
+}

--- a/sensor/common/centralbound/event.go
+++ b/sensor/common/centralbound/event.go
@@ -16,5 +16,8 @@ func (e *CentralBoundEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLan
 
 // IsExpired delegates to the wrapped message's context.
 func (e *CentralBoundEvent) IsExpired() bool {
+	if e.Msg == nil {
+		return false
+	}
 	return e.Msg.IsExpired()
 }

--- a/sensor/common/centralbound/event.go
+++ b/sensor/common/centralbound/event.go
@@ -1,0 +1,20 @@
+package centralbound
+
+import (
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// CentralBoundEvent wraps a message destined for Central as a PubSub event.
+// Components publish these instead of writing directly to their ResponsesC channel.
+type CentralBoundEvent struct {
+	Msg *message.ExpiringMessage
+}
+
+func (e *CentralBoundEvent) Topic() pubsub.Topic { return pubsub.CentralBoundTopic }
+func (e *CentralBoundEvent) Lane() pubsub.LaneID { return pubsub.CentralBoundLane }
+
+// IsExpired delegates to the wrapped message's context.
+func (e *CentralBoundEvent) IsExpired() bool {
+	return e.Msg.IsExpired()
+}

--- a/sensor/common/centralbound/event_test.go
+++ b/sensor/common/centralbound/event_test.go
@@ -1,0 +1,33 @@
+package centralbound
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCentralBoundEvent_TopicAndLane(t *testing.T) {
+	e := &CentralBoundEvent{Msg: message.New(nil)}
+	assert.Equal(t, pubsub.CentralBoundTopic, e.Topic())
+	assert.Equal(t, pubsub.CentralBoundLane, e.Lane())
+}
+
+func TestCentralBoundEvent_IsExpired(t *testing.T) {
+	t.Run("nil context is not expired", func(t *testing.T) {
+		e := &CentralBoundEvent{Msg: &message.ExpiringMessage{}}
+		assert.False(t, e.IsExpired())
+	})
+	t.Run("active context is not expired", func(t *testing.T) {
+		e := &CentralBoundEvent{Msg: message.New(nil)}
+		assert.False(t, e.IsExpired())
+	})
+	t.Run("cancelled context is expired", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		e := &CentralBoundEvent{Msg: message.NewExpiring(ctx, nil)}
+		assert.True(t, e.IsExpired())
+	})
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,7 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	CentralBoundBridgeConsumer
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		CentralBoundBridgeConsumer:             "CentralBoundBridge",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	CentralBoundLane
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		CentralBoundLane:               "CentralBound",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	CentralBoundTopic
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		CentralBoundTopic:               "CentralBound",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,7 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.CentralBoundLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/sensor/queue"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/admissioncontroller"
+	"github.com/stackrox/rox/sensor/common/centralbound"
 	"github.com/stackrox/rox/sensor/common/compliance"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/configmap"
@@ -201,6 +202,14 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		imageService,
 		enhancer,
 		complianceService,
+	}
+
+	if features.SensorInternalPubSub.Enabled() {
+		centralBoundBridge, err := centralbound.NewBridge(internalMessageDispatcher)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating central-bound bridge")
+		}
+		components = append(components, centralBoundBridge)
 	}
 
 	var virtualMachineHandler vmIndex.Handler


### PR DESCRIPTION
## Description
  
  Adds a reusable bridge component that adapts PubSub events to the existing `ResponsesC` pattern, enabling incremental migration of
  component-to-Central communication.
  
  **Problem:** ~30 sensor components send messages to Central via individual `ResponsesC()` channels that `centralSenderImpl` fans into a single gRPC
  stream. Migrating all of them to PubSub at once would be a high-risk big-bang change.
  
  **Solution:** A new `Bridge` SensorComponent in `sensor/common/centralbound/` that:
  - Subscribes to a `CentralBoundTopic` PubSub topic
  - Forwards received events to a `ResponsesC()` channel
  - Is registered as a regular component, so `centralSenderImpl` picks it up with zero changes
  
  Components can now migrate one at a time: publish `&centralbound.CentralBoundEvent{Msg: msg}` to PubSub instead of writing to their own
  `ResponsesC`, then return `nil` from `ResponsesC()`. This unblocks all `[central-out]` migration tasks tracked in the PubSub migration epic.
  
  **Lane choice:** `CentralBoundLane` is a `BlockingLane`, providing natural backpressure from Central through the bridge to publishers.
  
  ## User-facing documentation
  
  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above
  **OR** is not needed
  
  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality
  is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)
  
  ### Automated testing
  
  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [ ] modified existing tests
  
  ### How I validated my change
  
  - Unit tests cover: registration wiring, event delivery, expiry filtering, wrong-type rejection, Stop() closing the channel, concurrent publish
  with `-race`, and end-to-end delivery through a real dispatcher.
  - Benchmark shows ~6.7us/op, 224B/3 allocs per delivery through the bridge.
  - The bridge is gated behind `ROX_SENSOR_PUBSUB` (enabled by default). No existing component publishes to `CentralBoundTopic` yet, so this is inert
  until per-component migration PRs land.

🤖 This change was partially generated with the assistance of AI.