### PR TITLE
ROX-35642: Migrate scanner package Notify to PubSub

### DIFF
--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,26 +19,32 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	ScannerClientResetSensorOnlineConsumer
+	ScannerDefinitionsHandlerSensorOnlineConsumer
+	ScannerDefinitionsHandlerSensorOfflineConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:                            "NoConsumers",
-		DefaultConsumer:                        "Default",
-		ResolverConsumer:                       "Resolver",
-		EnrichedProcessConsumer:                "EnrichedProcess",
-		FileActivityEnrichedProcessConsumer:    "FileActivityEnrichedProcess",
-		UnenrichedProcessConsumer:              "UnenrichedProcess",
-		DetectorProcessIndicatorConsumer:       "DetectorProcessIndicator",
-		DetectorNetworkFlowConsumer:            "DetectorNetworkFlow",
-		DetectorFileAccessConsumer:             "DetectorFileAccess",
-		DetectorAuditLogConsumer:               "DetectorAuditLog",
-		DetectorDeploymentConsumer:             "DetectorDeployment",
-		DetectorScanResultConsumer:             "DetectorScanResult",
-		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
-		OutputQueueConsumer:                    "OutputQueue",
-		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
-		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		NoConsumers:                                    "NoConsumers",
+		DefaultConsumer:                                "Default",
+		ResolverConsumer:                               "Resolver",
+		EnrichedProcessConsumer:                        "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer:            "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:                      "UnenrichedProcess",
+		DetectorProcessIndicatorConsumer:               "DetectorProcessIndicator",
+		DetectorNetworkFlowConsumer:                    "DetectorNetworkFlow",
+		DetectorFileAccessConsumer:                     "DetectorFileAccess",
+		DetectorAuditLogConsumer:                       "DetectorAuditLog",
+		DetectorDeploymentConsumer:                     "DetectorDeployment",
+		DetectorScanResultConsumer:                     "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:              "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                            "OutputQueue",
+		NetworkFlowManagerResourceSyncConsumer:         "NetworkFlowManagerResourceSync",
+		SensorSoftRestartConsumer:                      "SensorSoftRestart",
+		ScannerClientResetSensorOnlineConsumer:         "ScannerClientResetSensorOnline",
+		ScannerDefinitionsHandlerSensorOnlineConsumer:  "ScannerDefinitionsHandlerSensorOnline",
+		ScannerDefinitionsHandlerSensorOfflineConsumer: "ScannerDefinitionsHandlerSensorOffline",
 	}
 )
 

