### PR TITLE
docs: Document CI image location in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ StackRox is a Kubernetes-native security platform with a distributed microservic
 - **Secured Cluster Services**: Deployed per monitored cluster (Sensor, Admission Controller)
 - **Multi-cluster support**: One Central instance monitors multiple Kubernetes clusters
 
+### CI Image (Prow / OpenShift CI)
+- The CI image is built from the **[stackrox/rox-ci-image](https://github.com/stackrox/rox-ci-image)** repo, not this repo.
+- Tool versions bundled in the CI image (e.g. roxie, helm, docker) are pinned in Dockerfiles in that repo.
+- `.openshift-ci/Dockerfile.build_root` in this repo only references the resulting image for validation purposes.
+
 ### Key Directories
 - `/central/` - Central management service code
 - `/sensor/` - Sensor agent code for cluster monitoring


### PR DESCRIPTION
## Description

Add a section to AGENTS.md noting that the CI image (Prow / OpenShift CI) is built from the [stackrox/rox-ci-image](https://github.com/stackrox/rox-ci-image) repo. This helps AI agents and developers know where to look when bumping tool versions in the CI image.

Inspired by the back-and-forth when creating https://github.com/stackrox/rox-ci-image/pull/254 to reduce friction in the future.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- No tests needed — documentation-only change.

### How I validated my change

- Markdown-only change to AGENTS.md, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)