### PR TITLE
ROX-35642: Migrate complianceoperator sync-finished to PubSub

### DIFF
--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,26 +19,28 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	ComplianceOperatorUpdaterSyncFinishedConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:                            "NoConsumers",
-		DefaultConsumer:                        "Default",
-		ResolverConsumer:                       "Resolver",
-		EnrichedProcessConsumer:                "EnrichedProcess",
-		FileActivityEnrichedProcessConsumer:    "FileActivityEnrichedProcess",
-		UnenrichedProcessConsumer:              "UnenrichedProcess",
-		DetectorProcessIndicatorConsumer:       "DetectorProcessIndicator",
-		DetectorNetworkFlowConsumer:            "DetectorNetworkFlow",
-		DetectorFileAccessConsumer:             "DetectorFileAccess",
-		DetectorAuditLogConsumer:               "DetectorAuditLog",
-		DetectorDeploymentConsumer:             "DetectorDeployment",
-		DetectorScanResultConsumer:             "DetectorScanResult",
-		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
-		OutputQueueConsumer:                    "OutputQueue",
-		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
-		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		NoConsumers:                                   "NoConsumers",
+		DefaultConsumer:                               "Default",
+		ResolverConsumer:                              "Resolver",
+		EnrichedProcessConsumer:                       "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer:           "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:                     "UnenrichedProcess",
+		DetectorProcessIndicatorConsumer:              "DetectorProcessIndicator",
+		DetectorNetworkFlowConsumer:                   "DetectorNetworkFlow",
+		DetectorFileAccessConsumer:                    "DetectorFileAccess",
+		DetectorAuditLogConsumer:                      "DetectorAuditLog",
+		DetectorDeploymentConsumer:                    "DetectorDeployment",
+		DetectorScanResultConsumer:                    "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:             "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                           "OutputQueue",
+		NetworkFlowManagerResourceSyncConsumer:        "NetworkFlowManagerResourceSync",
+		SensorSoftRestartConsumer:                     "SensorSoftRestart",
+		ComplianceOperatorUpdaterSyncFinishedConsumer: "ComplianceOperatorUpdaterSyncFinished",
 	}
 )
 

--- a/sensor/kubernetes/complianceoperator/updater.go
+++ b/sensor/kubernetes/complianceoperator/updater.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/complianceoperator"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/k8sintrospect"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protoutils"
@@ -17,7 +18,9 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 	"github.com/stackrox/rox/sensor/kubernetes/telemetry"
 	"github.com/stackrox/rox/sensor/utils"
@@ -86,7 +89,7 @@ func (u *updaterImpl) registerDiagnosticComplianceOperatorObjects(info *central.
 }
 
 // NewInfoUpdater return a sensor component that periodically collect information about the compliance operator.
-func NewInfoUpdater(client kubernetes.Interface, updateInterval time.Duration, readySignal *concurrency.Signal) InfoUpdater {
+func NewInfoUpdater(client kubernetes.Interface, updateInterval time.Duration, readySignal *concurrency.Signal, pubSubDispatcher common.PubSubDispatcher) InfoUpdater {
 	if updateInterval == 0 {
 		updateInterval = defaultInterval
 	}
@@ -102,6 +105,7 @@ func NewInfoUpdater(client kubernetes.Interface, updateInterval time.Duration, r
 		updateTicker:         updateTicker,
 		complianceOperatorNS: "openshift-compliance",
 		isReady:              readySignal,
+		pubSubDispatcher:     pubSubDispatcher,
 	}
 }
 
@@ -114,13 +118,28 @@ type updaterImpl struct {
 	stopSig              concurrency.Signal
 	complianceOperatorNS string
 	isReady              *concurrency.Signal
+	pubSubDispatcher     common.PubSubDispatcher
 }
 
 func (u *updaterImpl) Name() string {
 	return "complianceoperator.updaterImpl"
 }
 
+func (u *updaterImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && u.pubSubDispatcher != nil
+}
+
 func (u *updaterImpl) Start() error {
+	if u.pubSubEnabled() {
+		if err := u.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceOperatorUpdaterSyncFinishedConsumer,
+			pubsub.SyncFinishedTopic,
+			pubsub.SyncFinishedLane,
+			u.handleSyncFinishedEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance operator updater sync finished consumer")
+		}
+	}
 	go u.run(u.updateTicker.C)
 	return nil
 }
