### PR TITLE
ROX-35681: Conditionally Disables ScannerV2 Orchestrator Scans

### DIFF
--- a/central/cve/fetcher/manager.go
+++ b/central/cve/fetcher/manager.go
@@ -11,6 +11,7 @@ import (
 	cveMatcher "github.com/stackrox/rox/central/cve/matcher"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	pkgScanners "github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/clairify"
 	"github.com/stackrox/rox/pkg/scanners/types"
@@ -51,6 +52,11 @@ func NewOrchestratorIstioCVEManagerImpl(
 		},
 		updateSignal: concurrency.NewSignal(),
 	}
+	if !features.LegacyScanner.Enabled() {
+		log.Info("Orchestrator scanning is disabled: no orchestrator scanners are integrated")
+		return m, nil
+	}
+
 	clairifyName, clairifyCreator := clairify.OrchestratorScannerCreator()
 	m.orchestratorCVEMgr.creators[clairifyName] = clairifyCreator
 

--- a/central/cve/fetcher/manager_impl.go
+++ b/central/cve/fetcher/manager_impl.go
@@ -8,6 +8,7 @@ import (
 	cveMatcher "github.com/stackrox/rox/central/cve/matcher"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/throttle"
@@ -31,6 +32,9 @@ func (m *orchestratorIstioCVEManagerImpl) initialize() {
 
 // Start begins the process to periodically scan orchestrator-level components, asynchronously.
 func (m *orchestratorIstioCVEManagerImpl) Start() {
+	if !features.LegacyScanner.Enabled() {
+		return
+	}
 	go func() {
 		ticker := time.NewTicker(env.OrchestratorVulnScanInterval.DurationSetting())
 		defer ticker.Stop()
@@ -48,6 +52,9 @@ func (m *orchestratorIstioCVEManagerImpl) Start() {
 }
 
 func (m *orchestratorIstioCVEManagerImpl) HandleClusterConnection() {
+	if !features.LegacyScanner.Enabled() {
+		return
+	}
 	connectionDropThrottle.Run(func() {
 		m.updateSignal.Signal()
 	})

--- a/central/cve/fetcher/manager_test.go
+++ b/central/cve/fetcher/manager_test.go
@@ -1,0 +1,64 @@
+package fetcher
+
+import (
+	"testing"
+
+	mockClusterDataStore "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	mockClusterCVEEdgeDataStore "github.com/stackrox/rox/central/clustercveedge/datastore/mocks"
+	mockCVEDataStore "github.com/stackrox/rox/central/cve/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/cve/matcher"
+	mockImageDataStore "github.com/stackrox/rox/central/image/datastore/mocks"
+	mockImageV2DataStore "github.com/stackrox/rox/central/imagev2/datastore/mocks"
+	mockNSDataStore "github.com/stackrox/rox/central/namespace/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewOrchestratorIstioCVEManagerImpl(t *testing.T) {
+	tests := map[string]struct {
+		legacyScannerEnabled bool
+		setUp                func(t *testing.T, mockClusters *mockClusterDataStore.MockDataStore, mockCVEs *mockCVEDataStore.MockDataStore)
+	}{
+		"when LegacyScanner is disabled then no creators registered and initialize not called": {
+			legacyScannerEnabled: false,
+			setUp: func(t *testing.T, mockClusters *mockClusterDataStore.MockDataStore, mockCVEs *mockCVEDataStore.MockDataStore) {
+			},
+		},
+		"when LegacyScanner is enabled then Clairify creator registered and initialize called": {
+			legacyScannerEnabled: true,
+			setUp: func(t *testing.T, mockClusters *mockClusterDataStore.MockDataStore, mockCVEs *mockCVEDataStore.MockDataStore) {
+				mockClusters.EXPECT().GetClusters(gomock.Any()).Return([]*storage.Cluster{}, nil).Times(1)
+				mockCVEs.EXPECT().UpsertClusterCVEsInternal(gomock.Any(), storage.CVE_K8S_CVE).Return(nil).Times(1)
+				mockCVEs.EXPECT().UpsertClusterCVEsInternal(gomock.Any(), storage.CVE_OPENSHIFT_CVE).Return(nil).Times(1)
+				mockCVEs.EXPECT().UpsertClusterCVEsInternal(gomock.Any(), storage.CVE_ISTIO_CVE).Return(nil).Times(1)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			testutils.MustUpdateFeature(t, features.LegacyScanner, tt.legacyScannerEnabled)
+
+			ctrl := gomock.NewController(t)
+			mockClusters := mockClusterDataStore.NewMockDataStore(ctrl)
+			mockCVEs := mockCVEDataStore.NewMockDataStore(ctrl)
+			mockEdges := mockClusterCVEEdgeDataStore.NewMockDataStore(ctrl)
+			mockNamespaces := mockNSDataStore.NewMockDataStore(ctrl)
+			mockImages := mockImageDataStore.NewMockDataStore(ctrl)
+			mockImagesV2 := mockImageV2DataStore.NewMockDataStore(ctrl)
+
+			tt.setUp(t, mockClusters, mockCVEs)
+
+			cveMatcher, err := matcher.NewCVEMatcher(mockClusters, mockNamespaces, mockImages, mockImagesV2)
+			require.NoError(t, err)
+
+			mgr, err := NewOrchestratorIstioCVEManagerImpl(mockClusters, mockCVEs, mockEdges, cveMatcher)
+			assert.NoError(t, err)
+			assert.NotNil(t, mgr)
+		})
+	}
+}

--- a/central/cve/fetcher/manager_test.go
+++ b/central/cve/fetcher/manager_test.go
@@ -1,17 +1,20 @@
 package fetcher
 
 import (
+	"context"
 	"testing"
 
 	mockClusterDataStore "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	mockClusterCVEEdgeDataStore "github.com/stackrox/rox/central/clustercveedge/datastore/mocks"
 	mockCVEDataStore "github.com/stackrox/rox/central/cve/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/cve/converter/utils"
 	"github.com/stackrox/rox/central/cve/matcher"
 	mockImageDataStore "github.com/stackrox/rox/central/image/datastore/mocks"
 	mockImageV2DataStore "github.com/stackrox/rox/central/imagev2/datastore/mocks"
 	mockNSDataStore "github.com/stackrox/rox/central/namespace/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,4 +64,54 @@ func TestNewOrchestratorIstioCVEManagerImpl(t *testing.T) {
 			assert.NotNil(t, mgr)
 		})
 	}
+}
+
+func TestInertManager_ConsumerPathsSafe(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.LegacyScanner, false)
+
+	ctrl := gomock.NewController(t)
+	mockClusters := mockClusterDataStore.NewMockDataStore(ctrl)
+	mockCVEs := mockCVEDataStore.NewMockDataStore(ctrl)
+	mockEdges := mockClusterCVEEdgeDataStore.NewMockDataStore(ctrl)
+	mockNamespaces := mockNSDataStore.NewMockDataStore(ctrl)
+	mockImages := mockImageDataStore.NewMockDataStore(ctrl)
+	mockImagesV2 := mockImageV2DataStore.NewMockDataStore(ctrl)
+
+	cveMatcher, err := matcher.NewCVEMatcher(mockClusters, mockNamespaces, mockImages, mockImagesV2)
+	require.NoError(t, err)
+
+	mgr, err := NewOrchestratorIstioCVEManagerImpl(mockClusters, mockCVEs, mockEdges, cveMatcher)
+	require.NoError(t, err)
+
+	t.Run("GetAffectedClusters queries DB and returns results", func(t *testing.T) {
+		ctx := sac.WithAllAccess(context.Background())
+		expected := []*storage.Cluster{{Id: "cluster-1", Name: "test-cluster"}}
+		mockClusters.EXPECT().SearchRawClusters(gomock.Any(), gomock.Any()).Return(expected, nil).Times(1)
+
+		clusters, err := mgr.GetAffectedClusters(ctx, "CVE-2024-1234", utils.K8s, nil)
+		assert.NoError(t, err)
+		assert.Len(t, clusters, 1)
+		assert.Equal(t, "cluster-1", clusters[0].GetId())
+	})
+
+	t.Run("HandleClusterConnection does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			mgr.HandleClusterConnection()
+		})
+	})
+
+	t.Run("UpsertOrchestratorIntegration returns error for missing creator", func(t *testing.T) {
+		err := mgr.UpsertOrchestratorIntegration(&storage.OrchestratorIntegration{
+			Id:   "test-id",
+			Type: "clairify",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("RemoveIntegration does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			mgr.RemoveIntegration("nonexistent-id")
+		})
+	})
 }

