### PR TITLE
ROX-35620: Decouple process signal pipeline from detector via PubSub

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -875,6 +875,16 @@ func (d *detectorImpl) handleIndicatorEvent(event pubsub.Event) error {
 		return nil
 	}
 
+	// When the process signal pipeline publishes a raw indicator (no
+	// deployment snapshot), enrich it here before running detection.
+	if indicatorEvent.Deployment == nil {
+		enriched := d.enrichIndicator(indicatorEvent.Ctx, indicatorEvent.Indicator)
+		if enriched == nil {
+			return nil
+		}
+		indicatorEvent = enriched
+	}
+
 	d.detectAndAlertForIndicator(indicatorEvent)
 	return nil
 }

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -868,21 +868,23 @@ func (d *detectorImpl) handleIndicatorEvent(event pubsub.Event) error {
 		return errors.Errorf("unexpected event type: %T", event)
 	}
 
-	// Block while paused (offline mode)
-	select {
-	case <-d.runtimeRunning.Done():
-	case <-d.detectorStopper.Flow().StopRequested():
-		return nil
-	}
-
-	// When the process signal pipeline publishes a raw indicator (no
-	// deployment snapshot), enrich it here before running detection.
+	// Enrich before blocking so the deployment snapshot is captured while
+	// the deployment still exists in the store. If enrichment is deferred
+	// past the runtimeRunning gate, the deployment may be deleted during
+	// offline mode and the indicator silently dropped.
 	if indicatorEvent.Deployment == nil {
 		enriched := d.enrichIndicator(indicatorEvent.Ctx, indicatorEvent.Indicator)
 		if enriched == nil {
 			return nil
 		}
 		indicatorEvent = enriched
+	}
+
+	// Block while paused (offline mode)
+	select {
+	case <-d.runtimeRunning.Done():
+	case <-d.detectorStopper.Flow().StopRequested():
+		return nil
 	}
 
 	d.detectAndAlertForIndicator(indicatorEvent)

--- a/sensor/common/detector/detector_indicator_bench_test.go
+++ b/sensor/common/detector/detector_indicator_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,5 +38,34 @@ func BenchmarkIndicatorPipeline_SteadyState(b *testing.B) {
 				<-d.output
 			}
 		})
+	}
+}
+
+// BenchmarkIndicatorPipeline_UnenrichedPublish measures the new path where
+// an unenriched IndicatorEvent is published directly to the dispatcher (as
+// the process signal pipeline does after ROX-35620). The detector consumer
+// enriches the event before running detection.
+func BenchmarkIndicatorPipeline_UnenrichedPublish(b *testing.B) {
+	b.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	d := createBenchDetector(b, true)
+	require.NoError(b, d.Start())
+	b.Cleanup(d.Stop)
+
+	d.Notify(common.SensorComponentEventCentralReachable)
+
+	pi := &storage.ProcessIndicator{
+		Id:           "pi-bench",
+		DeploymentId: "dep-1",
+		Signal:       &storage.ProcessSignal{ExecFilePath: "/bin/test"},
+	}
+
+	for b.Loop() {
+		event := &detectorEvents.IndicatorEvent{
+			Ctx:       context.Background(),
+			Indicator: pi,
+		}
+		require.NoError(b, d.pubSubDispatcher.Publish(event))
+		<-d.output
 	}
 }

