### PR TITLE
ROX-36239: avoid SIGPIPE failures with grep -q under pipefail

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -77,7 +77,7 @@ jobs:
 
           anchored=$(printf '^%s$\n' "${files[@]}")
 
-          if echo "${anchored}" | grep -qF "^${WORKFLOW_FILE_PATH}$"; then
+          if grep -qF "^${WORKFLOW_FILE_PATH}$" <<< "${anchored}"; then
             echo "detect-changes.yml modified, running all jobs" >&2
             exit 0
           fi
@@ -85,7 +85,7 @@ jobs:
           if [[ -n "${RUN_ALL}" ]]; then
             while IFS= read -r pattern; do
               [[ -z "$pattern" ]] && continue
-              if echo "${anchored}" | grep -qF "$pattern"; then
+              if grep -qF "$pattern" <<< "${anchored}"; then
                 echo "run_all: matched '${pattern}', running all jobs" >&2
                 exit 0
               fi
@@ -99,7 +99,7 @@ jobs:
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
 
-            if ! echo "${anchored}" | grep -qv '^\^ui/'; then
+            if ! grep -qv '^\^ui/' <<< "${anchored}"; then
               echo "All changed files are under ui/" >&2
               echo "ui_only=true" >> "${GITHUB_OUTPUT}"
             fi

