### PR TITLE
ROX-35642: Migrate admissioncontroller alert handler to PubSub

### DIFF
--- a/sensor/common/admissioncontroller/alert_handler.go
+++ b/sensor/common/admissioncontroller/alert_handler.go
@@ -6,8 +6,11 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 )
 
@@ -29,13 +32,37 @@ type alertHandlerImpl struct {
 	output       chan *message.ExpiringMessage
 	stopSig      concurrency.Signal
 	centralReady concurrency.Signal
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (h *alertHandlerImpl) Name() string {
 	return "admissioncontroller.alertHandlerImpl"
 }
 
+func (h *alertHandlerImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && h.pubSubDispatcher != nil
+}
+
 func (h *alertHandlerImpl) Start() error {
+	if h.pubSubEnabled() {
+		if err := h.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.AlertHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			h.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register alert handler sensor online consumer")
+		}
+		if err := h.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.AlertHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			h.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register alert handler sensor offline consumer")
+		}
+	}
 	go h.run()
 	return nil
 }
@@ -44,8 +71,29 @@ func (h *alertHandlerImpl) Stop() {
 	h.stopSig.Signal()
 }
 
+func (h *alertHandlerImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReady.Signal()
+	return nil
+}
+
+func (h *alertHandlerImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReady.Reset()
+	return nil
+}
+
 func (h *alertHandlerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if h.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReady.Signal()

--- a/sensor/common/admissioncontroller/alert_handler_pubsub_test.go
+++ b/sensor/common/admissioncontroller/alert_handler_pubsub_test.go
@@ -1,0 +1,88 @@
+package admissioncontroller
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func TestHandleSensorOnlineEvent_SignalsCentralReady(t *testing.T) {
+	h := newAlertHandler(newTestOnlineOfflineDispatcher(t))
+	require.False(t, h.centralReady.IsDone())
+
+	require.NoError(t, h.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, h.centralReady.IsDone())
+}
+
+func TestHandleSensorOfflineEvent_ResetsCentralReady(t *testing.T) {
+	h := newAlertHandler(newTestOnlineOfflineDispatcher(t))
+	h.centralReady.Signal()
+	require.True(t, h.centralReady.IsDone())
+
+	require.NoError(t, h.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, h.centralReady.IsDone())
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	h := newAlertHandler(newTestOnlineOfflineDispatcher(t))
+
+	err := h.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	h := newAlertHandler(newTestOnlineOfflineDispatcher(t))
+
+	err := h.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestAlertHandlerStart_RegistersSensorOnlineOfflineConsumers verifies
+// Start() wires the online/offline handlers onto the SensorOnline/
+// SensorOffline topic and lane end-to-end through a real dispatcher, and
+// that legacy Notify no longer double-drives centralReady once PubSub is
+// enabled.
+func TestAlertHandlerStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		h := newAlertHandler(dispatcher)
+		require.NoError(t, h.Start())
+		defer h.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, h.centralReady.IsDone())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, h.centralReady.IsDone())
+
+		// Legacy Notify must be a no-op for these events in PubSub mode.
+		h.Notify(common.SensorComponentEventCentralReachable)
+		assert.False(t, h.centralReady.IsDone())
+	})
+}

