### PR TITLE
Enable prealloc check in golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - ineffassign
     - modernize
     - nolintlint
+    - prealloc
     - protogetter
     - revive # replaces golint
     - rowserrcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -190,6 +190,9 @@ linters:
           - forbidigo
         path: roxctl/central/generate/interactive.go
       - linters:
+          - prealloc
+        path-except: ^(central|sensor|pkg)/
+      - linters:
           - forbidigo
           - wrapcheck
         path: _test\.go


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This enables the prealloc golang lint check in the style check in the central, sensor, and pkg directories. The prealloc lint check, checks if the capacity of slices is set in cases in which it is possible to know the final size of the slice. This issue is known to occur in directories other than those three. However, they do not have a significant impact on performance.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Ran CI without the fixing the issues and saw the following

```
central/alert/datastore/bench_postgres_test.go:102:6: Consider preallocating expected with capacity len(sevToCount) (prealloc)
	var expected []*violationsBySeverity
	    ^
central/alert/datastore/datastore_impl_test.go:414:6: Consider preallocating createdAlerts with capacity len(alertIDs) (prealloc)
	var createdAlerts []*storage.Alert
	    ^
central/alert/datastore/internal/store/postgres/bench_test.go:28:6: Consider preallocating idx with capacity len(alerts) (prealloc)
	var idx []string
	    ^
central/cloudsources/service/service_impl_postgres_test.go:480:2: Consider preallocating result with capacity len(cloudSources) (prealloc)
	result := []*v1.CloudSource{}
	^
central/cluster/datastore/datastore_impl_test.go:203:8: Consider preallocating searchResults with capacity len(tc.results) (prealloc)
			var searchResults []pkgSearch.Result
			    ^
central/cluster/datastore/datastore_impl_test.go:204:8: Consider preallocating resultIDs with capacity len(tc.results) (prealloc)
			var resultIDs []string
			    ^
central/cluster/datastore/datastore_impl_test.go:255:9: Consider preallocating alertIDs with capacity len(tc.results) (prealloc)
				var alertIDs []string
				    ^
central/cluster/datastore/datastore_impl_test.go:256:9: Consider preallocating resolvedAlerts with capacity len(tc.results) (prealloc)
				var resolvedAlerts []*storage.Alert
				    ^
central/cluster/datastore/datastore_impl_test.go:336:8: Consider preallocating listSecrets with capacity len(tc.results) (prealloc)
			var listSecrets []*storage.ListSecret
			    ^
central/compliance/datastore/util.go:13:6: Consider preallocating sources with capacity len(allResults) (prealloc)
	var sources []*storage.ComplianceAggregation_Source
	    ^
central/compliance/handlers/csv.go:102:2: Consider preallocating value with capacity 10 (prealloc)
	value := []string{
	^
central/compliance/standards/utils.go:9:6: Consider preallocating registeredStandards (prealloc)
	var registeredStandards []string
	    ^
central/complianceoperator/v2/compliancemanager/manager_impl.go:276:6: Consider preallocating profiles with capacity len(scanRequest.GetProfiles()) (prealloc)
	var profiles []string
	    ^
central/complianceoperator/v2/compliancemanager/manager_impl_test.go:851:4: Consider preallocating testProfiles with capacity len(tc.profileNames) (prealloc)
			testProfiles := make([]*storage.ComplianceOperatorProfileV2, 0)
			^
central/complianceoperator/v2/compliancemanager/manager_impl_test.go:919:4: Consider preallocating newTestProfiles with capacity len(tc.newProfileNames) (prealloc)
			newTestProfiles := make([]*storage.ComplianceOperatorProfileV2, 0)
			^
```

And much more. This CI test was run with and without excluding directories other than central, sensor, and pkg. When checking for this issue in just those three directories, only issues in those directories where reported.