### PR TITLE
perf: eliminate O(N) public IP scan in cluster entity store

### DIFF
--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -3,6 +3,7 @@ package set
 import (
 	"fmt"
 	"iter"
+	"maps"
 	"sort"
 	"strings"
 )

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -3,7 +3,6 @@ package set
 import (
 	"fmt"
 	"iter"
-	"maps"
 	"sort"
 	"strings"
 )

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -311,8 +311,6 @@ func (e *Store) Apply(updates map[string]*EntityData, incremental bool, auxInfo 
 		}
 	}
 
-	// Order matters: Endpoints must be applied before IPs, as the IP store may query the endpoints store to check
-	// whether a given IP is used by other endpoints.
 	epChanged := e.endpointsStore.Apply(updates, incremental)
 	ipChanged := e.podIPsStore.Apply(updates, incremental)
 

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -313,10 +313,12 @@ func (e *Store) Apply(updates map[string]*EntityData, incremental bool, auxInfo 
 
 	// Order matters: Endpoints must be applied before IPs, as the IP store may query the endpoints store to check
 	// whether a given IP is used by other endpoints.
-	e.endpointsStore.Apply(updates, incremental)
-	e.podIPsStore.Apply(updates, incremental)
+	epChanged := e.endpointsStore.Apply(updates, incremental)
+	ipChanged := e.podIPsStore.Apply(updates, incremental)
 
-	e.updatePublicIPRefs(e.currentlyStoredPublicIPs())
+	if epChanged || ipChanged {
+		e.updatePublicIPRefs(e.currentlyStoredPublicIPs())
+	}
 
 	callbacks := e.containerIDsStore.Apply(updates, incremental)
 	if e.callbackChannel != nil && len(callbacks) > 0 {

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -316,18 +316,14 @@ func (e *Store) Apply(updates map[string]*EntityData, incremental bool, auxInfo 
 	epPublicIPs := e.endpointsStore.Apply(updates, incremental)
 	ipPublicIPs := e.podIPsStore.Apply(updates, incremental)
 
-	if len(epPublicIPs) > 0 || len(ipPublicIPs) > 0 {
-		allPublicIPs := epPublicIPs
-		if len(ipPublicIPs) > 0 {
-			if allPublicIPs == nil {
-				allPublicIPs = ipPublicIPs
-			} else {
-				for ip := range ipPublicIPs {
-					allPublicIPs.Add(ip)
-				}
-			}
+	if epPublicIPs != nil || ipPublicIPs != nil {
+		if epPublicIPs == nil {
+			epPublicIPs = e.endpointsStore.PublicIPs()
 		}
-		e.updatePublicIPRefs(allPublicIPs)
+		if ipPublicIPs == nil {
+			ipPublicIPs = e.podIPsStore.PublicIPs()
+		}
+		e.updatePublicIPRefs(epPublicIPs.Union(ipPublicIPs))
 	}
 
 	callbacks := e.containerIDsStore.Apply(updates, incremental)
@@ -338,32 +334,7 @@ func (e *Store) Apply(updates map[string]*EntityData, incremental bool, auxInfo 
 
 // currentlyStoredPublicIPs returns all public IPs currently stored in the store (including history).
 func (e *Store) currentlyStoredPublicIPs() set.Set[net.IPAddress] {
-	s := set.NewSet[net.IPAddress]()
-	concurrency.WithRLock(&e.endpointsStore.mutex, func() {
-		for endpoint := range e.endpointsStore.endpointMap {
-			if endpoint.IPAndPort.Address.IsPublic() {
-				s.Add(endpoint.IPAndPort.Address)
-			}
-		}
-		for endpoint := range e.endpointsStore.historicalEndpoints {
-			if endpoint.IPAndPort.Address.IsPublic() {
-				s.Add(endpoint.IPAndPort.Address)
-			}
-		}
-	})
-	concurrency.WithRLock(&e.podIPsStore.mutex, func() {
-		for address := range e.podIPsStore.ipMap {
-			if address.IsPublic() {
-				s.Add(address)
-			}
-		}
-		for address := range e.podIPsStore.historicalIPs {
-			if address.IsPublic() {
-				s.Add(address)
-			}
-		}
-	})
-	return s
+	return e.endpointsStore.PublicIPs().Union(e.podIPsStore.PublicIPs())
 }
 
 var slowRecordTickLogThreshold = env.ClusterEntitiesSlowRecordTickLogThreshold.DurationSetting()

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -313,11 +313,21 @@ func (e *Store) Apply(updates map[string]*EntityData, incremental bool, auxInfo 
 
 	// Order matters: Endpoints must be applied before IPs, as the IP store may query the endpoints store to check
 	// whether a given IP is used by other endpoints.
-	epChanged := e.endpointsStore.Apply(updates, incremental)
-	ipChanged := e.podIPsStore.Apply(updates, incremental)
+	epPublicIPs := e.endpointsStore.Apply(updates, incremental)
+	ipPublicIPs := e.podIPsStore.Apply(updates, incremental)
 
-	if epChanged || ipChanged {
-		e.updatePublicIPRefs(e.currentlyStoredPublicIPs())
+	if len(epPublicIPs) > 0 || len(ipPublicIPs) > 0 {
+		allPublicIPs := epPublicIPs
+		if len(ipPublicIPs) > 0 {
+			if allPublicIPs == nil {
+				allPublicIPs = ipPublicIPs
+			} else {
+				for ip := range ipPublicIPs {
+					allPublicIPs.Add(ip)
+				}
+			}
+		}
+		e.updatePublicIPRefs(allPublicIPs)
 	}
 
 	callbacks := e.containerIDsStore.Apply(updates, incremental)

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -313,17 +313,11 @@ func (e *Store) Apply(updates map[string]*EntityData, incremental bool, auxInfo 
 
 	// Order matters: Endpoints must be applied before IPs, as the IP store may query the endpoints store to check
 	// whether a given IP is used by other endpoints.
-	epPublicIPs := e.endpointsStore.Apply(updates, incremental)
-	ipPublicIPs := e.podIPsStore.Apply(updates, incremental)
+	epChanged := e.endpointsStore.Apply(updates, incremental)
+	ipChanged := e.podIPsStore.Apply(updates, incremental)
 
-	if epPublicIPs != nil || ipPublicIPs != nil {
-		if epPublicIPs == nil {
-			epPublicIPs = e.endpointsStore.PublicIPs()
-		}
-		if ipPublicIPs == nil {
-			ipPublicIPs = e.podIPsStore.PublicIPs()
-		}
-		e.updatePublicIPRefs(epPublicIPs.Union(ipPublicIPs))
+	if epChanged || ipChanged {
+		e.updatePublicIPRefs(e.currentlyStoredPublicIPs())
 	}
 
 	callbacks := e.containerIDsStore.Apply(updates, incremental)

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -109,7 +109,7 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 	if !incremental {
 		return e.replaceNoLock(updates)
 	}
-	touchedPublic := false
+	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
 			continue
@@ -126,7 +126,7 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 }
 
 func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[net.IPAddress] {
-	touchedPublic := false
+	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
 			// Must check before purge: purgeNoLock deletes reverseEndpointMap[deploymentID].
@@ -166,6 +166,12 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[n
 		return e.collectPublicIPsNoLock()
 	}
 	return nil
+}
+
+func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.collectPublicIPsNoLock()
 }
 
 func (e *endpointsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -102,6 +102,12 @@ func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool)
 	return e.applyNoLock(updates, incremental)
 }
 
+func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.collectPublicIPsNoLock()
+}
+
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
 	if !incremental {
@@ -168,12 +174,6 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 		}
 	}
 	return touchedPublic
-}
-
-func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
-	e.mutex.RLock()
-	defer e.mutex.RUnlock()
-	return e.collectPublicIPsNoLock()
 }
 
 func (e *endpointsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -27,6 +27,12 @@ type endpointsStore struct {
 	historicalEndpoints map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus
 	// reverseHistoricalEndpoints is mimicking reverseEndpointMap: deploymentID -> endpointInfo -> historyStatus
 	reverseHistoricalEndpoints map[string]map[net.NumericEndpoint]*entityStatus
+
+	// publicIPs is maintained incrementally via reference counting.
+	// Multiple endpoint keys (same IP, different ports) share one ref count.
+	publicIPs             set.Set[net.IPAddress]
+	publicIPEndpointCount map[net.IPAddress]int
+	publicIPsChanged      bool
 }
 
 func newEndpointsStoreWithMemory(numTicks uint16) *endpointsStore {
@@ -43,6 +49,10 @@ func (e *endpointsStore) initMapsNoLock() {
 
 	e.reverseHistoricalEndpoints = make(map[string]map[net.NumericEndpoint]*entityStatus)
 	e.historicalEndpoints = make(map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus)
+
+	e.publicIPs = set.NewSet[net.IPAddress]()
+	e.publicIPEndpointCount = make(map[net.IPAddress]int)
+	e.publicIPsChanged = false
 }
 
 func (e *endpointsStore) resetMaps() {
@@ -64,6 +74,7 @@ func (e *endpointsStore) resetMaps() {
 
 	e.endpointMap = make(map[net.NumericEndpoint]map[string]set.Set[EndpointTargetInfo])
 	e.reverseEndpointMap = make(map[string]set.Set[net.NumericEndpoint])
+	e.rebuildPublicIPsNoLock()
 	e.updateMetricsNoLock()
 }
 
@@ -80,20 +91,18 @@ func (e *endpointsStore) updateMetricsNoLock() {
 func (e *endpointsStore) RecordTick() bool {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "record_tick")
-	removedPublic := false
+	e.publicIPsChanged = false
 	for endpoint, m1 := range e.historicalEndpoints {
 		for deploymentID, m2 := range m1 {
 			for _, status := range m2 {
 				status.recordTick()
 			}
 			e.reverseHistoricalEndpoints[deploymentID][endpoint].recordTick()
-			// Remove all historical entries that expired in this tick.
-			removed := e.removeFromHistoryIfExpired(deploymentID, endpoint)
-			removedPublic = removedPublic || removed && endpoint.IPAndPort.Address.IsPublic()
+			e.removeFromHistoryIfExpired(deploymentID, endpoint)
 		}
 	}
 	e.updateMetricsNoLock()
-	return removedPublic
+	return e.publicIPsChanged
 }
 
 // Apply processes endpoint updates and returns all currently stored public IPs
@@ -106,63 +115,37 @@ func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool)
 
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	defer e.updateMetricsNoLock()
+	e.publicIPsChanged = false
 	if !incremental {
 		return e.replaceNoLock(updates)
 	}
-	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		e.applySingleNoLock(deploymentID, *data)
-		if !touchedPublic {
-			touchedPublic = containsPublicEndpoint(data.endpoints)
-		}
 	}
-	if touchedPublic {
+	if e.publicIPsChanged {
 		return e.collectPublicIPsNoLock()
 	}
 	return nil
 }
 
 func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[net.IPAddress] {
-	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply()->replaceNoLock() with empty payload of the updates map (no values) is meant to be a delete operation.
-			// Must check before purge: purgeNoLock deletes reverseEndpointMap[deploymentID].
-			if !touchedPublic {
-				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
-			}
 			e.purgeNoLock(deploymentID)
 			continue
 		}
 		// Fast path: if all endpoints are identical, skip the diff entirely.
-		// endpointsUnchangedNoLock handles all edge cases cheaply:
-		// - deployment not in store + empty new → true in O(1)
-		// - deployment not in store + non-empty new → false in O(1)
-		// - deployment in store with nil set + empty new → true (length match)
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
-			// the first time a deployment arrives with zero endpoints (e.g. a pod
-			// exists but no Service selects it yet). That marker later prevents
-			// the endpoint-takeover path from incorrectly moving other deployments
-			// to history when this deployment finally acquires real endpoints.
-			// Because endpointsUnchangedNoLock short-circuits "not-in-store +
-			// empty" as unchanged, we must replicate the marker here.
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}
 			continue
 		}
 		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
-		if !touchedPublic {
-			touchedPublic = containsPublicEndpoint(data.endpoints) ||
-				containsPublicEndpointInSet(currentEndpoints)
-		}
 		if !deploymentKnown {
-			// Brand-new deployment: use the full insert path which handles endpoint takeover.
 			e.applySingleNoLock(deploymentID, *data)
 			continue
 		}
@@ -173,7 +156,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[n
 			}
 		}
 	}
