### PR TITLE
ROX-35759: fix retry.WithRetry extra call after backoff cancel

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -82,6 +82,12 @@ func (t *retryOptions) do() (err error) {
 					// third retry after 400 milliseconds. Backoff time doubles after each attempt.
 					time.Sleep(time.Duration(100*math.Pow(2, float64(i))) * time.Millisecond)
 				}
+				// The between/backoff step above may block for a while, during which the
+				// context can be cancelled. Re-check here so we don't make one more call to
+				// t.function() after the caller already asked us to stop.
+				if t.ctx != nil && t.ctx.Err() != nil {
+					return t.ctx.Err()
+				}
 			} else {
 				// If we can't retry then return.
 				return err

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -120,6 +120,35 @@ func (suite *RetryTestSuite) TestLimitsTries() {
 	suite.Equal(2, inBetweenCount)
 }
 
+func (suite *RetryTestSuite) TestWithContextCancelledDuringBetweenAttempts() {
+	runCount := 0
+	inBetweenCount := 0
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel the context from within BetweenAttempts, simulating a ctx-aware backoff/wait
+	// that observes cancellation immediately, rather than the retried function noticing it.
+	// The retried function must not be invoked again once BetweenAttempts triggers the
+	// cancellation - runCount should stay at 2, not advance to 3.
+	err := WithRetry(func() error {
+		runCount = runCount + 1
+		return errors.New("some error")
+	},
+		Tries(99),
+		WithContext(ctx),
+		BetweenAttempts(func(previousAttempt int) {
+			inBetweenCount = inBetweenCount + 1
+			if inBetweenCount == 2 {
+				cancel()
+			}
+		}),
+	)
+
+	suite.Error(err)
+	suite.Equal(ctx.Err(), err)
+	suite.Equal(2, runCount)
+	suite.Equal(2, inBetweenCount)
+}
+
 func (suite *RetryTestSuite) TestAlwaysRetryableNoTries() {
 	runCount := 0
 	failCount := 0


### PR DESCRIPTION
## Description

`(*retryOptions).do()` in `pkg/retry/retry.go` only re-checked `t.ctx.Err()` once, at the top of each `for` loop iteration. If the context passed via `WithContext` was cancelled *during* the `BetweenAttempts` callback or the built-in `WithExponentialBackoff` sleep, the loop still called `t.function()` one more time before the next iteration's top-of-loop check caught the cancellation - an unwanted extra attempt for retried functions with real side effects (network calls, writes, RPCs).

Found via AI-assisted development on PR #21435 (`piotr/ROX-35190-roxagent-serve`), which uses a ctx-aware `BetweenAttempts` callback specifically to observe cancellation during backoff immediately, and still hit this bug.

The fix re-checks `t.ctx.Err()` immediately after the `between`/backoff step and returns it without calling `t.function()` again if non-nil. Every other retry semantic (tries counting, `canRetry`, `onFailure`, backoff timing) is unchanged.

Checked the two existing callers combining `WithContext` with `BetweenAttempts`/`WithExponentialBackoff` (`sensor/kubernetes/complianceoperator/handler_impl.go`, `pkg/signatures/factory.go`); their package tests still pass, as expected since this change only makes `do()` return sooner in the cancelled-during-backoff case.

Parts of this fix and its regression test were AI-generated.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- CI