### PR TITLE
ROX-34928: Add Exploit proto message for CISA KEV support

### DIFF
--- a/central/cve/cluster/datastore/store/postgres/store.go
+++ b/central/cve/cluster/datastore/store/postgres/store.go
@@ -105,6 +105,7 @@ func insertIntoClusterCves(batch *pgx.Batch, obj *storage.ClusterCVE) error {
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 		obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+		obj.GetCveBaseInfo().GetCisaKev(),
 		obj.GetCvss(),
 		obj.GetSeverity(),
 		obj.GetImpactScore(),
@@ -114,7 +115,7 @@ func insertIntoClusterCves(batch *pgx.Batch, obj *storage.ClusterCVE) error {
 		serialized,
 	}
 
-	finalStr := "INSERT INTO cluster_cves (Id, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, Cvss, Severity, ImpactScore, Snoozed, SnoozeExpiry, Type, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Snoozed = EXCLUDED.Snoozed, SnoozeExpiry = EXCLUDED.SnoozeExpiry, Type = EXCLUDED.Type, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO cluster_cves (Id, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev, Cvss, Severity, ImpactScore, Snoozed, SnoozeExpiry, Type, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev = EXCLUDED.CveBaseInfo_CisaKev, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Snoozed = EXCLUDED.Snoozed, SnoozeExpiry = EXCLUDED.SnoozeExpiry, Type = EXCLUDED.Type, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	return nil
@@ -126,6 +127,7 @@ var copyColsClusterCves = []string{
 	"cvebaseinfo_publishedon",
 	"cvebaseinfo_createdat",
 	"cvebaseinfo_epss_epssprobability",
+	"cvebaseinfo_cisakev",
 	"cvss",
 	"severity",
 	"impactscore",
@@ -171,6 +173,7 @@ func copyFromClusterCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetCveBaseInfo().GetCisaKev(),
 			obj.GetCvss(),
 			obj.GetSeverity(),
 			obj.GetImpactScore(),

--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -107,6 +107,7 @@ func insertIntoImageCvesV2(batch *pgx.Batch, obj *storage.ImageCVEV2) error {
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 		obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+		obj.GetCveBaseInfo().GetCisaKev(),
 		obj.GetCvss(),
 		obj.GetSeverity(),
 		obj.GetImpactScore(),
@@ -123,7 +124,7 @@ func insertIntoImageCvesV2(batch *pgx.Batch, obj *storage.ImageCVEV2) error {
 		serialized,
 	}
 
-	finalStr := "INSERT INTO image_cves_v2 (Id, ImageId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, Cvss, Severity, ImpactScore, Nvdcvss, FirstImageOccurrence, State, IsFixable, FixedBy, ComponentId, Advisory_Name, Advisory_Link, ImageIdV2, FixAvailableTimestamp, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, ImageId = EXCLUDED.ImageId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, FirstImageOccurrence = EXCLUDED.FirstImageOccurrence, State = EXCLUDED.State, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, ComponentId = EXCLUDED.ComponentId, Advisory_Name = EXCLUDED.Advisory_Name, Advisory_Link = EXCLUDED.Advisory_Link, ImageIdV2 = EXCLUDED.ImageIdV2, FixAvailableTimestamp = EXCLUDED.FixAvailableTimestamp, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO image_cves_v2 (Id, ImageId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev, Cvss, Severity, ImpactScore, Nvdcvss, FirstImageOccurrence, State, IsFixable, FixedBy, ComponentId, Advisory_Name, Advisory_Link, ImageIdV2, FixAvailableTimestamp, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, ImageId = EXCLUDED.ImageId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev = EXCLUDED.CveBaseInfo_CisaKev, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, FirstImageOccurrence = EXCLUDED.FirstImageOccurrence, State = EXCLUDED.State, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, ComponentId = EXCLUDED.ComponentId, Advisory_Name = EXCLUDED.Advisory_Name, Advisory_Link = EXCLUDED.Advisory_Link, ImageIdV2 = EXCLUDED.ImageIdV2, FixAvailableTimestamp = EXCLUDED.FixAvailableTimestamp, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	return nil
@@ -136,6 +137,7 @@ var copyColsImageCvesV2 = []string{
 	"cvebaseinfo_publishedon",
 	"cvebaseinfo_createdat",
 	"cvebaseinfo_epss_epssprobability",
+	"cvebaseinfo_cisakev",
 	"cvss",
 	"severity",
 	"impactscore",
@@ -189,6 +191,7 @@ func copyFromImageCvesV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetCveBaseInfo().GetCisaKev(),
 			obj.GetCvss(),
 			obj.GetSeverity(),
 			obj.GetImpactScore(),

--- a/central/cve/node/datastore/store/postgres/store.go
+++ b/central/cve/node/datastore/store/postgres/store.go
@@ -105,6 +105,7 @@ func insertIntoNodeCves(batch *pgx.Batch, obj *storage.NodeCVE) error {
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 		obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+		obj.GetCveBaseInfo().GetCisaKev(),
 		obj.GetOperatingSystem(),
 		obj.GetCvss(),
 		obj.GetSeverity(),
@@ -116,7 +117,7 @@ func insertIntoNodeCves(batch *pgx.Batch, obj *storage.NodeCVE) error {
 		serialized,
 	}
 
-	finalStr := "INSERT INTO node_cves (Id, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, OperatingSystem, Cvss, Severity, ImpactScore, Snoozed, SnoozeExpiry, Orphaned, OrphanedTime, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, OperatingSystem = EXCLUDED.OperatingSystem, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Snoozed = EXCLUDED.Snoozed, SnoozeExpiry = EXCLUDED.SnoozeExpiry, Orphaned = EXCLUDED.Orphaned, OrphanedTime = EXCLUDED.OrphanedTime, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO node_cves (Id, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev, OperatingSystem, Cvss, Severity, ImpactScore, Snoozed, SnoozeExpiry, Orphaned, OrphanedTime, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev = EXCLUDED.CveBaseInfo_CisaKev, OperatingSystem = EXCLUDED.OperatingSystem, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Snoozed = EXCLUDED.Snoozed, SnoozeExpiry = EXCLUDED.SnoozeExpiry, Orphaned = EXCLUDED.Orphaned, OrphanedTime = EXCLUDED.OrphanedTime, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	return nil
@@ -128,6 +129,7 @@ var copyColsNodeCves = []string{
 	"cvebaseinfo_publishedon",
 	"cvebaseinfo_createdat",
 	"cvebaseinfo_epss_epssprobability",
+	"cvebaseinfo_cisakev",
 	"operatingsystem",
 	"cvss",
 	"severity",
@@ -175,6 +177,7 @@ func copyFromNodeCves(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, 
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetCveBaseInfo().GetCisaKev(),
 			obj.GetOperatingSystem(),
 			obj.GetCvss(),
 			obj.GetSeverity(),

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -184,6 +184,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"types: [CVE_CVEType!]!",
 	}))
 	utils.Must(builder.AddType("CVEInfo", []string{
+		"cisaKev: Boolean!",
 		"createdAt: Time",
 		"cve: String!",
 		"cvssMetrics: [CVSSScore]!",
@@ -3283,6 +3284,11 @@ func (resolver *Resolver) wrapCVEInfosWithContext(ctx context.Context, values []
 		output[i] = &cVEInfoResolver{ctx: ctx, root: resolver, data: v}
 	}
 	return output, nil
+}
+
+func (resolver *cVEInfoResolver) CisaKev(ctx context.Context) bool {
+	value := resolver.data.GetCisaKev()
+	return value
 }
 
 func (resolver *cVEInfoResolver) CreatedAt(ctx context.Context) (*graphql.Time, error) {

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -190,6 +190,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"cvssV2: CVSSV2",
 		"cvssV3: CVSSV3",
 		"epss: EPSS",
+		"exploit: Exploit",
 		"lastModified: Time",
 		"link: String!",
 		"publishedOn: Time",
@@ -665,6 +666,13 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	}))
 	utils.Must(builder.AddType("Exclusion_Image", []string{
 		"name: String!",
+	}))
+	utils.Must(builder.AddType("Exploit", []string{
+		"dateAdded: String!",
+		"dueDate: String!",
+		"knownRansomwareCampaignUse: String!",
+		"requiredAction: String!",
+		"shortDescription: String!",
 	}))
 	utils.Must(builder.AddType("FalsePositiveRequest", []string{
 		"unused: String!",
@@ -3305,6 +3313,11 @@ func (resolver *cVEInfoResolver) CvssV3(ctx context.Context) (*cVSSV3Resolver, e
 func (resolver *cVEInfoResolver) Epss(ctx context.Context) (*ePSSResolver, error) {
 	value := resolver.data.GetEpss()
 	return resolver.root.wrapEPSS(value, true, nil)
+}
+
+func (resolver *cVEInfoResolver) Exploit(ctx context.Context) (*exploitResolver, error) {
+	value := resolver.data.GetExploit()
+	return resolver.root.wrapExploit(value, true, nil)
 }
 
 func (resolver *cVEInfoResolver) LastModified(ctx context.Context) (*graphql.Time, error) {
@@ -7976,6 +7989,73 @@ func (resolver *Resolver) wrapExclusion_ImagesWithContext(ctx context.Context, v
 
 func (resolver *exclusion_ImageResolver) Name(ctx context.Context) string {
 	value := resolver.data.GetName()
+	return value
+}
+
+type exploitResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data *storage.Exploit
+}
+
+func (resolver *Resolver) wrapExploit(value *storage.Exploit, ok bool, err error) (*exploitResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &exploitResolver{root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapExploits(values []*storage.Exploit, err error) ([]*exploitResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*exploitResolver, len(values))
+	for i, v := range values {
+		output[i] = &exploitResolver{root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *Resolver) wrapExploitWithContext(ctx context.Context, value *storage.Exploit, ok bool, err error) (*exploitResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &exploitResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapExploitsWithContext(ctx context.Context, values []*storage.Exploit, err error) ([]*exploitResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*exploitResolver, len(values))
+	for i, v := range values {
+		output[i] = &exploitResolver{ctx: ctx, root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *exploitResolver) DateAdded(ctx context.Context) string {
+	value := resolver.data.GetDateAdded()
+	return value
+}
+
+func (resolver *exploitResolver) DueDate(ctx context.Context) string {
+	value := resolver.data.GetDueDate()
+	return value
+}
+
+func (resolver *exploitResolver) KnownRansomwareCampaignUse(ctx context.Context) string {
+	value := resolver.data.GetKnownRansomwareCampaignUse()
+	return value
+}
+
+func (resolver *exploitResolver) RequiredAction(ctx context.Context) string {
+	value := resolver.data.GetRequiredAction()
+	return value
+}
+
+func (resolver *exploitResolver) ShortDescription(ctx context.Context) string {
+	value := resolver.data.GetShortDescription()
 	return value
 }
 

--- a/central/imagev2/datastore/store/postgres/store_test.go
+++ b/central/imagev2/datastore/store/postgres/store_test.go
@@ -106,6 +106,8 @@ func (s *ImagesV2StoreSuite) TestStore() {
 			vuln.SuppressExpiry = nil
 			vuln.Advisory = nil
 			vuln.FixAvailableTimestamp = nil
+			vuln.Exploit = nil
+			vuln.CisaKev = false
 		}
 		comp.License = nil
 	}

--- a/central/virtualmachine/cve/v2/datastore/store/postgres/store.go
+++ b/central/virtualmachine/cve/v2/datastore/store/postgres/store.go
@@ -108,6 +108,7 @@ func insertIntoVirtualMachineCvev2(batch *pgx.Batch, obj *storage.VirtualMachine
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 		protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 		obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+		obj.GetCveBaseInfo().GetCisaKev(),
 		obj.GetPreferredCvss(),
 		obj.GetSeverity(),
 		obj.GetImpactScore(),
@@ -120,7 +121,7 @@ func insertIntoVirtualMachineCvev2(batch *pgx.Batch, obj *storage.VirtualMachine
 		serialized,
 	}
 
-	finalStr := "INSERT INTO virtual_machine_cvev2 (Id, VmV2Id, VmComponentId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, PreferredCvss, Severity, ImpactScore, Nvdcvss, IsFixable, FixedBy, EpssProbability, Advisory_Name, Advisory_Link, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, VmV2Id = EXCLUDED.VmV2Id, VmComponentId = EXCLUDED.VmComponentId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, PreferredCvss = EXCLUDED.PreferredCvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, EpssProbability = EXCLUDED.EpssProbability, Advisory_Name = EXCLUDED.Advisory_Name, Advisory_Link = EXCLUDED.Advisory_Link, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO virtual_machine_cvev2 (Id, VmV2Id, VmComponentId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev, PreferredCvss, Severity, ImpactScore, Nvdcvss, IsFixable, FixedBy, EpssProbability, Advisory_Name, Advisory_Link, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, VmV2Id = EXCLUDED.VmV2Id, VmComponentId = EXCLUDED.VmComponentId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, CveBaseInfo_CisaKev = EXCLUDED.CveBaseInfo_CisaKev, PreferredCvss = EXCLUDED.PreferredCvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, EpssProbability = EXCLUDED.EpssProbability, Advisory_Name = EXCLUDED.Advisory_Name, Advisory_Link = EXCLUDED.Advisory_Link, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	return nil
@@ -134,6 +135,7 @@ var copyColsVirtualMachineCvev2 = []string{
 	"cvebaseinfo_publishedon",
 	"cvebaseinfo_createdat",
 	"cvebaseinfo_epss_epssprobability",
+	"cvebaseinfo_cisakev",
 	"preferredcvss",
 	"severity",
 	"impactscore",
@@ -184,6 +186,7 @@ func copyFromVirtualMachineCvev2(ctx context.Context, s pgSearch.Deleter, tx *po
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetPublishedOn()),
 			protocompat.NilOrTime(obj.GetCveBaseInfo().GetCreatedAt()),
 			obj.GetCveBaseInfo().GetEpss().GetEpssProbability(),
+			obj.GetCveBaseInfo().GetCisaKev(),
 			obj.GetPreferredCvss(),
 			obj.GetSeverity(),
 			obj.GetImpactScore(),

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -1016,9 +1016,36 @@
         "datasource": {
           "type": "string",
           "title": "datasource is for internal use only"
+        },
+        "exploit": {
+          "$ref": "#/definitions/storageExploit"
+        },
+        "cisaKev": {
+          "type": "boolean"
         }
       },
-      "title": "Next Tag: 27"
+      "title": "Next Tag: 29"
+    },
+    "storageExploit": {
+      "type": "object",
+      "properties": {
+        "dateAdded": {
+          "type": "string"
+        },
+        "shortDescription": {
+          "type": "string"
+        },
+        "requiredAction": {
+          "type": "string"
+        },
+        "dueDate": {
+          "type": "string"
+        },
+        "knownRansomwareCampaignUse": {
+          "type": "string"
+        }
+      },
+      "description": "Exploit stores CISA Known Exploited Vulnerabilities (KEV) catalog data."
     },
     "storageImage": {
       "type": "object",

--- a/generated/api/v1/node_service.swagger.json
+++ b/generated/api/v1/node_service.swagger.json
@@ -304,6 +304,9 @@
         },
         "exploit": {
           "$ref": "#/definitions/storageExploit"
+        },
+        "cisaKev": {
+          "type": "boolean"
         }
       }
     },

--- a/generated/api/v1/node_service.swagger.json
+++ b/generated/api/v1/node_service.swagger.json
@@ -301,6 +301,9 @@
         },
         "epss": {
           "$ref": "#/definitions/storageEPSS"
+        },
+        "exploit": {
+          "$ref": "#/definitions/storageExploit"
         }
       }
     },
@@ -658,9 +661,15 @@
         "datasource": {
           "type": "string",
           "title": "datasource is for internal use only"
+        },
+        "exploit": {
+          "$ref": "#/definitions/storageExploit"
+        },
+        "cisaKev": {
+          "type": "boolean"
         }
       },
-      "title": "Next Tag: 27"
+      "title": "Next Tag: 29"
     },
     "storageEmbeddedVulnerabilityScoreVersion": {
       "type": "string",
@@ -671,6 +680,27 @@
       "default": "V2",
       "description": "- V2: No unset for automatic backwards compatibility",
       "title": "ScoreVersion can be deprecated ROX-26066"
+    },
+    "storageExploit": {
+      "type": "object",
+      "properties": {
+        "dateAdded": {
+          "type": "string"
+        },
+        "shortDescription": {
+          "type": "string"
+        },
+        "requiredAction": {
+          "type": "string"
+        },
+        "dueDate": {
+          "type": "string"
+        },
+        "knownRansomwareCampaignUse": {
+          "type": "string"
+        }
+      },
+      "description": "Exploit stores CISA Known Exploited Vulnerabilities (KEV) catalog data."
     },
     "storageNode": {
       "type": "object",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -1001,9 +1001,36 @@
         "datasource": {
           "type": "string",
           "title": "datasource is for internal use only"
+        },
+        "exploit": {
+          "$ref": "#/definitions/storageExploit"
+        },
+        "cisaKev": {
+          "type": "boolean"
         }
       },
-      "title": "Next Tag: 27"
+      "title": "Next Tag: 29"
+    },
+    "storageExploit": {
+      "type": "object",
+      "properties": {
+        "dateAdded": {
+          "type": "string"
+        },
+        "shortDescription": {
+          "type": "string"
+        },
+        "requiredAction": {
+          "type": "string"
+        },
+        "dueDate": {
+          "type": "string"
+        },
+        "knownRansomwareCampaignUse": {
+          "type": "string"
+        }
+      },
+      "description": "Exploit stores CISA Known Exploited Vulnerabilities (KEV) catalog data."
     },
     "storageImage": {
       "type": "object",

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/cve.pb.go
+++ b/generated/storage/cve.pb.go
@@ -284,7 +284,7 @@ func (x CVE_CVEType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVE_CVEType.Descriptor instead.
 func (CVE_CVEType) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{1, 0}
+	return file_storage_cve_proto_rawDescGZIP(), []int{2, 0}
 }
 
 type CVE_ScoreVersion int32
@@ -333,7 +333,7 @@ func (x CVE_ScoreVersion) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVE_ScoreVersion.Descriptor instead.
 func (CVE_ScoreVersion) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{1, 1}
+	return file_storage_cve_proto_rawDescGZIP(), []int{2, 1}
 }
 
 // ScoreVersion can be deprecated ROX-26066
@@ -383,7 +383,7 @@ func (x CVEInfo_ScoreVersion) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVEInfo_ScoreVersion.Descriptor instead.
 func (CVEInfo_ScoreVersion) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{2, 0}
+	return file_storage_cve_proto_rawDescGZIP(), []int{3, 0}
 }
 
 type CVSSV2_Impact int32
@@ -432,7 +432,7 @@ func (x CVSSV2_Impact) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV2_Impact.Descriptor instead.
 func (CVSSV2_Impact) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{9, 0}
+	return file_storage_cve_proto_rawDescGZIP(), []int{10, 0}
 }
 
 type CVSSV2_AttackVector int32
@@ -481,7 +481,7 @@ func (x CVSSV2_AttackVector) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV2_AttackVector.Descriptor instead.
 func (CVSSV2_AttackVector) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{9, 1}
+	return file_storage_cve_proto_rawDescGZIP(), []int{10, 1}
 }
 
 type CVSSV2_AccessComplexity int32
@@ -530,7 +530,7 @@ func (x CVSSV2_AccessComplexity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV2_AccessComplexity.Descriptor instead.
 func (CVSSV2_AccessComplexity) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{9, 2}
+	return file_storage_cve_proto_rawDescGZIP(), []int{10, 2}
 }
 
 type CVSSV2_Authentication int32
@@ -579,7 +579,7 @@ func (x CVSSV2_Authentication) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV2_Authentication.Descriptor instead.
 func (CVSSV2_Authentication) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{9, 3}
+	return file_storage_cve_proto_rawDescGZIP(), []int{10, 3}
 }
 
 type CVSSV2_Severity int32
@@ -631,7 +631,7 @@ func (x CVSSV2_Severity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV2_Severity.Descriptor instead.
 func (CVSSV2_Severity) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{9, 4}
+	return file_storage_cve_proto_rawDescGZIP(), []int{10, 4}
 }
 
 type CVSSV3_Impact int32
@@ -680,7 +680,7 @@ func (x CVSSV3_Impact) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_Impact.Descriptor instead.
 func (CVSSV3_Impact) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 0}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 0}
 }
 
 type CVSSV3_AttackVector int32
