### PR TITLE
refactor(ci): switch upgrade tests to create-gke-cluster action

### DIFF
--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -124,12 +124,6 @@ jobs:
         from post_tests import FinalPost
         FinalPost(store_qa_tests_data=True).run()
 
-    - name: Teardown GKE cluster
-      if: always()
-      run: |
-        if [[ -z "${CLUSTER_NAME:-}" ]]; then exit 0; fi
-        scripts/ci/gke.sh teardown_and_report_gke_cluster false
-
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
@@ -243,12 +237,6 @@ jobs:
         from post_tests import FinalPost
         FinalPost(store_qa_tests_data=True).run()
 
-    - name: Teardown GKE cluster
-      if: always()
-      run: |
-        if [[ -z "${CLUSTER_NAME:-}" ]]; then exit 0; fi
-        scripts/ci/gke.sh teardown_and_report_gke_cluster false
-
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
@@ -348,12 +336,6 @@ jobs:
         sys.path.append('.openshift-ci')
         from post_tests import FinalPost
         FinalPost(store_qa_tests_data=False).run()
-
-    - name: Teardown GKE cluster
-      if: always()
-      run: |
-        if [[ -z "${CLUSTER_NAME:-}" ]]; then exit 0; fi
-        scripts/ci/gke.sh teardown_and_report_gke_cluster false
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -56,41 +56,20 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Create GKE cluster
-      env:
-        MACHINE_TYPE: e2-standard-8
-        NUM_NODES: "3"
-        GKE_SPOT: "true"
-      timeout-minutes: 20
-      run: |
-        source scripts/ci/gke.sh
-        provision_gke_cluster cent-up
-        {
-          echo "CLUSTER_NAME=${CLUSTER_NAME}"
-          echo "ZONE=${ZONE}"
-          echo "KUBECONFIG=${HOME}/.kube/config"
-        } >> "$GITHUB_ENV"
-
     - name: Docker login to Quay.io
       env:
         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
       run: docker login -u "${REGISTRY_USERNAME}" --password-stdin quay.io <<<"${REGISTRY_PASSWORD}"
 
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+    - name: Create GKE cluster
+      uses: ./.github/actions/create-gke-cluster
       with:
-        install_components: "gke-gcloud-auth-plugin"
+        cluster-name: cent-up
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Build roxctl
       run: make roxctl_linux-amd64
-
-    - name: Verify kubectl access and wait for cluster to stabilize
-      timeout-minutes: 5
-      run: |
-        kubectl cluster-info
-        kubectl get nodes
-        scripts/ci/gke.sh wait_for_cluster
 
     - name: Run pre-test
       shell: python
@@ -147,16 +126,9 @@ jobs:
 
     - name: Teardown GKE cluster
       if: always()
-      continue-on-error: true
       run: |
-        if [[ -z "${CLUSTER_NAME:-}" ]]; then
-          echo "No cluster to teardown"
-          exit 0
-        fi
-        if ! scripts/ci/gke.sh teardown_gke_cluster false; then
-          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
-          exit 6
-        fi
+        if [[ -z "${CLUSTER_NAME:-}" ]]; then exit 0; fi
+        scripts/ci/gke.sh teardown_and_report_gke_cluster false
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
@@ -204,41 +176,20 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Create GKE cluster
-      env:
-        MACHINE_TYPE: e2-standard-8
-        NUM_NODES: "3"
-        GKE_SPOT: "true"
-      timeout-minutes: 20
-      run: |
-        source scripts/ci/gke.sh
-        provision_gke_cluster pg-up
-        {
-          echo "CLUSTER_NAME=${CLUSTER_NAME}"
-          echo "ZONE=${ZONE}"
-          echo "KUBECONFIG=${HOME}/.kube/config"
-        } >> "$GITHUB_ENV"
-
     - name: Docker login to Quay.io
       env:
         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
       run: docker login -u "${REGISTRY_USERNAME}" --password-stdin quay.io <<<"${REGISTRY_PASSWORD}"
 
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+    - name: Create GKE cluster
+      uses: ./.github/actions/create-gke-cluster
       with:
-        install_components: "gke-gcloud-auth-plugin"
+        cluster-name: pg-up
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Build roxctl
       run: make roxctl_linux-amd64
-
-    - name: Verify kubectl access and wait for cluster to stabilize
-      timeout-minutes: 5
-      run: |
-        kubectl cluster-info
-        kubectl get nodes
-        scripts/ci/gke.sh wait_for_cluster
 
     - name: Run pre-test
       shell: python
@@ -294,16 +245,9 @@ jobs:
 
     - name: Teardown GKE cluster
       if: always()
-      continue-on-error: true
       run: |
