### PR TITLE
ROX-32912: pin v3 vulnerability bundle to release-4.11 tip

### DIFF
--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -6,4 +6,4 @@
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v2 tags/4.9.8-rc.2
-v3 heads/master
+v3 heads/e83e6e51034c51a851513daa2584700fae46834a


### PR DESCRIPTION
## Description

Pins the v3 vulnerability bundle stream to the release-4.11 tip (`e83e6e5103`), decoupling it from `heads/master`. This ensures the v3 bundle is built from a stable release branch rather than tracking master, where ongoing development could introduce unintended changes to the bundle contents.

The v3 stream on release-4.11 was introduced in #21663.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready

### How I validated my change

The release-4.11 commit `e83e6e5103` has `scanner/VULNERABILITY_VERSION=v3`, which matches the stream name. The workflow validation (`fetch_version`) will pass.