### PR TITLE
ROX-36126: add per-updater scheduling workflow

### DIFF
--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       skip_freshness_check:
-        description: "When true, bypass the freshness recheck (used for PR validation)"
+        description: "Skip the freshness recheck and run the update unconditionally"
         required: false
         type: boolean
         default: false
@@ -39,6 +39,7 @@ permissions:
 
 jobs:
   recheck:
+    if: ${{ !inputs.skip_freshness_check }}
     runs-on: ubuntu-latest
     outputs:
       result: ${{ steps.check.outputs.result }}
@@ -55,8 +56,7 @@ jobs:
     - name: Authenticate with GCS
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-33377): production cutover — use conditional credentials:
-        # credentials_json: ${{ github.event_name == 'pull_request' && secrets.GOOGLE_SA_CIRCLECI_SCANNER || secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
         credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK
@@ -68,12 +68,7 @@ jobs:
         GCS_OBJECT: ${{ inputs.object }}
         UPDATER_SOURCE: ${{ inputs.source }}
         SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
-        SKIP_FRESHNESS_CHECK: ${{ inputs.skip_freshness_check }}
       run: |
-        if [[ "$SKIP_FRESHNESS_CHECK" == "true" ]]; then
-            echo "result=run" >> "$GITHUB_OUTPUT"
-            exit 0
-        fi
         # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
         rc=0
         ./.github/workflows/scripts/scanner-updater-check-freshness.sh || rc=$?
@@ -85,24 +80,13 @@ jobs:
             echo "result=error" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Notify on recheck error
-      if: github.event_name != 'pull_request' && steps.check.outputs.result == 'error'
-      env:
-        OBJECT: ${{ inputs.object }}
-        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
-        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      run: |
-        curl -X POST -H 'Content-type: application/json' \
-          --data "{\"text\":\"Vulnerability updater freshness check failed for *${OBJECT}*: <${RUN_URL}|View logs>\"}" \
-          "$SLACK_WEBHOOK"
-
     - name: Fail on recheck error
       if: steps.check.outputs.result == 'error'
       run: exit 1
 
   update:
     needs: recheck
-    if: needs.recheck.outputs.result == 'run'
+    if: needs.recheck.result == 'skipped' || needs.recheck.outputs.result == 'run'
     runs-on: ubuntu-latest
     concurrency:
       group: scanner-updater-export-${{ inputs.object }}
@@ -166,8 +150,8 @@ jobs:
     - name: Authenticate with GCS for upload
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-33377): production cutover — use conditional credentials:
-        # credentials_json: ${{ github.event_name == 'pull_request' && secrets.GOOGLE_SA_CIRCLECI_SCANNER || secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER
+        # for non-PR runs (select via inputs.skip_freshness_check or a dedicated input).
         credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK
@@ -190,19 +174,28 @@ jobs:
 
         echo "Uploaded $src -> $GCS_OBJECT (digest=$digest)"
 
-    - name: Notify on failure
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
-        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      run: |
-        curl -X POST -H 'Content-type: application/json' \
-          --data "{\"text\":\"Vulnerability updater *${UPDATER_SOURCE}* failed: <${RUN_URL}|View logs>\"}" \
-          "$SLACK_WEBHOOK"
-
     - name: Checkout repository (cleanup)
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
       with:
         fetch-depth: 0
         persist-credentials: false
+
+  notify:
+    needs: [recheck, update]
+    if: >-
+      !inputs.skip_freshness_check &&
+      always() &&
+      (needs.recheck.result == 'failure' || needs.update.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify on failure
+      env:
+        SOURCE: ${{ inputs.source }}
+        OBJECT: ${{ inputs.object }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"Vulnerability updater *${SOURCE}* failed (object: ${OBJECT}): <${RUN_URL}|View logs>\"}" \
+          "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -1,0 +1,200 @@
+name: Scanner updater export
+
+on:
+  workflow_call:
+    inputs:
+      source:
+        description: "Updater name (e.g. alpine, nvd, osv)"
+        required: true
+        type: string
+      ref:
+        description: "Git reference to build the updater from"
+        required: true
+        type: string
+      object:
+        description: "Full GCS object path (gs://bucket/prefix/stream/sources/updater/data.json.zst)"
+        required: true
+        type: string
+      manual_url:
+        description: "URL to manual vulnerability data YAML"
+        required: true
+        type: string
+      skip_freshness_check:
+        description: "When true, bypass the freshness recheck (used for PR validation)"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GCP_SERVICE_ACCOUNT_STACKROX_CI:
+        required: true
+      GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER:
+        required: true
+      SLACK_ONCALL_SCANNER_WEBHOOK:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  recheck:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.check.outputs.result }}
+    concurrency:
+      group: scanner-updater-export-${{ inputs.object }}
+      cancel-in-progress: false
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Authenticate with GCS
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+
+    - name: Recheck freshness
+      id: check
+      env:
+        GCS_OBJECT: ${{ inputs.object }}
+        UPDATER_SOURCE: ${{ inputs.source }}
+        SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
+        SKIP_FRESHNESS_CHECK: ${{ inputs.skip_freshness_check }}
+      run: |
+        if [[ "$SKIP_FRESHNESS_CHECK" == "true" ]]; then
+            echo "result=run" >> "$GITHUB_OUTPUT"
+            exit 0
+        fi
+        # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
+        if ./.github/workflows/scripts/scanner-updater-check-freshness.sh; then
+            echo "result=skip" >> "$GITHUB_OUTPUT"
+        elif [[ $? -eq 1 ]]; then
+            echo "result=run" >> "$GITHUB_OUTPUT"
+        else
+            echo "result=error" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Notify on recheck error
+      if: github.event_name != 'pull_request' && steps.check.outputs.result == 'error'
+      env:
+        OBJECT: ${{ inputs.object }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"Vulnerability updater freshness check failed for *${OBJECT}*: <${RUN_URL}|View logs>\"}" \
+          "$SLACK_WEBHOOK"
+
+    - name: Fail on recheck error
+      if: steps.check.outputs.result == 'error'
+      run: exit 1
+
+  update:
+    needs: recheck
+    if: needs.recheck.outputs.result == 'run'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: scanner-updater-export-${{ inputs.object }}
+      cancel-in-progress: false
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.11@sha256:cea78f2b3a5a38c9ccda678712daaed90b7c372d6b5df963feb758b32dccebe1
+      volumes:
+      - /tmp:/tmp
+      - /usr:/mnt/usr
+      - /opt:/mnt/opt
+    env:
+      UPDATER_SOURCE: ${{ inputs.source }}
+      ROX_GIT_REF: ${{ inputs.ref }}
+      GCS_OBJECT: ${{ inputs.object }}
+      STACKROX_RHEL_VEX_COMPRESSED_FILE_TIMEOUT: "10m"
+    steps:
+    - name: Checkout repository (master for local actions)
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        free-disk-space: 50
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Checkout updater ref
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.ref }}
+        persist-credentials: false
+
+    - name: Download NVD
+      if: inputs.source == 'nvd'
+      run: |
+        set -eu
+        url="https://definitions.stackrox.io/v4/nvd/nvd-feeds.zip"
+        curl --fail --silent --show-error \
+          --retry 3 --retry-all-errors --retry-delay 5 \
+          --connect-timeout 10 --max-time 300 \
+          -o nvd.zip "$url"
+        echo "STACKROX_NVD_ZIP_PATH=$PWD/nvd.zip" >> "$GITHUB_ENV"
+
+    - name: Build updater
+      run: |
+        echo "Building updater for $UPDATER_SOURCE from ref $ROX_GIT_REF..."
+        make tag
+        make -C scanner bin/updater
+
+    - name: Run updater
+      env:
+        MANUAL_URL: ${{ inputs.manual_url }}
+      run: |
+        set -eu
+        export STACKROX_SCANNER_V4_UPDATER_SOURCES="$UPDATER_SOURCE"
+        mkdir -p bundles
+        scanner/bin/updater export --manual-url "$MANUAL_URL" bundles
+
+    - name: Authenticate with GCS for upload
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+
+    - name: Upload to GCS
+      run: |
+        set -eu
+        src="bundles/${UPDATER_SOURCE}.json.zst"
+        if [[ ! -f "$src" ]]; then
+            echo >&2 "ERROR: expected output file not found: $src"
+            exit 1
+        fi
+
+        digest="sha256:$(sha256sum "$src" | cut -d' ' -f1)"
+        completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+        gcloud storage cp "$src" "$GCS_OBJECT" \
+          --custom-metadata="git-ref=$ROX_GIT_REF,content-digest=$digest,refresh-completed-at=$completed_at"
+
+        echo "Uploaded $src -> $GCS_OBJECT (digest=$digest)"
+
+    - name: Notify on failure
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"Vulnerability updater *${UPDATER_SOURCE}* failed: <${RUN_URL}|View logs>\"}" \
+          "$SLACK_WEBHOOK"
+
+    - name: Checkout repository (cleanup)
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      if: always()
+      with:
+        fetch-depth: 0
+        persist-credentials: false

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -75,9 +75,11 @@ jobs:
             exit 0
         fi
         # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
