### PR TITLE
ROX-35722: Add ACK/NACK handling for VM scraper

### DIFF
--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -162,11 +162,10 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 
 	switch sensorAck.GetAction() {
 	case central.SensorACK_ACK:
-		// TODO(ROX-35722): placeholder, no action taken on ACK yet.
-		log.Infof("VMScraper: received acknowledgement for resource_id=%q", sensorAck.GetResourceId())
+		// No action needed on ACK currently.
+		log.Debugf("VMScraper: received acknowledgement for resource_id=%q", sensorAck.GetResourceId())
 	case central.SensorACK_NACK:
 		s.handleNACK(sensorAck.GetResourceId())
-		log.Infof("VMScraper: received negative acknowledgement for resource_id=%q, reason=%q", sensorAck.GetResourceId(), sensorAck.GetReason())
 	default:
 		log.Debugf("VMScraper: received unknown SensorACK action %v for resource_id=%q", sensorAck.GetAction(), sensorAck.GetResourceId())
 	}

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -152,8 +152,7 @@ func (s *VMScraper) Accepts(msg *central.MsgToSensor) bool {
 	return sensorAck != nil && sensorAck.GetMessageType() == central.SensorACK_VM_INDEX_REPORT
 }
 
-// ProcessMessage logs SensorACK/NACK messages that Central sends for VM
-// index reports pulled by this scraper.
+// ProcessMessage handles SensorACK/NACK for pull-mode VM index reports.
 func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	sensorAck := msg.GetSensorAck()
 	if sensorAck == nil {
@@ -162,7 +161,6 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 
 	switch sensorAck.GetAction() {
 	case central.SensorACK_ACK:
-		// No action needed on ACK currently.
 		log.Debugf("VMScraper: received acknowledgement for resource_id=%q", sensorAck.GetResourceId())
 	case central.SensorACK_NACK:
 		s.handleNACK(sensorAck.GetResourceId())
@@ -172,10 +170,7 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 	return nil
 }
 
-// handleNACK reacts to Central rejecting a previously-sent VM index report by
-// clearing the VM's cached generation, so the next poll fetches and resends a
-// full report instead of trusting roxagent's "unchanged" response and
-// waiting for the next mandatoryRefreshAfter window.
+// handleNACK clears the cached generation so the next poll resends a full report.
 func (s *VMScraper) handleNACK(resourceID string) {
 	key := s.findKeyByVMID(vmIDFromResourceID(resourceID))
 	if key == "" {
@@ -185,8 +180,6 @@ func (s *VMScraper) handleNACK(resourceID string) {
 
 	concurrency.WithLock(&s.mu, func() {
 		if state, ok := s.vmState[key]; ok {
-			// Sensor and roxagent must not agree on 'unchanged' when Central NACKed;
-			// force a full report on the next poll instead.
 			state.lastGeneration = 0
 		}
 	})
@@ -275,7 +268,7 @@ func (s *VMScraper) pollOnce(ctx context.Context) {
 
 func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrapedVMs set.StringSet) bool {
 	key := vmKey(vm)
-	state := s.getOrCreateState(key)
+	snap := s.snapshotVMState(key)
 
 	vmCtx, cancel := context.WithTimeout(ctx, s.perVMTimeout)
 	defer cancel()
@@ -287,8 +280,8 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 	// can make before dialing at all, so request the full report on this
 	// first (and only) round trip instead of asking "anything newer?" and
 	// re-dialing once told no.
-	ifNewerThan, knownEpoch := state.lastGeneration, state.lastEpoch
-	mandatoryRefreshDue := s.now().Sub(state.lastForwardedAt) > s.mandatoryRefreshAfter
+	ifNewerThan, knownEpoch := snap.lastGeneration, snap.lastEpoch
+	mandatoryRefreshDue := s.now().Sub(snap.lastForwardedAt) > s.mandatoryRefreshAfter
 	if mandatoryRefreshDue {
 		ifNewerThan, knownEpoch = 0, 0
 	}
@@ -318,15 +311,15 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 		// current roxagent can only report Unchanged for a reason other
 		// than the mandatory refresh — i.e. an epoch mismatch below.
 		epoch := result.Meta.GetEpoch()
-		epochMismatch := epoch != 0 && epoch != state.lastEpoch
+		epochMismatch := epoch != 0 && epoch != snap.lastEpoch
 		if !epochMismatch {
 			s.registerScrapedVM(scrapedVMs, vm)
-			log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, state.lastGeneration)
+			log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, snap.lastGeneration)
 			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
 			return true
 		}
 		log.Infof("VMScraper: roxagent on %q restarted (epoch changed from %d to %d, generation coincidentally matched cached value %d) — forcing full report",
-			key, state.lastEpoch, epoch, state.lastGeneration)
+			key, snap.lastEpoch, epoch, snap.lastGeneration)
 		result, ok = s.dialAndGetReport(vmCtx, vm, key, port, 0, 0)
 		if !ok {
 			return false
@@ -352,13 +345,15 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 		return false
 	}
 
-	state.lastGeneration = result.Meta.GetReportGeneration()
-	state.lastEpoch = result.Meta.GetEpoch()
-	state.lastForwardedAt = s.now()
+	// Skip the cache update if a NACK cleared the generation while Send was in flight.
+	newGen := result.Meta.GetReportGeneration()
+	if !s.commitVMState(snap.state, snap.lastGeneration, newGen, result.Meta.GetEpoch()) {
+		log.Debugf("VMScraper: dropping cache update for %q after NACK during send", key)
+	}
 	s.registerScrapedVM(scrapedVMs, vm)
 
 	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, total=%s",
-		key, state.lastGeneration, len(result.IndexReport.GetContents().GetPackages()), reportSize,
+		key, newGen, len(result.IndexReport.GetContents().GetPackages()), reportSize,
 		time.Since(totalStart).Truncate(time.Millisecond))
 	metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSuccess).Inc()
 	metrics.PullTotalDurationSeconds.Observe(time.Since(totalStart).Seconds())