-	if touchedPublic {
+	if e.publicIPsChanged {
 		return e.collectPublicIPsNoLock()
 	}
 	return nil
@@ -186,18 +169,49 @@ func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
 }
 
 func (e *endpointsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
-	s := set.NewSet[net.IPAddress]()
-	for endpoint := range e.endpointMap {
-		if endpoint.IPAndPort.Address.IsPublic() {
-			s.Add(endpoint.IPAndPort.Address)
+	return e.publicIPs.Clone()
+}
+
+func (e *endpointsStore) trackEndpointKeyAddedNoLock(ep net.NumericEndpoint) {
+	ip := ep.IPAndPort.Address
+	if ip.IsPublic() {
+		e.publicIPEndpointCount[ip]++
+		if e.publicIPs.Add(ip) {
+			e.publicIPsChanged = true
 		}
 	}
-	for endpoint := range e.historicalEndpoints {
-		if endpoint.IPAndPort.Address.IsPublic() {
-			s.Add(endpoint.IPAndPort.Address)
+}
+
+func (e *endpointsStore) trackEndpointKeyRemovedNoLock(ep net.NumericEndpoint) {
+	ip := ep.IPAndPort.Address
+	if ip.IsPublic() {
+		e.publicIPEndpointCount[ip]--
+		if e.publicIPEndpointCount[ip] <= 0 {
+			delete(e.publicIPEndpointCount, ip)
+			if e.publicIPs.Remove(ip) {
+				e.publicIPsChanged = true
+			}
 		}
 	}
-	return s
+}
+
+func (e *endpointsStore) rebuildPublicIPsNoLock() {
+	e.publicIPs = set.NewSet[net.IPAddress]()
+	e.publicIPEndpointCount = make(map[net.IPAddress]int)
+	for ep := range e.endpointMap {
+		ip := ep.IPAndPort.Address
+		if ip.IsPublic() {
+			e.publicIPEndpointCount[ip]++
+			e.publicIPs.Add(ip)
+		}
+	}
+	for ep := range e.historicalEndpoints {
+		ip := ep.IPAndPort.Address
+		if ip.IsPublic() {
+			e.publicIPEndpointCount[ip]++
+			e.publicIPs.Add(ip)
+		}
+	}
 }
 
 // diffReplaceNoLock applies an endpoint update by computing a per-endpoint diff
@@ -268,6 +282,7 @@ func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.
 	}
 	if _, ok := e.endpointMap[ep]; !ok {
 		e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{deploymentID: etiSet}
+		e.trackEndpointKeyAddedNoLock(ep)
 	} else {
 		e.endpointMap[ep][deploymentID] = etiSet
 	}
@@ -416,6 +431,7 @@ func (e *endpointsStore) applySingleNoLock(deploymentID string, data EntityData)
 			e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{
 				deploymentID: make(set.Set[EndpointTargetInfo], len(targetInfos)),
 			}
+			e.trackEndpointKeyAddedNoLock(ep)
 		} else if !deploymentFound {
 			// New deployment, but the endpoint exists - the new deployment takes over the already existing endpoint
 			e.endpointMap[ep][deploymentID] = make(set.Set[EndpointTargetInfo], len(targetInfos))
@@ -510,8 +526,9 @@ func (e *endpointsStore) deleteFromHistory(deploymentID string, ep net.NumericEn
 		delete(e.reverseHistoricalEndpoints, deploymentID)
 	}
 	delete(e.historicalEndpoints[ep], deploymentID)
-	if len(e.historicalEndpoints[ep]) == 0 {
+	if m, ok := e.historicalEndpoints[ep]; ok && len(m) == 0 {
 		delete(e.historicalEndpoints, ep)
+		e.trackEndpointKeyRemovedNoLock(ep)
 	}
 	return foundDepl || foundEp
 }
@@ -521,6 +538,7 @@ func (e *endpointsStore) deleteFromCurrent(deploymentID string, ep net.NumericEn
 	delete(e.endpointMap[ep], deploymentID)
 	if len(e.endpointMap[ep]) == 0 {
 		delete(e.endpointMap, ep)
+		e.trackEndpointKeyRemovedNoLock(ep)
 	}
 
 	dSet, found := e.reverseEndpointMap[deploymentID]
@@ -548,6 +566,7 @@ func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoin
 	// Prepare maps if empty
 	if _, ok := e.historicalEndpoints[ep]; !ok {
 		e.historicalEndpoints[ep] = make(map[string]map[EndpointTargetInfo]*entityStatus)
+		e.trackEndpointKeyAddedNoLock(ep)
 	}
 	if _, ok := e.historicalEndpoints[ep][deploymentID]; !ok {
 		e.historicalEndpoints[ep][deploymentID] = make(map[EndpointTargetInfo]*entityStatus)
@@ -560,24 +579,6 @@ func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoin
 		e.reverseHistoricalEndpoints[deploymentID] = make(map[net.NumericEndpoint]*entityStatus)
 	}
 	e.reverseHistoricalEndpoints[deploymentID][ep] = newHistoricalEntity(e.memorySize)
-}
-
-func containsPublicEndpoint(endpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
-	for ep := range endpoints {
-		if ep.IPAndPort.Address.IsPublic() {
-			return true
-		}
-	}
-	return false
-}
-
-func containsPublicEndpointInSet(eps set.Set[net.NumericEndpoint]) bool {
-	for ep := range eps {
-		if ep.IPAndPort.Address.IsPublic() {
-			return true
-		}
-	}
-	return false
 }
 
 func (e *endpointsStore) String() string {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -96,55 +96,52 @@ func (e *endpointsStore) RecordTick() bool {
 	return removedPublic
 }
 
-func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) {
+func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "apply")
-	e.applyNoLock(updates, incremental)
+	return e.applyNoLock(updates, incremental)
 }
 
-func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) {
+func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
 	if !incremental {
-		e.replaceNoLock(updates)
-		return
+		return e.replaceNoLock(updates)
 	}
+	touchedPublic := false
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		e.applySingleNoLock(deploymentID, *data)
+		if !touchedPublic {
+			touchedPublic = containsPublicEndpoint(data.endpoints)
+		}
 	}
+	return touchedPublic
 }
 
-func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
+func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
+	touchedPublic := false
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply()->replaceNoLock() with empty payload of the updates map (no values) is meant to be a delete operation.
+			if !touchedPublic {
+				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
+			}
 			e.purgeNoLock(deploymentID)
 			continue
 		}
-		// Fast path: if all endpoints are identical, skip the diff entirely.
-		// endpointsUnchangedNoLock handles all edge cases cheaply:
-		// - deployment not in store + empty new → true in O(1)
-		// - deployment not in store + non-empty new → false in O(1)
-		// - deployment in store with nil set + empty new → true (length match)
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
-			// the first time a deployment arrives with zero endpoints (e.g. a pod
-			// exists but no Service selects it yet). That marker later prevents
-			// the endpoint-takeover path from incorrectly moving other deployments
-			// to history when this deployment finally acquires real endpoints.
-			// Because endpointsUnchangedNoLock short-circuits "not-in-store +
-			// empty" as unchanged, we must replicate the marker here.
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}
 			continue
 		}
+		if !touchedPublic {
+			touchedPublic = containsPublicEndpoint(data.endpoints) ||
+				containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
+		}
 		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
 		if !deploymentKnown {
-			// Brand-new deployment: use the full insert path which handles endpoint takeover.
 			e.applySingleNoLock(deploymentID, *data)
 			continue
 		}
@@ -155,6 +152,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
 			}
 		}
 	}
+	return touchedPublic
 }
 
 // diffReplaceNoLock applies an endpoint update by computing a per-endpoint diff
@@ -517,6 +515,24 @@ func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoin
 		e.reverseHistoricalEndpoints[deploymentID] = make(map[net.NumericEndpoint]*entityStatus)
 	}
 	e.reverseHistoricalEndpoints[deploymentID][ep] = newHistoricalEntity(e.memorySize)
