### PR TITLE
chore: trim unused fields from benchmark test fixtures

### DIFF
--- a/central/complianceoperator/v2/benchmark/fixtures/bsi-benchmark-2022.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/bsi-benchmark-2022.json
@@ -1,34 +1,13 @@
 {
-  "id": "29a99c1e-7d12-416b-8055-78a04e2eac7c",
   "name": "Bundesamt für Sicherheit in der Informationstechnik",
-  "version": "2022",
-  "description": "",
   "provider": "Germany’s Federal Office for Information Security",
   "shortName": "BSI",
   "profiles": [
-    {
-      "profileName": "ocp4-bsi",
-      "profileVersion": "2022"
-    },
-    {
-      "profileName": "ocp4-bsi-node",
-      "profileVersion": "2022"
-    },
-    {
-      "profileName": "ocp4-bsi-2022",
-      "profileVersion": "2022"
-    },
-    {
-      "profileName": "ocp4-bsi-node-2022",
-      "profileVersion": "2022"
-    },
-    {
-      "profileName": "rhcos4-bsi",
-      "profileVersion": "2022"
-    },
-    {
-      "profileName": "rhcos4-bsi-2022",
-      "profileVersion": "2022"
-    }
+    { "profileName": "ocp4-bsi" },
+    { "profileName": "ocp4-bsi-node" },
+    { "profileName": "ocp4-bsi-2022" },
+    { "profileName": "ocp4-bsi-node-2022" },
+    { "profileName": "rhcos4-bsi" },
+    { "profileName": "rhcos4-bsi-2022" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/cis-benchmark-1-4.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/cis-benchmark-1-4.json
@@ -1,18 +1,9 @@
 {
-  "id": "93946d52-61e6-46dc-9071-39ebf07d0cd8",
   "name": "CIS Red Hat OpenShift Container Platform Benchmark",
-  "version": "v1.4.0",
-  "description": "",
   "provider": "CIS",
   "shortName": "CIS-OCP",
   "profiles": [
-    {
-      "profileName": "ocp4-cis-1-4",
-      "profileVersion": "1.4.0"
-    },
-    {
-      "profileName": "ocp4-cis-node-1-4",
-      "profileVersion": "1.4.0"
-    }
+    { "profileName": "ocp4-cis-1-4" },
+    { "profileName": "ocp4-cis-node-1-4" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/cis-benchmark-1-5.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/cis-benchmark-1-5.json
@@ -1,18 +1,9 @@
 {
-  "id": "4d0d96f7-3782-41ba-b3b7-c040686a421c",
   "name": "CIS Red Hat OpenShift Container Platform Benchmark",
-  "version": "v1.5.0",
-  "description": "",
   "provider": "CIS",
   "shortName": "CIS-OCP",
   "profiles": [
-    {
-      "profileName": "ocp4-cis-1-5",
-      "profileVersion": "1.5.0"
-    },
-    {
-      "profileName": "ocp4-cis-node-1-5",
-      "profileVersion": "1.5.0"
-    }
+    { "profileName": "ocp4-cis-1-5" },
+    { "profileName": "ocp4-cis-node-1-5" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/cis-benchmark-1-7.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/cis-benchmark-1-7.json
@@ -1,26 +1,11 @@
 {
-  "id": "58f60633-4f14-42cf-afe0-1cfbc6329466",
   "name": "CIS Red Hat OpenShift Container Platform Benchmark",
-  "version": "v1.7.0",
-  "description": "",
   "provider": "CIS",
   "shortName": "CIS-OCP",
   "profiles": [
-    {
-      "profileName": "ocp4-cis",
-      "profileVersion": "1.7.0"
-    },
-    {
-      "profileName": "ocp4-cis-node",
-      "profileVersion": "1.7.0"
-    },
-    {
-      "profileName": "ocp4-cis-1-7",
-      "profileVersion": "1.7.0"
-    },
-    {
-      "profileName": "ocp4-cis-node-1-7",
-      "profileVersion": "1.7.0"
-    }
+    { "profileName": "ocp4-cis" },
+    { "profileName": "ocp4-cis-node" },
+    { "profileName": "ocp4-cis-1-7" },
+    { "profileName": "ocp4-cis-node-1-7" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v1r1.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v1r1.json
@@ -1,22 +1,10 @@
 {
-  "id": "4fdab844-1464-4bc3-8d8f-026e0c2821cf",
   "name": "Defense Information Systems Agency Security Technical Implementation Guide",
-  "version": "V1R1",
-  "description": "",
   "provider": "DISA",
   "shortName": "STIG",
   "profiles": [
-    {
-      "profileName": "ocp4-stig-v1r1",
-      "profileVersion": "V1R1"
-    },
-    {
-      "profileName": "ocp4-stig-node-v1r1",
-      "profileVersion": "V1R1"
-    },
-    {
-      "profileName": "rhcos4-stig-v1r1",
-      "profileVersion": "V1R1"
-    }
+    { "profileName": "ocp4-stig-v1r1" },
+    { "profileName": "ocp4-stig-node-v1r1" },
+    { "profileName": "rhcos4-stig-v1r1" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v2r1.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v2r1.json
@@ -1,22 +1,10 @@
 {
-  "id": "65490c0b-2db8-4613-a8a3-a59df8c6a561",
   "name": "Defense Information Systems Agency Security Technical Implementation Guide",
-  "version": "V2R1",
-  "description": "",
   "provider": "DISA",
   "shortName": "STIG",
   "profiles": [
-    {
-      "profileName": "ocp4-stig-v2r1",
-      "profileVersion": "V2R1"
-    },
-    {
-      "profileName": "ocp4-stig-node-v2r1",
-      "profileVersion": "V2R1"
-    },
-    {
-      "profileName": "rhcos4-stig-v2r1",
-      "profileVersion": "V2R1"
-    }
+    { "profileName": "ocp4-stig-v2r1" },
+    { "profileName": "ocp4-stig-node-v2r1" },
+    { "profileName": "rhcos4-stig-v2r1" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v2r2.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v2r2.json
@@ -1,22 +1,10 @@
 {
-  "id": "411f67c1-db12-43f7-b408-3480b810ce1e",
   "name": "Defense Information Systems Agency Security Technical Implementation Guide",
-  "version": "V2R2",
-  "description": "",
   "provider": "DISA",
   "shortName": "STIG",
   "profiles": [
-    {
-      "profileName": "ocp4-stig-v2r2",
-      "profileVersion": "V2R2"
-    },
-    {
-      "profileName": "ocp4-stig-node-v2r2",
-      "profileVersion": "V2R2"
-    },
-    {
-      "profileName": "rhcos4-stig-v2r2",
-      "profileVersion": "V2R2"
-    }
+    { "profileName": "ocp4-stig-v2r2" },
+    { "profileName": "ocp4-stig-node-v2r2" },
+    { "profileName": "rhcos4-stig-v2r2" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v2r3.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/disa-stig-benchmark-v2r3.json
@@ -1,34 +1,13 @@
 {
-  "id": "aaedc84e-c526-4b06-bbba-d0612d509b03",
   "name": "Defense Information Systems Agency Security Technical Implementation Guide",
-  "version": "V2R3",
-  "description": "",
   "provider": "DISA",
   "shortName": "STIG",
   "profiles": [
-    {
-      "profileName": "ocp4-stig",
-      "profileVersion": "V2R3"
-    },
-    {
-      "profileName": "ocp4-stig-node",
-      "profileVersion": "V2R3"
-    },
-    {
-      "profileName": "rhcos4-stig",
-      "profileVersion": "V2R3"
-    },
-    {
-      "profileName": "ocp4-stig-v2r3",
-      "profileVersion": "V2R3"
-    },
-    {
-      "profileName": "ocp4-stig-node-v2r3",
-      "profileVersion": "V2R3"
-    },
-    {
-      "profileName": "rhcos4-stig-v2r3",
-      "profileVersion": "V2R3"
-    }
+    { "profileName": "ocp4-stig" },
+    { "profileName": "ocp4-stig-node" },
+    { "profileName": "rhcos4-stig" },
+    { "profileName": "ocp4-stig-v2r3" },
+    { "profileName": "ocp4-stig-node-v2r3" },
+    { "profileName": "rhcos4-stig-v2r3" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/e8-benchmark.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/e8-benchmark.json
@@ -1,18 +1,9 @@
 {
-  "id": "dcd2955f-8337-4f02-b713-60f1237229f0",
   "name": "Australian Cyber Security Centre (ACSC) Essential Eight",
-  "version": "",
-  "description": "",
   "provider": "ACSC",
   "shortName": "E8",
   "profiles": [
-    {
-      "profileName": "ocp4-e8",
-      "profileVersion": "latest"
-    },
-    {
-      "profileName": "rhcos4-e8",
-      "profileVersion": "latest"
-    }
+    { "profileName": "ocp4-e8" },
+    { "profileName": "rhcos4-e8" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/nerc-benchmark.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/nerc-benchmark.json
@@ -1,22 +1,10 @@
 {
-  "id": "199c1777-bc5c-4f5e-bf1f-02afa8bd4f59",
   "name": "North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile",
-  "version": "",
-  "description": "",
   "provider": "NERC",
   "shortName": "NERC-CIP",
   "profiles": [
-    {
-      "profileName": "ocp4-nerc-cip",
-      "profileVersion": "latest"
-    },
-    {
-      "profileName": "ocp4-nerc-cip-node",
-      "profileVersion": "latest"
-    },
-    {
-      "profileName": "rhcos4-nerc-cip",
-      "profileVersion": "latest"
-    }
+    { "profileName": "ocp4-nerc-cip" },
+    { "profileName": "ocp4-nerc-cip-node" },
+    { "profileName": "rhcos4-nerc-cip" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/nist-high-benchmark-revision-4.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/nist-high-benchmark-revision-4.json
@@ -1,34 +1,13 @@
 {
-  "id": "f5859d89-1a5a-4876-9ddc-fbcc52b79fe5",
   "name": "NIST 800-53 High-Impact Baseline",
-  "version": "Revision 4",
-  "description": "",
   "provider": "NIST",
   "shortName": "NIST-800-53",
   "profiles": [
-    {
-      "profileName": "ocp4-high",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "ocp4-high-node",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "rhcos4-high",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "ocp4-high-rev-4",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "ocp4-high-node-rev-4",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "rhcos4-high-rev-4",
-      "profileVersion": "Revision 4"
-    }
+    { "profileName": "ocp4-high" },
+    { "profileName": "ocp4-high-node" },
+    { "profileName": "rhcos4-high" },
+    { "profileName": "ocp4-high-rev-4" },
+    { "profileName": "ocp4-high-node-rev-4" },
+    { "profileName": "rhcos4-high-rev-4" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/nist-moderate-benchmark-revision-4.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/nist-moderate-benchmark-revision-4.json
@@ -1,34 +1,13 @@
 {
-  "id": "13d6b465-1467-4bfd-af0f-a3e2205048f1",
   "name": "NIST 800-53 Moderate-Impact Baseline",
-  "version": "Revision 4",
-  "description": "",
   "provider": "NIST",
   "shortName": "NIST-800-53",
   "profiles": [
-    {
-      "profileName": "ocp4-moderate",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "ocp4-moderate-node",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "rhcos4-moderate",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "ocp4-moderate-rev-4",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "ocp4-moderate-node-rev-4",
-      "profileVersion": "Revision 4"
-    },
-    {
-      "profileName": "rhcos4-moderate-rev-4",
-      "profileVersion": "Revision 4"
-    }
+    { "profileName": "ocp4-moderate" },
+    { "profileName": "ocp4-moderate-node" },
+    { "profileName": "rhcos4-moderate" },
+    { "profileName": "ocp4-moderate-rev-4" },
+    { "profileName": "ocp4-moderate-node-rev-4" },
+    { "profileName": "rhcos4-moderate-rev-4" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/pci-benchmark-3-2-1.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/pci-benchmark-3-2-1.json
@@ -1,26 +1,11 @@
 {
-  "id": "9f204799-c73d-46a1-8890-cd2ceec12d7e",
   "name": "PCI-DSS v3.2.1 Control Baseline",
-  "version": "3.2.1",
-  "description": "",
   "provider": "PCI",
   "shortName": "PCI-DSS",
   "profiles": [
-    {
-      "profileName": "ocp4-pci-dss",
-      "profileVersion": "3.2.1"
-    },
-    {
-      "profileName": "ocp4-pci-dss-node",
-      "profileVersion": "3.2.1"
-    },
-    {
-      "profileName": "ocp4-pci-dss-3-2",
-      "profileVersion": "3.2.1"
-    },
-    {
-      "profileName": "ocp4-pci-dss-node-3-2",
-      "profileVersion": "3.2.1"
-    }
+    { "profileName": "ocp4-pci-dss" },
+    { "profileName": "ocp4-pci-dss-node" },
+    { "profileName": "ocp4-pci-dss-3-2" },
+    { "profileName": "ocp4-pci-dss-node-3-2" }
   ]
 }

--- a/central/complianceoperator/v2/benchmark/fixtures/pci-benchmark-4-0.json
+++ b/central/complianceoperator/v2/benchmark/fixtures/pci-benchmark-4-0.json
@@ -1,18 +1,9 @@
 {
-  "id": "62fc8ca1-0cd2-4969-aae7-1e366ca5408e",
   "name": "PCI-DSS v4.0.0 Control Baseline",
-  "version": "4.0.0",
-  "description": "",
   "provider": "PCI",
   "shortName": "PCI-DSS",
   "profiles": [
-    {
-      "profileName": "ocp4-pci-dss-4-0",
-      "profileVersion": "4.0.0"
-    },
-    {
-      "profileName": "ocp4-pci-dss-node-4-0",
-      "profileVersion": "4.0.0"
-    }
+    { "profileName": "ocp4-pci-dss-4-0" },
+    { "profileName": "ocp4-pci-dss-node-4-0" }
   ]
 }


### PR DESCRIPTION
## Description

Remove unused fields (`id`, `version`, `description`, `profileVersion`) from the 14 benchmark JSON test fixtures. The backward-compatibility tests only assert on `name`, `provider`, `shortName`, and `profiles[].profileName`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Ran `go test -race -count=1 -timeout=30s -v ./central/complianceoperator/v2/benchmark/` — all 3 tests pass.