### PR TITLE
ROX-35781: Drop CA-fetch coalescer from CARefresher

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/tls.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/mdlayher/vsock"
-	"github.com/stackrox/rox/pkg/coalescer"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
@@ -34,10 +33,6 @@ const (
 	// gRPC method for the KubeVirt System.CABundle RPC.
 	// Proto: kubevirt.io/kubevirt/pkg/vsock/system/v1/system.proto
 	caBundleMethod = "/kubevirt.vsock.system.v1.System/CABundle"
-
-	// coalesceKey is the single key coalesced fetches are keyed on: there is
-	// only one CA bundle to fetch per CARefresher instance.
-	coalesceKey = "kubevirt-ca"
 )
 
 // fetchKubeVirtCA calls the KubeVirt System.CABundle gRPC service on
@@ -184,9 +179,17 @@ func extractBundleRaw(data []byte) ([]byte, error) {
 // what opens it. This works unchanged in "global" mode too, since the
 // service is always reachable there.
 //
-// Concurrent callers (e.g. multiple simultaneous handshakes) are coalesced
-// into a single underlying fetch via coalescer, so a stampede never results
-// in redundant dials to virt-handler.
+// By default there is exactly one caller: server.go's semaphore limits the
+// agent to a single in-flight connection, because the agent serves a
+// single Sensor poller (see maxConcurrentConns) - so ensureFreshPool is
+// never actually called concurrently in the supported topology. A second,
+// concurrent caller could only arise from a second, concurrent Sensor
+// instance ("color") dialing the same agent, which is not something this
+// agent currently supports or plans for. Even if it happened anyway,
+// r.mu's write lock keeps every individual cache read/swap consistent, so
+// no caller would observe a corrupted or partially-written pool - each
+// concurrent fetch would just cost an extra, redundant dial to
+// virt-handler instead of being deduplicated into one.
 type CARefresher struct {
 	mu        sync.RWMutex
 	pool      *x509.CertPool
@@ -195,7 +198,6 @@ type CARefresher struct {
 	interval     time.Duration
 	fetchTimeout time.Duration
 	fetchCA      func(ctx context.Context) ([]byte, error)
-	coalesce     *coalescer.Coalescer[*x509.CertPool]
 }
 
 // NewCARefresher creates a refresher with an empty cache. There is no
@@ -209,7 +211,6 @@ func NewCARefresher(opts ...CARefresherOption) *CARefresher {
 		interval:     defaultRefreshInterval,
 		fetchTimeout: defaultFetchTimeout,
 		fetchCA:      fetchKubeVirtCA,
-		coalesce:     coalescer.New[*x509.CertPool](),
 	}
 	for _, o := range opts {
 		o(r)
@@ -232,8 +233,9 @@ func WithFetchFunc(f func(ctx context.Context) ([]byte, error)) CARefresherOptio
 }
 
 // ensureFreshPool returns the cached CA pool if it is populated and not
-// older than r.interval, fetching a new one otherwise. Concurrent callers
-// are coalesced into a single underlying fetch.
+// older than r.interval, fetching a new one otherwise. There is normally
+// only ever one caller at a time; see the CARefresher doc comment for why,
+// and for what happens on the unsupported path where that stops being true.
 //
 // A failed (re)fetch is not fatal as long as some pool - however stale - is
 // already cached: certificates signed by an old CA remain valid until they
@@ -247,38 +249,7 @@ func (r *CARefresher) ensureFreshPool(ctx context.Context) (*x509.CertPool, erro
 		return pool, nil
 	}
 
-	pool, err := r.coalesce.Coalesce(ctx, coalesceKey, func() (*x509.CertPool, error) {
-		// Re-check: another caller may have refreshed the cache while we
-		// were waiting to enter the coalesced section.
-		if pool, ok := r.freshCachedPool(); ok {
-			return pool, nil
-		}
-
-		// ctx here belongs to whichever single caller happened to trigger
-		// this fetch, but the result is shared with every other concurrent
-		// caller waiting on it too. Don't let that one caller's own
-		// cancellation (e.g. its handshake being torn down) abort the fetch
-		// for everyone else: detach from ctx's cancellation/deadline with
-		// WithoutCancel, and bound the fetch by r.fetchTimeout alone.
-		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.fetchTimeout)
-		defer cancel()
-
-		ca, fetchErr := r.fetchCA(fetchCtx)
-		if fetchErr != nil {
-			return nil, fetchErr
-		}
-		newPool := x509.NewCertPool()
-		if !newPool.AppendCertsFromPEM(ca) {
-			return nil, errors.New("no valid certificates found in CA bundle")
-		}
-
-		concurrency.WithLock(&r.mu, func() {
-			r.pool = newPool
-			r.fetchedAt = time.Now()
-		})
-		log.Info("KubeVirt CA refreshed successfully")
-		return newPool, nil
-	})
+	pool, err := r.fetchAndCachePool(ctx)
 	if err == nil {
 		return pool, nil
 	}
@@ -288,6 +259,39 @@ func (r *CARefresher) ensureFreshPool(ctx context.Context) (*x509.CertPool, erro
 		return stale, nil
 	}
 	return nil, err
+}
+
+// fetchAndCachePool fetches a fresh CA bundle from KubeVirt, parses it, and
+// swaps it into the cache under r.mu's write lock. It returns the pool it
+// just fetched, which is what makes it safe to call from more than one
+// caller at once on the unsupported multi-caller path (see the CARefresher
+// doc comment): each caller gets back its own valid, non-nil pool
+// regardless of which write to r.pool happens to land last.
+func (r *CARefresher) fetchAndCachePool(ctx context.Context) (*x509.CertPool, error) {
+	// ctx belongs to the caller whose handshake triggered this fetch. If
+	// that handshake is torn down mid-fetch, ctx is cancelled - but the
+	// fetch already in flight can still finish and warm the cache for
+	// whichever handshake asks next. Don't let this caller's own
+	// cancellation abort that: detach from ctx's cancellation/deadline
+	// with WithoutCancel, and bound the fetch by r.fetchTimeout alone.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.fetchTimeout)
+	defer cancel()
+
+	ca, err := r.fetchCA(fetchCtx)
+	if err != nil {
+		return nil, err
+	}
+	newPool := x509.NewCertPool()
+	if !newPool.AppendCertsFromPEM(ca) {
+		return nil, errors.New("no valid certificates found in CA bundle")
+	}
+
+	concurrency.WithLock(&r.mu, func() {
+		r.pool = newPool
+		r.fetchedAt = time.Now()
+	})
+	log.Info("KubeVirt CA refreshed successfully")
+	return newPool, nil
 }
 
 // freshCachedPool returns the cached pool and true if it is populated and