+}
+
+func containsPublicEndpoint(endpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
+	for ep := range endpoints {
+		if ep.IPAndPort.Address.IsPublic() {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPublicEndpointInSet(eps set.Set[net.NumericEndpoint]) bool {
+	for ep := range eps {
+		if ep.IPAndPort.Address.IsPublic() {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *endpointsStore) String() string {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -27,6 +27,10 @@ type endpointsStore struct {
 	historicalEndpoints map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus
 	// reverseHistoricalEndpoints is mimicking reverseEndpointMap: deploymentID -> endpointInfo -> historyStatus
 	reverseHistoricalEndpoints map[string]map[net.NumericEndpoint]*entityStatus
+
+	publicIPs        set.Set[net.IPAddress]
+	publicIPRefCount map[net.IPAddress]int
+	publicIPsChanged bool
 }
 
 func newEndpointsStoreWithMemory(numTicks uint16) *endpointsStore {
@@ -43,6 +47,10 @@ func (e *endpointsStore) initMapsNoLock() {
 
 	e.reverseHistoricalEndpoints = make(map[string]map[net.NumericEndpoint]*entityStatus)
 	e.historicalEndpoints = make(map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus)
+
+	e.publicIPs = nil
+	e.publicIPRefCount = nil
+	e.publicIPsChanged = false
 }
 
 func (e *endpointsStore) resetMaps() {
@@ -64,6 +72,7 @@ func (e *endpointsStore) resetMaps() {
 
 	e.endpointMap = make(map[net.NumericEndpoint]map[string]set.Set[EndpointTargetInfo])
 	e.reverseEndpointMap = make(map[string]set.Set[net.NumericEndpoint])
+	e.rebuildPublicIPsNoLock()
 	e.updateMetricsNoLock()
 }
 
@@ -80,20 +89,18 @@ func (e *endpointsStore) updateMetricsNoLock() {
 func (e *endpointsStore) RecordTick() bool {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "record_tick")
-	removedPublic := false
+	e.publicIPsChanged = false
 	for endpoint, m1 := range e.historicalEndpoints {
 		for deploymentID, m2 := range m1 {
 			for _, status := range m2 {
 				status.recordTick()
 			}
 			e.reverseHistoricalEndpoints[deploymentID][endpoint].recordTick()
-			// Remove all historical entries that expired in this tick.
-			removed := e.removeFromHistoryIfExpired(deploymentID, endpoint)
-			removedPublic = removedPublic || removed && endpoint.IPAndPort.Address.IsPublic()
+			e.removeFromHistoryIfExpired(deploymentID, endpoint)
 		}
 	}
 	e.updateMetricsNoLock()
-	return removedPublic
+	return e.publicIPsChanged
 }
 
 func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
@@ -110,57 +117,36 @@ func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
 
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
+	e.publicIPsChanged = false
 	if !incremental {
 		return e.replaceNoLock(updates)
 	}
-	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
 			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		e.applySingleNoLock(deploymentID, *data)
-		if !touchedPublic {
-			touchedPublic = containsPublicEndpoint(data.endpoints)
-		}
 	}
-	return touchedPublic
+	return e.publicIPsChanged
 }
 
 func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
-	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
 			// A call to Apply()->replaceNoLock() with empty payload of the updates map (no values) is meant to be a delete operation.
-			if !touchedPublic {
-				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
-			}
 			e.purgeNoLock(deploymentID)
 			continue
 		}
 		// Fast path: if all endpoints are identical, skip the diff entirely.
-		// endpointsUnchangedNoLock handles all edge cases cheaply:
-		// - deployment not in store + empty new → true in O(1)
-		// - deployment not in store + non-empty new → false in O(1)
-		// - deployment in store with nil set + empty new → true (length match)
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
-			// the first time a deployment arrives with zero endpoints (e.g. a pod
-			// exists but no Service selects it yet). That marker later prevents
-			// the endpoint-takeover path from incorrectly moving other deployments
-			// to history when this deployment finally acquires real endpoints.
-			// Because endpointsUnchangedNoLock short-circuits "not-in-store +
-			// empty" as unchanged, we must replicate the marker here.
+			// Replicate the nil "seen" marker that applySingleNoLock would record.
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}
 			continue
 		}
 		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
-		if !touchedPublic {
-			touchedPublic = containsPublicEndpoint(data.endpoints) ||
-				containsPublicEndpointInSet(currentEndpoints)
-		}
 		if !deploymentKnown {
 			// Brand-new deployment: use the full insert path which handles endpoint takeover.
 			e.applySingleNoLock(deploymentID, *data)
@@ -173,22 +159,11 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 			}
 		}
 	}
-	return touchedPublic
+	return e.publicIPsChanged
 }
 
 func (e *endpointsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
-	s := set.NewSet[net.IPAddress]()
-	for endpoint := range e.endpointMap {
-		if endpoint.IPAndPort.Address.IsPublic() {
-			s.Add(endpoint.IPAndPort.Address)
-		}
-	}
-	for endpoint := range e.historicalEndpoints {
-		if endpoint.IPAndPort.Address.IsPublic() {
-			s.Add(endpoint.IPAndPort.Address)
-		}
-	}
-	return s
+	return e.publicIPs.Clone()
 }
 
 // diffReplaceNoLock applies an endpoint update by computing a per-endpoint diff
@@ -259,6 +234,7 @@ func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.
 	}
 	if _, ok := e.endpointMap[ep]; !ok {
 		e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{deploymentID: etiSet}
+		e.trackEndpointAdded(ep)
 	} else {
 		e.endpointMap[ep][deploymentID] = etiSet
 	}
@@ -407,6 +383,7 @@ func (e *endpointsStore) applySingleNoLock(deploymentID string, data EntityData)
 			e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{
 				deploymentID: make(set.Set[EndpointTargetInfo], len(targetInfos)),
 			}
