### PR TITLE
fix(ci): Adjust dispatch-any logic to properly skip in UI PRs

### DIFF
--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -98,7 +98,14 @@ jobs:
                 ]}
 
             write('jobs', json.dumps(jobs))
-            write('dispatch-any', str(any(jobs.values())).lower())
+
+            # dispatch_any==False is a shortcut to prevent executing the further workflow for draft PRs which don't
+            # qualify for running any actual e2e jobs.
+            # We must make sure that dispatch_any is True for non-drafts even if no actual jobs are to be dispatched
+            # (the case of UI-only PRs) because this lets GHA enter the corresponding workflows and skip the test jobs
+            # inside them "in proper way" that allows to satisfy branch protection rules.
+            dispatch_any = any(jobs.values()) or input.is_draft != 'true'
+            write('dispatch-any', str(dispatch_any).lower())
 
   # Waits for images to be built so we don't start testing until they are available.
   wait-for-images:


### PR DESCRIPTION
## Description

Context: https://redhat-internal.slack.com/archives/CELUQKESC/p1783603172338719?thread_ts=1783415871.588119&cid=CELUQKESC

This is hopefully the last fix required to make gha e2e tests required for PRs again.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No changes to actual tests.

### How I validated my change

Created UI-only change https://github.com/stackrox/stackrox/pull/21656.
- [x] Checked the observed outputs from `should-dispatch` there: https://github.com/stackrox/stackrox/actions/runs/29038667085/job/86190079800?pr=21656#step:2:79
- [x] Checked that e2e sub-workflows get entered and jobs there get skipped. https://github.com/stackrox/stackrox/actions/runs/29038667085?pr=21656