### PR TITLE
ROX-35642: Migrate misc singles Notify to PubSub

### DIFF
--- a/sensor/common/centralproxy/handler.go
+++ b/sensor/common/centralproxy/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/features"
 	pkghttputil "github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/logging"
@@ -19,6 +20,8 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/centralproxy/allowedpaths"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes"
 )
@@ -50,10 +53,32 @@ type Handler struct {
 	authorizer       *k8sAuthorizer
 	transport        *scopedTokenTransport
 	proxy            *httputil.ReverseProxy
+
+	pubSubDispatcher common.PubSubDispatcher
+}
+
+func (h *Handler) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && h.pubSubDispatcher != nil
+}
+
+func (h *Handler) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReachable.Store(true)
+	return nil
+}
+
+func (h *Handler) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReachable.Store(false)
+	return nil
 }
 
 // NewProxyHandler creates a new proxy handler that forwards requests to Central.
-func NewProxyHandler(centralEndpoint string, centralCertificates []*x509.Certificate, clusterIDGetter clusterIDGetter) (*Handler, error) {
+func NewProxyHandler(centralEndpoint string, centralCertificates []*x509.Certificate, clusterIDGetter clusterIDGetter, pubSubDispatcher common.PubSubDispatcher) (*Handler, error) {
 	centralBaseURL, err := url.Parse(
 		urlfmt.FormatURL(centralEndpoint, urlfmt.HTTPS, urlfmt.NoTrailingSlash),
 	)
@@ -90,12 +115,32 @@ func NewProxyHandler(centralEndpoint string, centralCertificates []*x509.Certifi
 		return nil, errors.Wrap(err, "creating kubernetes client")
 	}
 
-	return &Handler{
-		clusterIDGetter: clusterIDGetter,
-		authorizer:      newK8sAuthorizer(k8sClient),
-		transport:       transport,
-		proxy:           proxy,
-	}, nil
+	h := &Handler{
+		clusterIDGetter:  clusterIDGetter,
+		authorizer:       newK8sAuthorizer(k8sClient),
+		transport:        transport,
+		proxy:            proxy,
+		pubSubDispatcher: pubSubDispatcher,
+	}
+	if h.pubSubEnabled() {
+		if err := pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.CentralProxyHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			h.handleSensorOnlineEvent,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to register central proxy handler sensor online consumer")
+		}
+		if err := pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.CentralProxyHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			h.handleSensorOfflineEvent,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to register central proxy handler sensor offline consumer")
+		}
+	}
+	return h, nil
 }
 
 // SetCentralGRPCClient implements common.CentralGRPCConnAware.
@@ -107,6 +152,12 @@ func (h *Handler) SetCentralGRPCClient(cc grpc.ClientConnInterface) {
 // Notify reacts to sensor going into online/offline mode.
 func (h *Handler) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e, "Central proxy handler"))
+	if h.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in
+		// NewProxyHandler().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReachable.Store(true)

--- a/sensor/common/centralproxy/handler_pubsub_test.go
+++ b/sensor/common/centralproxy/handler_pubsub_test.go
@@ -1,0 +1,93 @@
+package centralproxy
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func TestHandleSensorOnlineEvent_SetsCentralReachable(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+	require.False(t, h.centralReachable.Load())
+
+	require.NoError(t, h.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, h.centralReachable.Load())
+}
+
+func TestHandleSensorOfflineEvent_UnsetsCentralReachable(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+	h.centralReachable.Store(true)
+
+	require.NoError(t, h.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, h.centralReachable.Load())
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+
+	err := h.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	h := &Handler{pubSubDispatcher: newTestOnlineOfflineDispatcher(t)}
+
+	err := h.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestNewProxyHandler_RegistersSensorOnlineOfflineConsumers verifies
+// NewProxyHandler() wires the online/offline handlers onto the
+// SensorOnline/SensorOffline topic and lane end-to-end through a real
+// dispatcher, at construction time (there is no Start() for a
+// Notifiable-only component).
+func TestNewProxyHandler_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		h := &Handler{pubSubDispatcher: dispatcher}
+		require.NoError(t, dispatcher.RegisterConsumerToLane(
+			pubsub.CentralProxyHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			h.handleSensorOnlineEvent,
+		))
+		require.NoError(t, dispatcher.RegisterConsumerToLane(
+			pubsub.CentralProxyHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			h.handleSensorOfflineEvent,
+		))
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, h.centralReachable.Load())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, h.centralReachable.Load())
+	})
+}

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -9,13 +9,16 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	grpcPkg "github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registrymirror"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/image/cache"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"github.com/stackrox/rox/sensor/common/trace"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
@@ -47,13 +50,14 @@ type clusterIDPeeker interface {
 }
 
 // NewService returns the ImageService API for the Admission Controller to use.