--- a/compliance/virtualmachines/roxagent/vsockserver/tls.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls.go
@@ -179,17 +179,10 @@ func extractBundleRaw(data []byte) ([]byte, error) {
 // what opens it. This works unchanged in "global" mode too, since the
 // service is always reachable there.
 //
-// By default there is exactly one caller: server.go's semaphore limits the
-// agent to a single in-flight connection, because the agent serves a
-// single Sensor poller (see maxConcurrentConns) - so ensureFreshPool is
-// never actually called concurrently in the supported topology. A second,
-// concurrent caller could only arise from a second, concurrent Sensor
-// instance ("color") dialing the same agent, which is not something this
-// agent currently supports or plans for. Even if it happened anyway,
-// r.mu's write lock keeps every individual cache read/swap consistent, so
-// no caller would observe a corrupted or partially-written pool - each
-// concurrent fetch would just cost an extra, redundant dial to
-// virt-handler instead of being deduplicated into one.
+// server.go's semaphore keeps ensureFreshPool single-caller in the
+// supported topology (one Sensor poller; see maxConcurrentConns). r.mu
+// still serializes every cache read/swap, so concurrent callers would
+// only pay for redundant fetches - never observe a corrupted pool.
 type CARefresher struct {
 	mu        sync.RWMutex
 	pool      *x509.CertPool
@@ -233,9 +226,9 @@ func WithFetchFunc(f func(ctx context.Context) ([]byte, error)) CARefresherOptio
 }
 
 // ensureFreshPool returns the cached CA pool if it is populated and not
-// older than r.interval, fetching a new one otherwise. There is normally
-// only ever one caller at a time; see the CARefresher doc comment for why,
-// and for what happens on the unsupported path where that stops being true.
+// older than r.interval, fetching a new one otherwise. See the CARefresher
+// doc comment for the single-caller assumption and how r.mu protects the
+// cache.
 //
 // A failed (re)fetch is not fatal as long as some pool - however stale - is
 // already cached: certificates signed by an old CA remain valid until they
@@ -263,10 +256,7 @@ func (r *CARefresher) ensureFreshPool(ctx context.Context) (*x509.CertPool, erro
 
 // fetchAndCachePool fetches a fresh CA bundle from KubeVirt, parses it, and
 // swaps it into the cache under r.mu's write lock. It returns the pool it
-// just fetched, which is what makes it safe to call from more than one
-// caller at once on the unsupported multi-caller path (see the CARefresher
-// doc comment): each caller gets back its own valid, non-nil pool
-// regardless of which write to r.pool happens to land last.
+// just wrote so the caller does not need a second locked read of r.pool.
 func (r *CARefresher) fetchAndCachePool(ctx context.Context) (*x509.CertPool, error) {
 	// ctx belongs to the caller whose handshake triggered this fetch. If
 	// that handshake is torn down mid-fetch, ctx is cancelled - but the

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -16,6 +16,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -188,22 +189,16 @@ func TestCARefresher_HandshakeFailsWhenCAServiceUnavailable(t *testing.T) {
 // TestCARefresher_ConcurrentHandshakesEachGetValidPool calls
 // ensureFreshPool directly from several goroutines at once, bypassing
 // server.go's semaphore (which limits the agent to one in-flight
-// connection in the supported single-Sensor-caller topology - see the
-// CARefresher doc comment) to exercise the defensive path that would only
-// matter if that stopped being true. It proves the behavior accepted in
-// place of coalescing: callers may each trigger their own fetch (no
-// fetchCount == 1 assertion), but the cache is never left corrupted or
-// partially written, and every caller gets back a valid, non-nil pool that
-// verifies the client cert it was given.
+// connection) to exercise the defensive path when multiple connections are established in parallel.
 func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		caPEM, caCert, caKey := testCA(t)
 
 		var fetchCount atomic.Int32
-		release := make(chan struct{})
+		fetchesMayProceed := concurrency.NewSignal()
 		r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
 			fetchCount.Add(1)
-			<-release // block until the test says every caller has arrived
+			fetchesMayProceed.Wait() // block until the test says all callers have arrived
 			return caPEM, nil
 		}))
 
@@ -220,16 +215,11 @@ func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 			}()
 		}
 
