### PR TITLE
ROX-35680: Gracefully handle node scans without v2 enabled

### DIFF
--- a/central/sensor/service/pipeline/nodeinventory/pipeline.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline.go
@@ -79,6 +79,12 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 		log.Warn("Removal of node inventory is unsupported action")
 		return nil
 	}
+	if !features.LegacyScanner.Enabled() {
+		replyCompliance(ctx, "", ninv.GetNodeName(), central.NodeInventoryACK_ACK, injector)
+		log.Debug("Discarding v2 NodeInventory because the legacy scanner is disabled")
+		return nil
+	}
+
 	ninv = ninv.CloneVT()
 
 	// Read the node from the database, if not found we fail.

--- a/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -67,6 +69,16 @@ func Test_pipelineImpl_Run(t *testing.T) {
 				a.injector = &recordingInjector{}
 			},
 			wantInjectorContain: []*central.NodeInventoryACK{},
+		},
+		{
+			name: "when LegacyScanner is disabled then ACK and discard",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, false)
+				a.msg = createMsg("node1")
+				a.msg.GetEvent().GetNodeInventory().NodeName = "test-node"
+				a.injector = &recordingInjector{}
+			},
+			wantInjectorContain: []*central.NodeInventoryACK{{Action: central.NodeInventoryACK_ACK, NodeName: "test-node"}},
 		},
 		{
 			name: "when event action is CREATE_RESOURCE then do not ignore event",

--- a/central/sensor/service/pipeline/nodes/pipeline.go
+++ b/central/sensor/service/pipeline/nodes/pipeline.go
@@ -13,10 +13,13 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/pipeline"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/nodes/enricher"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
@@ -107,6 +110,21 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		// the database before writing. This is safe because NodeInventory and Node
 		// pipelines never run concurrently by the Sensor Event worker queues.
 		node.Scan = nil
+		if err := p.nodeDatastore.UpsertNode(ctx, node); err != nil {
+			err = errors.Wrapf(err, "upserting node %s", nodeDatastore.NodeString(node))
+			log.Error(err)
+			return err
+		}
+		return nil
+	}
+
+	// If the node does NOT support v4 Node Scanning, AND the legacy scanner is not enabled,
+	// then we set the scan to unsupported and skip enrichment.
+	if !features.LegacyScanner.Enabled() {
+		node.Scan = &storage.NodeScan{
+			ScanTime: protocompat.TimestampNow(),
+			Notes:    []storage.NodeScan_Note{storage.NodeScan_UNSUPPORTED},
+		}
 		if err := p.nodeDatastore.UpsertNode(ctx, node); err != nil {
 			err = errors.Wrapf(err, "upserting node %s", nodeDatastore.NodeString(node))
 			log.Error(err)

--- a/central/sensor/service/pipeline/nodes/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodes/pipeline_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -91,6 +93,27 @@ func Test_pipelineImpl_Run(t *testing.T) {
 						DoAndReturn(func(node *storage.Node) error {
 							assert.Equal(t, node.GetClusterName(), "test cluster name")
 							assert.Equal(t, node.GetClusterId(), a.clusterID)
+							return nil
+						}).Times(1),
+				)
+			},
+		},
+		{
+			name: "when LegacyScanner is disabled and node is non-RHCOS then set UNSUPPORTED note",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, false)
+				a.msg = createMsg("Ubuntu 22.04.3 LTS")
+				a.clusterID = "test cluster id"
+				gomock.InOrder(
+					m.clusterStore.EXPECT().
+						GetClusterName(gomock.Any(), gomock.Eq(a.clusterID)).
+						Times(1).
+						Return("test cluster name", true, nil),
+					m.nodeDatastore.EXPECT().
+						UpsertNode(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(_ context.Context, node *storage.Node) error {
+							assert.Contains(t, node.GetScan().GetNotes(), storage.NodeScan_UNSUPPORTED)
+							assert.NotNil(t, node.GetScan().GetScanTime())
 							return nil
 						}).Times(1),
 				)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

* Adds Unsupported note to non-RHCOS nodes when they're scanned and the v2 scanner is disabled
* ACK and subsequently drop node inventory requests when the legacy scanner is not enabled.

PR Stack:
* https://github.com/stackrox/stackrox/pull/21709
  * https://github.com/stackrox/stackrox/pull/21710
    * https://github.com/stackrox/stackrox/pull/21715 `<-- you are here` 
      * https://github.com/stackrox/stackrox/pull/21737

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

## Baseline (flag enabled)