@@ -732,7 +732,7 @@ func (x CVSSV3_AttackVector) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_AttackVector.Descriptor instead.
 func (CVSSV3_AttackVector) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 1}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 1}
 }
 
 type CVSSV3_Complexity int32
@@ -778,7 +778,7 @@ func (x CVSSV3_Complexity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_Complexity.Descriptor instead.
 func (CVSSV3_Complexity) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 2}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 2}
 }
 
 type CVSSV3_Privileges int32
@@ -827,7 +827,7 @@ func (x CVSSV3_Privileges) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_Privileges.Descriptor instead.
 func (CVSSV3_Privileges) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 3}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 3}
 }
 
 type CVSSV3_UserInteraction int32
@@ -873,7 +873,7 @@ func (x CVSSV3_UserInteraction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_UserInteraction.Descriptor instead.
 func (CVSSV3_UserInteraction) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 4}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 4}
 }
 
 type CVSSV3_Scope int32
@@ -919,7 +919,7 @@ func (x CVSSV3_Scope) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_Scope.Descriptor instead.
 func (CVSSV3_Scope) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 5}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 5}
 }
 
 type CVSSV3_Severity int32
@@ -977,7 +977,7 @@ func (x CVSSV3_Severity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CVSSV3_Severity.Descriptor instead.
 func (CVSSV3_Severity) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10, 6}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11, 6}
 }
 
 // EPSS Score stores two epss metrics returned by scanner - epss probability and epss percentile
