### PR TITLE
ROX-35119: Affected VMs widget on single CVE page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/AffectedVirtualMachinesSummaryCard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/AffectedVirtualMachinesSummaryCard.tsx
@@ -1,0 +1,32 @@
+import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
+import pluralize from 'pluralize';
+
+type AffectedVirtualMachinesSummaryCardProps = {
+    affectedVirtualMachinesCount: number;
+    totalVirtualMachinesCount: number;
+    affectedGuestOsCount: number;
+};
+
+function AffectedVirtualMachinesSummaryCard({
+    affectedVirtualMachinesCount,
+    totalVirtualMachinesCount,
+    affectedGuestOsCount,
+}: AffectedVirtualMachinesSummaryCardProps) {
+    return (
+        <Card isCompact isFullHeight>
+            <CardTitle>Affected virtual machines</CardTitle>
+            <CardBody>
+                <Grid>
+                    <GridItem span={12}>
+                        {`${affectedVirtualMachinesCount} / ${totalVirtualMachinesCount} affected virtual machines`}
+                    </GridItem>
+                    <GridItem span={12}>
+                        {`${affectedGuestOsCount} ${pluralize('Guest OS', affectedGuestOsCount)} affected`}
+                    </GridItem>
+                </Grid>
+            </CardBody>
+        </Card>
+    );
+}
+
+export default AffectedVirtualMachinesSummaryCard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
@@ -7,7 +7,9 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useRestQuery from 'hooks/useRestQuery';
 import { getVMCVEDetail } from 'services/VirtualMachineService';
 
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import { getOverviewPagePath } from '../../utils/searchUtils';
+import AffectedVirtualMachinesSummaryCard from './AffectedVirtualMachinesSummaryCard';
 import VirtualMachineCvePageHeader from './VirtualMachineCvePageHeader';
 
 const virtualMachineCveOverviewCvePath = getOverviewPagePath('VirtualMachine', {
@@ -18,7 +20,7 @@ function VirtualMachineCvePage() {
     const { cveId } = useParams<{ cveId: string }>();
 
     const fetchCveDetail = useCallback(() => getVMCVEDetail(cveId ?? ''), [cveId]);
-    const { data: cveDetail } = useRestQuery(fetchCveDetail);
+    const { data: cveDetail, isLoading, error } = useRestQuery(fetchCveDetail);
 
     return (
         <>
@@ -34,6 +36,22 @@ function VirtualMachineCvePage() {
             <Divider component="div" />
             <PageSection>
                 <VirtualMachineCvePageHeader cveDetail={cveDetail} />
+            </PageSection>
+            <Divider component="div" />
+            <PageSection>
+                <SummaryCardLayout error={error} isLoading={isLoading}>
+                    <SummaryCard
+                        data={cveDetail}
+                        loadingText="Loading affected virtual machines summary"
+                        renderer={({ data }) => (
+                            <AffectedVirtualMachinesSummaryCard
+                                affectedVirtualMachinesCount={data.affectedVmCount}
+                                totalVirtualMachinesCount={data.totalVmCount}
+                                affectedGuestOsCount={data.affectedGuestOsCount}
+                            />
+                        )}
+                    />
+                </SummaryCardLayout>
             </PageSection>
         </>
     );


### PR DESCRIPTION
## Description

Adds the "Affected virtual machines" summary card to the VM CVE single page. Shows affected VM count out of total and affected guest OS count. Gated behind `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL`.

Data comes from the existing `GetVMCVEDetail` endpoint, no new API calls needed.

Filtering will come in a later PR.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified summary card renders with correct counts from API

<img width="1463" height="630" alt="Screenshot 2026-06-29 at 2 55 36 PM" src="https://github.com/user-attachments/assets/e5701ef1-d325-4e00-92d6-c9e1bcbcd619" />
