### PR TITLE
chore: remove dead ComplianceV2ScanResults function

### DIFF
--- a/central/convert/storagetov2/compliance_results_service.go
+++ b/central/convert/storagetov2/compliance_results_service.go
@@ -8,19 +8,6 @@ import (
 	types "github.com/stackrox/rox/pkg/protocompat"
 )
 
-type checkResultKey struct {
-	scanConfigName string
-	scanConfigID   string
-	profileName    string
-	checkName      string
-}
-
-type scanResultKey struct {
-	scanConfigName string
-	scanConfigID   string
-	profileName    string
-}
-
 // ComplianceV2CheckResult converts a storage check result to a v2 check result
 func ComplianceV2CheckResult(incoming *storage.ComplianceOperatorCheckResultV2, lastScanTime *types.Timestamp, ruleName string, controlResults []*compRule.ControlResult) *v2.ComplianceClusterCheckStatus {
 	converted := &v2.ComplianceClusterCheckStatus{
@@ -72,74 +59,6 @@ func ComplianceV2SpecificCheckResult(incoming []*storage.ComplianceOperatorCheck
 	}
 
 	return converted
-}
-
-// ComplianceV2ScanResults converts the storage check results to v2 scan results
-func ComplianceV2ScanResults(incoming []*storage.ComplianceOperatorCheckResultV2, scanToScanID map[string]string) []*v2.ComplianceScanResult {
-	// Since a check result can hold the status for multiple clusters we need to build from
-	// bottom up.  resultsByScanCheck holds check result based on the key combination of
-	// scanName, profileName, checkName.  Then when that key is encountered again we
-	// add the cluster information to the check result.
-	resultsByScanCheck := make(map[checkResultKey]*v2.ComplianceClusterCheckStatus)
-
-	// Used to maintain sort order from the query since maps are unordered.
-	var orderedKeys []checkResultKey
-	for _, result := range incoming {
-		key := checkResultKey{
-			scanConfigName: result.GetScanConfigName(),
-			scanConfigID:   scanToScanID[result.GetScanConfigName()],
-			profileName:    "",
-			checkName:      result.GetCheckName(),
-		}
-		workingResult, found := resultsByScanCheck[key]
-		// First time seeing this rule in the results.
-		if !found {
-			orderedKeys = append(orderedKeys, key)
-			resultsByScanCheck[key] = ComplianceV2CheckResult(result, nil, "", nil)
-		} else {
-			// Append the new cluster status to the v2 check result.
-			workingResult.Clusters = append(workingResult.Clusters, clusterStatus(result, nil))
-			resultsByScanCheck[key] = workingResult
-		}
-	}
-
-	// This builds the outer piece of the result.  The key is simply
-	// scan name and profile name.  The individual check results from
-	// resultsByScanCheck are appended to build the output
-	resultsByScan := make(map[scanResultKey][]*v2.ComplianceClusterCheckStatus)
-	var scanOrder []scanResultKey
-	var convertedResults []*v2.ComplianceScanResult
-	for _, key := range orderedKeys {
-		scanKey := scanResultKey{
-			scanConfigName: key.scanConfigName,
-			scanConfigID:   key.scanConfigID,
-			profileName:    key.profileName,
-		}
-		result, resultFound := resultsByScanCheck[key]
-		if !resultFound {
-			continue
-		}
-		workingResult, found := resultsByScan[scanKey]
-		// First time seeing this rule in the results.
-		if !found {
-			scanOrder = append(scanOrder, scanKey)
-			resultsByScan[scanKey] = []*v2.ComplianceClusterCheckStatus{result}
-		} else {
-			workingResult = append(workingResult, result)
-			resultsByScan[scanKey] = workingResult
-		}
-	}
-
-	for _, key := range scanOrder {
-		convertedResults = append(convertedResults, &v2.ComplianceScanResult{
-			ScanName:     key.scanConfigName,
-			ScanConfigId: key.scanConfigID,
-			ProfileName:  key.profileName,
-			CheckResults: resultsByScan[key],
-		})
-	}
-
-	return convertedResults
 }
 
 // ComplianceV2ProfileResults converts the counts to the v2 stats


### PR DESCRIPTION
## Description

Remove `ComplianceV2ScanResults` and its helper types `checkResultKey` and `scanResultKey` from `central/convert/storagetov2/compliance_results_service.go`.

The function has had zero callers since commit 0969d3f851d5 (ROX-23777, May 2024), when `searchComplianceCheckResults` in the check results service switched to `ComplianceV2CheckData`. The two struct types were only used inside the removed function.

Verified dead by: grep of entire repo (Go, proto, yaml), git log `-S`, and absence from any interface or test.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

No new tests needed — this is a pure deletion of unreachable code. Existing tests pass (`go test ./central/convert/storagetov2/...`).

### How I validated my change

- `grep -r ComplianceV2ScanResults` across the entire repo finds only the definition (zero callers)
- `git log -S ComplianceV2ScanResults` confirms the last caller was removed in May 2024 (ROX-23777)
- `go build ./central/convert/storagetov2/...` compiles cleanly
- `go test ./central/convert/storagetov2/...` passes