### PR TITLE
ROX-35642: Migrate compliance package Notify to PubSub

### DIFF
--- a/sensor/common/compliance/auditlog_manager.go
+++ b/sensor/common/compliance/auditlog_manager.go
@@ -46,7 +46,7 @@ type clusterIDWaiter interface {
 }
 
 // NewAuditLogCollectionManager creates a new instance of AuditLogCollectionManager, which provides an API to manage the lifecycle of audit log collection within the cluster
-func NewAuditLogCollectionManager(clusterID clusterIDWaiter) AuditLogCollectionManager {
+func NewAuditLogCollectionManager(clusterID clusterIDWaiter, pubSubDispatcher common.PubSubDispatcher) AuditLogCollectionManager {
 	return &auditLogCollectionManagerImpl{
 		// Need to use a getter instead of directly calling clusterid.Get because it may block if the communication with central is not yet finished
 		// Putting it as a getter so it can be overridden in tests
@@ -59,5 +59,6 @@ func NewAuditLogCollectionManager(clusterID clusterIDWaiter) AuditLogCollectionM
 		forceUpdateSig:          concurrency.NewSignal(),
 		centralReady:            concurrency.NewSignal(),
 		updaterTicker:           time.NewTicker(defaultInterval),
+		pubSubDispatcher:        pubSubDispatcher,
 	}
 }

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -4,15 +4,19 @@ import (
 	"maps"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 )
 
@@ -44,13 +48,37 @@ type auditLogCollectionManagerImpl struct {
 
 	fileStateLock  sync.RWMutex
 	connectionLock sync.RWMutex
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (a *auditLogCollectionManagerImpl) Name() string {
 	return "compliance.auditLogCollectionManagerImpl"
 }
 
+func (a *auditLogCollectionManagerImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && a.pubSubDispatcher != nil
+}
+
 func (a *auditLogCollectionManagerImpl) Start() error {
+	if a.pubSubEnabled() {
+		if err := a.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceAuditLogManagerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			a.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance audit log manager sensor online consumer")
+		}
+		if err := a.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceAuditLogManagerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			a.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance audit log manager sensor offline consumer")
+		}
+	}
 	go a.runStateSaver()
 	go a.runUpdater(a.updaterTicker.C)
 	return nil
@@ -65,8 +93,29 @@ func (a *auditLogCollectionManagerImpl) Stop() {
 	a.stopper.Client().Stop()
 }
 
+func (a *auditLogCollectionManagerImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	a.centralReady.Signal()
+	return nil
+}
+
+func (a *auditLogCollectionManagerImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	a.centralReady.Reset()
+	return nil
+}
+
 func (a *auditLogCollectionManagerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if a.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		a.centralReady.Signal()

--- a/sensor/common/compliance/auditlog_manager_pubsub_test.go
+++ b/sensor/common/compliance/auditlog_manager_pubsub_test.go
@@ -1,0 +1,89 @@
+package compliance
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAuditLogManagerWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher) *auditLogCollectionManagerImpl {
+	tb.Helper()
+	return &auditLogCollectionManagerImpl{
+		clusterID:               &fakeClusterIDWaiter{},
+		eligibleComplianceNodes: make(map[string]sensor.ComplianceService_CommunicateServer),
+		fileStates:              make(map[string]*storage.AuditLogFileState),
+		updaterTicker:           time.NewTicker(time.Minute),
+		stopper:                 concurrency.NewStopper(),
+		forceUpdateSig:          concurrency.NewSignal(),
+		centralReady:            concurrency.NewSignal(),
+		auditEventMsgs:          make(chan *sensor.MsgFromCompliance),
+		fileStateUpdates:        make(chan *message.ExpiringMessage),
+		pubSubDispatcher:        dispatcher,
+	}
+}
+
+func TestAuditLogManagerHandleSensorOnlineEvent_SignalsCentralReady(t *testing.T) {
+	a := newTestAuditLogManagerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	require.False(t, a.centralReady.IsDone())
+
+	require.NoError(t, a.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, a.centralReady.IsDone())
+}
+
+func TestAuditLogManagerHandleSensorOfflineEvent_ResetsCentralReady(t *testing.T) {
+	a := newTestAuditLogManagerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	a.centralReady.Signal()
+	require.True(t, a.centralReady.IsDone())
+
+	require.NoError(t, a.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, a.centralReady.IsDone())
+}
+
+func TestAuditLogManagerHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	a := newTestAuditLogManagerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := a.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestAuditLogManagerHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	a := newTestAuditLogManagerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := a.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestAuditLogManagerStart_RegistersSensorOnlineOfflineConsumers verifies
+// Start() wires the online/offline handlers onto the SensorOnline/
+// SensorOffline topic and lane end-to-end through a real dispatcher.
+func TestAuditLogManagerStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		a := newTestAuditLogManagerWithDispatcher(t, dispatcher)
+		require.NoError(t, a.Start())
+		defer a.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, a.centralReady.IsDone())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, a.centralReady.IsDone())
+	})
+}