@@ -448,18 +443,40 @@ func (s *VMScraper) registerScrapedVM(scrapedVMs set.StringSet, vm *virtualmachi
 	})
 }
 
-// getOrCreateState returns the vmState for key, creating it if absent.
-// The returned pointer is mutated outside the lock — this is safe because
-// each VM key is processed by exactly one goroutine per poll cycle
-// (the VM list contains unique entries, and errgroup assigns one goroutine each).
-func (s *VMScraper) getOrCreateState(key string) *vmState {
-	return concurrency.WithLock1(&s.mu, func() *vmState {
+type vmStateSnapshot struct {
+	state           *vmState
+	lastGeneration  uint32
+	lastEpoch       uint32
+	lastForwardedAt time.Time
+}
+
+func (s *VMScraper) snapshotVMState(key string) vmStateSnapshot {
+	return concurrency.WithLock1(&s.mu, func() vmStateSnapshot {
 		st, ok := s.vmState[key]
 		if !ok {
 			st = &vmState{}
 			s.vmState[key] = st
 		}
-		return st
+		return vmStateSnapshot{
+			state:           st,
+			lastGeneration:  st.lastGeneration,
+			lastEpoch:       st.lastEpoch,
+			lastForwardedAt: st.lastForwardedAt,
+		}
+	})
+}
+
+// commitVMState updates cached scrape state only if lastGeneration is still
+// observedGen, so a concurrent NACK reset is not overwritten by a late Send.
+func (s *VMScraper) commitVMState(state *vmState, observedGen, newGen, newEpoch uint32) bool {
+	return concurrency.WithLock1(&s.mu, func() bool {
+		if state.lastGeneration != observedGen {
+			return false
+		}
+		state.lastGeneration = newGen
+		state.lastEpoch = newEpoch
+		state.lastForwardedAt = s.now()
+		return true
 	})
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -143,10 +144,76 @@ func (s *VMScraper) Stop() {
 
 func (s *VMScraper) Capabilities() []centralsensor.SensorCapability { return nil }
 func (s *VMScraper) Notify(_ common.SensorComponentEvent)           {}
-func (s *VMScraper) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
+
+// Accepts reports whether this component wants to see SensorACK messages
+// for VM index reports.
+func (s *VMScraper) Accepts(msg *central.MsgToSensor) bool {
+	sensorAck := msg.GetSensorAck()
+	return sensorAck != nil && sensorAck.GetMessageType() == central.SensorACK_VM_INDEX_REPORT
+}
+
+// ProcessMessage logs SensorACK/NACK messages that Central sends for VM
+// index reports pulled by this scraper.
+func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
+	sensorAck := msg.GetSensorAck()
+	if sensorAck == nil {
+		return nil
+	}
+
+	switch sensorAck.GetAction() {
+	case central.SensorACK_ACK:
+		// TODO(ROX-35722): placeholder, no action taken on ACK yet.
+		log.Infof("VMScraper: received acknowledgement for resource_id=%q", sensorAck.GetResourceId())
+	case central.SensorACK_NACK:
+		s.handleNACK(sensorAck.GetResourceId())
+		log.Infof("VMScraper: received negative acknowledgement for resource_id=%q, reason=%q", sensorAck.GetResourceId(), sensorAck.GetReason())
+	default:
+		log.Debugf("VMScraper: received unknown SensorACK action %v for resource_id=%q", sensorAck.GetAction(), sensorAck.GetResourceId())
+	}
 	return nil
 }
-func (s *VMScraper) Accepts(_ *central.MsgToSensor) bool         { return false }
+
+// handleNACK reacts to Central rejecting a previously-sent VM index report by
+// clearing the VM's cached generation, so the next poll fetches and resends a
+// full report instead of trusting roxagent's "unchanged" response and
+// waiting for the next mandatoryRefreshAfter window.
+func (s *VMScraper) handleNACK(resourceID string) {
+	key := s.findKeyByVMID(vmIDFromResourceID(resourceID))
+	if key == "" {
+		log.Debugf("VMScraper: could not resolve VM for NACKed resource_id=%q; nothing to reset", resourceID)
+		return
+	}
+
+	concurrency.WithLock(&s.mu, func() {
+		if state, ok := s.vmState[key]; ok {
+			// Sensor and roxagent must not agree on 'unchanged' when Central NACKed;
+			// force a full report on the next poll instead.
+			state.lastGeneration = 0
+		}
+	})
+}
+
+// findKeyByVMID returns the vmState key ("namespace/name") for the currently
+// running VM with the given ID, or "" if none matches.
+func (s *VMScraper) findKeyByVMID(vmID string) string {
+	if vmID == "" {
+		return ""
+	}
+	for _, vm := range s.store.ListRunning() {
+		if string(vm.ID) == vmID {
+			return vmKey(vm)
+		}
+	}
+	return ""
+}
+
+// vmIDFromResourceID extracts the VM ID from a composite ACK resource ID
+// (format "vmID:vsockCID"; see central/sensor/service/common.VMIndexACKResourceID).
+func vmIDFromResourceID(resourceID string) string {
+	vmID, _, _ := strings.Cut(resourceID, ":")
+	return vmID
+}
+
 func (s *VMScraper) ResponsesC() <-chan *message.ExpiringMessage { return nil }
 
 func (s *VMScraper) run() {

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -49,9 +49,10 @@ func clampPollInterval(interval time.Duration) time.Duration {
 	return interval
 }
 
-// RunningVMStore provides the list of running VMs.
+// RunningVMStore provides lookups of running VMs.
 type RunningVMStore interface {
 	ListRunning() []*virtualmachine.Info
+	Get(id virtualmachine.VMID) *virtualmachine.Info
 }
 
 // VMDialer connects to a VM's VSOCK port.
@@ -178,11 +179,17 @@ func (s *VMScraper) handleNACK(resourceID string) {
 		return
 	}
 
-	concurrency.WithLock(&s.mu, func() {
-		if state, ok := s.vmState[key]; ok {
-			state.lastGeneration = 0
+	reset := concurrency.WithLock1(&s.mu, func() bool {
+		state, ok := s.vmState[key]
+		if !ok {
+			return false
 		}
+		state.lastGeneration = 0
+		return true
 	})
+	if reset {
+		log.Debugf("VMScraper: reset cached generation for %q after NACK for resource_id=%q", key, resourceID)
+	}
 }
 
 // findKeyByVMID returns the vmState key ("namespace/name") for the currently
@@ -191,12 +198,11 @@ func (s *VMScraper) findKeyByVMID(vmID string) string {
 	if vmID == "" {
 		return ""
 	}
-	for _, vm := range s.store.ListRunning() {
-		if string(vm.ID) == vmID {
-			return vmKey(vm)
-		}
+	vm := s.store.Get(virtualmachine.VMID(vmID))
+	if vm == nil || !vm.Running {
+		return ""
 	}
-	return ""
+	return vmKey(vm)
 }
 
 // vmIDFromResourceID extracts the VM ID from a composite ACK resource ID
@@ -345,11 +351,8 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info, scrap
 		return false
 	}
 
-	// Skip the cache update if a NACK cleared the generation while Send was in flight.
 	newGen := result.Meta.GetReportGeneration()
-	if !s.commitVMState(snap.state, snap.lastGeneration, newGen, result.Meta.GetEpoch()) {
-		log.Debugf("VMScraper: dropping cache update for %q after NACK during send", key)
-	}
+	s.commitVMState(key, newGen, result.Meta.GetEpoch())
 	s.registerScrapedVM(scrapedVMs, vm)
 
 	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, total=%s",
@@ -444,7 +447,6 @@ func (s *VMScraper) registerScrapedVM(scrapedVMs set.StringSet, vm *virtualmachi
 }
 
 type vmStateSnapshot struct {
-	state           *vmState
 	lastGeneration  uint32
 	lastEpoch       uint32
 	lastForwardedAt time.Time
@@ -458,7 +460,6 @@ func (s *VMScraper) snapshotVMState(key string) vmStateSnapshot {
 			s.vmState[key] = st
 		}
 		return vmStateSnapshot{
-			state:           st,
 			lastGeneration:  st.lastGeneration,
 			lastEpoch:       st.lastEpoch,
 			lastForwardedAt: st.lastForwardedAt,
@@ -466,17 +467,26 @@ func (s *VMScraper) snapshotVMState(key string) vmStateSnapshot {
 	})
 }
 
-// commitVMState updates cached scrape state only if lastGeneration is still
-// observedGen, so a concurrent NACK reset is not overwritten by a late Send.
-func (s *VMScraper) commitVMState(state *vmState, observedGen, newGen, newEpoch uint32) bool {
-	return concurrency.WithLock1(&s.mu, func() bool {
-		if state.lastGeneration != observedGen {
-			return false
+// commitVMState records the generation/epoch from a just-sent report as key's cached scrape state.
+//
+// Race: If a NACK arrives from Central faster than this function completes, for example, due to:
+//   - a scheduling delay on the caller's goroutine between Send returning and this function
+//     acquiring `s.mu` (a GC pause, CPU throttling, or GOMAXPROCS contention),
+//   - contention on `s.mu` itself, from other concurrent scrapes or NACKs delaying this
+//     function's lock acquisition,
+//
+// then the NACK will overwrite lastGeneration to 0, and then this code will set it back to
+// `newGen`, which cancels the NACK.
+// However, this race is really unlikely to happen in practice, thus we accept the risk and not protect against it.
+func (s *VMScraper) commitVMState(key string, newGen, newEpoch uint32) {
+	concurrency.WithLock(&s.mu, func() {
+		state, ok := s.vmState[key]
+		if !ok {
+			return
 		}
 		state.lastGeneration = newGen
 		state.lastEpoch = newEpoch
 		state.lastForwardedAt = s.now()
-		return true
 	})
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -156,7 +156,7 @@ func (s *VMScraper) Accepts(msg *central.MsgToSensor) bool {
 // ProcessMessage handles SensorACK/NACK for pull-mode VM index reports.
 func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
 	sensorAck := msg.GetSensorAck()
-	if sensorAck == nil {
+	if sensorAck == nil || sensorAck.GetMessageType() != central.SensorACK_VM_INDEX_REPORT {
 		return nil
 	}
 

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
@@ -381,25 +382,57 @@ func TestVMScraper_ForwardsOnGenerationChange(t *testing.T) {
 // generation, the next poll would see roxagent report "unchanged"
 // (report_generation didn't change) and skip resending, stranding the VM
 // until mandatoryRefreshAfter (4h) instead of retrying on the next poll
-// interval. It also verifies a NACK for an unrelated VM ID leaves the known
-// VM's state untouched instead of forcing a spurious resend.
+// interval. It also verifies that a NACK is a no-op when it doesn't resolve
+// to a currently-running, known VM (unrelated VM ID, malformed resource ID,
+// or a VM that stopped running), and that an ACK never touches the cached
+// generation.
 func TestVMScraper_NACK(t *testing.T) {
 	cases := map[string]struct {
+		ackAction                  central.SensorACK_Action
 		nackResourceID             string
+		vmRunning                  bool
 		pollResultAfterNack        *vsockclient.GetReportResult
 		wantIfNewerThanOnRetryPoll uint32
 		wantTotalSent              int
 	}{
 		"resets generation and forces an immediate resend when NACK matches the running VM": {
+			ackAction:                  central.SensorACK_NACK,
 			nackResourceID:             "vm-a-id:100",
+			vmRunning:                  true,
 			pollResultAfterNack:        makeReport(1),
 			wantIfNewerThanOnRetryPoll: 0, // on the second poll, the scraper should ask for a full report
 			wantTotalSent:              2,
 		},
 		"is a no-op when NACK references an unrelated VM ID": {
+			ackAction:                  central.SensorACK_NACK,
 			nackResourceID:             "unknown-vm-id:999",
+			vmRunning:                  true,
 			pollResultAfterNack:        unchangedResult(),
 			wantIfNewerThanOnRetryPoll: 1, // on the second poll, the scraper should keep trusting the old generation
+			wantTotalSent:              1,
+		},
+		"is a no-op when the resource ID has no vsockCID suffix": {
+			ackAction:                  central.SensorACK_NACK,
+			nackResourceID:             "vm-a-id-with-no-colon",
+			vmRunning:                  true,
+			pollResultAfterNack:        unchangedResult(),
+			wantIfNewerThanOnRetryPoll: 1,
+			wantTotalSent:              1,
+		},
+		"is a no-op when the NACKed VM is no longer running": {
+			ackAction:                  central.SensorACK_NACK,
+			nackResourceID:             "vm-a-id:100",
+			vmRunning:                  false,
+			pollResultAfterNack:        unchangedResult(),
+			wantIfNewerThanOnRetryPoll: 1,
+			wantTotalSent:              1,
+		},
+		"is a no-op for an ACK": {
+			ackAction:                  central.SensorACK_ACK,
+			nackResourceID:             "vm-a-id:100",
+			vmRunning:                  true,
+			pollResultAfterNack:        unchangedResult(),
+			wantIfNewerThanOnRetryPoll: 1,
 			wantTotalSent:              1,
 		},
 	}
@@ -419,11 +452,15 @@ func TestVMScraper_NACK(t *testing.T) {
 			s.pollOnce(context.Background())
 			require.Len(t, sender.sent, 1)
 
+			// Flip Running only after the first poll, so the VM is scraped normally
+			// once before the ACK/NACK under test is delivered.
+			vmA.Running = tc.vmRunning
+
 			err := s.ProcessMessage(context.Background(), &central.MsgToSensor{
 				Msg: &central.MsgToSensor_SensorAck{
 					SensorAck: &central.SensorACK{
 						MessageType: central.SensorACK_VM_INDEX_REPORT,
-						Action:      central.SensorACK_NACK,
+						Action:      tc.ackAction,
 						ResourceId:  tc.nackResourceID,
 					},
 				},
@@ -474,7 +511,7 @@ func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 		s := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
 
 		s.pollOnce(t.Context())
-		require.Equal(t, uint32(1), s.vmState["ns1/vm-a"].lastGeneration)
+		require.Equal(t, uint32(1), cachedGeneration(t, s, "ns1/vm-a"))
 
 		gate := &gateSender{
 			blockAt: 1,
@@ -503,12 +540,12 @@ func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 				},
 			},
 		}))
-		assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration,
+		assert.Equal(t, uint32(0), cachedGeneration(t, s, "ns1/vm-a"),
 			"NACK applies immediately while the send it targets is still in flight")
 
 		close(gate.release)
 		<-done
-		assert.Equal(t, uint32(2), s.vmState["ns1/vm-a"].lastGeneration,
+		assert.Equal(t, uint32(2), cachedGeneration(t, s, "ns1/vm-a"),
 			"the in-flight send's commit runs after the NACK reset and overwrites it unconditionally")
 	})
 }
@@ -625,6 +662,17 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 	assert.Len(t, s.vmState, 1, "stale vm-a state should be pruned")
 	assert.False(t, s.activeVMs.Contains("ns1/vm-a"), "vm-a should no longer be active")
 	assert.True(t, s.activeVMs.Contains("ns2/vm-b"))
+}
+
+// cachedGeneration reads a VM's cached generation under s.mu, so the read is
+// race-safe regardless of what locking handleNACK or commitVMState use internally.
+func cachedGeneration(t *testing.T, s *VMScraper, key string) uint32 {
+	t.Helper()
+	return concurrency.WithLock1(&s.mu, func() uint32 {
+		st, ok := s.vmState[key]
+		require.True(t, ok, "no cached state for %q", key)
+		return st.lastGeneration
+	})
 }
 
 func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -30,6 +30,15 @@ type mockStore struct {
 
 func (m *mockStore) ListRunning() []*virtualmachine.Info { return m.vms }
 
+func (m *mockStore) Get(id virtualmachine.VMID) *virtualmachine.Info {
+	for _, vm := range m.vms {
+		if vm.ID == id {
+			return vm
+		}
+	}
+	return nil
+}
+
 type mockDialer struct {
 	err      error
 	errQueue []error
@@ -455,7 +464,9 @@ func (g *gateSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.
 	return nil
 }
 
-func TestVMScraper_NACKWinsOverInFlightSend(t *testing.T) {
+// TestVMScraper_InFlightSendCanOverwriteNACKReset exercises a known race involving
+// an unusually slow execution of `commitVMState` and a quick NACK from Central.
+func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 	vmA := makeVM("ns1", "vm-a", 100)
 	vmA.ID = "vm-a-id"
 	store := &mockStore{vms: []*virtualmachine.Info{vmA}}
@@ -472,7 +483,7 @@ func TestVMScraper_NACKWinsOverInFlightSend(t *testing.T) {
 	}
 	s.sender = gate
 	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
 
 	done := make(chan struct{})
 	go func() {
@@ -495,7 +506,8 @@ func TestVMScraper_NACKWinsOverInFlightSend(t *testing.T) {
 			},
 		},
 	}))
-	assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration)
+	assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration,
+		"NACK applies immediately while the send it targets is still in flight")
 
 	close(gate.release)
 	select {
@@ -503,15 +515,8 @@ func TestVMScraper_NACKWinsOverInFlightSend(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for pollOnce to finish")
 	}
-	assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration,
-		"in-flight Send must not overwrite a concurrent NACK reset")
-
-	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
-	s.sender = &mockSender{}
-	s.pollOnce(t.Context())
-	require.Len(t, client.calls, 1)
-	assert.Equal(t, uint32(0), client.calls[0].ifNewerThan)
+	assert.Equal(t, uint32(2), s.vmState["ns1/vm-a"].lastGeneration,
+		"the in-flight send's commit runs after the NACK reset and overwrites it unconditionally")
 }
 
 func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -444,7 +445,6 @@ func TestVMScraper_NACK(t *testing.T) {
 // gateSender blocks the Nth Send (1-based) until release is closed.
 type gateSender struct {
 	blockAt int
-	entered chan struct{}
 	release chan struct{}
 	mu      sync.Mutex
 	n       int
@@ -458,7 +458,6 @@ func (g *gateSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.
 	g.sent = append(g.sent, report)
 	g.mu.Unlock()
 	if n == g.blockAt {
-		close(g.entered)
 		<-g.release
 	}
 	return nil
@@ -467,56 +466,51 @@ func (g *gateSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.
 // TestVMScraper_InFlightSendCanOverwriteNACKReset exercises a known race involving
 // an unusually slow execution of `commitVMState` and a quick NACK from Central.
 func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
-	vmA := makeVM("ns1", "vm-a", 100)
-	vmA.ID = "vm-a-id"
-	store := &mockStore{vms: []*virtualmachine.Info{vmA}}
-	client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport(1)}}
-	s := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+	synctest.Test(t, func(t *testing.T) {
+		vmA := makeVM("ns1", "vm-a", 100)
+		vmA.ID = "vm-a-id"
+		store := &mockStore{vms: []*virtualmachine.Info{vmA}}
+		client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport(1)}}
+		s := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
 
-	s.pollOnce(t.Context())
-	require.Equal(t, uint32(1), s.vmState["ns1/vm-a"].lastGeneration)
-
-	gate := &gateSender{
-		blockAt: 1,
-		entered: make(chan struct{}),
-		release: make(chan struct{}),
-	}
-	s.sender = gate
-	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
 		s.pollOnce(t.Context())
-	}()
+		require.Equal(t, uint32(1), s.vmState["ns1/vm-a"].lastGeneration)
 
-	select {
-	case <-gate.entered:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for in-flight Send")
-	}
+		gate := &gateSender{
+			blockAt: 1,
+			release: make(chan struct{}),
+		}
+		s.sender = gate
+		client.reset()
+		client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
 
-	require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
-		Msg: &central.MsgToSensor_SensorAck{
-			SensorAck: &central.SensorACK{
-				MessageType: central.SensorACK_VM_INDEX_REPORT,
-				Action:      central.SensorACK_NACK,
-				ResourceId:  "vm-a-id:100",
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s.pollOnce(t.Context())
+		}()
+
+		// Block until the scrape goroutine is durably blocked inside Send,
+		// i.e. the report has been handed off but not yet committed.
+		synctest.Wait()
+
+		require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
+			Msg: &central.MsgToSensor_SensorAck{
+				SensorAck: &central.SensorACK{
+					MessageType: central.SensorACK_VM_INDEX_REPORT,
+					Action:      central.SensorACK_NACK,
+					ResourceId:  "vm-a-id:100",
+				},
 			},
-		},
-	}))
-	assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration,
-		"NACK applies immediately while the send it targets is still in flight")
+		}))
+		assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration,
+			"NACK applies immediately while the send it targets is still in flight")
 
-	close(gate.release)
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for pollOnce to finish")
-	}
-	assert.Equal(t, uint32(2), s.vmState["ns1/vm-a"].lastGeneration,
-		"the in-flight send's commit runs after the NACK reset and overwrites it unconditionally")
+		close(gate.release)
+		<-done
+		assert.Equal(t, uint32(2), s.vmState["ns1/vm-a"].lastGeneration,
+			"the in-flight send's commit runs after the NACK reset and overwrites it unconditionally")
+	})
 }
 
 func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -432,6 +432,88 @@ func TestVMScraper_NACK(t *testing.T) {
 	}
 }
 
