### PR TITLE
feat(ci): expose build-tag as workflow_call output from build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
   workflow_call:
+    outputs:
+      build-tag:
+        description: The image tag produced by this build run.
+        value: ${{ jobs.define-job-matrix.outputs.build-tag }}
   push:
     tags:
     - '*-nightly-*'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,17 @@
+# Placeholder. This file exists on the default branch so that when the real
+# pull_request-triggered content lands (see PR #21721), GHA can evaluate it as
+# a modification to an existing workflow file rather than a brand-new one —
+# GHA does not run pull_request-triggered workflows defined in files that
+# don't yet exist on the base branch. Do not add a pull_request trigger here;
+# leave that to the PR that replaces this placeholder.
+name: PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-slim
+    steps:
+    - name: No-op
+      run: echo "Placeholder for the pr.yaml orchestrating workflow. See PR #21721."


### PR DESCRIPTION
## Description

Prerequisite for the `pr.yaml` orchestrator refactor (#21721).

Adds `build-tag` as a typed output to `build.yaml`'s `workflow_call` trigger. This allows callers of `build.yaml` (via `uses: ./.github/workflows/build.yaml`) to receive the computed image tag as a job output and thread it to downstream jobs — eliminating the need to re-derive the tag or poll the image registry.

The output references the existing `define-job-matrix` job output `build-tag` which is already computed and used internally throughout the workflow.

No behavior change for any existing callers (`release-ci.yaml`, `cut-rc.yml`, etc.) — adding outputs to a `workflow_call` block is backwards-compatible.

Also adds an inert `pr.yaml` placeholder (`workflow_dispatch` only, no `pull_request` trigger). GHA does not run `pull_request`-triggered workflows defined in files that don't yet exist on the base branch, and — confirmed empirically while testing #21721 — also validates a nested `uses: ./.github/workflows/build.yaml` call's input/output schema against `build.yaml`'s *base-branch* version at parse time, even though step execution uses the PR head. Landing both the output and the placeholder file here means #21721 can use the real `pr.yaml` filename and call `build.yaml` directly, with no workarounds.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Build.yaml already uses `define-job-matrix.outputs.build-tag` internally — this just surfaces it externally. No behavioral change. The pr.yaml placeholder is workflow_dispatch-only and does not affect any existing trigger.