### PR TITLE
ROX-33377: add source filtering to vulnerability updater

### DIFF
--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -6,15 +6,21 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/scanner/config"
 	"github.com/stackrox/rox/scanner/internal/logging"
 	"github.com/stackrox/rox/scanner/internal/version"
 	"github.com/stackrox/rox/scanner/updater"
 )
 
-const DefaultURL = "https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/manual/vulns.yaml"
+const (
+	defaultManualURL = "https://raw.githubusercontent.com/stackrox/stackrox/master/scanner/updater/manual/vulns.yaml"
+)
+
+var sourcesRaw = os.Getenv("STACKROX_SCANNER_V4_UPDATER_SOURCES")
 
 const logLevelEnvVar = "STACKROX_SCANNER_V4_UPDATER_LOG_LEVEL"
 
@@ -40,16 +46,17 @@ func tryExport(ctx context.Context, outputDir string, opts *updater.ExportOption
 	const timeout = 3 * time.Hour
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	err := updater.Export(ctx, outputDir, opts)
-	if err != nil {
-		return err
-	}
-	return nil
+	return updater.Export(ctx, outputDir, opts)
 }
 
 func main() {
 	if err := initializeLogging(); err != nil {
 		slog.Error("failed to initialize logging", "reason", err)
+		os.Exit(1)
+	}
+	sources := config.NormalizeStringList(strings.Split(sourcesRaw, ","))
+	if len(sourcesRaw) > 0 && len(sources) == 0 {
+		slog.Error("unable to parse sources", "raw_sources", sourcesRaw)
 		os.Exit(1)
 	}
 
@@ -79,7 +86,10 @@ func main() {
 					"attempt", attempt,
 					"manual_vulns_url", manualURL,
 					"output_directory", outputDir)
-				err := tryExport(ctx, outputDir, &updater.ExportOptions{ManualVulnURL: manualURL})
+				err := tryExport(ctx, outputDir, &updater.ExportOptions{
+					ManualVulnURL: manualURL,
+					Sources:       sources,
+				})
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) {
 						slog.WarnContext(ctx, "export failed; will retry if within retry limits",
@@ -95,7 +105,7 @@ func main() {
 			return errors.New("data export failed: max retries exceeded")
 		},
 	}
-	exportCmd.Flags().String("manual-url", DefaultURL, "URL to the manual vulnerability data.")
+	exportCmd.Flags().String("manual-url", defaultManualURL, "URL to the manual vulnerability data.")
 
 	var importCmd = &cobra.Command{
 		Use:   "import",

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -270,7 +270,23 @@ func (c *MatcherConfig) validate() error {
 		return fmt.Errorf("readiness: invalid readiness type %q", c.Readiness)
 	}
 
+	c.VulnBundleAllowlist = NormalizeStringList(c.VulnBundleAllowlist)
+
 	return nil
+}
+
+// NormalizeStringList trims whitespace from each entry and drops empty strings.
+func NormalizeStringList(entries []string) []string {
+	if entries == nil {
+		return nil
+	}
+	result := make([]string, 0, len(entries))
+	for _, s := range entries {
+		if t := strings.TrimSpace(s); t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
 }
 
 // Database provides database configuration for scanner backends.

--- a/scanner/config/config_test.go
+++ b/scanner/config/config_test.go
@@ -405,3 +405,38 @@ func Test_ProxyConfig_validate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestNormalizeStringList(t *testing.T) {
+	tests := map[string]struct {
+		input []string
+		want  []string
+	}{
+		"nil returns nil": {
+			input: nil,
+			want:  nil,
+		},
+		"empty slice returns empty": {
+			input: []string{},
+			want:  []string{},
+		},
+		"trims whitespace": {
+			input: []string{" a ", " b "},
+			want:  []string{"a", "b"},
+		},
+		"drops empties": {
+			input: []string{"a", "", " ", "b"},
+			want:  []string{"a", "b"},
+		},
+		"no changes needed": {
+			input: []string{"a", "b"},
+			want:  []string{"a", "b"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NormalizeStringList(tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -152,7 +152,7 @@ func New(ctx context.Context, opts Opts) (*Updater, error) {
 	}
 	u.iterateFunc = jsonblob.Iterate
 
-	u.vulnBundleAllowlist = set.NewFrozenSet(normalizeAllowlist(opts.VulnBundleAllowlist)...)
+	u.vulnBundleAllowlist = set.NewFrozenSet(opts.VulnBundleAllowlist...)
 
 	u.tryRemoveExiting()
 
@@ -612,19 +612,6 @@ func isRetryableDialError(err error) bool {
 		return false
 	}
 	return errors.Is(err, syscall.ECONNREFUSED) || opErr.Timeout()
-}
-
-// normalizeAllowlist trims whitespace from each entry and drops empty strings.
-// This handles cases the allowed names are configured with surrounding spaces,
-// e.g. from a comma-separated environment variable or YAML value.
-func normalizeAllowlist(entries []string) []string {
-	result := make([]string, 0, len(entries))
-	for _, s := range entries {
-		if t := strings.TrimSpace(s); t != "" {
-			result = append(result, t)
-		}
-	}
-	return result
 }
 
 // isBundleAllowed reports whether the named bundle file should be imported.

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -314,23 +314,6 @@ func TestUpdater_Initialized(t *testing.T) {
 	})
 }
 
-func TestNormalizeAllowlist(t *testing.T) {
-	// Simulates an allowlist with only whitespace.
-	input := []string{" ", "  ", "  \t   ", ""}
-	u := &Updater{vulnBundleAllowlist: set.NewFrozenSet(normalizeAllowlist(input)...)}
-	assert.True(t, u.isBundleAllowed("bundles/epss.json.zst"), "everything allowed when list empty")
-	assert.True(t, u.isBundleAllowed("hello-world"), "everything allowed when list empty")
-
-	// Simulates an allowlist with surrounding whitespace.
-	input = []string{" epss", " nvd ", "rhel-vex", "", "  "}
-	u = &Updater{vulnBundleAllowlist: set.NewFrozenSet(normalizeAllowlist(input)...)}
-	assert.True(t, u.isBundleAllowed("bundles/epss.json.zst"), "leading-space entry should match")
-	assert.True(t, u.isBundleAllowed("bundles/nvd.json.zst"), "surrounding-space entry should match")
-	assert.True(t, u.isBundleAllowed("bundles/rhel-vex.json.zst"), "clean entry should match")
-	assert.False(t, u.isBundleAllowed("bundles/alpine.json.zst"), "non-listed bundle should not match")
-	assert.Equal(t, 3, u.vulnBundleAllowlist.Cardinality(), "empty/whitespace-only entries should be dropped")
-}
-
 func TestIsBundleAllowed(t *testing.T) {
 	tests := map[string]struct {
 		allowlist set.FrozenSet[string]

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -49,6 +49,9 @@ var (
 
 type ExportOptions struct {
 	ManualVulnURL string
+	// Sources restricts which updaters run. When nil or empty, all updaters run.
+	// Values must be pre-normalized (trimmed, no empty entries).
+	Sources []string
 }
 
 // Export is responsible for triggering the updaters to download Common Vulnerabilities and Exposures (CVEs) data.
@@ -79,6 +82,15 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 			managerOpts = rhelVexOpts()
 		}
 		bundles[uSet] = managerOpts
+	}
+
+	if len(opts.Sources) > 0 {
+		filtered, err := filterSources(bundles, opts.Sources)
+		if err != nil {
+			return fmt.Errorf("filtering sources: %w", err)
+		}
+		slog.InfoContext(ctx, "source filter active", "running", len(filtered), "total", len(bundles), "sources", opts.Sources)
+		bundles = filtered
 	}
 
 	// Rate limit to ~16 requests/second by default.
@@ -225,6 +237,18 @@ func redhatCSAFOpts() []updates.ManagerOption {
 			"stackrox.rhel-csaf": csaf.NewFactory(),
 		}),
 	}
+}
+
+func filterSources(bundles map[string][]updates.ManagerOption, selected []string) (map[string][]updates.ManagerOption, error) {
+	filtered := make(map[string][]updates.ManagerOption, len(selected))
+	for _, s := range selected {
+		if o, ok := bundles[s]; ok {
+			filtered[s] = o
+		} else {
+			return nil, fmt.Errorf("unknown source: %q", s)
+		}
+	}
+	return filtered, nil
 }
 
 func zstdWriter(filename string) (io.WriteCloser, error) {

--- a/scanner/updater/export_test.go
+++ b/scanner/updater/export_test.go
@@ -1,0 +1,54 @@
+package updater
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/quay/claircore/libvuln/updates"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSources(t *testing.T) {
+	bundles := map[string][]updates.ManagerOption{
+		"alpha":   nil,
+		"bravo":   nil,
+		"charlie": nil,
+	}
+
+	tests := map[string]struct {
+		selected  []string
+		wantKeys  []string
+		wantError string
+	}{
+		"single source": {
+			selected: []string{"alpha"},
+			wantKeys: []string{"alpha"},
+		},
+		"multiple sources": {
+			selected: []string{"alpha", "charlie"},
+			wantKeys: []string{"alpha", "charlie"},
+		},
+		"unknown source": {
+			selected:  []string{"alpha", "bogus"},
+			wantError: `unknown source: "bogus"`,
+		},
+		"all sources": {
+			selected: []string{"alpha", "bravo", "charlie"},
+			wantKeys: []string{"alpha", "bravo", "charlie"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := filterSources(bundles, tc.selected)
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.wantKeys, slices.Collect(maps.Keys(result)))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Backport of #21601 to release-4.11 to enable per-source vulnerability bundle generation on the `v3` bundle stream.

Adds `STACKROX_SCANNER_V4_UPDATER_SOURCES` env var to the updater binary. When set (e.g., `STACKROX_SCANNER_V4_UPDATER_SOURCES=alpine`), only the named updaters execute. When unset, all updaters run as before.

Cherry-picked from master with conflict resolution in `main.go` only (release-4.11 doesn't have the logging refactor from master; kept release-4.11's existing conventions and added only the source filtering changes).

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed
- [x] documentation PR is created and is linked above OR is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests

### How I validated my change

Built the updater binary from release-4.11 with the backport. Build and tests pass.