--- a/sensor/common/compliance/command_handler.go
+++ b/sensor/common/compliance/command_handler.go
@@ -18,7 +18,7 @@ type CommandHandler interface {
 }
 
 // NewCommandHandler returns a new instance of a CommandHandler using the input image and Orchestrator.
-func NewCommandHandler(complianceService Service) CommandHandler {
+func NewCommandHandler(complianceService Service, pubSubDispatcher common.PubSubDispatcher) CommandHandler {
 	return &commandHandlerImpl{
 		service: complianceService,
 
@@ -29,5 +29,6 @@ func NewCommandHandler(complianceService Service) CommandHandler {
 
 		stopper:          concurrency.NewStopper(),
 		centralReachable: atomic.Bool{},
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -10,10 +10,13 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
 var (
@@ -30,6 +33,8 @@ type commandHandlerImpl struct {
 
 	stopper          concurrency.Stopper
 	centralReachable atomic.Bool
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (c *commandHandlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -40,7 +45,29 @@ func (c *commandHandlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return c.updates
 }
 
+func (c *commandHandlerImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && c.pubSubDispatcher != nil
+}
+
 func (c *commandHandlerImpl) Start() error {
+	if c.pubSubEnabled() {
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceCommandHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			c.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance command handler sensor online consumer")
+		}
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceCommandHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			c.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance command handler sensor offline consumer")
+		}
+	}
 	go c.run()
 	return nil
 }
@@ -53,8 +80,29 @@ func (c *commandHandlerImpl) Stop() {
 	c.stopper.Client().Stop()
 }
 
+func (c *commandHandlerImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	c.centralReachable.Store(true)
+	return nil
+}
+
+func (c *commandHandlerImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	c.centralReachable.Store(false)
+	return nil
+}
+
 func (c *commandHandlerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if c.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		c.centralReachable.Store(true)

--- a/sensor/common/compliance/command_handler_pubsub_test.go
+++ b/sensor/common/compliance/command_handler_pubsub_test.go
@@ -1,0 +1,103 @@
+package compliance
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/internalapi/compliance"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/compliance/mocks"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func newTestCommandHandlerWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher) *commandHandlerImpl {
+	tb.Helper()
+	mockService := mocks.NewMockService(gomock.NewController(tb))
+	mockService.EXPECT().Output().AnyTimes().DoAndReturn(func() chan *compliance.ComplianceReturn {
+		return make(chan *compliance.ComplianceReturn)
+	})
+	return &commandHandlerImpl{
+		service:          mockService,
+		commands:         make(chan *central.ScrapeCommand),
+		updates:          make(chan *message.ExpiringMessage),
+		scrapeIDToState:  make(map[string]*scrapeState),
+		stopper:          concurrency.NewStopper(),
+		pubSubDispatcher: dispatcher,
+	}
+}
+
+func TestCommandHandlerHandleSensorOnlineEvent_SetsCentralReachable(t *testing.T) {
+	c := newTestCommandHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	require.False(t, c.centralReachable.Load())
+
+	require.NoError(t, c.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, c.centralReachable.Load())
+}
+
+func TestCommandHandlerHandleSensorOfflineEvent_UnsetsCentralReachable(t *testing.T) {
+	c := newTestCommandHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	c.centralReachable.Store(true)
+
+	require.NoError(t, c.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, c.centralReachable.Load())
+}
+
+func TestCommandHandlerHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	c := newTestCommandHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := c.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestCommandHandlerHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	c := newTestCommandHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := c.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestCommandHandlerStart_RegistersSensorOnlineOfflineConsumers verifies
+// Start() wires the online/offline handlers onto the SensorOnline/
+// SensorOffline topic and lane end-to-end through a real dispatcher.
+func TestCommandHandlerStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		c := newTestCommandHandlerWithDispatcher(t, dispatcher)
+		require.NoError(t, c.Start())
+		defer c.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, c.centralReachable.Load())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, c.centralReachable.Load())
+	})
+}