-        if [[ -z "${CLUSTER_NAME:-}" ]]; then
-          echo "No cluster to teardown"
-          exit 0
-        fi
-        if ! scripts/ci/gke.sh teardown_gke_cluster false; then
-          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
-          exit 6
-        fi
+        if [[ -z "${CLUSTER_NAME:-}" ]]; then exit 0; fi
+        scripts/ci/gke.sh teardown_and_report_gke_cluster false
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
@@ -351,41 +295,20 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Create GKE cluster
-      env:
-        MACHINE_TYPE: e2-standard-8
-        NUM_NODES: "3"
-        GKE_SPOT: "true"
-      timeout-minutes: 20
-      run: |
-        source scripts/ci/gke.sh
-        provision_gke_cluster sens-up
-        {
-          echo "CLUSTER_NAME=${CLUSTER_NAME}"
-          echo "ZONE=${ZONE}"
-          echo "KUBECONFIG=${HOME}/.kube/config"
-        } >> "$GITHUB_ENV"
-
     - name: Docker login to Quay.io
       env:
         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
       run: docker login -u "${REGISTRY_USERNAME}" --password-stdin quay.io <<<"${REGISTRY_PASSWORD}"
 
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+    - name: Create GKE cluster
+      uses: ./.github/actions/create-gke-cluster
       with:
-        install_components: "gke-gcloud-auth-plugin"
+        cluster-name: sens-up
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Build roxctl and upgrader
       run: make roxctl_linux-amd64 upgrader
-
-    - name: Verify kubectl access and wait for cluster to stabilize
-      timeout-minutes: 5
-      run: |
-        kubectl cluster-info
-        kubectl get nodes
-        scripts/ci/gke.sh wait_for_cluster
 
     - name: Run pre-test
       shell: python
@@ -428,16 +351,9 @@ jobs:
 
     - name: Teardown GKE cluster
       if: always()
-      continue-on-error: true
       run: |
-        if [[ -z "${CLUSTER_NAME:-}" ]]; then
-          echo "No cluster to teardown"
-          exit 0
-        fi
-        if ! scripts/ci/gke.sh teardown_gke_cluster false; then
-          echo "::warning::WARNING: Could not tear down cluster ${CLUSTER_NAME}. See Teardown step logs for details."
-          exit 6
-        fi
+        if [[ -z "${CLUSTER_NAME:-}" ]]; then exit 0; fi
+        scripts/ci/gke.sh teardown_and_report_gke_cluster false
 
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -66,7 +66,6 @@ jobs:
       uses: ./.github/actions/create-gke-cluster
       with:
         cluster-name: cent-up
-        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Build roxctl
       run: make roxctl_linux-amd64
@@ -180,7 +179,6 @@ jobs:
       uses: ./.github/actions/create-gke-cluster
       with:
         cluster-name: pg-up
-        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Build roxctl
       run: make roxctl_linux-amd64
@@ -293,7 +291,6 @@ jobs:
       uses: ./.github/actions/create-gke-cluster
       with:
         cluster-name: sens-up
-        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Build roxctl and upgrader
       run: make roxctl_linux-amd64 upgrader

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -70,6 +70,12 @@ jobs:
     - name: Build roxctl
       run: make roxctl_linux-amd64
 
+    - name: Wait for cluster
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+        scripts/ci/gke.sh wait_for_cluster
+
     - name: Run pre-test
       shell: python
       env:
@@ -183,6 +189,12 @@ jobs:
     - name: Build roxctl
       run: make roxctl_linux-amd64
 
+    - name: Wait for cluster
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+        scripts/ci/gke.sh wait_for_cluster
+
     - name: Run pre-test
       shell: python
       env:
@@ -294,6 +306,12 @@ jobs:
 
     - name: Build roxctl and upgrader
       run: make roxctl_linux-amd64 upgrader
+
+    - name: Wait for cluster
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+        scripts/ci/gke.sh wait_for_cluster
 
     - name: Run pre-test
       shell: python


### PR DESCRIPTION
## Description

Extends #21690 to apply the \`create-gke-cluster\` composite action to the three upgrade test jobs (\`gke-upgrade-tests-central\`, \`gke-upgrade-tests-postgres\`, \`gke-upgrade-tests-sensor\`), which were still using inline cluster creation copied from master.

Each job loses: inline \`Create GKE cluster\` (source + manual env exports) + standalone \`Set up Cloud SDK\` + \`Verify kubectl access and wait for cluster to stabilize\` + inline \`Teardown GKE cluster\` (continue-on-error, ::warning::).

Each job gains: \`uses: ./.github/actions/create-gke-cluster\` + \`Teardown GKE cluster\` via \`teardown_and_report_gke_cluster\` with JUnit/JIRA reporting — matching what byodb, nongroovy, and db-backup-restore already use after #21690.

Net: -102 lines across the workflow file.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

e2e-gke-upgrade-tests (central, postgres, sensor) run via e2e-dispatch on the base branch PR (#21690).