+			e.trackEndpointAdded(ep)
 		} else if !deploymentFound {
 			// New deployment, but the endpoint exists - the new deployment takes over the already existing endpoint
 			e.endpointMap[ep][deploymentID] = make(set.Set[EndpointTargetInfo], len(targetInfos))
@@ -500,9 +477,11 @@ func (e *endpointsStore) deleteFromHistory(deploymentID string, ep net.NumericEn
 	if len(e.reverseHistoricalEndpoints[deploymentID]) == 0 {
 		delete(e.reverseHistoricalEndpoints, deploymentID)
 	}
+	_, hadEp := e.historicalEndpoints[ep]
 	delete(e.historicalEndpoints[ep], deploymentID)
-	if len(e.historicalEndpoints[ep]) == 0 {
+	if hadEp && len(e.historicalEndpoints[ep]) == 0 {
 		delete(e.historicalEndpoints, ep)
+		e.trackEndpointRemoved(ep)
 	}
 	return foundDepl || foundEp
 }
@@ -512,6 +491,7 @@ func (e *endpointsStore) deleteFromCurrent(deploymentID string, ep net.NumericEn
 	delete(e.endpointMap[ep], deploymentID)
 	if len(e.endpointMap[ep]) == 0 {
 		delete(e.endpointMap, ep)
+		e.trackEndpointRemoved(ep)
 	}
 
 	dSet, found := e.reverseEndpointMap[deploymentID]
@@ -536,9 +516,9 @@ func (e *endpointsStore) deleteFromCurrent(deploymentID string, ep net.NumericEn
 // impacts how long endpointsStore mutex is held during Apply(), and therefore affects Sensor
 // throughput and event pipeline latency.
 func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoint) {
-	// Prepare maps if empty
 	if _, ok := e.historicalEndpoints[ep]; !ok {
 		e.historicalEndpoints[ep] = make(map[string]map[EndpointTargetInfo]*entityStatus)
+		e.trackEndpointAdded(ep)
 	}
 	if _, ok := e.historicalEndpoints[ep][deploymentID]; !ok {
 		e.historicalEndpoints[ep][deploymentID] = make(map[EndpointTargetInfo]*entityStatus)
@@ -553,22 +533,46 @@ func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoin
 	e.reverseHistoricalEndpoints[deploymentID][ep] = newHistoricalEntity(e.memorySize)
 }
 
-func containsPublicEndpoint(endpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
-	for ep := range endpoints {
-		if ep.IPAndPort.Address.IsPublic() {
-			return true
-		}
+func (e *endpointsStore) trackEndpointAdded(ep net.NumericEndpoint) {
+	ip := ep.IPAndPort.Address
+	if !ip.IsPublic() {
+		return
 	}
-	return false
+	if e.publicIPRefCount == nil {
+		e.publicIPRefCount = make(map[net.IPAddress]int)
+	}
+	e.publicIPRefCount[ip]++
+	if e.publicIPs.Add(ip) {
+		e.publicIPsChanged = true
+	}
 }
 
-func containsPublicEndpointInSet(eps set.Set[net.NumericEndpoint]) bool {
-	for ep := range eps {
-		if ep.IPAndPort.Address.IsPublic() {
-			return true
+func (e *endpointsStore) trackEndpointRemoved(ep net.NumericEndpoint) {
+	ip := ep.IPAndPort.Address
+	if !ip.IsPublic() {
+		return
+	}
+	e.publicIPRefCount[ip]--
+	if e.publicIPRefCount[ip] <= 0 {
+		delete(e.publicIPRefCount, ip)
+		if e.publicIPs.Remove(ip) {
+			e.publicIPsChanged = true
 		}
 	}
-	return false
+}
+
+func (e *endpointsStore) rebuildPublicIPsNoLock() {
+	e.publicIPs = nil
+	e.publicIPRefCount = nil
+	for ep := range e.endpointMap {
+		e.trackEndpointAdded(ep)
+	}
+	for ep := range e.historicalEndpoints {
+		if _, inCurrent := e.endpointMap[ep]; inCurrent {
+			continue
+		}
+		e.trackEndpointAdded(ep)
+	}
 }
 
 func (e *endpointsStore) String() string {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -27,12 +27,6 @@ type endpointsStore struct {
 	historicalEndpoints map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus
 	// reverseHistoricalEndpoints is mimicking reverseEndpointMap: deploymentID -> endpointInfo -> historyStatus
 	reverseHistoricalEndpoints map[string]map[net.NumericEndpoint]*entityStatus
-
-	// publicIPs is maintained incrementally via reference counting.
-	// Multiple endpoint keys (same IP, different ports) share one ref count.
-	publicIPs             set.Set[net.IPAddress]
-	publicIPEndpointCount map[net.IPAddress]int
-	publicIPsChanged      bool
 }
 
 func newEndpointsStoreWithMemory(numTicks uint16) *endpointsStore {
@@ -49,10 +43,6 @@ func (e *endpointsStore) initMapsNoLock() {
 
 	e.reverseHistoricalEndpoints = make(map[string]map[net.NumericEndpoint]*entityStatus)
 	e.historicalEndpoints = make(map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus)
-
-	e.publicIPs = set.NewSet[net.IPAddress]()
-	e.publicIPEndpointCount = make(map[net.IPAddress]int)
-	e.publicIPsChanged = false
 }
 
 func (e *endpointsStore) resetMaps() {
@@ -74,7 +64,6 @@ func (e *endpointsStore) resetMaps() {
 
 	e.endpointMap = make(map[net.NumericEndpoint]map[string]set.Set[EndpointTargetInfo])
 	e.reverseEndpointMap = make(map[string]set.Set[net.NumericEndpoint])
-	e.rebuildPublicIPsNoLock()
 	e.updateMetricsNoLock()
 }
 
@@ -91,21 +80,22 @@ func (e *endpointsStore) updateMetricsNoLock() {
 func (e *endpointsStore) RecordTick() bool {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "record_tick")
-	e.publicIPsChanged = false
+	removedPublic := false
 	for endpoint, m1 := range e.historicalEndpoints {
 		for deploymentID, m2 := range m1 {
 			for _, status := range m2 {
 				status.recordTick()
 			}
 			e.reverseHistoricalEndpoints[deploymentID][endpoint].recordTick()
-			e.removeFromHistoryIfExpired(deploymentID, endpoint)
+			// Remove all historical entries that expired in this tick.
+			removed := e.removeFromHistoryIfExpired(deploymentID, endpoint)
+			removedPublic = removedPublic || removed && endpoint.IPAndPort.Address.IsPublic()
 		}
 	}
 	e.updateMetricsNoLock()
-	return e.publicIPsChanged
+	return removedPublic
 }
 
-// Apply processes endpoint updates and returns true if any public IP was added or removed.
 func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "apply")
@@ -114,26 +104,32 @@ func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool)
 
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
-	e.publicIPsChanged = false
 	if !incremental {
 		return e.replaceNoLock(updates)
 	}
+	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
 			continue
 		}
 		e.applySingleNoLock(deploymentID, *data)
+		if !touchedPublic {
+			touchedPublic = containsPublicEndpoint(data.endpoints)
+		}
 	}
-	return e.publicIPsChanged
+	return touchedPublic
 }
 
 func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
+	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			if !touchedPublic {
+				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
+			}
 			e.purgeNoLock(deploymentID)
 			continue
 		}
-		// Fast path: if all endpoints are identical, skip the diff entirely.
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
@@ -141,6 +137,10 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 			continue
 		}
 		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
+		if !touchedPublic {
+			touchedPublic = containsPublicEndpoint(data.endpoints) ||
+				containsPublicEndpointInSet(currentEndpoints)
+		}
 		if !deploymentKnown {
 			e.applySingleNoLock(deploymentID, *data)
 			continue
@@ -152,7 +152,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 			}
 		}
 	}
-	return e.publicIPsChanged
+	return touchedPublic
 }
 
 func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
@@ -162,49 +162,18 @@ func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {
 }
 
 func (e *endpointsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
-	return e.publicIPs.Clone()
-}
-
-func (e *endpointsStore) trackEndpointKeyAddedNoLock(ep net.NumericEndpoint) {
-	ip := ep.IPAndPort.Address
-	if ip.IsPublic() {
-		e.publicIPEndpointCount[ip]++
-		if e.publicIPs.Add(ip) {
-			e.publicIPsChanged = true
+	s := set.NewSet[net.IPAddress]()
+	for endpoint := range e.endpointMap {
+		if endpoint.IPAndPort.Address.IsPublic() {
+			s.Add(endpoint.IPAndPort.Address)
 		}
 	}
-}
-
-func (e *endpointsStore) trackEndpointKeyRemovedNoLock(ep net.NumericEndpoint) {
-	ip := ep.IPAndPort.Address
-	if ip.IsPublic() {
-		e.publicIPEndpointCount[ip]--
-		if e.publicIPEndpointCount[ip] <= 0 {
-			delete(e.publicIPEndpointCount, ip)
-			if e.publicIPs.Remove(ip) {
-				e.publicIPsChanged = true
-			}
+	for endpoint := range e.historicalEndpoints {
+		if endpoint.IPAndPort.Address.IsPublic() {
+			s.Add(endpoint.IPAndPort.Address)
 		}
 	}
-}
-
-func (e *endpointsStore) rebuildPublicIPsNoLock() {
-	e.publicIPs = set.NewSet[net.IPAddress]()
-	e.publicIPEndpointCount = make(map[net.IPAddress]int)
-	for ep := range e.endpointMap {
-		ip := ep.IPAndPort.Address
-		if ip.IsPublic() {
-			e.publicIPEndpointCount[ip]++
-			e.publicIPs.Add(ip)
-		}
-	}
-	for ep := range e.historicalEndpoints {
-		ip := ep.IPAndPort.Address
-		if ip.IsPublic() {
-			e.publicIPEndpointCount[ip]++
-			e.publicIPs.Add(ip)
-		}
-	}
+	return s
 }
 
 // diffReplaceNoLock applies an endpoint update by computing a per-endpoint diff
@@ -275,7 +244,6 @@ func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.
 	}
 	if _, ok := e.endpointMap[ep]; !ok {
 		e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{deploymentID: etiSet}
-		e.trackEndpointKeyAddedNoLock(ep)
 	} else {
 		e.endpointMap[ep][deploymentID] = etiSet
 	}
@@ -424,7 +392,6 @@ func (e *endpointsStore) applySingleNoLock(deploymentID string, data EntityData)
 			e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{
 				deploymentID: make(set.Set[EndpointTargetInfo], len(targetInfos)),
 			}
-			e.trackEndpointKeyAddedNoLock(ep)
 		} else if !deploymentFound {
 			// New deployment, but the endpoint exists - the new deployment takes over the already existing endpoint
 			e.endpointMap[ep][deploymentID] = make(set.Set[EndpointTargetInfo], len(targetInfos))
@@ -519,9 +486,8 @@ func (e *endpointsStore) deleteFromHistory(deploymentID string, ep net.NumericEn
 		delete(e.reverseHistoricalEndpoints, deploymentID)
 	}
 	delete(e.historicalEndpoints[ep], deploymentID)
-	if m, ok := e.historicalEndpoints[ep]; ok && len(m) == 0 {
+	if len(e.historicalEndpoints[ep]) == 0 {
 		delete(e.historicalEndpoints, ep)
-		e.trackEndpointKeyRemovedNoLock(ep)
 	}
 	return foundDepl || foundEp
 }
@@ -531,7 +497,6 @@ func (e *endpointsStore) deleteFromCurrent(deploymentID string, ep net.NumericEn
 	delete(e.endpointMap[ep], deploymentID)
 	if len(e.endpointMap[ep]) == 0 {
 		delete(e.endpointMap, ep)
-		e.trackEndpointKeyRemovedNoLock(ep)
 	}
 
 	dSet, found := e.reverseEndpointMap[deploymentID]
@@ -559,7 +524,6 @@ func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoin
 	// Prepare maps if empty
 	if _, ok := e.historicalEndpoints[ep]; !ok {
 		e.historicalEndpoints[ep] = make(map[string]map[EndpointTargetInfo]*entityStatus)
-		e.trackEndpointKeyAddedNoLock(ep)
 	}
 	if _, ok := e.historicalEndpoints[ep][deploymentID]; !ok {
 		e.historicalEndpoints[ep][deploymentID] = make(map[EndpointTargetInfo]*entityStatus)
@@ -572,6 +536,24 @@ func (e *endpointsStore) addToHistory(deploymentID string, ep net.NumericEndpoin
 		e.reverseHistoricalEndpoints[deploymentID] = make(map[net.NumericEndpoint]*entityStatus)
 	}
 	e.reverseHistoricalEndpoints[deploymentID][ep] = newHistoricalEntity(e.memorySize)
+}
+
+func containsPublicEndpoint(endpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
+	for ep := range endpoints {
+		if ep.IPAndPort.Address.IsPublic() {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPublicEndpointInSet(eps set.Set[net.NumericEndpoint]) bool {
+	for ep := range eps {
+		if ep.IPAndPort.Address.IsPublic() {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *endpointsStore) String() string {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -563,6 +563,8 @@ func (e *endpointsStore) trackEndpointRemoved(ep net.NumericEndpoint) {
 	}
 }
 
+// rebuildPublicIPsNoLock must only be called when endpointMap is empty (i.e. after resetMaps clears it),
+// because it skips historical entries already present in endpointMap to avoid double-counting.
 func (e *endpointsStore) rebuildPublicIPsNoLock() {
 	e.publicIPs = nil
 	e.publicIPRefCount = nil

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -124,6 +124,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 	touchedPublic := false
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// Must check before purge: purgeNoLock deletes reverseEndpointMap[deploymentID].
 			if !touchedPublic {
 				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
 			}
@@ -136,11 +137,11 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 			}
 			continue
 		}
+		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
 		if !touchedPublic {
 			touchedPublic = containsPublicEndpoint(data.endpoints) ||
-				containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
+				containsPublicEndpointInSet(currentEndpoints)
 		}
-		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
 		if !deploymentKnown {
 			e.applySingleNoLock(deploymentID, *data)
 			continue

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -112,6 +112,7 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		e.applySingleNoLock(deploymentID, *data)
@@ -129,6 +130,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[n
 	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// A call to Apply()->replaceNoLock() with empty payload of the updates map (no values) is meant to be a delete operation.
 			// Must check before purge: purgeNoLock deletes reverseEndpointMap[deploymentID].
 			if !touchedPublic {
 				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
@@ -136,11 +138,19 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[n
 			e.purgeNoLock(deploymentID)
 			continue
 		}
+		// Fast path: if all endpoints are identical, skip the diff entirely.
+		// endpointsUnchangedNoLock handles all edge cases cheaply:
+		// - deployment not in store + empty new → true in O(1)
+		// - deployment not in store + non-empty new → false in O(1)
+		// - deployment in store with nil set + empty new → true (length match)
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-			// Nil marker prevents the endpoint-takeover path from incorrectly
-			// moving other deployments to history when this deployment finally
-			// acquires real endpoints. Replicated here because
-			// endpointsUnchangedNoLock short-circuits "not-in-store + empty".
+			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
+			// the first time a deployment arrives with zero endpoints (e.g. a pod
+			// exists but no Service selects it yet). That marker later prevents
+			// the endpoint-takeover path from incorrectly moving other deployments
+			// to history when this deployment finally acquires real endpoints.
+			// Because endpointsUnchangedNoLock short-circuits "not-in-store +
+			// empty" as unchanged, we must replicate the marker here.
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}
@@ -152,6 +162,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[n
 				containsPublicEndpointInSet(currentEndpoints)
 		}
 		if !deploymentKnown {
+			// Brand-new deployment: use the full insert path which handles endpoint takeover.
 			e.applySingleNoLock(deploymentID, *data)
 			continue
 		}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -96,16 +96,15 @@ func (e *endpointsStore) RecordTick() bool {
 	return removedPublic
 }
 
-// Apply processes endpoint updates and reports whether any public IP was involved,
-// so the caller can decide whether to refresh the public IP listener.
-func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) (touchedPublic bool) {
+// Apply processes endpoint updates and returns all currently stored public IPs
+// if the update touched any public IP, or nil otherwise.
+func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "apply")
-	touchedPublic = e.applyNoLock(updates, incremental)
-	return touchedPublic
+	return e.applyNoLock(updates, incremental)
 }
 
-func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
+func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	defer e.updateMetricsNoLock()
 	if !incremental {
 		return e.replaceNoLock(updates)
@@ -120,10 +119,13 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 			touchedPublic = containsPublicEndpoint(data.endpoints)
 		}
 	}
-	return touchedPublic
+	if touchedPublic {
+		return e.collectPublicIPsNoLock()
+	}
+	return nil
 }
 
-func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
+func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[net.IPAddress] {
 	touchedPublic := false
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
@@ -160,7 +162,25 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 			}
 		}
 	}
-	return touchedPublic
+	if touchedPublic {
+		return e.collectPublicIPsNoLock()
+	}
+	return nil
+}
+
+func (e *endpointsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
+	s := set.NewSet[net.IPAddress]()
+	for endpoint := range e.endpointMap {
+		if endpoint.IPAndPort.Address.IsPublic() {
+			s.Add(endpoint.IPAndPort.Address)
+		}
+	}
+	for endpoint := range e.historicalEndpoints {
+		if endpoint.IPAndPort.Address.IsPublic() {
+			s.Add(endpoint.IPAndPort.Address)
+		}
+	}
+	return s
 }
 
 // diffReplaceNoLock applies an endpoint update by computing a per-endpoint diff

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -73,6 +73,7 @@ func (e *endpointsStore) resetMaps() {
 	e.endpointMap = make(map[net.NumericEndpoint]map[string]set.Set[EndpointTargetInfo])
 	e.reverseEndpointMap = make(map[string]set.Set[net.NumericEndpoint])
 	e.rebuildPublicIPsNoLock()
+	e.publicIPsChanged = false
 	e.updateMetricsNoLock()
 }
 
@@ -140,7 +141,8 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 		}
 		// Fast path: if all endpoints are identical, skip the diff entirely.
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-			// Replicate the nil "seen" marker that applySingleNoLock would record.
+			// Without this marker, a subsequent Apply would treat this deployment as new and
+			// run the endpoint-takeover path, incorrectly moving other deployments to history.
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -96,10 +96,13 @@ func (e *endpointsStore) RecordTick() bool {
 	return removedPublic
 }
 
-func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
+// Apply processes endpoint updates and reports whether any public IP was involved,
+// so the caller can decide whether to refresh the public IP listener.
+func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) (touchedPublic bool) {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "apply")
-	return e.applyNoLock(updates, incremental)
+	touchedPublic = e.applyNoLock(updates, incremental)
+	return touchedPublic
 }
 
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
@@ -132,6 +135,10 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 			continue
 		}
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
+			// Nil marker prevents the endpoint-takeover path from incorrectly
+			// moving other deployments to history when this deployment finally
+			// acquires real endpoints. Replicated here because
+			// endpointsUnchangedNoLock short-circuits "not-in-store + empty".
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -105,15 +105,14 @@ func (e *endpointsStore) RecordTick() bool {
 	return e.publicIPsChanged
 }
 
-// Apply processes endpoint updates and returns all currently stored public IPs
-// if the update touched any public IP, or nil otherwise.
-func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
+// Apply processes endpoint updates and returns true if any public IP was added or removed.
+func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
 	e.mutex.Lock()
 	defer deferUnlock(e.mutex.Unlock, time.Now(), "endpoints", "apply")
 	return e.applyNoLock(updates, incremental)
 }
 