--- a/sensor/common/scannerclient/reset_notifiable.go
+++ b/sensor/common/scannerclient/reset_notifiable.go
@@ -1,8 +1,12 @@
 package scannerclient
 
 import (
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
 var (
@@ -14,9 +18,19 @@ var (
 
 // ResetNotifiable returns a notifiable that resets
 // the gRPC client singleton when notified.
-func ResetNotifiable() common.Notifiable {
+func ResetNotifiable(pubSubDispatcher common.PubSubDispatcher) common.Notifiable {
 	notifiableOnce.Do(func() {
-		notifiable = &resetNotifiable{}
+		notifiable = &resetNotifiable{pubSubDispatcher: pubSubDispatcher}
+		if notifiable.pubSubEnabled() {
+			if err := pubSubDispatcher.RegisterConsumerToLane(
+				pubsub.ScannerClientResetSensorOnlineConsumer,
+				pubsub.SensorOnlineTopic,
+				pubsub.SensorOnlineLane,
+				notifiable.handleSensorOnlineEvent,
+			); err != nil {
+				log.Errorf("failed to register scanner client reset sensor online consumer: %v", err)
+			}
+		}
 	})
 
 	return notifiable
@@ -27,10 +41,30 @@ func ResetNotifiable() common.Notifiable {
 // for re-evaluation, for example, of central capabilities.
 type resetNotifiable struct {
 	common.Notifiable
+
+	pubSubDispatcher common.PubSubDispatcher
+}
+
+func (r *resetNotifiable) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && r.pubSubDispatcher != nil
+}
+
+func (r *resetNotifiable) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	resetGRPCClient()
+	log.Debug("Reset scanner client")
+	return nil
 }
 
 func (r *resetNotifiable) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if r.pubSubEnabled() {
+		// Online transitions are handled by the SensorOnlineEvent PubSub
+		// subscription registered in ResetNotifiable().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		resetGRPCClient()

--- a/sensor/common/scannerclient/reset_notifiable_pubsub_test.go
+++ b/sensor/common/scannerclient/reset_notifiable_pubsub_test.go
@@ -1,0 +1,95 @@
+package scannerclient
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/registries/types"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeScannerClient struct {
+	closed bool
+}
+
+func (f *fakeScannerClient) GetImageAnalysis(context.Context, *storage.Image, *types.Config) (*ImageAnalysis, error) {
+	return nil, nil
+}
+
+func (f *fakeScannerClient) Close() error {
+	f.closed = true
+	return nil
+}
+
+func newTestOnlineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+// resetSingleton clears the package-level ResetNotifiable singleton so tests
+// don't leak state (and don't skip registration) across each other.
+func resetSingleton(tb testing.TB) {
+	tb.Helper()
+	notifiable = nil
+	notifiableOnce = sync.Once{}
+}
+
+func TestHandleSensorOnlineEvent_ResetsScannerClient(t *testing.T) {
+	fake := &fakeScannerClient{}
+	scannerClient = fake
+	defer func() { scannerClient = nil }()
+
+	r := &resetNotifiable{pubSubDispatcher: newTestOnlineDispatcher(t)}
+
+	require.NoError(t, r.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, fake.closed)
+	assert.Nil(t, scannerClient)
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	r := &resetNotifiable{pubSubDispatcher: newTestOnlineDispatcher(t)}
+
+	err := r.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestResetNotifiable_RegistersSensorOnlineConsumer verifies
+// ResetNotifiable() wires the online handler onto the SensorOnline topic and
+// lane end-to-end through a real dispatcher, at construction time (there is
+// no Start() for a Notifiable-only component).
+func TestResetNotifiable_RegistersSensorOnlineConsumer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		resetSingleton(t)
+		defer resetSingleton(t)
+
+		fake := &fakeScannerClient{}
+		scannerClient = fake
+		defer func() { scannerClient = nil }()
+
+		dispatcher := newTestOnlineDispatcher(t)
+		ResetNotifiable(dispatcher)
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+
+		assert.True(t, fake.closed)
+		assert.Nil(t, scannerClient)
+	})
+}

--- a/sensor/common/scannerclient/reset_notifiable_pubsub_test.go
+++ b/sensor/common/scannerclient/reset_notifiable_pubsub_test.go
@@ -40,6 +40,18 @@ func newTestOnlineDispatcher(tb testing.TB) common.PubSubDispatcher {
 	return dispatcher
 }
 
+// newTestDispatcherMissingOnlineLane returns a dispatcher that never
+// registered the SensorOnlineLane, so registering a consumer onto it fails.
+func newTestDispatcherMissingOnlineLane(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
 // resetSingleton clears the package-level ResetNotifiable singleton so tests
 // don't leak state (and don't skip registration) across each other.
 func resetSingleton(tb testing.TB) {
@@ -92,4 +104,36 @@ func TestResetNotifiable_RegistersSensorOnlineConsumer(t *testing.T) {
 		assert.True(t, fake.closed)
 		assert.Nil(t, scannerClient)
 	})
+}
+
+// TestResetNotifiable_RegistrationFailure_ReturnsUsableNotifiable verifies
+// that a lane registration failure (e.g. the SensorOnlineLane isn't wired up
+// on the dispatcher) is logged rather than causing ResetNotifiable() to
+// panic or return a broken notifiable -- sensor startup must survive it.
+func TestResetNotifiable_RegistrationFailure_ReturnsUsableNotifiable(t *testing.T) {
+	resetSingleton(t)
+	defer resetSingleton(t)
+
+	n := ResetNotifiable(newTestDispatcherMissingOnlineLane(t))
+
+	require.NotNil(t, n)
+	assert.Same(t, notifiable, n)
+}
+
+// TestNotify_NoOpWhenPubSubEnabled verifies that Notify() is a no-op once
+// PubSub is enabled, since the SensorOnlineEvent subscription registered in
+// ResetNotifiable() is responsible for resetting the client instead. If this
+// early return regressed, both paths would fire on every transition.
+func TestNotify_NoOpWhenPubSubEnabled(t *testing.T) {
+	fake := &fakeScannerClient{}
+	scannerClient = fake
+	defer func() { scannerClient = nil }()
+
+	r := &resetNotifiable{pubSubDispatcher: newTestOnlineDispatcher(t)}
+	require.True(t, r.pubSubEnabled())
+
+	r.Notify(common.SensorComponentEventCentralReachable)
+
+	assert.False(t, fake.closed)
+	assert.Same(t, fake, scannerClient)
 }

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -8,12 +8,15 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralclient"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"google.golang.org/grpc/codes"
 )
 
@@ -29,22 +32,70 @@ var (
 type Handler struct {
 	centralClient    *http.Client
 	centralReachable atomic.Bool
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 // NewDefinitionsHandler creates a new scanner definitions handler.
-func NewDefinitionsHandler(centralEndpoint string, centralCertificates []*x509.Certificate) (*Handler, error) {
+func NewDefinitionsHandler(centralEndpoint string, centralCertificates []*x509.Certificate, pubSubDispatcher common.PubSubDispatcher) (*Handler, error) {
 	client, err := centralclient.AuthenticatedCentralHTTPClient(centralEndpoint, centralCertificates)
 	if err != nil {
 		return nil, errors.Wrap(err, "instantiating central HTTP transport")
 	}
-	return &Handler{
-		centralClient: client,
-	}, nil
+	h := &Handler{
+		centralClient:    client,
+		pubSubDispatcher: pubSubDispatcher,
+	}
+	if h.pubSubEnabled() {
+		if err := pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ScannerDefinitionsHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			h.handleSensorOnlineEvent,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to register scanner definitions handler sensor online consumer")
+		}
+		if err := pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ScannerDefinitionsHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			h.handleSensorOfflineEvent,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to register scanner definitions handler sensor offline consumer")
+		}
+	}
+	return h, nil
+}
+
+func (h *Handler) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && h.pubSubDispatcher != nil
+}
+
+func (h *Handler) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReachable.Store(true)
+	return nil
+}
+
+func (h *Handler) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReachable.Store(false)
+	return nil
 }
 
 // Notify reacts to sensor going into online/offline mode.
 func (h *Handler) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e, "Scanner definitions handler"))
