### PR TITLE
ROX-34535: Fixes leaking connections on delayed integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-35006: Go runtime upgraded to 1.26. Unbracketed IPv6 addresses (e.g. `2001:db8::1`) are no longer accepted; use bracketed format instead (e.g. `[2001:db8::1]:443`).
 - ROX-34804: The machine access configuration for `config-controller` now validates the audience (`aud` claim) of the service account token. The expected audience is `central.stackrox.io`. When users have added their own role bindings to this machine access configuration, the audience check is not enforced by default to keep backwards compatibility. It is recommended to set the expected audience to `central.stackrox.io` after ensuring that all exchange tokens are being created with this audience claim.
 
+- ROX-34535: Fixes an issue where if ScannerV2 is disabled or unavailable on initial startup the central deployment leaks GRPC connections until the scanner becomes available.
+
 ## [4.11.0]
 
 ### Added Features

--- a/central/imageintegration/store/defaults.go
+++ b/central/imageintegration/store/defaults.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/scanners/clairify"
 	"github.com/stackrox/rox/pkg/scanners/scannerv4"
 	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 // DefaultImageIntegrations are the default public registries
@@ -159,6 +161,9 @@ func makeDelayedIntegration(imageIntegration *storage.ImageIntegration, creatorF
 			scanner, err := creator(imageIntegration)
 			if err != nil {
 				return false
+			}
+			if closer, ok := scanner.(io.Closer); ok {
+				defer utils.IgnoreError(closer.Close)
 			}
 			return scanner.Test() == nil
 		},

--- a/central/imageintegration/store/defaults_test.go
+++ b/central/imageintegration/store/defaults_test.go
@@ -1,12 +1,17 @@
 package store
 
 import (
+	"errors"
 	"testing"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/scanners"
+	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestGetDelayedIntegrations(t *testing.T) {
@@ -33,8 +38,95 @@ func TestGetDelayedIntegrations(t *testing.T) {
 			if tc.expectCount == 0 {
 				assert.Empty(t, integrations)
 			} else {
-				require.Len(t, integrations, tc.expectCount)
+				assert.Len(t, integrations, tc.expectCount)
 				assert.Equal(t, defaultScanner.GetName(), integrations[0].Integration.GetName())
+			}
+		})
+	}
+}
+
+type mockScanner struct {
+	testErr error
+}
+
+func (m *mockScanner) MaxConcurrentScanSemaphore() *semaphore.Weighted { return nil }
+func (m *mockScanner) GetScan(_ *storage.Image) (*storage.ImageScan, error) {
+	return nil, nil
+}
+func (m *mockScanner) Match(_ *storage.ImageName) bool { return false }
+func (m *mockScanner) Test() error                     { return m.testErr }
+func (m *mockScanner) Type() string                    { return "mock" }
+func (m *mockScanner) Name() string                    { return "mock" }
+func (m *mockScanner) GetVulnDefinitionsInfo() (*v1.VulnDefinitionsInfo, error) {
+	return nil, nil
+}
+
+type mockClosableScanner struct {
+	mockScanner
+	closeCalled bool
+}
+
+func (m *mockClosableScanner) Close() error {
+	m.closeCalled = true
+	return nil
+}
+
+func TestMakeDelayedIntegration(t *testing.T) {
+	integration := &storage.ImageIntegration{Id: "test-id", Name: "test"}
+
+	tests := map[string]struct {
+		creatorErr    error
+		testErr       error
+		closable      bool
+		expectTrigger bool
+		expectClosed  bool
+	}{
+		"scanner test succeeds and Close is called": {
+			closable:      true,
+			expectTrigger: true,
+			expectClosed:  true,
+		},
+		"scanner test fails and Close is called": {
+			testErr:       errors.New("connection refused"),
+			closable:      true,
+			expectTrigger: false,
+			expectClosed:  true,
+		},
+		"creator returns error so no scanner to close": {
+			creatorErr:    errors.New("bad config"),
+			expectTrigger: false,
+			expectClosed:  false,
+		},
+		"scanner without io.Closer works without panic": {
+			closable:      false,
+			expectTrigger: true,
+			expectClosed:  false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var closable *mockClosableScanner
+
+			creatorFactory := func() scanners.Creator {
+				return func(_ *storage.ImageIntegration) (scannerTypes.Scanner, error) {
+					if tc.creatorErr != nil {
+						return nil, tc.creatorErr
+					}
+					if tc.closable {
+						closable = &mockClosableScanner{mockScanner: mockScanner{testErr: tc.testErr}}
+						return closable, nil
+					}
+					return &mockScanner{testErr: tc.testErr}, nil
+				}
+			}
+
+			di := makeDelayedIntegration(integration, creatorFactory)
+			result := di.Trigger()
+
+			assert.Equal(t, tc.expectTrigger, result)
+			if tc.expectClosed {
+				assert.True(t, closable.closeCalled, "Close() should have been called")
 			}
 		})
 	}