@@ -130,10 +149,27 @@ func (u *updaterImpl) Stop() {
 	u.stopSig.Signal()
 }
 
+func (u *updaterImpl) handleSyncFinishedEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SyncFinishedEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	if centralcaps.Has(centralsensor.ComplianceV2Integrations) {
+		u.updateTicker.Reset(u.updateInterval)
+		return nil
+	}
+	u.updateTicker.Stop()
+	return nil
+}
+
 func (u *updaterImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
 	switch e {
 	case common.SensorComponentEventSyncFinished:
+		if u.pubSubEnabled() {
+			// Handled by handleSyncFinishedEvent via the SyncFinished PubSub
+			// subscription registered in Start().
+			return
+		}
 		if centralcaps.Has(centralsensor.ComplianceV2Integrations) {
 			u.updateTicker.Reset(u.updateInterval)
 			return

--- a/sensor/kubernetes/complianceoperator/updater_pubsub_test.go
+++ b/sensor/kubernetes/complianceoperator/updater_pubsub_test.go
@@ -1,0 +1,107 @@
+package complianceoperator
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newTestSyncFinishedDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{lane.NewBlockingLane(pubsub.SyncFinishedLane)},
+	))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func newTestUpdaterWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher, updateInterval time.Duration) *updaterImpl {
+	tb.Helper()
+	readySignal := concurrency.NewSignal()
+	u := NewInfoUpdater(fake.NewClientset(), updateInterval, &readySignal, dispatcher)
+	return u.(*updaterImpl)
+}
+
+func TestHandleSyncFinishedEvent_WrongEventType(t *testing.T) {
+	u := newTestUpdaterWithDispatcher(t, newTestSyncFinishedDispatcher(t), time.Millisecond*10)
+
+	err := u.handleSyncFinishedEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSyncFinishedEvent_ResetsTickerWhenCapabilityPresent(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+	defer centralcaps.Set([]centralsensor.CentralCapability{})
+
+	u := newTestUpdaterWithDispatcher(t, newTestSyncFinishedDispatcher(t), time.Millisecond*10)
+
+	require.NoError(t, u.handleSyncFinishedEvent(&events.SyncFinishedEvent{}))
+
+	select {
+	case <-u.updateTicker.C:
+		// Ticker fired: it was reset (running) as expected.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected ticker to be reset and fire")
+	}
+}
+
+func TestHandleSyncFinishedEvent_StopsTickerWhenCapabilityAbsent(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{})
+
+	u := newTestUpdaterWithDispatcher(t, newTestSyncFinishedDispatcher(t), time.Millisecond*10)
+	u.updateTicker.Reset(u.updateInterval) // Simulate a previously-running ticker.
+
+	require.NoError(t, u.handleSyncFinishedEvent(&events.SyncFinishedEvent{}))
+
+	select {
+	case <-u.updateTicker.C:
+		t.Fatal("expected ticker to be stopped, but it fired")
+	case <-time.After(50 * time.Millisecond):
+		// No fire: ticker was stopped as expected.
+	}
+}
+
+// TestUpdaterStart_RegistersSyncFinishedConsumer verifies Start() wires
+// handleSyncFinishedEvent onto the SyncFinished topic/lane end-to-end through
+// a real (non-mocked) dispatcher.
+func TestUpdaterStart_RegistersSyncFinishedConsumer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+		defer centralcaps.Set([]centralsensor.CentralCapability{})
+
+		dispatcher := newTestSyncFinishedDispatcher(t)
+		u := newTestUpdaterWithDispatcher(t, dispatcher, time.Millisecond*10)
+		require.NoError(t, u.Start())
+		defer u.Stop()
+
+		// Drain the unconditional first response sent by run() at startup.
+		<-u.ResponsesC()
+
+		require.NoError(t, dispatcher.Publish(&events.SyncFinishedEvent{}))
+		synctest.Wait()
+
+		// The ticker was reset by the PubSub-driven handler; the run loop
+		// should eventually emit another response once it fires.
+		select {
+		case resp := <-u.ResponsesC():
+			assert.NotNil(t, resp)
+		case <-time.After(time.Second):
+			t.Fatal("expected updater to emit a response after SyncFinished ticker reset")
+		}
+	})
+}