-        if ./.github/workflows/scripts/scanner-updater-check-freshness.sh; then
+        rc=0
+        ./.github/workflows/scripts/scanner-updater-check-freshness.sh || rc=$?
+        if [[ $rc -eq 0 ]]; then
             echo "result=skip" >> "$GITHUB_OUTPUT"
-        elif [[ $? -eq 1 ]]; then
+        elif [[ $rc -eq 1 ]]; then
             echo "result=run" >> "$GITHUB_OUTPUT"
         else
             echo "result=error" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -82,7 +82,9 @@ jobs:
 
     - name: Fail on recheck error
       if: steps.check.outputs.result == 'error'
-      run: exit 1
+      run: |
+        echo "::error::freshness recheck failed for ${{ inputs.source }} (object: ${{ inputs.object }})"
+        exit 1
 
   update:
     needs: recheck
@@ -162,7 +164,7 @@ jobs:
         set -eu
         src="bundles/${UPDATER_SOURCE}.json.zst"
         if [[ ! -f "$src" ]]; then
-            echo >&2 "ERROR: expected output file not found: $src"
+            echo "::error::expected output file not found: $src"
             exit 1
         fi
 

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -27,6 +27,8 @@ on:
     secrets:
       GCP_SERVICE_ACCOUNT_STACKROX_CI:
         required: true
+      GOOGLE_SA_CIRCLECI_SCANNER:
+        required: true
       GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER:
         required: true
       SLACK_ONCALL_SCANNER_WEBHOOK:
@@ -53,7 +55,9 @@ jobs:
     - name: Authenticate with GCS
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        # TODO(ROX-33377): production cutover — use conditional credentials:
+        # credentials_json: ${{ github.event_name == 'pull_request' && secrets.GOOGLE_SA_CIRCLECI_SCANNER || secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
@@ -160,7 +164,9 @@ jobs:
     - name: Authenticate with GCS for upload
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        # TODO(ROX-33377): production cutover — use conditional credentials:
+        # credentials_json: ${{ github.event_name == 'pull_request' && secrets.GOOGLE_SA_CIRCLECI_SCANNER || secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -126,7 +126,7 @@ jobs:
     - name: Download NVD
       if: inputs.source == 'nvd'
       run: |
-        set -eu
+        set -euo pipefail
         url="https://definitions.stackrox.io/v4/nvd/nvd-feeds.zip"
         curl --fail --silent --show-error \
           --retry 3 --retry-all-errors --retry-delay 5 \
@@ -144,7 +144,7 @@ jobs:
       env:
         MANUAL_URL: ${{ inputs.manual_url }}
       run: |
-        set -eu
+        set -euo pipefail
         export STACKROX_SCANNER_V4_UPDATER_SOURCES="$UPDATER_SOURCE"
         mkdir -p bundles
         scanner/bin/updater export --manual-url "$MANUAL_URL" bundles
@@ -161,7 +161,7 @@ jobs:
 
     - name: Upload to GCS
       run: |
-        set -eu
+        set -euo pipefail
         src="bundles/${UPDATER_SOURCE}.json.zst"
         if [[ ! -f "$src" ]]; then
             echo "::error::expected output file not found: $src"

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -86,7 +86,7 @@ jobs:
 
   update:
     needs: recheck