-func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
+func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
 	e.publicIPsChanged = false
 	if !incremental {
@@ -125,13 +124,10 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
-	if e.publicIPsChanged {
-		return e.collectPublicIPsNoLock()
-	}
-	return nil
+	return e.publicIPsChanged
 }
 
-func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[net.IPAddress] {
+func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
 			e.purgeNoLock(deploymentID)
@@ -156,10 +152,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) set.Set[n
 			}
 		}
 	}
-	if e.publicIPsChanged {
-		return e.collectPublicIPsNoLock()
-	}
-	return nil
+	return e.publicIPsChanged
 }
 
 func (e *endpointsStore) PublicIPs() set.Set[net.IPAddress] {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -110,6 +110,7 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		e.applySingleNoLock(deploymentID, *data)
@@ -124,13 +125,26 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 	var touchedPublic bool
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// A call to Apply()->replaceNoLock() with empty payload of the updates map (no values) is meant to be a delete operation.
 			if !touchedPublic {
 				touchedPublic = containsPublicEndpointInSet(e.reverseEndpointMap[deploymentID])
 			}
 			e.purgeNoLock(deploymentID)
 			continue
 		}
+		// Fast path: if all endpoints are identical, skip the diff entirely.
+		// endpointsUnchangedNoLock handles all edge cases cheaply:
+		// - deployment not in store + empty new → true in O(1)
+		// - deployment not in store + non-empty new → false in O(1)
+		// - deployment in store with nil set + empty new → true (length match)
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
+			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
+			// the first time a deployment arrives with zero endpoints (e.g. a pod
+			// exists but no Service selects it yet). That marker later prevents
+			// the endpoint-takeover path from incorrectly moving other deployments
+			// to history when this deployment finally acquires real endpoints.
+			// Because endpointsUnchangedNoLock short-circuits "not-in-store +
+			// empty" as unchanged, we must replicate the marker here.
 			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
 				e.reverseEndpointMap[deploymentID] = nil
 			}