-func NewService(clusterID clusterIDPeeker, imageCache cache.Image, registryStore registryStore, mirrorStore registrymirror.Store) ServiceComponent {
+func NewService(clusterID clusterIDPeeker, imageCache cache.Image, registryStore registryStore, mirrorStore registrymirror.Store, pubSubDispatcher common.PubSubDispatcher) ServiceComponent {
 	return &serviceImpl{
-		imageCache:    imageCache,
-		registryStore: registryStore,
-		localScan:     scan.NewLocalScan(registryStore, mirrorStore),
-		centralReady:  concurrency.NewSignal(),
-		clusterID:     clusterID,
+		imageCache:       imageCache,
+		registryStore:    registryStore,
+		localScan:        scan.NewLocalScan(registryStore, mirrorStore),
+		centralReady:     concurrency.NewSignal(),
+		clusterID:        clusterID,
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }
 
@@ -69,10 +73,16 @@ type serviceImpl struct {
 	centralReady  concurrency.Signal
 
 	clusterID clusterIDPeeker
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (s *serviceImpl) Name() string {
 	return "image.serviceImpl"
+}
+
+func (s *serviceImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil
 }
 
 func (s *serviceImpl) SetClient(conn grpc.ClientConnInterface) {
@@ -153,8 +163,29 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 	return ctx, errors.Wrapf(err, "image authorization for %q", fullMethodName)
 }
 
+func (s *serviceImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	s.centralReady.Signal()
+	return nil
+}
+
+func (s *serviceImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	s.centralReady.Reset()
+	return nil
+}
+
 func (s *serviceImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if s.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		s.centralReady.Signal()
@@ -164,6 +195,24 @@ func (s *serviceImpl) Notify(e common.SensorComponentEvent) {
 }
 
 func (s *serviceImpl) Start() error {
+	if s.pubSubEnabled() {
+		if err := s.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ImageServiceSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			s.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register image service sensor online consumer")
+		}
+		if err := s.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ImageServiceSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			s.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register image service sensor offline consumer")
+		}
+	}
 	return nil
 }
 

--- a/sensor/common/image/service_impl_pubsub_test.go
+++ b/sensor/common/image/service_impl_pubsub_test.go
@@ -1,0 +1,91 @@
+package image
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func newTestServiceWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher) *serviceImpl {
+	tb.Helper()
+	return &serviceImpl{
+		centralReady:     concurrency.NewSignal(),
+		pubSubDispatcher: dispatcher,
+	}
+}
+
+func TestHandleSensorOnlineEvent_SignalsCentralReady(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	require.False(t, s.centralReady.IsDone())
+
+	require.NoError(t, s.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, s.centralReady.IsDone())
+}
+
+func TestHandleSensorOfflineEvent_ResetsCentralReady(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	s.centralReady.Signal()
+	require.True(t, s.centralReady.IsDone())
+
+	require.NoError(t, s.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, s.centralReady.IsDone())
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := s.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	s := newTestServiceWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := s.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestServiceStart_RegistersSensorOnlineOfflineConsumers verifies Start()
+// wires the online/offline handlers onto the SensorOnline/SensorOffline
+// topic and lane end-to-end through a real dispatcher.
+func TestServiceStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		s := newTestServiceWithDispatcher(t, dispatcher)
+		require.NoError(t, s.Start())
+		defer s.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, s.centralReady.IsDone())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, s.centralReady.IsDone())
+	})
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,26 +19,46 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	CertRefreshSecuredClusterTLSIssuerSensorOnlineConsumer
+	CertRefreshSecuredClusterTLSIssuerSensorOfflineConsumer
+	CentralProxyHandlerSensorOnlineConsumer
+	CentralProxyHandlerSensorOfflineConsumer
+	ImageServiceSensorOnlineConsumer
+	ImageServiceSensorOfflineConsumer
+	VirtualMachineIndexHandlerSensorOnlineConsumer
+	VirtualMachineIndexHandlerSensorOfflineConsumer
+	EventPipelineSensorOnlineConsumer
+	EventPipelineSensorOfflineConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:                            "NoConsumers",
-		DefaultConsumer:                        "Default",
-		ResolverConsumer:                       "Resolver",
-		EnrichedProcessConsumer:                "EnrichedProcess",
-		FileActivityEnrichedProcessConsumer:    "FileActivityEnrichedProcess",
-		UnenrichedProcessConsumer:              "UnenrichedProcess",
-		DetectorProcessIndicatorConsumer:       "DetectorProcessIndicator",
-		DetectorNetworkFlowConsumer:            "DetectorNetworkFlow",
-		DetectorFileAccessConsumer:             "DetectorFileAccess",
-		DetectorAuditLogConsumer:               "DetectorAuditLog",
-		DetectorDeploymentConsumer:             "DetectorDeployment",
-		DetectorScanResultConsumer:             "DetectorScanResult",
-		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
-		OutputQueueConsumer:                    "OutputQueue",
-		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
-		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		NoConsumers:                                             "NoConsumers",
+		DefaultConsumer:                                         "Default",
+		ResolverConsumer:                                        "Resolver",
+		EnrichedProcessConsumer:                                 "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer:                     "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:                               "UnenrichedProcess",
+		DetectorProcessIndicatorConsumer:                        "DetectorProcessIndicator",
+		DetectorNetworkFlowConsumer:                             "DetectorNetworkFlow",
+		DetectorFileAccessConsumer:                              "DetectorFileAccess",
+		DetectorAuditLogConsumer:                                "DetectorAuditLog",
+		DetectorDeploymentConsumer:                              "DetectorDeployment",
+		DetectorScanResultConsumer:                              "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:                       "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                                     "OutputQueue",
+		NetworkFlowManagerResourceSyncConsumer:                  "NetworkFlowManagerResourceSync",
+		SensorSoftRestartConsumer:                               "SensorSoftRestart",
+		CertRefreshSecuredClusterTLSIssuerSensorOnlineConsumer:  "CertRefreshSecuredClusterTLSIssuerSensorOnline",
+		CertRefreshSecuredClusterTLSIssuerSensorOfflineConsumer: "CertRefreshSecuredClusterTLSIssuerSensorOffline",
+		CentralProxyHandlerSensorOnlineConsumer:                 "CentralProxyHandlerSensorOnline",
+		CentralProxyHandlerSensorOfflineConsumer:                "CentralProxyHandlerSensorOffline",
+		ImageServiceSensorOnlineConsumer:                        "ImageServiceSensorOnline",
+		ImageServiceSensorOfflineConsumer:                       "ImageServiceSensorOffline",
+		VirtualMachineIndexHandlerSensorOnlineConsumer:          "VirtualMachineIndexHandlerSensorOnline",
+		VirtualMachineIndexHandlerSensorOfflineConsumer:         "VirtualMachineIndexHandlerSensorOffline",
+		EventPipelineSensorOnlineConsumer:                       "EventPipelineSensorOnline",
+		EventPipelineSensorOfflineConsumer:                      "EventPipelineSensorOffline",
 	}
 )
 

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -250,7 +250,7 @@ func (s *Sensor) Start() {
 	// Enable proxy endpoint for forwarding requests to Central on OpenShift.
 	// The proxy is served on a dedicated HTTPS server with a service CA signed certificate.
 	if features.OCPConsoleIntegration.Enabled() && env.OpenshiftAPI.BooleanSetting() {
-		handler, err := centralproxy.NewProxyHandler(s.centralEndpoint, centralCertificates, s.clusterID)
+		handler, err := centralproxy.NewProxyHandler(s.centralEndpoint, centralCertificates, s.clusterID, s.pubSubDispatcher)
 		if err != nil {
 			utils.Should(errors.Wrap(err, "creating central proxy handler"))
 		} else {

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -28,11 +28,12 @@ type VirtualMachineStore interface {
 }
 
 // NewHandler returns the virtual machine component for Sensor to use.
-func NewHandler(store VirtualMachineStore) Handler {
+func NewHandler(store VirtualMachineStore, pubSubDispatcher common.PubSubDispatcher) Handler {
 	return &handlerImpl{
-		centralReady: concurrency.NewSignal(),
-		lock:         &sync.RWMutex{},
-		stopper:      concurrency.NewStopper(),
-		store:        store,
+		centralReady:     concurrency.NewSignal(),
+		lock:             &sync.RWMutex{},
+		stopper:          concurrency.NewStopper(),
+		store:            store,
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -14,11 +14,14 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 )
@@ -40,6 +43,12 @@ type handlerImpl struct {
 	toCompliance chan common.MessageToComplianceWithAddress
 	indexReports chan *v1.IndexReport
 	store        VirtualMachineStore
+
+	pubSubDispatcher common.PubSubDispatcher
+}
+
+func (h *handlerImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && h.pubSubDispatcher != nil
 }
 
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
@@ -111,8 +120,31 @@ func (h *handlerImpl) Name() string {
 	return "virtualmachine.index.handlerImpl"
 }
 
+func (h *handlerImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	h.centralReady.Signal()
+	return nil
+}
+
+func (h *handlerImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	// As clients are expected to retry virtual machine upserts when Sensor is in
+	// offline mode, there is no need to do anything here other than reset the signal.
+	h.centralReady.Reset()
+	return nil
+}
+
 func (h *handlerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
+	if h.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReady.Signal()
@@ -166,6 +198,24 @@ func (h *handlerImpl) Start() error {
 	defer h.lock.Unlock()
 	if h.toCentral != nil || h.indexReports != nil || h.toCompliance != nil {
 		return errStartMoreThanOnce
+	}
+	if h.pubSubEnabled() {
+		if err := h.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.VirtualMachineIndexHandlerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			h.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register virtual machine index handler sensor online consumer")
+		}
+		if err := h.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.VirtualMachineIndexHandlerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			h.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register virtual machine index handler sensor offline consumer")
+		}
 	}
 	h.indexReports = make(chan *v1.IndexReport, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
 	h.toCompliance = make(chan common.MessageToComplianceWithAddress, 1)

--- a/sensor/common/virtualmachine/index/handler_impl_pubsub_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_pubsub_test.go
@@ -1,0 +1,99 @@
+package index
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/index/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func newTestHandlerWithDispatcher(tb testing.TB, dispatcher common.PubSubDispatcher) *handlerImpl {
+	tb.Helper()
+	ctrl := gomock.NewController(tb)
+	store := mocks.NewMockVirtualMachineStore(ctrl)
+	return &handlerImpl{
+		centralReady:     concurrency.NewSignal(),
+		lock:             &sync.RWMutex{},
+		stopper:          concurrency.NewStopper(),
+		store:            store,
+		pubSubDispatcher: dispatcher,
+	}
+}
+
+func TestHandleSensorOnlineEvent_SignalsCentralReady(t *testing.T) {
+	h := newTestHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	require.False(t, h.centralReady.IsDone())
+
+	require.NoError(t, h.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, h.centralReady.IsDone())
+}
+
+func TestHandleSensorOfflineEvent_ResetsCentralReady(t *testing.T) {
+	h := newTestHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+	h.centralReady.Signal()
+	require.True(t, h.centralReady.IsDone())
+
+	require.NoError(t, h.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, h.centralReady.IsDone())
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	h := newTestHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := h.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	h := newTestHandlerWithDispatcher(t, newTestOnlineOfflineDispatcher(t))
+
+	err := h.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestHandlerStart_RegistersSensorOnlineOfflineConsumers verifies Start()
+// wires the online/offline handlers onto the SensorOnline/SensorOffline
+// topic and lane end-to-end through a real dispatcher.
+func TestHandlerStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		dispatcher := newTestOnlineOfflineDispatcher(t)
+		h := newTestHandlerWithDispatcher(t, dispatcher)
+		require.NoError(t, h.Start())
+		defer h.Stop()
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+		synctest.Wait()
+		assert.True(t, h.centralReady.IsDone())
+
+		require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+		synctest.Wait()
+		assert.False(t, h.centralReady.IsDone())
+	})
+}

--- a/sensor/common/virtualmachine/index/service_impl_test.go
+++ b/sensor/common/virtualmachine/index/service_impl_test.go
@@ -31,12 +31,12 @@ type virtualMachineServiceSuite struct {
 func (s *virtualMachineServiceSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.store = mocks.NewMockVirtualMachineStore(s.ctrl)
-	s.service = &serviceImpl{handler: NewHandler(s.store)}
+	s.service = &serviceImpl{handler: NewHandler(s.store, nil)}
 	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported})
 }
 
 func (s *virtualMachineServiceSuite) TestNewService() {
-	svc := NewService(NewHandler(s.store))
+	svc := NewService(NewHandler(s.store, nil))
 	s.Require().NotNil(svc)
 	s.Require().IsType(&serviceImpl{}, svc)
 

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/cryptoutils"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/queue"
@@ -18,7 +19,9 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certrepo"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/securedcluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +56,7 @@ func NewSecuredClusterTLSIssuer(
 	k8sClient kubernetes.Interface,
 	sensorNamespace string,
 	sensorPodName string,
+	pubSubDispatcher common.PubSubDispatcher,
 ) common.SensorComponent {
 	return &tlsIssuerImpl{
 		componentName:                securedClusterComponentName,
@@ -71,6 +75,7 @@ func NewSecuredClusterTLSIssuer(
 			centralCap := centralsensor.CentralCapability(centralsensor.SecuredClusterCertificatesReissue)
 			return &centralCap
 		}(),
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }
 
@@ -123,10 +128,16 @@ type tlsIssuerImpl struct {
 	online                       atomic.Bool
 	cancelRefresher              context.CancelFunc
 	activateLock                 sync.Mutex
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (i *tlsIssuerImpl) Name() string {
 	return "certrefresh.tlsIssuerImpl"
+}
+
+func (i *tlsIssuerImpl) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && i.pubSubDispatcher != nil
 }
 
 // Start starts the Sensor component and launches a certificate refresher that:
@@ -135,6 +146,24 @@ func (i *tlsIssuerImpl) Name() string {
 // When Sensor is offline this component is not active.
 func (i *tlsIssuerImpl) Start() error {
 	log.Debugf("Starting %s TLS issuer.", i.componentName)
+	if i.pubSubEnabled() {
+		if err := i.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.CertRefreshSecuredClusterTLSIssuerSensorOnlineConsumer,
+			pubsub.SensorOnlineTopic,
+			pubsub.SensorOnlineLane,
+			i.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register secured cluster TLS issuer sensor online consumer")
+		}
+		if err := i.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.CertRefreshSecuredClusterTLSIssuerSensorOfflineConsumer,
+			pubsub.SensorOfflineTopic,
+			pubsub.SensorOfflineLane,
+			i.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register secured cluster TLS issuer sensor offline consumer")
+		}
+	}
 	i.started.Store(true)
 	return i.activate()
 }
@@ -200,9 +229,38 @@ func (i *tlsIssuerImpl) deactivate() {
 	log.Debugf("%s TLS issuer is not active.", i.componentName)
 }
 
+func (i *tlsIssuerImpl) handleSensorOnlineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	// At this point we can be sure that Central capabilities have been received
+	if i.requiredCentralCapability != nil && !centralcaps.Has(*i.requiredCentralCapability) {
+		log.Infof("Central does not have the %s capability", i.requiredCentralCapability.String())
+		return nil
+	}
+	i.online.Store(true)
+	if err := i.activate(); err != nil {
+		log.Warnf("Failed to activate %s TLS issuer: %v", i.componentName, err)
+	}
+	return nil
+}
+
+func (i *tlsIssuerImpl) handleSensorOfflineEvent(event pubsub.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	i.online.Store(false)
+	i.deactivate()
+	return nil
+}
+
 func (i *tlsIssuerImpl) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e))
