### PR TITLE
ROX-35642: Migrate detector online/offline gate to real PubSub

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector/queue"
 	"github.com/stackrox/rox/sensor/common/detector/unified"
 	"github.com/stackrox/rox/sensor/common/enforcer"
+	sensorEvents "github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/externalsrcs"
 	"github.com/stackrox/rox/sensor/common/filesystem"
 	fsUtils "github.com/stackrox/rox/sensor/common/filesystem/utils"
@@ -276,6 +277,22 @@ func (d *detectorImpl) Start() error {
 		); err != nil {
 			return errors.Wrap(err, "failed to register detector deploy alert output consumer")
 		}
+		if err := d.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.DetectorSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			d.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register detector sensor online consumer")
+		}
+		if err := d.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.DetectorSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			d.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register detector sensor offline consumer")
+		}
 	}
 
 	if !d.pubSubEnabled() {
@@ -406,24 +423,41 @@ func (d *detectorImpl) Stop() {
 
 func (d *detectorImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if d.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start() (see
+		// handleSensorOnlineEvent/handleSensorOfflineEvent), which keeps
+		// runtimeRunning ordered with the other PubSub consumers on this
+		// dispatcher. Driving it from here too raced the PubSub-driven
+		// indicator processing and silently dropped events (ROX-35620).
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
-		if d.pubSubEnabled() {
-			d.runtimeRunning.Signal()
-		} else {
-			d.indicatorsQueue.Resume()
-			d.networkFlowsQueue.Resume()
-			d.fileAccessQueue.Resume()
-		}
+		d.indicatorsQueue.Resume()
+		d.networkFlowsQueue.Resume()
+		d.fileAccessQueue.Resume()
 	case common.SensorComponentEventOfflineMode:
-		if d.pubSubEnabled() {
-			d.runtimeRunning.Reset()
-		} else {
-			d.indicatorsQueue.Pause()
-			d.networkFlowsQueue.Pause()
-			d.fileAccessQueue.Pause()
-		}
+		d.indicatorsQueue.Pause()
+		d.networkFlowsQueue.Pause()
+		d.fileAccessQueue.Pause()
 	}
+}
+
+func (d *detectorImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*sensorEvents.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	d.runtimeRunning.Signal()
+	return nil
+}
+
+func (d *detectorImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*sensorEvents.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	d.runtimeRunning.Reset()
+	return nil
 }
 
 func (d *detectorImpl) Capabilities() []centralsensor.SensorCapability {

--- a/sensor/common/detector/detector_deployment_bench_test.go
+++ b/sensor/common/detector/detector_deployment_bench_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/sensor/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +24,7 @@ func BenchmarkDeploymentPipeline_SteadyState(b *testing.B) {
 			require.NoError(b, d.Start())
 			b.Cleanup(d.Stop)
 
-			d.Notify(common.SensorComponentEventCentralReachable)
+			goOnline(b, d)
 
 			deployment := &storage.Deployment{
 				Id:        "dep-1",

--- a/sensor/common/detector/detector_deployment_test.go
+++ b/sensor/common/detector/detector_deployment_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/sensor/common"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,7 +122,7 @@ func TestDeploymentPipeline(t *testing.T) {
 					require.NoError(t, d.Start())
 					defer d.Stop()
 
-					d.Notify(common.SensorComponentEventCentralReachable)
+					goOnline(t, d)
 
 					d.ProcessDeployment(context.Background(), tc.deployment, tc.action)
 					synctest.Wait()
@@ -179,7 +178,7 @@ func TestDeploymentPipelineDropsWhenFull(t *testing.T) {
 				require.NoError(t, d.Start())
 				defer d.Stop()
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 
 				// Hold the deploymentDetectionLock so the consumer blocks,
 				// causing events to queue up and eventually drop.

--- a/sensor/common/detector/detector_file_access_bench_test.go
+++ b/sensor/common/detector/detector_file_access_bench_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/sensor/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +23,7 @@ func BenchmarkFileAccessPipeline_SteadyState(b *testing.B) {
 			require.NoError(b, d.Start())
 			b.Cleanup(d.Stop)
 
-			d.Notify(common.SensorComponentEventCentralReachable)
+			goOnline(b, d)
 
 			access := &storage.FileAccess{
 				Process:   &storage.ProcessIndicator{DeploymentId: "dep-1"},

--- a/sensor/common/detector/detector_file_access_test.go
+++ b/sensor/common/detector/detector_file_access_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/sensor/common"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,7 +120,7 @@ func TestFileAccessPipeline(t *testing.T) {
 					require.NoError(t, d.Start())
 					defer d.Stop()
 
-					d.Notify(common.SensorComponentEventCentralReachable)
+					goOnline(t, d)
 
 					d.ProcessFileAccess(context.Background(), tc.access)
 					synctest.Wait()
@@ -183,7 +182,7 @@ func TestFileAccessPipelineOfflineBlocks(t *testing.T) {
 				default:
 				}
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 				synctest.Wait()
 
 				select {
@@ -243,7 +242,7 @@ func TestFileAccessPipelineDropsWhenFull(t *testing.T) {
 				default:
 				}
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 				synctest.Wait()
 
 				// The legacy queue holds exactly bufferSize items.

--- a/sensor/common/detector/detector_helpers_test.go
+++ b/sensor/common/detector/detector_helpers_test.go
@@ -150,18 +150,6 @@ func goOnline(tb testing.TB, d *detectorImpl) {
 	d.Notify(common.SensorComponentEventCentralReachable)
 }
 
-// goOffline transitions d to "offline" mode using whichever mechanism is
-// active: a real SensorOfflineEvent publish when pubSubEnabled, legacy Notify
-// otherwise.
-func goOffline(tb testing.TB, d *detectorImpl) {
-	tb.Helper()
-	if d.pubSubEnabled() {
-		require.NoError(tb, d.pubSubDispatcher.Publish(&sensorEvents.SensorOfflineEvent{}))
-		return
-	}
-	d.Notify(common.SensorComponentEventOfflineMode)
-}
-
 const benchBufferSize = 20000
 
 func createBenchDetector(b *testing.B, pubSubEnabled bool) *detectorImpl {

--- a/sensor/common/detector/detector_helpers_test.go
+++ b/sensor/common/detector/detector_helpers_test.go
@@ -16,6 +16,7 @@ import (
 	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	networkBaselineEval "github.com/stackrox/rox/sensor/common/detector/networkbaseline"
 	"github.com/stackrox/rox/sensor/common/detector/queue"
+	sensorEvents "github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/pubsub/consumer"
@@ -124,6 +125,8 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 				),
 				lane.NewBlockingLane(pubsub.DetectorScanResultLane),
 				lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
+				lane.NewBlockingLane(pubsub.SensorOnlineLane),
+				lane.NewBlockingLane(pubsub.SensorOfflineLane),
 			},
 		))
 		require.NoError(tb, err)
@@ -133,6 +136,30 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 	}
 
 	return d, deploymentStore, networkPolicyStore, nodeStore
+}
+
+// goOnline transitions d to "online" mode using whichever mechanism is
+// active: a real SensorOnlineEvent publish when pubSubEnabled, legacy Notify
+// otherwise. This lets test bodies stay agnostic to the migration.
+func goOnline(tb testing.TB, d *detectorImpl) {
+	tb.Helper()
+	if d.pubSubEnabled() {
+		require.NoError(tb, d.pubSubDispatcher.Publish(&sensorEvents.SensorOnlineEvent{}))
+		return
+	}
+	d.Notify(common.SensorComponentEventCentralReachable)
+}
+
+// goOffline transitions d to "offline" mode using whichever mechanism is
+// active: a real SensorOfflineEvent publish when pubSubEnabled, legacy Notify
+// otherwise.
+func goOffline(tb testing.TB, d *detectorImpl) {
+	tb.Helper()
+	if d.pubSubEnabled() {
+		require.NoError(tb, d.pubSubDispatcher.Publish(&sensorEvents.SensorOfflineEvent{}))
+		return
+	}
+	d.Notify(common.SensorComponentEventOfflineMode)
 }
 
 const benchBufferSize = 20000

--- a/sensor/common/detector/detector_indicator_bench_test.go
+++ b/sensor/common/detector/detector_indicator_bench_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/sensor/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +23,7 @@ func BenchmarkIndicatorPipeline_SteadyState(b *testing.B) {
 			require.NoError(b, d.Start())
 			b.Cleanup(d.Stop)
 
-			d.Notify(common.SensorComponentEventCentralReachable)
+			goOnline(b, d)
 
 			pi := &storage.ProcessIndicator{
 				Id:           "pi-bench",

--- a/sensor/common/detector/detector_indicator_test.go
+++ b/sensor/common/detector/detector_indicator_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/sensor/common"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,7 +87,7 @@ func TestIndicatorPipeline(t *testing.T) {
 					require.NoError(t, d.Start())
 					defer d.Stop()
 
-					d.Notify(common.SensorComponentEventCentralReachable)
+					goOnline(t, d)
 
 					d.ProcessIndicator(context.Background(), tc.indicator)
 					synctest.Wait()
@@ -153,7 +152,7 @@ func TestIndicatorPipelineOfflineBlocks(t *testing.T) {
 				}
 
 				// Go online — buffered event should be processed
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 				synctest.Wait()
 
 				select {
@@ -214,7 +213,7 @@ func TestIndicatorPipelineDropsWhenFull(t *testing.T) {
 				}
 
 				// Go online
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 				synctest.Wait()
 
 				// Drain and count.

--- a/sensor/common/detector/detector_network_flow_bench_test.go
+++ b/sensor/common/detector/detector_network_flow_bench_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/sensor/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +24,7 @@ func BenchmarkNetworkFlowPipeline_SteadyState(b *testing.B) {
 			require.NoError(b, d.Start())
 			b.Cleanup(d.Stop)
 
-			d.Notify(common.SensorComponentEventCentralReachable)
+			goOnline(b, d)
 
 			flow := &storage.NetworkFlow{
 				Props: &storage.NetworkFlowProperties{

--- a/sensor/common/detector/detector_network_flow_test.go
+++ b/sensor/common/detector/detector_network_flow_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/sensor/common"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,7 +111,7 @@ func TestNetworkFlowPipeline(t *testing.T) {
 					require.NoError(t, d.Start())
 					defer d.Stop()
 
-					d.Notify(common.SensorComponentEventCentralReachable)
+					goOnline(t, d)
 
 					d.ProcessNetworkFlow(context.Background(), tc.flow)
 					synctest.Wait()
@@ -167,7 +166,7 @@ func TestNetworkFlowPipelineOfflineBlocks(t *testing.T) {
 				default:
 				}
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 				synctest.Wait()
 
 				select {
@@ -232,7 +231,7 @@ func TestNetworkFlowPipelineDropsWhenFull(t *testing.T) {
 				default:
 				}
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 				synctest.Wait()
 
 				// The legacy queue holds exactly bufferSize items.

--- a/sensor/common/detector/detector_online_offline_test.go
+++ b/sensor/common/detector/detector_online_offline_test.go
@@ -1,0 +1,69 @@
+package detector
+
+import (
+	"testing"
+	"testing/synctest"
+
+	sensorEvents "github.com/stackrox/rox/sensor/common/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleSensorOnlineEvent_SignalsRuntimeRunning(t *testing.T) {
+	d, _, _, _ := createTestDetector(t, true)
+	require.False(t, d.runtimeRunning.IsDone())
+
+	require.NoError(t, d.handleSensorOnlineEvent(&sensorEvents.SensorOnlineEvent{}))
+
+	assert.True(t, d.runtimeRunning.IsDone())
+}
+
+func TestHandleSensorOfflineEvent_ResetsRuntimeRunning(t *testing.T) {
+	d, _, _, _ := createTestDetector(t, true)
+	d.runtimeRunning.Signal()
+	require.True(t, d.runtimeRunning.IsDone())
+
+	require.NoError(t, d.handleSensorOfflineEvent(&sensorEvents.SensorOfflineEvent{}))
+
+	assert.False(t, d.runtimeRunning.IsDone())
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	d, _, _, _ := createTestDetector(t, true)
+
+	err := d.handleSensorOnlineEvent(&sensorEvents.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	d, _, _, _ := createTestDetector(t, true)
+
+	err := d.handleSensorOfflineEvent(&sensorEvents.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestDetectorStart_RegistersSensorOnlineOfflineConsumers verifies Start()
+// wires the online/offline handlers onto the SensorOnline/SensorOffline
+// topic and lane, and that a published event flips runtimeRunning end-to-end
+// through the dispatcher. This is the regression test for ROX-35620, where
+// runtimeRunning was driven by the legacy Notify call even in PubSub mode,
+// racing against the dispatcher's own PubSub-driven consumers.
+func TestDetectorStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		d, _, _, _ := createTestDetector(t, true)
+		require.NoError(t, d.Start())
+		defer d.Stop()
+
+		require.NoError(t, d.pubSubDispatcher.Publish(&sensorEvents.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, d.runtimeRunning.IsDone())
+
+		require.NoError(t, d.pubSubDispatcher.Publish(&sensorEvents.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, d.runtimeRunning.IsDone())
+	})
+}

--- a/sensor/common/detector/detector_serializer_test.go
+++ b/sensor/common/detector/detector_serializer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/sensor/common"
 	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +32,7 @@ func TestSerializerOlderUpdateIsIgnored(t *testing.T) {
 				require.NoError(t, d.Start())
 				defer d.Stop()
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 
 				// CREATE with timestamp 100
 				depNew := &storage.Deployment{
@@ -80,7 +79,7 @@ func TestSerializerCreateEnforces(t *testing.T) {
 				require.NoError(t, d.Start())
 				defer d.Stop()
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 
 				dep := &storage.Deployment{Id: "dep-1", Name: "test", Namespace: "default"}
 				d.ProcessDeployment(context.Background(), dep, central.ResourceAction_CREATE_RESOURCE)
@@ -105,7 +104,7 @@ func TestSerializerRemoveDeletesFromProcessingMap(t *testing.T) {
 				require.NoError(t, d.Start())
 				defer d.Stop()
 
-				d.Notify(common.SensorComponentEventCentralReachable)
+				goOnline(t, d)
 
 				dep := &storage.Deployment{Id: "dep-1", Name: "test", Namespace: "default"}
 
@@ -200,7 +199,7 @@ func TestSerializerPubSubStopUnblocksOutputSend(t *testing.T) {
 
 		require.NoError(t, d.Start())
 
-		d.Notify(common.SensorComponentEventCentralReachable)
+		goOnline(t, d)
 
 		dep := &storage.Deployment{Id: "dep-1", Name: "test", Namespace: "default"}
 		d.ProcessDeployment(context.Background(), dep, central.ResourceAction_CREATE_RESOURCE)

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -16,6 +16,8 @@ const (
 	DetectorDeploymentConsumer
 	DetectorScanResultConsumer
 	DetectorDeployAlertOutputConsumer
+	DetectorSensorOnlineConsumer
+	DetectorSensorOfflineConsumer
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
@@ -36,6 +38,8 @@ var (
 		DetectorDeploymentConsumer:             "DetectorDeployment",
 		DetectorScanResultConsumer:             "DetectorScanResult",
 		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
+		DetectorSensorOnlineConsumer:           "DetectorSensorOnline",
+		DetectorSensorOfflineConsumer:          "DetectorSensorOffline",
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",


### PR DESCRIPTION
## Description

PR 1 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854). Migrates sensor/common/detector/detector.go online/offline gating (runtimeRunning signal) from the legacy Notify(SensorComponentEvent) path onto a real PubSub subscription.

detector.go is already PubSub-migrated for other signals (process indicators, network flows, file access, audit log, deployment, scan result, deploy-alert-output), but its runtimeRunning gate was still being driven from inside Notify() even when PubSub is enabled -- it just swapped queue pause/resume for runtimeRunning.Signal()/Reset(). Mixing a Notify-driven gate with PubSub-driven consumers on the same dispatcher breaks ordering guarantees between them, which caused ROX-35620 (indicators silently dropped during offline mode). This PR adds a genuine PubSub subscription to SensorOnlineTopic/SensorOfflineTopic (defined by the infra PR) on the same dispatcher/lane as the other detector consumers, and makes Notify() a no-op for those two events in PubSub mode.

Adds DetectorSensorOnlineConsumer/DetectorSensorOfflineConsumer and handleSensorOnlineEvent/handleSensorOfflineEvent. Test helpers goOnline/goOffline let the ~19 existing test call sites toggle online/offline without duplicating pubsub-vs-legacy branching in every test.

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added sensor/common/detector/detector_online_offline_test.go: handler unit tests for signal/reset behavior, wrong-event-type cases, and an end-to-end Start() + Publish() wiring test (the regression test for the ROX-35620 class of bug).
- Updated the ~19 existing detector test call sites (indicator/network-flow/file-access/deployment/serializer, including benchmarks) to go through the new PubSub path via a goOnline/goOffline test helper, covering both pubSubEnabled=true and =false.
- go test ./sensor/common/detector/... ./sensor/common/pubsub/... -- all pass.
- go test -race -count=1 on the same packages -- no races detected. Ran deliberately given this change touches a concurrency.Signal shared across the new PubSub consumer goroutine and the existing indicator/network-flow/file-access handlers that block on it.
- Feature is gated by ROX_SENSOR_PUBSUB, off by default; legacy Notify path is unchanged when disabled.

## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - **PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742) (this PR)**
  - PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763)
  - PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762)
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765)
  - PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766)
  - PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767)
  - PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771)
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)