@@ -142,6 +156,7 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) bool {
 				containsPublicEndpointInSet(currentEndpoints)
 		}
 		if !deploymentKnown {
+			// Brand-new deployment: use the full insert path which handles endpoint takeover.
 			e.applySingleNoLock(deploymentID, *data)
 			continue
 		}

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -44,7 +44,6 @@ func BenchmarkEndpointsStoreAddToHistory(b *testing.B) {
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			store, deploymentID, endpoint := benchmarkSeedEndpointsStore(tc.numEndpoints)
-			b.ResetTimer()
 			for b.Loop() {
 				// Keep the current-map shape constant and measure addToHistory only.
 				store.historicalEndpoints = make(map[net.NumericEndpoint]map[string]map[EndpointTargetInfo]*entityStatus)

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -27,12 +27,6 @@ type podIPsStore struct {
 	reverseIPMap map[string]set.FrozenSet[net.IPAddress]
 	// historicalIPs is mimicking ipMap: IP Address -> deploymentID -> historyStatus
 	historicalIPs map[net.IPAddress]map[string]*entityStatus
-
-	// publicIPs is maintained incrementally: every mutation that adds or removes
-	// an IP from ipMap or historicalIPs updates this set, so collectPublicIPsNoLock
-	// returns a clone in O(P) instead of scanning O(N) entries.
-	publicIPs        set.Set[net.IPAddress]
-	publicIPsChanged bool
 }
 
 func newPodIPsStoreWithMemory(numTicks uint16) *podIPsStore {
@@ -47,8 +41,6 @@ func (e *podIPsStore) initMapsNoLock() {
 	e.ipMap = make(map[net.IPAddress]set.StringSet)
 	e.reverseIPMap = make(map[string]set.FrozenSet[net.IPAddress])
 	e.historicalIPs = make(map[net.IPAddress]map[string]*entityStatus)
-	e.publicIPs = set.NewSet[net.IPAddress]()
-	e.publicIPsChanged = false
 }
 
 func (e *podIPsStore) resetMaps() {
@@ -82,18 +74,19 @@ func (e *podIPsStore) updateMetricsNoLock() {
 func (e *podIPsStore) RecordTick() bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	e.publicIPsChanged = false
+	removedPublic := false
 	for ip, m := range e.historicalIPs {
 		for deploymentID, status := range m {
 			status.recordTick()
-			e.removeFromHistoryIfExpired(deploymentID, ip)
+			// Remove all historical entries that expired in this tick.
+			removed := e.removeFromHistoryIfExpired(deploymentID, ip)
+			removedPublic = removedPublic || removed && ip.IsPublic()
 		}
 	}
 	e.updateMetricsNoLock()
-	return e.publicIPsChanged
+	return removedPublic
 }
 
-// Apply processes pod IP updates and returns true if any public IP was added or removed.
 func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
@@ -102,9 +95,12 @@ func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bo
 
 func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
-	e.publicIPsChanged = false
+	var touchedPublic bool
 	if !incremental {
 		for deploymentID := range updates {
+			if !touchedPublic {
+				touchedPublic = containsPublicIPInFrozenSet(e.reverseIPMap[deploymentID])
+			}
 			e.purgeDeploymentNoLock(deploymentID)
 		}
 	}
@@ -112,9 +108,12 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 		if data.isDeleteOnly() {
 			continue
 		}
+		if !touchedPublic {
+			touchedPublic = containsPublicIP(data.ips)
+		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
-	return e.publicIPsChanged
+	return touchedPublic
 }
 
 func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
@@ -124,35 +123,18 @@ func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
 }
 
 func (e *podIPsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
-	return e.publicIPs.Clone()
-}
-
-func (e *podIPsStore) trackPublicIPAddedNoLock(ip net.IPAddress) {
-	if ip.IsPublic() {
-		if e.publicIPs.Add(ip) {
-			e.publicIPsChanged = true
+	s := set.NewSet[net.IPAddress]()
+	for address := range e.ipMap {
+		if address.IsPublic() {
+			s.Add(address)
 		}
 	}
-}
-
-func (e *podIPsStore) trackPublicIPRemovedFromCurrentNoLock(ip net.IPAddress) {
-	if ip.IsPublic() {
-		if _, inHistory := e.historicalIPs[ip]; !inHistory {
-			if e.publicIPs.Remove(ip) {
-				e.publicIPsChanged = true
-			}
+	for address := range e.historicalIPs {
+		if address.IsPublic() {
+			s.Add(address)
 		}
 	}
-}
-
-func (e *podIPsStore) trackPublicIPRemovedFromHistoryNoLock(ip net.IPAddress) {
-	if ip.IsPublic() {
-		if _, inCurrent := e.ipMap[ip]; !inCurrent {
-			if e.publicIPs.Remove(ip) {
-				e.publicIPsChanged = true
-			}
-		}
-	}
+	return s
 }
 
 func (e *podIPsStore) purgeDeploymentNoLock(deploymentID string) {
@@ -206,7 +188,6 @@ func (e *podIPsStore) applySingleNoLock(deploymentID string, data EntityData) {
 			metrics.ObserveManyDeploymentsSharingSingleIP(ip.AsNetIP().String())
 		}
 		e.ipMap[ip] = deplSet
-		e.trackPublicIPAddedNoLock(ip)
 		// If the IP being currently added was already in history,
 		// we must remove it from there to prevent unwanted expiration.
 		_ = e.deleteFromHistory(deploymentID, ip)
@@ -227,7 +208,6 @@ func (e *podIPsStore) addToHistory(deploymentID string) {
 			e.historicalIPs[ip] = make(map[string]*entityStatus)
 		}
 		e.historicalIPs[ip][deploymentID] = newHistoricalEntity(e.memorySize)
-		e.trackPublicIPAddedNoLock(ip)
 	}
 }
 
@@ -239,7 +219,6 @@ func (e *podIPsStore) deleteDeploymentFromCurrent(deploymentID string) {
 		deploymentsHavingIP.Remove(deploymentID)
 		if deploymentsHavingIP.Cardinality() == 0 {
 			delete(e.ipMap, address)
-			e.trackPublicIPRemovedFromCurrentNoLock(address)
 		}
 	}
 	delete(e.reverseIPMap, deploymentID)
@@ -256,7 +235,6 @@ func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) b
 	delete(e.historicalIPs[ip], deploymentID)
 	if len(e.historicalIPs[ip]) == 0 {
 		delete(e.historicalIPs, ip)
-		e.trackPublicIPRemovedFromHistoryNoLock(ip)
 	}
 	return true
 }
@@ -264,6 +242,24 @@ func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) b
 func (e *podIPsStore) removeFromHistoryIfExpired(deploymentID string, ip net.IPAddress) bool {
 	if status, ok := e.historicalIPs[ip][deploymentID]; ok && status.IsExpired() {
 		return e.deleteFromHistory(deploymentID, ip)
+	}
+	return false
+}
+
+func containsPublicIP(ips map[net.IPAddress]struct{}) bool {
+	for ip := range ips {
+		if ip.IsPublic() {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPublicIPInFrozenSet(ips set.FrozenSet[net.IPAddress]) bool {
+	for ip := range ips.All() {
+		if ip.IsPublic() {
+			return true
+		}
 	}
 	return false
 }

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -238,7 +238,7 @@ func containsPublicIP(ips map[net.IPAddress]struct{}) bool {
 }
 
 func containsPublicIPInFrozenSet(ips set.FrozenSet[net.IPAddress]) bool {
-	for _, ip := range ips.AsSlice() {
+	for ip := range ips.All() {
 		if ip.IsPublic() {
 			return true
 		}

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -87,15 +87,15 @@ func (e *podIPsStore) RecordTick() bool {
 	return removedPublic
 }
 
-// Apply processes pod IP updates and reports whether any public IP was involved,
-// so the caller can decide whether to refresh the public IP listener.
-func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) (touchedPublic bool) {
+// Apply processes pod IP updates and returns all currently stored public IPs
+// if the update touched any public IP, or nil otherwise.
+func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 	return e.applyNoLock(updates, incremental)
 }
 
-func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
+func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	defer e.updateMetricsNoLock()
 	touchedPublic := false
 	if !incremental {
@@ -116,7 +116,25 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
-	return touchedPublic
+	if touchedPublic {
+		return e.collectPublicIPsNoLock()
+	}
+	return nil
+}
+
+func (e *podIPsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
+	s := set.NewSet[net.IPAddress]()
+	for address := range e.ipMap {
+		if address.IsPublic() {
+			s.Add(address)
+		}
+	}
+	for address := range e.historicalIPs {
+		if address.IsPublic() {
+			s.Add(address)
+		}
+	}
+	return s
 }
 
 func (e *podIPsStore) purgeDeploymentNoLock(deploymentID string) {

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -87,26 +87,33 @@ func (e *podIPsStore) RecordTick() bool {
 	return removedPublic
 }
 
-func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) {
+func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	e.applyNoLock(updates, incremental)
+	return e.applyNoLock(updates, incremental)
 }
 
-func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) {
+func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
+	touchedPublic := false
 	if !incremental {
 		for deploymentID := range updates {
+			if !touchedPublic {
+				touchedPublic = containsPublicIPInFrozenSet(e.reverseIPMap[deploymentID])
+			}
 			e.purgeDeploymentNoLock(deploymentID)
 		}
 	}
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
+		}
+		if !touchedPublic {
+			touchedPublic = containsPublicIP(data.ips)
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
+	return touchedPublic
 }
 
 func (e *podIPsStore) purgeDeploymentNoLock(deploymentID string) {
@@ -214,6 +221,24 @@ func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) b
 func (e *podIPsStore) removeFromHistoryIfExpired(deploymentID string, ip net.IPAddress) bool {
 	if status, ok := e.historicalIPs[ip][deploymentID]; ok && status.IsExpired() {
 		return e.deleteFromHistory(deploymentID, ip)
+	}
+	return false
+}
+
+func containsPublicIP(ips map[net.IPAddress]struct{}) bool {
+	for ip := range ips {
+		if ip.IsPublic() {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPublicIPInFrozenSet(ips set.FrozenSet[net.IPAddress]) bool {
+	for _, ip := range ips.AsSlice() {
+		if ip.IsPublic() {
+			return true
+		}
 	}
 	return false
 }

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -93,6 +93,12 @@ func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bo
 	return e.applyNoLock(updates, incremental)
 }
 
+func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.collectPublicIPsNoLock()
+}
+
 func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
 	var touchedPublic bool
@@ -115,12 +121,6 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 		e.applySingleNoLock(deploymentID, *data)
 	}
 	return touchedPublic
-}
-
-func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
-	e.mutex.RLock()
-	defer e.mutex.RUnlock()
-	return e.collectPublicIPsNoLock()
 }
 
 func (e *podIPsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -27,6 +27,9 @@ type podIPsStore struct {
 	reverseIPMap map[string]set.FrozenSet[net.IPAddress]
 	// historicalIPs is mimicking ipMap: IP Address -> deploymentID -> historyStatus
 	historicalIPs map[net.IPAddress]map[string]*entityStatus
+
+	publicIPs        set.Set[net.IPAddress]
+	publicIPsChanged bool
 }
 
 func newPodIPsStoreWithMemory(numTicks uint16) *podIPsStore {
@@ -41,6 +44,8 @@ func (e *podIPsStore) initMapsNoLock() {
 	e.ipMap = make(map[net.IPAddress]set.StringSet)
 	e.reverseIPMap = make(map[string]set.FrozenSet[net.IPAddress])
 	e.historicalIPs = make(map[net.IPAddress]map[string]*entityStatus)
+	e.publicIPs = nil
+	e.publicIPsChanged = false
 }
 
 func (e *podIPsStore) resetMaps() {
@@ -74,17 +79,15 @@ func (e *podIPsStore) updateMetricsNoLock() {
 func (e *podIPsStore) RecordTick() bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	removedPublic := false
+	e.publicIPsChanged = false
 	for ip, m := range e.historicalIPs {
 		for deploymentID, status := range m {
 			status.recordTick()
-			// Remove all historical entries that expired in this tick.
-			removed := e.removeFromHistoryIfExpired(deploymentID, ip)
-			removedPublic = removedPublic || removed && ip.IsPublic()
+			e.removeFromHistoryIfExpired(deploymentID, ip)
 		}
 	}
 	e.updateMetricsNoLock()
-	return removedPublic
+	return e.publicIPsChanged
 }
 
 func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
@@ -101,41 +104,23 @@ func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
 
 func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
-	var touchedPublic bool
+	e.publicIPsChanged = false
 	if !incremental {
 		for deploymentID := range updates {
-			if !touchedPublic {
-				touchedPublic = containsPublicIPInFrozenSet(e.reverseIPMap[deploymentID])
-			}
 			e.purgeDeploymentNoLock(deploymentID)
 		}
 	}
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
-		}
-		if !touchedPublic {
-			touchedPublic = containsPublicIP(data.ips)
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
-	return touchedPublic
+	return e.publicIPsChanged
 }
 
 func (e *podIPsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
-	s := set.NewSet[net.IPAddress]()
-	for address := range e.ipMap {
-		if address.IsPublic() {
-			s.Add(address)
-		}
-	}
-	for address := range e.historicalIPs {
-		if address.IsPublic() {
-			s.Add(address)
-		}
-	}
-	return s
+	return e.publicIPs.Clone()
 }
 
 func (e *podIPsStore) purgeDeploymentNoLock(deploymentID string) {
@@ -179,18 +164,17 @@ func (e *podIPsStore) applySingleNoLock(deploymentID string, data EntityData) {
 	for ip := range data.ips {
 		ipsSet.Add(ip)
 
-		// Check if this IP already belongs to other deployment.
-		// If the `ip` is not in the `ipMap` then `e.ipMap[ip]` returns the zero-value of the StringSet,
-		// which is an empty (but initialized) StringSet.
 		deplSet := e.ipMap[ip]
 		deplSet.Add(deploymentID)
-		// This IP has more than one deployment! Interesting, let's record it.
 		if deplSet.Cardinality() > 1 {
 			metrics.ObserveManyDeploymentsSharingSingleIP(ip.AsNetIP().String())
 		}
 		e.ipMap[ip] = deplSet
-		// If the IP being currently added was already in history,
-		// we must remove it from there to prevent unwanted expiration.
+		if ip.IsPublic() {
+			if e.publicIPs.Add(ip) {
+				e.publicIPsChanged = true
+			}
+		}
 		_ = e.deleteFromHistory(deploymentID, ip)
 	}
 	e.reverseIPMap[deploymentID] = ipsSet.Freeze()
@@ -209,6 +193,11 @@ func (e *podIPsStore) addToHistory(deploymentID string) {
 			e.historicalIPs[ip] = make(map[string]*entityStatus)
 		}
 		e.historicalIPs[ip][deploymentID] = newHistoricalEntity(e.memorySize)
+		if ip.IsPublic() {
+			if e.publicIPs.Add(ip) {
+				e.publicIPsChanged = true
+			}
+		}
 	}
 }
 
@@ -220,6 +209,11 @@ func (e *podIPsStore) deleteDeploymentFromCurrent(deploymentID string) {
 		deploymentsHavingIP.Remove(deploymentID)
 		if deploymentsHavingIP.Cardinality() == 0 {
 			delete(e.ipMap, address)
+			if address.IsPublic() && len(e.historicalIPs[address]) == 0 {
+				if e.publicIPs.Remove(address) {
+					e.publicIPsChanged = true
+				}
+			}
 		}
 	}
 	delete(e.reverseIPMap, deploymentID)
@@ -229,13 +223,16 @@ func (e *podIPsStore) deleteDeploymentFromCurrent(deploymentID string) {
 // It does not check whether the historical entry has expired.
 func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) bool {
 	if _, ok := e.historicalIPs[ip]; !ok {
-		return false // nothing to remove
+		return false
 	}
-	// In most of the cases, "delete(e.historicalIPs, ip)"
-	// should be enough as one IP should belong maximally to one deployment, but let's cover here the general case.
 	delete(e.historicalIPs[ip], deploymentID)
 	if len(e.historicalIPs[ip]) == 0 {
 		delete(e.historicalIPs, ip)
+		if ip.IsPublic() && len(e.ipMap[ip]) == 0 {
+			if e.publicIPs.Remove(ip) {
+				e.publicIPsChanged = true
+			}
+		}
 	}
 	return true
 }
@@ -243,24 +240,6 @@ func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) b
 func (e *podIPsStore) removeFromHistoryIfExpired(deploymentID string, ip net.IPAddress) bool {
 	if status, ok := e.historicalIPs[ip][deploymentID]; ok && status.IsExpired() {
 		return e.deleteFromHistory(deploymentID, ip)
-	}
-	return false
-}
-
-func containsPublicIP(ips map[net.IPAddress]struct{}) bool {
-	for ip := range ips {
-		if ip.IsPublic() {
-			return true
-		}
-	}
-	return false
-}
-
-func containsPublicIPInFrozenSet(ips set.FrozenSet[net.IPAddress]) bool {
-	for ip := range ips.All() {
-		if ip.IsPublic() {
-			return true
-		}
 	}
 	return false
 }

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -109,6 +109,7 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 	}
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		if !touchedPublic {

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -87,7 +87,9 @@ func (e *podIPsStore) RecordTick() bool {
 	return removedPublic
 }
 
-func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
+// Apply processes pod IP updates and reports whether any public IP was involved,
+// so the caller can decide whether to refresh the public IP listener.
+func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) (touchedPublic bool) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 	return e.applyNoLock(updates, incremental)

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -27,6 +27,12 @@ type podIPsStore struct {
 	reverseIPMap map[string]set.FrozenSet[net.IPAddress]
 	// historicalIPs is mimicking ipMap: IP Address -> deploymentID -> historyStatus
 	historicalIPs map[net.IPAddress]map[string]*entityStatus
+
+	// publicIPs is maintained incrementally: every mutation that adds or removes
+	// an IP from ipMap or historicalIPs updates this set, so collectPublicIPsNoLock
+	// returns a clone in O(P) instead of scanning O(N) entries.
+	publicIPs        set.Set[net.IPAddress]
+	publicIPsChanged bool
 }
 
 func newPodIPsStoreWithMemory(numTicks uint16) *podIPsStore {
@@ -41,6 +47,8 @@ func (e *podIPsStore) initMapsNoLock() {
 	e.ipMap = make(map[net.IPAddress]set.StringSet)
 	e.reverseIPMap = make(map[string]set.FrozenSet[net.IPAddress])
 	e.historicalIPs = make(map[net.IPAddress]map[string]*entityStatus)
+	e.publicIPs = set.NewSet[net.IPAddress]()
+	e.publicIPsChanged = false
 }
 
 func (e *podIPsStore) resetMaps() {
@@ -74,17 +82,15 @@ func (e *podIPsStore) updateMetricsNoLock() {
 func (e *podIPsStore) RecordTick() bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
-	removedPublic := false
+	e.publicIPsChanged = false
 	for ip, m := range e.historicalIPs {
 		for deploymentID, status := range m {
 			status.recordTick()
-			// Remove all historical entries that expired in this tick.
-			removed := e.removeFromHistoryIfExpired(deploymentID, ip)
-			removedPublic = removedPublic || removed && ip.IsPublic()
+			e.removeFromHistoryIfExpired(deploymentID, ip)
 		}
 	}
 	e.updateMetricsNoLock()
-	return removedPublic
+	return e.publicIPsChanged
 }
 
 // Apply processes pod IP updates and returns all currently stored public IPs
@@ -97,27 +103,19 @@ func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) se
 
 func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	defer e.updateMetricsNoLock()
-	var touchedPublic bool
+	e.publicIPsChanged = false
 	if !incremental {
 		for deploymentID := range updates {
-			// Must check before purge: purgeDeploymentNoLock deletes reverseIPMap[deploymentID].
-			if !touchedPublic {
-				touchedPublic = containsPublicIPInFrozenSet(e.reverseIPMap[deploymentID])
-			}
 			e.purgeDeploymentNoLock(deploymentID)
 		}
 	}
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
-		}
-		if !touchedPublic {
-			touchedPublic = containsPublicIP(data.ips)
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
-	if touchedPublic {
+	if e.publicIPsChanged {
 		return e.collectPublicIPsNoLock()
 	}
 	return nil
@@ -130,18 +128,35 @@ func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
 }
 
 func (e *podIPsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {
-	s := set.NewSet[net.IPAddress]()
-	for address := range e.ipMap {
-		if address.IsPublic() {
-			s.Add(address)
+	return e.publicIPs.Clone()
+}
+
+func (e *podIPsStore) trackPublicIPAddedNoLock(ip net.IPAddress) {
+	if ip.IsPublic() {
+		if e.publicIPs.Add(ip) {
+			e.publicIPsChanged = true
 		}
 	}
-	for address := range e.historicalIPs {
-		if address.IsPublic() {
-			s.Add(address)
+}
+
+func (e *podIPsStore) trackPublicIPRemovedFromCurrentNoLock(ip net.IPAddress) {
+	if ip.IsPublic() {
+		if _, inHistory := e.historicalIPs[ip]; !inHistory {
+			if e.publicIPs.Remove(ip) {
+				e.publicIPsChanged = true
+			}
 		}
 	}
-	return s
+}
+
+func (e *podIPsStore) trackPublicIPRemovedFromHistoryNoLock(ip net.IPAddress) {
+	if ip.IsPublic() {
+		if _, inCurrent := e.ipMap[ip]; !inCurrent {
+			if e.publicIPs.Remove(ip) {
+				e.publicIPsChanged = true
+			}
+		}
+	}
 }
 
 func (e *podIPsStore) purgeDeploymentNoLock(deploymentID string) {
@@ -195,6 +210,7 @@ func (e *podIPsStore) applySingleNoLock(deploymentID string, data EntityData) {
 			metrics.ObserveManyDeploymentsSharingSingleIP(ip.AsNetIP().String())
 		}
 		e.ipMap[ip] = deplSet
+		e.trackPublicIPAddedNoLock(ip)
 		// If the IP being currently added was already in history,
 		// we must remove it from there to prevent unwanted expiration.
 		_ = e.deleteFromHistory(deploymentID, ip)
@@ -215,6 +231,7 @@ func (e *podIPsStore) addToHistory(deploymentID string) {
 			e.historicalIPs[ip] = make(map[string]*entityStatus)
 		}
 		e.historicalIPs[ip][deploymentID] = newHistoricalEntity(e.memorySize)
+		e.trackPublicIPAddedNoLock(ip)
 	}
 }
 
@@ -226,6 +243,7 @@ func (e *podIPsStore) deleteDeploymentFromCurrent(deploymentID string) {
 		deploymentsHavingIP.Remove(deploymentID)
 		if deploymentsHavingIP.Cardinality() == 0 {
 			delete(e.ipMap, address)
+			e.trackPublicIPRemovedFromCurrentNoLock(address)
 		}
 	}
 	delete(e.reverseIPMap, deploymentID)
@@ -242,6 +260,7 @@ func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) b
 	delete(e.historicalIPs[ip], deploymentID)
 	if len(e.historicalIPs[ip]) == 0 {
 		delete(e.historicalIPs, ip)
+		e.trackPublicIPRemovedFromHistoryNoLock(ip)
 	}
 	return true
 }
@@ -249,24 +268,6 @@ func (e *podIPsStore) deleteFromHistory(deploymentID string, ip net.IPAddress) b
 func (e *podIPsStore) removeFromHistoryIfExpired(deploymentID string, ip net.IPAddress) bool {
 	if status, ok := e.historicalIPs[ip][deploymentID]; ok && status.IsExpired() {
 		return e.deleteFromHistory(deploymentID, ip)
-	}
-	return false
-}
-
-func containsPublicIP(ips map[net.IPAddress]struct{}) bool {
-	for ip := range ips {
-		if ip.IsPublic() {
-			return true
-		}
-	}
-	return false
-}
-
-func containsPublicIPInFrozenSet(ips set.FrozenSet[net.IPAddress]) bool {
-	for ip := range ips.All() {
-		if ip.IsPublic() {
-			return true
-		}
 	}
 	return false
 }

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -97,7 +97,7 @@ func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) se
 
 func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
 	defer e.updateMetricsNoLock()
-	touchedPublic := false
+	var touchedPublic bool
 	if !incremental {
 		for deploymentID := range updates {
 			// Must check before purge: purgeDeploymentNoLock deletes reverseIPMap[deploymentID].
@@ -120,6 +120,12 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 		return e.collectPublicIPsNoLock()
 	}
 	return nil
+}
+
+func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.collectPublicIPsNoLock()
 }
 
 func (e *podIPsStore) collectPublicIPsNoLock() set.Set[net.IPAddress] {

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -106,6 +106,7 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 	}
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
+			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
 			continue
 		}
 		if !touchedPublic {

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -93,15 +93,14 @@ func (e *podIPsStore) RecordTick() bool {
 	return e.publicIPsChanged
 }
 
-// Apply processes pod IP updates and returns all currently stored public IPs
-// if the update touched any public IP, or nil otherwise.
-func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
+// Apply processes pod IP updates and returns true if any public IP was added or removed.
+func (e *podIPsStore) Apply(updates map[string]*EntityData, incremental bool) bool {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 	return e.applyNoLock(updates, incremental)
 }
 
-func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) set.Set[net.IPAddress] {
+func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bool) bool {
 	defer e.updateMetricsNoLock()
 	e.publicIPsChanged = false
 	if !incremental {
@@ -115,10 +114,7 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
-	if e.publicIPsChanged {
-		return e.collectPublicIPsNoLock()
-	}
-	return nil
+	return e.publicIPsChanged
 }
 
 func (e *podIPsStore) PublicIPs() set.Set[net.IPAddress] {

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -98,6 +98,7 @@ func (e *podIPsStore) applyNoLock(updates map[string]*EntityData, incremental bo
 	touchedPublic := false
 	if !incremental {
 		for deploymentID := range updates {
+			// Must check before purge: purgeDeploymentNoLock deletes reverseIPMap[deploymentID].
 			if !touchedPublic {
 				touchedPublic = containsPublicIPInFrozenSet(e.reverseIPMap[deploymentID])
 			}

--- a/sensor/common/clusterentities/store_public_ip_bench_test.go
+++ b/sensor/common/clusterentities/store_public_ip_bench_test.go
@@ -25,7 +25,6 @@ func BenchmarkStoreApplyPrivateIPsOnly(b *testing.B) {
 				"new-depl": entityUpdate("192.168.1.1", "new-cont", 9090),
 			}
 			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
 				store.Apply(update, true)
 			}
@@ -43,7 +42,6 @@ func BenchmarkStoreApplyWithPublicIP(b *testing.B) {
 				"new-depl": entityUpdate("8.8.8.8", "new-cont", 9090),
 			}
 			b.ReportAllocs()
-			b.ResetTimer()
 			for b.Loop() {
 				store.Apply(update, true)
 			}

--- a/sensor/common/clusterentities/store_public_ip_bench_test.go
+++ b/sensor/common/clusterentities/store_public_ip_bench_test.go
@@ -1,0 +1,77 @@
+package clusterentities
+
+import (
+	"fmt"
+	"testing"
+)
+
+func populateStoreWithPrivateIPs(store *Store, numDeployments int) {
+	for i := range numDeployments {
+		ip := fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
+		deplID := fmt.Sprintf("depl-%d", i)
+		store.Apply(map[string]*EntityData{
+			deplID: entityUpdate(ip, fmt.Sprintf("cont-%d", i), 8080),
+		}, true)
+	}
+}
+
+func BenchmarkStoreApplyPrivateIPsOnly(b *testing.B) {
+	for _, numStored := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("stored_%d", numStored), func(b *testing.B) {
+			store := NewStore(5, nil, false)
+			populateStoreWithPrivateIPs(store, numStored)
+
+			update := map[string]*EntityData{
+				"new-depl": entityUpdate("192.168.1.1", "new-cont", 9090),
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				store.Apply(update, true)
+			}
+		})
+	}
+}
+
+func BenchmarkStoreApplyWithPublicIP(b *testing.B) {
+	for _, numStored := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("stored_%d", numStored), func(b *testing.B) {
+			store := NewStore(5, nil, false)
+			populateStoreWithPrivateIPs(store, numStored)
+
+			update := map[string]*EntityData{
+				"new-depl": entityUpdate("8.8.8.8", "new-cont", 9090),
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				store.Apply(update, true)
+			}
+		})
+	}
+}
+
+func BenchmarkStoreApplyMixed(b *testing.B) {
+	for _, numStored := range []int{100, 1000, 5000} {
+		b.Run(fmt.Sprintf("stored_%d", numStored), func(b *testing.B) {
+			store := NewStore(5, nil, false)
+			populateStoreWithPrivateIPs(store, numStored)
+
+			privateUpdate := map[string]*EntityData{
+				"new-depl": entityUpdate("192.168.1.1", "new-cont", 9090),
+			}
+			publicUpdate := map[string]*EntityData{
+				"pub-depl": entityUpdate("8.8.8.8", "pub-cont", 443),
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				if i%10 == 0 {
+					store.Apply(publicUpdate, true)
+				} else {
+					store.Apply(privateUpdate, true)
+				}
+			}
+		})
+	}
+}

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -337,6 +337,21 @@ func (s *ClusterEntitiesStoreTestSuite) TestPublicIPListenerConditionalUpdate() 
 			// 8.8.8.8 moved to history (memorySize=1), still present
 			expected: []string{"8.8.8.8"},
 		},
+		"cross-store: updating one sub-store must not drop IPs from the other": {
+			setup: func(store *Store) {
+				// depl1 has a public endpoint but no pod IP
+				ed := &EntityData{}
+				ed.AddEndpoint(buildEndpoint("8.8.8.8", 80), EndpointTargetInfo{ContainerPort: 80})
+				store.Apply(map[string]*EntityData{"depl1": ed}, true)
+			},
+			action: func(store *Store) {
+				// depl2 has a public pod IP but no endpoint
+				ed := &EntityData{}
+				ed.AddIP(net.ParseIP("1.1.1.1"))
+				store.Apply(map[string]*EntityData{"depl2": ed}, true)
+			},
+			expected: []string{"8.8.8.8", "1.1.1.1"},
+		},
 	}
 
 	for name, tc := range tests {

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -339,13 +339,11 @@ func (s *ClusterEntitiesStoreTestSuite) TestPublicIPListenerConditionalUpdate() 
 		},
 		"cross-store: updating one sub-store must not drop IPs from the other": {
 			setup: func(store *Store) {
-				// depl1 has a public endpoint but no pod IP
 				ed := &EntityData{}
 				ed.AddEndpoint(buildEndpoint("8.8.8.8", 80), EndpointTargetInfo{ContainerPort: 80})
 				store.Apply(map[string]*EntityData{"depl1": ed}, true)
 			},
 			action: func(store *Store) {
-				// depl2 has a public pod IP but no endpoint
 				ed := &EntityData{}
 				ed.AddIP(net.ParseIP("1.1.1.1"))
 				store.Apply(map[string]*EntityData{"depl2": ed}, true)

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -246,3 +246,128 @@ func TestEntityData_GetPodIPs(t *testing.T) {
 		})
 	}
 }
+
+func (s *ClusterEntitiesStoreTestSuite) TestPublicIPListenerConditionalUpdate() {
+	tests := map[string]struct {
+		setup    func(store *Store)
+		action   func(store *Store)
+		expected []string
+	}{
+		"private-only incremental add should not trigger listener": {
+			action: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("10.0.0.1", "cont1", 80),
+				}, true)
+			},
+			expected: nil,
+		},
+		"public IP incremental add should trigger listener": {
+			action: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("34.118.224.226", "cont1", 80),
+				}, true)
+			},
+			expected: []string{"34.118.224.226"},
+		},
+		"public IP non-incremental replace should trigger listener": {
+			setup: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("8.8.8.8", "cont1", 80),
+				}, true)
+			},
+			action: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("1.1.1.1", "cont2", 80),
+				}, false)
+			},
+			// 8.8.8.8 moved to history, 1.1.1.1 added to current
+			expected: []string{"1.1.1.1", "8.8.8.8"},
+		},
+		"public IP removal via delete should trigger listener": {
+			setup: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("8.8.8.8", "cont1", 80),
+				}, true)
+			},
+			action: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("", "", 0),
+				}, false)
+			},
+			// 8.8.8.8 moved to history (memorySize=1), still present
+			expected: []string{"8.8.8.8"},
+		},
+		"mixed private and public should report only public": {
+			action: func(store *Store) {
+				ed := &EntityData{}
+				ep1 := buildEndpoint("10.0.0.1", 80)
+				ed.AddEndpoint(ep1, EndpointTargetInfo{ContainerPort: 80})
+				ed.AddIP(ep1.IPAndPort.Address)
+				ep2 := buildEndpoint("8.8.8.8", 443)
+				ed.AddEndpoint(ep2, EndpointTargetInfo{ContainerPort: 443})
+				ed.AddIP(ep2.IPAndPort.Address)
+				store.Apply(map[string]*EntityData{"depl1": ed}, true)
+			},
+			expected: []string{"8.8.8.8"},
+		},
+		"replacing public with private should still show history": {
+			setup: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("8.8.8.8", "cont1", 80),
+				}, true)
+			},
+			action: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("10.0.0.1", "cont2", 80),
+				}, false)
+			},
+			// 8.8.8.8 moved to history (memorySize=1), still present
+			expected: []string{"8.8.8.8"},
+		},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+			store := NewStore(1, nil, false)
+			listener := newTestPublicIPsListener(s.T())
+			store.RegisterPublicIPsListener(listener)
+			defer store.UnregisterPublicIPsListener(listener)
+
+			if tc.setup != nil {
+				tc.setup(store)
+			}
+			tc.action(store)
+
+			if tc.expected == nil {
+				s.Empty(listener.data, "expected no public IPs")
+			} else {
+				s.Equal(len(tc.expected), listener.data.Cardinality(), "wrong number of public IPs")
+				for _, ip := range tc.expected {
+					s.True(listener.data.Contains(net.ParseIP(ip)), "missing expected IP %s", ip)
+				}
+			}
+		})
+	}
+}
+
+func (s *ClusterEntitiesStoreTestSuite) TestPublicIPHistoryExpiry() {
+	store := NewStore(1, nil, false)
+	listener := newTestPublicIPsListener(s.T())
+	store.RegisterPublicIPsListener(listener)
+	defer store.UnregisterPublicIPsListener(listener)
+
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("8.8.8.8", "cont1", 80),
+	}, true)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")))
+
+	// Replace with private — public IP moves to history
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("10.0.0.1", "cont2", 80),
+	}, false)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")), "should still be in history")
+
+	// Tick expires history (memorySize=1 means 1 tick to expire)
+	store.RecordTick()
+	s.Empty(listener.data, "history should have expired after tick")
+}

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -376,6 +376,63 @@ func (s *ClusterEntitiesStoreTestSuite) TestPublicIPListenerConditionalUpdate() 
 	}
 }
 