--- a/pkg/scanners/clairify/clairify.go
+++ b/pkg/scanners/clairify/clairify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -53,6 +54,7 @@ var (
 	_ scannerTypes.Scanner                  = (*clairify)(nil)
 	_ scannerTypes.ImageVulnerabilityGetter = (*clairify)(nil)
 	_ scannerTypes.NodeScanner              = (*clairify)(nil)
+	_ io.Closer                             = (*clairify)(nil)
 
 	log             = logging.LoggerForModule()
 	scannerEndpoint = fmt.Sprintf("scanner.%s.svc", env.Namespace.Setting())
@@ -87,6 +89,7 @@ type clairify struct {
 	protoImageIntegration *storage.ImageIntegration
 	activeRegistries      registries.Set
 
+	gRPCConnection         *grpc.ClientConn
 	pingServiceClient      clairGRPCV1.PingServiceClient
 	imageScanServiceClient clairGRPCV1.ImageScanServiceClient
 	nodeScanServiceClient  clairGRPCV1.NodeScanServiceClient
@@ -140,6 +143,7 @@ func newScanner(protoImageIntegration *storage.ImageIntegration, activeRegistrie
 		protoImageIntegration: protoImageIntegration,
 		activeRegistries:      activeRegistries,
 
+		gRPCConnection:         gRPCConnection,
 		imageScanServiceClient: clairGRPCV1.NewImageScanServiceClient(gRPCConnection),
 
 		ScanSemaphore: scannerTypes.NewSemaphoreWithValue(numConcurrentScans),
@@ -191,6 +195,7 @@ func newNodeScanner(protoNodeIntegration *storage.NodeIntegration) (*clairify, e
 	return &clairify{
 		NodeScanSemaphore:      scannerTypes.NewNodeSemaphoreWithValue(defaultMaxConcurrentScans),
 		conf:                   conf,
+		gRPCConnection:         gRPCConnection,
 		pingServiceClient:      pingServiceClient,
 		nodeScanServiceClient:  scanServiceClient,
 		imageScanServiceClient: imageScanServiceClient,
@@ -206,6 +211,14 @@ func getTLSConfig() (*tls.Config, error) {
 		return nil, errors.Wrap(err, "failed to initialize TLS config")
 	}
 	return tlsConfig, nil
+}
+
+// Close closes the underlying gRPC connection.
+func (c *clairify) Close() error {
+	if c.gRPCConnection != nil {
+		return c.gRPCConnection.Close()
+	}
+	return nil
 }
 
 // Test initiates a test of the Clairify Scanner which verifies that we have the proper scan permissions
@@ -534,6 +547,7 @@ func newOrchestratorScanner(integration *storage.OrchestratorIntegration) (*clai
 	return &clairify{
 		ScanSemaphore:                 scannerTypes.NewSemaphoreWithValue(defaultMaxConcurrentScans),
 		conf:                          conf,
+		gRPCConnection:                gRPCConnection,
 		protoOrchestratorIntegration:  integration,
 		orchestratorScanServiceClient: clairGRPCV1.NewOrchestratorScanServiceClient(gRPCConnection),
 	}, nil

--- a/pkg/scanners/clairify/clairify_test.go
+++ b/pkg/scanners/clairify/clairify_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stackrox/rox/pkg/protoassert"
 	clairV1 "github.com/stackrox/scanner/api/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func getTestScan() (*clairV1.LayerEnvelope, *storage.ImageScan, *storage.Image) {
@@ -39,6 +43,21 @@ func getTestScan() (*clairV1.LayerEnvelope, *storage.ImageScan, *storage.Image) 
 		},
 	}
 	return &env, protoScan, image
+}
+
+func TestClairifyClose_NilConnection(t *testing.T) {
+	scanner := &clairify{}
+	assert.NoError(t, scanner.Close())
+}
+
+func TestClairifyClose_ClosesGRPCConnection(t *testing.T) {
+	conn, err := grpc.Dial("localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	scanner := &clairify{gRPCConnection: conn}
+	require.NoError(t, scanner.Close())
+
+	assert.Equal(t, connectivity.Shutdown, conn.GetState())
 }
 
 func TestConvertLayerToImageScan(t *testing.T) {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Fixes the leaked grpc connection with delayed integrations

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The bug requires Central to start **without** a reachable Scanner v2 pod and **without** an existing StackRox Scanner integration. Here's how to reproduce and validate:


1. Create the leak condition

```bash
# Scale down Scanner v2 (the clairify scanner, not Scanner V4)
kubectl -n acs-central scale deploy/scanner --replicas=0

# Remove scanner integration from database in case it's registered already:
roxcurl /v1/imageintegrations | jq '.integrations[] | select(.name == "Stackrox Scanner")'
# and delete it
roxcurl /v1/imageintegrations/[id from output of last command] -X DELETE

# Delete the existing StackRox Scanner integration if one exists,
# so the delayed integration mechanism activates on next restart
kubectl -n acs-central rollout restart deploy/central
```

3. Monitor for leaked connections

While Central is running and Scanner v2 is down, watch for accumulating connections to the scanner gRPC endpoint (port 8443):

```bash
# Watch TCP connections from Central to the scanner endpoint
# Run this every few seconds — count should stay stable with the fix
kubectl -n acs-central exec deploy/central -- \
  sh -c 'while true; do echo "$(date): $(cat /proc/net/tcp | wc -l) TCP connections"; sleep 10; done'
```

**Without the fix:** the connection count grows by 1-2 every 5 seconds.
**With the fix:** the count stays at 0 or 1 (the connection is created and immediately closed).

The key signal is that the TCP connection count to port 8443 stays flat over several minutes while Scanner is down, rather than climbing linearly.

---
Test results - Some logs omitted for brevity:

*Without the fix deployed*:
```
➜ kubectl -n acs-central exec deploy/central -- \
  sh -c 'while true; do echo "$(date): $(cat /proc/net/tcp | wc -l) TCP connections"; sleep 10; done'
Fri Jul 10 15:16:25 UTC 2026: 33 TCP connections
Fri Jul 10 15:16:35 UTC 2026: 33 TCP connections
Fri Jul 10 15:16:45 UTC 2026: 35 TCP connections
Fri Jul 10 15:16:55 UTC 2026: 31 TCP connections
Fri Jul 10 15:17:05 UTC 2026: 35 TCP connections
Fri Jul 10 15:17:15 UTC 2026: 34 TCP connections
Fri Jul 10 15:17:25 UTC 2026: 35 TCP connections
Fri Jul 10 15:17:35 UTC 2026: 36 TCP connections
Fri Jul 10 15:17:45 UTC 2026: 38 TCP connections
Fri Jul 10 15:17:55 UTC 2026: 37 TCP connections
Fri Jul 10 15:18:05 UTC 2026: 36 TCP connections
Fri Jul 10 15:18:15 UTC 2026: 43 TCP connections
...
Fri Jul 10 15:25:36 UTC 2026: 66 TCP connections
Fri Jul 10 15:25:46 UTC 2026: 63 TCP connections
Fri Jul 10 15:25:56 UTC 2026: 71 TCP connections
Fri Jul 10 15:26:06 UTC 2026: 69 TCP connections
Fri Jul 10 15:26:16 UTC 2026: 80 TCP connections
Fri Jul 10 15:26:26 UTC 2026: 73 TCP connections
Fri Jul 10 15:26:36 UTC 2026: 66 TCP connections
Fri Jul 10 15:26:46 UTC 2026: 62 TCP connections
Fri Jul 10 15:26:56 UTC 2026: 76 TCP connections
```

*With the fix deployed*:
```
➜ kubectl -n acs-central exec deploy/central -- \
  sh -c 'while true; do echo "$(date): $(cat /proc/net/tcp | wc -l) TCP connections"; sleep 10; done'
Fri Jul 10 14:38:40 UTC 2026: 54 TCP connections
...
Fri Jul 10 14:52:12 UTC 2026: 55 TCP connections
...
Fri Jul 10 14:53:42 UTC 2026: 54 TCP connections
...
Fri Jul 10 14:58:53 UTC 2026: 52 TCP connections
Fri Jul 10 14:59:03 UTC 2026: 48 TCP connections
...
Fri Jul 10 15:00:23 UTC 2026: 44 TCP connections
...
Fri Jul 10 15:00:53 UTC 2026: 22 TCP connections
...
Fri Jul 10 15:03:44 UTC 2026: 21 TCP connections
...
Fri Jul 10 15:09:44 UTC 2026: 21 TCP connections
Fri Jul 10 15:09:54 UTC 2026: 13 TCP connections
...
Fri Jul 10 15:12:15 UTC 2026: 14 TCP connections
...
Fri Jul 10 15:13:35 UTC 2026: 14 TCP connections
```