-		// synctest.Wait blocks until every goroutine in the bubble is
-		// durably blocked on <-release inside fetchFunc, i.e. every
-		// caller has actually reached its own fetch - not merely been
-		// scheduled - so closing release can't race a late arrival.
-		synctest.Wait()
-		close(release)
+		synctest.Wait() // Wait until all callers are blocked on fetchesMayProceed.Wait
+		fetchesMayProceed.Signal()
 
 		// A leaf cert signed by the fetched CA must verify against every
-		// pool handed back: if a caller's pool were corrupted or
-		// partially written, this would fail for that caller specifically.
+		// pool handed back. Corrupted pool would fail this assertion.
 		leaf := testLeafCert(t, caCert, caKey)
 		leafCert, err := x509.ParseCertificate(leaf.Certificate[0])
 		require.NoError(t, err)

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -185,9 +185,19 @@ func TestCARefresher_HandshakeFailsWhenCAServiceUnavailable(t *testing.T) {
 	assert.NoError(t, dial(), "handshake should succeed once the CA service becomes available")
 }
 
-func TestCARefresher_ConcurrentHandshakesCoalesceFetch(t *testing.T) {
+// TestCARefresher_ConcurrentHandshakesEachGetValidPool calls
+// ensureFreshPool directly from several goroutines at once, bypassing
+// server.go's semaphore (which limits the agent to one in-flight
+// connection in the supported single-Sensor-caller topology - see the
+// CARefresher doc comment) to exercise the defensive path that would only
+// matter if that stopped being true. It proves the behavior accepted in
+// place of coalescing: callers may each trigger their own fetch (no
+// fetchCount == 1 assertion), but the cache is never left corrupted or
+// partially written, and every caller gets back a valid, non-nil pool that
+// verifies the client cert it was given.
+func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		caPEM, _, _ := testCA(t)
+		caPEM, caCert, caKey := testCA(t)
 
 		var fetchCount atomic.Int32
 		release := make(chan struct{})
@@ -198,30 +208,47 @@ func TestCARefresher_ConcurrentHandshakesCoalesceFetch(t *testing.T) {
 		}))
 
 		const callers = 5
