### PR TITLE
chore(ci): Enable janitor cluster cleanup after 2 hours

### DIFF
--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -79,7 +79,7 @@ jobs:
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
-        provision_gke_cluster byodb
+        provision_gke_cluster roxci
         {
           echo "CLUSTER_NAME=${CLUSTER_NAME}"
           echo "ZONE=${ZONE}"

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -65,7 +65,7 @@ jobs:
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
-        provision_gke_cluster dbbr
+        provision_gke_cluster roxci
         {
           echo "CLUSTER_NAME=${CLUSTER_NAME}"
           echo "ZONE=${ZONE}"

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -64,7 +64,7 @@ jobs:
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
-        provision_gke_cluster cent-up
+        provision_gke_cluster roxci
         {
           echo "CLUSTER_NAME=${CLUSTER_NAME}"
           echo "ZONE=${ZONE}"
@@ -212,7 +212,7 @@ jobs:
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
-        provision_gke_cluster pg-up
+        provision_gke_cluster roxci
         {
           echo "CLUSTER_NAME=${CLUSTER_NAME}"
           echo "ZONE=${ZONE}"
@@ -359,7 +359,7 @@ jobs:
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
-        provision_gke_cluster sens-up
+        provision_gke_cluster roxci
         {
           echo "CLUSTER_NAME=${CLUSTER_NAME}"
           echo "ZONE=${ZONE}"

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -79,7 +79,7 @@ jobs:
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
-        provision_gke_cluster nongroovy
+        provision_gke_cluster roxci
         {
           echo "CLUSTER_NAME=${CLUSTER_NAME}"
           echo "ZONE=${ZONE}"


### PR DESCRIPTION
## Description

See:
- https://redhat-internal.slack.com/archives/CC5UHD0KA/p1783515607828889
- https://docs.google.com/document/d/1vNOM7adAjpF0ZzgfItzFuwvwUeLsKbGOoAX22ZRuNOk/edit?disco=AAAB_n3-CbA
- https://github.com/stackrox/janitor/blob/77f055e36b0200dfee7d6a1180ae6de3ec1a4005/pkg/reclamationrules/rules.go#L36-L59

`roxci` prefix should give us automatic cluster cleanup after 2 hours.
Previously, the clusters leaked.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

I don't know how to validate Janitor. I'll just check that CI is happy here and will hope Janitor will be happy.