### PR TITLE
ROX-34097: Add versioncompatibility pkg

### DIFF
--- a/pkg/version/productstreams/product_streams.go
+++ b/pkg/version/productstreams/product_streams.go
@@ -113,7 +113,8 @@ func parseBumpsData(data []byte) ([]parsedBump, error) {
 
 // Distance returns the absolute distance in Y-stream releases between v
 // and other, correctly walking through major version bumps.
-// Returns -1 if the walk cannot reach other (missing bump data).
+// Returns -1 if the walk cannot reach other (missing bump data) or if
+// other is a phantom version past a bump point.
 func (v XYVersion) Distance(other XYVersion) int {
 	lo, hi := v, other
 	if other.Compare(v) < 0 {
@@ -128,7 +129,7 @@ func (v XYVersion) Distance(other XYVersion) int {
 			return -1
 		}
 		if next.X == cur.X && next.X < hi.X {
-			if !hasBumpAhead(cur.X, next.Y) {
+			if _, ok := findBumpFrom(cur.X); !ok {
 				return -1
 			}
 		}
@@ -137,13 +138,43 @@ func (v XYVersion) Distance(other XYVersion) int {
 	return dist
 }
 
-func hasBumpAhead(major, minY int) bool {
+// NaiveDistance returns the distance between v and other using bumps only
+// to cross major boundaries and linear Y arithmetic within the target
+// major. This handles phantom versions (past a bump point that was
+// delayed or cancelled) by ignoring bumps within the target major.
+// Returns -1 if the target major cannot be reached.
+func (v XYVersion) NaiveDistance(other XYVersion) int {
+	lo, hi := v, other
+	if other.Compare(v) < 0 {
+		lo, hi = other, v
+	}
+
+	dist := 0
+	cur := lo
+
+	for cur.X < hi.X {
+		bump, ok := findBumpFrom(cur.X)
+		if !ok || bump.From.Y < cur.Y {
+			return -1
+		}
+		dist += bump.From.Y - cur.Y + 1
+		cur = bump.To
+	}
+
+	d := hi.Y - cur.Y
+	if d < 0 {
+		d = -d
+	}
+	return dist + d
+}
+
+func findBumpFrom(major int) (parsedBump, bool) {
 	for _, b := range parsedBumps {
-		if b.From.X == major && b.From.Y >= minY {
-			return true
+		if b.From.X == major {
+			return b, true
 		}
 	}
-	return false
+	return parsedBump{}, false
 }
 
 // GetNextYStream returns the next Y-stream version for a given major.minor.

--- a/pkg/version/productstreams/product_streams.go
+++ b/pkg/version/productstreams/product_streams.go
@@ -111,33 +111,6 @@ func parseBumpsData(data []byte) ([]parsedBump, error) {
 	return result, nil
 }
 
-// Distance returns the absolute distance in Y-stream releases between v
-// and other, correctly walking through major version bumps.
-// Returns -1 if the walk cannot reach other (missing bump data) or if
-// other is a phantom version past a bump point.
-func (v XYVersion) Distance(other XYVersion) int {
-	lo, hi := v, other
-	if other.Compare(v) < 0 {
-		lo, hi = other, v
-	}
-	dist := 0
-	cur := lo
-	for cur != hi {
-		next := GetNextYStream(cur)
-		dist++
-		if next.Compare(hi) > 0 {
-			return -1
-		}
-		if next.X == cur.X && next.X < hi.X {
-			if _, ok := findBumpFrom(cur.X); !ok {
-				return -1
-			}
-		}
-		cur = next
-	}
-	return dist
-}
-
 // NaiveDistance returns the distance between v and other using bumps only
 // to cross major boundaries and linear Y arithmetic within the target
 // major. This handles phantom versions (past a bump point that was

--- a/pkg/version/productstreams/product_streams.go
+++ b/pkg/version/productstreams/product_streams.go
@@ -111,6 +111,86 @@ func parseBumpsData(data []byte) ([]parsedBump, error) {
 	return result, nil
 }
 
+// Distance returns the absolute distance in Y-stream releases between v
+// and other, correctly walking through major version bumps.
+// Returns -1 if the walk cannot reach other (missing bump data).
+func (v XYVersion) Distance(other XYVersion) int {
+	lo, hi := v, other
+	if other.Compare(v) < 0 {
+		lo, hi = other, v
+	}
+	dist := 0
+	cur := lo
+	for cur != hi {
+		next := GetNextYStream(cur)
+		dist++
+		if next.Compare(hi) > 0 {
+			return -1
+		}
+		if next.X == cur.X && next.X < hi.X {
+			if !hasBumpAhead(cur.X, next.Y) {
+				return -1
+			}
+		}
+		cur = next
+	}
+	return dist
+}
+
+func hasBumpAhead(major, minY int) bool {
+	for _, b := range parsedBumps {
+		if b.From.X == major && b.From.Y >= minY {
+			return true
+		}
+	}
+	return false
+}
+
+// GetNextYStream returns the next Y-stream version for a given major.minor.
+// If v matches a bump's From field, the next version is the bump's To
+// (e.g., {4,11} -> {5,0}). Otherwise, it is simply {v.X, v.Y+1}.
+func GetNextYStream(v XYVersion) XYVersion {
+	for _, b := range parsedBumps {
+		if b.From == v {
+			return b.To
+		}
+	}
+	return XYVersion{X: v.X, Y: v.Y + 1}
+}
+
+// ParseXYFromVersionString extracts the major.minor (X.Y) components from
+// a full version string. It accepts formats such as "4.11", "4.11.2",
+// "4.11.0-rc.1", "4.11.x-123-gabcdef1234", and the legacy 4-component
+// format "3.0.61.1" (where parts[1] is the marketing minor, skipped).
+func ParseXYFromVersionString(version string) (XYVersion, error) {
+	before, _, _ := strings.Cut(version, "-")
+	parts := strings.Split(before, ".")
+	switch {
+	case len(parts) == 4:
+		major, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return XYVersion{}, fmt.Errorf("invalid major %q in version %q: %w", parts[0], version, err)
+		}
+		minor, err := strconv.Atoi(parts[2])
+		if err != nil {
+			return XYVersion{}, fmt.Errorf("invalid minor %q in version %q: %w", parts[2], version, err)
+		}
+		return XYVersion{X: major, Y: minor}, nil
+	case len(parts) >= 2:
+		major, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return XYVersion{}, fmt.Errorf("invalid major %q in version %q: %w", parts[0], version, err)
+		}
+		minor, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return XYVersion{}, fmt.Errorf("invalid minor %q in version %q: %w", parts[1], version, err)
+		}
+		return XYVersion{X: major, Y: minor}, nil
+	default:
+		return XYVersion{}, fmt.Errorf("expected at least major.minor format, got %q", version)
+	}
+}
+
 // GetPreviousYStream returns the previous Y-stream version for a given major.minor.
 // If minor > 0, the previous Y-stream is simply major.(minor-1).
 // If minor == 0, it looks up the major version bump history from major_version_bumps.yaml.

--- a/pkg/version/productstreams/product_streams.go
+++ b/pkg/version/productstreams/product_streams.go
@@ -177,6 +177,16 @@ func findBumpFrom(major int) (parsedBump, bool) {
 	return parsedBump{}, false
 }
 
+// OverrideBumpsForTesting replaces the parsed bump data with the given YAML
+// for the duration of the test, restoring the original data on cleanup.
+func OverrideBumpsForTesting(t interface {
+	Cleanup(func())
+}, data []byte) {
+	old := parsedBumps
+	parsedBumps = mustParseBumpsData(data)
+	t.Cleanup(func() { parsedBumps = old })
+}
+
 // GetNextYStream returns the next Y-stream version for a given major.minor.
 // If v matches a bump's From field, the next version is the bump's To
 // (e.g., {4,11} -> {5,0}). Otherwise, it is simply {v.X, v.Y+1}.

--- a/pkg/version/productstreams/product_streams_test.go
+++ b/pkg/version/productstreams/product_streams_test.go
@@ -151,6 +151,146 @@ func formatBumps(bumps []parsedBump) string {
 	return strings.Join(parts, ";")
 }
 
+func TestGetNextYStream(t *testing.T) {
+	tests := map[string]struct {
+		input XYVersion
+		want  XYVersion
+	}{
+		"normal increment": {
+			input: XYVersion{X: 4, Y: 5},
+			want:  XYVersion{X: 4, Y: 6},
+		},
+		"bump crossing 3.74 -> 4.0": {
+			input: XYVersion{X: 3, Y: 74},
+			want:  XYVersion{X: 4, Y: 0},
+		},
+		"bump crossing 4.11 -> 5.0": {
+			input: XYVersion{X: 4, Y: 11},
+			want:  XYVersion{X: 5, Y: 0},
+		},
+		"no bump at boundary": {
+			input: XYVersion{X: 5, Y: 3},
+			want:  XYVersion{X: 5, Y: 4},
+		},
+		"version before bump point": {
+			input: XYVersion{X: 4, Y: 10},
+			want:  XYVersion{X: 4, Y: 11},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GetNextYStream(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseXYFromVersionString(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		want    XYVersion
+		wantErr string
+	}{
+		"simple X.Y": {
+			input: "4.11",
+			want:  XYVersion{X: 4, Y: 11},
+		},
+		"X.Y.Z release": {
+			input: "4.11.2",
+			want:  XYVersion{X: 4, Y: 11},
+		},
+		"rc version": {
+			input: "5.0.0-rc.1",
+			want:  XYVersion{X: 5, Y: 0},
+		},
+		"nightly version": {
+			input: "4.11.x-nightly-20210405",
+			want:  XYVersion{X: 4, Y: 11},
+		},
+		"dev version with git hash": {
+			input: "4.11.x-123-gabcdef1234",
+			want:  XYVersion{X: 4, Y: 11},
+		},
+		"legacy 4-component format": {
+			input: "3.0.61.1",
+			want:  XYVersion{X: 3, Y: 61},
+		},
+		"legacy 4-component with x patch": {
+			input: "3.0.49.x-1-ga0897a21ee",
+			want:  XYVersion{X: 3, Y: 49},
+		},
+		"single component": {
+			input:   "4",
+			wantErr: "expected at least major.minor format",
+		},
+		"empty string": {
+			input:   "",
+			wantErr: "expected at least major.minor format",
+		},
+		"non-numeric major": {
+			input:   "abc.11",
+			wantErr: "invalid major",
+		},
+		"non-numeric minor": {
+			input:   "4.abc",
+			wantErr: "invalid minor",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseXYFromVersionString(tt.input)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDistance(t *testing.T) {
+	tests := map[string]struct {
+		a    XYVersion
+		b    XYVersion
+		want int
+	}{
+		"same version": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 5}, want: 0,
+		},
+		"within same major": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 8}, want: 3,
+		},
+		"reversed order": {
+			a: XYVersion{X: 4, Y: 8}, b: XYVersion{X: 4, Y: 5}, want: 3,
+		},
+		"across one bump": {
+			a: XYVersion{X: 4, Y: 11}, b: XYVersion{X: 5, Y: 0}, want: 1,
+		},
+		"across bump with distance": {
+			a: XYVersion{X: 4, Y: 10}, b: XYVersion{X: 5, Y: 1}, want: 3,
+		},
+		"across two bumps": {
+			a: XYVersion{X: 3, Y: 73}, b: XYVersion{X: 5, Y: 1}, want: 15,
+		},
+		"adjacent": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 6}, want: 1,
+		},
+		"missing bump data": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 6, Y: 0}, want: -1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.a.Distance(tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetPreviousYStream(t *testing.T) {
 	tests := map[string]struct {
 		input   XYVersion

--- a/pkg/version/productstreams/product_streams_test.go
+++ b/pkg/version/productstreams/product_streams_test.go
@@ -291,6 +291,49 @@ func TestDistance(t *testing.T) {
 	}
 }
 
+func TestNaiveDistance(t *testing.T) {
+	tests := map[string]struct {
+		a    XYVersion
+		b    XYVersion
+		want int
+	}{
+		"same version": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 5}, want: 0,
+		},
+		"same major": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 8}, want: 3,
+		},
+		"same major reversed": {
+			a: XYVersion{X: 4, Y: 8}, b: XYVersion{X: 4, Y: 5}, want: 3,
+		},
+		"cross major via bump": {
+			a: XYVersion{X: 4, Y: 10}, b: XYVersion{X: 5, Y: 1}, want: 3,
+		},
+		"phantom version past bump in target major": {
+			a: XYVersion{X: 4, Y: 11}, b: XYVersion{X: 5, Y: 2}, want: 3,
+		},
+		"phantom version far past bump": {
+			a: XYVersion{X: 4, Y: 10}, b: XYVersion{X: 5, Y: 40}, want: 42,
+		},
+		"same major ignores bump": {
+			a: XYVersion{X: 4, Y: 10}, b: XYVersion{X: 4, Y: 40}, want: 30,
+		},
+		"missing bump data": {
+			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 6, Y: 0}, want: -1,
+		},
+		"phantom past bump point cross major": {
+			a: XYVersion{X: 4, Y: 12}, b: XYVersion{X: 5, Y: 0}, want: -1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tt.a.NaiveDistance(tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetPreviousYStream(t *testing.T) {
 	tests := map[string]struct {
 		input   XYVersion

--- a/pkg/version/productstreams/product_streams_test.go
+++ b/pkg/version/productstreams/product_streams_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testBumpsYAML = `bumps:
+  - from: "3.74"
+    to: "4.0"
+  - from: "4.11"
+    to: "5.0"
+`
+
+func overrideTestBumps(t *testing.T) {
+	OverrideBumpsForTesting(t, []byte(testBumpsYAML))
+}
+
 func TestMustParseBumpsDataPanicsOnInvalidInput(t *testing.T) {
 	assert.Panics(t, func() {
 		mustParseBumpsData([]byte(`[not valid yaml`))
@@ -152,6 +163,8 @@ func formatBumps(bumps []parsedBump) string {
 }
 
 func TestGetNextYStream(t *testing.T) {
+	overrideTestBumps(t)
+
 	tests := map[string]struct {
 		input XYVersion
 		want  XYVersion
@@ -252,6 +265,8 @@ func TestParseXYFromVersionString(t *testing.T) {
 }
 
 func TestDistance(t *testing.T) {
+	overrideTestBumps(t)
+
 	tests := map[string]struct {
 		a    XYVersion
 		b    XYVersion
@@ -292,6 +307,8 @@ func TestDistance(t *testing.T) {
 }
 
 func TestNaiveDistance(t *testing.T) {
+	overrideTestBumps(t)
+
 	tests := map[string]struct {
 		a    XYVersion
 		b    XYVersion
@@ -335,6 +352,8 @@ func TestNaiveDistance(t *testing.T) {
 }
 
 func TestGetPreviousYStream(t *testing.T) {
+	overrideTestBumps(t)
+
 	tests := map[string]struct {
 		input   XYVersion
 		want    XYVersion

--- a/pkg/version/productstreams/product_streams_test.go
+++ b/pkg/version/productstreams/product_streams_test.go
@@ -264,48 +264,6 @@ func TestParseXYFromVersionString(t *testing.T) {
 	}
 }
 
-func TestDistance(t *testing.T) {
-	overrideTestBumps(t)
-
-	tests := map[string]struct {
-		a    XYVersion
-		b    XYVersion
-		want int
-	}{
-		"same version": {
-			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 5}, want: 0,
-		},
-		"within same major": {
-			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 8}, want: 3,
-		},
-		"reversed order": {
-			a: XYVersion{X: 4, Y: 8}, b: XYVersion{X: 4, Y: 5}, want: 3,
-		},
-		"across one bump": {
-			a: XYVersion{X: 4, Y: 11}, b: XYVersion{X: 5, Y: 0}, want: 1,
-		},
-		"across bump with distance": {
-			a: XYVersion{X: 4, Y: 10}, b: XYVersion{X: 5, Y: 1}, want: 3,
-		},
-		"across two bumps": {
-			a: XYVersion{X: 3, Y: 73}, b: XYVersion{X: 5, Y: 1}, want: 15,
-		},
-		"adjacent": {
-			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 4, Y: 6}, want: 1,
-		},
-		"missing bump data": {
-			a: XYVersion{X: 4, Y: 5}, b: XYVersion{X: 6, Y: 0}, want: -1,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := tt.a.Distance(tt.b)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestNaiveDistance(t *testing.T) {
 	overrideTestBumps(t)
 

--- a/pkg/version/versioncompatibility/compatibility.go
+++ b/pkg/version/versioncompatibility/compatibility.go
@@ -1,0 +1,114 @@
+package versioncompatibility
+
+import (
+	"slices"
+
+	"github.com/stackrox/rox/pkg/version/productstreams"
+)
+
+// DefaultSkew is the number of minor version steps for the supported
+// version compatibility range (N +/- DefaultSkew).
+const DefaultSkew = 3
+
+// Compatibility represents the version compatibility classification between
+// two components (e.g., Central and Sensor, or roxctl and Central).
+// Values map 1:1 to storage.SensorVersionCompatibility proto enum values.
+type Compatibility int
+
+const (
+	Unknown            Compatibility = iota
+	Matched                          // Same X.Y version.
+	CompatibleBehind                 // Remote is older but within range.
+	CompatibleAhead                  // Remote is newer but within range.
+	IncompatibleBehind               // Remote is too old.
+	IncompatibleAhead                // Remote is too new.
+)
+
+func (c Compatibility) String() string {
+	switch c {
+	case Unknown:
+		return "UNKNOWN"
+	case Matched:
+		return "MATCHED"
+	case CompatibleBehind:
+		return "COMPATIBLE_BEHIND"
+	case CompatibleAhead:
+		return "COMPATIBLE_AHEAD"
+	case IncompatibleBehind:
+		return "INCOMPATIBLE_BEHIND"
+	case IncompatibleAhead:
+		return "INCOMPATIBLE_AHEAD"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// CompatibleVersions returns the compatible version range for self using
+// the default skew tolerance (DefaultSkew).
+func CompatibleVersions(self productstreams.XYVersion) []productstreams.XYVersion {
+	return CompatibleVersionRange(self, DefaultSkew)
+}
+
+// ClassifyVersion classifies remote relative to self using the default
+// skew tolerance (DefaultSkew).
+func ClassifyVersion(self, remote productstreams.XYVersion) Compatibility {
+	return Classify(self, remote, DefaultSkew)
+}
+
+// CompatibleVersionRange computes the range of X.Y versions compatible with
+// self, spanning n minor versions in each direction. It correctly crosses
+// major version boundaries using the bump history embedded in the
+// majorversions package.
+//
+// Returns the ordered list of compatible versions from oldest to newest,
+// including self. The list contains 2*n+1 elements when all steps succeed,
+// or fewer if the backward walk cannot go far enough.
+func CompatibleVersionRange(self productstreams.XYVersion, n int) []productstreams.XYVersion {
+	backward := make([]productstreams.XYVersion, 0, n)
+	cur := self
+	for range n {
+		prev, err := productstreams.GetPreviousYStream(cur)
+		if err != nil {
+			break
+		}
+		backward = append(backward, prev)
+		cur = prev
+	}
+	slices.Reverse(backward)
+
+	forward := make([]productstreams.XYVersion, 0, n)
+	cur = self
+	for range n {
+		next := productstreams.GetNextYStream(cur)
+		forward = append(forward, next)
+		cur = next
+	}
+
+	result := make([]productstreams.XYVersion, 0, len(backward)+1+len(forward))
+	result = append(result, backward...)
+	result = append(result, self)
+	result = append(result, forward...)
+	return result
+}
+
+// Classify determines the compatibility of remote relative to self with
+// a custom skew tolerance n.
+func Classify(self, remote productstreams.XYVersion, n int) Compatibility {
+	cmp := self.Compare(remote)
+	if cmp == 0 {
+		return Matched
+	}
+
+	dist := self.Distance(remote)
+
+	if cmp > 0 {
+		if dist >= 0 && dist <= n {
+			return CompatibleBehind
+		}
+		return IncompatibleBehind
+	}
+	if dist >= 0 && dist <= n {
+		return CompatibleAhead
+	}
+	return IncompatibleAhead
+}

--- a/pkg/version/versioncompatibility/compatibility.go
+++ b/pkg/version/versioncompatibility/compatibility.go
@@ -99,16 +99,18 @@ func Classify(self, remote productstreams.XYVersion, n int) Compatibility {
 		return Matched
 	}
 
-	dist := self.Distance(remote)
+	versions := CompatibleVersionRange(self, n)
+	oldest := versions[0]
+	newest := versions[len(versions)-1]
 
-	if cmp > 0 {
-		if dist >= 0 && dist <= n {
-			return CompatibleBehind
-		}
+	if remote.Compare(oldest) < 0 {
 		return IncompatibleBehind
 	}
-	if dist >= 0 && dist <= n {
-		return CompatibleAhead
+	if remote.Compare(newest) > 0 {
+		return IncompatibleAhead
 	}
-	return IncompatibleAhead
+	if cmp > 0 {
+		return CompatibleBehind
+	}
+	return CompatibleAhead
 }

--- a/pkg/version/versioncompatibility/compatibility.go
+++ b/pkg/version/versioncompatibility/compatibility.go
@@ -100,17 +100,26 @@ func Classify(self, remote productstreams.XYVersion, n int) Compatibility {
 	}
 
 	versions := CompatibleVersionRange(self, n)
-	oldest := versions[0]
-	newest := versions[len(versions)-1]
+	if slices.Contains(versions, remote) {
+		if cmp > 0 {
+			return CompatibleBehind
+		}
+		return CompatibleAhead
+	}
 
-	if remote.Compare(oldest) < 0 {
+	// Remote is not in the known compatible set. Fall back to naive
+	// distance (uses bumps only to cross majors, linear Y within)
+	// to handle phantom versions past a bump point that was delayed
+	// or cancelled.
+	if dist := self.NaiveDistance(remote); dist >= 0 && dist <= n {
+		if cmp > 0 {
+			return CompatibleBehind
+		}
+		return CompatibleAhead
+	}
+
+	if cmp > 0 {
 		return IncompatibleBehind
 	}
-	if remote.Compare(newest) > 0 {
-		return IncompatibleAhead
-	}
-	if cmp > 0 {
-		return CompatibleBehind
-	}
-	return CompatibleAhead
+	return IncompatibleAhead
 }

--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -7,11 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testBumpsYAML = `bumps:
+  - from: "3.74"
+    to: "4.0"
+  - from: "4.11"
+    to: "5.0"
+`
+
+func overrideTestBumps(t *testing.T) {
+	productstreams.OverrideBumpsForTesting(t, []byte(testBumpsYAML))
+}
 func xy(x, y int) productstreams.XYVersion {
 	return productstreams.XYVersion{X: x, Y: y}
 }
 
 func TestCompatibleVersionRange(t *testing.T) {
+	overrideTestBumps(t)
 	tests := map[string]struct {
 		self productstreams.XYVersion
 		n    int
@@ -114,6 +125,7 @@ func TestCompatibleVersionRange(t *testing.T) {
 }
 
 func TestCompatibleVersions(t *testing.T) {
+	overrideTestBumps(t)
 	got := CompatibleVersions(xy(4, 11))
 	want := []productstreams.XYVersion{
 		xy(4, 8), xy(4, 9), xy(4, 10),
@@ -124,6 +136,7 @@ func TestCompatibleVersions(t *testing.T) {
 }
 
 func TestClassify(t *testing.T) {
+	overrideTestBumps(t)
 	tests := map[string]struct {
 		self   productstreams.XYVersion
 		remote productstreams.XYVersion
@@ -217,6 +230,7 @@ func TestClassify(t *testing.T) {
 }
 
 func TestClassifyVersion(t *testing.T) {
+	overrideTestBumps(t)
 	assert.Equal(t, Matched, ClassifyVersion(xy(4, 11), xy(4, 11)))
 	assert.Equal(t, CompatibleBehind, ClassifyVersion(xy(4, 11), xy(4, 9)))
 	assert.Equal(t, CompatibleAhead, ClassifyVersion(xy(4, 11), xy(5, 2)))

--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -188,11 +188,15 @@ func TestClassify(t *testing.T) {
 		},
 		"phantom version far past bump point same major": {
 			self: xy(4, 10), remote: xy(4, 40), n: 3,
-			want: CompatibleAhead,
+			want: IncompatibleAhead,
 		},
 		"phantom version cross major self ahead": {
 			self: xy(5, 0), remote: xy(4, 40), n: 3,
-			want: CompatibleBehind,
+			want: IncompatibleBehind,
+		},
+		"phantom version in target major within skew": {
+			self: xy(4, 11), remote: xy(5, 2), n: 3,
+			want: CompatibleAhead,
 		},
 		"custom n=1 compatible": {
 			self: xy(4, 5), remote: xy(4, 6), n: 1,

--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -1,0 +1,230 @@
+package versioncompatibility
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/version/productstreams"
+	"github.com/stretchr/testify/assert"
+)
+
+func xy(x, y int) productstreams.XYVersion {
+	return productstreams.XYVersion{X: x, Y: y}
+}
+
+func TestCompatibleVersionRange(t *testing.T) {
+	tests := map[string]struct {
+		self productstreams.XYVersion
+		n    int
+		want []productstreams.XYVersion
+	}{
+		"mid-range no boundary": {
+			self: xy(4, 5),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(4, 2), xy(4, 3), xy(4, 4),
+				xy(4, 5),
+				xy(4, 6), xy(4, 7), xy(4, 8),
+			},
+		},
+		"crossing backward into major 3": {
+			self: xy(4, 1),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(3, 73), xy(3, 74), xy(4, 0),
+				xy(4, 1),
+				xy(4, 2), xy(4, 3), xy(4, 4),
+			},
+		},
+		"at major boundary 4.0": {
+			self: xy(4, 0),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(3, 72), xy(3, 73), xy(3, 74),
+				xy(4, 0),
+				xy(4, 1), xy(4, 2), xy(4, 3),
+			},
+		},
+		"crossing forward into major 5": {
+			self: xy(4, 10),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(4, 7), xy(4, 8), xy(4, 9),
+				xy(4, 10),
+				xy(4, 11), xy(5, 0), xy(5, 1),
+			},
+		},
+		"at bump point 4.11": {
+			self: xy(4, 11),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(4, 8), xy(4, 9), xy(4, 10),
+				xy(4, 11),
+				xy(5, 0), xy(5, 1), xy(5, 2),
+			},
+		},
+		"at major boundary 5.0": {
+			self: xy(5, 0),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(4, 9), xy(4, 10), xy(4, 11),
+				xy(5, 0),
+				xy(5, 1), xy(5, 2), xy(5, 3),
+			},
+		},
+		"5.1 spans both sides of boundary": {
+			self: xy(5, 1),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(4, 10), xy(4, 11), xy(5, 0),
+				xy(5, 1),
+				xy(5, 2), xy(5, 3), xy(5, 4),
+			},
+		},
+		"truncated backward near earliest known": {
+			self: xy(3, 73),
+			n:    3,
+			want: []productstreams.XYVersion{
+				xy(3, 70), xy(3, 71), xy(3, 72),
+				xy(3, 73),
+				xy(3, 74), xy(4, 0), xy(4, 1),
+			},
+		},
+		"n=0 returns only self": {
+			self: xy(4, 5),
+			n:    0,
+			want: []productstreams.XYVersion{xy(4, 5)},
+		},
+		"n=1": {
+			self: xy(5, 0),
+			n:    1,
+			want: []productstreams.XYVersion{
+				xy(4, 11),
+				xy(5, 0),
+				xy(5, 1),
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := CompatibleVersionRange(tt.self, tt.n)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCompatibleVersions(t *testing.T) {
+	got := CompatibleVersions(xy(4, 11))
+	want := []productstreams.XYVersion{
+		xy(4, 8), xy(4, 9), xy(4, 10),
+		xy(4, 11),
+		xy(5, 0), xy(5, 1), xy(5, 2),
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestClassify(t *testing.T) {
+	tests := map[string]struct {
+		self   productstreams.XYVersion
+		remote productstreams.XYVersion
+		n      int
+		want   Compatibility
+	}{
+		"matched": {
+			self: xy(4, 11), remote: xy(4, 11), n: 3,
+			want: Matched,
+		},
+		"compatible behind by 1": {
+			self: xy(4, 11), remote: xy(4, 10), n: 3,
+			want: CompatibleBehind,
+		},
+		"compatible behind by 3": {
+			self: xy(4, 11), remote: xy(4, 8), n: 3,
+			want: CompatibleBehind,
+		},
+		"compatible behind across boundary": {
+			self: xy(5, 1), remote: xy(4, 10), n: 3,
+			want: CompatibleBehind,
+		},
+		"incompatible behind by 4": {
+			self: xy(4, 11), remote: xy(4, 7), n: 3,
+			want: IncompatibleBehind,
+		},
+		"incompatible behind far": {
+			self: xy(5, 1), remote: xy(3, 74), n: 3,
+			want: IncompatibleBehind,
+		},
+		"compatible ahead by 1": {
+			self: xy(4, 11), remote: xy(5, 0), n: 3,
+			want: CompatibleAhead,
+		},
+		"compatible ahead by 3": {
+			self: xy(4, 11), remote: xy(5, 2), n: 3,
+			want: CompatibleAhead,
+		},
+		"compatible ahead across boundary": {
+			self: xy(4, 9), remote: xy(5, 0), n: 3,
+			want: CompatibleAhead,
+		},
+		"incompatible ahead by 4": {
+			self: xy(4, 11), remote: xy(5, 3), n: 3,
+			want: IncompatibleAhead,
+		},
+		"incompatible ahead far": {
+			self: xy(4, 5), remote: xy(5, 3), n: 3,
+			want: IncompatibleAhead,
+		},
+		"incompatible ahead beyond known bumps": {
+			self: xy(4, 8), remote: xy(6, 0), n: 3,
+			want: IncompatibleAhead,
+		},
+		"incompatible behind beyond known bumps": {
+			self: xy(6, 0), remote: xy(4, 8), n: 3,
+			want: IncompatibleBehind,
+		},
+		"custom n=1 compatible": {
+			self: xy(4, 5), remote: xy(4, 6), n: 1,
+			want: CompatibleAhead,
+		},
+		"custom n=1 incompatible": {
+			self: xy(4, 5), remote: xy(4, 7), n: 1,
+			want: IncompatibleAhead,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Classify(tt.self, tt.remote, tt.n)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClassifyVersion(t *testing.T) {
+	assert.Equal(t, Matched, ClassifyVersion(xy(4, 11), xy(4, 11)))
+	assert.Equal(t, CompatibleBehind, ClassifyVersion(xy(4, 11), xy(4, 9)))
+	assert.Equal(t, CompatibleAhead, ClassifyVersion(xy(4, 11), xy(5, 2)))
+	assert.Equal(t, IncompatibleBehind, ClassifyVersion(xy(4, 11), xy(4, 7)))
+	assert.Equal(t, IncompatibleAhead, ClassifyVersion(xy(4, 11), xy(5, 3)))
+}
+
+func TestCompatibilityString(t *testing.T) {
+	tests := map[string]struct {
+		c    Compatibility
+		want string
+	}{
+		"unknown":             {Unknown, "UNKNOWN"},
+		"matched":             {Matched, "MATCHED"},
+		"compatible behind":   {CompatibleBehind, "COMPATIBLE_BEHIND"},
+		"compatible ahead":    {CompatibleAhead, "COMPATIBLE_AHEAD"},
+		"incompatible behind": {IncompatibleBehind, "INCOMPATIBLE_BEHIND"},
+		"incompatible ahead":  {IncompatibleAhead, "INCOMPATIBLE_AHEAD"},
+		"invalid value":       {Compatibility(99), "UNKNOWN"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.c.String())
+		})
+	}
+}

--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -182,6 +182,18 @@ func TestClassify(t *testing.T) {
 			self: xy(6, 0), remote: xy(4, 8), n: 3,
 			want: IncompatibleBehind,
 		},
+		"phantom version 1 past bump point": {
+			self: xy(4, 10), remote: xy(4, 12), n: 3,
+			want: CompatibleAhead,
+		},
+		"phantom version far past bump point same major": {
+			self: xy(4, 10), remote: xy(4, 40), n: 3,
+			want: CompatibleAhead,
+		},
+		"phantom version cross major self ahead": {
+			self: xy(5, 0), remote: xy(4, 40), n: 3,
+			want: CompatibleBehind,
+		},
 		"custom n=1 compatible": {
 			self: xy(4, 5), remote: xy(4, 6), n: 1,
 			want: CompatibleAhead,

--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -229,6 +229,141 @@ func TestClassify(t *testing.T) {
 	}
 }
 
+func TestClassifyCancelledBump(t *testing.T) {
+	// Bump 5.6→6.0 is scheduled but gets cancelled. Versions 5.7, 5.8, etc.
+	// are released instead.
+	majorversions.OverrideBumpsForTesting(t, []byte(`bumps:
+  - from: "4.11"
+    to: "5.0"
+  - from: "5.6"
+    to: "6.0"
+`))
+
+	tests := map[string]struct {
+		self   majorversions.XYVersion
+		remote majorversions.XYVersion
+		n      int
+		want   Compatibility
+	}{
+		"cancelled bump remote within skew": {
+			self: xy(5, 5), remote: xy(5, 8), n: 3,
+			want: CompatibleAhead,
+		},
+		"cancelled bump remote at skew boundary": {
+			self: xy(5, 5), remote: xy(5, 7), n: 3,
+			want: CompatibleAhead,
+		},
+		"cancelled bump remote beyond skew": {
+			self: xy(5, 5), remote: xy(5, 9), n: 3,
+			want: IncompatibleAhead,
+		},
+		"cancelled bump remote behind within skew": {
+			self: xy(5, 8), remote: xy(5, 5), n: 3,
+			want: CompatibleBehind,
+		},
+		"cancelled bump remote behind beyond skew": {
+			self: xy(5, 9), remote: xy(5, 5), n: 3,
+			want: IncompatibleBehind,
+		},
+		"cancelled bump range still includes bump versions": {
+			self: xy(5, 5), remote: xy(6, 0), n: 3,
+			want: CompatibleAhead,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Classify(tt.self, tt.remote, tt.n)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClassifyThreeConsecutiveBumps(t *testing.T) {
+	majorversions.OverrideBumpsForTesting(t, []byte(`bumps:
+  - from: "1.3"
+    to: "2.0"
+  - from: "2.5"
+    to: "3.0"
+  - from: "3.2"
+    to: "4.0"
+`))
+
+	tests := map[string]struct {
+		self   majorversions.XYVersion
+		remote majorversions.XYVersion
+		n      int
+		want   Compatibility
+	}{
+		"chain across two bumps compatible": {
+			self: xy(2, 4), remote: xy(3, 1), n: 3,
+			want: CompatibleAhead,
+		},
+		"chain across two bumps incompatible": {
+			self: xy(2, 3), remote: xy(3, 1), n: 3,
+			want: IncompatibleAhead,
+		},
+		"chain across three bumps always incompatible": {
+			self: xy(1, 3), remote: xy(4, 0), n: 3,
+			want: IncompatibleAhead,
+		},
+		"at bump boundary matched": {
+			self: xy(2, 5), remote: xy(2, 5), n: 3,
+			want: Matched,
+		},
+		"short range near bump": {
+			self: xy(3, 2), remote: xy(4, 0), n: 1,
+			want: CompatibleAhead,
+		},
+		"short range near bump incompatible": {
+			self: xy(3, 2), remote: xy(4, 1), n: 1,
+			want: IncompatibleAhead,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Classify(tt.self, tt.remote, tt.n)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClassifyNoBumps(t *testing.T) {
+	majorversions.OverrideBumpsForTesting(t, []byte(`bumps: []`))
+
+	tests := map[string]struct {
+		self   majorversions.XYVersion
+		remote majorversions.XYVersion
+		n      int
+		want   Compatibility
+	}{
+		"same major compatible": {
+			self: xy(4, 5), remote: xy(4, 8), n: 3,
+			want: CompatibleAhead,
+		},
+		"same major incompatible": {
+			self: xy(4, 5), remote: xy(4, 9), n: 3,
+			want: IncompatibleAhead,
+		},
+		"different major always incompatible": {
+			self: xy(4, 5), remote: xy(5, 0), n: 3,
+			want: IncompatibleAhead,
+		},
+		"matched": {
+			self: xy(4, 5), remote: xy(4, 5), n: 3,
+			want: Matched,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := Classify(tt.self, tt.remote, tt.n)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestClassifyVersion(t *testing.T) {
 	overrideTestBumps(t)
 	assert.Equal(t, Matched, ClassifyVersion(xy(4, 11), xy(4, 11)))


### PR DESCRIPTION
## Description

Add `pkg/version/versioncompatibility` package with helper functions for version skew detection between Central/Sensor and roxctl/Central (ROX-34097).

**majorversions additions:**
- `GetNextYStream` — forward counterpart to `GetPreviousYStream`, crosses major boundaries via bump data
- `ParseXYFromVersionString` — extracts X.Y from full version strings (including legacy `3.0.Y.Z` format)
- `NaiveDistance` — distance using bumps only to cross majors, linear Y within target major (handles phantom versions)
- `OverrideBumpsForTesting` — test helper to swap bump data without coupling tests to the embedded YAML

**New versioncompatibility package:**
- `Compatibility` type mapping 1:1 to `storage.SensorVersionCompatibility` proto enum
- `CompatibleVersionRange` / `CompatibleVersions` — compute the N±3 compatible version range
- `Classify` / `ClassifyVersion` — classify a remote version as Matched, CompatibleBehind/Ahead, or IncompatibleBehind/Ahead
- Phantom version handling via `NaiveDistance` fallback for versions past a delayed/cancelled bump point

Depends on #21589.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests cover: normal ranges, major boundary crossings, phantom versions (CI delays, cancelled bumps), chained bumps, no bumps, custom skew values, and beyond-known-bumps scenarios. All tests use `OverrideBumpsForTesting` to decouple from the embedded YAML.

```
go test ./pkg/version/majorversions/... ./pkg/version/versioncompatibility/... -race -count=1 -v
```