1. **Check node scan status for non-RHCOS nodes:**
   ```bash
➜ roxcurl "/v1/nodes/394e4438-8e48-4041-8b54-d5696440a77f" | jq '.nodes[] | select(.osImage | test("Red Hat Enterprise Linux CoreOS") | not) | {name, osImage, scan: .scan.notes}'

{
  "name": "gke-kb-07-21-1-default-pool-fee2970a-6g76",
  "osImage": "Ubuntu 24.04.4 LTS",
  "scan": []
}
{
  "name": "gke-kb-07-21-1-default-pool-fee2970a-v854",
  "osImage": "Ubuntu 24.04.4 LTS",
  "scan": []
}
{
  "name": "gke-kb-07-21-1-default-pool-fee2970a-g7xb",
  "osImage": "Ubuntu 24.04.4 LTS",
  "scan": []
}
   ```
   **Expected:** Non-RHCOS nodes have scan results (possibly with vulnerabilities or `MISSING_SCAN_DATA` if scanner isn't reachable, but NOT `UNSUPPORTED`).

2. **Check RHCOS nodes have scan data:**
   ```bash
➜ roxcurl "/v1/nodes/0c5d3fd6-7148-4cd0-bd05-989cddba6571" | jq '.nodes[] | select(.osImage | test("Red Hat Enterprise Linux CoreOS")) | {name, osImage, scanComponents: (.scan.components | length)}'

{
  "name": "ip-10-0-0-69.ec2.internal",
  "osImage": "Red Hat Enterprise Linux CoreOS 9.6.20260630-0 (Plow)",
  "scanComponents": 0
}
{
  "name": "ip-10-0-0-166.ec2.internal",
  "osImage": "Red Hat Enterprise Linux CoreOS 9.6.20260630-0 (Plow)",
  "scanComponents": 0
}
   ```
   **Expected:** RHCOS nodes have scan components from the NodeInventory pipeline.

### Validation (flag disabled)

1. **Non-RHCOS nodes show UNSUPPORTED:**
   ```bash
➜ roxcurl "/v1/nodes/394e4438-8e48-4041-8b54-d5696440a77f" | jq '.nodes[] | select(.osImage | test("Red Hat Enterprise Linux CoreOS") | not) | {name, osImage, scan: .scan.notes}'

{
  "name": "gke-kb-07-21-1-default-pool-fee2970a-v854",
  "osImage": "Ubuntu 24.04.4 LTS",
  "scan": [
    "UNSUPPORTED"
  ]
}
{
  "name": "gke-kb-07-21-1-default-pool-fee2970a-g7xb",
  "osImage": "Ubuntu 24.04.4 LTS",
  "scan": [
    "UNSUPPORTED"
  ]
}
{
  "name": "gke-kb-07-21-1-default-pool-fee2970a-6g76",
  "osImage": "Ubuntu 24.04.4 LTS",
  "scan": [
    "UNSUPPORTED"
  ]
}
   ```
   **Expected:** Non-RHCOS nodes have `scan.notes` containing `UNSUPPORTED`. In the UI, these nodes display: "Scanning this node is not supported at this time."

2. **RHCOS nodes still scanned via Scanner V4:**
   ```bash
➜ roxcurl "/v1/nodes/0c5d3fd6-7148-4cd0-bd05-989cddba6571" | jq '.nodes[] | select(.osImage | test("Red Hat Enterprise Linux CoreOS")) | {name, osImage, scanComponents: (.scan.components | length)}'

{
  "name": "ip-10-0-0-166.ec2.internal",
  "osImage": "Red Hat Enterprise Linux CoreOS 9.6.20260630-0 (Plow)",
  "scanComponents": 0
}
{
  "name": "ip-10-0-0-69.ec2.internal",
  "osImage": "Red Hat Enterprise Linux CoreOS 9.6.20260630-0 (Plow)",
  "scanComponents": 0
}
   ```
   **Expected:** RHCOS nodes still have scan results via Scanner V4 (NodeIndex pipeline is unaffected).

3. **UI check:** Navigate to Vulnerability Management > Dashboard [Deprecated] > Nodes. Non-RHCOS nodes should show "Scanning this node is not supported at this time." instead of scan failure errors.
    <img width="619" height="577" alt="Screenshot 2026-07-21 at 9 55 37 AM" src="https://github.com/user-attachments/assets/7d406379-484b-4f87-8172-97d196c453a9" />


> **Note:** If your test cluster only has RHCOS nodes (e.g., OpenShift), the UNSUPPORTED note path won't trigger. You'd need a mixed cluster or a non-OpenShift k8s cluster to see non-RHCOS nodes.