-    if: needs.recheck.result == 'skipped' || needs.recheck.outputs.result == 'run'
+    if: always() && (needs.recheck.result == 'skipped' || needs.recheck.outputs.result == 'run')
     runs-on: ubuntu-latest
     concurrency:
       group: scanner-updater-export-${{ inputs.object }}

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -37,7 +37,8 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+        # TODO(ROX-33377): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK
       if: github.event_name != 'pull_request'
@@ -138,5 +139,6 @@ jobs:
       skip_freshness_check: ${{ github.event_name == 'pull_request' }}
     secrets:
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+      GOOGLE_SA_CIRCLECI_SCANNER: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
       GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
       SLACK_ONCALL_SCANNER_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -1,0 +1,142 @@
+name: Scanner updater schedule
+# This workflow writes to the test bucket while under validation.
+# Once the bundler workflow is ready and the full pipeline is verified,
+# update storage.bucket in source-config.yaml to definitions.stackrox.io
+# and remove the schedule from scanner-versioned-definitions-update.yaml.
+
+on:
+  schedule:
+  - cron: "17 * * * *"
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-matrix:
+    if: >-
+      github.repository_owner == 'stackrox' && (
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
+      )
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Authenticate with GCS
+      if: github.event_name != 'pull_request'
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+
+    - name: Set up Cloud SDK
+      if: github.event_name != 'pull_request'
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+
+    - name: Build updater matrix (scheduled/dispatch)
+      if: github.event_name != 'pull_request'
+      id: matrix-scheduled
+      env:
+        SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
+      run: |
+        set -euo pipefail
+        result=$(./.github/workflows/scripts/scanner-updater-matrix.sh)
+        {
+          echo "has_errors=$(echo "$result" | jq -r '.has_errors')"
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "errors<<$EOF"
+          echo "$result" | jq -r '.errors | join(", ")'
+          echo "$EOF"
+        } >> "$GITHUB_OUTPUT"
+        echo "$result" > matrix-result.json
+
+    - name: Notify on matrix errors
+      if: github.event_name != 'pull_request' && steps.matrix-scheduled.outputs.has_errors == 'true'
+      env:
+        ERRORS: ${{ steps.matrix-scheduled.outputs.errors }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"Vulnerability updater scheduling errors: ${ERRORS}. <${RUN_URL}|View logs>\"}" \
+          "$SLACK_WEBHOOK"
+
+    - name: Build updater matrix (PR)
+      if: github.event_name == 'pull_request'
+      env:
+        SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
+        PR_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        bucket=$(yq '.storage.bucket' "$SOURCE_CONFIG")
+        prefix=$(yq '.storage.prefix' "$SOURCE_CONFIG")
+        matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual/data.json.zst\"}]}"
+        printf '{"has_due":true,"has_errors":false,"errors":[],"matrix":%s}\n' "$matrix" > matrix-result.json
+
+    - name: Validate matrix builder (scheduled/dispatch)
+      if: github.event_name != 'pull_request'
+      env:
+        SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
+      run: |
+        echo "Running matrix builder for validation (output not used for scheduling):"
+        ./.github/workflows/scripts/scanner-updater-matrix.sh | jq .
+
+    - name: Upload matrix result
+      uses: ./.github/actions/upload-artifact-with-retry
+      with:
+        name: matrix-result
+        path: matrix-result.json
+
+  plan:
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    outputs:
+      has_due: ${{ steps.emit.outputs.has_due }}
+      matrix: ${{ steps.emit.outputs.matrix }}
+    steps:
+    - name: Download matrix result
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+      with:
+        name: matrix-result
+
+    - name: Emit matrix outputs
+      id: emit
+      run: |
+        set -euo pipefail
+        result=$(cat matrix-result.json)
+        {
+          echo "has_due=$(echo "$result" | jq -r '.has_due')"
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "matrix<<$EOF"
+          echo "$result" | jq -c '.matrix'
+          echo "$EOF"
+        } >> "$GITHUB_OUTPUT"
+
+  update:
+    needs: plan
+    if: needs.plan.outputs.has_due == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    uses: ./.github/workflows/scanner-updater-export.yaml
+    with:
+      source: ${{ matrix.source }}
+      ref: ${{ matrix.ref }}
+      object: ${{ matrix.object }}
+      manual_url: ${{ github.event_name == 'pull_request' && format('https://raw.githubusercontent.com/stackrox/stackrox/{0}/scanner/updater/manual/vulns.yaml', github.event.pull_request.head.sha) || 'https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/manual/vulns.yaml' }}
+      skip_freshness_check: ${{ github.event_name == 'pull_request' }}
+    secrets:
+      GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+      GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+      SLACK_ONCALL_SCANNER_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -37,7 +37,7 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-33377): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
+        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
         credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -85,8 +85,8 @@ jobs:
         matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual/data.json.zst\"}]}"
         printf '{"has_due":true,"has_errors":false,"errors":[],"matrix":%s}\n' "$matrix" > matrix-result.json
 