--- a/sensor/common/detector/detector_indicator_test.go
+++ b/sensor/common/detector/detector_indicator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -166,6 +167,53 @@ func TestIndicatorPipelineOfflineBlocks(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestHandleUnenrichedIndicatorEvent(t *testing.T) {
+	deployment := &storage.Deployment{
+		Id:        "dep-1",
+		Name:      "test-deployment",
+		Namespace: "default",
+	}
+
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	synctest.Test(t, func(t *testing.T) {
+		d, ds, nps, _ := createTestDetector(t, true)
+		d.unifiedDetector = &fakeUnifiedDetector{
+			alerts: []*storage.Alert{{Id: "alert-1", Policy: &storage.Policy{Id: "p1"}}},
+		}
+		ds.EXPECT().GetSnapshot("dep-1").Return(deployment)
+		nps.EXPECT().Find("default", gomock.Any()).Return(nil)
+
+		require.NoError(t, d.Start())
+		defer d.Stop()
+
+		d.Notify(common.SensorComponentEventCentralReachable)
+
+		// Publish an unenriched event directly — simulates the process
+		// pipeline publishing a raw indicator without a deployment snapshot.
+		event := &detectorEvents.IndicatorEvent{
+			Ctx: context.Background(),
+			Indicator: &storage.ProcessIndicator{
+				Id:           "pi-unenriched",
+				DeploymentId: "dep-1",
+				Signal:       &storage.ProcessSignal{ExecFilePath: "/bin/bash"},
+			},
+		}
+		require.NoError(t, d.pubSubDispatcher.Publish(event))
+		synctest.Wait()
+
+		select {
+		case msg := <-d.output:
+			require.NotNil(t, msg)
+			alertResults := msg.GetEvent().GetAlertResults()
+			assert.Equal(t, "dep-1", alertResults.GetDeploymentId())
+			assert.NotEmpty(t, alertResults.GetAlerts())
+		default:
+			t.Fatal("expected output from unenriched indicator event")
+		}
+	})
 }
 
 func TestIndicatorPipelineDropsWhenFull(t *testing.T) {

--- a/sensor/common/processsignal/pipeline.go
+++ b/sensor/common/processsignal/pipeline.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/pubsub"
@@ -35,16 +36,18 @@ type processPipeline interface {
 type basePipeline struct {
 	processFilter     filter.Filter
 	detector          detector.Detector
+	pubSubDispatcher  common.PubSubDispatcher
 	stopper           concurrency.Stopper
 	cancelEnricherCtx context.CancelCauseFunc
 	enricher          *enricher
 	indicators        chan *message.ExpiringMessage
 }
 
-func newBasePipeline(indicators chan *message.ExpiringMessage, enricher *enricher, processFilter filter.Filter, detector detector.Detector, stopper concurrency.Stopper, cancelEnricherCtx context.CancelCauseFunc) basePipeline {
+func newBasePipeline(indicators chan *message.ExpiringMessage, enricher *enricher, processFilter filter.Filter, detector detector.Detector, pubSubDispatcher common.PubSubDispatcher, stopper concurrency.Stopper, cancelEnricherCtx context.CancelCauseFunc) basePipeline {
 	return basePipeline{
 		processFilter:     processFilter,
 		detector:          detector,
+		pubSubDispatcher:  pubSubDispatcher,
 		stopper:           stopper,
 		enricher:          enricher,
 		cancelEnricherCtx: cancelEnricherCtx,
@@ -103,7 +106,14 @@ func (p *basePipeline) processEnrichedIndicator(event pubsub.Event) error {
 }
 
 func (p *basePipeline) handleEnrichedIndicator(ctx context.Context, indicator *storage.ProcessIndicator) {
-	p.detector.ProcessIndicator(ctx, indicator)
+	if features.SensorInternalPubSub.Enabled() && p.pubSubDispatcher != nil {
+		event := &detectorEvents.IndicatorEvent{Ctx: ctx, Indicator: indicator}
+		if err := p.pubSubDispatcher.Publish(event); err != nil {
+			log.Errorf("Failed to publish indicator event to detector: %v", err)
+		}
+	} else {
+		p.detector.ProcessIndicator(ctx, indicator)
+	}
 
 	p.sendToCentral(
 		message.NewExpiring(ctx, &central.MsgFromSensor{
@@ -247,7 +257,7 @@ func NewProcessPipeline(indicators chan *message.ExpiringMessage, clusterEntitie
 	}
 
 	stopper := concurrency.NewStopper()
-	base := newBasePipeline(indicators, en, processFilter, detector, stopper, cancelEnricherCtx)
+	base := newBasePipeline(indicators, en, processFilter, detector, pubSubDispatcher, stopper, cancelEnricherCtx)
 
 	var inner processPipeline
 	var pipelineMode string

--- a/sensor/common/processsignal/pipeline_test.go
+++ b/sensor/common/processsignal/pipeline_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
@@ -312,6 +313,7 @@ func newTestDispatcher(t *testing.T) common.PubSubDispatcher {
 		[]pubsub.LaneConfig{
 			lane.NewBlockingLane(pubsub.UnenrichedProcessIndicatorLane),
 			lane.NewBlockingLane(pubsub.EnrichedProcessIndicatorLane),
+			lane.NewBlockingLane(pubsub.DetectorProcessIndicatorLane),
 		},
 	))
 	require.NoError(t, err)
@@ -331,6 +333,23 @@ func TestPubSubPipelineEnrichesAndDeliversIndicator(t *testing.T) {
 		mockDetector := mocks.NewMockDetector(mockCtrl)
 		dispatcher := newTestDispatcher(t)
 
+		// Register a test consumer to capture the event published to the
+		// detector topic — the pipeline no longer calls detector.ProcessIndicator()
+		// directly in pubsub mode.
+		var receivedEvent *detectorEvents.IndicatorEvent
+		err := dispatcher.RegisterConsumerToLane(
+			pubsub.DetectorProcessIndicatorConsumer,
+			pubsub.DetectorProcessIndicatorTopic,
+			pubsub.DetectorProcessIndicatorLane,
+			func(e pubsub.Event) error {
+				ie, ok := e.(*detectorEvents.IndicatorEvent)
+				require.True(t, ok, "expected *detectorEvents.IndicatorEvent, got %T", e)
+				receivedEvent = ie
+				return nil
+			},
+		)
+		require.NoError(t, err)
+
 		p, err := NewProcessPipeline(sensorEvents, mockStore, filter.NewFilter(5, 5, []int{10, 10, 10}),
 			mockDetector, dispatcher)
 		require.NoError(t, err)
@@ -344,15 +363,17 @@ func TestPubSubPipelineEnrichesAndDeliversIndicator(t *testing.T) {
 		}
 		updateStore(containerID, deploymentID, containerMetadata, mockStore)
 
-		mockDetector.EXPECT().ProcessIndicator(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, ind *storage.ProcessIndicator) {
-			assert.Equal(t, deploymentID, ind.GetDeploymentId())
-		})
-
 		p.Process(&storage.ProcessSignal{ContainerId: containerID})
 
 		// Wait for all goroutines in the bubble to settle.
 		synctest.Wait()
 
+		// Verify the indicator was published to the detector topic.
+		require.NotNil(t, receivedEvent, "expected an IndicatorEvent published to the detector topic")
+		assert.Equal(t, deploymentID, receivedEvent.Indicator.GetDeploymentId())
+		assert.Equal(t, containerID, receivedEvent.Indicator.GetSignal().GetContainerId())
+
+		// Verify the indicator was also sent to Central via the output channel.
 		msg := <-sensorEvents
 		require.NotNil(t, msg)
 		assert.Equal(t, deploymentID, msg.GetEvent().GetProcessIndicator().GetDeploymentId())

--- a/sensor/common/signal/signal_service.go
+++ b/sensor/common/signal/signal_service.go
@@ -21,8 +21,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const maxBufferSize = 10000
-
 var (
 	log = logging.LoggerForModule()
 )
@@ -57,7 +55,6 @@ type serviceImpl struct {
 
 	sensorAPI.UnimplementedSignalServiceServer
 
-	queue      chan *v1.Signal
 	indicators chan *message.ExpiringMessage
 
 	processPipeline  Pipeline

--- a/sensor/common/signal/singleton.go
+++ b/sensor/common/signal/singleton.go
@@ -1,14 +1,12 @@
 package signal
 
 import (
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/sensor/common/message"
 )
 
 // New creates a new signal service
 func New(pipeline Pipeline, indicators chan *message.ExpiringMessage, opts ...Option) Service {
 	srv := &serviceImpl{
-		queue:            make(chan *v1.Signal, maxBufferSize),
 		indicators:       indicators,
 		processPipeline:  pipeline,
 		authFuncOverride: authFuncOverride,


### PR DESCRIPTION
## Description
  Decouples the process signal pipeline from the detector by replacing the
  direct `detector.ProcessIndicator()` call with a PubSub publish, behind
  the `ROX_SENSOR_PUBSUB` feature flag.

  **What changed:**

  - `pipeline.handleEnrichedIndicator()` now publishes a
    `DetectorProcessIndicatorEvent` to the dispatcher instead of calling
    `detector.ProcessIndicator()` directly (pubsub mode only).
  - The detector's `handleIndicatorEvent` callback handles unenriched
    events (no deployment snapshot) by enriching them before running
    detection — necessary because the pipeline doesn't carry deployment
    context.
  - Removed dead code: `serviceImpl.queue` (`chan *v1.Signal`, buffer
    10000) was allocated but never read or written.

  **Why publish unenriched events?** The pipeline doesn't have the
  deployment snapshot at hand. The detector already has
  `enrichIndicator()` for exactly this purpose, so letting it handle
  enrichment on receive avoids duplicating store lookups in the pipeline.

  Legacy path (`ROX_SENSOR_PUBSUB=false`) is unchanged.

  > [!NOTE]
  > This PR was partially generated with the assistance of AI (Claude Code).

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above
  **OR** is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality
  is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing
  
  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change
  
  - `TestPubSubPipelineEnrichesAndDeliversIndicator` — verifies the
    pipeline publishes to the detector topic instead of calling
    `ProcessIndicator()` directly, and the indicator still reaches Central.
  - `TestHandleUnenrichedIndicatorEvent` — verifies the detector enriches
    a raw indicator (no deployment snapshot) and produces alerts.
  - `BenchmarkIndicatorPipeline_UnenrichedPublish` — measures the new
    unenriched publish path end-to-end.
  - All existing detector and pipeline tests pass unchanged.