--- a/sensor/common/admissioncontroller/alert_handler_test.go
+++ b/sensor/common/admissioncontroller/alert_handler_test.go
@@ -52,7 +52,7 @@ func (s *alertHandlerSuite) TestProcessAlert() {
 	}
 	for testName, c := range cases {
 		s.Run(testName, func() {
-			h := newAlertHandler()
+			h := newAlertHandler(nil)
 			h.Notify(c.notify)
 			admissionControlAlerts := createAlertResults(c.deploymentID, c.policyID, c.stage, c.source)
 			err := h.ProcessAlerts(admissionControlAlerts)

--- a/sensor/common/admissioncontroller/singleton.go
+++ b/sensor/common/admissioncontroller/singleton.go
@@ -3,6 +3,7 @@ package admissioncontroller
 import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
 )
 
@@ -11,18 +12,19 @@ var (
 	once     sync.Once
 )
 
-func newAlertHandler() *alertHandlerImpl {
+func newAlertHandler(pubSubDispatcher common.PubSubDispatcher) *alertHandlerImpl {
 	return &alertHandlerImpl{
-		stopSig:      concurrency.NewSignal(),
-		output:       make(chan *message.ExpiringMessage),
-		centralReady: concurrency.NewSignal(),
+		stopSig:          concurrency.NewSignal(),
+		output:           make(chan *message.ExpiringMessage),
+		centralReady:     concurrency.NewSignal(),
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }
 
 // AlertHandlerSingleton returns the singleton instance for the admission controller alert handler handler.
-func AlertHandlerSingleton() AlertHandler {
+func AlertHandlerSingleton(pubSubDispatcher common.PubSubDispatcher) AlertHandler {
 	once.Do(func() {
-		instance = newAlertHandler()
+		instance = newAlertHandler(pubSubDispatcher)
 	})
 	return instance
 }

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,8 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	AlertHandlerSensorOnlineConsumer
+	AlertHandlerSensorOfflineConsumer
 )
 
 var (
@@ -39,6 +41,8 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		AlertHandlerSensorOnlineConsumer:       "AlertHandlerSensorOnline",
+		AlertHandlerSensorOfflineConsumer:      "AlertHandlerSensorOffline",
 	}
 )
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -187,7 +187,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		processSignals,
 		telemetry.NewCommandHandler(cfg.k8sClient.Kubernetes(), storeProvider),
 		externalsrcs.Singleton(),
-		admissioncontroller.AlertHandlerSingleton(),
+		admissioncontroller.AlertHandlerSingleton(internalMessageDispatcher),
 		auditLogCollectionManager,
 		reprocessorHandler,
 		delegatedRegistryHandler,
@@ -305,7 +305,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	if admCtrlSettingsMgr != nil {
-		apiServices = append(apiServices, admissioncontroller.NewManagementService(admCtrlSettingsMgr, admissioncontroller.AlertHandlerSingleton()))
+		apiServices = append(apiServices, admissioncontroller.NewManagementService(admCtrlSettingsMgr, admissioncontroller.AlertHandlerSingleton(internalMessageDispatcher)))
 	}
 
 	s.AddAPIServices(apiServices...)


### PR DESCRIPTION
## Description

PR 2 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854). Migrates `sensor/common/admissioncontroller/alert_handler.go`'s online/offline gating from the legacy `Notify(SensorComponentEvent)` path onto a real PubSub subscription.

`alertHandlerImpl.centralReady` signals/resets central-reachability based on `CentralReachable`/`OfflineMode` events, but that was still driven purely through the legacy `Notify()` broadcast. This PR adds genuine PubSub subscriptions to `SensorOnlineTopic`/`SensorOfflineTopic` (defined by the infra PR) via new `AlertHandlerSensorOnlineConsumer`/`AlertHandlerSensorOfflineConsumer`, replicating the exact signal/reset logic in `handleSensorOnlineEvent`/`handleSensorOfflineEvent`. Like the detector PR (PR 1), `Notify()` gets a blanket early-return in PubSub mode, since it has no other responsibilities left once these two cases move.

`alertHandlerImpl` is constructed through a no-arg singleton (`AlertHandlerSingleton`), unlike detector/complianceoperator which take the dispatcher directly as a constructor param wired in `sensor.go`. Rather than introduce a new late-binding pattern (e.g. the design doc's `SetDispatcher`) for a single component, `AlertHandlerSingleton` now takes the dispatcher as a parameter; `sync.Once` means only the first caller's argument is actually used, so both call sites in `sensor.go` now pass `internalMessageDispatcher`.

`message_forwarder.go` (also listed under this task in the plan doc) needs no change: `admCtrlMsgForwarderImpl.Notify` is a pure fan-out to sub-components with no state of its own, and its only sub-component (the k8s event pipeline) isn't migrated yet -- that's tracked separately as PR 8 (misc singles).

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added `sensor/common/admissioncontroller/alert_handler_pubsub_test.go`: handler unit tests for the signal/reset behavior, wrong-event-type cases, and an end-to-end `Start()` + `Publish()` wiring test using `synctest`, including a regression assertion that legacy `Notify` no longer double-drives `centralReady` when PubSub is enabled.
- Updated the existing `alert_handler_test.go` call site to pass a `nil` dispatcher, keeping its existing tests on the legacy Notify path unchanged.
- `go build ./sensor/...` -- clean.
- `go test ./sensor/common/admissioncontroller/... ./sensor/kubernetes/sensor/...` -- all pass.
- `go vet` and `quickstyle` (golangci-lint/imports/blanks/fmt/roxvet) -- all clean.
- Feature is gated by `ROX_SENSOR_PUBSUB`, off by default; legacy Notify path is unchanged when disabled.

## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742)
  - **PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763) (this PR)**
  - PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762)
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765)
  - PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766)
  - PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767)
  - PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771)
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)