-    - name: Validate matrix builder (scheduled/dispatch)
-      if: github.event_name != 'pull_request'
+    - name: Validate matrix builder (PR)
+      if: github.event_name == 'pull_request'
       env:
         SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
       run: |

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -68,6 +68,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
+        echo "::error::vulnerability updater scheduling errors: ${ERRORS}"
         curl -X POST -H 'Content-type: application/json' \
           --data "{\"text\":\"Vulnerability updater scheduling errors: ${ERRORS}. <${RUN_URL}|View logs>\"}" \
           "$SLACK_WEBHOOK"

--- a/.github/workflows/scripts/scanner-updater-check-freshness.sh
+++ b/.github/workflows/scripts/scanner-updater-check-freshness.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 # failing command's code (usually 1), making it indistinguishable from the
 # intentional "not fresh" exit. The trap guarantees that exit 1 can only come
 # from our explicit exit 1 calls.
-trap 'echo >&2 "ERROR: unexpected failure at line $LINENO"; exit 2' ERR
+trap 'echo "::error::unexpected failure in check-freshness.sh at line $LINENO"; exit 2' ERR
 
 object="${GCS_OBJECT:?GCS_OBJECT is required}"
 updater="${UPDATER_SOURCE:?UPDATER_SOURCE is required}"
@@ -45,7 +45,7 @@ duration_to_seconds() {
         elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
             total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
         else
-            echo >&2 "ERROR: cannot parse duration: $remaining"; exit 2
+            echo "::error::cannot parse duration: $remaining"; exit 2
         fi
     done
     echo "$total"
@@ -80,7 +80,7 @@ case "$http_code" in
         exit 1
         ;;
     *)
-        echo >&2 "ERROR: ${object}: GCS returned HTTP $http_code"
+        echo "::error::${object}: GCS returned HTTP $http_code"
         exit 2
         ;;
 esac

