### PR TITLE
fix(notifiers): make SMTP connect timeout configurable

### DIFF
--- a/central/notifiers/email/email.go
+++ b/central/notifiers/email/email.go
@@ -42,7 +42,6 @@ var (
 )
 
 const (
-	connectTimeout  = 5 * time.Second
 	emailLineLength = 78
 )
 
@@ -445,14 +444,16 @@ func (e *email) createClient(conn net.Conn) (c *smtp.Client, err error) {
 	// This particular failure mode seems sufficiently unlikely.
 	// Importantly, a net.Conn can have multiple clients safely call methods
 	// on it at the same time, including Close().
-	t := time.AfterFunc(connectTimeout, func() {
+	timeout := env.EmailConnectTimeout.DurationSetting()
+	t := time.AfterFunc(timeout, func() {
 		timedOut.Toggle()
 		defer utils.IgnoreError(conn.Close)
 	})
 	defer func() {
 		t.Stop()
 		if timedOut.Get() {
-			err = errors.New("timeout: possibly speaking unencrypted to a server running TLS")
+			err = errors.Errorf("timeout waiting for SMTP server greeting after %s (consider increasing %s)",
+				timeout, env.EmailConnectTimeout.EnvVar())
 		}
 	}()
 
@@ -460,7 +461,7 @@ func (e *email) createClient(conn net.Conn) (c *smtp.Client, err error) {
 }
 
 func (e *email) connection(ctx context.Context) (conn net.Conn, auth smtp.Auth, err error) {
-	ctx, cancel := context.WithTimeout(ctx, connectTimeout)
+	ctx, cancel := context.WithTimeout(ctx, env.EmailConnectTimeout.DurationSetting())
 	defer cancel()
 
 	if e.config.GetDisableTLS() {

--- a/pkg/env/email.go
+++ b/pkg/env/email.go
@@ -1,0 +1,11 @@
+package env
+
+import "time"
+
+var (
+	// EmailConnectTimeout controls the timeout for establishing an SMTP connection,
+	// including both the TCP dial and waiting for the server's 220 greeting banner.
+	// SMTP servers may delay the banner for reverse DNS lookups or other checks,
+	// which can exceed the default timeout.
+	EmailConnectTimeout = registerDurationSetting("ROX_EMAIL_CONNECT_TIMEOUT", 5*time.Second)
+)


### PR DESCRIPTION
## Description

The email notifier's SMTP connect timeout was hard-coded at 5 seconds (`connectTimeout` constant in `central/notifiers/email/email.go`), used for both the TCP dial and waiting for the server's 220 greeting banner. Enterprise SMTP servers commonly delay the banner for reverse DNS (PTR) lookups on the connecting client IP, which can take 5-30 seconds. RFC 5321 Section 4.5.3.2 recommends clients wait at least 5 minutes for the initial greeting.

This surfaces as a misleading error: _"timeout: possibly speaking unencrypted to a server running TLS"_ — even when TLS is not involved at all.

**Changes:**
- Add `ROX_EMAIL_CONNECT_TIMEOUT` environment variable (default: `5s`, preserving existing behavior) so operators can raise it without a code change
- Replace the misleading timeout error message with: _"timeout waiting for SMTP server greeting after 5s (consider increasing ROX_EMAIL_CONNECT_TIMEOUT)"_

**Alternative considered:** Separate env vars for TCP dial timeout vs. banner read timeout. Rejected because both are part of "establishing SMTP connection" from the user's perspective, and a single knob is simpler to configure. RFC 5321 treats the initial greeting as part of connection establishment.

**Context:** Customer case 04446533 — ACS 4.9.2 email notifier fails with the misleading TLS error when connecting to a plain SMTP server on port 25. Root cause is the SMTP server doing reverse DNS lookups on the pod IP (no PTR record), which times out after ~10s, exceeding the 5s hard-coded timeout.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added. The env var plumbing is covered by existing `pkg/env` tests (`TestDurationSetting`, `TestSettingEnvVarsStartWithRox`). The behavioral change (timeout duration) was validated manually on a real cluster.

### How I validated my change

Deployed a patched Central binary to an OCP 4.22 cluster (ga-ocp4-cron) and tested against two SMTP servers in the same cluster:

**1. Slow SMTP server (6-second banner delay) — without env var (default 5s):**
- Result: Failed at 5.4s with new error message
- Central log: `"timeout waiting for SMTP server greeting after 5s (consider increasing ROX_EMAIL_CONNECT_TIMEOUT)"`
- Confirms backward-compatible default behavior and improved error message

**2. Slow SMTP server (6-second banner delay) — with `ROX_EMAIL_CONNECT_TIMEOUT=30s`:**
- Result: Connected successfully after 6.5s, proceeded to SMTP handshake
- Central log: `SMTP DATA command failed (code: 250)` (test server protocol limitation, not a real error)
- Confirms the env var override works — the connection that previously timed out now succeeds

**3. Fast SMTP server (instant banner) — with `ROX_EMAIL_CONNECT_TIMEOUT=30s`:**
- Result: Succeeded in 0.6s
- Confirms no regression for normal SMTP servers

All unit tests pass: `go test ./central/notifiers/email/...` and `go test ./pkg/env/...`.