### PR TITLE
ROX-35545: UI for ACL file access violations

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
@@ -29,9 +29,12 @@ const aclTypeLabels: Map<AclType, string> = new Map([
     ['ACL_TYPE_DEFAULT', 'Default'],
 ]);
 
-// The proto field is uint32 with 0xFFFFFFFF meaning "not applicable", but the
-// GraphQL layer exposes it as int32, which wraps the sentinel to -1.
-const NO_ID = -1;
+// The proto field is uint32 with 0xFFFFFFFF meaning "not applicable".
+// The API returns the raw unsigned value (4294967295). Guard against
+// both representations in case serialization ever wraps it to -1.
+function isNoId(id: number): boolean {
+    return id === 0xffffffff || id === -1;
+}
 
 // Map each octal digit (0-7) to its rwx permission string.
 // Shared between formatFileMode (full 9-char mode) and ACL entry formatting.
@@ -53,7 +56,7 @@ function formatOctalDigit(digit: number): string {
 function formatAclEntry(entry: AclEntry): string {
     const tagLabel = aclTagLabels.get(entry.tag) || entry.tag;
     const permStr = formatOctalDigit(entry.perm);
-    if ((entry.tag === 'ACL_TAG_USER' || entry.tag === 'ACL_TAG_GROUP') && entry.id !== NO_ID) {
+    if ((entry.tag === 'ACL_TAG_USER' || entry.tag === 'ACL_TAG_GROUP') && !isNoId(entry.id)) {
         return `${tagLabel}(${entry.id}): ${permStr}`;
     }
     return `${tagLabel}: ${permStr}`;

--- a/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
@@ -53,13 +53,13 @@ function formatOctalDigit(digit: number): string {
     return octalToPermission[String(digit % 8)] || '---';
 }
 
-function formatAclEntry(entry: AclEntry): string {
+function formatAclEntry(entry: AclEntry): { label: string; permission: string } {
     const tagLabel = aclTagLabels.get(entry.tag) || entry.tag;
-    const permStr = formatOctalDigit(entry.perm);
+    const permission = formatOctalDigit(entry.perm);
     if ((entry.tag === 'ACL_TAG_USER' || entry.tag === 'ACL_TAG_GROUP') && !isNoId(entry.id)) {
-        return `${tagLabel}(${entry.id}): ${permStr}`;
+        return { label: `${tagLabel}(${entry.id})`, permission };
     }
-    return `${tagLabel}: ${permStr}`;
+    return { label: tagLabel, permission };
 }
 
 function formatOperation(operation: FileOperation): string {
@@ -168,11 +168,14 @@ function FileAccessCardContent({ event }: FileAccessCardContentProps): ReactElem
                             {file.meta.aclEntries?.length > 0 && (
                                 <DescriptionListItem
                                     term="ACL entries"
-                                    desc={file.meta.aclEntries.map((entry) => (
-                                        <div key={`${entry.tag}-${entry.id}-${entry.perm}`}>
-                                            {formatAclEntry(entry)}
-                                        </div>
-                                    ))}
+                                    desc={file.meta.aclEntries.map((entry) => {
+                                        const { label, permission } = formatAclEntry(entry);
+                                        return (
+                                            <div key={`${entry.tag}-${entry.id}-${entry.perm}`}>
+                                                {label}: {permission}
+                                            </div>
+                                        );
+                                    })}
                                 />
                             )}
                         </>

--- a/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
@@ -3,7 +3,7 @@ import { DescriptionList, Divider, Flex, Title } from '@patternfly/react-core';
 
 import DescriptionListItem from 'Components/DescriptionListItem';
 import { getDateTime } from 'utils/dateUtils';
-import type { FileAccess, FileOperation } from 'types/fileAccess.proto';
+import type { AclEntry, AclTag, AclType, FileAccess, FileOperation } from 'types/fileAccess.proto';
 
 const fileOperations: Map<FileOperation, string> = new Map([
     ['OPEN', 'Open (Writable)'],
@@ -12,7 +12,52 @@ const fileOperations: Map<FileOperation, string> = new Map([
     ['RENAME', 'Rename'],
     ['PERMISSION_CHANGE', 'Permission change'],
     ['OWNERSHIP_CHANGE', 'Ownership change'],
+    ['ACL_CHANGE', 'ACL change'],
 ]);
+
+const aclTagLabels: Map<AclTag, string> = new Map([
+    ['ACL_TAG_USER_OBJ', 'Owner'],
+    ['ACL_TAG_USER', 'User'],
+    ['ACL_TAG_GROUP_OBJ', 'Owning group'],
+    ['ACL_TAG_GROUP', 'Group'],
+    ['ACL_TAG_MASK', 'Mask'],
+    ['ACL_TAG_OTHER', 'Other'],
+]);
+
+const aclTypeLabels: Map<AclType, string> = new Map([
+    ['ACL_TYPE_ACCESS', 'Access'],
+    ['ACL_TYPE_DEFAULT', 'Default'],
+]);
+
+// The proto field is uint32 with 0xFFFFFFFF meaning "not applicable", but the
+// GraphQL layer exposes it as int32, which wraps the sentinel to -1.
+const NO_ID = -1;
+
+// Map each octal digit (0-7) to its rwx permission string.
+// Shared between formatFileMode (full 9-char mode) and ACL entry formatting.
+const octalToPermission: Record<string, string> = {
+    '0': '---',
+    '1': '--x',
+    '2': '-w-',
+    '3': '-wx',
+    '4': 'r--',
+    '5': 'r-x',
+    '6': 'rw-',
+    '7': 'rwx',
+};
+
+function formatOctalDigit(digit: number): string {
+    return octalToPermission[String(digit % 8)] || '---';
+}
+
+function formatAclEntry(entry: AclEntry): string {
+    const tagLabel = aclTagLabels.get(entry.tag) || entry.tag;
+    const permStr = formatOctalDigit(entry.perm);
+    if ((entry.tag === 'ACL_TAG_USER' || entry.tag === 'ACL_TAG_GROUP') && entry.id !== NO_ID) {
+        return `${tagLabel}(${entry.id}): ${permStr}`;
+    }
+    return `${tagLabel}: ${permStr}`;
+}
 
 function formatOperation(operation: FileOperation): string {
     return fileOperations.get(operation) || 'Unknown';
@@ -30,18 +75,6 @@ function formatOperation(operation: FileOperation): string {
  * formatFileMode(16877) // returns "rwxr-xr-x" (directory with 0o755)
  */
 function formatFileMode(mode: number): string {
-    // Map each octal digit (0-7) to its rwx permission string
-    const octalToPermission: Record<string, string> = {
-        '0': '---',
-        '1': '--x',
-        '2': '-w-',
-        '3': '-wx',
-        '4': 'r--',
-        '5': 'r-x',
-        '6': 'rw-',
-        '7': 'rwx',
-    };
-
     // Extract the permission bits (lower 9 bits) and convert to octal string
     const permissionBits = mode % 512; // 512 = 0o1000, equivalent to mode & 0o777
     const octalString = permissionBits.toString(8).padStart(3, '0');
@@ -99,21 +132,47 @@ function FileAccessCardContent({ event }: FileAccessCardContentProps): ReactElem
             {file.meta && <Title headingLevel="h4">File metadata</Title>}
             {file.meta && (
                 <DescriptionList columnModifier={{ default: '2Col' }}>
-                    {file.meta.username && (
-                        <DescriptionListItem term="Owner" desc={file.meta.username} />
+                    {operation === 'OWNERSHIP_CHANGE' && (
+                        <>
+                            {file.meta.username && (
+                                <DescriptionListItem term="Owner" desc={file.meta.username} />
+                            )}
+                            {file.meta.group && (
+                                <DescriptionListItem term="Group" desc={file.meta.group} />
+                            )}
+                            {Number.isInteger(file.meta.uid) && (
+                                <DescriptionListItem term="UID" desc={file.meta.uid} />
+                            )}
+                            {Number.isInteger(file.meta.gid) && (
+                                <DescriptionListItem term="GID" desc={file.meta.gid} />
+                            )}
+                        </>
                     )}
-                    {file.meta.group && <DescriptionListItem term="Group" desc={file.meta.group} />}
-                    {Number.isInteger(file.meta.uid) && (
-                        <DescriptionListItem term="UID" desc={file.meta.uid} />
-                    )}
-                    {Number.isInteger(file.meta.gid) && (
-                        <DescriptionListItem term="GID" desc={file.meta.gid} />
-                    )}
-                    {Number.isInteger(file.meta.mode) && (
+                    {operation === 'PERMISSION_CHANGE' && Number.isInteger(file.meta.mode) && (
                         <DescriptionListItem
                             term="Permissions"
                             desc={`${formatFileMode(Number(file.meta.mode))} (${Number(file.meta.mode).toString(8).padStart(4, '0')})`}
                         />
+                    )}
+                    {operation === 'ACL_CHANGE' && (
+                        <>
+                            {file.meta.aclType && file.meta.aclType !== 'ACL_TYPE_UNSPECIFIED' && (
+                                <DescriptionListItem
+                                    term="ACL type"
+                                    desc={aclTypeLabels.get(file.meta.aclType) || file.meta.aclType}
+                                />
+                            )}
+                            {file.meta.aclEntries?.length > 0 && (
+                                <DescriptionListItem
+                                    term="ACL entries"
+                                    desc={file.meta.aclEntries.map((entry) => (
+                                        <div key={`${entry.tag}-${entry.id}-${entry.perm}`}>
+                                            {formatAclEntry(entry)}
+                                        </div>
+                                    ))}
+                                />
+                            )}
+                        </>
                     )}
                 </DescriptionList>
             )}

--- a/ui/apps/platform/src/types/fileAccess.proto.ts
+++ b/ui/apps/platform/src/types/fileAccess.proto.ts
@@ -22,6 +22,25 @@ export type FileMetadata = {
     mode: number | null; // only relevant for PERMISSION_CHANGE events
     username: string | null; // only relevant for OWNERSHIP_CHANGE events
     group: string | null; // only relevant for OWNERSHIP_CHANGE events
+    aclType: AclType | null; // only relevant for ACL_CHANGE events
+    aclEntries: AclEntry[]; // only relevant for ACL_CHANGE events
+};
+
+export type AclTag =
+    | 'ACL_TAG_UNSPECIFIED'
+    | 'ACL_TAG_USER_OBJ'
+    | 'ACL_TAG_USER'
+    | 'ACL_TAG_GROUP_OBJ'
+    | 'ACL_TAG_GROUP'
+    | 'ACL_TAG_MASK'
+    | 'ACL_TAG_OTHER';
+
+export type AclType = 'ACL_TYPE_UNSPECIFIED' | 'ACL_TYPE_ACCESS' | 'ACL_TYPE_DEFAULT';
+
+export type AclEntry = {
+    tag: AclTag;
+    perm: number; // Permission bits (e.g. 7 = rwx, 6 = rw-, 4 = r--)
+    id: number; // uid or gid for USER/GROUP entries, -1 when not applicable (uint32 0xFFFFFFFF wraps to int32 -1 via GraphQL)
 };
 
 export type FileOperation =
@@ -30,4 +49,5 @@ export type FileOperation =
     | 'RENAME'
     | 'PERMISSION_CHANGE'
     | 'OWNERSHIP_CHANGE'
-    | 'OPEN';
+    | 'OPEN'
+    | 'ACL_CHANGE';


### PR DESCRIPTION
## Description

Add ACL change rendering to the violations detail page:
- ACL type and entries display in FileAccessCardContent
- AclTag, AclType, AclEntry TypeScript types
- ACL_CHANGE file operation support

Partially generated by AI.

Depends on #21532 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="995" height="657" alt="acl-better-format" src="https://github.com/user-attachments/assets/818f8164-a29b-46c2-85a7-5d20c867fe37" />

Not sure if tests are needed, will add some if requested.