+func (s *ClusterEntitiesStoreTestSuite) TestPublicIPReaddAfterRemoval() {
+	store := NewStore(1, nil, false)
+	listener := newTestPublicIPsListener(s.T())
+	store.RegisterPublicIPsListener(listener)
+	defer store.UnregisterPublicIPsListener(listener)
+
+	// Add a public IP, then remove it via replacement, then expire history.
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("8.8.8.8", "cont1", 80),
+	}, true)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")))
+
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("10.0.0.1", "cont2", 80),
+	}, false)
+	store.RecordTick()
+	s.Empty(listener.data, "public IP should be gone after history expiry")
+
+	// Re-add the same public IP — ref count must resurrect from zero.
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("8.8.8.8", "cont3", 80),
+	}, false)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")), "public IP should reappear after re-add")
+}
+
+func (s *ClusterEntitiesStoreTestSuite) TestPublicIPSharedBetweenDeployments() {
+	store := NewStore(1, nil, false)
+	listener := newTestPublicIPsListener(s.T())
+	store.RegisterPublicIPsListener(listener)
+	defer store.UnregisterPublicIPsListener(listener)
+
+	// Two deployments share the same public IP (different ports).
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("8.8.8.8", "cont1", 80),
+	}, true)
+	store.Apply(map[string]*EntityData{
+		"depl2": entityUpdate("8.8.8.8", "cont2", 443),
+	}, true)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")))
+
+	// Remove one deployment — the IP should survive via the other's ref count.
+	store.Apply(map[string]*EntityData{
+		"depl1": entityUpdate("", "", 0),
+	}, false)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")), "public IP should persist while second deployment still uses it")
+
+	// Remove the second deployment — IP moves to history.
+	store.Apply(map[string]*EntityData{
+		"depl2": entityUpdate("", "", 0),
+	}, false)
+	s.True(listener.data.Contains(net.ParseIP("8.8.8.8")), "public IP should be in history")
+
+	// Expire history.
+	store.RecordTick()
+	s.Empty(listener.data, "public IP should be gone after history expiry")
+}
+
 func (s *ClusterEntitiesStoreTestSuite) TestPublicIPHistoryExpiry() {
 	store := NewStore(1, nil, false)
 	listener := newTestPublicIPsListener(s.T())

--- a/sensor/common/clusterentities/store_test.go
+++ b/sensor/common/clusterentities/store_test.go
@@ -261,6 +261,19 @@ func (s *ClusterEntitiesStoreTestSuite) TestPublicIPListenerConditionalUpdate() 
 			},
 			expected: nil,
 		},