--- a/sensor/kubernetes/complianceoperator/updater_test.go
+++ b/sensor/kubernetes/complianceoperator/updater_test.go
@@ -269,7 +269,7 @@ func getKeys(m map[string]bool) []string {
 func (s *UpdaterTestSuite) getInfo(times int, updateInterval time.Duration) *central.ComplianceOperatorInfo {
 	timer := time.NewTimer(responseTimeout)
 	readySignal := concurrency.NewSignal()
-	updater := NewInfoUpdater(s.client, updateInterval, &readySignal)
+	updater := NewInfoUpdater(s.client, updateInterval, &readySignal, nil)
 
 	updater.Notify(common.SensorComponentEventSyncFinished)
 	err := updater.Start()

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -211,7 +211,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	components = append(components, nodeInventoryHandler, complianceMultiplexer)
 
 	coReadySignal := concurrency.NewSignal()
-	coInfoUpdater := complianceoperator.NewInfoUpdater(cfg.k8sClient.Kubernetes(), 0, &coReadySignal)
+	coInfoUpdater := complianceoperator.NewInfoUpdater(cfg.k8sClient.Kubernetes(), 0, &coReadySignal, internalMessageDispatcher)
 	components = append(components, coInfoUpdater, complianceoperator.NewRequestHandler(cfg.k8sClient.Dynamic(), coInfoUpdater, &coReadySignal))
 
 	if !cfg.localSensor {


### PR DESCRIPTION
## Description

PR 3 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854). Migrates sensor/kubernetes/complianceoperator/updater.go SyncFinished handling from the legacy Notify(SensorComponentEvent) path onto a real PubSub subscription.

updater.go resets or stops its info-collection ticker based on the ComplianceV2Integrations capability whenever a SyncFinished event fires, but that logic was still driven purely through the legacy Notify() broadcast. This PR adds a genuine PubSub subscription to SyncFinishedTopic (defined by the infra PR) via a new ComplianceOperatorUpdaterSyncFinishedConsumer, replicating the exact ticker-reset-or-stop logic in a new handleSyncFinishedEvent. Unlike the detector PR (PR 1), the Notify() bypass here is scoped to only the SyncFinished case, not a blanket early-return, because updater.go OfflineMode handling (isReady.Reset()) is out of scope for this PR and stays on the legacy path.

The no-op Notify in handler_impl.go is untouched; it is deleted only in the series final cleanup PR once all consumer PRs have merged.

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added sensor/kubernetes/complianceoperator/updater_pubsub_test.go: handler unit tests for the ticker reset/stop behavior driven by the ComplianceV2Integrations capability, a wrong-event-type case, and an end-to-end Start() + Publish() wiring test using synctest.
- Updated the existing updater_test.go call site (getInfo helper) to pass a nil dispatcher, keeping its 6 existing tests on the legacy Notify path unchanged.
- go build ./sensor/... -- clean.
- go test ./sensor/kubernetes/complianceoperator/... -- all pass, including under -race.
- go vet, gofmt, and quickstyle (golangci-lint/imports/blanks/fmt/roxvet) -- all clean.
- Feature is gated by ROX_SENSOR_PUBSUB, off by default; legacy Notify path is unchanged when disabled.

## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742)
  - PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763)
  - **PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762) (this PR)**
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765)
  - PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766)
  - PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767)
  - PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771)
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)


