### PR TITLE
ROX-35773: fix PolicyAsCode e2e test flake

### DIFF
--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -191,7 +191,7 @@ func (pc *PolicyAsCodeSuite) TestCreateDefaultCR() {
 	pc.Require().NoError(err)
 
 	message := "status never updated"
-	timer := time.NewTimer(time.Second * 5)
+	timer := time.NewTimer(time.Second * 30)
 	for {
 		select {
 		case <-timer.C:
@@ -215,7 +215,7 @@ func (pc *PolicyAsCodeSuite) TestRenameToDefaultCR() {
 	pc.fromUnstructured(u, k8sPolicy)
 
 	message := "status never updated"
-	timer := time.NewTimer(time.Second * 5)
+	timer := time.NewTimer(time.Second * 30)
 	for {
 		accepted := false
 		select {
@@ -239,9 +239,9 @@ func (pc *PolicyAsCodeSuite) TestRenameToDefaultCR() {
 		u, err = pc.k8sClient.Get(pc.ctx, k8sPolicy.GetName(), metav1.GetOptions{})
 		pc.fromUnstructured(u, k8sPolicy)
 		k8sPolicy.Spec.PolicyName = "90-Day Image Age"
-	}, time.Second*5, time.Millisecond*30)
+	}, time.Second*30, time.Millisecond*200)
 
-	timer = time.NewTimer(time.Second * 5)
+	timer = time.NewTimer(time.Second * 30)
 	for {
 		var policy *v1alpha1.SecurityPolicy
 		select {
@@ -356,7 +356,7 @@ func (pc *PolicyAsCodeSuite) createPolicyInK8s(toCreate *v1alpha1.SecurityPolicy
 	pc.Require().NoError(err)
 
 	message := "status never updated"
-	timer := time.NewTimer(time.Second * 5)
+	timer := time.NewTimer(time.Second * 30)
 	for {
 		select {
 		case <-timer.C:
@@ -415,7 +415,7 @@ func (pc *PolicyAsCodeSuite) checkPolicyIsDeclarative(id string) {
 		if policy.GetSource() != storage.PolicySource_DECLARATIVE {
 			collect.Errorf("Policy %s was not marked as declarative in Central", id)
 		}
-	}, time.Second*5, time.Millisecond*30)
+	}, time.Second*30, time.Millisecond*200)
 }
 
 func (pc *PolicyAsCodeSuite) updateCRandObserveInCentral(k8sPolicy *v1alpha1.SecurityPolicy, id string) {
@@ -432,7 +432,7 @@ func (pc *PolicyAsCodeSuite) updateCRandObserveInCentral(k8sPolicy *v1alpha1.Sec
 		if criteriaValue != "3" {
 			collect.Errorf("Policy criteria not updated in Central. Expected 3 but got %s", criteriaValue)
 		}
-	}, time.Second*5, time.Millisecond*30)
+	}, time.Second*30, time.Millisecond*200)
 }
 
 func (pc *PolicyAsCodeSuite) deleteCRandObserveInCentral(k8sPolicy *v1alpha1.SecurityPolicy, id string) {
@@ -448,7 +448,7 @@ func (pc *PolicyAsCodeSuite) deleteCRandObserveInCentral(k8sPolicy *v1alpha1.Sec
 		} else {
 			collect.Errorf("Successfully fetched policy %s when it should be deleted", id)
 		}
-	}, time.Second*5, time.Millisecond*30, "Policy CR deletion not propogated to Central")
+	}, time.Second*30, time.Millisecond*200, "Policy CR deletion not propagated to Central")
 }
 
 func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.SecurityPolicy) string {
@@ -468,7 +468,7 @@ func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.Secu
 			}
 		}
 		assert.NotEmpty(collect, policyId)
-	}, time.Second*5, time.Millisecond*30)
+	}, time.Second*30, time.Millisecond*200)
 	return policyId
 }
 


### PR DESCRIPTION
## Description

The `TestPolicyAsCode/TestCreateCR` e2e test fails intermittently with "Condition never satisfied" because all reconciliation waits use a 5-second timeout. Under CI load, the config-controller reconciliation pipeline (K8s CR → controller informer → Central gRPC) regularly exceeds 5 seconds — CI logs show individual `ListPolicies` calls taking 8+ seconds.

Increase all reconciliation timeouts from 5s to 30s and polling intervals from 30ms to 200ms. The overall test budget is 15 minutes, so 30s per step is well within budget while being resilient to CI load spikes.

Also fixes a typo: "propogated" → "propagated".

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- The change is test-only — increases timeouts in `EventuallyWithT` and `time.NewTimer` calls
- No functional logic changed; only timing constants and a typo fix
- The failing CI run shows gRPC calls taking 8+ seconds, confirming 5-second timeouts are insufficient