+// gateSender blocks the Nth Send (1-based) until release is closed.
+type gateSender struct {
+	blockAt int
+	entered chan struct{}
+	release chan struct{}
+	mu      sync.Mutex
+	n       int
+	sent    []*v4.IndexReport
+}
+
+func (g *gateSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+	g.mu.Lock()
+	g.n++
+	n := g.n
+	g.sent = append(g.sent, report)
+	g.mu.Unlock()
+	if n == g.blockAt {
+		close(g.entered)
+		<-g.release
+	}
+	return nil
+}
+
+func TestVMScraper_NACKWinsOverInFlightSend(t *testing.T) {
+	vmA := makeVM("ns1", "vm-a", 100)
+	vmA.ID = "vm-a-id"
+	store := &mockStore{vms: []*virtualmachine.Info{vmA}}
+	client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport(1)}}
+	s := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+
+	s.pollOnce(t.Context())
+	require.Equal(t, uint32(1), s.vmState["ns1/vm-a"].lastGeneration)
+
+	gate := &gateSender{
+		blockAt: 1,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	s.sender = gate
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.pollOnce(t.Context())
+	}()
+
+	select {
+	case <-gate.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for in-flight Send")
+	}
+
+	require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{
+			SensorAck: &central.SensorACK{
+				MessageType: central.SensorACK_VM_INDEX_REPORT,
+				Action:      central.SensorACK_NACK,
+				ResourceId:  "vm-a-id:100",
+			},
+		},
+	}))
+	assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration)
+
+	close(gate.release)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for pollOnce to finish")
+	}
+	assert.Equal(t, uint32(0), s.vmState["ns1/vm-a"].lastGeneration,
+		"in-flight Send must not overwrite a concurrent NACK reset")
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
+	s.sender = &mockSender{}
+	s.pollOnce(t.Context())
+	require.Len(t, client.calls, 1)
+	assert.Equal(t, uint32(0), client.calls[0].ifNewerThan)
+}
+
 func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 	vms := []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/set"