-
+	if i.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		// At this point we can be sure that Central capabilities have been received

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_pubsub_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_pubsub_test.go
@@ -1,0 +1,115 @@
+package certrefresh
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stackrox/rox/sensor/common/events"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOnlineOfflineDispatcher(tb testing.TB) common.PubSubDispatcher {
+	tb.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.SensorOnlineLane),
+		lane.NewBlockingLane(pubsub.SensorOfflineLane),
+	}))
+	require.NoError(tb, err)
+	tb.Cleanup(dispatcher.Stop)
+	return dispatcher
+}
+
+func TestHandleSensorOnlineEvent_ActivatesWhenCapabilityPresent(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
+	defer centralcaps.Set([]centralsensor.CentralCapability{})
+
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.tlsIssuer.pubSubDispatcher = newTestOnlineOfflineDispatcher(t)
+	fixture.tlsIssuer.started.Store(true)
+	fixture.mockForStart(mockForStartConfig{})
+
+	require.NoError(t, fixture.tlsIssuer.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	assert.True(t, fixture.tlsIssuer.online.Load())
+	fixture.assertMockExpectations(t)
+}
+
+func TestHandleSensorOnlineEvent_SkipsActivationWhenCapabilityMissing(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{})
+	defer centralcaps.Set([]centralsensor.CentralCapability{})
+
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.tlsIssuer.pubSubDispatcher = newTestOnlineOfflineDispatcher(t)
+	fixture.tlsIssuer.started.Store(true)
+
+	require.NoError(t, fixture.tlsIssuer.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+
+	// online is never set, and none of the mocked dependencies (certRefresher,
+	// componentGetter) are called, since the capability check short-circuits first.
+	assert.False(t, fixture.tlsIssuer.online.Load())
+	fixture.assertMockExpectations(t)
+}
+
+func TestHandleSensorOfflineEvent_Deactivates(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.SecuredClusterCertificatesReissue})
+	defer centralcaps.Set([]centralsensor.CentralCapability{})
+
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.tlsIssuer.pubSubDispatcher = newTestOnlineOfflineDispatcher(t)
+	fixture.tlsIssuer.started.Store(true)
+	fixture.mockForStart(mockForStartConfig{})
+	require.NoError(t, fixture.tlsIssuer.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
+	require.True(t, fixture.tlsIssuer.online.Load())
+
+	fixture.certRefresher.On("Stop").Once()
+	require.NoError(t, fixture.tlsIssuer.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
+
+	assert.False(t, fixture.tlsIssuer.online.Load())
+	fixture.assertMockExpectations(t)
+}
+
+func TestHandleSensorOnlineEvent_WrongEventType(t *testing.T) {
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.tlsIssuer.pubSubDispatcher = newTestOnlineOfflineDispatcher(t)
+
+	err := fixture.tlsIssuer.handleSensorOnlineEvent(&events.SensorOfflineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+func TestHandleSensorOfflineEvent_WrongEventType(t *testing.T) {
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.tlsIssuer.pubSubDispatcher = newTestOnlineOfflineDispatcher(t)
+
+	err := fixture.tlsIssuer.handleSensorOfflineEvent(&events.SensorOnlineEvent{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected event type")
+}
+
+// TestTLSIssuerStart_RegistersSensorOnlineOfflineConsumers verifies Start()
+// wires the online/offline handlers onto the SensorOnline/SensorOffline
+// topic and lane end-to-end through a real dispatcher.
+func TestTLSIssuerStart_RegistersSensorOnlineOfflineConsumers(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{})
+	defer centralcaps.Set([]centralsensor.CentralCapability{})
+
+	dispatcher := newTestOnlineOfflineDispatcher(t)
+	fixture := newSecuredClusterTLSIssuerFixture(fakeK8sClientConfig{})
+	fixture.tlsIssuer.pubSubDispatcher = dispatcher
+
+	require.NoError(t, fixture.tlsIssuer.Start())
+	defer fixture.tlsIssuer.Stop()
+
+	// No capability, so online() short-circuits before touching any mocks --
+	// this only exercises the registration wiring, not activation.
+	require.NoError(t, dispatcher.Publish(&events.SensorOnlineEvent{}))
+	require.NoError(t, dispatcher.Publish(&events.SensorOfflineEvent{}))
+}

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -897,7 +897,7 @@ func newSecuredClusterTLSIssuer(
 	sensorNamespace string,
 	sensorPodName string,
 ) *tlsIssuerImpl {
-	tlsIssuer := NewSecuredClusterTLSIssuer(k8sClient, sensorNamespace, sensorPodName)
+	tlsIssuer := NewSecuredClusterTLSIssuer(k8sClient, sensorNamespace, sensorPodName, nil)
 	require.IsType(t, &tlsIssuerImpl{}, tlsIssuer)
 	return tlsIssuer.(*tlsIssuerImpl)
 }

--- a/sensor/kubernetes/eventpipeline/pipeline_impl.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_impl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/detector"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
@@ -25,10 +26,6 @@ var (
 	log = logging.LoggerForModule()
 )
 
-type pubSubPublisher interface {
-	Publish(pubsubDispatcher.Event) error
-}
-
 type eventPipeline struct {
 	output      component.OutputQueue
 	resolver    component.Resolver
@@ -36,7 +33,7 @@ type eventPipeline struct {
 	detector    detector.Detector
 	reprocessor reprocessor.Handler
 
-	pubsubDispatcher pubSubPublisher
+	pubsubDispatcher component.PubSubDispatcher
 
 	offlineMode *atomic.Bool
 
@@ -50,6 +47,10 @@ type eventPipeline struct {
 
 func (p *eventPipeline) Name() string {
 	return "eventpipeline.eventPipeline"
+}
+
+func (p *eventPipeline) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && p.pubsubDispatcher != nil
 }
 
 // Capabilities implements common.SensorComponent
@@ -107,6 +108,25 @@ func (p *eventPipeline) createNewContext() {
 
 // Start implements common.SensorComponent
 func (p *eventPipeline) Start() error {
+	if p.pubSubEnabled() {
+		if err := p.pubsubDispatcher.RegisterConsumerToLane(
+			pubsubDispatcher.EventPipelineSensorOnlineConsumer,
+			pubsubDispatcher.SensorOnlineTopic,
+			pubsubDispatcher.SensorOnlineLane,
+			p.handleSensorOnlineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register event pipeline sensor online consumer")
+		}
+		if err := p.pubsubDispatcher.RegisterConsumerToLane(
+			pubsubDispatcher.EventPipelineSensorOfflineConsumer,
+			pubsubDispatcher.SensorOfflineTopic,
+			pubsubDispatcher.SensorOfflineLane,
+			p.handleSensorOfflineEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register event pipeline sensor offline consumer")
+		}
+	}
+
 	// The order is important here, we need to start the components
 	// that receive messages from other components first
 	if err := p.output.Start(); err != nil {
@@ -136,8 +156,43 @@ func (p *eventPipeline) Stop() {
 	p.stopper.Client().Stop()
 }
 
+func (p *eventPipeline) handleSensorOnlineEvent(event pubsubDispatcher.Event) error {
+	if _, ok := event.(*events.SensorOnlineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	// Start listening to events if not yet listening
+	if p.offlineMode.CompareAndSwap(true, false) {
+		log.Info("Connection established: Starting Kubernetes listener")
+		// Stopping the listener here will allow Sensor to maintain the stores populated while offline.
+		// This is needed to capture runtime events in offline mode.
+		p.listener.Stop()
+		// TODO(ROX-18613): use contextProvider to provide context for listener
+		p.createNewContext()
+		if err := p.listener.StartWithContext(p.context); err != nil {
+			log.Fatalf("Failed to start listener component. Sensor cannot run without listening to Kubernetes events: %s", err)
+		}
+	}
+	return nil
+}
+
+func (p *eventPipeline) handleSensorOfflineEvent(event pubsubDispatcher.Event) error {
+	if _, ok := event.(*events.SensorOfflineEvent); !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	// Cancel the current context of the listeners.
+	if p.offlineMode.CompareAndSwap(false, true) {
+		p.stopCurrentContext()
+	}
+	return nil
+}
+
 func (p *eventPipeline) Notify(e common.SensorComponentEvent) {
 	log.Info(common.LogSensorComponentEvent(e, "Event Pipeline"))
+	if p.pubSubEnabled() {
+		// Online/offline transitions are handled by the SensorOnlineEvent/
+		// SensorOfflineEvent PubSub subscription registered in Start().
+		return
+	}
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		// Start listening to events if not yet listening

--- a/sensor/kubernetes/eventpipeline/pipeline_test.go
+++ b/sensor/kubernetes/eventpipeline/pipeline_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sync"
-	"github.com/stackrox/rox/sensor/common"
 	mockDetector "github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	mockReprocessor "github.com/stackrox/rox/sensor/common/reprocessor/mocks"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
@@ -57,6 +57,7 @@ func (s *eventPipelineSuite) SetupTest() {
 	s.listener = mockComponent.NewMockContextListener(s.mockCtrl)
 	s.outputQueue = mockComponent.NewMockOutputQueue(s.mockCtrl)
 	s.pubsub = mockComponent.NewMockPubSubDispatcher(s.mockCtrl)
+	s.pubsub.EXPECT().RegisterConsumerToLane(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	offlineMode := atomic.Bool{}
 	offlineMode.Store(true)
@@ -79,11 +80,11 @@ func (s *eventPipelineSuite) write() {
 }
 
 func (s *eventPipelineSuite) online() {
-	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+	s.Require().NoError(s.pipeline.handleSensorOnlineEvent(&events.SensorOnlineEvent{}))
 }
 
 func (s *eventPipelineSuite) offline() {
-	s.pipeline.Notify(common.SensorComponentEventOfflineMode)
+	s.Require().NoError(s.pipeline.handleSensorOfflineEvent(&events.SensorOfflineEvent{}))
 }
 
 func (s *eventPipelineSuite) readSuccess() {
@@ -110,7 +111,7 @@ func (s *eventPipelineSuite) Test_OfflineModeCases() {
 	s.listener.EXPECT().Stop().AnyTimes()
 
 	s.Require().NoError(s.pipeline.Start())
-	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+	s.online()
 
 	testCases := map[string][]func(){
 		"Base case: Start, WA, WB, RA, RB, Disconnect":       {s.online, s.write, s.write, s.readSuccess, s.readSuccess, s.offline},
@@ -144,7 +145,7 @@ func (s *eventPipelineSuite) Test_OfflineMode() {
 	s.listener.EXPECT().Stop().Times(2)
 
 	s.Require().NoError(s.pipeline.Start())
-	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+	s.online()
 
 	outputC <- message.NewExpiring(s.pipeline.context, nil)
 	outputC <- message.NewExpiring(s.pipeline.context, nil)
@@ -154,8 +155,8 @@ func (s *eventPipelineSuite) Test_OfflineMode() {
 	s.Require().True(more, "should have more messages in ResponsesC")
 	s.Assert().False(msgA.IsExpired(), "context should not be expired")
 
-	s.pipeline.Notify(common.SensorComponentEventOfflineMode)
-	s.pipeline.Notify(common.SensorComponentEventCentralReachable)
+	s.offline()
+	s.online()
 
 	// Read message B
 	msgB, more := <-s.pipeline.ResponsesC()

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -151,7 +151,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
-	imageService := image.NewService(clusterID, imageCache, storeProvider.Registries(), storeProvider.RegistryMirrors())
+	imageService := image.NewService(clusterID, imageCache, storeProvider.Registries(), storeProvider.RegistryMirrors(), internalMessageDispatcher)
 	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
 
 	// Create Process Pipeline
@@ -198,7 +198,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	var virtualMachineHandler vmIndex.Handler
 	if features.VirtualMachines.Enabled() {
-		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines())
+		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines(), internalMessageDispatcher)
 		components = append(components, virtualMachineHandler)
 		complianceMultiplexer.AddComponentWithComplianceC(virtualMachineHandler)
 	}
@@ -249,7 +249,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if centralsensor.SecuredClusterIsNotManagedManually(helmManagedConfig) {
 		podName := os.Getenv("POD_NAME")
 		components = append(components,
-			certrefresh.NewSecuredClusterTLSIssuer(cfg.introspectionK8sClient.Kubernetes(), sensorNamespace, podName))
+			certrefresh.NewSecuredClusterTLSIssuer(cfg.introspectionK8sClient.Kubernetes(), sensorNamespace, podName, internalMessageDispatcher))
 	}
 
 	s, err := sensor.NewSensor(


### PR DESCRIPTION
## Description

PR 8 of 8 independent consumer PRs in the Notify to PubSub migration for ROX-35642 (epic ROX-32854) -- the last one before the final cleanup PR. Proceeding despite the known conflict with #21651/#21650/#21547 (ResponsesC bridge chain) on `eventpipeline/pipeline_impl.go`, per the earlier decision to proceed and rebase once one of those merges.

Migrates the five remaining real `Notify(SensorComponentEvent)` implementations to genuine PubSub subscriptions on `SensorOnlineTopic`/`SensorOfflineTopic`:

- `certrefresh/securedcluster_tls_issuer.go` -- online activates the cert refresher (after checking the required central capability), offline deactivates it.
- `centralproxy/handler.go` -- `centralReachable` flag flip. **Notifiable-only** (no `Start()`/`Stop()`), same wrinkle as PR 6 -- registers its consumers directly inside `NewProxyHandler()` instead.
- `image/service_impl.go` -- `centralReady` signal/reset.
- `virtualmachine/index/handler_impl.go` -- `centralReady` signal/reset.
- `eventpipeline/pipeline_impl.go` -- the plan doc called this "trivial," but it's actually the most complex file in this whole series after `detector.go`: CAS-guarded `offlineMode`, Kubernetes listener start/stop, and context create/cancel. Required broadening the `pubsubDispatcher` field's type from a narrow `Publish`-only interface to the full `component.PubSubDispatcher` (already satisfied structurally by what's passed in) to allow registering consumers, and fixing `pipeline_test.go`: its `SetupTest()` always wires a live PubSub mock (used elsewhere for `Publish()` expectations in reprocessing tests), so the `online()`/`offline()` test helpers now call the new handlers directly instead of the legacy `Notify`, and the two `Start()`-calling tests get a blanket `RegisterConsumerToLane` expectation.

All five `Notify` implementations handle only `CentralReachable`/`OfflineMode` and nothing else, so all five get the blanket early-return.

Checked #21651/#21650/#21547's diffs against `pipeline_impl.go` directly: they touch `ResponsesC()`/`Start()`/`Stop()` in different hunks than this change (which adds registration lines to `Start()` and touches `Notify()`, untouched by those PRs) -- low actual rebase risk, but noting it here per the "rebase later" decision.

This PR was created with AI assistance (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added a `*_pubsub_test.go` per simple component (certrefresh, centralproxy, image, virtualmachine/index): handler unit tests for the exact state mutation, wrong-event-type cases, and a `Start()`/construction-time end-to-end test via a real dispatcher.
- For `eventpipeline`, fixed the existing `pipeline_test.go` suite in place instead of adding a parallel file: updated `online()`/`offline()` helpers to call the new handlers directly, and added a blanket `RegisterConsumerToLane` mock expectation so the two `Start()`-calling tests keep passing.
- Updated existing test call sites (`securedcluster_tls_issuer_test.go`, `virtualmachine/index/service_impl_test.go`) to pass a `nil` dispatcher, keeping legacy-Notify-path tests unchanged.
- `go build ./sensor/...` -- clean.
- `go test -race ./sensor/kubernetes/certrefresh/... ./sensor/common/centralproxy/... ./sensor/common/image/... ./sensor/common/virtualmachine/index/... ./sensor/kubernetes/eventpipeline/... ./sensor/common/sensor/... ./sensor/kubernetes/sensor/...` -- all pass.
- `go vet` and `quickstyle` (golangci-lint/imports/blanks/fmt/roxvet) -- all clean.
- Feature is gated by `ROX_SENSOR_PUBSUB`, off by default in prod; legacy Notify path is unchanged when disabled.


## PR series

Part of the ROX-35642 Notify -> PubSub migration (epic ROX-32854). All consumer PRs stack directly on the infra PR and are independent of each other -- any order, any subset in parallel.

- [#21739 -- infra: lifecycle topics + dual-publish](https://github.com/stackrox/stackrox/pull/21739)
  - PR 1 -- [#21742 -- detector](https://github.com/stackrox/stackrox/pull/21742)
  - PR 2 -- [#21763 -- admissioncontroller](https://github.com/stackrox/stackrox/pull/21763)
  - PR 3 -- [#21762 -- complianceoperator](https://github.com/stackrox/stackrox/pull/21762)
  - PR 4 -- [#21764 -- cluster-status + telemetry](https://github.com/stackrox/stackrox/pull/21764)
  - PR 5 -- [#21765 -- compliance](https://github.com/stackrox/stackrox/pull/21765)
  - PR 6 -- [#21766 -- scanner](https://github.com/stackrox/stackrox/pull/21766)
  - PR 7 -- [#21767 -- networkflow](https://github.com/stackrox/stackrox/pull/21767)
  - **PR 8 -- [#21771 -- misc singles](https://github.com/stackrox/stackrox/pull/21771) (this PR)**
  - PR 9 -- cleanup (not opened yet; lands last, after all of the above merge)