+		"incremental delete-only should not trigger listener": {
+			setup: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("10.0.0.1", "cont1", 80),
+				}, true)
+			},
+			action: func(store *Store) {
+				store.Apply(map[string]*EntityData{
+					"depl1": entityUpdate("", "", 0),
+				}, true)
+			},
+			expected: nil,
+		},
 		"public IP incremental add should trigger listener": {
 			action: func(store *Store) {
 				store.Apply(map[string]*EntityData{


### PR DESCRIPTION
## Description

<img width="1209" height="441" alt="download" src="https://github.com/user-attachments/assets/b6222f4e-3afd-4024-8d94-9aefc76bbe86" />



CPU profiling showed `(*Store).Apply` consuming 1.74 min of 6.99 min total (25%). The dominant cost was `currentlyStoredPublicIPs()` which full-scans 4 maps (`endpointMap`, `historicalEndpoints`, `ipMap`, `historicalIPs`) on every `Apply()` call, calling `IsPublic()` on every address.

The full-scan approach was introduced in f27e4592af (ROX-27099, Dec 2024) to replace a buggy incremental ref-counting scheme. That PR deliberately chose correctness over speed, noting the scan could be optimized later.

### What this PR does

1. **Refactors sub-store `Apply()` to return `bool`** indicating whether public IPs changed, replacing the previous `set.Set` return. `currentlyStoredPublicIPs()` delegates to sub-store `PublicIPs()` methods instead of reaching into internals.

2. **Maintains public IPs incrementally in both sub-stores.** Each mutation site (add/remove from current maps and history) updates a cached `publicIPs` set with O(1) `IsPublic()` checks per changed entry. `PublicIPs()` returns `publicIPs.Clone()` — O(P) where P is typically 0-5.

   - `podIPsStore`: uses a simple `set.Set` (no ref counting needed — `ipMap` keys are `net.IPAddress`, so existence checks are O(1))
   - `endpointsStore`: uses ref counting (`publicIPRefCount map[net.IPAddress]int`) because `endpointMap` keys are `net.NumericEndpoint` (IP+port+proto) — multiple keys can share an IP

3. **Adds `FrozenSet.All() iter.Seq[T]`** to avoid `AsSlice()` allocations when iterating frozen sets.

### Alternatives considered

- **Conditional scan only** (skip full scan when update has no public IPs) — implemented first as an intermediate step. Eliminates the private-only hot path but still O(N) when a public IP IS present. The incremental approach eliminates the scan entirely.

### Benchstat (10 runs, `-benchtime=3s`)

```
                                       │    master    │         incremental          │
                                       │    sec/op    │    sec/op     vs base        │
StoreApplyPrivateIPsOnly/stored_100-8     8.309µ ± 5%    4.292µ ±  5%  -48.34% (p=0.000 n=10)
StoreApplyPrivateIPsOnly/stored_1000-8   46.346µ ± 4%    4.311µ ± 12%  -90.70% (p=0.000 n=10)
StoreApplyPrivateIPsOnly/stored_5000-8  258.700µ ± 5%    4.349µ ±  6%  -98.32% (p=0.000 n=10)
StoreApplyWithPublicIP/stored_100-8       8.669µ ± 6%    4.442µ ±  9%  -48.76% (p=0.000 n=10)
StoreApplyWithPublicIP/stored_1000-8     45.997µ ± 4%    4.886µ ±  9%  -89.38% (p=0.000 n=10)
StoreApplyWithPublicIP/stored_5000-8    280.370µ ± 2%    4.838µ ± 10%  -98.27% (p=0.000 n=10)
StoreApplyMixed/stored_100-8              9.080µ ± 5%    4.552µ ± 10%  -49.87% (p=0.000 n=10)
StoreApplyMixed/stored_1000-8            48.058µ ± 4%    4.319µ ±  3%  -91.01% (p=0.000 n=10)
StoreApplyMixed/stored_5000-8           257.503µ ± 4%    4.713µ ±  9%  -98.17% (p=0.000 n=10)
geomean                                   47.59µ          4.517µ       -90.51%
```

Apply is now constant-time regardless of store size across all paths.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All existing tests pass (`go test ./sensor/common/clusterentities/...`)
- Benchmarks with `-count=20 -benchtime=3s` compared via benchstat (see above)
- `TestPublicIPListenerConditionalUpdate` and `TestPublicIPHistoryExpiry` verify
  correctness of the public IP sets reported to the listener

AI-assisted: code partially generated with Claude.