@@ -363,6 +364,72 @@ func TestVMScraper_ForwardsOnGenerationChange(t *testing.T) {
 	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
 	s.pollOnce(context.Background())
 	assert.Len(t, sender.sent, 2, "should forward on generation change")
+}
+
+// TestVMScraper_NACK reproduces a scenario where Central NACKs a report
+// (e.g. Scanner was still starting up). Without resetting the cached
+// generation, the next poll would see roxagent report "unchanged"
+// (report_generation didn't change) and skip resending, stranding the VM
+// until mandatoryRefreshAfter (4h) instead of retrying on the next poll
+// interval. It also verifies a NACK for an unrelated VM ID leaves the known
+// VM's state untouched instead of forcing a spurious resend.
+func TestVMScraper_NACK(t *testing.T) {
+	cases := map[string]struct {
+		nackResourceID             string
+		pollResultAfterNack        *vsockclient.GetReportResult
+		wantIfNewerThanOnRetryPoll uint32
+		wantTotalSent              int
+	}{
+		"resets generation and forces an immediate resend when NACK matches the running VM": {
+			nackResourceID:             "vm-a-id:100",
+			pollResultAfterNack:        makeReport(1),
+			wantIfNewerThanOnRetryPoll: 0, // on the second poll, the scraper should ask for a full report
+			wantTotalSent:              2,
+		},
+		"is a no-op when NACK references an unrelated VM ID": {
+			nackResourceID:             "unknown-vm-id:999",
+			pollResultAfterNack:        unchangedResult(),
+			wantIfNewerThanOnRetryPoll: 1, // on the second poll, the scraper should keep trusting the old generation
+			wantTotalSent:              1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			vmA := makeVM("ns1", "vm-a", 100)
+			vmA.ID = "vm-a-id"
+			store := &mockStore{vms: []*virtualmachine.Info{vmA}}
+			sender := &mockSender{}
+			dialer := &mockDialer{}
+			client := &mockProtocolClient{
+				resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+			}
+
+			s := newTestScraper(store, sender, dialer, client)
+			s.pollOnce(context.Background())
+			require.Len(t, sender.sent, 1)
+
+			err := s.ProcessMessage(context.Background(), &central.MsgToSensor{
+				Msg: &central.MsgToSensor_SensorAck{
+					SensorAck: &central.SensorACK{
+						MessageType: central.SensorACK_VM_INDEX_REPORT,
+						Action:      central.SensorACK_NACK,
+						ResourceId:  tc.nackResourceID,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			client.reset()
+			client.resultQueue = []*vsockclient.GetReportResult{tc.pollResultAfterNack}
+			s.pollOnce(context.Background())
+
+			require.Len(t, client.calls, 1)
+			assert.Equal(t, tc.wantIfNewerThanOnRetryPoll, client.calls[0].ifNewerThan,
+				"generation the scraper requests on the poll following the NACK")
+			assert.Len(t, sender.sent, tc.wantTotalSent, "total reports handed to the sender across both polls")
+		})
+	}
 }
 
 func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {


### PR DESCRIPTION
## Description

Pull-mode VMScraper sent index reports to Central fire-and-forget: it never looked at Central's SensorACK/NACK response.
If a report is NACKed (e.g. Scanner is still starting up), roxagent's cached report_generation doesn't change, so the next poll sees "unchanged" and silently skips resending — stranding the VM until the 4h mandatoryRefreshAfter forced refresh instead of retrying on the very next poll interval.

This PR:
- Wires VMScraper up to receive SensorACK/NACK messages for VM index reports (`Accepts`/`ProcessMessage`). ACK is currently a no-op (debug-logged only).
- On NACK, resets the affected VM's cached generation, so the next poll requests and resends a full report immediately instead of waiting for the 4h window.

Kept intentionally minimal/expandable: only the generation is reset for now; further NACK handling (e.g. resending a cached payload instead of waiting for the next poll) can build on the same `handleNACK` hook later.

The existing VSOCK-push-mode ACK/NACK pipeline (`sensor/common/virtualmachine/index`) is untouched by this change.

Partially generated with AI assistance (Cursor).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- CI
- Manually on a cluster: Deploy a fresh cluster; let scanner-v4-matcher load the vuln definitions for ~10 minutes; observe first VM scan appears after 10 minutes - not 4 hours.
- More detailed manual test:
<details>
<summary><b>Manual verification: PASS</b> - Sensor receives Central NACK, resets generation, and retries on the next poll</summary>

**Setup:** `ROX_VIRTUAL_MACHINES=true`, OpenShift + CNV, RHEL9 VM with `roxagent serve` (pull mode). `ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL=1m`. Sensor `LOGLEVEL=debug` for this test. Forced NACKs with Central `ROX_VM_INDEX_REPORT_RATE_LIMIT=0.000001` and `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=1` (one accept, then rate-limit NACKs). Branch tip also needs the vsockdialer `https` scheme fix from #22042.

1. First report is accepted (ACK), then force a second report while the rate limiter is exhausted (restart `roxagent serve` without restarting Sensor). Central rate-limits it:
   `kubectl -n stackrox logs deploy/central --since=5m | grep rate-limited`
   ```
   Request is rate-limited for cluster ... and event type VirtualMachineIndexReport. Reason: rate limit exceeded
   ```

2. Sensor receives the NACK and clears the cached generation (this is the direct proof, debug log):
   `kubectl -n stackrox logs deploy/sensor --since=5m | grep 'after NACK'`
   ```
   VMScraper: reset cached generation for "openshift-cnv/rhel9-1" after NACK for resource_id="fe3cbe6a-b257-4420-9748-eed4fb094898:3979672571"
   ```

3. Sensor metrics show ACK/NACK counts from Central:
   `curl -s http://127.0.0.1:9090/metrics | grep virtual_machine_index_report_acks_received_total`
   (Sensor `ROX_METRICS_PORT=:9090`, then `kubectl -n stackrox port-forward deploy/sensor 9090:9090`)
   ```
   rox_sensor_virtual_machine_index_report_acks_received_total{action="ACK"} 1
   rox_sensor_virtual_machine_index_report_acks_received_total{action="NACK"} 2
   ```

4. On the next poll after NACK, Sensor pulls and resends a full report again (not stuck on "unchanged" until 4h):
   ```
   VMScraper: successfully pulled report for "openshift-cnv/rhel9-1": generation=1, packages=491, ...
   VMScraper: reset cached generation for "openshift-cnv/rhel9-1" after NACK for resource_id="..."
   ```
   (NACK metric continues to increase while the rate limit remains exhausted.)

</details>