-		results := make(chan error, callers)
+		type result struct {
+			pool *x509.CertPool
+			err  error
+		}
+		results := make(chan result, callers)
 		for range callers {
 			go func() {
-				_, err := r.ensureFreshPool(context.Background())
-				results <- err
+				pool, err := r.ensureFreshPool(context.Background())
+				results <- result{pool: pool, err: err}
 			}()
 		}
 
 		// synctest.Wait blocks until every goroutine in the bubble is
-		// durably blocked: the one leader inside fetchFunc on <-release,
-		// and every follower inside Coalesce's select on the shared
-		// singleflight result channel. Unlike a WaitGroup fired at
-		// goroutine entry (started.Done, before ensureFreshPool even
-		// runs), this can't observe "started" before a caller has
-		// actually reached the coalesced section - so closing release
-		// right after can never race a late arrival into a second,
-		// uncoalesced fetch.
+		// durably blocked on <-release inside fetchFunc, i.e. every
+		// caller has actually reached its own fetch - not merely been
+		// scheduled - so closing release can't race a late arrival.
 		synctest.Wait()
 		close(release)
 
+		// A leaf cert signed by the fetched CA must verify against every
+		// pool handed back: if a caller's pool were corrupted or
+		// partially written, this would fail for that caller specifically.
+		leaf := testLeafCert(t, caCert, caKey)
+		leafCert, err := x509.ParseCertificate(leaf.Certificate[0])
+		require.NoError(t, err)
+
 		for range callers {
-			require.NoError(t, <-results)
+			res := <-results
+			require.NoError(t, res.err)
+			require.NotNil(t, res.pool, "every caller must get back a valid pool")
+			_, verifyErr := leafCert.Verify(x509.VerifyOptions{
+				Roots:     res.pool,
+				KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			})
+			require.NoError(t, verifyErr, "pool returned to caller must be able to verify a cert signed by the fetched CA")
 		}
-		assert.Equal(t, int32(1), fetchCount.Load(), "concurrent callers should coalesce into a single fetch")
+		assert.GreaterOrEqual(t, fetchCount.Load(), int32(1), "at least one caller must have triggered a fetch")
+
+		finalPool, _, ok := r.cachedPool()
+		require.True(t, ok, "cache must be populated after concurrent fetches complete")
+		require.NotNil(t, finalPool)
 	})
 }
 


### PR DESCRIPTION
## Description

Follow-up to #21435 (ROX-35190) and [ADR discussion thread ](https://github.com/stackrox/architecture-decision-records/pull/41#discussion_r3577860480).

The `server.go`'s semaphore already limits the agent to one in-flight connection, since the agent serves a single Sensor poller. That means `CARefresher.ensureFreshPool` never actually has concurrent callers in the supported topology, so the `pkg/coalescer` dedup around its fetch wasn't buying anything.

Note: `pkg/coalescer` itself is untouched - it's still used by `sensor/common/centralproxy` and `sensor/admission-control/manager`, where concurrent callers are the norm, not the exception.

⚠️ The drop of the coalescer does not reduce the amount of code significantly. It slightly reduces the complexity by removing one function that wraps everything:

It turns:
```go
pool, err := r.coalesce.Coalesce(ctx, coalesceKey, func() (*x509.CertPool, error) {
	if pool, ok := r.freshCachedPool(); ok {
		return pool, nil
	}
    (stuff)
}
```

into:

```go
(stuff)
```

### When a coalescer would be needed?

It would be beneficial if there are two or more concurent calls from Agent to Kubevirt to fetch CA certificate.
That is only possible when two or more Sensors calls a single Roxagent & the roxagent needs to refresh the cert.
So in the current implementation and under the current assumptions: never.

### Authors point of view

We can leave it (4 extra lines and 1 level of indent) or drop it. I am fine with both, but want to ask for other's opinion.

Note that there is not a clear win in terms of code reduction - the diff is larger, because we placed extra comments to explain why there is safe to run without coalescer and because the unit test `TestCARefresher_ConcurrentHandshakesCoalesceFetch` tested a behavior that is getting removed.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- There is a unit test covering this change
- This is hard to test on a cluster actually... would need to allow 2 sensors call the same agent and then see that the agent makes 2 calls (instead of 1) to kubevirt API to refresh the cert.