--- a/.github/workflows/scripts/scanner-updater-check-freshness.sh
+++ b/.github/workflows/scripts/scanner-updater-check-freshness.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Check whether an updater's vulnerability data is fresh.
+#
+# Uses an unauthenticated curl against the public GCS download URL to
+# classify the object state (200/404/other), then gcloud for creation_time
+# when the object exists.
+#
+# Exit codes:
+#   0 — object exists and is fresh (age < interval)
+#   1 — object is missing (404) or stale (age >= interval)
+#   2 — unexpected failure: caller should treat as error and notify
+#
+# Inputs (environment):
+#   GCS_OBJECT       — full GCS object path (gs://bucket/path/to/data.json.zst)
+#   UPDATER_SOURCE   — updater name, used to look up interval in config
+#   SOURCE_CONFIG    — path to source-config.yaml
+#
+# Requires: curl, yq, gcloud.
+
+set -euo pipefail
+
+# The ERR trap below forces any unexpected command failure to exit 2 instead of
+# the failing command's own exit code. Without it, set -e would exit with the
+# failing command's code (usually 1), making it indistinguishable from the
+# intentional "not fresh" exit. The trap guarantees that exit 1 can only come
+# from our explicit exit 1 calls.
+trap 'echo >&2 "ERROR: unexpected failure at line $LINENO"; exit 2' ERR
+
+object="${GCS_OBJECT:?GCS_OBJECT is required}"
+updater="${UPDATER_SOURCE:?UPDATER_SOURCE is required}"
+config="${SOURCE_CONFIG:?SOURCE_CONFIG is required}"
+
+# Derive the download URL from the gs:// path.
+download_url="https://storage.googleapis.com/${object#gs://}"
+
+duration_to_seconds() {
+    local dur="${1:?}"
+    local total=0 remaining="$dur"
+    while [[ -n "$remaining" ]]; do
+        if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
+        elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
+        elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
+        else
+            echo >&2 "ERROR: cannot parse duration: $remaining"; exit 2
+        fi
+    done
+    echo "$total"
+}
+
+# Read interval from config.
+default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
+interval=$(yq ".updaters.\"${updater}\".interval // \"$default_interval\"" "$config")
+interval_secs=$(duration_to_seconds "$interval")
+
+# Check object existence via unauthenticated curl.
+http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    --connect-timeout 10 --max-time 15 \
+    "$download_url")
+
+case "$http_code" in
+    200)
+        creation_time=$(gcloud storage objects describe "$object" \
+            --format="value(creation_time)")
+        created_epoch=$(date -d "$creation_time" +%s)
+        now=$(date +%s)
+        age=$(( now - created_epoch ))
+        if (( age < interval_secs )); then
+            echo >&2 "INFO: ${object}: fresh (age=${age}s < interval=${interval_secs}s)"
+            exit 0
+        fi
+        echo >&2 "INFO: ${object}: stale (age=${age}s >= interval=${interval_secs}s)"
+        exit 1
+        ;;
+    404)
+        echo >&2 "INFO: ${object}: not found"
+        exit 1
+        ;;
+    *)
+        echo >&2 "ERROR: ${object}: GCS returned HTTP $http_code"
+        exit 2
+        ;;
+esac

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Build a GitHub Actions matrix of updater/stream pairs that are due
+# for a refresh.
+#
+# Expands stream/ref pairs (from scanner-get-released-tags.sh) against
+# per-stream updater lists (from source-config.yaml), then calls
+# scanner-updater-check-freshness.sh for each pair. Only due pairs
+# are emitted.
+#
+# Inputs (environment):
+#   SOURCE_CONFIG — path to source-config.yaml
+#
+# Outputs (stdout):
+#   JSON object with "has_due", "has_errors", "errors", and "matrix"
+#   for GitHub Actions.
+#
+# Requires: yq, jq, and scanner-get-released-tags.sh and
+# scanner-updater-check-freshness.sh in the same repo checkout.
+
+set -euo pipefail
+
+config="${SOURCE_CONFIG:?SOURCE_CONFIG is required}"
+
+for cmd in yq jq; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo >&2 "ERROR: $cmd is required but not found"
+        exit 1
+    fi
+done
+
+# Read storage location from config.
+bucket=$(yq '.storage.bucket' "$config")
+prefix=$(yq '.storage.prefix' "$config")
+
+# Expand stream/ref/updater triples, check freshness, emit due pairs.
+./.github/workflows/scripts/scanner-get-released-tags.sh \
+    | jq -r '.[] | "\(.version) \(.ref)"' \
+    | while read -r stream ref; do
+          yq ".bundles.\"$stream\" | .[]" "$config" \
+              | while read -r updater; do
+                    echo "$stream $ref $updater"
+                done
+      done \
+    | while read -r stream ref updater; do
+          object="gs://${bucket}/${prefix}/${stream}/sources/${updater}/data.json.zst"
+
+          # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
+          if GCS_OBJECT="$object" \
+             UPDATER_SOURCE="$updater" \
+             SOURCE_CONFIG="$config" \
+             ./.github/workflows/scripts/scanner-updater-check-freshness.sh
+          then
+              continue
+          elif [[ $? -eq 1 ]]; then
+              jq -n \
+                  --arg source "$updater" \
+                  --arg ref "$ref" \
+                  --arg object "$object" \
+                  '{source: $source, ref: $ref, object: $object}'
+          else
+              echo >&2 "ERROR: ${object}: freshness check failed"
+              jq -n --arg msg "${object}: freshness check failed" '{error: $msg}'
+              continue
+          fi
+      done \
+    | jq -s '{
+          has_due:    (map(select(.source)) | length > 0 | tostring),
+          has_errors: (map(select(.error))  | length > 0 | tostring),
+          errors:     [.[] | .error // empty],
+          matrix:     {include: [.[] | select(.source)]}
+      }'

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -24,7 +24,7 @@ config="${SOURCE_CONFIG:?SOURCE_CONFIG is required}"
 
 for cmd in yq jq; do
     if ! command -v "$cmd" &>/dev/null; then
