### PR TITLE
ROX-35677: Removes Legacy Scanner when Disabled

### DIFF
--- a/central/imageintegration/store/defaults.go
+++ b/central/imageintegration/store/defaults.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	registryTypes "github.com/stackrox/rox/pkg/registries/types"
 	"github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/clairify"
@@ -179,12 +180,19 @@ var (
 			},
 		},
 	}
+)
 
-	// DelayedIntegrations are default integrations to be added only when the trigger function returns true
-	DelayedIntegrations = []DelayedIntegration{
+// GetDelayedIntegrations returns default integrations to be added only when
+// the trigger function returns true.
+func GetDelayedIntegrations() []DelayedIntegration {
+	if !features.LegacyScanner.Enabled() {
+		return nil
+	}
+
+	return []DelayedIntegration{
 		makeDelayedIntegration(defaultScanner, func() scanners.Creator {
 			_, creator := clairify.Creator(nil)
 			return creator
 		}),
 	}
-)
+}

--- a/central/imageintegration/store/defaults_test.go
+++ b/central/imageintegration/store/defaults_test.go
@@ -34,7 +34,7 @@ func TestGetDelayedIntegrations(t *testing.T) {
 				assert.Empty(t, integrations)
 			} else {
 				require.Len(t, integrations, tc.expectCount)
-				assert.Equal(t, "Stackrox Scanner", integrations[0].Integration.GetName())
+				assert.Equal(t, defaultScanner.GetName(), integrations[0].Integration.GetName())
 			}
 		})
 	}

--- a/central/imageintegration/store/defaults_test.go
+++ b/central/imageintegration/store/defaults_test.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDelayedIntegrations(t *testing.T) {
+	tests := map[string]struct {
+		legacyScannerEnabled bool
+		expectCount          int
+	}{
+		"when LegacyScanner is enabled, returns Clairify scanner": {
+			legacyScannerEnabled: true,
+			expectCount:          1,
+		},
+		"when LegacyScanner is disabled, returns empty list": {
+			legacyScannerEnabled: false,
+			expectCount:          0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			testutils.MustUpdateFeature(t, features.LegacyScanner, tc.legacyScannerEnabled)
+
+			integrations := GetDelayedIntegrations()
+
+			if tc.expectCount == 0 {
+				assert.Empty(t, integrations)
+			} else {
+				require.Len(t, integrations, tc.expectCount)
+				assert.Equal(t, "Stackrox Scanner", integrations[0].Integration.GetName())
+			}
+		})
+	}
+}

--- a/central/main.go
+++ b/central/main.go
@@ -395,7 +395,12 @@ func startServices() {
 		platformReprocessor.Singleton().Start()
 	}
 
