### PR TITLE
ROX-32912: Revert v2 vulnerability bundle bump

### DIFF
--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -5,4 +5,4 @@
 # Each vulnerability bundle version serves the Scanner V4 requesting it, which is, by default, based on the version specified in scanner/VULNERABILITY_VERSION in the related Scanner V4 tag.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
-v2 heads/2859e843d618d59df8b68bb751507bcd815c890e
+v2 tags/4.9.8-rc.2

--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -6,3 +6,4 @@
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v2 tags/4.9.8-rc.2
+v3 heads/2859e843d618d59df8b68bb751507bcd815c890e

--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -6,4 +6,3 @@
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v2 tags/4.9.8-rc.2
-v3 heads/2859e843d618d59df8b68bb751507bcd815c890e


### PR DESCRIPTION
## Description

Reverts "ROX-32912: Bump v2 vulnerability bundle to release-4.11 (#21577)" (commit fe6cbeb443df9469592d69921a56c89213986008)

Theory: New `Invert: true` (not affected) records present in updated bundles are being inserted into pre 4.11.1 scanner-v4-db's as if they are normal vulns, leading to false positives.

4.11.0 instances will encounter errors loading vulns

```
{"level":"ERROR","source":"[github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Start](http://github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Start)","time":"2026-07-09T18:08:04.655514675Z","msg":"errors encountered during updater run","host":"scanner-v4-matcher-5cb8874df7-7chff","reason":"updating bundle bundles/alpine.json.zst: importing vulnerabilities: iterating on the reader: json: cannot unmarshal string into Go struct field Alias.Self.Space of type unique.Handle[string]"}
```

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Ongoing
