### PR TITLE
ROX-35642: Migrate networkflow purger ResourceSyncFinished to PubSub

### DIFF
--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -182,7 +182,7 @@ func NewManager(
 			"Applying default of 4 hours", maxAgeSetting, enricherCycle)
 		maxAgeSetting = 4 * time.Hour
 	}
-	mgr.purger = NewNetworkFlowPurger(clusterEntities, maxAgeSetting, WithManager(mgr))
+	mgr.purger = NewNetworkFlowPurger(clusterEntities, maxAgeSetting, pubSubDispatcher, WithManager(mgr))
 
 	enricherTicker.Stop()
 	mgr.sensorUpdates = make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.NetworkFlowBufferSize))

--- a/sensor/common/networkflow/manager/purger.go
+++ b/sensor/common/networkflow/manager/purger.go
@@ -8,10 +8,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
 	flowMetrics "github.com/stackrox/rox/sensor/common/networkflow/metrics"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
 type PurgerOption func(purger *NetworkFlowPurger)
@@ -43,6 +46,8 @@ type NetworkFlowPurger struct {
 	stopper concurrency.Stopper
 	// purgingDone is signaled on each finished purging action
 	purgingDone concurrency.Signal
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 // NewNetworkFlowPurger implements Sensor Component and is tightly bound to the networkFlowManager.
@@ -50,23 +55,42 @@ type NetworkFlowPurger struct {
 // is done by using the `WithPurger` option when constructing the manager: `manager.NewManager(..., manager.WithPurger(purger))`.
 // The purger is designed to always consume the messages from `purgerTickerC` - even if the binding to networkFlowManager
 // fails or the purger is explicitly disabled using env var.
-func NewNetworkFlowPurger(clusterEntities EntityStore, maxAge time.Duration, opts ...PurgerOption) *NetworkFlowPurger {
+func NewNetworkFlowPurger(clusterEntities EntityStore, maxAge time.Duration, pubSubDispatcher common.PubSubDispatcher, opts ...PurgerOption) *NetworkFlowPurger {
 	purgerTicker := time.NewTicker(nonZeroPurgerCycle())
 	defer purgerTicker.Stop()
 
 	p := &NetworkFlowPurger{
-		clusterEntities: clusterEntities,
-		manager:         nil,
-		purgerTicker:    purgerTicker,
-		purgerTickerC:   purgerTicker.C,
-		maxAge:          maxAge,
-		stopper:         concurrency.NewStopper(),
-		purgingDone:     concurrency.NewSignal(),
+		clusterEntities:  clusterEntities,
+		manager:          nil,
+		purgerTicker:     purgerTicker,
+		purgerTickerC:    purgerTicker.C,
+		maxAge:           maxAge,
+		stopper:          concurrency.NewStopper(),
+		purgingDone:      concurrency.NewSignal(),
+		pubSubDispatcher: pubSubDispatcher,
 	}
 	for _, o := range opts {
 		o(p)
 	}
 	return p
+}
+
+func (p *NetworkFlowPurger) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && p.pubSubDispatcher != nil
+}
+
+func (p *NetworkFlowPurger) handleResourceSyncFinishedEvent(event pubsub.Event) error {
+	evt, ok := event.(*events.ResourceSyncFinishedEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	if evt.IsExpired() {
+		return nil
+	}
+	d := nonZeroPurgerCycle()
+	p.purgerTicker.Reset(d)
+	log.Debugf("NetworkFlowPurger will execute in %s", d.String())
+	return nil
 }
 
 func (p *NetworkFlowPurger) Start() error {
@@ -77,6 +101,17 @@ func (p *NetworkFlowPurger) Start() error {
 	if env.EnrichmentPurgerTickerCycle.DurationSetting() == 0 {
 		p.stopper.Flow().ReportStopped() // to ensure that Stop doesn't block
 		return errors.New("network flow purger is disabled")
+	}
+
+	if p.pubSubEnabled() {
+		if err := p.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.NetworkFlowPurgerResourceSyncFinishedConsumer,
+			pubsub.ResourceSyncFinishedTopic,
+			pubsub.ResourceSyncFinishedLane,
+			p.handleResourceSyncFinishedEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register network flow purger resource sync finished consumer")
+		}
 	}
 
 	// Allow starting the purger without a manager. This is done to prevent blocking of the entire component when
@@ -114,6 +149,11 @@ func (p *NetworkFlowPurger) Notify(e common.SensorComponentEvent) {
 	// Purger could start earlier than this, but we stick to the `SensorComponentEventResourceSyncFinished` as it also
 	// enables the networkFlowManager.
 	case common.SensorComponentEventResourceSyncFinished:
+		if p.pubSubEnabled() {
+			// Handled by handleResourceSyncFinishedEvent via the
+			// ResourceSyncFinished PubSub subscription registered in Start().
+			return
+		}
 		d := nonZeroPurgerCycle()
 		p.purgerTicker.Reset(d)
 		log.Debugf("NetworkFlowPurger will execute in %s", d.String())

--- a/sensor/common/networkflow/manager/purger_pubsub_test.go
+++ b/sensor/common/networkflow/manager/purger_pubsub_test.go
@@ -16,6 +16,28 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+type capturingDispatcher struct {
+	consumerID pubsub.ConsumerID
+	topic      pubsub.Topic
+	laneID     pubsub.LaneID
+	callback   pubsub.EventCallback
+}
+
+func (d *capturingDispatcher) RegisterConsumer(_ pubsub.ConsumerID, _ pubsub.Topic, _ pubsub.EventCallback) error {
+	return nil
+}
+
+func (d *capturingDispatcher) RegisterConsumerToLane(id pubsub.ConsumerID, topic pubsub.Topic, laneID pubsub.LaneID, cb pubsub.EventCallback) error {
+	d.consumerID = id
+	d.topic = topic
+	d.laneID = laneID
+	d.callback = cb
+	return nil
+}
+
+func (d *capturingDispatcher) Publish(_ pubsub.Event) error { return nil }
+func (d *capturingDispatcher) Stop()                        {}
+
 // newPurgerForPubSubTest builds a purger with a fast real ticker (not the
 // WithPurgerTicker test override, which decouples purgerTickerC from
 // purgerTicker -- Reset()ing the real ticker wouldn't be observable through
@@ -84,7 +106,7 @@ func TestNewNetworkFlowPurger_PubSubEnabled_CallbackSkipsExpiredEvent(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	require.NoError(t, capturing.callback(&events.ResourceSyncFinishedEvent{Validity: ctx}))
+	require.NoError(t, capturing.callback(&events.ResourceSyncFinishedEvent{LifecycleEvent: events.LifecycleEvent{Validity: ctx}}))
 
 	assert.Never(t, purger.purgingDone.IsDone, 200*time.Millisecond, 10*time.Millisecond,
 		"purgingDone must not be signaled for an expired event since the ticker isn't reset")
@@ -101,7 +123,7 @@ func TestNewNetworkFlowPurger_PubSubEnabled_CallbackRejectsWrongEventType(t *tes
 	require.NoError(t, purger.Start())
 	require.NotNil(t, capturing.callback)
 
-	err := capturing.callback(&events.SoftRestartEvent{Text: "wrong type"})
+	err := capturing.callback(&events.SoftRestartEvent{LifecycleEvent: events.LifecycleEvent{Text: "wrong type"}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected event type")
 }

--- a/sensor/common/networkflow/manager/purger_pubsub_test.go
+++ b/sensor/common/networkflow/manager/purger_pubsub_test.go
@@ -1,0 +1,138 @@
+package manager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// newPurgerForPubSubTest builds a purger with a fast real ticker (not the
+// WithPurgerTicker test override, which decouples purgerTickerC from
+// purgerTicker -- Reset()ing the real ticker wouldn't be observable through
+// an overridden channel), so that resetting purgerTicker via the PubSub
+// callback is observable through purgingDone firing.
+func newPurgerForPubSubTest(t *testing.T, dispatcher *capturingDispatcher) *NetworkFlowPurger {
+	t.Helper()
+	t.Setenv(env.EnrichmentPurgerTickerCycle.EnvVar(), "10ms")
+
+	mockCtrl := gomock.NewController(t)
+	enrichTickerC := make(chan time.Time)
+	t.Cleanup(func() { close(enrichTickerC) })
+
+	m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
+	return NewNetworkFlowPurger(mockEntityStore, time.Hour, dispatcher, WithManager(m))
+}
+
+// TestNewNetworkFlowPurger_PubSubEnabled_RegistersConsumer verifies that when
+// the pubsub feature flag is enabled, Start() registers a consumer for
+// ResourceSyncFinishedTopic.
+func TestNewNetworkFlowPurger_PubSubEnabled_RegistersConsumer(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	capturing := &capturingDispatcher{}
+	purger := newPurgerForPubSubTest(t, capturing)
+	defer purger.Stop()
+
+	require.NoError(t, purger.Start())
+
+	require.NotNil(t, capturing.callback, "expected RegisterConsumerToLane to be called with a non-nil callback")
+	assert.Equal(t, pubsub.NetworkFlowPurgerResourceSyncFinishedConsumer, capturing.consumerID)
+	assert.Equal(t, pubsub.ResourceSyncFinishedTopic, capturing.topic)
+	assert.Equal(t, pubsub.ResourceSyncFinishedLane, capturing.laneID)
+}
+
+// TestNewNetworkFlowPurger_PubSubEnabled_CallbackResetsTicker verifies the
+// callback resets the purger ticker, mirroring the legacy Notify behavior
+// exercised by TestPurgerStartWithTicker.
+func TestNewNetworkFlowPurger_PubSubEnabled_CallbackResetsTicker(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	capturing := &capturingDispatcher{}
+	purger := newPurgerForPubSubTest(t, capturing)
+	defer purger.Stop()
+	require.NoError(t, purger.Start())
+	require.NotNil(t, capturing.callback)
+
+	require.NoError(t, capturing.callback(&events.ResourceSyncFinishedEvent{}))
+
+	assert.Eventually(t, purger.purgingDone.IsDone, 2*time.Second, 10*time.Millisecond,
+		"purgingDone must be signaled once the ticker (reset by the callback) fires")
+}
+
+// TestNewNetworkFlowPurger_PubSubEnabled_CallbackSkipsExpiredEvent verifies
+// that the callback drops stale events whose validity context has been
+// cancelled, without resetting the ticker.
+func TestNewNetworkFlowPurger_PubSubEnabled_CallbackSkipsExpiredEvent(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	capturing := &capturingDispatcher{}
+	purger := newPurgerForPubSubTest(t, capturing)
+	defer purger.Stop()
+	require.NoError(t, purger.Start())
+	require.NotNil(t, capturing.callback)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, capturing.callback(&events.ResourceSyncFinishedEvent{Validity: ctx}))
+
+	assert.Never(t, purger.purgingDone.IsDone, 200*time.Millisecond, 10*time.Millisecond,
+		"purgingDone must not be signaled for an expired event since the ticker isn't reset")
+}
+
+// TestNewNetworkFlowPurger_PubSubEnabled_CallbackRejectsWrongEventType
+// verifies that the callback returns an error for an unexpected event type.
+func TestNewNetworkFlowPurger_PubSubEnabled_CallbackRejectsWrongEventType(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	capturing := &capturingDispatcher{}
+	purger := newPurgerForPubSubTest(t, capturing)
+	defer purger.Stop()
+	require.NoError(t, purger.Start())
+	require.NotNil(t, capturing.callback)
+
+	err := capturing.callback(&events.SoftRestartEvent{Text: "wrong type"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestNewNetworkFlowPurger_PubSubEnabled_RealDispatcher creates a real PubSub
+// dispatcher (not a capturing mock), publishes a ResourceSyncFinishedEvent
+// through it, and verifies purgingDone eventually signals -- exercising the
+// actual lane routing end-to-end.
+func TestNewNetworkFlowPurger_PubSubEnabled_RealDispatcher(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	t.Setenv(env.EnrichmentPurgerTickerCycle.EnvVar(), "10ms")
+
+	disp, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+		},
+	))
+	require.NoError(t, err)
+	defer disp.Stop()
+
+	mockCtrl := gomock.NewController(t)
+	enrichTickerC := make(chan time.Time)
+	defer close(enrichTickerC)
+	m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
+
+	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, disp, WithManager(m))
+	require.NoError(t, purger.Start())
+	defer purger.Stop()
+
+	require.NoError(t, disp.Publish(&events.ResourceSyncFinishedEvent{}))
+
+	assert.Eventually(t, purger.purgingDone.IsDone, 2*time.Second, 10*time.Millisecond,
+		"purgingDone must be signaled after publishing through the real dispatcher")
+}

--- a/sensor/common/networkflow/manager/purger_test.go
+++ b/sensor/common/networkflow/manager/purger_test.go
@@ -31,7 +31,7 @@ func (s *NetworkFlowPurgerTestSuite) TestPurgerStartWithTicker() {
 	s.Equal(time.Second, nonZeroPurgerCycle())
 
 	m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
-	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, WithManager(m))
+	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, nil, WithManager(m))
 	s.NoError(purger.Start())
 	// Enable the ticker after going online - send the same signal that activates the manager
 	purger.Notify(common.SensorComponentEventResourceSyncFinished)
@@ -50,7 +50,7 @@ func (s *NetworkFlowPurgerTestSuite) TestDisabledPurger() {
 	s.T().Setenv(env.EnrichmentPurgerTickerCycle.EnvVar(), "0s")
 
 	m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
-	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, WithManager(m), WithPurgerTicker(s.T(), purgerTickerC))
+	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, nil, WithManager(m), WithPurgerTicker(s.T(), purgerTickerC))
 
 	s.ErrorContains(purger.Start(), "purger is disabled")
 
@@ -73,7 +73,7 @@ func (s *NetworkFlowPurgerTestSuite) TestPurgerWithoutManager() {
 	defer mockCtrl.Finish()
 	_, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
 	// Don't set manager to explicitly simulate disconnected purger
-	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, WithPurgerTicker(s.T(), purgerTickerC))
+	purger := NewNetworkFlowPurger(mockEntityStore, time.Hour, nil, WithPurgerTicker(s.T(), purgerTickerC))
 
 	s.ErrorContains(purger.Start(), "not bound to a network flow manager")
 	select {
@@ -124,7 +124,7 @@ func (s *NetworkFlowPurgerTestSuite) TestPurgerWithManager() {
 			lastUpdateTS := timestamp.FromGoTime(now.Add(-tc.lastUpdateTime))
 
 			m, mockEntityStore, _, _ := createManager(mockCtrl, enrichTickerC)
-			purger := NewNetworkFlowPurger(mockEntityStore, tc.purgerMaxAge, WithManager(m), WithPurgerTicker(s.T(), purgerTickerC))
+			purger := NewNetworkFlowPurger(mockEntityStore, tc.purgerMaxAge, nil, WithManager(m), WithPurgerTicker(s.T(), purgerTickerC))
 
 			expectationsEndpointPurger(mockEntityStore, tc.isKnownEndpoint, true, false)
 			ep := createEndpointPair(timestamp.FromGoTime(now.Add(-tc.firstSeen)), lastUpdateTS)

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,26 +19,28 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	NetworkFlowPurgerResourceSyncFinishedConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:                            "NoConsumers",
-		DefaultConsumer:                        "Default",
-		ResolverConsumer:                       "Resolver",
-		EnrichedProcessConsumer:                "EnrichedProcess",
-		FileActivityEnrichedProcessConsumer:    "FileActivityEnrichedProcess",
-		UnenrichedProcessConsumer:              "UnenrichedProcess",
-		DetectorProcessIndicatorConsumer:       "DetectorProcessIndicator",
-		DetectorNetworkFlowConsumer:            "DetectorNetworkFlow",
-		DetectorFileAccessConsumer:             "DetectorFileAccess",
-		DetectorAuditLogConsumer:               "DetectorAuditLog",
-		DetectorDeploymentConsumer:             "DetectorDeployment",
-		DetectorScanResultConsumer:             "DetectorScanResult",
-		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
-		OutputQueueConsumer:                    "OutputQueue",
-		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
-		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		NoConsumers:                                   "NoConsumers",
+		DefaultConsumer:                               "Default",
+		ResolverConsumer:                              "Resolver",
+		EnrichedProcessConsumer:                       "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer:           "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:                     "UnenrichedProcess",
+		DetectorProcessIndicatorConsumer:              "DetectorProcessIndicator",
+		DetectorNetworkFlowConsumer:                   "DetectorNetworkFlow",
+		DetectorFileAccessConsumer:                    "DetectorFileAccess",
+		DetectorAuditLogConsumer:                      "DetectorAuditLog",
+		DetectorDeploymentConsumer:                    "DetectorDeployment",
+		DetectorScanResultConsumer:                    "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:             "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                           "OutputQueue",
+		NetworkFlowManagerResourceSyncConsumer:        "NetworkFlowManagerResourceSync",
+		SensorSoftRestartConsumer:                     "SensorSoftRestart",
+		NetworkFlowPurgerResourceSyncFinishedConsumer: "NetworkFlowPurgerResourceSyncFinished",
 	}
 )
 


### PR DESCRIPTION
## Description

PR 7 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854). This PR proceeds ahead of the other still-conflicting one (PR 8, misc singles) by decision.

**Scope correction vs. the plan doc**: reading the current code (which already includes #21316's merged-in `ResourceSyncFinished` work, inherited via the branch stack -- see below) shows `manager_impl.go`'s `Notify` has no `CentralReachable` case at all, and its `OfflineMode` case is already a bare no-op `return` -- nothing to dual-path there. `purger.go`'s `Notify` also has no `CentralReachable` case, and its `OfflineMode` case is an intentional no-op ("Continue purging even in offline mode when buffering events"). The only real remaining work was `purger.go`'s `ResourceSyncFinished` handling, which wasn't migrated yet.

Adds a genuine PubSub subscription to `ResourceSyncFinishedTopic` (already defined) via a new `NetworkFlowPurgerResourceSyncFinishedConsumer`, replicating the exact ticker-reset logic (including the expiry check already used by manager's own callback) in a new `handleResourceSyncFinishedEvent`. `Notify()` gets a scoped early-return for just the `ResourceSyncFinished` case, matching the complianceoperator precedent, since the `OfflineMode` case is orthogonal and untouched.

**Also fixes a pre-existing anti-pattern**: `manager_impl.go`'s own `ResourceSyncFinished` PubSub callback (added by #21316) was calling `mgr.purger.Notify(...)` directly from inside a PubSub handler -- exactly the "PubSub must never call Notify" violation the architecture rules forbid. It was harmless only because `purger.Notify` had no PubSub guard yet. Removed now that purger subscribes to the same topic/lane directly and will react independently (the framework delivers to all subscribers on a lane). `manager_impl.go`'s own `Notify()` method's legacy forwarding to the purger is unrelated and untouched -- that's correct dual-path propagation, and becomes a no-op once purger's own `Notify` short-circuits in PubSub mode.

**Why this one first despite the "conflicts" list**: the infra branch this whole series stacks on is itself stacked on top of #21316's branch (`jschnath/ROX-34887_Refactor_network_flows`), so #21316's changes to `manager_impl.go` are already inherited into this branch -- there's no git-level conflict today, only a routine rebase once #21316 merges to master (already documented in the plan doc's "Branch convention" section).

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added `purger_pubsub_test.go`, mirroring the already-merged `manager_pubsub_test.go`'s shape and idioms exactly, reusing its `capturingDispatcher` fake: registration test, ticker-reset test, expired-event test, wrong-event-type test, and a real-dispatcher end-to-end test.
- Updated the 4 existing `NewNetworkFlowPurger(...)` call sites in `purger_test.go` to pass a `nil` dispatcher, keeping the legacy-Notify-path tests unchanged.
- `go build ./sensor/...` -- clean.
- `go test -race ./sensor/common/networkflow/manager/...` -- all pass.
- `go vet` and `quickstyle` (golangci-lint/imports/blanks/fmt/roxvet) -- all clean.
- Feature is gated by `ROX_SENSOR_PUBSUB`, off by default in prod; legacy Notify path is unchanged when disabled.


## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742)
  - PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763)
  - PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762)
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765)
  - PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766)
  - **PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767) (this PR)**
  - PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771)
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)