--- a/sensor/common/compliance/node_inventory_handler.go
+++ b/sensor/common/compliance/node_inventory_handler.go
@@ -11,7 +11,7 @@ import (
 var _ common.ComplianceComponent = (*nodeInventoryHandlerImpl)(nil)
 
 // NewNodeInventoryHandler returns a new instance of a NodeInventoryHandler
-func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, iw <-chan *index.IndexReportWrap, nodeIDMatcher NodeIDMatcher, nodeRHCOSmatcher NodeRHCOSMatcher) *nodeInventoryHandlerImpl {
+func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, iw <-chan *index.IndexReportWrap, nodeIDMatcher NodeIDMatcher, nodeRHCOSmatcher NodeRHCOSMatcher, pubSubDispatcher common.PubSubDispatcher) *nodeInventoryHandlerImpl {
 	return &nodeInventoryHandlerImpl{
 		inventories:      ch,
 		reportWraps:      iw,
@@ -24,5 +24,6 @@ func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, iw <-chan *index.
 		nodeMatcher:      nodeIDMatcher,
 		nodeRHCOSMatcher: nodeRHCOSmatcher,
 		archCache:        make(map[string]string),
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -15,12 +15,15 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/compliance/index"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
 var (
@@ -56,10 +59,16 @@ type nodeInventoryHandlerImpl struct {
 	// archCache stores an architecture per node, so that it can be used in the index report for
 	// the 'rhcos' package. The arch is discovered once and then reused for subsequent scans.
 	archCache map[string]string
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (c *nodeInventoryHandlerImpl) Name() string {
 	return "compliance.nodeInventoryHandlerImpl"
+}
+
+func (c *nodeInventoryHandlerImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && c.pubSubDispatcher != nil
 }
 
 func (c *nodeInventoryHandlerImpl) Stopped() concurrency.ReadOnlyErrorSignal {
@@ -91,6 +100,24 @@ func (c *nodeInventoryHandlerImpl) Start() error {
 	if c.toCentral != nil || c.toCompliance != nil {
 		return errStartMoreThanOnce
 	}
+	if c.pubSubEnabled() {
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceNodeInventoryHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			c.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance node inventory handler sensor online consumer")
+		}
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceNodeInventoryHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			c.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance node inventory handler sensor offline consumer")
+		}
+	}
 	c.toCompliance = make(chan common.MessageToComplianceWithAddress)
 	c.toCentral = c.run()
 	return nil
@@ -103,8 +130,31 @@ func (c *nodeInventoryHandlerImpl) Stop() {
 	c.stopper.Client().Stop()
 }
 
+func (c *nodeInventoryHandlerImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	c.centralReady.Signal()
+	return nil
+}
+
+func (c *nodeInventoryHandlerImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	// As Compliance enters a retry loop when it is not receiving an ACK,
+	// there is no need to do anything else when entering offline mode.
+	c.centralReady.Reset()
+	return nil
+}
+
 func (c *nodeInventoryHandlerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if c.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		c.centralReady.Signal()

--- a/sensor/common/compliance/node_inventory_handler_pubsub_test.go
+++ b/sensor/common/compliance/node_inventory_handler_pubsub_test.go
@@ -1,0 +1,82 @@
+package compliance
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/compliance/index"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestNodeInventoryHandlerWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher) *nodeInventoryHandlerImpl {
+	tb.Helper()
+	inventories := make(chan *storage.NodeInventory)
+	reports := make(chan *index.IndexReportWrap)
+	tb.Cleanup(func() {
+		close(inventories)
+		close(reports)
+	})
+	return NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, dispatcher)
+}
+
+func TestNodeInventoryHandlerHandleSensorOnlineEvent_SignalsCentralReady(t *testing.T) {
+	h := newTestNodeInventoryHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	require.False(t, h.centralReady.IsDone())
+
+	require.NoError(t, h.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, h.centralReady.IsDone())
+}
+
+func TestNodeInventoryHandlerHandleSensorOfflineEvent_ResetsCentralReady(t *testing.T) {
+	h := newTestNodeInventoryHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	h.centralReady.Signal()
+	require.True(t, h.centralReady.IsDone())
+
+	require.NoError(t, h.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, h.centralReady.IsDone())
+}
+
+func TestNodeInventoryHandlerHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	h := newTestNodeInventoryHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := h.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestNodeInventoryHandlerHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	h := newTestNodeInventoryHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := h.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestNodeInventoryHandlerStart_RegistersSensorOnlineOfflineConsumers
+// verifies Start() wires the online/offline handlers onto the
+// SensorOnline/SensorOffline topic and lane end-to-end through a real
+// dispatcher.
+func TestNodeInventoryHandlerStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		h := newTestNodeInventoryHandlerWithDispatcher(t, dispatcher)
+		require.NoError(t, h.Start())
+		defer h.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, h.centralReady.IsDone())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, h.centralReady.IsDone())
+	})
+}

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -219,7 +219,7 @@ func (s *NodeInventoryHandlerTestSuite) TestCapabilities() {
 	defer close(inventories)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	caps := h.Capabilities()
 	s.Require().Len(caps, 1)
 	s.Equal(centralsensor.SensorACKSupport, caps[0])
@@ -230,7 +230,7 @@ func (s *NodeInventoryHandlerTestSuite) TestResponsesCShouldPanicWhenNotStarted(
 	defer close(inventories)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.Panics(func() {
 		h.ResponsesC()
 	})
@@ -246,7 +246,7 @@ func (s *NodeInventoryHandlerTestSuite) TestStopHandler() {
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
 	producer := concurrency.NewStopper()
-	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.NoError(h.Start())
 	h.Notify(common.SensorComponentEventCentralReachable)
 	consumer := consumeAndCount(h.ResponsesC(), 1)
@@ -277,7 +277,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerRegularRoutine() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -294,7 +294,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerStopIgnoresError() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -346,7 +346,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerCentralACKsToCompliance() {
 			defer close(ch)
 			reports := make(chan *index.IndexReportWrap)
 			defer close(reports)
-			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 			s.NoError(handler.Start())
 			handler.Notify(common.SensorComponentEventCentralReachable)
 
@@ -468,7 +468,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerSensorACKsToCompliance() {
 			defer close(ch)
 			reports := make(chan *index.IndexReportWrap)
 			defer close(reports)
-			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 			s.NoError(handler.Start())
 			handler.Notify(common.SensorComponentEventCentralReachable)
 
@@ -541,7 +541,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerAcceptsBothAckTypes() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 
 	// Test legacy NodeInventoryACK
 	legacyMsg := &central.MsgToSensor{
@@ -588,7 +588,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.NoError(h.Start())
 
 	states := []testState{
@@ -737,7 +737,7 @@ func (s *NodeInventoryHandlerTestSuite) TestMultipleStartHandler() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
@@ -763,7 +763,7 @@ func (s *NodeInventoryHandlerTestSuite) TestDoubleStopHandler() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -781,7 +781,7 @@ func (s *NodeInventoryHandlerTestSuite) TestInputChannelClosed() {
 	ch, producer := s.generateTestInputNoClose(10)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -816,7 +816,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerNilInput() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateNilTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -833,7 +833,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerNodeUnknown() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockNeverHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockNeverHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -854,7 +854,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerCentralNotReady() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.NoError(h.Start())
 	// expect centralConsumer to get 0 messages - sensor should NACK to compliance when the connection with central is not ready
 	centralConsumer := consumeAndCount(h.ResponsesC(), 0)

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -22,8 +22,10 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/compliance/index"
 	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/orchestrator"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 	"google.golang.org/grpc"
 )
@@ -56,8 +58,33 @@ func (s *serviceImpl) Name() string {
 	return "compliance.serviceImpl"
 }
 
+func (s *serviceImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil
+}
+
+func (s *serviceImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	s.offlineMode.Store(false)
+	return nil
+}
+
+func (s *serviceImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	s.offlineMode.Store(true)
+	return nil
+}
+
 func (s *serviceImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if s.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		s.offlineMode.Store(false)
@@ -67,6 +94,24 @@ func (s *serviceImpl) Notify(e common.SensorComponentEvent) {
 }
 
 func (s *serviceImpl) Start() error {
+	if s.pubSubEnabled() {
+		if err := s.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceServiceSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			s.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance service sensor online consumer")
+		}
+		if err := s.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceServiceSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			s.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance service sensor offline consumer")
+		}
+	}
 	return nil
 }
 

--- a/sensor/common/compliance/service_impl_pubsub_test.go
+++ b/sensor/common/compliance/service_impl_pubsub_test.go
@@ -1,0 +1,82 @@
+package compliance
+
+import (
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServiceWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher) *serviceImpl {
+	tb.Helper()
+	offlineMode := &atomic.Bool{}
+	offlineMode.Store(true)
+	return &serviceImpl{
+		connectionManager: newConnectionManager(),
+		offlineMode:       offlineMode,
+		stopper:           set.NewSet[concurrency.Stopper](),
+		pubSubDispatcher:  dispatcher,
+	}
+}
+
+func TestServiceHandleSensorOnlineEvent_ClearsOfflineMode(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	require.True(t, s.offlineMode.Load())
+
+	require.NoError(t, s.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.False(t, s.offlineMode.Load())
+}
+
+func TestServiceHandleSensorOfflineEvent_SetsOfflineMode(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	s.offlineMode.Store(false)
+
+	require.NoError(t, s.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.True(t, s.offlineMode.Load())
+}
+
+func TestServiceHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := s.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestServiceHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := s.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestServiceStart_RegistersSensorOnlineOfflineConsumers verifies Start()
+// wires the online/offline handlers onto the SensorOnline/SensorOffline
+// topic and lane end-to-end through a real dispatcher.
+func TestServiceStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		s := newTestServiceWithDispatcher(t, dispatcher)
+		require.NoError(t, s.Start())
+		defer s.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.False(t, s.offlineMode.Load())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.True(t, s.offlineMode.Load())
+	})
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,26 +19,42 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	ComplianceCommandHandlerSensorOnlineConsumer
+	ComplianceCommandHandlerSensorOfflineConsumer
+	ComplianceAuditLogManagerSensorOnlineConsumer
+	ComplianceAuditLogManagerSensorOfflineConsumer
+	ComplianceNodeInventoryHandlerSensorOnlineConsumer
+	ComplianceNodeInventoryHandlerSensorOfflineConsumer
+	ComplianceServiceSensorOnlineConsumer
+	ComplianceServiceSensorOfflineConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:                            "NoConsumers",
-		DefaultConsumer:                        "Default",
-		ResolverConsumer:                       "Resolver",
-		EnrichedProcessConsumer:                "EnrichedProcess",
-		FileActivityEnrichedProcessConsumer:    "FileActivityEnrichedProcess",
-		UnenrichedProcessConsumer:              "UnenrichedProcess",
-		DetectorProcessIndicatorConsumer:       "DetectorProcessIndicator",
-		DetectorNetworkFlowConsumer:            "DetectorNetworkFlow",
-		DetectorFileAccessConsumer:             "DetectorFileAccess",
-		DetectorAuditLogConsumer:               "DetectorAuditLog",
-		DetectorDeploymentConsumer:             "DetectorDeployment",
-		DetectorScanResultConsumer:             "DetectorScanResult",
-		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
-		OutputQueueConsumer:                    "OutputQueue",
-		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
-		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		NoConsumers:                                         "NoConsumers",
+		DefaultConsumer:                                     "Default",
+		ResolverConsumer:                                    "Resolver",
+		EnrichedProcessConsumer:                             "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer:                 "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:                           "UnenrichedProcess",
+		DetectorProcessIndicatorConsumer:                    "DetectorProcessIndicator",
+		DetectorNetworkFlowConsumer:                         "DetectorNetworkFlow",
+		DetectorFileAccessConsumer:                          "DetectorFileAccess",
+		DetectorAuditLogConsumer:                            "DetectorAuditLog",
+		DetectorDeploymentConsumer:                          "DetectorDeployment",
+		DetectorScanResultConsumer:                          "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:                   "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                                 "OutputQueue",
+		NetworkFlowManagerResourceSyncConsumer:              "NetworkFlowManagerResourceSync",
+		SensorSoftRestartConsumer:                           "SensorSoftRestart",
+		ComplianceCommandHandlerSensorOnlineConsumer:        "ComplianceCommandHandlerSensorOnline",
+		ComplianceCommandHandlerSensorOfflineConsumer:       "ComplianceCommandHandlerSensorOffline",
+		ComplianceAuditLogManagerSensorOnlineConsumer:       "ComplianceAuditLogManagerSensorOnline",
+		ComplianceAuditLogManagerSensorOfflineConsumer:      "ComplianceAuditLogManagerSensorOffline",
+		ComplianceNodeInventoryHandlerSensorOnlineConsumer:  "ComplianceNodeInventoryHandlerSensorOnline",
+		ComplianceNodeInventoryHandlerSensorOfflineConsumer: "ComplianceNodeInventoryHandlerSensorOffline",
+		ComplianceServiceSensorOnlineConsumer:               "ComplianceServiceSensorOnline",
+		ComplianceServiceSensorOfflineConsumer:              "ComplianceServiceSensorOffline",
 	}
 )
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -123,7 +123,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	auditLogEventsInput := make(chan *sensorInternal.AuditEvents)
-	auditLogCollectionManager := compliance.NewAuditLogCollectionManager(clusterID)
+	auditLogCollectionManager := compliance.NewAuditLogCollectionManager(clusterID, internalMessageDispatcher)
 
 	o := orchestrator.New(cfg.k8sClient.Kubernetes())
 	complianceMultiplexer := compliance.NewMultiplexer()
@@ -152,7 +152,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(clusterID, imageCache, storeProvider.Registries(), storeProvider.RegistryMirrors())
-	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
+	complianceCommandHandler := compliance.NewCommandHandler(complianceService, internalMessageDispatcher)
 
 	// Create Process Pipeline
 	indicators := make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.ProcessIndicatorBufferSize))
@@ -204,7 +204,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	matcher := compliance.NewNodeIDMatcher(storeProvider.Nodes())
-	nodeInventoryHandler := compliance.NewNodeInventoryHandler(complianceService.NodeInventories(), complianceService.IndexReportWraps(), matcher, matcher)
+	nodeInventoryHandler := compliance.NewNodeInventoryHandler(complianceService.NodeInventories(), complianceService.IndexReportWraps(), matcher, matcher, internalMessageDispatcher)
 	complianceMultiplexer.AddComponentWithComplianceC(nodeInventoryHandler)
 	// complianceMultiplexer must start after all components that implement common.ComplianceComponent
 	// i.e., after nodeInventoryHandler


### PR DESCRIPTION
## Description

PR 5 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854). Migrates the four real `Notify(SensorComponentEvent)` implementations in `sensor/common/compliance` to genuine PubSub subscriptions on `SensorOnlineTopic`/`SensorOfflineTopic`:

- `command_handler_impl.go` -- `centralReachable` flag flip.
- `auditlog_manager_impl.go` -- `centralReady` signal/reset.
- `node_inventory_handler_impl.go` -- `centralReady` signal/reset (offline is a no-op beyond the reset, since Compliance retries on its own).
- `service_impl.go` -- `offlineMode` flag flip. This one already had a `pubSubDispatcher` field and `features.SensorInternalPubSub` import (used today to publish `AuditLogEvent`s), so only `Start()`/`Notify()`/handlers were added here -- no constructor or `sensor.go` wiring change needed.

`multiplexer.go` is untouched: its `Notify` already ignores the event unconditionally -- a genuine no-op today, matching the plan doc's note to leave it in place until the PR 9 cleanup deletes it.

All four `Notify` implementations handle only `CentralReachable`/`OfflineMode` and nothing else, so all four get the detector/alert_handler-style blanket early-return in `Notify` (established in PRs 1/2/4). Three needed a new `pubSubDispatcher` constructor param threaded from `sensor.go`'s `internalMessageDispatcher`: `NewCommandHandler`, `NewAuditLogCollectionManager`, `NewNodeInventoryHandler`.

Checked all currently-open PRs for file overlap before picking this task: none of these five files are touched by #21316, #21671, or #21651/#21650/#21547.

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added a `*_pubsub_test.go` per component (command_handler, auditlog_manager, node_inventory_handler, service_impl): handler unit tests for the exact state mutation, wrong-event-type cases, and a `Start()` + `Publish()` end-to-end wiring test via `synctest`.
- Updated the 15 `NewNodeInventoryHandler(...)` call sites in `node_inventory_handler_test.go` to pass a `nil` dispatcher via a single `replace_all`, keeping existing legacy-Notify-path tests unchanged. `command_handler_test.go`, `auditlog_manager_test.go`, and `service_impl_test.go` construct their structs via named-field literals, so no edits were needed there -- the new field defaults to nil.
- `go build ./sensor/...` -- clean.
- `go test ./sensor/common/compliance/... ./sensor/kubernetes/sensor/...` -- all pass.
- `go vet` and `quickstyle` (golangci-lint/imports/blanks/fmt/roxvet) -- all clean.
- Feature is gated by `ROX_SENSOR_PUBSUB`, off by default in prod; legacy Notify path is unchanged when disabled.


## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742)
  - PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763)
  - PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762)
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - **PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765) (this PR)**
  - PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766)
  - PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767)
  - PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771)
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)