-	go registerDelayedIntegrations(iiStore.GetDelayedIntegrations())
+	// If we have no delayed integrations, we can skip spawning the goroutine
+	delayedIntegrations := iiStore.GetDelayedIntegrations()
+	log.Debug("Registering delayed integrations", "numIntegrations", len(delayedIntegrations))
+	if len(delayedIntegrations) > 0 {
+		go registerDelayedIntegrations(delayedIntegrations)
+	}
 
 	if env.DeclarativeConfiguration.BooleanSetting() {
 		declarativeconfig.ManagerSingleton().ReconcileDeclarativeConfigurations()
@@ -710,6 +715,7 @@ func addCentralIdentityGatherers(c *phonehomeClient.CentralClient) {
 func registerDelayedIntegrations(integrationsInput []iiStore.DelayedIntegration) {
 	numIntegrations := len(integrationsInput)
 	if numIntegrations == 0 {
+		// we shouldn't get here, but in case we do let's just bail out here
 		log.Debug("No delayed integrations to register")
 		return
 	}

--- a/central/main.go
+++ b/central/main.go
@@ -395,7 +395,7 @@ func startServices() {
 		platformReprocessor.Singleton().Start()
 	}
 
-	go registerDelayedIntegrations(iiStore.DelayedIntegrations)
+	go registerDelayedIntegrations(iiStore.GetDelayedIntegrations())
 
 	if env.DeclarativeConfiguration.BooleanSetting() {
 		declarativeconfig.ManagerSingleton().ReconcileDeclarativeConfigurations()
@@ -708,9 +708,15 @@ func addCentralIdentityGatherers(c *phonehomeClient.CentralClient) {
 }
 
 func registerDelayedIntegrations(integrationsInput []iiStore.DelayedIntegration) {
+	numIntegrations := len(integrationsInput)
+	if numIntegrations == 0 {
+		log.Debug("No delayed integrations to register")
+		return
+	}
+
 	integrationManager := enrichment.ManagerSingleton()
 
-	integrations := make(map[int]iiStore.DelayedIntegration, len(integrationsInput))
+	integrations := make(map[int]iiStore.DelayedIntegration, numIntegrations)
 	for k, v := range integrationsInput {
 		integrations[k] = v
 	}

--- a/pkg/scanners/factory.go
+++ b/pkg/scanners/factory.go
@@ -34,8 +34,10 @@ func NewFactory(set registries.Set) Factory {
 	clairV4ScannerType, clairV4ScannerCreator := clairV4Scanner.Creator(set)
 	reg.creators[clairV4ScannerType] = clairV4ScannerCreator
 
-	clairifyScannerType, clairifyScannerCreator := clairifyScanner.Creator(set)
-	reg.creators[clairifyScannerType] = clairifyScannerCreator
+	if features.LegacyScanner.Enabled() {
+		clairifyScannerType, clairifyScannerCreator := clairifyScanner.Creator(set)
+		reg.creators[clairifyScannerType] = clairifyScannerCreator
+	}
 
 	googleScannerType, googleScannerCreator := googleScanner.Creator()
 	reg.creators[googleScannerType] = googleScannerCreator

--- a/pkg/scanners/factory_test.go
+++ b/pkg/scanners/factory_test.go
@@ -48,9 +48,7 @@ func TestNewFactory_ClairifyRegistration(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), `scanner with type "clairify" does not exist`)
 			} else {
-				if err != nil {
-					assert.NotContains(t, err.Error(), "does not exist")
-				}
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/scanners/factory_test.go
+++ b/pkg/scanners/factory_test.go
@@ -1,6 +1,7 @@
 package scanners
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -45,8 +46,7 @@ func TestNewFactory_ClairifyRegistration(t *testing.T) {
 			_, err := factory.CreateScanner(clairifyIntegration)
 
 			if tc.expectDoesNotExist {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), `scanner with type "clairify" does not exist`)
+				assert.ErrorContains(t, err, fmt.Sprintf("scanner with type %q does not exist", scannerTypes.Clairify))
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/scanners/factory_test.go
+++ b/pkg/scanners/factory_test.go
@@ -1,0 +1,57 @@
+package scanners
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	scannerTypes "github.com/stackrox/rox/pkg/scanners/types"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFactory_ClairifyRegistration(t *testing.T) {
+	clairifyIntegration := &storage.ImageIntegration{
+		Id:   "test-clairify",
+		Name: "Test Clairify",
+		Type: scannerTypes.Clairify,
+		IntegrationConfig: &storage.ImageIntegration_Clairify{
+			Clairify: &storage.ClairifyConfig{
+				Endpoint: "https://localhost:8080",
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		legacyScannerEnabled bool
+		expectDoesNotExist   bool
+	}{
+		"when LegacyScanner is enabled, Clairify creator is registered": {
+			legacyScannerEnabled: true,
+			expectDoesNotExist:   false,
+		},
+		"when LegacyScanner is disabled, Clairify creator is not registered": {
+			legacyScannerEnabled: false,
+			expectDoesNotExist:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			testutils.MustUpdateFeature(t, features.LegacyScanner, tc.legacyScannerEnabled)
+
+			factory := NewFactory(nil)
+			_, err := factory.CreateScanner(clairifyIntegration)
+
+			if tc.expectDoesNotExist {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), `scanner with type "clairify" does not exist`)
+			} else {
+				if err != nil {
+					assert.NotContains(t, err.Error(), "does not exist")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Prevents Legacy Scanner from registering if explicitly disabled.

PR Stack:
* https://github.com/stackrox/stackrox/pull/21709 `<-- you are here`
  * https://github.com/stackrox/stackrox/pull/21710 
    * https://github.com/stackrox/stackrox/pull/21715
      * https://github.com/stackrox/stackrox/pull/21737

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [x] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

* Debug log messages added that validate functionality is turned off.

### Baseline (flag enabled)

1. **Check Clairify integration exists:**
   ```bash
   roxcurl /v1/imageintegrations | jq '.integrations[] | select(.type == "clairify") | {id, name, type}'
   ```
   **Expected:** One integration named "StackRox Scanner" with type "clairify".

2. **Check integration health:**
   ```bash
   roxcurl /v1/integrationhealth/imageintegrations | jq '.integrationHealth[] | select(.name == "StackRox Scanner") | {id, name, status}'
   ```
   **Expected:** Health entry exists for "StackRox Scanner".

### Validation (flag disabled)

1. **Check Clairify integration is NOT auto-created:**
   ```bash
   roxcurl /v1/imageintegrations | jq '.integrations[] | select(.type == "clairify")'
   ```
   **Expected:** No results (empty). The delayed registration was skipped.

2. **Verify Scanner V4 integration still exists:**
   ```bash
   roxcurl /v1/imageintegrations | jq '.integrations[] | select(.type == "scannerv4") | {id, name, type}'
   ```
   **Expected:** Scanner V4 integration present and functional.


```
➜ roxcurl /v1/imageintegrations | jq '.integrations[] | select(.type == "clairify") | {id, name, type}'
{
  "id": "169b0d3f-8277-4900-bbce-1127077defae",
  "name": "Stackrox Scanner",
  "type": "clairify"
}

➜ roxcurl /v1/integrationhealth/imageintegrations | jq '.integrationHealth[] | select(.name == "Stackrox Scanner") | {id, name, status}'
{
  "id": "169b0d3f-8277-4900-bbce-1127077defae",
  "name": "Stackrox Scanner",
  "status": "UNINITIALIZED"
}

➜ oc edit deployment -n stackrox central
deployment.apps/central edited

➜ roxcurl /v1/imageintegrations | jq '.integrations[] | select(.type == "clairify")'


➜ roxcurl /v1/imageintegrations | jq '.integrations[] | select(.type == "scannerv4") | {id, name, type}'
{
  "id": "a87471e6-9678-4e66-8348-91e302b6de07",
  "name": "Scanner V4",
  "type": "scannerv4"
}
```