### PR TITLE
ROX-35546: UI for xattr file access violations

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -200,6 +200,7 @@ const fileOperationOptions: DescriptorOption[] = [
     ['UNLINK', 'Delete (Unlink)'],
     ['PERMISSION_CHANGE', 'Permission change'],
     ['OWNERSHIP_CHANGE', 'Ownership change'],
+    ['XATTR_CHANGE', 'Extended attribute change'],
 ].map(([value, label]) => ({ value, label }));
 
 const processActivityDescriptors: Descriptor[] = [

--- a/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/FileAccessCardContent.tsx
@@ -13,6 +13,8 @@ const fileOperations: Map<FileOperation, string> = new Map([
     ['PERMISSION_CHANGE', 'Permission change'],
     ['OWNERSHIP_CHANGE', 'Ownership change'],
     ['ACL_CHANGE', 'ACL change'],
+    ['XATTR_SET', 'Extended attribute set'],
+    ['XATTR_REMOVE', 'Extended attribute removed'],
 ]);
 
 const aclTagLabels: Map<AclTag, string> = new Map([
@@ -179,6 +181,12 @@ function FileAccessCardContent({ event }: FileAccessCardContentProps): ReactElem
                                 />
                             )}
                         </>
+                    )}
+                    {file.meta.xattrName && (
+                        <DescriptionListItem
+                            term="Extended attribute name"
+                            desc={file.meta.xattrName}
+                        />
                     )}
                 </DescriptionList>
             )}

--- a/ui/apps/platform/src/types/fileAccess.proto.ts
+++ b/ui/apps/platform/src/types/fileAccess.proto.ts
@@ -24,6 +24,7 @@ export type FileMetadata = {
     group: string | null; // only relevant for OWNERSHIP_CHANGE events
     aclType: AclType | null; // only relevant for ACL_CHANGE events
     aclEntries: AclEntry[]; // only relevant for ACL_CHANGE events
+    xattrName: string | null; // only relevant for XATTR_SET and XATTR_REMOVE events
 };
 
 export type AclTag =
@@ -50,4 +51,6 @@ export type FileOperation =
     | 'PERMISSION_CHANGE'
     | 'OWNERSHIP_CHANGE'
     | 'OPEN'
-    | 'ACL_CHANGE';
+    | 'ACL_CHANGE'
+    | 'XATTR_SET'
+    | 'XATTR_REMOVE';


### PR DESCRIPTION
## Description

Add xattr change rendering to violations and policy wizard:
- XATTR_SET and XATTR_REMOVE file operation support
- xattrName field in FileMetadata type
- Xattr change option in policy criteria descriptors

Partially generated by AI.

Depends on #21621 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="996" height="642" alt="xattr-violation" src="https://github.com/user-attachments/assets/4d532037-66c3-45c8-bc7e-7cadb2a88147" />