@@ -1033,6 +1033,83 @@ func (x *EPSS) GetEpssPercentile() float32 {
 	return 0
 }
 
+// Exploit stores CISA Known Exploited Vulnerabilities (KEV) catalog data.
+type Exploit struct {
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	DateAdded                  string                 `protobuf:"bytes,1,opt,name=date_added,json=dateAdded,proto3" json:"date_added,omitempty"`
+	ShortDescription           string                 `protobuf:"bytes,2,opt,name=short_description,json=shortDescription,proto3" json:"short_description,omitempty"`
+	RequiredAction             string                 `protobuf:"bytes,3,opt,name=required_action,json=requiredAction,proto3" json:"required_action,omitempty"`
+	DueDate                    string                 `protobuf:"bytes,4,opt,name=due_date,json=dueDate,proto3" json:"due_date,omitempty"`
+	KnownRansomwareCampaignUse string                 `protobuf:"bytes,5,opt,name=known_ransomware_campaign_use,json=knownRansomwareCampaignUse,proto3" json:"known_ransomware_campaign_use,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *Exploit) Reset() {
+	*x = Exploit{}
+	mi := &file_storage_cve_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Exploit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Exploit) ProtoMessage() {}
+
+func (x *Exploit) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_cve_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Exploit.ProtoReflect.Descriptor instead.
+func (*Exploit) Descriptor() ([]byte, []int) {
+	return file_storage_cve_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Exploit) GetDateAdded() string {
+	if x != nil {
+		return x.DateAdded
+	}
+	return ""
+}
+
+func (x *Exploit) GetShortDescription() string {
+	if x != nil {
+		return x.ShortDescription
+	}
+	return ""
+}
+
+func (x *Exploit) GetRequiredAction() string {
+	if x != nil {
+		return x.RequiredAction
+	}
+	return ""
+}
+
+func (x *Exploit) GetDueDate() string {
+	if x != nil {
+		return x.DueDate
+	}
+	return ""
+}
+
+func (x *Exploit) GetKnownRansomwareCampaignUse() string {
+	if x != nil {
+		return x.KnownRansomwareCampaignUse
+	}
+	return ""
+}
+
 // ******************************
 // This proto is deprecated.
 // ******************************
@@ -1066,7 +1143,7 @@ type CVE struct {
 
 func (x *CVE) Reset() {
 	*x = CVE{}
-	mi := &file_storage_cve_proto_msgTypes[1]
+	mi := &file_storage_cve_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1078,7 +1155,7 @@ func (x *CVE) String() string {
 func (*CVE) ProtoMessage() {}
 
 func (x *CVE) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[1]
+	mi := &file_storage_cve_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1091,7 +1168,7 @@ func (x *CVE) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVE.ProtoReflect.Descriptor instead.
 func (*CVE) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{1}
+	return file_storage_cve_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *CVE) GetId() string {
@@ -1245,13 +1322,14 @@ type CVEInfo struct {
 	// cvss_metrics stores list of cvss scores from different sources like nvd, Redhat etc
 	CvssMetrics   []*CVSSScore `protobuf:"bytes,11,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
 	Epss          *EPSS        `protobuf:"bytes,12,opt,name=epss,proto3" json:"epss,omitempty"`
+	Exploit       *Exploit     `protobuf:"bytes,13,opt,name=exploit,proto3" json:"exploit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CVEInfo) Reset() {
 	*x = CVEInfo{}
-	mi := &file_storage_cve_proto_msgTypes[2]
+	mi := &file_storage_cve_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1263,7 +1341,7 @@ func (x *CVEInfo) String() string {
 func (*CVEInfo) ProtoMessage() {}
 
 func (x *CVEInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[2]
+	mi := &file_storage_cve_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1276,7 +1354,7 @@ func (x *CVEInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVEInfo.ProtoReflect.Descriptor instead.
 func (*CVEInfo) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{2}
+	return file_storage_cve_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CVEInfo) GetCve() string {
@@ -1363,6 +1441,13 @@ func (x *CVEInfo) GetEpss() *EPSS {
 	return nil
 }
 
+func (x *CVEInfo) GetExploit() *Exploit {
+	if x != nil {
+		return x.Exploit
+	}
+	return nil
+}
+
 type Advisory struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty" search:"Advisory Name"` // @gotags: search:"Advisory Name"
@@ -1373,7 +1458,7 @@ type Advisory struct {
 
 func (x *Advisory) Reset() {
 	*x = Advisory{}
-	mi := &file_storage_cve_proto_msgTypes[3]
+	mi := &file_storage_cve_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1385,7 +1470,7 @@ func (x *Advisory) String() string {
 func (*Advisory) ProtoMessage() {}
 
 func (x *Advisory) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[3]
+	mi := &file_storage_cve_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1398,7 +1483,7 @@ func (x *Advisory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Advisory.ProtoReflect.Descriptor instead.
 func (*Advisory) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{3}
+	return file_storage_cve_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Advisory) GetName() string {
@@ -1444,7 +1529,7 @@ type ImageCVE struct {
 
 func (x *ImageCVE) Reset() {
 	*x = ImageCVE{}
-	mi := &file_storage_cve_proto_msgTypes[4]
+	mi := &file_storage_cve_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1456,7 +1541,7 @@ func (x *ImageCVE) String() string {
 func (*ImageCVE) ProtoMessage() {}
 
 func (x *ImageCVE) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[4]
+	mi := &file_storage_cve_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1469,7 +1554,7 @@ func (x *ImageCVE) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageCVE.ProtoReflect.Descriptor instead.
 func (*ImageCVE) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{4}
+	return file_storage_cve_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ImageCVE) GetId() string {
@@ -1597,7 +1682,7 @@ type ImageCVEV2 struct {
 
 func (x *ImageCVEV2) Reset() {
 	*x = ImageCVEV2{}
-	mi := &file_storage_cve_proto_msgTypes[5]
+	mi := &file_storage_cve_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1609,7 +1694,7 @@ func (x *ImageCVEV2) String() string {
 func (*ImageCVEV2) ProtoMessage() {}
 
 func (x *ImageCVEV2) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[5]
+	mi := &file_storage_cve_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1622,7 +1707,7 @@ func (x *ImageCVEV2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageCVEV2.ProtoReflect.Descriptor instead.
 func (*ImageCVEV2) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{5}
+	return file_storage_cve_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ImageCVEV2) GetId() string {
@@ -1783,7 +1868,7 @@ type NodeCVE struct {
 
 func (x *NodeCVE) Reset() {
 	*x = NodeCVE{}
-	mi := &file_storage_cve_proto_msgTypes[6]
+	mi := &file_storage_cve_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1795,7 +1880,7 @@ func (x *NodeCVE) String() string {
 func (*NodeCVE) ProtoMessage() {}
 
 func (x *NodeCVE) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[6]
+	mi := &file_storage_cve_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1808,7 +1893,7 @@ func (x *NodeCVE) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeCVE.ProtoReflect.Descriptor instead.
 func (*NodeCVE) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{6}
+	return file_storage_cve_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *NodeCVE) GetId() string {
@@ -1905,7 +1990,7 @@ type ClusterCVE struct {
 
 func (x *ClusterCVE) Reset() {
 	*x = ClusterCVE{}
-	mi := &file_storage_cve_proto_msgTypes[7]
+	mi := &file_storage_cve_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1917,7 +2002,7 @@ func (x *ClusterCVE) String() string {
 func (*ClusterCVE) ProtoMessage() {}
 
 func (x *ClusterCVE) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[7]
+	mi := &file_storage_cve_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1930,7 +2015,7 @@ func (x *ClusterCVE) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterCVE.ProtoReflect.Descriptor instead.
 func (*ClusterCVE) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{7}
+	return file_storage_cve_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ClusterCVE) GetId() string {
@@ -2011,7 +2096,7 @@ type CVSSScore struct {
 
 func (x *CVSSScore) Reset() {
 	*x = CVSSScore{}
-	mi := &file_storage_cve_proto_msgTypes[8]
+	mi := &file_storage_cve_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2023,7 +2108,7 @@ func (x *CVSSScore) String() string {
 func (*CVSSScore) ProtoMessage() {}
 
 func (x *CVSSScore) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[8]
+	mi := &file_storage_cve_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2036,7 +2121,7 @@ func (x *CVSSScore) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVSSScore.ProtoReflect.Descriptor instead.
 func (*CVSSScore) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{8}
+	return file_storage_cve_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *CVSSScore) GetSource() Source {
@@ -2113,7 +2198,7 @@ type CVSSV2 struct {
 
 func (x *CVSSV2) Reset() {
 	*x = CVSSV2{}
-	mi := &file_storage_cve_proto_msgTypes[9]
+	mi := &file_storage_cve_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2125,7 +2210,7 @@ func (x *CVSSV2) String() string {
 func (*CVSSV2) ProtoMessage() {}
 
 func (x *CVSSV2) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[9]
+	mi := &file_storage_cve_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2138,7 +2223,7 @@ func (x *CVSSV2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVSSV2.ProtoReflect.Descriptor instead.
 func (*CVSSV2) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{9}
+	return file_storage_cve_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CVSSV2) GetVector() string {
@@ -2239,7 +2324,7 @@ type CVSSV3 struct {
 
 func (x *CVSSV3) Reset() {
 	*x = CVSSV3{}
-	mi := &file_storage_cve_proto_msgTypes[10]
+	mi := &file_storage_cve_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2251,7 +2336,7 @@ func (x *CVSSV3) String() string {
 func (*CVSSV3) ProtoMessage() {}
 
 func (x *CVSSV3) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[10]
+	mi := &file_storage_cve_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2264,7 +2349,7 @@ func (x *CVSSV3) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVSSV3.ProtoReflect.Descriptor instead.
 func (*CVSSV3) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{10}
+	return file_storage_cve_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *CVSSV3) GetVector() string {
@@ -2372,7 +2457,7 @@ type ImageCVEInfo struct {
 
 func (x *ImageCVEInfo) Reset() {
 	*x = ImageCVEInfo{}
-	mi := &file_storage_cve_proto_msgTypes[11]
+	mi := &file_storage_cve_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2384,7 +2469,7 @@ func (x *ImageCVEInfo) String() string {
 func (*ImageCVEInfo) ProtoMessage() {}
 
 func (x *ImageCVEInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[11]
+	mi := &file_storage_cve_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2397,7 +2482,7 @@ func (x *ImageCVEInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImageCVEInfo.ProtoReflect.Descriptor instead.
 func (*ImageCVEInfo) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{11}
+	return file_storage_cve_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ImageCVEInfo) GetId() string {
@@ -2441,7 +2526,7 @@ type CVE_DistroSpecific struct {
 
 func (x *CVE_DistroSpecific) Reset() {
 	*x = CVE_DistroSpecific{}
-	mi := &file_storage_cve_proto_msgTypes[12]
+	mi := &file_storage_cve_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2453,7 +2538,7 @@ func (x *CVE_DistroSpecific) String() string {
 func (*CVE_DistroSpecific) ProtoMessage() {}
 
 func (x *CVE_DistroSpecific) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[12]
+	mi := &file_storage_cve_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2466,7 +2551,7 @@ func (x *CVE_DistroSpecific) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVE_DistroSpecific.ProtoReflect.Descriptor instead.
 func (*CVE_DistroSpecific) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{1, 0}
+	return file_storage_cve_proto_rawDescGZIP(), []int{2, 0}
 }
 
 func (x *CVE_DistroSpecific) GetSeverity() VulnerabilitySeverity {
@@ -2514,7 +2599,7 @@ type CVE_Reference struct {
 
 func (x *CVE_Reference) Reset() {
 	*x = CVE_Reference{}
-	mi := &file_storage_cve_proto_msgTypes[13]
+	mi := &file_storage_cve_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2526,7 +2611,7 @@ func (x *CVE_Reference) String() string {
 func (*CVE_Reference) ProtoMessage() {}
 
 func (x *CVE_Reference) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[13]
+	mi := &file_storage_cve_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2539,7 +2624,7 @@ func (x *CVE_Reference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVE_Reference.ProtoReflect.Descriptor instead.
 func (*CVE_Reference) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{1, 1}
+	return file_storage_cve_proto_rawDescGZIP(), []int{2, 1}
 }
 
 func (x *CVE_Reference) GetURI() string {
@@ -2566,7 +2651,7 @@ type CVEInfo_Reference struct {
 
 func (x *CVEInfo_Reference) Reset() {
 	*x = CVEInfo_Reference{}
-	mi := &file_storage_cve_proto_msgTypes[15]
+	mi := &file_storage_cve_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2578,7 +2663,7 @@ func (x *CVEInfo_Reference) String() string {
 func (*CVEInfo_Reference) ProtoMessage() {}
 
 func (x *CVEInfo_Reference) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cve_proto_msgTypes[15]
+	mi := &file_storage_cve_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2591,7 +2676,7 @@ func (x *CVEInfo_Reference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CVEInfo_Reference.ProtoReflect.Descriptor instead.
 func (*CVEInfo_Reference) Descriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{2, 0}
+	return file_storage_cve_proto_rawDescGZIP(), []int{3, 0}
 }
 
 func (x *CVEInfo_Reference) GetURI() string {
@@ -2615,7 +2700,14 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\x11storage/cve.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\"Z\n" +
 	"\x04EPSS\x12)\n" +
 	"\x10epss_probability\x18\x01 \x01(\x02R\x0fepssProbability\x12'\n" +
-	"\x0fepss_percentile\x18\x02 \x01(\x02R\x0eepssPercentile\"\xbf\v\n" +
+	"\x0fepss_percentile\x18\x02 \x01(\x02R\x0eepssPercentile\"\xdc\x01\n" +
+	"\aExploit\x12\x1d\n" +
+	"\n" +
+	"date_added\x18\x01 \x01(\tR\tdateAdded\x12+\n" +
+	"\x11short_description\x18\x02 \x01(\tR\x10shortDescription\x12'\n" +
+	"\x0frequired_action\x18\x03 \x01(\tR\x0erequiredAction\x12\x19\n" +
+	"\bdue_date\x18\x04 \x01(\tR\adueDate\x12A\n" +
+	"\x1dknown_ransomware_campaign_use\x18\x05 \x01(\tR\x1aknownRansomwareCampaignUse\"\xbf\v\n" +
 	"\x03CVE\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04cvss\x18\x02 \x01(\x02R\x04cvss\x12!\n" +
@@ -2664,7 +2756,7 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\fScoreVersion\x12\x06\n" +
 	"\x02V2\x10\x00\x12\x06\n" +
 	"\x02V3\x10\x01\x12\v\n" +
-	"\aUNKNOWN\x10\x02J\x04\b\x16\x10\x17J\x04\b\x15\x10\x16\"\x92\x05\n" +
+	"\aUNKNOWN\x10\x02J\x04\b\x16\x10\x17J\x04\b\x15\x10\x16\"\xbe\x05\n" +
 	"\aCVEInfo\x12\x10\n" +
 	"\x03cve\x18\x01 \x01(\tR\x03cve\x12\x18\n" +
 	"\asummary\x18\x02 \x01(\tR\asummary\x12\x12\n" +
@@ -2681,7 +2773,8 @@ const file_storage_cve_proto_rawDesc = "" +
 	" \x03(\v2\x1a.storage.CVEInfo.ReferenceR\n" +
 	"references\x125\n" +
 	"\fcvss_metrics\x18\v \x03(\v2\x12.storage.CVSSScoreR\vcvssMetrics\x12!\n" +
-	"\x04epss\x18\f \x01(\v2\r.storage.EPSSR\x04epss\x1a1\n" +
+	"\x04epss\x18\f \x01(\v2\r.storage.EPSSR\x04epss\x12*\n" +
+	"\aexploit\x18\r \x01(\v2\x10.storage.ExploitR\aexploit\x1a1\n" +
 	"\tReference\x12\x10\n" +
 	"\x03URI\x18\x01 \x01(\tR\x03URI\x12\x12\n" +
 	"\x04tags\x18\x02 \x03(\tR\x04tags\"+\n" +
@@ -2886,7 +2979,7 @@ func file_storage_cve_proto_rawDescGZIP() []byte {
 }
 
 var file_storage_cve_proto_enumTypes = make([]protoimpl.EnumInfo, 19)
-var file_storage_cve_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_storage_cve_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_storage_cve_proto_goTypes = []any{
 	(VulnerabilityState)(0),       // 0: storage.VulnerabilityState
 	(VulnerabilitySeverity)(0),    // 1: storage.VulnerabilitySeverity
@@ -2908,100 +3001,102 @@ var file_storage_cve_proto_goTypes = []any{
 	(CVSSV3_Scope)(0),             // 17: storage.CVSSV3.Scope
 	(CVSSV3_Severity)(0),          // 18: storage.CVSSV3.Severity
 	(*EPSS)(nil),                  // 19: storage.EPSS
-	(*CVE)(nil),                   // 20: storage.CVE
-	(*CVEInfo)(nil),               // 21: storage.CVEInfo
-	(*Advisory)(nil),              // 22: storage.Advisory
-	(*ImageCVE)(nil),              // 23: storage.ImageCVE
-	(*ImageCVEV2)(nil),            // 24: storage.ImageCVEV2
-	(*NodeCVE)(nil),               // 25: storage.NodeCVE
-	(*ClusterCVE)(nil),            // 26: storage.ClusterCVE
-	(*CVSSScore)(nil),             // 27: storage.CVSSScore
-	(*CVSSV2)(nil),                // 28: storage.CVSSV2
-	(*CVSSV3)(nil),                // 29: storage.CVSSV3
-	(*ImageCVEInfo)(nil),          // 30: storage.ImageCVEInfo
-	(*CVE_DistroSpecific)(nil),    // 31: storage.CVE.DistroSpecific
-	(*CVE_Reference)(nil),         // 32: storage.CVE.Reference
-	nil,                           // 33: storage.CVE.DistroSpecificsEntry
-	(*CVEInfo_Reference)(nil),     // 34: storage.CVEInfo.Reference
-	(*timestamppb.Timestamp)(nil), // 35: google.protobuf.Timestamp
+	(*Exploit)(nil),               // 20: storage.Exploit
+	(*CVE)(nil),                   // 21: storage.CVE
+	(*CVEInfo)(nil),               // 22: storage.CVEInfo
+	(*Advisory)(nil),              // 23: storage.Advisory
+	(*ImageCVE)(nil),              // 24: storage.ImageCVE
+	(*ImageCVEV2)(nil),            // 25: storage.ImageCVEV2
+	(*NodeCVE)(nil),               // 26: storage.NodeCVE
+	(*ClusterCVE)(nil),            // 27: storage.ClusterCVE
+	(*CVSSScore)(nil),             // 28: storage.CVSSScore
+	(*CVSSV2)(nil),                // 29: storage.CVSSV2
+	(*CVSSV3)(nil),                // 30: storage.CVSSV3
+	(*ImageCVEInfo)(nil),          // 31: storage.ImageCVEInfo
+	(*CVE_DistroSpecific)(nil),    // 32: storage.CVE.DistroSpecific
+	(*CVE_Reference)(nil),         // 33: storage.CVE.Reference
+	nil,                           // 34: storage.CVE.DistroSpecificsEntry
+	(*CVEInfo_Reference)(nil),     // 35: storage.CVEInfo.Reference
+	(*timestamppb.Timestamp)(nil), // 36: google.protobuf.Timestamp
 }
 var file_storage_cve_proto_depIdxs = []int32{
 	4,  // 0: storage.CVE.type:type_name -> storage.CVE.CVEType
 	4,  // 1: storage.CVE.types:type_name -> storage.CVE.CVEType
-	35, // 2: storage.CVE.published_on:type_name -> google.protobuf.Timestamp
-	35, // 3: storage.CVE.created_at:type_name -> google.protobuf.Timestamp
-	35, // 4: storage.CVE.last_modified:type_name -> google.protobuf.Timestamp
-	32, // 5: storage.CVE.references:type_name -> storage.CVE.Reference
+	36, // 2: storage.CVE.published_on:type_name -> google.protobuf.Timestamp
+	36, // 3: storage.CVE.created_at:type_name -> google.protobuf.Timestamp
+	36, // 4: storage.CVE.last_modified:type_name -> google.protobuf.Timestamp
+	33, // 5: storage.CVE.references:type_name -> storage.CVE.Reference
 	5,  // 6: storage.CVE.score_version:type_name -> storage.CVE.ScoreVersion
-	28, // 7: storage.CVE.cvss_v2:type_name -> storage.CVSSV2
-	29, // 8: storage.CVE.cvss_v3:type_name -> storage.CVSSV3
-	35, // 9: storage.CVE.suppress_activation:type_name -> google.protobuf.Timestamp
-	35, // 10: storage.CVE.suppress_expiry:type_name -> google.protobuf.Timestamp
-	33, // 11: storage.CVE.distro_specifics:type_name -> storage.CVE.DistroSpecificsEntry
+	29, // 7: storage.CVE.cvss_v2:type_name -> storage.CVSSV2
+	30, // 8: storage.CVE.cvss_v3:type_name -> storage.CVSSV3
+	36, // 9: storage.CVE.suppress_activation:type_name -> google.protobuf.Timestamp
+	36, // 10: storage.CVE.suppress_expiry:type_name -> google.protobuf.Timestamp
+	34, // 11: storage.CVE.distro_specifics:type_name -> storage.CVE.DistroSpecificsEntry
 	1,  // 12: storage.CVE.severity:type_name -> storage.VulnerabilitySeverity
-	35, // 13: storage.CVEInfo.published_on:type_name -> google.protobuf.Timestamp
-	35, // 14: storage.CVEInfo.created_at:type_name -> google.protobuf.Timestamp
-	35, // 15: storage.CVEInfo.last_modified:type_name -> google.protobuf.Timestamp
+	36, // 13: storage.CVEInfo.published_on:type_name -> google.protobuf.Timestamp
+	36, // 14: storage.CVEInfo.created_at:type_name -> google.protobuf.Timestamp
+	36, // 15: storage.CVEInfo.last_modified:type_name -> google.protobuf.Timestamp
 	6,  // 16: storage.CVEInfo.score_version:type_name -> storage.CVEInfo.ScoreVersion
-	28, // 17: storage.CVEInfo.cvss_v2:type_name -> storage.CVSSV2
-	29, // 18: storage.CVEInfo.cvss_v3:type_name -> storage.CVSSV3
-	34, // 19: storage.CVEInfo.references:type_name -> storage.CVEInfo.Reference
-	27, // 20: storage.CVEInfo.cvss_metrics:type_name -> storage.CVSSScore
+	29, // 17: storage.CVEInfo.cvss_v2:type_name -> storage.CVSSV2
+	30, // 18: storage.CVEInfo.cvss_v3:type_name -> storage.CVSSV3
+	35, // 19: storage.CVEInfo.references:type_name -> storage.CVEInfo.Reference
+	28, // 20: storage.CVEInfo.cvss_metrics:type_name -> storage.CVSSScore
 	19, // 21: storage.CVEInfo.epss:type_name -> storage.EPSS
-	21, // 22: storage.ImageCVE.cve_base_info:type_name -> storage.CVEInfo
-	1,  // 23: storage.ImageCVE.severity:type_name -> storage.VulnerabilitySeverity
-	35, // 24: storage.ImageCVE.snooze_start:type_name -> google.protobuf.Timestamp
-	35, // 25: storage.ImageCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
-	27, // 26: storage.ImageCVE.cvss_metrics:type_name -> storage.CVSSScore
-	3,  // 27: storage.ImageCVE.nvd_score_version:type_name -> storage.CvssScoreVersion
-	21, // 28: storage.ImageCVEV2.cve_base_info:type_name -> storage.CVEInfo
-	1,  // 29: storage.ImageCVEV2.severity:type_name -> storage.VulnerabilitySeverity
-	3,  // 30: storage.ImageCVEV2.nvd_score_version:type_name -> storage.CvssScoreVersion
-	35, // 31: storage.ImageCVEV2.first_image_occurrence:type_name -> google.protobuf.Timestamp
-	0,  // 32: storage.ImageCVEV2.state:type_name -> storage.VulnerabilityState
-	22, // 33: storage.ImageCVEV2.advisory:type_name -> storage.Advisory
-	35, // 34: storage.ImageCVEV2.fix_available_timestamp:type_name -> google.protobuf.Timestamp
-	21, // 35: storage.NodeCVE.cve_base_info:type_name -> storage.CVEInfo
-	1,  // 36: storage.NodeCVE.severity:type_name -> storage.VulnerabilitySeverity
-	35, // 37: storage.NodeCVE.snooze_start:type_name -> google.protobuf.Timestamp
-	35, // 38: storage.NodeCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
-	35, // 39: storage.NodeCVE.orphaned_time:type_name -> google.protobuf.Timestamp
-	21, // 40: storage.ClusterCVE.cve_base_info:type_name -> storage.CVEInfo
-	1,  // 41: storage.ClusterCVE.severity:type_name -> storage.VulnerabilitySeverity
-	35, // 42: storage.ClusterCVE.snooze_start:type_name -> google.protobuf.Timestamp
-	35, // 43: storage.ClusterCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
-	4,  // 44: storage.ClusterCVE.type:type_name -> storage.CVE.CVEType
-	2,  // 45: storage.CVSSScore.source:type_name -> storage.Source
-	28, // 46: storage.CVSSScore.cvssv2:type_name -> storage.CVSSV2
-	29, // 47: storage.CVSSScore.cvssv3:type_name -> storage.CVSSV3
-	8,  // 48: storage.CVSSV2.attack_vector:type_name -> storage.CVSSV2.AttackVector
-	9,  // 49: storage.CVSSV2.access_complexity:type_name -> storage.CVSSV2.AccessComplexity
-	10, // 50: storage.CVSSV2.authentication:type_name -> storage.CVSSV2.Authentication
-	7,  // 51: storage.CVSSV2.confidentiality:type_name -> storage.CVSSV2.Impact
-	7,  // 52: storage.CVSSV2.integrity:type_name -> storage.CVSSV2.Impact
-	7,  // 53: storage.CVSSV2.availability:type_name -> storage.CVSSV2.Impact
-	11, // 54: storage.CVSSV2.severity:type_name -> storage.CVSSV2.Severity
-	13, // 55: storage.CVSSV3.attack_vector:type_name -> storage.CVSSV3.AttackVector
-	14, // 56: storage.CVSSV3.attack_complexity:type_name -> storage.CVSSV3.Complexity
-	15, // 57: storage.CVSSV3.privileges_required:type_name -> storage.CVSSV3.Privileges
-	16, // 58: storage.CVSSV3.user_interaction:type_name -> storage.CVSSV3.UserInteraction
-	17, // 59: storage.CVSSV3.scope:type_name -> storage.CVSSV3.Scope
-	12, // 60: storage.CVSSV3.confidentiality:type_name -> storage.CVSSV3.Impact
-	12, // 61: storage.CVSSV3.integrity:type_name -> storage.CVSSV3.Impact
-	12, // 62: storage.CVSSV3.availability:type_name -> storage.CVSSV3.Impact
-	18, // 63: storage.CVSSV3.severity:type_name -> storage.CVSSV3.Severity
-	35, // 64: storage.ImageCVEInfo.fix_available_timestamp:type_name -> google.protobuf.Timestamp
-	35, // 65: storage.ImageCVEInfo.first_system_occurrence:type_name -> google.protobuf.Timestamp
-	1,  // 66: storage.CVE.DistroSpecific.severity:type_name -> storage.VulnerabilitySeverity
-	5,  // 67: storage.CVE.DistroSpecific.score_version:type_name -> storage.CVE.ScoreVersion
-	28, // 68: storage.CVE.DistroSpecific.cvss_v2:type_name -> storage.CVSSV2
-	29, // 69: storage.CVE.DistroSpecific.cvss_v3:type_name -> storage.CVSSV3
-	31, // 70: storage.CVE.DistroSpecificsEntry.value:type_name -> storage.CVE.DistroSpecific
-	71, // [71:71] is the sub-list for method output_type
-	71, // [71:71] is the sub-list for method input_type
-	71, // [71:71] is the sub-list for extension type_name
-	71, // [71:71] is the sub-list for extension extendee
-	0,  // [0:71] is the sub-list for field type_name
+	20, // 22: storage.CVEInfo.exploit:type_name -> storage.Exploit
+	22, // 23: storage.ImageCVE.cve_base_info:type_name -> storage.CVEInfo
+	1,  // 24: storage.ImageCVE.severity:type_name -> storage.VulnerabilitySeverity
+	36, // 25: storage.ImageCVE.snooze_start:type_name -> google.protobuf.Timestamp
+	36, // 26: storage.ImageCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
+	28, // 27: storage.ImageCVE.cvss_metrics:type_name -> storage.CVSSScore
+	3,  // 28: storage.ImageCVE.nvd_score_version:type_name -> storage.CvssScoreVersion
+	22, // 29: storage.ImageCVEV2.cve_base_info:type_name -> storage.CVEInfo
+	1,  // 30: storage.ImageCVEV2.severity:type_name -> storage.VulnerabilitySeverity
+	3,  // 31: storage.ImageCVEV2.nvd_score_version:type_name -> storage.CvssScoreVersion
+	36, // 32: storage.ImageCVEV2.first_image_occurrence:type_name -> google.protobuf.Timestamp
+	0,  // 33: storage.ImageCVEV2.state:type_name -> storage.VulnerabilityState
+	23, // 34: storage.ImageCVEV2.advisory:type_name -> storage.Advisory
+	36, // 35: storage.ImageCVEV2.fix_available_timestamp:type_name -> google.protobuf.Timestamp
+	22, // 36: storage.NodeCVE.cve_base_info:type_name -> storage.CVEInfo
+	1,  // 37: storage.NodeCVE.severity:type_name -> storage.VulnerabilitySeverity
+	36, // 38: storage.NodeCVE.snooze_start:type_name -> google.protobuf.Timestamp
+	36, // 39: storage.NodeCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
+	36, // 40: storage.NodeCVE.orphaned_time:type_name -> google.protobuf.Timestamp
+	22, // 41: storage.ClusterCVE.cve_base_info:type_name -> storage.CVEInfo
+	1,  // 42: storage.ClusterCVE.severity:type_name -> storage.VulnerabilitySeverity
+	36, // 43: storage.ClusterCVE.snooze_start:type_name -> google.protobuf.Timestamp
+	36, // 44: storage.ClusterCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
+	4,  // 45: storage.ClusterCVE.type:type_name -> storage.CVE.CVEType
+	2,  // 46: storage.CVSSScore.source:type_name -> storage.Source
+	29, // 47: storage.CVSSScore.cvssv2:type_name -> storage.CVSSV2
+	30, // 48: storage.CVSSScore.cvssv3:type_name -> storage.CVSSV3
+	8,  // 49: storage.CVSSV2.attack_vector:type_name -> storage.CVSSV2.AttackVector
+	9,  // 50: storage.CVSSV2.access_complexity:type_name -> storage.CVSSV2.AccessComplexity
+	10, // 51: storage.CVSSV2.authentication:type_name -> storage.CVSSV2.Authentication
+	7,  // 52: storage.CVSSV2.confidentiality:type_name -> storage.CVSSV2.Impact
+	7,  // 53: storage.CVSSV2.integrity:type_name -> storage.CVSSV2.Impact
+	7,  // 54: storage.CVSSV2.availability:type_name -> storage.CVSSV2.Impact
+	11, // 55: storage.CVSSV2.severity:type_name -> storage.CVSSV2.Severity
+	13, // 56: storage.CVSSV3.attack_vector:type_name -> storage.CVSSV3.AttackVector
+	14, // 57: storage.CVSSV3.attack_complexity:type_name -> storage.CVSSV3.Complexity
+	15, // 58: storage.CVSSV3.privileges_required:type_name -> storage.CVSSV3.Privileges
+	16, // 59: storage.CVSSV3.user_interaction:type_name -> storage.CVSSV3.UserInteraction
+	17, // 60: storage.CVSSV3.scope:type_name -> storage.CVSSV3.Scope
+	12, // 61: storage.CVSSV3.confidentiality:type_name -> storage.CVSSV3.Impact
+	12, // 62: storage.CVSSV3.integrity:type_name -> storage.CVSSV3.Impact
+	12, // 63: storage.CVSSV3.availability:type_name -> storage.CVSSV3.Impact
+	18, // 64: storage.CVSSV3.severity:type_name -> storage.CVSSV3.Severity
+	36, // 65: storage.ImageCVEInfo.fix_available_timestamp:type_name -> google.protobuf.Timestamp
+	36, // 66: storage.ImageCVEInfo.first_system_occurrence:type_name -> google.protobuf.Timestamp
+	1,  // 67: storage.CVE.DistroSpecific.severity:type_name -> storage.VulnerabilitySeverity
+	5,  // 68: storage.CVE.DistroSpecific.score_version:type_name -> storage.CVE.ScoreVersion
+	29, // 69: storage.CVE.DistroSpecific.cvss_v2:type_name -> storage.CVSSV2
+	30, // 70: storage.CVE.DistroSpecific.cvss_v3:type_name -> storage.CVSSV3
+	32, // 71: storage.CVE.DistroSpecificsEntry.value:type_name -> storage.CVE.DistroSpecific
+	72, // [72:72] is the sub-list for method output_type
+	72, // [72:72] is the sub-list for method input_type
+	72, // [72:72] is the sub-list for extension type_name
+	72, // [72:72] is the sub-list for extension extendee
+	0,  // [0:72] is the sub-list for field type_name
 }
 
 func init() { file_storage_cve_proto_init() }
@@ -3009,10 +3104,10 @@ func file_storage_cve_proto_init() {
 	if File_storage_cve_proto != nil {
 		return
 	}
-	file_storage_cve_proto_msgTypes[5].OneofWrappers = []any{
+	file_storage_cve_proto_msgTypes[6].OneofWrappers = []any{
 		(*ImageCVEV2_FixedBy)(nil),
 	}
-	file_storage_cve_proto_msgTypes[8].OneofWrappers = []any{
+	file_storage_cve_proto_msgTypes[9].OneofWrappers = []any{
 		(*CVSSScore_Cvssv2)(nil),
 		(*CVSSScore_Cvssv3)(nil),
 	}
@@ -3022,7 +3117,7 @@ func file_storage_cve_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_cve_proto_rawDesc), len(file_storage_cve_proto_rawDesc)),
 			NumEnums:      19,
-			NumMessages:   16,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/storage/cve.pb.go
+++ b/generated/storage/cve.pb.go
@@ -1323,6 +1323,7 @@ type CVEInfo struct {
 	CvssMetrics   []*CVSSScore `protobuf:"bytes,11,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
 	Epss          *EPSS        `protobuf:"bytes,12,opt,name=epss,proto3" json:"epss,omitempty"`
 	Exploit       *Exploit     `protobuf:"bytes,13,opt,name=exploit,proto3" json:"exploit,omitempty"`
+	CisaKev       bool         `protobuf:"varint,14,opt,name=cisa_kev,json=cisaKev,proto3" json:"cisa_kev,omitempty" search:"CISA KEV"` // @gotags: search:"CISA KEV"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1446,6 +1447,13 @@ func (x *CVEInfo) GetExploit() *Exploit {
 		return x.Exploit
 	}
 	return nil
+}
+
+func (x *CVEInfo) GetCisaKev() bool {
+	if x != nil {
+		return x.CisaKev
+	}
+	return false
 }
 
 type Advisory struct {
@@ -2756,7 +2764,7 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\fScoreVersion\x12\x06\n" +
 	"\x02V2\x10\x00\x12\x06\n" +
 	"\x02V3\x10\x01\x12\v\n" +
-	"\aUNKNOWN\x10\x02J\x04\b\x16\x10\x17J\x04\b\x15\x10\x16\"\xbe\x05\n" +
+	"\aUNKNOWN\x10\x02J\x04\b\x16\x10\x17J\x04\b\x15\x10\x16\"\xd9\x05\n" +
 	"\aCVEInfo\x12\x10\n" +
 	"\x03cve\x18\x01 \x01(\tR\x03cve\x12\x18\n" +
 	"\asummary\x18\x02 \x01(\tR\asummary\x12\x12\n" +
@@ -2774,7 +2782,8 @@ const file_storage_cve_proto_rawDesc = "" +
 	"references\x125\n" +
 	"\fcvss_metrics\x18\v \x03(\v2\x12.storage.CVSSScoreR\vcvssMetrics\x12!\n" +
 	"\x04epss\x18\f \x01(\v2\r.storage.EPSSR\x04epss\x12*\n" +
-	"\aexploit\x18\r \x01(\v2\x10.storage.ExploitR\aexploit\x1a1\n" +
+	"\aexploit\x18\r \x01(\v2\x10.storage.ExploitR\aexploit\x12\x19\n" +
+	"\bcisa_kev\x18\x0e \x01(\bR\acisaKev\x1a1\n" +
 	"\tReference\x12\x10\n" +
 	"\x03URI\x18\x01 \x01(\tR\x03URI\x12\x12\n" +
 	"\x04tags\x18\x02 \x03(\tR\x04tags\"+\n" +

--- a/generated/storage/cve_vtproto.pb.go
+++ b/generated/storage/cve_vtproto.pb.go
@@ -195,6 +195,7 @@ func (m *CVEInfo) CloneVT() *CVEInfo {
 	r.CvssV3 = m.CvssV3.CloneVT()
 	r.Epss = m.Epss.CloneVT()
 	r.Exploit = m.Exploit.CloneVT()
+	r.CisaKev = m.CisaKev
 	if rhs := m.References; rhs != nil {
 		tmpContainer := make([]*CVEInfo_Reference, len(rhs))
 		for k, v := range rhs {
@@ -806,6 +807,9 @@ func (this *CVEInfo) EqualVT(that *CVEInfo) bool {
 		return false
 	}
 	if !this.Exploit.EqualVT(that.Exploit) {
+		return false
+	}
+	if this.CisaKev != that.CisaKev {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1842,6 +1846,16 @@ func (m *CVEInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.CisaKev {
+		i--
+		if m.CisaKev {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x70
 	}
 	if m.Exploit != nil {
 		size, err := m.Exploit.MarshalToSizedBufferVT(dAtA[:i])
@@ -3174,6 +3188,9 @@ func (m *CVEInfo) SizeVT() (n int) {
 	if m.Exploit != nil {
 		l = m.Exploit.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CisaKev {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5469,6 +5486,26 @@ func (m *CVEInfo) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 14:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CisaKev", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.CisaKev = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -9913,6 +9950,26 @@ func (m *CVEInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 14:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CisaKev", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.CisaKev = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/storage/cve_vtproto.pb.go
+++ b/generated/storage/cve_vtproto.pb.go
@@ -42,6 +42,27 @@ func (m *EPSS) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *Exploit) CloneVT() *Exploit {
+	if m == nil {
+		return (*Exploit)(nil)
+	}
+	r := new(Exploit)
+	r.DateAdded = m.DateAdded
+	r.ShortDescription = m.ShortDescription
+	r.RequiredAction = m.RequiredAction
+	r.DueDate = m.DueDate
+	r.KnownRansomwareCampaignUse = m.KnownRansomwareCampaignUse
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *Exploit) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *CVE_DistroSpecific) CloneVT() *CVE_DistroSpecific {
 	if m == nil {
 		return (*CVE_DistroSpecific)(nil)
@@ -173,6 +194,7 @@ func (m *CVEInfo) CloneVT() *CVEInfo {
 	r.CvssV2 = m.CvssV2.CloneVT()
 	r.CvssV3 = m.CvssV3.CloneVT()
 	r.Epss = m.Epss.CloneVT()
+	r.Exploit = m.Exploit.CloneVT()
 	if rhs := m.References; rhs != nil {
 		tmpContainer := make([]*CVEInfo_Reference, len(rhs))
 		for k, v := range rhs {
@@ -485,6 +507,37 @@ func (this *EPSS) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (this *Exploit) EqualVT(that *Exploit) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.DateAdded != that.DateAdded {
+		return false
+	}
+	if this.ShortDescription != that.ShortDescription {
+		return false
+	}
+	if this.RequiredAction != that.RequiredAction {
+		return false
+	}
+	if this.DueDate != that.DueDate {
+		return false
+	}
+	if this.KnownRansomwareCampaignUse != that.KnownRansomwareCampaignUse {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *Exploit) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*Exploit)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *CVE_DistroSpecific) EqualVT(that *CVE_DistroSpecific) bool {
 	if this == that {
 		return true
@@ -750,6 +803,9 @@ func (this *CVEInfo) EqualVT(that *CVEInfo) bool {
 		}
 	}
 	if !this.Epss.EqualVT(that.Epss) {
+		return false
+	}
+	if !this.Exploit.EqualVT(that.Exploit) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1296,6 +1352,74 @@ func (m *EPSS) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Exploit) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Exploit) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *Exploit) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.KnownRansomwareCampaignUse) > 0 {
+		i -= len(m.KnownRansomwareCampaignUse)
+		copy(dAtA[i:], m.KnownRansomwareCampaignUse)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.KnownRansomwareCampaignUse)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.DueDate) > 0 {
+		i -= len(m.DueDate)
+		copy(dAtA[i:], m.DueDate)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DueDate)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RequiredAction) > 0 {
+		i -= len(m.RequiredAction)
+		copy(dAtA[i:], m.RequiredAction)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RequiredAction)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.ShortDescription) > 0 {
+		i -= len(m.ShortDescription)
+		copy(dAtA[i:], m.ShortDescription)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ShortDescription)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.DateAdded) > 0 {
+		i -= len(m.DateAdded)
+		copy(dAtA[i:], m.DateAdded)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DateAdded)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *CVE_DistroSpecific) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1718,6 +1842,16 @@ func (m *CVEInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Exploit != nil {
+		size, err := m.Exploit.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x6a
 	}
 	if m.Epss != nil {
 		size, err := m.Epss.MarshalToSizedBufferVT(dAtA[:i])
@@ -2789,6 +2923,36 @@ func (m *EPSS) SizeVT() (n int) {
 	return n
 }
 
+func (m *Exploit) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DateAdded)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ShortDescription)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.RequiredAction)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DueDate)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.KnownRansomwareCampaignUse)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *CVE_DistroSpecific) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -3005,6 +3169,10 @@ func (m *CVEInfo) SizeVT() (n int) {
 	}
 	if m.Epss != nil {
 		l = m.Epss.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Exploit != nil {
+		l = m.Exploit.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -3472,6 +3640,217 @@ func (m *EPSS) UnmarshalVT(dAtA []byte) error {
 			v = uint32(binary.LittleEndian.Uint32(dAtA[iNdEx:]))
 			iNdEx += 4
 			m.EpssPercentile = float32(math.Float32frombits(v))
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Exploit) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Exploit: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Exploit: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DateAdded", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DateAdded = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShortDescription", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ShortDescription = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredAction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RequiredAction = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DueDate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DueDate = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownRansomwareCampaignUse", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KnownRansomwareCampaignUse = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5051,6 +5430,42 @@ func (m *CVEInfo) UnmarshalVT(dAtA []byte) error {
 				m.Epss = &EPSS{}
 			}
 			if err := m.Epss.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &Exploit{}
+			}
+			if err := m.Exploit.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -7627,6 +8042,237 @@ func (m *EPSS) UnmarshalVTUnsafe(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *Exploit) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Exploit: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Exploit: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DateAdded", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DateAdded = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ShortDescription", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ShortDescription = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequiredAction", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.RequiredAction = stringValue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DueDate", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DueDate = stringValue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KnownRansomwareCampaignUse", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.KnownRansomwareCampaignUse = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *CVE_DistroSpecific) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -9228,6 +9874,42 @@ func (m *CVEInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.Epss = &EPSS{}
 			}
 			if err := m.Epss.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &Exploit{}
+			}
+			if err := m.Exploit.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/generated/storage/vulnerability.pb.go
+++ b/generated/storage/vulnerability.pb.go
@@ -168,7 +168,7 @@ type EmbeddedVulnerability struct {
 	// datasource is for internal use only
 	Datasource    string   `protobuf:"bytes,26,opt,name=datasource,proto3" json:"-" hash:"ignore"` // @gotags: json:"-" hash:"ignore"
 	Exploit       *Exploit `protobuf:"bytes,27,opt,name=exploit,proto3" json:"exploit,omitempty"`
-	CisaKev       bool     `protobuf:"varint,28,opt,name=cisa_kev,json=cisaKev,proto3" json:"cisa_kev,omitempty" search:"CISA KEV"` // @gotags: search:"CISA KEV"
+	CisaKev       bool     `protobuf:"varint,28,opt,name=cisa_kev,json=cisaKev,proto3" json:"cisa_kev,omitempty" policy:"CISA KEV"` // @gotags: policy:"CISA KEV"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/generated/storage/vulnerability.pb.go
+++ b/generated/storage/vulnerability.pb.go
@@ -127,7 +127,7 @@ func (EmbeddedVulnerability_VulnerabilityType) EnumDescriptor() ([]byte, []int) 
 	return file_storage_vulnerability_proto_rawDescGZIP(), []int{0, 1}
 }
 
-// Next Tag: 27
+// Next Tag: 29
 type EmbeddedVulnerability struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Cve      string                 `protobuf:"bytes,1,opt,name=cve,proto3" json:"cve,omitempty" search:"CVE"` // @gotags: search:"CVE"
@@ -166,7 +166,9 @@ type EmbeddedVulnerability struct {
 	NvdCvss     float32      `protobuf:"fixed32,22,opt,name=nvd_cvss,json=nvdCvss,proto3" json:"nvd_cvss,omitempty" search:"NVD CVSS"` // @gotags: search:"NVD CVSS"
 	Epss        *EPSS        `protobuf:"bytes,23,opt,name=epss,proto3" json:"epss,omitempty"`
 	// datasource is for internal use only
-	Datasource    string `protobuf:"bytes,26,opt,name=datasource,proto3" json:"-" hash:"ignore"` // @gotags: json:"-" hash:"ignore"
+	Datasource    string   `protobuf:"bytes,26,opt,name=datasource,proto3" json:"-" hash:"ignore"` // @gotags: json:"-" hash:"ignore"
+	Exploit       *Exploit `protobuf:"bytes,27,opt,name=exploit,proto3" json:"exploit,omitempty"`
+	CisaKev       bool     `protobuf:"varint,28,opt,name=cisa_kev,json=cisaKev,proto3" json:"cisa_kev,omitempty" search:"CISA KEV"` // @gotags: search:"CISA KEV"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -385,6 +387,20 @@ func (x *EmbeddedVulnerability) GetDatasource() string {
 	return ""
 }
 
+func (x *EmbeddedVulnerability) GetExploit() *Exploit {
+	if x != nil {
+		return x.Exploit
+	}
+	return nil
+}
+
+func (x *EmbeddedVulnerability) GetCisaKev() bool {
+	if x != nil {
+		return x.CisaKev
+	}
+	return false
+}
+
 type isEmbeddedVulnerability_SetFixedBy interface {
 	isEmbeddedVulnerability_SetFixedBy()
 }
@@ -513,7 +529,7 @@ var File_storage_vulnerability_proto protoreflect.FileDescriptor
 
 const file_storage_vulnerability_proto_rawDesc = "" +
 	"\n" +
-	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xb6\f\n" +
+	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xfd\f\n" +
 	"\x15EmbeddedVulnerability\x12\x10\n" +
 	"\x03cve\x18\x01 \x01(\tR\x03cve\x12-\n" +
 	"\badvisory\x18\x18 \x01(\v2\x11.storage.AdvisoryR\badvisory\x12\x12\n" +
@@ -544,7 +560,9 @@ const file_storage_vulnerability_proto_rawDesc = "" +
 	"\x04epss\x18\x17 \x01(\v2\r.storage.EPSSR\x04epss\x12\x1e\n" +
 	"\n" +
 	"datasource\x18\x1a \x01(\tR\n" +
-	"datasource\"\x1e\n" +
+	"datasource\x12*\n" +
+	"\aexploit\x18\x1b \x01(\v2\x10.storage.ExploitR\aexploit\x12\x19\n" +
+	"\bcisa_kev\x18\x1c \x01(\bR\acisaKev\"\x1e\n" +
 	"\fScoreVersion\x12\x06\n" +
 	"\x02V2\x10\x00\x12\x06\n" +
 	"\x02V3\x10\x01\"\xac\x01\n" +
@@ -594,7 +612,8 @@ var file_storage_vulnerability_proto_goTypes = []any{
 	(VulnerabilityState)(0),                      // 9: storage.VulnerabilityState
 	(*CVSSScore)(nil),                            // 10: storage.CVSSScore
 	(*EPSS)(nil),                                 // 11: storage.EPSS
-	(*CVEInfo)(nil),                              // 12: storage.CVEInfo
+	(*Exploit)(nil),                              // 12: storage.Exploit
+	(*CVEInfo)(nil),                              // 13: storage.CVEInfo
 }
 var file_storage_vulnerability_proto_depIdxs = []int32{
 	4,  // 0: storage.EmbeddedVulnerability.advisory:type_name -> storage.Advisory
@@ -614,15 +633,16 @@ var file_storage_vulnerability_proto_depIdxs = []int32{
 	9,  // 14: storage.EmbeddedVulnerability.state:type_name -> storage.VulnerabilityState
 	10, // 15: storage.EmbeddedVulnerability.cvss_metrics:type_name -> storage.CVSSScore
 	11, // 16: storage.EmbeddedVulnerability.epss:type_name -> storage.EPSS
-	12, // 17: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
-	8,  // 18: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
-	7,  // 19: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
-	7,  // 20: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	12, // 17: storage.EmbeddedVulnerability.exploit:type_name -> storage.Exploit
+	13, // 18: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
+	8,  // 19: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
+	7,  // 20: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
+	7,  // 21: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
+	22, // [22:22] is the sub-list for method output_type
+	22, // [22:22] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_storage_vulnerability_proto_init() }

--- a/generated/storage/vulnerability_vtproto.pb.go
+++ b/generated/storage/vulnerability_vtproto.pb.go
@@ -51,6 +51,8 @@ func (m *EmbeddedVulnerability) CloneVT() *EmbeddedVulnerability {
 	r.NvdCvss = m.NvdCvss
 	r.Epss = m.Epss.CloneVT()
 	r.Datasource = m.Datasource
+	r.Exploit = m.Exploit.CloneVT()
+	r.CisaKev = m.CisaKev
 	if m.SetFixedBy != nil {
 		r.SetFixedBy = m.SetFixedBy.(interface {
 			CloneVT() isEmbeddedVulnerability_SetFixedBy
@@ -234,6 +236,12 @@ func (this *EmbeddedVulnerability) EqualVT(that *EmbeddedVulnerability) bool {
 	if this.Datasource != that.Datasource {
 		return false
 	}
+	if !this.Exploit.EqualVT(that.Exploit) {
+		return false
+	}
+	if this.CisaKev != that.CisaKev {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -362,6 +370,30 @@ func (m *EmbeddedVulnerability) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 			return 0, err
 		}
 		i -= size
+	}
+	if m.CisaKev {
+		i--
+		if m.CisaKev {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.Exploit != nil {
+		size, err := m.Exploit.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
 	}
 	if len(m.Datasource) > 0 {
 		i -= len(m.Datasource)
@@ -822,6 +854,13 @@ func (m *EmbeddedVulnerability) SizeVT() (n int) {
 	l = len(m.Datasource)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Exploit != nil {
+		l = m.Exploit.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CisaKev {
+		n += 3
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1687,6 +1726,62 @@ func (m *EmbeddedVulnerability) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Datasource = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 27:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &Exploit{}
+			}
+			if err := m.Exploit.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 28:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CisaKev", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.CisaKev = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2776,6 +2871,62 @@ func (m *EmbeddedVulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.Datasource = stringValue
 			iNdEx = postIndex
+		case 27:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exploit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Exploit == nil {
+				m.Exploit = &Exploit{}
+			}
+			if err := m.Exploit.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 28:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CisaKev", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.CisaKev = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/nodes/converter/convert_utils_test.go
+++ b/pkg/nodes/converter/convert_utils_test.go
@@ -21,6 +21,7 @@ func TestNodeVulnConv(t *testing.T) {
 	nodeVuln.CveBaseInfo.References = nil
 	nodeVuln.CveBaseInfo.CvssMetrics = nil
 	nodeVuln.CveBaseInfo.Epss = nil
+	nodeVuln.CveBaseInfo.Exploit = nil
 	embedvuln := EmbeddedVulnerabilityToNodeVulnerability(vuln)
 	protoassert.Equal(t, nodeVuln, embedvuln)
 }

--- a/pkg/nodes/converter/convert_utils_test.go
+++ b/pkg/nodes/converter/convert_utils_test.go
@@ -22,6 +22,7 @@ func TestNodeVulnConv(t *testing.T) {
 	nodeVuln.CveBaseInfo.CvssMetrics = nil
 	nodeVuln.CveBaseInfo.Epss = nil
 	nodeVuln.CveBaseInfo.Exploit = nil
+	nodeVuln.CveBaseInfo.CisaKev = false
 	embedvuln := EmbeddedVulnerabilityToNodeVulnerability(vuln)
 	protoassert.Equal(t, nodeVuln, embedvuln)
 }

--- a/pkg/postgres/schema/cluster_cves.go
+++ b/pkg/postgres/schema/cluster_cves.go
@@ -57,6 +57,7 @@ type ClusterCves struct {
 	CveBaseInfoPublishedOn         *time.Time                    `gorm:"column:cvebaseinfo_publishedon;type:timestamp"`
 	CveBaseInfoCreatedAt           *time.Time                    `gorm:"column:cvebaseinfo_createdat;type:timestamp"`
 	CveBaseInfoEpssEpssProbability float32                       `gorm:"column:cvebaseinfo_epss_epssprobability;type:numeric"`
+	CveBaseInfoCisaKev             bool                          `gorm:"column:cvebaseinfo_cisakev;type:bool"`
 	Cvss                           float32                       `gorm:"column:cvss;type:numeric"`
 	Severity                       storage.VulnerabilitySeverity `gorm:"column:severity;type:integer"`
 	ImpactScore                    float32                       `gorm:"column:impactscore;type:numeric"`

--- a/pkg/postgres/schema/image_cves_v2.go
+++ b/pkg/postgres/schema/image_cves_v2.go
@@ -77,6 +77,7 @@ type ImageCvesV2 struct {
 	CveBaseInfoPublishedOn         *time.Time                    `gorm:"column:cvebaseinfo_publishedon;type:timestamp"`
 	CveBaseInfoCreatedAt           *time.Time                    `gorm:"column:cvebaseinfo_createdat;type:timestamp"`
 	CveBaseInfoEpssEpssProbability float32                       `gorm:"column:cvebaseinfo_epss_epssprobability;type:numeric"`
+	CveBaseInfoCisaKev             bool                          `gorm:"column:cvebaseinfo_cisakev;type:bool"`
 	Cvss                           float32                       `gorm:"column:cvss;type:numeric"`
 	Severity                       storage.VulnerabilitySeverity `gorm:"column:severity;type:integer"`
 	ImpactScore                    float32                       `gorm:"column:impactscore;type:numeric"`

--- a/pkg/postgres/schema/node_cves.go
+++ b/pkg/postgres/schema/node_cves.go
@@ -60,6 +60,7 @@ type NodeCves struct {
 	CveBaseInfoPublishedOn         *time.Time                    `gorm:"column:cvebaseinfo_publishedon;type:timestamp"`
 	CveBaseInfoCreatedAt           *time.Time                    `gorm:"column:cvebaseinfo_createdat;type:timestamp"`
 	CveBaseInfoEpssEpssProbability float32                       `gorm:"column:cvebaseinfo_epss_epssprobability;type:numeric"`
+	CveBaseInfoCisaKev             bool                          `gorm:"column:cvebaseinfo_cisakev;type:bool"`
 	OperatingSystem                string                        `gorm:"column:operatingsystem;type:varchar"`
 	Cvss                           float32                       `gorm:"column:cvss;type:numeric"`
 	Severity                       storage.VulnerabilitySeverity `gorm:"column:severity;type:integer"`

--- a/pkg/postgres/schema/virtual_machine_cvev2.go
+++ b/pkg/postgres/schema/virtual_machine_cvev2.go
@@ -75,6 +75,7 @@ type VirtualMachineCvev2 struct {
 	CveBaseInfoPublishedOn         *time.Time                    `gorm:"column:cvebaseinfo_publishedon;type:timestamp"`
 	CveBaseInfoCreatedAt           *time.Time                    `gorm:"column:cvebaseinfo_createdat;type:timestamp"`
 	CveBaseInfoEpssEpssProbability float32                       `gorm:"column:cvebaseinfo_epss_epssprobability;type:numeric"`
+	CveBaseInfoCisaKev             bool                          `gorm:"column:cvebaseinfo_cisakev;type:bool"`
 	PreferredCvss                  float32                       `gorm:"column:preferredcvss;type:numeric"`
 	Severity                       storage.VulnerabilitySeverity `gorm:"column:severity;type:integer"`
 	ImpactScore                    float32                       `gorm:"column:impactscore;type:numeric"`

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -69,6 +69,7 @@ var (
 	EPSSProbablity     = newFieldLabel("EPSS Probability")
 	AdvisoryName       = newFieldLabel("Advisory Name")
 	AdvisoryLink       = newFieldLabel("Advisory Link")
+	CisaKev            = newFieldLabel("CISA KEV")
 
 	CVEInfo = newFieldLabel("CVE Info")
 

--- a/proto/storage/cve.proto
+++ b/proto/storage/cve.proto
@@ -42,6 +42,15 @@ message EPSS {
   float epss_percentile = 2;
 }
 
+// Exploit stores CISA Known Exploited Vulnerabilities (KEV) catalog data.
+message Exploit {
+  string date_added = 1;
+  string short_description = 2;
+  string required_action = 3;
+  string due_date = 4;
+  string known_ransomware_campaign_use = 5;
+}
+
 // ******************************
 // This proto is deprecated.
 // ******************************
@@ -140,6 +149,7 @@ message CVEInfo {
   // cvss_metrics stores list of cvss scores from different sources like nvd, Redhat etc
   repeated CVSSScore cvss_metrics = 11;
   EPSS epss = 12;
+  Exploit exploit = 13;
 }
 
 message Advisory {

--- a/proto/storage/cve.proto
+++ b/proto/storage/cve.proto
@@ -150,6 +150,7 @@ message CVEInfo {
   repeated CVSSScore cvss_metrics = 11;
   EPSS epss = 12;
   Exploit exploit = 13;
+  bool cisa_kev = 14; // @gotags: search:"CISA KEV"
 }
 
 message Advisory {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -6331,6 +6331,36 @@
             ]
           },
           {
+            "name": "Exploit",
+            "fields": [
+              {
+                "id": 1,
+                "name": "date_added",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "short_description",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "required_action",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "due_date",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "known_ransomware_campaign_use",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "CVE",
             "fields": [
               {
@@ -6553,6 +6583,11 @@
                 "id": 12,
                 "name": "epss",
                 "type": "EPSS"
+              },
+              {
+                "id": 13,
+                "name": "exploit",
+                "type": "Exploit"
               }
             ],
             "messages": [
@@ -20801,6 +20836,16 @@
                 "id": 26,
                 "name": "datasource",
                 "type": "string"
+              },
+              {
+                "id": 27,
+                "name": "exploit",
+                "type": "Exploit"
+              },
+              {
+                "id": 28,
+                "name": "cisa_kev",
+                "type": "bool"
               }
             ],
             "reserved_ids": [

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -6588,6 +6588,11 @@
                 "id": 13,
                 "name": "exploit",
                 "type": "Exploit"
+              },
+              {
+                "id": 14,
+                "name": "cisa_kev",
+                "type": "bool"
               }
             ],
             "messages": [

--- a/proto/storage/vulnerability.proto
+++ b/proto/storage/vulnerability.proto
@@ -65,7 +65,7 @@ message EmbeddedVulnerability {
   // datasource is for internal use only
   string datasource = 26; // @gotags: json:"-" hash:"ignore"
   Exploit exploit = 27;
-  bool cisa_kev = 28; // @gotags: search:"CISA KEV"
+  bool cisa_kev = 28; // @gotags: policy:"CISA KEV"
 }
 
 message NodeVulnerability {

--- a/proto/storage/vulnerability.proto
+++ b/proto/storage/vulnerability.proto
@@ -8,7 +8,7 @@ import "storage/cve.proto";
 option go_package = "./storage;storage";
 option java_package = "io.stackrox.proto.storage";
 
-// Next Tag: 27
+// Next Tag: 29
 message EmbeddedVulnerability {
   // ScoreVersion can be deprecated ROX-26066
   enum ScoreVersion {
@@ -64,6 +64,8 @@ message EmbeddedVulnerability {
   EPSS epss = 23;
   // datasource is for internal use only
   string datasource = 26; // @gotags: json:"-" hash:"ignore"
+  Exploit exploit = 27;
+  bool cisa_kev = 28; // @gotags: search:"CISA KEV"
 }
 
 message NodeVulnerability {


### PR DESCRIPTION
## Description

Add storage proto infrastructure for CISA KEV (Known Exploited Vulnerabilities) support. This is PR 1/3 in a stack.

- Add `storage.Exploit` message to `cve.proto` with KEV catalog fields (date_added, short_description, required_action, due_date, known_ransomware_campaign_use)
- Add `exploit` field to `CVEInfo` message
- Add `exploit` and `cisa_kev` (boolean search field) to `EmbeddedVulnerability`
- Add `CISAExploit` message to scanner V4 vulnerability report proto (matching PR #21595)
- Regenerate all proto-generated code

Follows the EPSS enrichment pattern. Gated behind the existing `ROX_CISA_KEV` feature flag.

**Stack:** 1/3 — Proto changes → [Converter wiring] → [Reporting + GraphQL]

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Proto-only changes; no new logic to unit test. Code generation verified by compilation.

### How I validated my change

- `go build ./generated/storage/... ./central/graphql/resolvers/...` compiles clean
- Proto field tag numbers verified (no conflicts with existing fields)