+	if h.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in
+		// NewDefinitionsHandler().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReachable.Store(true)

--- a/sensor/common/scannerdefinitions/http_handler_pubsub_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_pubsub_test.go
@@ -95,3 +95,18 @@ func TestDefinitionsHandler_RegistersSensorOnlineOfflineConsumers(t *testing.T) 
 		assert.False(t, h.centralReachable.Load())
 	})
 }
+
+// TestNotify_NoOpWhenPubSubEnabled verifies that Notify() is a no-op once
+// PubSub is enabled, since the SensorOnlineEvent/SensorOfflineEvent
+// subscriptions registered in NewDefinitionsHandler() are responsible for
+// flipping centralReachable instead. If this early return regressed, both
+// paths would fire on every transition.
+func TestNotify_NoOpWhenPubSubEnabled(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+	require.True(t, h.pubSubEnabled())
+	h.centralReachable.Store(true)
+
+	h.Notify(common.SensorComponentEventOfflineMode)
+
+	assert.True(t, h.centralReachable.Load())
+}

--- a/sensor/common/scannerdefinitions/http_handler_pubsub_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_pubsub_test.go
@@ -1,0 +1,97 @@
+package scannerdefinitions
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func TestHandleSensorOnlineEvent_SetsCentralReachable(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+	require.False(t, h.centralReachable.Load())
+
+	require.NoError(t, h.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, h.centralReachable.Load())
+}
+
+func TestHandleSensorOfflineEvent_UnsetsCentralReachable(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+	h.centralReachable.Store(true)
+
+	require.NoError(t, h.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, h.centralReachable.Load())
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+
+	err := h.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+
+	err := h.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestDefinitionsHandler_RegistersSensorOnlineOfflineConsumers verifies the
+// same registration NewDefinitionsHandler() performs at construction time
+// (there is no Start() for a Notifiable-only component) wires the
+// online/offline handlers onto the SensorOnline/SensorOffline topic and
+// lane end-to-end through a real dispatcher. NewDefinitionsHandler() itself
+// isn't called here because it requires a live mTLS service-cert
+// environment (AuthenticatedCentralHTTPClient) unrelated to this migration
+// -- same reason the existing ServeHTTP tests in http_handler_test.go build
+// &Handler{...} directly instead of going through the constructor.
+func TestDefinitionsHandler_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		h := &Handler{pubSubDispatcher: dispatcher}
+		require.NoError(t, dispatcher.RegisterConsumerToLane(
+			pubsub.ScannerDefinitionsHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			h.handleSensorOnlineEvent,
+		))
+		require.NoError(t, dispatcher.RegisterConsumerToLane(
+			pubsub.ScannerDefinitionsHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			h.handleSensorOfflineEvent,
+		))
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, h.centralReachable.Load())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, h.centralReachable.Load())
+	})
+}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -244,7 +244,7 @@ func (s *Sensor) Start() {
 		}
 		customRoutes = append(customRoutes, *route)
 
