### PR TITLE
ROX-34864: add Virtualization benchmark tab to compliance dashboard

### DIFF
--- a/central/complianceoperator/v2/benchmark/benchmark.go
+++ b/central/complianceoperator/v2/benchmark/benchmark.go
@@ -22,7 +22,8 @@ var (
 		regexp.MustCompile(".+-nerc-cip$|.+-nerc-cip-.+"): {shortName: "NERC-CIP", provider: "NERC"},
 		regexp.MustCompile(".+-pci-dss$|.+-pci-dss-.+"):   {shortName: "PCI-DSS", provider: "PCI"},
 
-		regexp.MustCompile("^ocp4-cis$|^ocp4-cis-.+"):               {shortName: "CIS-OCP", provider: "CIS"},
+		regexp.MustCompile(".+-cis-vm-extension($|-.+)"):             {shortName: "Virtualization", provider: "CIS"},
+		regexp.MustCompile("^ocp4-cis$|^ocp4-cis-(?:node|[0-9]).*"): {shortName: "CIS-OCP", provider: "CIS"},
 		regexp.MustCompile("^ocp4-high$|^ocp4-high-.+"):             {shortName: "NIST-800-53", provider: "NIST"},
 		regexp.MustCompile("^ocp4-moderate$|^ocp4-moderate-.+"):     {shortName: "NIST-800-53", provider: "NIST"},
 		regexp.MustCompile("^rhcos4-high$|^rhcos4-high-.+"):         {shortName: "NIST-800-53", provider: "NIST"},

--- a/central/complianceoperator/v2/benchmark/fixtures/cis-vm-extension-benchmark.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/cis-vm-extension-benchmark.json
@@ -1,0 +1,16 @@
+{
+  "name": "CIS Red Hat OpenShift Virtual Machine Extension Benchmark",
+  "provider": "CIS",
+  "shortName": "Virtualization",
+  "profiles": [
+    {
+      "profileName": "ocp4-cis-vm-extension"
+    },
+    {
+      "profileName": "ocp4-cis-vm-extension-node"
+    },
+    {
+      "profileName": "ocp4-cis-vm-extension-1-1"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Map the `ocp4-cis-vm-extension` profile (shipped by Compliance Operator 1.10 as part of the CIS OpenShift Virtual Machine Extension Benchmark) to a "Virtualization" tab in the compliance coverage UI.

The compliance coverage tab system is fully data-driven from the `standards[].shortName` field returned by the API. Adding a regex entry in the backend benchmark map is the only change needed — no frontend, proto, or migration changes.

The existing CIS-OCP regex was tightened from `^ocp4-cis-.+` to `^ocp4-cis-(?:node|[0-9]).*` to prevent ambiguous matching with the new vm-extension profile, since Go map iteration order is non-deterministic.

**Alternatives considered**: Frontend-side grouping, annotation-based grouping — both rejected because they fight the existing architecture that puts all naming-to-standard mapping in one place (Go regex map) and lets the UI be purely data-driven.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All benchmark unit tests pass (`go test -v ./central/complianceoperator/v2/benchmark/...`), including backward-compatibility tests that automatically pick up the new fixture.
- The tightened CIS-OCP regex was verified to match all 8 existing CIS profile names and exclude `ocp4-cis-vm-extension`.
- End-to-end UI validation pending CO 1.10 availability (the tab only appears when the CIS VM Extension profile is present on the cluster).
- To be able to see the UI changes before CO 1.10 is available, I created a tailored profile with the same name as the future ocpvirt profile, and [these rules](https://github.com/complianceascode/compliance-operator/tree/master/config/samples/custom-rules/openshift-virtualization), and scheduled it. I manually changed its kind in central DB from tailored profile to profile, because the future ocpvirt profile will be a regular profile, not tailored. I then confirmed in the UI that it is shown under the right tab:
<img width="1329" height="814" alt="Screenshot 2026-07-15 at 15 34 16" src="https://github.com/user-attachments/assets/bb87afeb-7159-4ab5-88c7-5842da7b4ed4" />