--- a/central/main.go
+++ b/central/main.go
@@ -529,7 +529,9 @@ func servicesToRegister() []pkgGRPC.APIService {
 	}
 
 	// Start cluster-level (Kubernetes, OpenShift, Istio) vulnerability data fetcher.
-	fetcher.SingletonManager().Start()
+	if features.LegacyScanner.Enabled() {
+		fetcher.SingletonManager().Start()
+	}
 
 	if devbuild.IsEnabled() {
 		servicesToRegister = append(servicesToRegister, developmentService.Singleton())


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This disables Orchestrator scanner during ACS startup when the feature flag is set to "false". Additionally adds tests to validate that existing paths still work as expected, with the orchestrator disabled, and do not create panics or otherwise blow up.

PR Stack:
* https://github.com/stackrox/stackrox/pull/21709
  * https://github.com/stackrox/stackrox/pull/21710
    * https://github.com/stackrox/stackrox/pull/21715
      * https://github.com/stackrox/stackrox/pull/21737 `<-- you are here` 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

### Baseline (flag enabled)

1. **Check orchestrator scanning is running:*
```bash
➜ kubectl -n stackrox logs deploy/central | grep -i "orchestrator"
cve/fetcher: 2026/07/21 13:45:50.891245 orchestrator.go:60: Info: Found 2 clusters to scan for orchestrator vulnerabilities.
cve/fetcher: 2026/07/21 13:45:50.891343 orchestrator.go:64: Error: failed to reconcile orchestrator Kubernetes CVEs: no orchestrator scanners are integrated
cve/fetcher: 2026/07/21 13:45:50.891459 orchestrator.go:68: Error: failed to reconcile orchestrator OpenShift CVEs: no orchestrator scanners are integrated
cve/fetcher: 2026/07/21 13:45:50.894554 orchestrator.go:230: Info: Successfully fetched 0 Istio CVEs
cve/fetcher: 2026/07/21 13:45:50.937099 orchestrator.go:60: Info: Found 2 clusters to scan for orchestrator vulnerabilities.
cve/fetcher: 2026/07/21 13:45:51.024100 orchestrator.go:230: Info: Successfully fetched 5 Kubernetes CVEs
cve/fetcher: 2026/07/21 13:45:51.063029 orchestrator.go:230: Info: Successfully fetched 90 OpenShift CVEs
cve/fetcher: 2026/07/21 13:45:51.065188 orchestrator.go:230: Info: Successfully fetched 0 Istio CVEs
cve/fetcher: 2026/07/21 13:46:34.091144 manager_impl.go:70: Info: Start orchestrator-level vulnerability reconciliation
cve/fetcher: 2026/07/21 13:46:34.093037 orchestrator.go:60: Info: Found 2 clusters to scan for orchestrator vulnerabilities.
cve/fetcher: 2026/07/21 13:46:34.108332 orchestrator.go:230: Info: Successfully fetched 5 Kubernetes CVEs
cve/fetcher: 2026/07/21 13:46:34.139101 orchestrator.go:230: Info: Successfully fetched 90 OpenShift CVEs
cve/fetcher: 2026/07/21 13:46:34.142671 orchestrator.go:230: Info: Successfully fetched 0 Istio CVEs
```
   **Expected:** Log lines like:
   - `Found N clusters to scan for orchestrator vulnerabilities.`
   - `Successfully fetched N Kubernetes CVEs`
   - `Start orchestrator-level vulnerability reconciliation` (every 2 hours)

2. **Check cluster CVEs exist (UI):** Navigate to Vulnerability Management > Cluster CVEs. Should show K8s/OpenShift/Istio CVEs if any exist for the cluster's versions.

### Validation (flag disabled)

1. **Check orchestrator scanning is disabled:
```bash
➜ kubectl -n stackrox logs deploy/central | grep -i "orchestrator"
cve/fetcher: 2026/07/21 13:52:10.619969 manager.go:56: Info: Orchestrator scanning is disabled: no orchestrator scanners are integrated
```
   **Expected:** Single log line at startup: `Orchestrator scanning is disabled: no orchestrator scanners are integrated`. No periodic reconciliation messages.

3. **Verify no new orchestrator CVE reconciliation:**
 ```bash
➜ kubectl -n stackrox logs deploy/central | grep "Start orchestrator-level vulnerability reconciliation"


```
   **Expected:** No results. The periodic goroutine was never started.

4. **Cluster CVEs page still loads (UI):** Navigate to Vulnerability Management > Platform. The page should load without errors. It may show stale data from before the flag was disabled, or be empty on a fresh deploy — but it should not error out.
<img width="996" height="815" alt="Screenshot 2026-07-21 at 10 01 35 AM" src="https://github.com/user-attachments/assets/09b8bc5b-0b57-463f-ae2c-5ab433270ee4" />
