### PR TITLE
ROX-33524: seed userpki auth for OpenShift Prometheus

### DIFF
--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -1,0 +1,224 @@
+package openshift
+
+import (
+	"context"
+	"errors"
+
+	groupDataStore "github.com/stackrox/rox/central/group/datastore"
+	rolePkg "github.com/stackrox/rox/central/role"
+	roleDataStore "github.com/stackrox/rox/central/role/datastore"
+	"github.com/stackrox/rox/central/tlsconfig"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
+	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/k8scfgwatch"
+	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	authProviderID  = "b3070020-ecc3-4f34-a3f6-ad28ffc9b80f"
+	permissionSetID = "b3070020-ecc3-4f34-a3f6-ad28ffc9b80e"
+	groupPropsID    = "b3070020-ecc3-4f34-a3f6-ad28ffc9b80d"
+
+	// Auth provider is hidden from the login screen but visible in Access Control.
+	// It trusts the Kubernetes client CA from extension-apiserver-authentication,
+	// which signs Prometheus client certs. This adds the CA to userTrustRoots on the
+	// public :8443 endpoint (optional client cert verification).
+	authProviderName  = "OpenShift Platform Client Certificates"
+	roleName          = "OpenShift Prometheus Metrics Reader"
+	permissionSetName = "OpenShift Prometheus Metrics Reader"
+)
+
+var log = logging.LoggerForModule()
+
+// SeedMetricsAuthProvider ensures that the userpki auth provider, permission set, role,
+// and group mapping required for OpenShift Prometheus to scrape /metrics exist.
+//
+// The auth provider uses the Kubernetes client CA from the
+// extension-apiserver-authentication ConfigMap (same CA that signs Prometheus client
+// certs). A ConfigMap watcher keeps the CA current across rotations.
+//
+// All seeded objects use IMPERATIVE origin. Ideally they would be DEFAULT
+// (non-user-modifiable), but the auth provider datastore rejects non-IMPERATIVE
+// origins through the normal creation path (see CanModifyResource).
+func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registry, roleDS roleDataStore.DataStore, groupDS groupDataStore.DataStore) {
+	if !tlsconfig.OpenShiftTLSConfigured() {
+		return
+	}
+
+	clientset, err := newK8sClient()
+	if err != nil {
+		log.Warnf("Cannot create Kubernetes client for OpenShift metrics auth: %v", err)
+		return
+	}
+
+	caPEM := readClientCA(clientset)
+	if caPEM == "" {
+		return
+	}
+
+	ensurePermissionSet(ctx, roleDS)
+	ensureRole(ctx, roleDS)
+	ensureAuthProvider(ctx, registry, caPEM)
+	ensureGroup(ctx, groupDS)
+
+	watchClientCA(ctx, clientset, registry)
+}
+
+func newK8sClient() (kubernetes.Interface, error) {
+	config, err := k8sutil.GetK8sInClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+func readClientCA(clientset kubernetes.Interface) string {
+	cm, err := clientset.CoreV1().ConfigMaps(
+		env.SecureMetricsClientCANamespace.Setting(),
+	).Get(context.Background(), env.SecureMetricsClientCAConfigMap.Setting(), metav1.GetOptions{})
+	if err != nil {
+		log.Warnf("Cannot read client CA ConfigMap %s/%s: %v",
+			env.SecureMetricsClientCANamespace.Setting(),
+			env.SecureMetricsClientCAConfigMap.Setting(), err)
+		return ""
+	}
+	pem, ok := cm.Data[env.SecureMetricsClientCAKey.Setting()]
+	if !ok || pem == "" {
+		log.Warnf("Client CA key %q not found in ConfigMap %s/%s",
+			env.SecureMetricsClientCAKey.Setting(),
+			env.SecureMetricsClientCANamespace.Setting(),
+			env.SecureMetricsClientCAConfigMap.Setting())
+		return ""
+	}
+	return pem
+}
+
+func watchClientCA(ctx context.Context, clientset kubernetes.Interface, registry authproviders.Registry) {
+	watcher := k8scfgwatch.NewConfigMapWatcher(clientset, func(cm *v1.ConfigMap) {
+		if cm == nil {
+			return
+		}
+		pem, ok := cm.Data[env.SecureMetricsClientCAKey.Setting()]
+		if !ok || pem == "" {
+			return
+		}
+		provider := registry.GetProvider(authProviderID)
+		if provider == nil {
+			return
+		}
+		refreshCA(ctx, registry, provider, pem)
+	})
+	watcher.Watch(
+		ctx,
+		env.SecureMetricsClientCANamespace.Setting(),
+		env.SecureMetricsClientCAConfigMap.Setting(),
+	)
+}
+
+func refreshCA(ctx context.Context, registry authproviders.Registry, provider authproviders.Provider, caPEM string) {
+	config := provider.StorageView().GetConfig()
+	if config[userpki.ConfigKeys] == caPEM {
+		return
+	}
+	log.Info("Client CA changed, updating OpenShift metrics auth provider")
+	config[userpki.ConfigKeys] = caPEM
+	if _, err := registry.UpdateProvider(ctx, authProviderID, authproviders.WithConfig(config)); err != nil {
+		log.Warnf("Failed to update client CA in auth provider: %v", err)
+	}
+}
+
+func ensurePermissionSet(ctx context.Context, roleDS roleDataStore.DataStore) {
+	if _, exists, err := roleDS.GetPermissionSet(ctx, permissionSetID); err != nil {
+		log.Warnf("Failed to check OpenShift metrics permission set: %v", err)
+		return
+	} else if exists {
+		return
+	}
+
+	ps := &storage.PermissionSet{
+		Id:          permissionSetID,
+		Name:        permissionSetName,
+		Description: "For OpenShift Prometheus: read access to Administration for /metrics scraping",
+		ResourceToAccess: permissionsUtils.FromResourcesWithAccess(
+			permissions.View(resources.Administration),
+		),
+	}
+	if err := roleDS.AddPermissionSet(ctx, ps); err != nil {
+		log.Warnf("Failed to create OpenShift metrics permission set: %v", err)
+	}
+}
+
+func ensureRole(ctx context.Context, roleDS roleDataStore.DataStore) {
+	if _, exists, err := roleDS.GetRole(ctx, roleName); err != nil {
+		log.Warnf("Failed to check OpenShift metrics role: %v", err)
+		return
+	} else if exists {
+		return
+	}
+
+	role := &storage.Role{
+		Name:            roleName,
+		Description:     "Maps OpenShift Prometheus service account to /metrics read access",
+		PermissionSetId: permissionSetID,
+		AccessScopeId:   rolePkg.AccessScopeIncludeAll.GetId(),
+	}
+	if err := roleDS.AddRole(ctx, role); err != nil {
+		log.Warnf("Failed to create OpenShift metrics role: %v", err)
+	}
+}
+
+func ensureAuthProvider(ctx context.Context, registry authproviders.Registry, caPEM string) {
+	if existing := registry.GetProvider(authProviderID); existing != nil {
+		refreshCA(ctx, registry, existing, caPEM)
+		return
+	}
+
+	_, err := registry.CreateProvider(ctx,
+		authproviders.WithType(userpki.TypeName),
+		authproviders.WithID(authProviderID),
+		authproviders.WithName(authProviderName),
+		authproviders.WithEnabled(true),
+		authproviders.WithActive(true),
+		authproviders.WithVisibility(storage.Traits_HIDDEN),
+		authproviders.WithConfig(map[string]string{
+			userpki.ConfigKeys: caPEM,
+		}),
+	)
+	if err != nil {
+		log.Warnf("Failed to create OpenShift metrics auth provider: %v", err)
+	}
+}
+
+func ensureGroup(ctx context.Context, groupDS groupDataStore.DataStore) {
+	props := &storage.GroupProperties{
+		Id:             groupPropsID,
+		AuthProviderId: authProviderID,
+		Key:            "name",
+		Value:          env.SecureMetricsClientCertCN.Setting(),
+	}
+	existing, err := groupDS.Get(ctx, props)
+	if err != nil && !errors.Is(err, errox.NotFound) {
+		log.Warnf("Failed to check OpenShift metrics group: %v", err)
+		return
+	}
+	if existing != nil {
+		return
+	}
+	group := &storage.Group{
+		Props:    props,
+		RoleName: roleName,
+	}
+	if err := groupDS.Add(ctx, group); err != nil {
+		log.Warnf("Failed to create OpenShift metrics group: %v", err)
+	}
+}

--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -10,14 +10,12 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
-	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/sac/resources"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -144,9 +142,8 @@ func ensurePermissionSet(ctx context.Context, roleDS roleDataStore.DataStore) {
 		Id:          permissionSetID,
 		Name:        permissionSetName,
 		Description: "For OpenShift Prometheus: read access to Administration for /metrics scraping",
-		ResourceToAccess: permissionsUtils.FromResourcesWithAccess(
-			permissions.View(resources.Administration),
-		),
+		// Let's give no permissions by default to avoid unexpected sensitive data exposure.
+		ResourceToAccess: permissionsUtils.FromResourcesWithAccess(),
 	}
 	if err := roleDS.AddPermissionSet(ctx, ps); err != nil {
 		log.Warnf("Failed to create OpenShift metrics permission set: %v", err)

--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -2,7 +2,6 @@ package openshift
 
 import (
 	"context"
-	"errors"
 
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
 	rolePkg "github.com/stackrox/rox/central/role"
@@ -14,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"github.com/stackrox/rox/pkg/logging"
@@ -27,7 +25,6 @@ import (
 const (
 	authProviderID  = "b3070020-ecc3-4f34-a3f6-ad28ffc9b80f"
 	permissionSetID = "b3070020-ecc3-4f34-a3f6-ad28ffc9b80e"
-	groupPropsID    = "b3070020-ecc3-4f34-a3f6-ad28ffc9b80d"
 
 	// Auth provider is hidden from the login screen but visible in Access Control.
 	// It trusts the Kubernetes client CA from extension-apiserver-authentication,
@@ -200,22 +197,24 @@ func ensureAuthProvider(ctx context.Context, registry authproviders.Registry, ca
 }
 
 func ensureGroup(ctx context.Context, groupDS groupDataStore.DataStore) {
-	props := &storage.GroupProperties{
-		Id:             groupPropsID,
-		AuthProviderId: authProviderID,
-		Key:            "name",
-		Value:          env.SecureMetricsClientCertCN.Setting(),
-	}
-	existing, err := groupDS.Get(ctx, props)
-	if err != nil && !errors.Is(err, errox.NotFound) {
+	cn := env.SecureMetricsClientCertCN.Setting()
+	existing, err := groupDS.GetFiltered(ctx, func(g *storage.Group) bool {
+		p := g.GetProps()
+		return p.GetAuthProviderId() == authProviderID && p.GetKey() == "name" && p.GetValue() == cn
+	})
+	if err != nil {
 		log.Warnf("Failed to check OpenShift metrics group: %v", err)
 		return
 	}
-	if existing != nil {
+	if len(existing) > 0 {
 		return
 	}
 	group := &storage.Group{
-		Props:    props,
+		Props: &storage.GroupProperties{
+			AuthProviderId: authProviderID,
+			Key:            "name",
+			Value:          cn,
+		},
 		RoleName: roleName,
 	}
 	if err := groupDS.Add(ctx, group); err != nil {

--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -58,17 +58,18 @@ func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registr
 		return
 	}
 
-	caPEM := readClientCA(clientset)
-	if caPEM == "" {
-		return
+	onCA := func(caPEM string) {
+		ensurePermissionSet(ctx, roleDS)
+		ensureRole(ctx, roleDS)
+		ensureAuthProvider(ctx, registry, caPEM)
+		ensureGroup(ctx, groupDS)
 	}
 
-	ensurePermissionSet(ctx, roleDS)
-	ensureRole(ctx, roleDS)
-	ensureAuthProvider(ctx, registry, caPEM)
-	ensureGroup(ctx, groupDS)
+	if caPEM := readClientCA(ctx, clientset); caPEM != "" {
+		onCA(caPEM)
+	}
 
-	watchClientCA(ctx, clientset, registry)
+	watchClientCA(ctx, clientset, onCA)
 }
 
 func newK8sClient() (kubernetes.Interface, error) {
@@ -79,10 +80,10 @@ func newK8sClient() (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(config)
 }
 
-func readClientCA(clientset kubernetes.Interface) string {
+func readClientCA(ctx context.Context, clientset kubernetes.Interface) string {
 	cm, err := clientset.CoreV1().ConfigMaps(
 		env.SecureMetricsClientCANamespace.Setting(),
-	).Get(context.Background(), env.SecureMetricsClientCAConfigMap.Setting(), metav1.GetOptions{})
+	).Get(ctx, env.SecureMetricsClientCAConfigMap.Setting(), metav1.GetOptions{})
 	if err != nil {
 		log.Warnf("Cannot read client CA ConfigMap %s/%s: %v",
 			env.SecureMetricsClientCANamespace.Setting(),
@@ -100,7 +101,7 @@ func readClientCA(clientset kubernetes.Interface) string {
 	return pem
 }
 
-func watchClientCA(ctx context.Context, clientset kubernetes.Interface, registry authproviders.Registry) {
+func watchClientCA(ctx context.Context, clientset kubernetes.Interface, onCA func(string)) {
 	watcher := k8scfgwatch.NewConfigMapWatcher(clientset, func(cm *v1.ConfigMap) {
 		if cm == nil {
 			return
@@ -109,11 +110,7 @@ func watchClientCA(ctx context.Context, clientset kubernetes.Interface, registry
 		if !ok || pem == "" {
 			return
 		}
-		provider := registry.GetProvider(authProviderID)
-		if provider == nil {
-			return
-		}
-		refreshCA(ctx, registry, provider, pem)
+		onCA(pem)
 	})
 	watcher.Watch(
 		ctx,

--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/k8sutil"
@@ -184,6 +185,7 @@ func ensureAuthProvider(ctx context.Context, registry authproviders.Registry, ca
 		authproviders.WithEnabled(true),
 		authproviders.WithActive(true),
 		authproviders.WithVisibility(storage.Traits_HIDDEN),
+		authproviders.WithOrigin(storage.Traits_DEFAULT),
 		authproviders.WithConfig(map[string]string{
 			userpki.ConfigKeys: caPEM,
 		}),
@@ -211,10 +213,15 @@ func ensureGroup(ctx context.Context, groupDS groupDataStore.DataStore) {
 			AuthProviderId: authProviderID,
 			Key:            "name",
 			Value:          cn,
+			Traits: &storage.Traits{
+				Origin: storage.Traits_DEFAULT,
+			},
 		},
 		RoleName: roleName,
 	}
-	if err := groupDS.Add(ctx, group); err != nil {
+	// Group uses DEFAULT origin so a user can't repoint or delete the mapping and thereby
+	// orphan (and delete) the role out from under it.
+	if err := groupDS.Add(declarativeconfig.WithModifyDefaultResource(ctx), group); err != nil {
 		log.Warnf("Failed to create OpenShift metrics group: %v", err)
 	}
 }

--- a/central/auth/openshift/metrics_auth_test.go
+++ b/central/auth/openshift/metrics_auth_test.go
@@ -1,0 +1,111 @@
+package openshift
+
+import (
+	"context"
+	"testing"
+
+	groupMocks "github.com/stackrox/rox/central/group/datastore/mocks"
+	roleMocks "github.com/stackrox/rox/central/role/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	providerMocks "github.com/stackrox/rox/pkg/auth/authproviders/mocks"
+	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"go.uber.org/mock/gomock"
+)
+
+const testCAPEM = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"
+
+func setupMocks(t *testing.T) (*providerMocks.MockRegistry, *roleMocks.MockDataStore, *groupMocks.MockDataStore) {
+	ctrl := gomock.NewController(t)
+	return providerMocks.NewMockRegistry(ctrl),
+		roleMocks.NewMockDataStore(ctrl),
+		groupMocks.NewMockDataStore(ctrl)
+}
+
+func TestSeed_FirstBoot_CreatesAllObjects(t *testing.T) {
+	registry, roleDS, groupDS := setupMocks(t)
+	ctx := context.Background()
+
+	roleDS.EXPECT().GetPermissionSet(gomock.Any(), permissionSetID).Return(nil, false, nil)
+	roleDS.EXPECT().AddPermissionSet(gomock.Any(), gomock.Any()).Return(nil)
+	roleDS.EXPECT().GetRole(gomock.Any(), roleName).Return(nil, false, nil)
+	roleDS.EXPECT().AddRole(gomock.Any(), gomock.Any()).Return(nil)
+
+	// Auth provider created BEFORE group.
+	providerCreated := false
+	registry.EXPECT().GetProvider(authProviderID).Return(nil)
+	registry.EXPECT().CreateProvider(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ ...interface{}) (interface{}, error) {
+			providerCreated = true
+			return nil, nil
+		})
+	groupDS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *storage.Group) error {
+			if !providerCreated {
+				t.Error("group Add called before provider creation")
+			}
+			return nil
+		})
+
+	ensurePermissionSet(ctx, roleDS)
+	ensureRole(ctx, roleDS)
+	ensureAuthProvider(ctx, registry, testCAPEM)
+	ensureGroup(ctx, groupDS)
+}
+
+func TestSeed_SubsequentBoot_CAUnchanged_NoUpdate(t *testing.T) {
+	registry, _, _ := setupMocks(t)
+	ctx := context.Background()
+
+	existing := providerMocks.NewMockProvider(gomock.NewController(t))
+	existing.EXPECT().StorageView().Return(&storage.AuthProvider{
+		Config: map[string]string{userpki.ConfigKeys: testCAPEM},
+	})
+	registry.EXPECT().GetProvider(authProviderID).Return(existing)
+
+	ensureAuthProvider(ctx, registry, testCAPEM)
+}
+
+func TestSeed_CARotation_UpdatesConfig(t *testing.T) {
+	registry, _, _ := setupMocks(t)
+	ctx := context.Background()
+
+	existing := providerMocks.NewMockProvider(gomock.NewController(t))
+	existing.EXPECT().StorageView().Return(&storage.AuthProvider{
+		Config: map[string]string{userpki.ConfigKeys: "old-ca"},
+	})
+	registry.EXPECT().GetProvider(authProviderID).Return(existing)
+	registry.EXPECT().UpdateProvider(gomock.Any(), authProviderID, gomock.Any()).Return(nil, nil)
+
+	ensureAuthProvider(ctx, registry, testCAPEM)
+}
+
+func TestSeed_PartialRecovery_PermissionSetExists_RoleMissing(t *testing.T) {
+	registry, roleDS, groupDS := setupMocks(t)
+	ctx := context.Background()
+
+	roleDS.EXPECT().GetPermissionSet(gomock.Any(), permissionSetID).Return(&storage.PermissionSet{}, true, nil)
+	roleDS.EXPECT().GetRole(gomock.Any(), roleName).Return(nil, false, nil)
+	roleDS.EXPECT().AddRole(gomock.Any(), gomock.Any()).Return(nil)
+	registry.EXPECT().GetProvider(authProviderID).Return(nil)
+	registry.EXPECT().CreateProvider(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil)
+
+	ensurePermissionSet(ctx, roleDS)
+	ensureRole(ctx, roleDS)
+	ensureAuthProvider(ctx, registry, testCAPEM)
+	ensureGroup(ctx, groupDS)
+}
+
+func TestSeed_SubsequentBoot_GroupExists_NotOverwritten(t *testing.T) {
+	_, _, groupDS := setupMocks(t)
+	ctx := context.Background()
+
+	groupDS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Group{
+		Props:    &storage.GroupProperties{Id: groupPropsID},
+		RoleName: "User Modified Role",
+	}, nil)
+
+	ensureGroup(ctx, groupDS)
+}

--- a/central/auth/openshift/metrics_auth_test.go
+++ b/central/auth/openshift/metrics_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	providerMocks "github.com/stackrox/rox/pkg/auth/authproviders/mocks"
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"go.uber.org/mock/gomock"
 )
 
@@ -30,7 +31,6 @@ func TestSeed_FirstBoot_CreatesAllObjects(t *testing.T) {
 	roleDS.EXPECT().GetRole(gomock.Any(), roleName).Return(nil, false, nil)
 	roleDS.EXPECT().AddRole(gomock.Any(), gomock.Any()).Return(nil)
 
-	// Auth provider created BEFORE group.
 	providerCreated := false
 	registry.EXPECT().GetProvider(authProviderID).Return(nil)
 	registry.EXPECT().CreateProvider(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -95,6 +95,25 @@ func TestSeed_PartialRecovery_PermissionSetExists_RoleMissing(t *testing.T) {
 	ensurePermissionSet(ctx, roleDS)
 	ensureRole(ctx, roleDS)
 	ensureAuthProvider(ctx, registry, testCAPEM)
+	ensureGroup(ctx, groupDS)
+}
+
+func TestSeed_Group_IsDefaultOriginAndImmutable(t *testing.T) {
+	_, _, groupDS := setupMocks(t)
+	ctx := context.Background()
+
+	groupDS.EXPECT().GetFiltered(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(addCtx context.Context, group *storage.Group) error {
+			if group.GetProps().GetTraits().GetOrigin() != storage.Traits_DEFAULT {
+				t.Errorf("expected group to use DEFAULT origin, got %v", group.GetProps().GetTraits().GetOrigin())
+			}
+			if !declarativeconfig.CanModifyResource(addCtx, group.GetProps()) {
+				t.Error("expected ensureGroup to pass a context that can modify DEFAULT-origin resources")
+			}
+			return nil
+		})
+
 	ensureGroup(ctx, groupDS)
 }
 

--- a/central/auth/openshift/metrics_auth_test.go
+++ b/central/auth/openshift/metrics_auth_test.go
@@ -38,7 +38,7 @@ func TestSeed_FirstBoot_CreatesAllObjects(t *testing.T) {
 			providerCreated = true
 			return nil, nil
 		})
-	groupDS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().GetFiltered(gomock.Any(), gomock.Any()).Return(nil, nil)
 	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ *storage.Group) error {
 			if !providerCreated {
@@ -89,7 +89,7 @@ func TestSeed_PartialRecovery_PermissionSetExists_RoleMissing(t *testing.T) {
 	roleDS.EXPECT().AddRole(gomock.Any(), gomock.Any()).Return(nil)
 	registry.EXPECT().GetProvider(authProviderID).Return(nil)
 	registry.EXPECT().CreateProvider(gomock.Any(), gomock.Any()).Return(nil, nil)
-	groupDS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().GetFiltered(gomock.Any(), gomock.Any()).Return(nil, nil)
 	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil)
 
 	ensurePermissionSet(ctx, roleDS)
@@ -102,10 +102,10 @@ func TestSeed_SubsequentBoot_GroupExists_NotOverwritten(t *testing.T) {
 	_, _, groupDS := setupMocks(t)
 	ctx := context.Background()
 
-	groupDS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&storage.Group{
-		Props:    &storage.GroupProperties{Id: groupPropsID},
+	groupDS.EXPECT().GetFiltered(gomock.Any(), gomock.Any()).Return([]*storage.Group{{
+		Props:    &storage.GroupProperties{AuthProviderId: authProviderID, Key: "name", Value: "system:serviceaccount:openshift-monitoring:prometheus-k8s"},
 		RoleName: "User Modified Role",
-	}, nil)
+	}}, nil)
 
 	ensureGroup(ctx, groupDS)
 }

--- a/central/main.go
+++ b/central/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackrox/rox/central/audit"
 	authDS "github.com/stackrox/rox/central/auth/datastore"
 	internalTokenAuthService "github.com/stackrox/rox/central/auth/internaltokens/service"
+	openshiftAuth "github.com/stackrox/rox/central/auth/openshift"
 	authService "github.com/stackrox/rox/central/auth/service"
 	"github.com/stackrox/rox/central/auth/userpass"
 	authProviderRegistry "github.com/stackrox/rox/central/authprovider/registry"
@@ -590,6 +591,8 @@ func startGRPCServer() {
 	}
 
 	basicAuthProvider := userpass.RegisterAuthProviderOrPanic(authProviderRegisteringCtx, basicAuthMgr, registry)
+
+	openshiftAuth.SeedMetricsAuthProvider(authProviderRegisteringCtx, registry, roleDataStore.Singleton(), groupDataStore.Singleton())
 
 	clusterInitBackend := backend.Singleton()
 	serviceMTLSExtractor, err := service.NewExtractorWithCertValidation(clusterInitBackend)

--- a/central/tlsconfig/openshift_tls.go
+++ b/central/tlsconfig/openshift_tls.go
@@ -16,6 +16,9 @@ func OpenShiftTLSConfigured() bool {
 		return false
 	}
 	exists, err := fileutils.Exists(env.OpenShiftTLSCertDir.Setting())
+	if err != nil {
+		log.Warnf("Cannot check OpenShift TLS certificate directory %s: %v", env.OpenShiftTLSCertDir.Setting(), err)
+	}
 	return exists && err == nil
 }
 

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -77,8 +77,14 @@ spec:
     matchNames:
       - "{{ .Release.Namespace }}"
 
+{{- if and ._rox.monitoring.openshift.custom ._rox.monitoring.openshift.custom.enabled -}}
 ---
 
+{{- /*
+The ServiceMonitor is placed into the openshift-monitoring namespace to comply with the
+OpenShift monitoring namespace label requirements. This is an exception to the rule
+that leaking resources into system namespaces should be avoided.
+*/}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -105,7 +111,7 @@ spec:
   namespaceSelector:
     matchNames:
       - "{{ .Release.Namespace }}"
-
+{{- end -}}
 ---
 
 {{- /*

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -77,7 +77,7 @@ spec:
     matchNames:
       - "{{ .Release.Namespace }}"
 
-{{- if and ._rox.monitoring.openshift.custom ._rox.monitoring.openshift.custom.enabled -}}
+{{- if and ._rox.monitoring.openshift.custom ._rox.monitoring.openshift.custom.enabled }}
 ---
 
 {{- /*
@@ -111,7 +111,8 @@ spec:
   namespaceSelector:
     matchNames:
       - "{{ .Release.Namespace }}"
-{{- end -}}
+
+{{- end }}
 ---
 
 {{- /*

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -79,6 +79,35 @@ spec:
 
 ---
 
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: "central-ocp-monitor-{{ .Release.Namespace }}"
+  namespace: openshift-monitoring
+  labels:
+    {{- include "srox.labels" (list . "servicemonitor" (print "central-ocp-monitor-" .Release.Namespace)) | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "servicemonitor" (print "central-ocp-monitor-" .Release.Namespace)) | nindent 4 }}
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: "central-ocp.{{ .Release.Namespace }}.svc"
+  selector:
+    matchLabels:
+      stackrox.io/ocp-api: "true"
+  namespaceSelector:
+    matchNames:
+      - "{{ .Release.Namespace }}"
+
+---
+
 {{- /*
 TODO(ROX-22188): Switch to a ClusterRoleBinding to avoid leaking to kube-system namespace.
 */}}

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -738,3 +738,6 @@
 #   # Enables integration with OpenShift platform monitoring.
 #   openshift:
 #     enabled: true
+#     # Enables custom metrics integration.
+#     custom:
+#       enabled: false

--- a/image/templates/helm/stackrox-central/values.yaml.htpl
+++ b/image/templates/helm/stackrox-central/values.yaml.htpl
@@ -569,3 +569,6 @@ central:
 #  # Enables integration with OpenShift platform monitoring.
 #  openshift:
 #    enabled: true
+#    # Enables custom metrics integration.
+#    custom:
+#      enabled: false

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -166,3 +166,18 @@ func WithVisibility(visibility storage.Traits_Visibility) ProviderOption {
 		return nil
 	}
 }
+
+// WithOrigin sets the origin for the auth provider.
+func WithOrigin(origin storage.Traits_Origin) ProviderOption {
+	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		if pr.storedInfo.GetTraits() != nil {
+			pr.storedInfo.Traits.Origin = origin
+		} else {
+			pr.storedInfo.Traits = &storage.Traits{Origin: origin}
+		}
+		return nil
+	}
+}

--- a/pkg/declarativeconfig/context.go
+++ b/pkg/declarativeconfig/context.go
@@ -10,6 +10,7 @@ type originCheckerKey struct{}
 
 const allowOnlyDeclarativeOperations = 0
 const allowModifyDeclarativeOrImperative = 1
+const allowDefaultOperations = 2
 
 // WithModifyDeclarativeResource returns a context that is a child of the given context and allows to modify
 // proto messages with the traits origin == DECLARATIVE.
@@ -21,6 +22,13 @@ func WithModifyDeclarativeResource(ctx context.Context) context.Context {
 // proto messages with the traits origin == DECLARATIVE or DECLARATIVE_ORPHANED or IMPERATIVE
 func WithModifyDeclarativeOrImperative(ctx context.Context) context.Context {
 	return context.WithValue(ctx, originCheckerKey{}, allowModifyDeclarativeOrImperative)
+}
+
+// WithModifyDefaultResource returns a context that allows creating and modifying
+// proto messages with the traits origin == DEFAULT. This is intended for internal
+// seeding of system-managed objects that should not be user-modifiable.
+func WithModifyDefaultResource(ctx context.Context) context.Context {
+	return context.WithValue(ctx, originCheckerKey{}, allowDefaultOperations)
 }
 
 // ResourceWithTraits is a common interface for proto messages containing storage.Traits.
@@ -37,11 +45,14 @@ func HasModifyDeclarativeResourceKey(ctx context.Context) bool {
 
 // CanModifyResource returns whether context holder is allowed to modify resource.
 func CanModifyResource(ctx context.Context, resource ResourceWithTraits) bool {
-	if ctx.Value(originCheckerKey{}) == allowOnlyDeclarativeOperations {
+	switch ctx.Value(originCheckerKey{}) {
+	case allowOnlyDeclarativeOperations:
 		return IsDeclarativeOrigin(resource)
-	}
-	if ctx.Value(originCheckerKey{}) == allowModifyDeclarativeOrImperative {
+	case allowModifyDeclarativeOrImperative:
 		return IsDeclarativeOrigin(resource) || IsImperativeOrigin(resource) || IsEphemeralOrigin(resource)
+	case allowDefaultOperations:
+		return IsDefaultOrigin(resource)
+	default:
+		return IsImperativeOrigin(resource) || IsEphemeralOrigin(resource)
 	}
-	return IsImperativeOrigin(resource) || IsEphemeralOrigin(resource)
 }

--- a/pkg/declarativeconfig/context_test.go
+++ b/pkg/declarativeconfig/context_test.go
@@ -24,6 +24,7 @@ func TestContext(t *testing.T) {
 	ctx := context.Background()
 	declarativeCtx := WithModifyDeclarativeResource(ctx)
 	declarativeOrImperativeCtx := WithModifyDeclarativeOrImperative(ctx)
+	defaultCtx := WithModifyDefaultResource(ctx)
 	// 1.1. empty context can modify imperative origin
 	assert.True(t, CanModifyResource(ctx, imperativeResource))
 	// 1.2. empty context can modify ephemeral origin
@@ -48,4 +49,10 @@ func TestContext(t *testing.T) {
 	assert.True(t, CanModifyResource(declarativeOrImperativeCtx, ephemeralResource))
 	// 9. context.WithModifyDeclarativeOrImperative can't modify default origin
 	assert.False(t, CanModifyResource(declarativeOrImperativeCtx, defaultResource))
+	// 10. context.WithModifyDefaultResource can modify default origin
+	assert.True(t, CanModifyResource(defaultCtx, defaultResource))
+	// 11.1. context.WithModifyDefaultResource can't modify imperative origin
+	assert.False(t, CanModifyResource(defaultCtx, imperativeResource))
+	// 11.2. context.WithModifyDefaultResource can't modify declarative origin
+	assert.False(t, CanModifyResource(defaultCtx, declarativeResource))
 }

--- a/pkg/declarativeconfig/origin.go
+++ b/pkg/declarativeconfig/origin.go
@@ -28,3 +28,8 @@ func IsEphemeralOrigin(resource ResourceWithTraits) bool {
 func IsImperativeOrigin(resource ResourceWithTraits) bool {
 	return resource.GetTraits().GetOrigin() == storage.Traits_IMPERATIVE
 }
+
+// IsDefaultOrigin returns whether origin of resource is default or not.
+func IsDefaultOrigin(resource ResourceWithTraits) bool {
+	return resource.GetTraits().GetOrigin() == storage.Traits_DEFAULT
+}

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -20,6 +20,11 @@ tests:
             assertThat(.metadata.namespace == "openshift-monitoring"),
             assertThat(.spec.endpoints[].port == "monitoring-tls")
           ]
+        .servicemonitors["central-ocp-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[].port == "https"),
+            assertThat(.spec.endpoints[].path == "/metrics")
+          ]
         .services["central-ocp"] | assertThat(. != null)
 
     - name: "secure metrics endpoint is enabled"
@@ -69,6 +74,11 @@ tests:
         .servicemonitors["central-monitor-stackrox"] | [
             assertThat(.metadata.namespace == "openshift-monitoring"),
             assertThat(.spec.endpoints[].port == "monitoring-tls")
+          ]
+        .servicemonitors["central-ocp-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[].port == "https"),
+            assertThat(.spec.endpoints[].path == "/metrics")
           ]
         .services["central-ocp"] | assertThat(. != null)
         .rolebindings["rhacs-scanner-v4-auth-reader-stackrox"] | assertThat(. != null)
@@ -146,6 +156,7 @@ tests:
         .rolebindings["central-prometheus-k8s"] | assertThat(. == null)
         .rolebindings["rhacs-central-auth-reader-stackrox"] | assertThat(. == null)
         .servicemonitors["central-monitor-stackrox"] | assertThat(. == null)
+        .servicemonitors["central-ocp-monitor-stackrox"] | assertThat(. == null)
         .services["central-ocp"] | assertThat(. == null)
 
     - name: "secure metrics endpoint is disabled"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -20,11 +20,6 @@ tests:
             assertThat(.metadata.namespace == "openshift-monitoring"),
             assertThat(.spec.endpoints[].port == "monitoring-tls")
           ]
-        .servicemonitors["central-ocp-monitor-stackrox"] | [
-            assertThat(.metadata.namespace == "openshift-monitoring"),
-            assertThat(.spec.endpoints[].port == "https"),
-            assertThat(.spec.endpoints[].path == "/metrics")
-          ]
         .services["central-ocp"] | assertThat(. != null)
 
     - name: "secure metrics endpoint is enabled"
@@ -59,6 +54,31 @@ tests:
     env.openshift: 4
   tests: *enabled-test
 
+- name: "Custom metrics"
+  set:
+    env.openshift: 4
+  tests:
+    - name: "openshift metrics disabled"
+      expect: |
+        .servicemonitors["central-ocp-monitor-stackrox"] | assertThat(. == null)
+
+    - name: "custom metrics disabled"
+      set:
+        monitoring.openshift.enabled: true
+      expect: |
+        .servicemonitors["central-ocp-monitor-stackrox"] | assertThat(. == null)
+
+    - name: "custom metrics enabled"
+      set:
+        monitoring.openshift.enabled: true
+        monitoring.openshift.custom.enabled: true
+      expect: |
+        .servicemonitors["central-ocp-monitor-stackrox"] | [
+            assertThat(.metadata.namespace == "openshift-monitoring"),
+            assertThat(.spec.endpoints[].port == "https"),
+            assertThat(.spec.endpoints[].path == "/metrics")
+          ]
+
 - name: "When enabled with Scanner V4"
   set:
     monitoring.openshift.enabled: true
@@ -74,11 +94,6 @@ tests:
         .servicemonitors["central-monitor-stackrox"] | [
             assertThat(.metadata.namespace == "openshift-monitoring"),
             assertThat(.spec.endpoints[].port == "monitoring-tls")
-          ]
-        .servicemonitors["central-ocp-monitor-stackrox"] | [
-            assertThat(.metadata.namespace == "openshift-monitoring"),
-            assertThat(.spec.endpoints[].port == "https"),
-            assertThat(.spec.endpoints[].path == "/metrics")
           ]
         .services["central-ocp"] | assertThat(. != null)
         .rolebindings["rhacs-scanner-v4-auth-reader-stackrox"] | assertThat(. != null)

--- a/pkg/mtls/README.md
+++ b/pkg/mtls/README.md
@@ -45,12 +45,12 @@ This document covers **StackRox internal CA mTLS** only.
 - Sensor cert refresh (TLS challenge + CA bundle): `sensor/kubernetes/certrefresh/`
 - Postgres DB cert reload (Central DB, Scanner V4 DB): `image/postgres/scripts/cert-watcher.sh`, `image/templates/helm/shared/templates/_cert-watcher.tpl`
 
-### Central has four independent cert-handling paths
+### Central has three independent cert-handling paths
 
 1. **TLS manager** (`TLSConfigHolder`) — incoming connections. Composes default cert (watched) + internal cert (watched) + OpenShift cert (watched, if configured) + sync.Once trust roots.
+   - **OpenShift service-serving TLS** (`central/tlsconfig/openshift_tls.go`) — on OpenShift, watches certs issued for the `central-ocp` Service. Loaded into the TLS manager and presented via SNI on the same `:8443` listener alongside the StackRox internal cert.
 2. **Outbound client connections** (`clientconn.TLSConfig`) — reads leaf cert from disk on each TLS handshake, trust pool from `mtls.CACert()`.
 3. **TLS challenge endpoint** (`central/metadata/service`) — reads primary leaf via certwatch, issues secondary leaf with short validity and auto-renewal, reads CA via `mtls.CACert()`.
-4. **OpenShift service-serving TLS** (`central/tlsconfig/openshift_tls.go`) — on OpenShift, watches certs issued for the `central-ocp` Service. Presented via SNI on the same `:8443` listener alongside the StackRox internal cert.
 
 ## Certificate caching
 


### PR DESCRIPTION
## Description

Seed a Client Certificate Auth Provider (userpki) on OpenShift so that the built-in Prometheus can authenticate to Central's `/metrics` endpoint via client cert — no manual configuration required.

**What gets seeded on first OpenShift boot:**
- Userpki auth provider trusting the Kubernetes client CA (`extension-apiserver-authentication`)
- Permission set with `View(Administration)`
- Role "OpenShift Prometheus Metrics Reader" with Unrestricted access scope
- Group mapping: Prometheus SA cert CN → role

**Design decisions:**
- All objects are IMPERATIVE-origin — users can modify role, scope, and mapping in the UI
- Objects are created once; user edits survive restarts
- Client CA is refreshed at startup and via ConfigMap watcher (handles rotation)
- Auth provider is HIDDEN from login screen but visible in Access Control
- CN comes from `ROX_SECURE_METRICS_CLIENT_CERT_CN` env var (shared with port 9091)
- The client CA is added to `userTrustRoots` on the public :8443 endpoint via userpki's `OnEnable` callback (optional client cert verification) — this is inherent to the PKI auth provider approach

**ServiceMonitor:** The `central-ocp-monitor` ServiceMonitor uses OpenShift service-serving TLS only (`caFile` for server verification).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

- Unit tests: `go test ./central/auth/openshift/...` — 5 tests covering first boot, subsequent no-op, CA rotation, partial recovery, group preservation
- Helm tests: `go test ./pkg/helm/charts/tests/centralservices/ -run 'TestWithHelmtest/testdata/helmtest/openshift-monitoring'` — all pass with updated ServiceMonitor assertions (no mTLS client certs)
- Full build: `go build ./central/...` — clean

<img width="1432" height="222" alt="image" src="https://github.com/user-attachments/assets/bf47b5ec-7993-442b-95cf-34d35970b44e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21770**
    * **PR #21785** 👈
      * **PR #21789**
<!-- GHIT dependencies end -->