--- a/.github/workflows/scripts/scanner-get-released-tags.sh
+++ b/.github/workflows/scripts/scanner-get-released-tags.sh
@@ -83,7 +83,7 @@ done < <(./.github/workflows/scripts/scanner-output-release-versions.sh | jq -r 
 # (see redirect below).
 while read -r line; do
     # Skip lines that are comments or empty
-    echo "$line" | grep -qE '^\s*(#.*|$)' && continue
+    grep -qE '^\s*(#.*|$)' <<< "$line" && continue
 
     read -r version ref <<< "$line"
 

--- a/.github/workflows/scripts/scanner-output-release-versions.sh
+++ b/.github/workflows/scripts/scanner-output-release-versions.sh
@@ -25,7 +25,7 @@ tag() {
     echo >&2 "WARNING: Version '$ver' is not a tag in the repository"
 
     # Sanity check: Fail open if this doesn't look like a release version.
-    if ! echo "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    if ! grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<< "$ver"; then
         echo >&2 "ERROR: Version '$ver' is not in X.Y.Z format"
         return 1
     fi
@@ -55,7 +55,7 @@ tag() {
 echo '{"versions": ['
 
 while IFS= read -r version; do
-    echo "$version" | grep -qE '^\s*(#.*|$)' && continue
+    grep -qE '^\s*(#.*|$)' <<< "$version" && continue
     tag_value=$(tag "$version") || continue
     cat <<EOF
   {"tag": "$tag_value", "version": "$version"},

--- a/scripts/ci/add-vms/deploy-vms.sh
+++ b/scripts/ci/add-vms/deploy-vms.sh
@@ -278,7 +278,7 @@ dump_vmi_status() {
 # Returns 0 if the VM is reachable, 1 otherwise.
 ssh_probe_with_key() {
     local vm_name="$1"
-    virtctl ssh \
+    grep -q "SSH_PROBE_OK" < <(virtctl ssh \
         --namespace "$NAMESPACE" \
         --identity-file "$AUTOMATION_SSH_PRIVKEY" \
         --local-ssh-opts="-o StrictHostKeyChecking=no" \
@@ -286,7 +286,7 @@ ssh_probe_with_key() {
         --local-ssh-opts="-o BatchMode=yes" \
         --local-ssh-opts="-o ConnectTimeout=10" \
         --command "echo SSH_PROBE_OK" \
-        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null | grep -q "SSH_PROBE_OK"
+        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null)
 }
 
 # Extracts the VM password from the infractl artifacts directory.
@@ -328,14 +328,14 @@ adopt_vm_with_password() {
     # Use sshpass to inject automation public key (base64-encode to avoid shell injection)
     local auto_pub_b64
     auto_pub_b64="$(echo "$auto_pub" | base64 -w0)"
-    if sshpass -p "$password" virtctl ssh \
+    if grep -q "ADOPT_OK" < <(sshpass -p "$password" virtctl ssh \
         --namespace "$NAMESPACE" \
         --local-ssh-opts="-o StrictHostKeyChecking=no" \
         --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
         --local-ssh-opts="-o ConnectTimeout=10" \
         --local-ssh-opts="-o PubkeyAuthentication=no" \
         --command "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo ${auto_pub_b64} | base64 -d >> ~/.ssh/authorized_keys && sort -u -o ~/.ssh/authorized_keys ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && echo ADOPT_OK" \
-        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null | grep -q "ADOPT_OK"; then
+        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null); then
         echo "  Adopted $vm_name — automation key injected."
         return 0
     fi

--- a/scripts/ci/jobs/check-pr-fixes.sh
+++ b/scripts/ci/jobs/check-pr-fixes.sh
@@ -24,7 +24,7 @@ check-pr-fixes() {
         exit 0
     fi
 
-    if get_pr_details | jq -r '.title' | grep -iqF 'revert'; then
+    if grep -iqF 'revert' < <(get_pr_details | jq -r '.title'); then
        echo "This PR is a revert of another PR - it may introduce new TODOs!"
        exit 0
     fi

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1351,7 +1351,7 @@ pr_has_label() {
     if is_openshift_CI_rehearse_PR; then
         pr_has_label_in_body "${expected_label}" "$pr_details"
     else
-        jq '([.labels | .[].name]  // []) | .[]' -r <<<"$pr_details" | grep -qx "${expected_label}"
+        grep -qx "${expected_label}" < <(jq '([.labels | .[].name]  // []) | .[]' -r <<<"$pr_details")
     fi
 }
 

--- a/scripts/sync-release-branch.sh
+++ b/scripts/sync-release-branch.sh
@@ -85,7 +85,7 @@ fi
 arg_milestone="${1}"
 
 if [[ -n "$arg_milestone" ]]; then
-  printf '%s\n' "${milestones[@]}" | grep -F -x -q "$arg_milestone" || die "No such milestone '${arg_milestone}'! Known milestones: [${milestones[*]}]"
+  grep -F -x -q "$arg_milestone" < <(printf '%s\n' "${milestones[@]}") || die "No such milestone '${arg_milestone}'! Known milestones: [${milestones[*]}]"
   milestones=("$arg_milestone")
 else
   echo "Found milestones:"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1426,20 +1426,20 @@ remove_existing_stackrox_resources() {
     # Check API Server Capabilities.
     local k8s_api_resources
     k8s_api_resources=$(retrying_kubectl </dev/null api-resources -o name)
-    if echo "${k8s_api_resources}" | grep -q "^securitycontextconstraints\.security\.openshift\.io$"; then
+    if grep -q "^securitycontextconstraints\.security\.openshift\.io$" <<< "${k8s_api_resources}"; then
         resource_types="${resource_types},SecurityContextConstraints"
     fi
-    if echo "${k8s_api_resources}" | grep -q "^consoleplugins\.console\.openshift\.io$"; then
+    if grep -q "^consoleplugins\.console\.openshift\.io$" <<< "${k8s_api_resources}"; then
         global_resource_types="${global_resource_types},consoleplugins.console.openshift.io"
     fi
-    if echo "${k8s_api_resources}" | grep -q "^podsecuritypolicies\.policy$"; then
+    if grep -q "^podsecuritypolicies\.policy$" <<< "${k8s_api_resources}"; then
         psps_supported=true
         global_resource_types="${global_resource_types},psp"
     fi
-    if echo "${k8s_api_resources}" | grep -q "^centrals\.platform\.stackrox\.io$"; then
+    if grep -q "^centrals\.platform\.stackrox\.io$" <<< "${k8s_api_resources}"; then
         centrals_supported=true
     fi
-    if echo "${k8s_api_resources}" | grep -q "^securedclusters\.platform\.stackrox\.io$"; then
+    if grep -q "^securedclusters\.platform\.stackrox\.io$" <<< "${k8s_api_resources}"; then
         securedclusters_supported=true
     fi
 

--- a/tests/yamls/roxctl_verification.sh
+++ b/tests/yamls/roxctl_verification.sh
@@ -106,7 +106,7 @@ for yaml_file in "${!TEST_CASES[@]}"; do
         # Verify each expected policy was found
         all_found=true
         for expected_policy in "${expected_array[@]}"; do
-            if ! echo "$matching_policies" | grep -Fq "$expected_policy"; then
+            if ! grep -Fq "$expected_policy" <<< "$matching_policies"; then
                 >&2 echo "FAILED: $yaml_file - missing expected policy: $expected_policy"
                 all_found=false
             fi

--- a/tools/admission-control/generate-image-pool.sh
+++ b/tools/admission-control/generate-image-pool.sh
@@ -96,7 +96,7 @@ cache_is_fresh() {
         now_epoch=$(date +%s)
         (( (now_epoch - mod_epoch) < CACHE_MAX_AGE_S ))
     else
-        find "$CACHE_FILE" -maxdepth 0 -mmin "-$(( CACHE_MAX_AGE_S / 60 ))" | grep -q .
+        grep -q . < <(find "$CACHE_FILE" -maxdepth 0 -mmin "-$(( CACHE_MAX_AGE_S / 60 ))")
     fi
 }
 


### PR DESCRIPTION
## Description

Under `set -o pipefail`, `grep -q` exits early on match, which can cause the producer side of the pipe to receive SIGPIPE and fail the pipeline. Replace `echo "$var" | grep -q` with here-strings and `command | grep -q` with process substitution to avoid pipes entirely.

For context, a change to shellcheck has been approved, which will flag these problematic patterns in the future: https://github.com/koalaman/shellcheck/pull/3498.

Partially generated by AI.

## User-facing documentation

n/a

## Testing and quality

n/a

### Automated testing

Relying on current testing.

### How I validated my change

Just CI.
.github/workflows/lint.yml` | 176-265 | `echo ... \| grep -q ...` | < 1KB |

## Demonstration

```bash
set -o pipefail

# Generate input larger than the pipe buffer (~64KB).
big=$(seq 1 100000)

# Broken: grep -q exits early, echo gets SIGPIPE, pipeline fails.
if echo "$big" | grep -q '^1$'; then
  echo "MATCH"    # expected
else
  echo "NO MATCH" # actually taken
fi

# Fixed: here-string uses a temp file, no pipe, no SIGPIPE.
if grep -q '^1$' <<< "$big"; then
  echo "MATCH"    # correctly taken
fi
```

