### PR TITLE
perf: add FrozenSet.All() iterator to avoid AsSlice allocations

### DIFF
--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -430,7 +430,7 @@ func (s *datastorePostgresTestSuite) addRoles(
 		Traits: objectTraits.CloneVT(),
 	}))
 
-	for _, role := range testRoles.AsSlice() {
+	for role := range testRoles.All() {
 		s.Require().NoError(roleStore.Upsert(s.ctx, &storage.Role{
 			Name:            namePrefix + role,
 			Description:     "test role",

--- a/central/auth/service/service_impl_test.go
+++ b/central/auth/service/service_impl_test.go
@@ -791,7 +791,7 @@ func (s *authServiceAccessControlTestSuite) addRoles() {
 		},
 	}))
 
-	for _, role := range testRoles.AsSlice() {
+	for role := range testRoles.All() {
 		s.Require().NoError(s.roleDS.AddRole(s.accessCtx, &storage.Role{
 			Name:            role,
 			Description:     "test role",

--- a/central/cve/matcher/matcher.go
+++ b/central/cve/matcher/matcher.go
@@ -139,7 +139,7 @@ func (m *CVEMatcher) IsClusterAffectedByIstioCVE(ctx context.Context, cluster *s
 		return false, nil
 	}
 	for _, node := range cve.Configurations.Nodes {
-		for _, version := range versions.AsSlice() {
+		for version := range versions {
 			matched, err := m.MatchVersions(node, version, utils.Istio)
 			// If we could determine CVE impact from one of cpe string, we skip logging error
 			if matched {

--- a/central/declarativeconfig/watch_handler.go
+++ b/central/declarativeconfig/watch_handler.go
@@ -151,7 +151,7 @@ func (w *watchHandler) checkForDeletedFiles(fileContents map[string][]byte) bool
 	}
 
 	newCachedFileHashes := maputil.ShallowClone(w.cachedFileHashes)
-	for _, removedFile := range removedFiles.AsSlice() {
+	for removedFile := range removedFiles {
 		delete(newCachedFileHashes, removedFile)
 	}
 

--- a/central/postgres/pruning_test.go
+++ b/central/postgres/pruning_test.go
@@ -344,12 +344,12 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
 			s.Require().NoError(err)
-			for _, deploymentID := range c.deployments.AsSlice() {
+			for deploymentID := range c.deployments.All() {
 				s.Require().NoError(deploymentDS.UpsertDeployment(s.ctx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
 			}
 
 			podDS := podStore.GetTestPostgresDataStore(s.T(), s.testDB.DB)
-			for _, podID := range c.pods.AsSlice() {
+			for podID := range c.pods.All() {
 				err := podDS.UpsertPod(s.ctx, &storage.Pod{Id: podID, ClusterId: fixtureconsts.Cluster1})
 				s.Require().NoError(err)
 			}
@@ -375,11 +375,11 @@ func (s *PostgresPruningSuite) TestRemoveOrphanedProcesses() {
 			}
 			s.Require().NoError(processDatastore.RemoveProcessIndicators(s.ctx, cleanupIDs, processIndicatorDatastore.RemovalReasonProcessFilter))
 
-			for _, deploymentID := range c.deployments.AsSlice() {
+			for deploymentID := range c.deployments.All() {
 				s.Require().NoError(deploymentDS.RemoveDeployment(s.ctx, fixtureconsts.Cluster1, deploymentID))
 			}
 
-			for _, podID := range c.pods.AsSlice() {
+			for podID := range c.pods.All() {
 				s.Require().NoError(podDS.RemovePod(s.ctx, podID))
 			}
 		})

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -2468,11 +2468,11 @@ func (suite *PLOPDataStoreTestSuite) TestRemoveOrphanedPLOPs() {
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
 			suite.Nil(err)
-			for _, deploymentID := range c.deployments.AsSlice() {
+			for deploymentID := range c.deployments.All() {
 				suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
 			}
 
-			for _, podID := range c.pods.AsSlice() {
+			for podID := range c.pods.All() {
 				insertPod := fmt.Sprintf("INSERT INTO pods (id, clusterid) VALUES ('%s', '%s')", podID, fixtureconsts.Cluster1)
 				_, err := suite.postgres.DB.Exec(suite.hasWriteCtx, insertPod)
 				suite.Nil(err)
@@ -2637,11 +2637,11 @@ func (suite *PLOPDataStoreTestSuite) TestRemoveOrphanedPLOPsByProcesses() {
 			// Add deployments if necessary
 			deploymentDS, err := deploymentStore.GetTestPostgresDataStore(suite.T(), suite.postgres.DB)
 			suite.Nil(err)
-			for _, deploymentID := range c.deployments.AsSlice() {
+			for deploymentID := range c.deployments.All() {
 				suite.NoError(deploymentDS.UpsertDeployment(suite.hasAllCtx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
 			}
 
-			for _, podID := range c.pods.AsSlice() {
+			for podID := range c.pods.All() {
 				insertPod := fmt.Sprintf("INSERT INTO pods (id, clusterid) VALUES ('%s', '%s')", podID, fixtureconsts.Cluster1)
 				_, err := suite.postgres.DB.Exec(suite.hasWriteCtx, insertPod)
 				suite.Nil(err)

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -587,7 +587,7 @@ func (g *garbageCollectorImpl) removeOrphanedNetworkFlows(clusters set.FrozenStr
 
 	// Each cluster has a separate store thus we can take advantage of doing these deletions concurrently.  If we don't
 	// the entire prune job will be stuck waiting on processing the network flows deletions in cluster sequence.
-	for _, c := range clusters.AsSlice() {
+	for c := range clusters.All() {
 		if err := sema.Acquire(pruningCtx, 1); err != nil {
 			log.Errorf("context cancelled via stop: %v", err)
 			return

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -1526,12 +1526,12 @@ func (s *PruningTestSuite) TestRemoveOrphanedProcesses() {
 			// Populate some actual data so the query returns what needs deleted
 			deploymentDS, err := deploymentDatastore.GetTestPostgresDataStore(t, db.DB)
 			s.Nil(err)
-			for _, deploymentID := range c.deployments.AsSlice() {
+			for deploymentID := range c.deployments.All() {
 				s.NoError(deploymentDS.UpsertDeployment(s.ctx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
 			}
 
 			podDS := podDatastore.GetTestPostgresDataStore(t, db.DB)
-			for _, podID := range c.pods.AsSlice() {
+			for podID := range c.pods.All() {
 				err := podDS.UpsertPod(s.ctx, &storage.Pod{Id: podID, ClusterId: fixtureconsts.Cluster1})
 				s.Nil(err)
 			}
@@ -1722,12 +1722,12 @@ func (s *PruningTestSuite) TestRemoveOrphanedPLOPs() {
 			// Populate some actual data so the query returns what needs deleted
 			deploymentDS, err := deploymentDatastore.GetTestPostgresDataStore(t, db.DB)
 			s.Nil(err)
-			for _, deploymentID := range c.deployments.AsSlice() {
+			for deploymentID := range c.deployments.All() {
 				s.NoError(deploymentDS.UpsertDeployment(s.ctx, &storage.Deployment{Id: deploymentID, ClusterId: fixtureconsts.Cluster1}))
 			}
 
 			podDS := podDatastore.GetTestPostgresDataStore(t, db.DB)
-			for _, podID := range c.pods.AsSlice() {
+			for podID := range c.pods.All() {
 				err := podDS.UpsertPod(s.ctx, &storage.Pod{Id: podID, ClusterId: fixtureconsts.Cluster1})
 				s.Nil(err)
 			}
@@ -1836,7 +1836,7 @@ func (s *PruningTestSuite) TestMarkOrphanedAlerts() {
 			deploymentDS, err := deploymentDatastore.GetTestPostgresDataStore(t, db.DB)
 			assert.NoError(t, err)
 
-			for _, depID := range c.deployments.AsSlice() {
+			for depID := range c.deployments.All() {
 				assert.NoError(t, deploymentDS.UpsertDeployment(pruningCtx, &storage.Deployment{Id: depID}))
 			}
 			for _, la := range c.initialAlerts {

--- a/central/role/datastore/datastore_impl.go
+++ b/central/role/datastore/datastore_impl.go
@@ -1018,7 +1018,7 @@ func (ds *dataStoreImpl) RemoveFilteredPermissionSets(ctx context.Context, filte
 
 	// Delete permission sets that are not referenced.
 	deletedCount := 0
-	for _, id := range candidateSet.AsSlice() {
+	for id := range candidateSet {
 		if err := ds.permissionSetStorage.Delete(ctx, id); err != nil {
 			log.Errorf("Failed to delete filtered permission set %q: %v", id, err)
 		} else {
@@ -1068,7 +1068,7 @@ func (ds *dataStoreImpl) RemoveFilteredAccessScopes(ctx context.Context, filter 
 
 	// Delete access scopes that are not referenced.
 	deletedCount := 0
-	for _, id := range candidateSet.AsSlice() {
+	for id := range candidateSet {
 		if err := ds.accessScopeStorage.Delete(ctx, id); err != nil {
 			log.Errorf("Failed to delete filtered access scope %q: %v", id, err)
 		} else {

--- a/central/role/datastore/defaults.go
+++ b/central/role/datastore/defaults.go
@@ -143,7 +143,7 @@ var defaultPermissionSets = map[string]permSetAttributes{
 
 func getDefaultRoles() []*storage.Role {
 	roles := make([]*storage.Role, 0, len(defaultPermissionSets))
-	for _, roleName := range accesscontrol.DefaultRoleNames.AsSlice() {
+	for roleName := range accesscontrol.DefaultRoleNames {
 		attributes, found := defaultPermissionSets[roleName]
 		if !found {
 			utils.Should(errors.Errorf("Default role %s does not have permission set defined", roleName))

--- a/central/securedclustercertgen/certificates.go
+++ b/central/securedclustercertgen/certificates.go
@@ -129,7 +129,7 @@ func (c *certIssuerImpl) issueCertificates(namespace string, clusterID string) (
 	var caPem []byte
 
 	serviceCerts := make([]*storage.TypedServiceCertificate, 0, c.serviceTypes.Cardinality())
-	for _, serviceType := range c.serviceTypes.AsSlice() {
+	for serviceType := range c.serviceTypes.All() {
 		ca, cert, err := c.certificateFor(serviceType, namespace, clusterID)
 		if err != nil {
 			certIssueError = multierror.Append(certIssueError, err)

--- a/central/securedclustercertgen/certificates_test.go
+++ b/central/securedclustercertgen/certificates_test.go
@@ -194,7 +194,7 @@ func (s *securedClusterCertGenSuite) TestServiceIssueLocalScannerCerts() {
 			serviceTypes = localScannerServiceTypes
 		}
 		serviceTypeNames := make([]string, 0, serviceTypes.Cardinality())
-		for _, serviceType := range serviceTypes.AsSlice() {
+		for serviceType := range serviceTypes.All() {
 			serviceTypeNames = append(serviceTypeNames, serviceType.String())
 		}
 		return set.NewFrozenSet(serviceTypeNames...)

--- a/compliance/collection/auditlog/auditlog_impl_test.go
+++ b/compliance/collection/auditlog/auditlog_impl_test.go
@@ -36,7 +36,7 @@ type ComplianceAuditLogReaderTestSuite struct {
 }
 
 func (s *ComplianceAuditLogReaderTestSuite) TestCompareK8sResourceLists() {
-	for _, r := range resourceTypesAllowList.AsSlice() {
+	for r := range resourceTypesAllowList.All() {
 		if _, ok := auditResourceToKubeResource[fmt.Sprintf("%v", r)]; !ok {
 			s.T().Errorf("Missing entry in auditResourceToKubeResource map for resource %v", r)
 		}

--- a/pkg/booleanpolicy/compile.go
+++ b/pkg/booleanpolicy/compile.go
@@ -94,7 +94,7 @@ func constructRemainingContextQueries(stage storage.LifecycleStage, section *sto
 	for _, group := range section.GetPolicyGroups() {
 		if metadata := FieldMetadataSingleton().findField(group.GetFieldName()); metadata != nil {
 			if contextFieldsToAdd, ok := metadata.contextFields[stage]; ok {
-				for _, contextField := range contextFieldsToAdd.AsSlice() {
+				for contextField := range contextFieldsToAdd.All() {
 					contextFieldSet.Add(contextField)
 				}
 			}

--- a/pkg/notifiers/format.go
+++ b/pkg/notifiers/format.go
@@ -132,7 +132,7 @@ func FormatAlert(alert *storage.Alert, alertLink string, funcMap template.FuncMa
 	if funcMap == nil {
 		return "", errors.New("Function map passed to FormatAlert cannot be nil")
 	}
-	for _, k := range requiredFunctions.AsSlice() {
+	for k := range requiredFunctions.All() {
 		if _, ok := funcMap[k]; !ok {
 			return "", fmt.Errorf("FuncMap key '%v' must be defined", k)
 		}

--- a/pkg/set/frozen_set_test.go
+++ b/pkg/set/frozen_set_test.go
@@ -46,6 +46,38 @@ func TestFrozenStringSet(t *testing.T) {
 	assertFrozenSetContainsExactly(t, emptyFS)
 }
 
+func TestFrozenSetAll(t *testing.T) {
+	tests := map[string]struct {
+		elements []string
+	}{
+		"empty set":         {elements: nil},
+		"single element":    {elements: []string{"x"}},
+		"multiple elements": {elements: []string{"a", "b", "c"}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			fs := NewFrozenSet(tc.elements...)
+			var collected []string
+			for elem := range fs.All() {
+				collected = append(collected, elem)
+			}
+			assert.ElementsMatch(t, fs.AsSlice(), collected)
+		})
+	}
+}
+
+func TestFrozenSetAllEarlyBreak(t *testing.T) {
+	fs := NewFrozenSet("a", "b", "c", "d", "e")
+	count := 0
+	for range fs.All() {
+		count++
+		if count == 2 {
+			break
+		}
+	}
+	assert.Equal(t, 2, count)
+}
+
 func TestFrozenStringSetAfterFreeze(t *testing.T) {
 	set := NewSet[string]()
 	set.Add("a")

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -3,6 +3,7 @@ package set
 import (
 	"fmt"
 	"iter"
+	"maps"
 	"sort"
 	"strings"
 )
@@ -365,7 +366,7 @@ func (k FrozenSet[KeyType]) IsEmpty() bool {
 
 // All returns an iterator over the elements of the set.
 func (k FrozenSet[KeyType]) All() iter.Seq[KeyType] {
-	return maps.Values(k)
+	return maps.Keys(k.underlying)
 }
 
 // AsSlice returns the elements of the set. The order is unspecified.

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -365,13 +365,7 @@ func (k FrozenSet[KeyType]) IsEmpty() bool {
 
 // All returns an iterator over the elements of the set.
 func (k FrozenSet[KeyType]) All() iter.Seq[KeyType] {
-	return func(yield func(KeyType) bool) {
-		for elem := range k.underlying {
-			if !yield(elem) {
-				return
-			}
-		}
-	}
+	return maps.Values(k)
 }
 
 // AsSlice returns the elements of the set. The order is unspecified.

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"fmt"
+	"iter"
 	"sort"
 	"strings"
 )
@@ -360,6 +361,17 @@ func (k FrozenSet[KeyType]) Cardinality() int {
 // IsEmpty returns whether the underlying set is empty (includes uninitialized).
 func (k FrozenSet[KeyType]) IsEmpty() bool {
 	return len(k.underlying) == 0
+}
+
+// All returns an iterator over the elements of the set.
+func (k FrozenSet[KeyType]) All() iter.Seq[KeyType] {
+	return func(yield func(KeyType) bool) {
+		for elem := range k.underlying {
+			if !yield(elem) {
+				return
+			}
+		}
+	}
 }
 
 // AsSlice returns the elements of the set. The order is unspecified.

--- a/sensor/common/clusterentities/debug.go
+++ b/sensor/common/clusterentities/debug.go
@@ -92,7 +92,7 @@ func (e *podIPsStore) debug() interface{} {
 		for deplID, addrSet := range e.reverseIPMap {
 			// addrSet.AsSlice() does not print well
 			arr := make([]string, 0, addrSet.Cardinality())
-			for _, addr := range addrSet.AsSlice() {
+			for addr := range addrSet.All() {
 				arr = append(arr, addr.String())
 			}
 			dbg["reverseIPMap"][deplID] = arr

--- a/sensor/common/clusterentities/debug.go
+++ b/sensor/common/clusterentities/debug.go
@@ -127,7 +127,7 @@ func (e *endpointsStore) debug() interface{} {
 		for deplID, setOfEp := range e.reverseEndpointMap {
 			// setOfEp.AsSlice() does not print well
 			arr := make([]string, 0, setOfEp.Cardinality())
-			for _, ep := range setOfEp.AsSlice() {
+			for ep := range setOfEp {
 				arr = append(arr, ep.String())
 			}
 			// we need dummy entry "deployments" to fit into the dbg declaration

--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -175,7 +175,7 @@ func (e *podIPsStore) moveDeploymentToHistory(deploymentID string) {
 
 func (e *podIPsStore) addToHistory(deploymentID string) {
 	ipSet := e.reverseIPMap[deploymentID]
-	for _, ip := range ipSet.AsSlice() {
+	for ip := range ipSet.All() {
 		if _, ok := e.historicalIPs[ip]; !ok {
 			e.historicalIPs[ip] = make(map[string]*entityStatus)
 		}
@@ -186,7 +186,7 @@ func (e *podIPsStore) addToHistory(deploymentID string) {
 // deleteDeploymentFromCurrent deletes all data for given deployment from the current map
 func (e *podIPsStore) deleteDeploymentFromCurrent(deploymentID string) {
 	ips := e.reverseIPMap[deploymentID]
-	for _, address := range ips.AsSlice() {
+	for address := range ips.All() {
 		deploymentsHavingIP := e.ipMap[address]
 		deploymentsHavingIP.Remove(deploymentID)
 		if deploymentsHavingIP.Cardinality() == 0 {

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -72,7 +72,7 @@ func (s *serviceImpl) Start() error {
 
 func (s *serviceImpl) Stop() {
 	concurrency.WithLock(&s.stopperLock, func() {
-		for _, stopper := range s.stopper.AsSlice() {
+		for stopper := range s.stopper {
 			stopper.Client().Stop()
 			_ = stopper.Client().Stopped().Wait()
 		}

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -79,7 +79,7 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 	// Proxy relevant headers.
-	for _, headerName := range headersToProxy.AsSlice() {
+	for headerName := range headersToProxy.All() {
 		for _, value := range request.Header.Values(headerName) {
 			centralRequest.Header.Add(headerName, value)
 		}

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -99,7 +99,7 @@ func TestServeHTTP_Responses(t *testing.T) {
 					centralClient: &http.Client{
 						Transport: httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 							assert.Equal(t, tt.args.request.URL.RawQuery, req.URL.RawQuery)
-							for _, header := range headersToProxy.AsSlice() {
+							for header := range headersToProxy.All() {
 								assert.Equal(t, tt.args.request.Header.Values(header), req.Header.Values(header))
 							}
 							return &http.Response{

--- a/sensor/kubernetes/listener/resources/rbac/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/rbac/dispatcher.go
@@ -44,7 +44,7 @@ func (r *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAct
 
 func mapReference(subjects set.Set[namespacedSubject]) []resolver.NamespaceServiceAccount {
 	var result []resolver.NamespaceServiceAccount
-	for _, subj := range subjects.AsSlice() {
+	for subj := range subjects {
 		namespace, serviceAccount, err := subj.splitNamespaceAndName()
 		if err != nil {
 			log.Errorf("failed to decode namespaced service account (%s) in RBAC in-memory store: %s", subj, err)

--- a/tools/roxvet/analyzers/setasslice/analyzer.go
+++ b/tools/roxvet/analyzers/setasslice/analyzer.go
@@ -1,0 +1,58 @@
+package setasslice
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+const doc = `check for .AsSlice() calls in range loops over set types`
+
+// Analyzer is the analyzer.
+var Analyzer = &analysis.Analyzer{
+	Name:     "setasslice",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+const setPkgPath = "github.com/stackrox/rox/pkg/set"
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspectResult := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	nodeFilter := []ast.Node{(*ast.RangeStmt)(nil)}
+	inspectResult.Preorder(nodeFilter, func(n ast.Node) {
+		rangeStmt := n.(*ast.RangeStmt)
+		call, ok := rangeStmt.X.(*ast.CallExpr)
+		if !ok {
+			return
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "AsSlice" {
+			return
+		}
+		fn, ok := typeutil.Callee(pass.TypesInfo, call).(*types.Func)
+		if !ok {
+			return
+		}
+		sig, ok := fn.Type().(*types.Signature)
+		if !ok || sig.Recv() == nil {
+			return
+		}
+		recvType := sig.Recv().Type().String()
+		if !strings.HasPrefix(recvType, setPkgPath+".") {
+			return
+		}
+		if strings.Contains(recvType, "FrozenSet") {
+			pass.Reportf(sel.Sel.Pos(), "use .All() instead of .AsSlice() in range loops to avoid allocation")
+		} else {
+			pass.Reportf(sel.Sel.Pos(), "range over the set directly instead of calling .AsSlice()")
+		}
+	})
+	return nil, nil
+}

--- a/tools/roxvet/analyzers/setasslice/analyzer_test.go
+++ b/tools/roxvet/analyzers/setasslice/analyzer_test.go
@@ -1,0 +1,12 @@
+package setasslice
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "a")
+}

--- a/tools/roxvet/analyzers/setasslice/testdata/src/a/a.go
+++ b/tools/roxvet/analyzers/setasslice/testdata/src/a/a.go
@@ -1,0 +1,44 @@
+package a
+
+import "github.com/stackrox/rox/pkg/set"
+
+func frozenSetInRange() {
+	fs := set.NewFrozenSet("a", "b", "c")
+	for _, x := range fs.AsSlice() { // want `use \.All\(\) instead of \.AsSlice\(\) in range loops to avoid allocation`
+		_ = x
+	}
+}
+
+func frozenSetAllOK() {
+	fs := set.NewFrozenSet("a", "b", "c")
+	for x := range fs.All() {
+		_ = x
+	}
+}
+
+func frozenSetAsSliceNotInRange() {
+	fs := set.NewFrozenSet("a", "b", "c")
+	_ = fs.AsSlice()
+}
+
+func mutableSetInRange() {
+	s := make(set.StringSet)
+	for _, x := range s.AsSlice() { // want `range over the set directly instead of calling \.AsSlice\(\)`
+		_ = x
+	}
+}
+
+func mutableSetDirectRangeOK() {
+	s := make(set.StringSet)
+	for x := range s {
+		_ = x
+	}
+}
+
+func frozenStringSetAlias() {
+	fs := set.NewFrozenSet("a", "b")
+	var fss set.FrozenStringSet = fs
+	for _, x := range fss.AsSlice() { // want `use \.All\(\) instead of \.AsSlice\(\) in range loops to avoid allocation`
+		_ = x
+	}
+}

--- a/tools/roxvet/analyzers/setasslice/testdata/src/github.com/stackrox/rox/pkg/set/set.go
+++ b/tools/roxvet/analyzers/setasslice/testdata/src/github.com/stackrox/rox/pkg/set/set.go
@@ -1,0 +1,46 @@
+package set
+
+import "iter"
+
+type Set[KeyType comparable] map[KeyType]struct{}
+
+func (k Set[KeyType]) AsSlice() []KeyType {
+	elems := make([]KeyType, 0, len(k))
+	for elem := range k {
+		elems = append(elems, elem)
+	}
+	return elems
+}
+
+type FrozenSet[KeyType comparable] struct {
+	underlying map[KeyType]struct{}
+}
+
+func NewFrozenSet[KeyType comparable](elems ...KeyType) FrozenSet[KeyType] {
+	m := make(map[KeyType]struct{}, len(elems))
+	for _, e := range elems {
+		m[e] = struct{}{}
+	}
+	return FrozenSet[KeyType]{underlying: m}
+}
+
+func (k FrozenSet[KeyType]) AsSlice() []KeyType {
+	elems := make([]KeyType, 0, len(k.underlying))
+	for elem := range k.underlying {
+		elems = append(elems, elem)
+	}
+	return elems
+}
+
+func (k FrozenSet[KeyType]) All() iter.Seq[KeyType] {
+	return func(yield func(KeyType) bool) {
+		for elem := range k.underlying {
+			if !yield(elem) {
+				return
+			}
+		}
+	}
+}
+
+type FrozenStringSet = FrozenSet[string]
+type StringSet = Set[string]

--- a/tools/roxvet/roxvet.go
+++ b/tools/roxvet/roxvet.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoclone"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/protoptrs"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/regexes"
+	"github.com/stackrox/rox/tools/roxvet/analyzers/setasslice"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/sortslices"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/storeinterface"
 	"github.com/stackrox/rox/tools/roxvet/analyzers/structuredlogs"
@@ -37,6 +38,7 @@ func main() {
 		protoclone.Analyzer,
 		protoptrs.Analyzer,
 		regexes.Analyzer,
+		setasslice.Analyzer,
 		sortslices.Analyzer,
 		storeinterface.Analyzer,
 		structuredlogs.Analyzer,


### PR DESCRIPTION
## Description

`FrozenSet` wraps an unexported map, so callers must use `AsSlice()` to iterate — allocating a new slice every time. Add `All() iter.Seq[T]` for zero-alloc iteration and replace all for-range loops over `FrozenSet.AsSlice()` with `All()`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI