### PR TITLE
ROX-35684: parallelize vulnerability bundle processing

### DIFF
--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -32,6 +33,7 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
 	"github.com/stackrox/rox/scanner/updater/jsonblob"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -445,15 +447,25 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 	}
 	slog.InfoContext(ctx, "pre-registered vulnerability bundles", "count", len(bundles))
 
-	// Process each vulnerability bundle in the .zip archive.
+	// Process vulnerability bundles concurrently. Each bundle operates on independent
+	// updater namespaces and holds its own PostgreSQL advisory lock, so parallel
+	// execution is safe.
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(runtime.GOMAXPROCS(0))
 	for _, bundleF := range bundles {
-		bundleCtx := log.With(ctx, "bundle", bundleF.Name)
-		slog.InfoContext(bundleCtx, "starting bundle update")
-		if err := u.updateBundle(bundleCtx, bundleF, zipTime, prevTime); err != nil {
-			slog.ErrorContext(bundleCtx, "updating bundle failed", "reason", err)
-			return false, fmt.Errorf("updating bundle %s: %w", bundleF.Name, err)
-		}
-		slog.InfoContext(bundleCtx, "completed bundle update")
+		g.Go(func() error {
+			bundleCtx := log.With(gCtx, "bundle", bundleF.Name)
+			slog.InfoContext(bundleCtx, "starting bundle update")
+			if err := u.updateBundle(bundleCtx, bundleF, zipTime, prevTime); err != nil {
+				slog.ErrorContext(bundleCtx, "updating bundle failed", "reason", err)
+				return fmt.Errorf("updating bundle %s: %w", bundleF.Name, err)
+			}
+			slog.InfoContext(bundleCtx, "completed bundle update")
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return false, err
 	}
 
 	// Clean updaters that were deleted (not in the zip and older than this update).

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/datastore"
@@ -30,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/errgroup"
 )
 
 var _ updates.LockSource = (*testLocker)(nil)
@@ -759,6 +762,132 @@ func TestUpdater_Import(t *testing.T) {
 		assert.Error(t, err, "iterating on vulnerabilities: fake error")
 		if !cmp.Equal(got, want) {
 			t.Error(cmp.Diff(got, want))
+		}
+	})
+}
+
+func createZstZip(tb testing.TB, bundleNames []string) []byte {
+	tb.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, name := range bundleNames {
+		w, err := zw.Create(name)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		enc, err := zstd.NewWriter(w)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		enc.Close()
+	}
+	if err := zw.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func BenchmarkMultiBundleUpdate(b *testing.B) {
+	bundleNames := []string{
+		"alpine.json.zst", "debian.json.zst", "epss.json.zst",
+		"manual.json.zst", "nvd.json.zst", "osv.json.zst",
+		"rhel-vex.json.zst", "stackrox-rhel-csaf.json.zst", "ubuntu.json.zst",
+	}
+	zipData := createZstZip(b, bundleNames)
+
+	now, _ := http.ParseTime(time.Now().UTC().Format(http.TimeFormat))
+	prevTime := now.Add(-time.Minute)
+
+	const importDelay = 50 * time.Millisecond
+
+	setup := func(b *testing.B) *Updater {
+		b.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeContent(w, r, "test-file", now, bytes.NewReader(zipData))
+		}))
+		b.Cleanup(srv.Close)
+
+		ctrl := gomock.NewController(b)
+		store := mocks.NewMockMatcherStore(ctrl)
+		metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
+
+		metadataStore.EXPECT().
+			GetLastVulnerabilityUpdate(gomock.Any()).
+			Return(prevTime, nil).AnyTimes()
+		metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(prevTime, nil).AnyTimes()
+		metadataStore.EXPECT().
+			SetLastVulnerabilityUpdate(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil).AnyTimes()
+		metadataStore.EXPECT().
+			GCVulnerabilityUpdates(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil).AnyTimes()
+		store.EXPECT().
+			Distributions(gomock.Any()).
+			Return(nil, nil).AnyTimes()
+
+		return &Updater{
+			locker:        &testLocker{locker: updates.NewLocalLockSource()},
+			store:         store,
+			metadataStore: metadataStore,
+			client:        srv.Client(),
+			urls:          []string{srv.URL},
+			root:          b.TempDir(),
+			skipGC:        true,
+			importFunc: func(_ context.Context, _ io.Reader) error {
+				time.Sleep(importDelay)
+				return nil
+			},
+			retryDelay:  1 * time.Second,
+			retryMax:    1,
+			distManager: newDistManager(store),
+		}
+	}
+
+	b.Run("sequential", func(b *testing.B) {
+		u := setup(b)
+		b.ResetTimer()
+		for range b.N {
+			ctx := context.Background()
+			zipFile, zipTime, err := u.fetch(ctx, prevTime)
+			if err != nil {
+				b.Fatal(err)
+			}
+			zipInfo, _ := zipFile.Stat()
+			zipReader, _ := zip.NewReader(zipFile, zipInfo.Size())
+			for _, f := range zipReader.File {
+				if err := u.updateBundle(ctx, f, zipTime, prevTime); err != nil {
+					b.Fatal(err)
+				}
+			}
+			zipFile.Close()
+			os.Remove(zipFile.Name())
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		u := setup(b)
+		b.ResetTimer()
+		for range b.N {
+			ctx := context.Background()
+			zipFile, zipTime, err := u.fetch(ctx, prevTime)
+			if err != nil {
+				b.Fatal(err)
+			}
+			zipInfo, _ := zipFile.Stat()
+			zipReader, _ := zip.NewReader(zipFile, zipInfo.Size())
+			g, gCtx := errgroup.WithContext(ctx)
+			for _, f := range zipReader.File {
+				g.Go(func() error {
+					return u.updateBundle(gCtx, f, zipTime, prevTime)
+				})
+			}
+			if err := g.Wait(); err != nil {
+				b.Fatal(err)
+			}
+			zipFile.Close()
+			os.Remove(zipFile.Name())
 		}
 	})
 }


### PR DESCRIPTION
## Description

Sequential processing of 9 independent bundles was the bottleneck on the StackRox side. Each bundle operates on its own updater namespace and PostgreSQL advisory lock, so parallel execution is safe.

Uses errgroup with GOMAXPROCS concurrency limit, matching claircore's own Manager.Run() pattern.

Benchmark results (9 bundles, 50ms simulated import each, 8 CPUs):
  - sequential: ~456ms/op
  - parallel:   ~53ms/op  (~8.7x speedup)

Partially generated by AI.
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