-		s.AddNotifiable(scannerclient.ResetNotifiable())
+		s.AddNotifiable(scannerclient.ResetNotifiable(s.pubSubDispatcher))
 	}
 
 	// Enable proxy endpoint for forwarding requests to Central on OpenShift.
@@ -320,7 +320,7 @@ func (s *Sensor) Start() {
 // newScannerDefinitionsRoute returns a custom route that serves scanner
 // definitions retrieved from Central.
 func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string, centralCertificates []*x509.Certificate) (*routes.CustomRoute, error) {
-	handler, err := scannerdefinitions.NewDefinitionsHandler(centralEndpoint, centralCertificates)
+	handler, err := scannerdefinitions.NewDefinitionsHandler(centralEndpoint, centralCertificates, s.pubSubDispatcher)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating scanner definitions handler")
 	}


### PR DESCRIPTION
## Description

PR 6 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854). Migrates the two `Notify(SensorComponentEvent)` implementations in `sensor/common/scannerclient` and `sensor/common/scannerdefinitions` to genuine PubSub subscriptions on `SensorOnlineTopic`/`SensorOfflineTopic`:

- `reset_notifiable.go` -- resets the scanner gRPC client singleton on online only. Its `Notify` never had an `OfflineMode` case, so this is the first asymmetric migration in the series: an online-only consumer, no offline topic registered.
- `http_handler.go` -- `centralReachable` flag flip on both online and offline.

**Architectural wrinkle vs. prior PRs**: both types implement only `common.Notifiable` (just `Notify`), not the full `common.SensorComponent` interface every component migrated so far implements, so neither has a `Start()`/`Stop()` to hook a `RegisterConsumerToLane` call into. They're wired via `Sensor.AddNotifiable(...)` in `sensor/common/sensor/sensor.go` -- a different layer from the `sensor/kubernetes/sensor/sensor.go` components slice used by PRs 1/2/3/4/5. Registered the PubSub consumer(s) inside each type's constructor instead (`ResetNotifiable`'s `sync.Once`, and `NewDefinitionsHandler` directly), since construction is their only lifecycle hook. This mirrors the existing `registerSoftRestartHandler`/`makeSoftRestartCallback` precedent already merged in the same file, which does sensor-core-level PubSub registration outside of any component `Start()`.

Both call sites already run inside `Sensor.Start()` with `s.pubSubDispatcher` in scope (the same field `registerSoftRestartHandler` uses), so no additional wiring was needed beyond passing it through.

Checked all currently-open PRs for file overlap before picking this task: none of these two files are touched by #21316, #21671, or #21651/#21650/#21547.

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added `reset_notifiable_pubsub_test.go`: handler unit test verifying the scanner client singleton gets closed and nilled, a wrong-event-type case, and a construction-time end-to-end test (resetting the package-level singleton vars first) that publishes through a real dispatcher.
- Added `http_handler_pubsub_test.go`: handler unit tests for the flag flip, wrong-event-type cases, and an end-to-end registration test. `NewDefinitionsHandler()` itself isn't called in the end-to-end test since it requires a live mTLS service-cert environment unrelated to this migration -- same reason the existing `ServeHTTP` tests in `http_handler_test.go` build `&Handler{...}` directly instead of going through the constructor.
- No existing test call sites needed changes: `http_handler_test.go` constructs `Handler{...}` via a named-field struct literal (new field defaults to nil); no test file calls `ResetNotifiable()` or `NewDefinitionsHandler()` directly.
- `go build ./sensor/...` -- clean.
- `go test ./sensor/common/scannerclient/... ./sensor/common/scannerdefinitions/... ./sensor/common/sensor/...` -- all pass.
- `go vet` and `quickstyle` (golangci-lint/imports/blanks/fmt/roxvet) -- all clean.
- Feature is gated by `ROX_SENSOR_PUBSUB`, off by default in prod; legacy Notify path is unchanged when disabled.


## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742)
  - PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763)
  - PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762)
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765)
  - **PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766) (this PR)**
  - PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767)
  - PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771)
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)