-        echo >&2 "ERROR: $cmd is required but not found"
+        echo "::error::$cmd is required but not found"
         exit 1
     fi
 done
@@ -59,7 +59,7 @@ prefix=$(yq '.storage.prefix' "$config")
                   --arg object "$object" \
                   '{source: $source, ref: $ref, object: $object}'
           else
-              echo >&2 "ERROR: ${object}: freshness check failed"
+              echo "::error::${object}: freshness check failed"
               jq -n --arg msg "${object}: freshness check failed" '{error: $msg}'
               continue
           fi

--- a/scanner/updater/ci/source-config.yaml
+++ b/scanner/updater/ci/source-config.yaml
@@ -1,0 +1,50 @@
+# Per-updater configuration for the vulnerability update workflow.
+#
+# storage: GCS location for per-updater data objects. The object path
+# pattern is gs://<bucket>/<prefix>/<stream>/sources/<updater>/data.json.zst,
+# constructed by the matrix builder and passed to all downstream consumers.
+#
+# bundles: defines which updaters to include in each version stream's bundle.
+# The stream-to-ref mapping comes from VULNERABILITY_BUNDLE_VERSION.
+#
+# updaters: per-updater configuration. Each updater inherits from 'default'
+# unless it overrides a field. New configuration sections can be added here
+# as the pipeline evolves.
+
+storage:
+  bucket: scanner-v4-test
+  prefix: vulnerability-bundles
+
+bundles:
+  dev:
+    - alpine
+    - aws
+    - debian
+    - epss
+    - manual
+    - nvd
+    - oracle
+    - osv
+    - photon
+    - rhel-vex
+    - stackrox-rhel-csaf
+    - suse
+    - ubuntu
+  v2:
+    - alpine
+    - aws
+    - debian
+    - epss
+    - manual
+    - nvd
+    - oracle
+    - osv
+    - photon
+    - rhel-vex
+    - stackrox-rhel-csaf
+    - suse
+    - ubuntu
+
+updaters:
+  default:
+    interval: 4h

--- a/scanner/updater/ci/source-config.yaml
+++ b/scanner/updater/ci/source-config.yaml
@@ -44,6 +44,20 @@ bundles:
     - stackrox-rhel-csaf
     - suse
     - ubuntu
+  v3:
+    - alpine
+    - aws
+    - debian
+    - epss
+    - manual
+    - nvd
+    - oracle
+    - osv
+    - photon
+    - rhel-vex
+    - stackrox-rhel-csaf
+    - suse
+    - ubuntu
 
 updaters:
   default:


### PR DESCRIPTION
## Description

Adds the per-updater dynamic scheduling workflow for the Scanner V4 vulnerability pipeline. This PR stacks on #21601 (source filtering env var).

New files:
- `scanner/updater/ci/source-config.yaml` — per-stream updater lists and scheduling parameters
- `.github/workflows/scanner-updater-schedule.yaml` — hourly scheduler with dynamic matrix
- `.github/workflows/scanner-updater-export.yaml` — per-updater export with freshness recheck
- `.github/workflows/scripts/scanner-updater-matrix.sh` — matrix builder
- `.github/workflows/scripts/scanner-updater-check-freshness.sh` — three-state GCS freshness check

Writes to the `scanner-v4-test` bucket. Does not modify the existing vulnerability update workflow.

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed
- [x] documentation PR is created and is linked above OR is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests

### How I validated my change

The `pr-update-scanner-vulns` label triggers the new workflow against `manual/dev` using the PR's code. The matrix builder validation step also runs the full matrix against the test bucket without spawning build jobs.