### PR TITLE
ROX-34167: make compliance scan node roles configurable

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -340,7 +340,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 		// id for the request message to sensor
 		sensorRequestID := uuid.NewV4().String()
 
-		sensorMessage := buildScanConfigSensorMsg(sensorRequestID, cron, profiles, profileRefs, scanRequest.GetScanConfigName(), createScanRequest)
+		sensorMessage := buildScanConfigSensorMsg(sensorRequestID, cron, profiles, profileRefs, scanRequest.GetScanConfigName(), createScanRequest, scanRequest.GetNodeRoles())
 		err := m.sensorConnMgr.SendMessage(clusterID, sensorMessage)
 		var status string
 		if err != nil {

--- a/central/complianceoperator/v2/compliancemanager/utils.go
+++ b/central/complianceoperator/v2/compliancemanager/utils.go
@@ -2,7 +2,15 @@ package compliancemanager
 
 import "github.com/stackrox/rox/generated/internalapi/central"
 
-func buildScanConfigSensorMsg(msgID string, cron string, profiles []string, profileRefs []*central.ApplyComplianceScanConfigRequest_BaseScanSettings_ProfileReference, configName string, createConfig bool) *central.MsgToSensor {
+func buildScanConfigSensorMsg(msgID string, cron string, profiles []string, profileRefs []*central.ApplyComplianceScanConfigRequest_BaseScanSettings_ProfileReference, configName string, createConfig bool, nodeRoles []string) *central.MsgToSensor {
+	baseScanSettings := &central.ApplyComplianceScanConfigRequest_BaseScanSettings{
+		ScanName:       configName,
+		StrictNodeScan: true,
+		Profiles:       profiles,
+		ProfileRefs:    profileRefs,
+		NodeRoles:      nodeRoles,
+	}
+
 	if createConfig {
 		return &central.MsgToSensor{
 			Msg: &central.MsgToSensor_ComplianceRequest{
@@ -12,13 +20,8 @@ func buildScanConfigSensorMsg(msgID string, cron string, profiles []string, prof
 							Id: msgID,
 							ScanRequest: &central.ApplyComplianceScanConfigRequest_ScheduledScan_{
 								ScheduledScan: &central.ApplyComplianceScanConfigRequest_ScheduledScan{
-									ScanSettings: &central.ApplyComplianceScanConfigRequest_BaseScanSettings{
-										ScanName:       configName,
-										StrictNodeScan: true,
-										Profiles:       profiles,
-										ProfileRefs:    profileRefs,
-									},
-									Cron: cron,
+									ScanSettings: baseScanSettings,
+									Cron:         cron,
 								},
 							},
 						},
@@ -36,13 +39,8 @@ func buildScanConfigSensorMsg(msgID string, cron string, profiles []string, prof
 						Id: msgID,
 						ScanRequest: &central.ApplyComplianceScanConfigRequest_UpdateScan{
 							UpdateScan: &central.ApplyComplianceScanConfigRequest_UpdateScheduledScan{
-								ScanSettings: &central.ApplyComplianceScanConfigRequest_BaseScanSettings{
-									ScanName:       configName,
-									StrictNodeScan: true,
-									Profiles:       profiles,
-									ProfileRefs:    profileRefs,
-								},
-								Cron: cron,
+								ScanSettings: baseScanSettings,
+								Cron:         cron,
 							},
 						},
 					},

--- a/central/complianceoperator/v2/scanconfigurations/service/convert.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/convert.go
@@ -27,7 +27,16 @@ storage type to apiV2 type conversions
 
 const (
 	suiteComplete = "DONE"
+
+	// allNodesRole is the special Compliance Operator value that matches all nodes.
+	allNodesRole = "@all"
 )
+
+// defaultNodeRoles returns the backward-compatible default roles used when
+// the user does not specify any.
+func defaultNodeRoles() []string {
+	return []string{"master", "worker"}
+}
 
 var (
 	v2IntervalTypeToStorage = map[v2.Schedule_IntervalType]storage.Schedule_IntervalType{
@@ -95,6 +104,7 @@ func convertStorageScanConfigToV2(ctx context.Context, scanConfig *storage.Compl
 			ScanSchedule: convertProtoScheduleToV2(scanConfig.GetSchedule()),
 			Profiles:     profiles,
 			Description:  scanConfig.GetDescription(),
+			NodeRoles:    scanConfig.GetNodeRoles(),
 		},
 	}, nil
 }
@@ -173,6 +183,11 @@ func convertV2ScanConfigToStorage(ctx context.Context, scanConfig *v2.Compliance
 
 	}
 
+	nodeRoles := scanConfig.GetScanConfig().GetNodeRoles()
+	if len(nodeRoles) == 0 {
+		nodeRoles = defaultNodeRoles()
+	}
+
 	return &storage.ComplianceOperatorScanConfigurationV2{
 		Id:                     scanConfig.GetId(),
 		ScanConfigName:         scanConfig.GetScanName(),
@@ -186,6 +201,7 @@ func convertV2ScanConfigToStorage(ctx context.Context, scanConfig *v2.Compliance
 		Description:            scanConfig.GetScanConfig().GetDescription(),
 		Clusters:               clusters,
 		Notifiers:              notifiers,
+		NodeRoles:              nodeRoles,
 	}
 }
 
@@ -295,6 +311,7 @@ func convertStorageReportDataToV2ScanStatus(ctx context.Context, reportData *sto
 			ScanSchedule: convertProtoScheduleToV2(reportData.GetScanConfiguration().GetSchedule()),
 			Description:  reportData.GetScanConfiguration().GetDescription(),
 			Notifiers:    notifiers,
+			NodeRoles:    reportData.GetScanConfiguration().GetNodeRoles(),
 		},
 		ClusterStatus: func() []*v2.ClusterScanStatus {
 
@@ -424,6 +441,7 @@ func convertStorageScanConfigToV2ScanStatus(ctx context.Context,
 			Profiles:     profiles,
 			Description:  scanConfig.GetDescription(),
 			Notifiers:    notifiers,
+			NodeRoles:    scanConfig.GetNodeRoles(),
 		},
 		ModifiedBy: &v2.SlimUser{
 			Id:   scanConfig.GetModifiedBy().GetId(),

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -514,6 +514,10 @@ func (s *serviceImpl) ListComplianceScanConfigClusterProfiles(ctx context.Contex
 	}, nil
 }
 
+// nodeRoleRegexp matches the Compliance Operator validation for a single role value:
+// alphanumeric characters and hyphens, 1-39 characters.
+var nodeRoleRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]{1,39}$`)
+
 func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
 	if len(req.GetClusters()) == 0 {
 		return errors.Wrap(errox.InvalidArgs, "At least one cluster is required for a scan configuration")
@@ -525,6 +529,47 @@ func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
 
 	if len(req.GetScanConfig().GetProfiles()) == 0 {
 		return errors.Wrap(errox.InvalidArgs, "At least one profile is required for a scan configuration")
+	}
+
+	if err := validateNodeRoles(req.GetScanConfig().GetNodeRoles()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateNodeRoles validates the node roles following the Compliance Operator rules:
+// - Each role must match ^[a-zA-Z0-9-]{1,39}$ or be "@all"
+// - "@all" cannot be mixed with other roles
+// - Empty list is valid (defaults to ["master", "worker"])
+func validateNodeRoles(roles []string) error {
+	if len(roles) == 0 {
+		return nil
+	}
+
+	hasAll := false
+	seen := make(map[string]struct{}, len(roles))
+	for _, role := range roles {
+		if role == "" {
+			return errors.Wrap(errox.InvalidArgs, "Node role must not be empty")
+		}
+		if _, dup := seen[role]; dup {
+			return errors.Wrapf(errox.InvalidArgs, "Duplicate node role %q", role)
+		}
+		seen[role] = struct{}{}
+		if role == allNodesRole {
+			hasAll = true
+			continue
+		}
+		if !nodeRoleRegexp.MatchString(role) {
+			return errors.Wrapf(errox.InvalidArgs,
+				"Node role %q is invalid: must contain only alphanumeric characters and hyphens, 1-39 characters", role)
+		}
+	}
+
+	if hasAll && len(roles) > 1 {
+		return errors.Wrap(errox.InvalidArgs,
+			"The \"@all\" node role targets all nodes and cannot be combined with other roles")
 	}
 
 	return nil

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -203,6 +203,53 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	s.Require().Nil(config)
 }
 
+func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigurationNodeRoleValidation() {
+	allAccessContext := sac.WithAllAccess(context.Background())
+
+	// Valid: custom roles
+	request := getTestAPIRec()
+	request.ScanConfig.NodeRoles = []string{"infra", "control-plane"}
+	s.Require().NoError(validateScanConfiguration(request))
+
+	// Valid: @all alone
+	request = getTestAPIRec()
+	request.ScanConfig.NodeRoles = []string{"@all"}
+	s.Require().NoError(validateScanConfiguration(request))
+
+	// Valid: empty (defaults applied elsewhere)
+	request = getTestAPIRec()
+	request.ScanConfig.NodeRoles = nil
+	s.Require().NoError(validateScanConfiguration(request))
+
+	// Invalid: @all mixed with other roles
+	request = getTestAPIRec()
+	request.ScanConfig.NodeRoles = []string{"@all", "worker"}
+	_, err := s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "@all")
+
+	// Invalid: special characters
+	request = getTestAPIRec()
+	request.ScanConfig.NodeRoles = []string{"inv@lid"}
+	_, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "invalid")
+
+	// Invalid: empty string in list
+	request = getTestAPIRec()
+	request.ScanConfig.NodeRoles = []string{"master", ""}
+	_, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "empty")
+
+	// Invalid: too long
+	request = getTestAPIRec()
+	request.ScanConfig.NodeRoles = []string{"aaaaaaaaaa-bbbbbbbbbbb-cccccccccc-dddddddddd"}
+	_, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "invalid")
+}
+
 func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfiguration() {
 	allAccessContext := sac.WithAllAccess(context.Background())
 
@@ -358,6 +405,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestListComplianceScanConfigurati
 						ModifiedBy:      storageRequester,
 						Description:     "test-description",
 						Notifiers:       []*storage.NotifierConfiguration{},
+						NodeRoles:       []string{"master", "worker"},
 					},
 				}, nil).Times(1)
 
@@ -468,6 +516,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetComplianceScanConfiguratio
 						ModifiedBy:      storageRequester,
 						Description:     "test-description",
 						Notifiers:       []*storage.NotifierConfiguration{},
+						NodeRoles:       []string{"master", "worker"},
 					}, true, nil).Times(1)
 
 				s.suiteDataStore.EXPECT().GetSuites(allAccessContext, gomock.Any()).Return([]*storage.ComplianceOperatorSuiteV2{
@@ -1178,6 +1227,7 @@ func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *apiV2.Complian
 			ScanSchedule: defaultAPISchedule,
 			Description:  "test-description",
 			Notifiers:    []*v2.NotifierConfiguration{},
+			NodeRoles:    []string{"master", "worker"},
 		},
 		ClusterStatus: []*apiV2.ClusterScanStatus{
 			{
@@ -1219,6 +1269,7 @@ func getTestAPIRec() *apiV2.ComplianceScanConfiguration {
 			Profiles:     []string{"ocp4-cis"},
 			ScanSchedule: defaultAPISchedule,
 			Description:  "test-description",
+			NodeRoles:    []string{"master", "worker"},
 		},
 		Clusters: []string{fixtureconsts.Cluster1},
 	}

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -662,6 +662,7 @@ func (c *sensorConnection) getScanConfigurationMsg(ctx context.Context) (*centra
 						StrictNodeScan:         scanConfig.GetStrictNodeScan(),
 						AutoApplyRemediations:  scanConfig.GetAutoApplyRemediations(),
 						AutoUpdateRemediations: scanConfig.GetAutoUpdateRemediations(),
+						NodeRoles:              scanConfig.GetNodeRoles(),
 					},
 					Cron: cron,
 				},

--- a/generated/api/v2/compliance_scan_configuration_service.pb.go
+++ b/generated/api/v2/compliance_scan_configuration_service.pb.go
@@ -250,14 +250,19 @@ func (x *ClusterScanStatus) GetSuiteStatus() *ClusterScanStatus_SuiteStatus {
 	return nil
 }
 
-// Next available tag: 5
+// Next available tag: 7
 type BaseComplianceScanConfigurationSettings struct {
-	state         protoimpl.MessageState   `protogen:"open.v1"`
-	OneTimeScan   bool                     `protobuf:"varint,1,opt,name=one_time_scan,json=oneTimeScan,proto3" json:"one_time_scan,omitempty"`
-	Profiles      []string                 `protobuf:"bytes,2,rep,name=profiles,proto3" json:"profiles,omitempty"`
-	ScanSchedule  *Schedule                `protobuf:"bytes,3,opt,name=scan_schedule,json=scanSchedule,proto3" json:"scan_schedule,omitempty"`
-	Description   string                   `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
-	Notifiers     []*NotifierConfiguration `protobuf:"bytes,5,rep,name=notifiers,proto3" json:"notifiers,omitempty"`
+	state        protoimpl.MessageState   `protogen:"open.v1"`
+	OneTimeScan  bool                     `protobuf:"varint,1,opt,name=one_time_scan,json=oneTimeScan,proto3" json:"one_time_scan,omitempty"`
+	Profiles     []string                 `protobuf:"bytes,2,rep,name=profiles,proto3" json:"profiles,omitempty"`
+	ScanSchedule *Schedule                `protobuf:"bytes,3,opt,name=scan_schedule,json=scanSchedule,proto3" json:"scan_schedule,omitempty"`
+	Description  string                   `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
+	Notifiers    []*NotifierConfiguration `protobuf:"bytes,5,rep,name=notifiers,proto3" json:"notifiers,omitempty"`
+	// node_roles specifies which node roles the compliance scan should target.
+	// Each value maps to a Kubernetes node label "node-role.kubernetes.io/<role>".
+	// The special value "@all" targets all nodes and cannot be mixed with other roles.
+	// Defaults to ["master", "worker"] when empty.
+	NodeRoles     []string `protobuf:"bytes,6,rep,name=node_roles,json=nodeRoles,proto3" json:"node_roles,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -323,6 +328,13 @@ func (x *BaseComplianceScanConfigurationSettings) GetDescription() string {
 func (x *BaseComplianceScanConfigurationSettings) GetNotifiers() []*NotifierConfiguration {
 	if x != nil {
 		return x.Notifiers
+	}
+	return nil
+}
+
+func (x *BaseComplianceScanConfigurationSettings) GetNodeRoles() []string {
+	if x != nil {
+		return x.NodeRoles
 	}
 	return nil
 }
@@ -1274,13 +1286,15 @@ const file_api_v2_compliance_scan_configuration_service_proto_rawDesc = "" +
 	"\x05phase\x18\x01 \x01(\tR\x05phase\x12\x16\n" +
 	"\x06result\x18\x02 \x01(\tR\x06result\x12#\n" +
 	"\rerror_message\x18\x03 \x01(\tR\ferrorMessage\x12L\n" +
-	"\x14last_transition_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x12lastTransitionTime\"\xf7\x01\n" +
+	"\x14last_transition_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x12lastTransitionTime\"\x96\x02\n" +
 	"'BaseComplianceScanConfigurationSettings\x12\"\n" +
 	"\rone_time_scan\x18\x01 \x01(\bR\voneTimeScan\x12\x1a\n" +
 	"\bprofiles\x18\x02 \x03(\tR\bprofiles\x121\n" +
 	"\rscan_schedule\x18\x03 \x01(\v2\f.v2.ScheduleR\fscanSchedule\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x127\n" +
-	"\tnotifiers\x18\x05 \x03(\v2\x19.v2.NotifierConfigurationR\tnotifiers\"\xb4\x01\n" +
+	"\tnotifiers\x18\x05 \x03(\v2\x19.v2.NotifierConfigurationR\tnotifiers\x12\x1d\n" +
+	"\n" +
+	"node_roles\x18\x06 \x03(\tR\tnodeRoles\"\xb4\x01\n" +
 	"\x1bComplianceScanConfiguration\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1b\n" +
 	"\tscan_name\x18\x02 \x01(\tR\bscanName\x12L\n" +

--- a/generated/api/v2/compliance_scan_configuration_service.swagger.json
+++ b/generated/api/v2/compliance_scan_configuration_service.swagger.json
@@ -749,9 +749,16 @@
             "type": "object",
             "$ref": "#/definitions/v2NotifierConfiguration"
           }
+        },
+        "nodeRoles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "node_roles specifies which node roles the compliance scan should target.\nEach value maps to a Kubernetes node label \"node-role.kubernetes.io/<role>\".\nThe special value \"@all\" targets all nodes and cannot be mixed with other roles.\nDefaults to [\"master\", \"worker\"] when empty."
         }
       },
-      "title": "Next available tag: 5"
+      "title": "Next available tag: 7"
     },
     "v2ClusterScanStatus": {
       "type": "object",

--- a/generated/api/v2/compliance_scan_configuration_service_vtproto.pb.go
+++ b/generated/api/v2/compliance_scan_configuration_service_vtproto.pb.go
@@ -86,6 +86,11 @@ func (m *BaseComplianceScanConfigurationSettings) CloneVT() *BaseComplianceScanC
 		}
 		r.Notifiers = tmpContainer
 	}
+	if rhs := m.NodeRoles; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.NodeRoles = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -495,6 +500,15 @@ func (this *BaseComplianceScanConfigurationSettings) EqualVT(that *BaseComplianc
 			if !p.EqualVT(q) {
 				return false
 			}
+		}
+	}
+	if len(this.NodeRoles) != len(that.NodeRoles) {
+		return false
+	}
+	for i, vx := range this.NodeRoles {
+		vy := that.NodeRoles[i]
+		if vx != vy {
+			return false
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1111,6 +1125,15 @@ func (m *BaseComplianceScanConfigurationSettings) MarshalToSizedBufferVT(dAtA []
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.NodeRoles) > 0 {
+		for iNdEx := len(m.NodeRoles) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.NodeRoles[iNdEx])
+			copy(dAtA[i:], m.NodeRoles[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.NodeRoles[iNdEx])))
+			i--
+			dAtA[i] = 0x32
+		}
 	}
 	if len(m.Notifiers) > 0 {
 		for iNdEx := len(m.Notifiers) - 1; iNdEx >= 0; iNdEx-- {
@@ -2079,6 +2102,12 @@ func (m *BaseComplianceScanConfigurationSettings) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
+	if len(m.NodeRoles) > 0 {
+		for _, s := range m.NodeRoles {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2962,6 +2991,38 @@ func (m *BaseComplianceScanConfigurationSettings) UnmarshalVT(dAtA []byte) error
 			if err := m.Notifiers[len(m.Notifiers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NodeRoles = append(m.NodeRoles, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5748,6 +5809,42 @@ func (m *BaseComplianceScanConfigurationSettings) UnmarshalVTUnsafe(dAtA []byte)
 			if err := m.Notifiers[len(m.Notifiers)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.NodeRoles = append(m.NodeRoles, stringValue)
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/internalapi/central/compliance_operator.pb.go
+++ b/generated/internalapi/central/compliance_operator.pb.go
@@ -2003,7 +2003,11 @@ type ApplyComplianceScanConfigRequest_BaseScanSettings struct {
 	// profile_refs carries profile names together with their compliance operator kind.
 	// Populated by Central alongside the legacy profiles field.
 	// Sensor should prefer this field when non-empty, and fall back to profiles otherwise.
-	ProfileRefs   []*ApplyComplianceScanConfigRequest_BaseScanSettings_ProfileReference `protobuf:"bytes,8,rep,name=profile_refs,json=profileRefs,proto3" json:"profile_refs,omitempty"`
+	ProfileRefs []*ApplyComplianceScanConfigRequest_BaseScanSettings_ProfileReference `protobuf:"bytes,8,rep,name=profile_refs,json=profileRefs,proto3" json:"profile_refs,omitempty"`
+	// node_roles specifies which node roles the compliance scan should target.
+	// When empty, Sensor defaults to ["master", "worker"] for backward compatibility
+	// (handles messages from old Central versions that don't populate this field).
+	NodeRoles     []string `protobuf:"bytes,9,rep,name=node_roles,json=nodeRoles,proto3" json:"node_roles,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2090,6 +2094,13 @@ func (x *ApplyComplianceScanConfigRequest_BaseScanSettings) GetAutoUpdateRemedia
 func (x *ApplyComplianceScanConfigRequest_BaseScanSettings) GetProfileRefs() []*ApplyComplianceScanConfigRequest_BaseScanSettings_ProfileReference {
 	if x != nil {
 		return x.ProfileRefs
+	}
+	return nil
+}
+
+func (x *ApplyComplianceScanConfigRequest_BaseScanSettings) GetNodeRoles() []string {
+	if x != nil {
+		return x.NodeRoles
 	}
 	return nil
 }
@@ -2841,7 +2852,7 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\x18DisableComplianceRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"o\n" +
 	"\x1fSyncComplianceScanConfigRequest\x12L\n" +
-	"\fscan_configs\x18\x01 \x03(\v2).central.ApplyComplianceScanConfigRequestR\vscanConfigs\"\xed\f\n" +
+	"\fscan_configs\x18\x01 \x03(\v2).central.ApplyComplianceScanConfigRequestR\vscanConfigs\"\x8c\r\n" +
 	" ApplyComplianceScanConfigRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12`\n" +
 	"\x0escheduled_scan\x18\x03 \x01(\v27.central.ApplyComplianceScanConfigRequest.ScheduledScanH\x00R\rscheduledScan\x12]\n" +
@@ -2851,7 +2862,7 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\vresume_scan\x18\x06 \x01(\v2=.central.ApplyComplianceScanConfigRequest.ResumeScheduledScanH\x00R\n" +
 	"resumeScan\x12`\n" +
 	"\vupdate_scan\x18\a \x01(\v2=.central.ApplyComplianceScanConfigRequest.UpdateScheduledScanH\x00R\n" +
-	"updateScan\x1a\x98\x04\n" +
+	"updateScan\x1a\xb7\x04\n" +
 	"\x10BaseScanSettings\x12 \n" +
 	"\fdb_record_id\x18\x01 \x01(\tR\n" +
 	"dbRecordId\x12\x1b\n" +
@@ -2861,7 +2872,9 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\x10strict_node_scan\x18\x05 \x01(\bR\x0estrictNodeScan\x126\n" +
 	"\x17auto_apply_remediations\x18\x06 \x01(\bR\x15autoApplyRemediations\x128\n" +
 	"\x18auto_update_remediations\x18\a \x01(\bR\x16autoUpdateRemediations\x12n\n" +
-	"\fprofile_refs\x18\b \x03(\v2K.central.ApplyComplianceScanConfigRequest.BaseScanSettings.ProfileReferenceR\vprofileRefs\x1am\n" +
+	"\fprofile_refs\x18\b \x03(\v2K.central.ApplyComplianceScanConfigRequest.BaseScanSettings.ProfileReferenceR\vprofileRefs\x12\x1d\n" +
+	"\n" +
+	"node_roles\x18\t \x03(\tR\tnodeRoles\x1am\n" +
 	"\x10ProfileReference\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12E\n" +
 	"\x04kind\x18\x02 \x01(\x0e21.central.ComplianceOperatorProfileV2.OperatorKindR\x04kind\x1an\n" +

--- a/generated/internalapi/central/compliance_operator_vtproto.pb.go
+++ b/generated/internalapi/central/compliance_operator_vtproto.pb.go
@@ -168,6 +168,11 @@ func (m *ApplyComplianceScanConfigRequest_BaseScanSettings) CloneVT() *ApplyComp
 		}
 		r.ProfileRefs = tmpContainer
 	}
+	if rhs := m.NodeRoles; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.NodeRoles = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1214,6 +1219,15 @@ func (this *ApplyComplianceScanConfigRequest_BaseScanSettings) EqualVT(that *App
 			if !p.EqualVT(q) {
 				return false
 			}
+		}
+	}
+	if len(this.NodeRoles) != len(that.NodeRoles) {
+		return false
+	}
+	for i, vx := range this.NodeRoles {
+		vy := that.NodeRoles[i]
+		if vx != vy {
+			return false
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2908,6 +2922,15 @@ func (m *ApplyComplianceScanConfigRequest_BaseScanSettings) MarshalToSizedBuffer
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.NodeRoles) > 0 {
+		for iNdEx := len(m.NodeRoles) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.NodeRoles[iNdEx])
+			copy(dAtA[i:], m.NodeRoles[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.NodeRoles[iNdEx])))
+			i--
+			dAtA[i] = 0x4a
+		}
 	}
 	if len(m.ProfileRefs) > 0 {
 		for iNdEx := len(m.ProfileRefs) - 1; iNdEx >= 0; iNdEx-- {
@@ -5312,6 +5335,12 @@ func (m *ApplyComplianceScanConfigRequest_BaseScanSettings) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
+	if len(m.NodeRoles) > 0 {
+		for _, s := range m.NodeRoles {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -7081,6 +7110,38 @@ func (m *ApplyComplianceScanConfigRequest_BaseScanSettings) UnmarshalVT(dAtA []b
 			if err := m.ProfileRefs[len(m.ProfileRefs)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NodeRoles = append(m.NodeRoles, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -14095,6 +14156,42 @@ func (m *ApplyComplianceScanConfigRequest_BaseScanSettings) UnmarshalVTUnsafe(dA
 			if err := m.ProfileRefs[len(m.ProfileRefs)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.NodeRoles = append(m.NodeRoles, stringValue)
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/storage/compliance_operator_v2.pb.go
+++ b/generated/storage/compliance_operator_v2.pb.go
@@ -962,7 +962,7 @@ func (x *RuleControls) GetControl() string {
 	return ""
 }
 
-// Next Tag: 19
+// Next Tag: 20
 type ComplianceOperatorScanConfigurationV2 struct {
 	state                  protoimpl.MessageState                               `protogen:"open.v1"`
 	Id                     string                                               `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Compliance Scan Config ID,hidden" sql:"pk,type(uuid)"`                                                 // @gotags: search:"Compliance Scan Config ID,hidden" sql:"pk,type(uuid)"
@@ -977,7 +977,6 @@ type ComplianceOperatorScanConfigurationV2 struct {
 	// Stored in the serialized blob only (not indexed); populated on create/update so the
 	// startup sync path can forward correct kinds to Sensor on reconnect.
 	ProfileRefs []*ComplianceOperatorScanConfigurationV2_ProfileReference `protobuf:"bytes,18,rep,name=profile_refs,json=profileRefs,proto3" json:"profile_refs,omitempty"`
-	NodeRoles   []NodeRole                                                `protobuf:"varint,9,rep,packed,name=node_roles,json=nodeRoles,proto3,enum=storage.NodeRole" json:"node_roles,omitempty"`
 	// Will be configurable via env var
 	StrictNodeScan bool `protobuf:"varint,10,opt,name=strict_node_scan,json=strictNodeScan,proto3" json:"strict_node_scan,omitempty"`
 	// Starting point for schedule will probably have to build upon it
@@ -985,10 +984,15 @@ type ComplianceOperatorScanConfigurationV2 struct {
 	CreatedTime     *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=created_time,json=createdTime,proto3" json:"created_time,omitempty"`
 	LastUpdatedTime *timestamppb.Timestamp `protobuf:"bytes,13,opt,name=last_updated_time,json=lastUpdatedTime,proto3" json:"last_updated_time,omitempty"`
 	// Most recent user to update the scan configurations
-	ModifiedBy    *SlimUser                                        `protobuf:"bytes,14,opt,name=modified_by,json=modifiedBy,proto3" json:"modified_by,omitempty" sql:"ignore_labels(User ID)"` // @gotags: sql:"ignore_labels(User ID)"
-	Description   string                                           `protobuf:"bytes,15,opt,name=description,proto3" json:"description,omitempty"`
-	Clusters      []*ComplianceOperatorScanConfigurationV2_Cluster `protobuf:"bytes,16,rep,name=clusters,proto3" json:"clusters,omitempty"`
-	Notifiers     []*NotifierConfiguration                         `protobuf:"bytes,17,rep,name=notifiers,proto3" json:"notifiers,omitempty"`
+	ModifiedBy  *SlimUser                                        `protobuf:"bytes,14,opt,name=modified_by,json=modifiedBy,proto3" json:"modified_by,omitempty" sql:"ignore_labels(User ID)"` // @gotags: sql:"ignore_labels(User ID)"
+	Description string                                           `protobuf:"bytes,15,opt,name=description,proto3" json:"description,omitempty"`
+	Clusters    []*ComplianceOperatorScanConfigurationV2_Cluster `protobuf:"bytes,16,rep,name=clusters,proto3" json:"clusters,omitempty"`
+	Notifiers   []*NotifierConfiguration                         `protobuf:"bytes,17,rep,name=notifiers,proto3" json:"notifiers,omitempty"`
+	// node_roles specifies which node roles the compliance scan should target.
+	// Each value must match the Compliance Operator validation: alphanumeric + hyphens,
+	// 1-39 chars, or the special value "@all" (which cannot be mixed with other roles).
+	// Defaults to ["master", "worker"] for backward compatibility when empty.
+	NodeRoles     []string `protobuf:"bytes,19,rep,name=node_roles,json=nodeRoles,proto3" json:"node_roles,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1086,13 +1090,6 @@ func (x *ComplianceOperatorScanConfigurationV2) GetProfileRefs() []*ComplianceOp
 	return nil
 }
 
-func (x *ComplianceOperatorScanConfigurationV2) GetNodeRoles() []NodeRole {
-	if x != nil {
-		return x.NodeRoles
-	}
-	return nil
-}
-
 func (x *ComplianceOperatorScanConfigurationV2) GetStrictNodeScan() bool {
 	if x != nil {
 		return x.StrictNodeScan
@@ -1145,6 +1142,13 @@ func (x *ComplianceOperatorScanConfigurationV2) GetClusters() []*ComplianceOpera
 func (x *ComplianceOperatorScanConfigurationV2) GetNotifiers() []*NotifierConfiguration {
 	if x != nil {
 		return x.Notifiers
+	}
+	return nil
+}
+
+func (x *ComplianceOperatorScanConfigurationV2) GetNodeRoles() []string {
+	if x != nil {
+		return x.NodeRoles
 	}
 	return nil
 }
@@ -3089,7 +3093,7 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\fRuleControls\x12\x1a\n" +
 	"\bstandard\x18\x01 \x01(\tR\bstandard\x12\x1e\n" +
 	"\bcontrols\x18\x02 \x03(\tB\x02\x18\x01R\bcontrols\x12\x18\n" +
-	"\acontrol\x18\x03 \x01(\tR\acontrol\"\xaa\v\n" +
+	"\acontrol\x18\x03 \x01(\tR\acontrol\"\x9d\v\n" +
 	"%ComplianceOperatorScanConfigurationV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12(\n" +
 	"\x10scan_config_name\x18\x02 \x01(\tR\x0escanConfigName\x126\n" +
@@ -3099,9 +3103,7 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\x06labels\x18\x06 \x03(\v2:.storage.ComplianceOperatorScanConfigurationV2.LabelsEntryR\x06labels\x12a\n" +
 	"\vannotations\x18\a \x03(\v2?.storage.ComplianceOperatorScanConfigurationV2.AnnotationsEntryR\vannotations\x12V\n" +
 	"\bprofiles\x18\b \x03(\v2:.storage.ComplianceOperatorScanConfigurationV2.ProfileNameR\bprofiles\x12b\n" +
-	"\fprofile_refs\x18\x12 \x03(\v2?.storage.ComplianceOperatorScanConfigurationV2.ProfileReferenceR\vprofileRefs\x120\n" +
-	"\n" +
-	"node_roles\x18\t \x03(\x0e2\x11.storage.NodeRoleR\tnodeRoles\x12(\n" +
+	"\fprofile_refs\x18\x12 \x03(\v2?.storage.ComplianceOperatorScanConfigurationV2.ProfileReferenceR\vprofileRefs\x12(\n" +
 	"\x10strict_node_scan\x18\n" +
 	" \x01(\bR\x0estrictNodeScan\x12-\n" +
 	"\bschedule\x18\v \x01(\v2\x11.storage.ScheduleR\bschedule\x12=\n" +
@@ -3111,7 +3113,9 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"modifiedBy\x12 \n" +
 	"\vdescription\x18\x0f \x01(\tR\vdescription\x12R\n" +
 	"\bclusters\x18\x10 \x03(\v26.storage.ComplianceOperatorScanConfigurationV2.ClusterR\bclusters\x12<\n" +
-	"\tnotifiers\x18\x11 \x03(\v2\x1e.storage.NotifierConfigurationR\tnotifiers\x1a9\n" +
+	"\tnotifiers\x18\x11 \x03(\v2\x1e.storage.NotifierConfigurationR\tnotifiers\x12\x1d\n" +
+	"\n" +
+	"node_roles\x18\x13 \x03(\tR\tnodeRoles\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
@@ -3125,7 +3129,8 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\x04kind\x18\x02 \x01(\x0e21.storage.ComplianceOperatorProfileV2.OperatorKindR\x04kind\x1a(\n" +
 	"\aCluster\x12\x1d\n" +
 	"\n" +
-	"cluster_id\x18\x01 \x01(\tR\tclusterId\"\x83\x02\n" +
+	"cluster_id\x18\x01 \x01(\tR\tclusterIdJ\x04\b\t\x10\n" +
+	"\"\x83\x02\n" +
 	")ComplianceOperatorClusterScanConfigStatus\x12\x0e\n" +
 	"\x02id\x18\x06 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -3426,58 +3431,57 @@ var file_storage_compliance_operator_v2_proto_depIdxs = []int32{
 	34, // 11: storage.ComplianceOperatorScanConfigurationV2.annotations:type_name -> storage.ComplianceOperatorScanConfigurationV2.AnnotationsEntry
 	35, // 12: storage.ComplianceOperatorScanConfigurationV2.profiles:type_name -> storage.ComplianceOperatorScanConfigurationV2.ProfileName
 	36, // 13: storage.ComplianceOperatorScanConfigurationV2.profile_refs:type_name -> storage.ComplianceOperatorScanConfigurationV2.ProfileReference
-	0,  // 14: storage.ComplianceOperatorScanConfigurationV2.node_roles:type_name -> storage.NodeRole
-	49, // 15: storage.ComplianceOperatorScanConfigurationV2.schedule:type_name -> storage.Schedule
-	50, // 16: storage.ComplianceOperatorScanConfigurationV2.created_time:type_name -> google.protobuf.Timestamp
-	50, // 17: storage.ComplianceOperatorScanConfigurationV2.last_updated_time:type_name -> google.protobuf.Timestamp
-	51, // 18: storage.ComplianceOperatorScanConfigurationV2.modified_by:type_name -> storage.SlimUser
-	37, // 19: storage.ComplianceOperatorScanConfigurationV2.clusters:type_name -> storage.ComplianceOperatorScanConfigurationV2.Cluster
-	52, // 20: storage.ComplianceOperatorScanConfigurationV2.notifiers:type_name -> storage.NotifierConfiguration
-	50, // 21: storage.ComplianceOperatorClusterScanConfigStatus.last_updated_time:type_name -> google.protobuf.Timestamp
-	38, // 22: storage.ComplianceOperatorBenchmarkV2.profiles:type_name -> storage.ComplianceOperatorBenchmarkV2.Profile
-	5,  // 23: storage.ComplianceOperatorCheckResultV2.status:type_name -> storage.ComplianceOperatorCheckResultV2.CheckStatus
-	2,  // 24: storage.ComplianceOperatorCheckResultV2.severity:type_name -> storage.RuleSeverity
-	39, // 25: storage.ComplianceOperatorCheckResultV2.labels:type_name -> storage.ComplianceOperatorCheckResultV2.LabelsEntry
-	40, // 26: storage.ComplianceOperatorCheckResultV2.annotations:type_name -> storage.ComplianceOperatorCheckResultV2.AnnotationsEntry
-	50, // 27: storage.ComplianceOperatorCheckResultV2.created_time:type_name -> google.protobuf.Timestamp
-	50, // 28: storage.ComplianceOperatorCheckResultV2.last_started_time:type_name -> google.protobuf.Timestamp
-	9,  // 29: storage.ComplianceOperatorScanV2.profile:type_name -> storage.ProfileShim
-	41, // 30: storage.ComplianceOperatorScanV2.labels:type_name -> storage.ComplianceOperatorScanV2.LabelsEntry
-	42, // 31: storage.ComplianceOperatorScanV2.annotations:type_name -> storage.ComplianceOperatorScanV2.AnnotationsEntry
-	1,  // 32: storage.ComplianceOperatorScanV2.scan_type:type_name -> storage.ScanType
-	0,  // 33: storage.ComplianceOperatorScanV2.node_selector:type_name -> storage.NodeRole
-	17, // 34: storage.ComplianceOperatorScanV2.status:type_name -> storage.ScanStatus
-	50, // 35: storage.ComplianceOperatorScanV2.created_time:type_name -> google.protobuf.Timestamp
-	50, // 36: storage.ComplianceOperatorScanV2.last_executed_time:type_name -> google.protobuf.Timestamp
-	50, // 37: storage.ComplianceOperatorScanV2.last_started_time:type_name -> google.protobuf.Timestamp
-	43, // 38: storage.ComplianceOperatorScanSettingBindingV2.labels:type_name -> storage.ComplianceOperatorScanSettingBindingV2.LabelsEntry
-	44, // 39: storage.ComplianceOperatorScanSettingBindingV2.annotations:type_name -> storage.ComplianceOperatorScanSettingBindingV2.AnnotationsEntry
-	21, // 40: storage.ComplianceOperatorScanSettingBindingV2.status:type_name -> storage.ComplianceOperatorStatus
-	50, // 41: storage.ComplianceOperatorCondition.last_transition_time:type_name -> google.protobuf.Timestamp
-	20, // 42: storage.ComplianceOperatorStatus.conditions:type_name -> storage.ComplianceOperatorCondition
-	21, // 43: storage.ComplianceOperatorSuiteV2.status:type_name -> storage.ComplianceOperatorStatus
-	26, // 44: storage.ComplianceOperatorReportSnapshotV2.report_status:type_name -> storage.ComplianceOperatorReportStatus
-	51, // 45: storage.ComplianceOperatorReportSnapshotV2.user:type_name -> storage.SlimUser
-	45, // 46: storage.ComplianceOperatorReportSnapshotV2.scans:type_name -> storage.ComplianceOperatorReportSnapshotV2.Scan
-	25, // 47: storage.ComplianceOperatorReportSnapshotV2.report_data:type_name -> storage.ComplianceOperatorReportData
-	46, // 48: storage.ComplianceOperatorReportSnapshotV2.failed_clusters:type_name -> storage.ComplianceOperatorReportSnapshotV2.FailedCluster
-	13, // 49: storage.ComplianceOperatorReportData.scan_configuration:type_name -> storage.ComplianceOperatorScanConfigurationV2
-	48, // 50: storage.ComplianceOperatorReportData.cluster_status:type_name -> storage.ComplianceOperatorReportData.ClusterStatus
-	50, // 51: storage.ComplianceOperatorReportData.last_executed_time:type_name -> google.protobuf.Timestamp
-	6,  // 52: storage.ComplianceOperatorReportStatus.run_state:type_name -> storage.ComplianceOperatorReportStatus.RunState
-	50, // 53: storage.ComplianceOperatorReportStatus.started_at:type_name -> google.protobuf.Timestamp
-	50, // 54: storage.ComplianceOperatorReportStatus.completed_at:type_name -> google.protobuf.Timestamp
-	8,  // 55: storage.ComplianceOperatorReportStatus.report_request_type:type_name -> storage.ComplianceOperatorReportStatus.RunMethod
-	7,  // 56: storage.ComplianceOperatorReportStatus.report_notification_method:type_name -> storage.ComplianceOperatorReportStatus.NotificationMethod
-	3,  // 57: storage.ComplianceOperatorScanConfigurationV2.ProfileReference.kind:type_name -> storage.ComplianceOperatorProfileV2.OperatorKind
-	50, // 58: storage.ComplianceOperatorReportSnapshotV2.Scan.last_started_time:type_name -> google.protobuf.Timestamp
-	50, // 59: storage.ComplianceOperatorReportData.SuiteStatus.last_transition_time:type_name -> google.protobuf.Timestamp
-	47, // 60: storage.ComplianceOperatorReportData.ClusterStatus.suite_status:type_name -> storage.ComplianceOperatorReportData.SuiteStatus
-	61, // [61:61] is the sub-list for method output_type
-	61, // [61:61] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	49, // 14: storage.ComplianceOperatorScanConfigurationV2.schedule:type_name -> storage.Schedule
+	50, // 15: storage.ComplianceOperatorScanConfigurationV2.created_time:type_name -> google.protobuf.Timestamp
+	50, // 16: storage.ComplianceOperatorScanConfigurationV2.last_updated_time:type_name -> google.protobuf.Timestamp
+	51, // 17: storage.ComplianceOperatorScanConfigurationV2.modified_by:type_name -> storage.SlimUser
+	37, // 18: storage.ComplianceOperatorScanConfigurationV2.clusters:type_name -> storage.ComplianceOperatorScanConfigurationV2.Cluster
+	52, // 19: storage.ComplianceOperatorScanConfigurationV2.notifiers:type_name -> storage.NotifierConfiguration
+	50, // 20: storage.ComplianceOperatorClusterScanConfigStatus.last_updated_time:type_name -> google.protobuf.Timestamp
+	38, // 21: storage.ComplianceOperatorBenchmarkV2.profiles:type_name -> storage.ComplianceOperatorBenchmarkV2.Profile
+	5,  // 22: storage.ComplianceOperatorCheckResultV2.status:type_name -> storage.ComplianceOperatorCheckResultV2.CheckStatus
+	2,  // 23: storage.ComplianceOperatorCheckResultV2.severity:type_name -> storage.RuleSeverity
+	39, // 24: storage.ComplianceOperatorCheckResultV2.labels:type_name -> storage.ComplianceOperatorCheckResultV2.LabelsEntry
+	40, // 25: storage.ComplianceOperatorCheckResultV2.annotations:type_name -> storage.ComplianceOperatorCheckResultV2.AnnotationsEntry
+	50, // 26: storage.ComplianceOperatorCheckResultV2.created_time:type_name -> google.protobuf.Timestamp
+	50, // 27: storage.ComplianceOperatorCheckResultV2.last_started_time:type_name -> google.protobuf.Timestamp
+	9,  // 28: storage.ComplianceOperatorScanV2.profile:type_name -> storage.ProfileShim
+	41, // 29: storage.ComplianceOperatorScanV2.labels:type_name -> storage.ComplianceOperatorScanV2.LabelsEntry
+	42, // 30: storage.ComplianceOperatorScanV2.annotations:type_name -> storage.ComplianceOperatorScanV2.AnnotationsEntry
+	1,  // 31: storage.ComplianceOperatorScanV2.scan_type:type_name -> storage.ScanType
+	0,  // 32: storage.ComplianceOperatorScanV2.node_selector:type_name -> storage.NodeRole
+	17, // 33: storage.ComplianceOperatorScanV2.status:type_name -> storage.ScanStatus
+	50, // 34: storage.ComplianceOperatorScanV2.created_time:type_name -> google.protobuf.Timestamp
+	50, // 35: storage.ComplianceOperatorScanV2.last_executed_time:type_name -> google.protobuf.Timestamp
+	50, // 36: storage.ComplianceOperatorScanV2.last_started_time:type_name -> google.protobuf.Timestamp
+	43, // 37: storage.ComplianceOperatorScanSettingBindingV2.labels:type_name -> storage.ComplianceOperatorScanSettingBindingV2.LabelsEntry
+	44, // 38: storage.ComplianceOperatorScanSettingBindingV2.annotations:type_name -> storage.ComplianceOperatorScanSettingBindingV2.AnnotationsEntry
+	21, // 39: storage.ComplianceOperatorScanSettingBindingV2.status:type_name -> storage.ComplianceOperatorStatus
+	50, // 40: storage.ComplianceOperatorCondition.last_transition_time:type_name -> google.protobuf.Timestamp
+	20, // 41: storage.ComplianceOperatorStatus.conditions:type_name -> storage.ComplianceOperatorCondition
+	21, // 42: storage.ComplianceOperatorSuiteV2.status:type_name -> storage.ComplianceOperatorStatus
+	26, // 43: storage.ComplianceOperatorReportSnapshotV2.report_status:type_name -> storage.ComplianceOperatorReportStatus
+	51, // 44: storage.ComplianceOperatorReportSnapshotV2.user:type_name -> storage.SlimUser
+	45, // 45: storage.ComplianceOperatorReportSnapshotV2.scans:type_name -> storage.ComplianceOperatorReportSnapshotV2.Scan
+	25, // 46: storage.ComplianceOperatorReportSnapshotV2.report_data:type_name -> storage.ComplianceOperatorReportData
+	46, // 47: storage.ComplianceOperatorReportSnapshotV2.failed_clusters:type_name -> storage.ComplianceOperatorReportSnapshotV2.FailedCluster
+	13, // 48: storage.ComplianceOperatorReportData.scan_configuration:type_name -> storage.ComplianceOperatorScanConfigurationV2
+	48, // 49: storage.ComplianceOperatorReportData.cluster_status:type_name -> storage.ComplianceOperatorReportData.ClusterStatus
+	50, // 50: storage.ComplianceOperatorReportData.last_executed_time:type_name -> google.protobuf.Timestamp
+	6,  // 51: storage.ComplianceOperatorReportStatus.run_state:type_name -> storage.ComplianceOperatorReportStatus.RunState
+	50, // 52: storage.ComplianceOperatorReportStatus.started_at:type_name -> google.protobuf.Timestamp
+	50, // 53: storage.ComplianceOperatorReportStatus.completed_at:type_name -> google.protobuf.Timestamp
+	8,  // 54: storage.ComplianceOperatorReportStatus.report_request_type:type_name -> storage.ComplianceOperatorReportStatus.RunMethod
+	7,  // 55: storage.ComplianceOperatorReportStatus.report_notification_method:type_name -> storage.ComplianceOperatorReportStatus.NotificationMethod
+	3,  // 56: storage.ComplianceOperatorScanConfigurationV2.ProfileReference.kind:type_name -> storage.ComplianceOperatorProfileV2.OperatorKind
+	50, // 57: storage.ComplianceOperatorReportSnapshotV2.Scan.last_started_time:type_name -> google.protobuf.Timestamp
+	50, // 58: storage.ComplianceOperatorReportData.SuiteStatus.last_transition_time:type_name -> google.protobuf.Timestamp
+	47, // 59: storage.ComplianceOperatorReportData.ClusterStatus.suite_status:type_name -> storage.ComplianceOperatorReportData.SuiteStatus
+	60, // [60:60] is the sub-list for method output_type
+	60, // [60:60] is the sub-list for method input_type
+	60, // [60:60] is the sub-list for extension type_name
+	60, // [60:60] is the sub-list for extension extendee
+	0,  // [0:60] is the sub-list for field type_name
 }
 
 func init() { file_storage_compliance_operator_v2_proto_init() }

--- a/generated/storage/compliance_operator_v2_vtproto.pb.go
+++ b/generated/storage/compliance_operator_v2_vtproto.pb.go
@@ -306,11 +306,6 @@ func (m *ComplianceOperatorScanConfigurationV2) CloneVT() *ComplianceOperatorSca
 		}
 		r.ProfileRefs = tmpContainer
 	}
-	if rhs := m.NodeRoles; rhs != nil {
-		tmpContainer := make([]NodeRole, len(rhs))
-		copy(tmpContainer, rhs)
-		r.NodeRoles = tmpContainer
-	}
 	if rhs := m.Clusters; rhs != nil {
 		tmpContainer := make([]*ComplianceOperatorScanConfigurationV2_Cluster, len(rhs))
 		for k, v := range rhs {
@@ -324,6 +319,11 @@ func (m *ComplianceOperatorScanConfigurationV2) CloneVT() *ComplianceOperatorSca
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Notifiers = tmpContainer
+	}
+	if rhs := m.NodeRoles; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.NodeRoles = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -1269,15 +1269,6 @@ func (this *ComplianceOperatorScanConfigurationV2) EqualVT(that *ComplianceOpera
 			}
 		}
 	}
-	if len(this.NodeRoles) != len(that.NodeRoles) {
-		return false
-	}
-	for i, vx := range this.NodeRoles {
-		vy := that.NodeRoles[i]
-		if vx != vy {
-			return false
-		}
-	}
 	if this.StrictNodeScan != that.StrictNodeScan {
 		return false
 	}
@@ -1345,6 +1336,15 @@ func (this *ComplianceOperatorScanConfigurationV2) EqualVT(that *ComplianceOpera
 			if !p.EqualVT(q) {
 				return false
 			}
+		}
+	}
+	if len(this.NodeRoles) != len(that.NodeRoles) {
+		return false
+	}
+	for i, vx := range this.NodeRoles {
+		vy := that.NodeRoles[i]
+		if vx != vy {
+			return false
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2878,6 +2878,17 @@ func (m *ComplianceOperatorScanConfigurationV2) MarshalToSizedBufferVT(dAtA []by
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.NodeRoles) > 0 {
+		for iNdEx := len(m.NodeRoles) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.NodeRoles[iNdEx])
+			copy(dAtA[i:], m.NodeRoles[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.NodeRoles[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
 	if len(m.ProfileRefs) > 0 {
 		for iNdEx := len(m.ProfileRefs) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.ProfileRefs[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -2976,27 +2987,6 @@ func (m *ComplianceOperatorScanConfigurationV2) MarshalToSizedBufferVT(dAtA []by
 		}
 		i--
 		dAtA[i] = 0x50
-	}
-	if len(m.NodeRoles) > 0 {
-		var pksize2 int
-		for _, num := range m.NodeRoles {
-			pksize2 += protohelpers.SizeOfVarint(uint64(num))
-		}
-		i -= pksize2
-		j1 := i
-		for _, num1 := range m.NodeRoles {
-			num := uint64(num1)
-			for num >= 1<<7 {
-				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
-				num >>= 7
-				j1++
-			}
-			dAtA[j1] = uint8(num)
-			j1++
-		}
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
-		i--
-		dAtA[i] = 0x4a
 	}
 	if len(m.Profiles) > 0 {
 		for iNdEx := len(m.Profiles) - 1; iNdEx >= 0; iNdEx-- {
@@ -5026,13 +5016,6 @@ func (m *ComplianceOperatorScanConfigurationV2) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
-	if len(m.NodeRoles) > 0 {
-		l = 0
-		for _, e := range m.NodeRoles {
-			l += protohelpers.SizeOfVarint(uint64(e))
-		}
-		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
-	}
 	if m.StrictNodeScan {
 		n += 2
 	}
@@ -5071,6 +5054,12 @@ func (m *ComplianceOperatorScanConfigurationV2) SizeVT() (n int) {
 	if len(m.ProfileRefs) > 0 {
 		for _, e := range m.ProfileRefs {
 			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.NodeRoles) > 0 {
+		for _, s := range m.NodeRoles {
+			l = len(s)
 			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
@@ -8472,75 +8461,6 @@ func (m *ComplianceOperatorScanConfigurationV2) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 9:
-			if wireType == 0 {
-				var v NodeRole
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= NodeRole(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.NodeRoles = append(m.NodeRoles, v)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.NodeRoles) == 0 {
-					m.NodeRoles = make([]NodeRole, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v NodeRole
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= NodeRole(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.NodeRoles = append(m.NodeRoles, v)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
-			}
 		case 10:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field StrictNodeScan", wireType)
@@ -8838,6 +8758,38 @@ func (m *ComplianceOperatorScanConfigurationV2) UnmarshalVT(dAtA []byte) error {
 			if err := m.ProfileRefs[len(m.ProfileRefs)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NodeRoles = append(m.NodeRoles, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -16986,75 +16938,6 @@ func (m *ComplianceOperatorScanConfigurationV2) UnmarshalVTUnsafe(dAtA []byte) e
 				return err
 			}
 			iNdEx = postIndex
-		case 9:
-			if wireType == 0 {
-				var v NodeRole
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					v |= NodeRole(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				m.NodeRoles = append(m.NodeRoles, v)
-			} else if wireType == 2 {
-				var packedLen int
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return protohelpers.ErrIntOverflow
-					}
-					if iNdEx >= l {
-						return io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					packedLen |= int(b&0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				if packedLen < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				postIndex := iNdEx + packedLen
-				if postIndex < 0 {
-					return protohelpers.ErrInvalidLength
-				}
-				if postIndex > l {
-					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.NodeRoles) == 0 {
-					m.NodeRoles = make([]NodeRole, 0, elementCount)
-				}
-				for iNdEx < postIndex {
-					var v NodeRole
-					for shift := uint(0); ; shift += 7 {
-						if shift >= 64 {
-							return protohelpers.ErrIntOverflow
-						}
-						if iNdEx >= l {
-							return io.ErrUnexpectedEOF
-						}
-						b := dAtA[iNdEx]
-						iNdEx++
-						v |= NodeRole(b&0x7F) << shift
-						if b < 0x80 {
-							break
-						}
-					}
-					m.NodeRoles = append(m.NodeRoles, v)
-				}
-			} else {
-				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
-			}
 		case 10:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field StrictNodeScan", wireType)
@@ -17356,6 +17239,42 @@ func (m *ComplianceOperatorScanConfigurationV2) UnmarshalVTUnsafe(dAtA []byte) e
 			if err := m.ProfileRefs[len(m.ProfileRefs)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeRoles", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.NodeRoles = append(m.NodeRoles, stringValue)
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/api/v2/compliance_scan_configuration_service.proto
+++ b/proto/api/v2/compliance_scan_configuration_service.proto
@@ -32,13 +32,18 @@ message ClusterScanStatus {
   SuiteStatus suite_status = 4;
 }
 
-// Next available tag: 5
+// Next available tag: 7
 message BaseComplianceScanConfigurationSettings {
   bool one_time_scan = 1;
   repeated string profiles = 2;
   Schedule scan_schedule = 3;
   string description = 4;
   repeated NotifierConfiguration notifiers = 5;
+  // node_roles specifies which node roles the compliance scan should target.
+  // Each value maps to a Kubernetes node label "node-role.kubernetes.io/<role>".
+  // The special value "@all" targets all nodes and cannot be mixed with other roles.
+  // Defaults to ["master", "worker"] when empty.
+  repeated string node_roles = 6;
 }
 
 // Next available tag: 5

--- a/proto/internalapi/central/compliance_operator.proto
+++ b/proto/internalapi/central/compliance_operator.proto
@@ -60,6 +60,11 @@ message ApplyComplianceScanConfigRequest {
     // Populated by Central alongside the legacy profiles field.
     // Sensor should prefer this field when non-empty, and fall back to profiles otherwise.
     repeated ProfileReference profile_refs = 8;
+
+    // node_roles specifies which node roles the compliance scan should target.
+    // When empty, Sensor defaults to ["master", "worker"] for backward compatibility
+    // (handles messages from old Central versions that don't populate this field).
+    repeated string node_roles = 9;
   }
 
   message OneTimeScan {

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -109,7 +109,7 @@ message RuleControls {
   string control = 3; // @gotags: search:"Compliance Control,hidden"
 }
 
-// Next Tag: 19
+// Next Tag: 20
 message ComplianceOperatorScanConfigurationV2 {
   string id = 1; // @gotags: search:"Compliance Scan Config ID,hidden" sql:"pk,type(uuid)"
   string scan_config_name = 2; // @gotags: search:"Compliance Scan Config Name" sql:"unique"
@@ -133,7 +133,7 @@ message ComplianceOperatorScanConfigurationV2 {
   // Stored in the serialized blob only (not indexed); populated on create/update so the
   // startup sync path can forward correct kinds to Sensor on reconnect.
   repeated ProfileReference profile_refs = 18;
-  repeated NodeRole node_roles = 9;
+  reserved 9; // was repeated NodeRole node_roles, never populated
   // Will be configurable via env var
   bool strict_node_scan = 10;
   // Starting point for schedule will probably have to build upon it
@@ -148,6 +148,11 @@ message ComplianceOperatorScanConfigurationV2 {
   }
   repeated Cluster clusters = 16;
   repeated NotifierConfiguration notifiers = 17;
+  // node_roles specifies which node roles the compliance scan should target.
+  // Each value must match the Compliance Operator validation: alphanumeric + hyphens,
+  // 1-39 chars, or the special value "@all" (which cannot be mixed with other roles).
+  // Defaults to ["master", "worker"] for backward compatibility when empty.
+  repeated string node_roles = 19;
 }
 
 // Next Tag: 7

--- a/sensor/kubernetes/complianceoperator/types.go
+++ b/sensor/kubernetes/complianceoperator/types.go
@@ -7,10 +7,14 @@ import (
 )
 
 const (
-	masterRole       = "master"
-	workerRole       = "worker"
 	rescanAnnotation = v1alpha1.ComplianceScanRescanAnnotation
 )
+
+// defaultNodeRoles returns the backward-compatible default roles used when
+// Central does not specify any (e.g. old Central version).
+func defaultNodeRoles() []string {
+	return []string{"master", "worker"}
+}
 
 var (
 	defaultScanSettingName = "default-" + branding.GetProductNameShort()

--- a/sensor/kubernetes/complianceoperator/utils.go
+++ b/sensor/kubernetes/complianceoperator/utils.go
@@ -102,6 +102,14 @@ func validateScanName(req scanNameGetter) error {
 	return nil
 }
 
+func nodeRolesFromRequest(request *central.ApplyComplianceScanConfigRequest_BaseScanSettings) []string {
+	roles := request.GetNodeRoles()
+	if len(roles) == 0 {
+		return defaultNodeRoles()
+	}
+	return roles
+}
+
 func convertCentralRequestToScanSetting(namespace string, request *central.ApplyComplianceScanConfigRequest_BaseScanSettings, cron string) runtime.Object {
 	return &v1alpha1.ScanSetting{
 		TypeMeta: v1.TypeMeta{
@@ -114,7 +122,7 @@ func convertCentralRequestToScanSetting(namespace string, request *central.Apply
 			Labels:      utils.GetSensorKubernetesLabels(),
 			Annotations: utils.GetSensorKubernetesAnnotations(),
 		},
-		Roles: []string{masterRole, workerRole},
+		Roles: nodeRolesFromRequest(request),
 		ComplianceSuiteSettings: v1alpha1.ComplianceSuiteSettings{
 			AutoApplyRemediations:  false,
 			AutoUpdateRemediations: false,
@@ -153,8 +161,7 @@ func convertCentralRequestToScanSettingBinding(namespace string, request *centra
 }
 
 func updateScanSettingFromCentralRequest(scanSetting *v1alpha1.ScanSetting, request *central.ApplyComplianceScanConfigRequest_UpdateScheduledScan) *v1alpha1.ScanSetting {
-	// TODO:  Update additional fields as ACS capability expands
-	scanSetting.Roles = []string{masterRole, workerRole}
+	scanSetting.Roles = nodeRolesFromRequest(request.GetScanSettings())
 	scanSetting.ComplianceSuiteSettings = v1alpha1.ComplianceSuiteSettings{
 		AutoApplyRemediations:  false,
 		AutoUpdateRemediations: false,

--- a/sensor/kubernetes/complianceoperator/utils_test.go
+++ b/sensor/kubernetes/complianceoperator/utils_test.go
@@ -105,3 +105,34 @@ func TestBuildScanSettingBindingProfileRefsLegacyFallback(t *testing.T) {
 		assert.Equal(t, complianceoperator.Profile.Kind, refs[i].Kind)
 	}
 }
+
+func TestNodeRolesFromRequest(t *testing.T) {
+	testCases := map[string]struct {
+		request  *central.ApplyComplianceScanConfigRequest_BaseScanSettings
+		expected []string
+	}{
+		"explicit roles": {
+			request:  &central.ApplyComplianceScanConfigRequest_BaseScanSettings{NodeRoles: []string{"infra", "worker"}},
+			expected: []string{"infra", "worker"},
+		},
+		"empty roles defaults to master and worker": {
+			request:  &central.ApplyComplianceScanConfigRequest_BaseScanSettings{},
+			expected: []string{"master", "worker"},
+		},
+		"nil request defaults to master and worker": {
+			request:  nil,
+			expected: []string{"master", "worker"},
+		},
+		"@all role": {
+			request:  &central.ApplyComplianceScanConfigRequest_BaseScanSettings{NodeRoles: []string{"@all"}},
+			expected: []string{"@all"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := nodeRolesFromRequest(tc.request)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReviewConfig.tsx
@@ -75,6 +75,7 @@ function ReviewConfig({ clusters, errorMessage }: ReviewConfigProps) {
                     scanName={formikValues.parameters.name}
                     description={formikValues.parameters.description}
                     scanSchedule={scanSchedule}
+                    nodeRoles={formikValues.parameters.nodeRoles}
                 />
                 <Flex direction={{ default: 'column' }}>
                     <Flex spaceItems={{ default: 'spaceItemsSm' }}>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent, ReactElement } from 'react';
+import { type FormEvent, type ReactElement, useState, type KeyboardEvent } from 'react';
 import { useFormikContext } from 'formik';
 import type { FormikContextType } from 'formik';
 import {
@@ -6,6 +6,8 @@ import {
     Flex,
     FlexItem,
     Form,
+    Label,
+    LabelGroup,
     PageSection,
     Stack,
     StackItem,
@@ -26,10 +28,15 @@ import { helperTextForName, helperTextForNameEdit, helperTextForTime } from './u
 
 import './ScanConfigOptions.css';
 
+const nodeRoleRegex = /^[a-zA-Z0-9-]{1,39}$/;
+const allNodesRole = '@all';
+
 function ScanConfigOptions(): ReactElement {
     const formik: FormikContextType<ScanConfigFormValues> = useFormikContext();
     const { pageAction } = usePageAction<PageActions>();
     const isEditAction = pageAction === 'edit';
+    const [nodeRoleInput, setNodeRoleInput] = useState('');
+    const [nodeRoleInputError, setNodeRoleInputError] = useState('');
 
     function handleSelectChange(id: string, value: string): void {
         formik.setFieldValue('parameters.daysOfWeek', []);
@@ -43,6 +50,48 @@ function ScanConfigOptions(): ReactElement {
 
     function onScheduledDaysChange(id: string, selection: string[]) {
         formik.setFieldValue(id, selection, true);
+    }
+
+    function addNodeRole(role: string) {
+        const trimmed = role.trim();
+        if (!trimmed) {
+            return;
+        }
+        if (trimmed !== allNodesRole && !nodeRoleRegex.test(trimmed)) {
+            setNodeRoleInputError(
+                `"${trimmed}" is invalid. Use alphanumeric characters and hyphens, 1-39 characters, or @all.`
+            );
+            return;
+        }
+        setNodeRoleInputError('');
+        const currentRoles = formik.values.parameters.nodeRoles;
+        if (currentRoles.includes(trimmed)) {
+            setNodeRoleInput('');
+            return;
+        }
+        let newRoles: string[];
+        if (trimmed === allNodesRole) {
+            newRoles = [allNodesRole];
+        } else if (currentRoles.includes(allNodesRole)) {
+            newRoles = [trimmed];
+        } else {
+            newRoles = [...currentRoles, trimmed];
+        }
+        formik.setFieldValue('parameters.nodeRoles', newRoles);
+        setNodeRoleInput('');
+    }
+
+    function removeNodeRole(role: string) {
+        const newRoles = formik.values.parameters.nodeRoles.filter((r) => r !== role);
+        formik.setFieldValue('parameters.nodeRoles', newRoles);
+    }
+
+    function handleNodeRoleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            e.stopPropagation();
+            addNodeRole(nodeRoleInput);
+        }
     }
 
     return (
@@ -221,6 +270,69 @@ function ScanConfigOptions(): ReactElement {
                                         </FormLabelGroup>
                                     </FlexItem>
                                 </Flex>
+                            </FlexItem>
+                        </Flex>
+                    </StackItem>
+                    <StackItem>
+                        <Divider component="div" />
+                    </StackItem>
+                    <StackItem>
+                        <Flex direction={{ default: 'column' }}>
+                            <FlexItem>
+                                <Title headingLevel="h3">Node roles</Title>
+                            </FlexItem>
+                            <FlexItem>
+                                <FormLabelGroup
+                                    label="Roles"
+                                    fieldId="parameters.nodeRoles"
+                                    errors={formik.errors}
+                                    touched={formik.touched}
+                                    helperText="Determines which nodes are scanned for node-type profiles. If left empty, defaults to master and worker. Common roles: master, worker, infra, control-plane. Use @all to scan all nodes."
+                                >
+                                    <Stack hasGutter>
+                                        <StackItem>
+                                            <TextInput
+                                                type="text"
+                                                id="parameters.nodeRoleInput"
+                                                placeholder="Type a role and press Enter to add"
+                                                value={nodeRoleInput}
+                                                validated={
+                                                    nodeRoleInputError ? 'error' : 'default'
+                                                }
+                                                onChange={(_event, value) => {
+                                                    setNodeRoleInput(value);
+                                                    if (nodeRoleInputError) {
+                                                        setNodeRoleInputError('');
+                                                    }
+                                                }}
+                                                onKeyDown={handleNodeRoleKeyDown}
+                                            />
+                                            {nodeRoleInputError && (
+                                                <div className="pf-v6-u-color-status-danger pf-v6-u-font-size-sm pf-v6-u-mt-xs">
+                                                    {nodeRoleInputError}
+                                                </div>
+                                            )}
+                                        </StackItem>
+                                        {formik.values.parameters.nodeRoles.length > 0 && (
+                                            <StackItem>
+                                                <LabelGroup>
+                                                    {formik.values.parameters.nodeRoles.map(
+                                                        (role) => (
+                                                            <Label
+                                                                key={role}
+                                                                onClose={() =>
+                                                                    removeNodeRole(role)
+                                                                }
+                                                            >
+                                                                {role}
+                                                            </Label>
+                                                        )
+                                                    )}
+                                                </LabelGroup>
+                                            </StackItem>
+                                        )}
+                                    </Stack>
+                                </FormLabelGroup>
                             </FlexItem>
                         </Flex>
                     </StackItem>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/useFormikScanConfig.tsx
@@ -8,6 +8,7 @@ import {
 } from 'Components/EmailTemplate/EmailTemplate.utils';
 
 import type { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
+import { defaultNodeRoles } from '../compliance.scanConfigs.utils';
 
 export const defaultScanConfigFormValues: ScanConfigFormValues = {
     parameters: {
@@ -17,6 +18,7 @@ export const defaultScanConfigFormValues: ScanConfigFormValues = {
         time: '',
         daysOfWeek: [],
         daysOfMonth: [],
+        nodeRoles: [...defaultNodeRoles],
     },
     clusters: [],
     profiles: [],
@@ -71,6 +73,7 @@ const validationSchema = yup.object().shape({
                     ? schema.of(yup.string()).min(1, 'Selection is required')
                     : schema.notRequired()
             ),
+        nodeRoles: yup.array().of(yup.string().required()),
     }),
     clusters: yup.array().min(1),
     profiles: yup.array().min(1),

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.test.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.test.ts
@@ -17,6 +17,7 @@ describe('compliance.scanConfigs.utils', () => {
                 time: '03:00',
                 daysOfWeek: [],
                 daysOfMonth: [],
+                nodeRoles: ['master', 'worker'],
             };
 
             const scanConfig = convertFormikParametersToSchedule(formValues);
@@ -37,6 +38,7 @@ describe('compliance.scanConfigs.utils', () => {
                 time: '13:00',
                 daysOfWeek: ['1'],
                 daysOfMonth: [],
+                nodeRoles: ['master', 'worker'],
             };
 
             const scanConfig = convertFormikParametersToSchedule(formValues);
@@ -60,6 +62,7 @@ describe('compliance.scanConfigs.utils', () => {
                 time: '23:00',
                 daysOfWeek: [],
                 daysOfMonth: ['1', '15'],
+                nodeRoles: ['master', 'worker'],
             };
 
             const scanConfig = convertFormikParametersToSchedule(formValues);

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/compliance.scanConfigs.utils.tsx
@@ -15,6 +15,8 @@ import type {
 } from 'types/schedule.proto';
 import { getHourMinuteStringFromScheduleBase } from 'utils/dateUtils';
 
+export const defaultNodeRoles: string[] = ['master', 'worker'];
+
 export type ScanConfigParameters = {
     name: string;
     description: string;
@@ -22,6 +24,7 @@ export type ScanConfigParameters = {
     time: string;
     daysOfWeek: DayOfWeek[];
     daysOfMonth: DayOfMonth[];
+    nodeRoles: string[];
 };
 
 export type ScanReportConfiguration = {
@@ -137,7 +140,7 @@ export function convertFormikToScanConfig(
     formikValues: ScanConfigFormValues
 ): ComplianceScanConfiguration {
     const { id, parameters, clusters, profiles, report } = formikValues;
-    const { name, description } = parameters;
+    const { name, description, nodeRoles } = parameters;
     const { notifierConfigurations } = report;
 
     const scanSchedule = convertFormikParametersToSchedule(parameters);
@@ -151,6 +154,7 @@ export function convertFormikToScanConfig(
             profiles,
             scanSchedule,
             notifiers: notifierConfigurations,
+            nodeRoles,
         },
         clusters,
     };
@@ -160,7 +164,7 @@ export function convertScanConfigToFormik(
     existingConfig: ComplianceScanConfigurationStatus
 ): ScanConfigFormValues {
     const { id, scanName, scanConfig, clusterStatus } = existingConfig;
-    const { description = '', notifiers, profiles, scanSchedule } = scanConfig;
+    const { description = '', notifiers, profiles, scanSchedule, nodeRoles } = scanConfig;
 
     const { intervalType, time, daysOfWeek, daysOfMonth } =
         convertScheduleToFormikParameters(scanSchedule);
@@ -174,6 +178,7 @@ export function convertScanConfigToFormik(
             time,
             daysOfWeek,
             daysOfMonth,
+            nodeRoles: nodeRoles && nodeRoles.length > 0 ? nodeRoles : defaultNodeRoles,
         },
         clusters: clusterStatus.map((clusterStatus) => clusterStatus.clusterId),
         profiles,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ConfigDetails.tsx
@@ -53,6 +53,7 @@ function ConfigDetails({ isLoading, error, scanConfig }: ConfigDetailsProps) {
                     scanName={scanConfig.scanName}
                     description={scanConfig.scanConfig.description}
                     scanSchedule={scanConfig.scanConfig.scanSchedule}
+                    nodeRoles={scanConfig.scanConfig.nodeRoles}
                 >
                     <DescriptionListGroup>
                         <DescriptionListTerm>Last scanned</DescriptionListTerm>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigParametersView.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ScanConfigParametersView.tsx
@@ -16,6 +16,7 @@ type ScanConfigParametersViewProps = {
     scanName: string;
     description?: string;
     scanSchedule: Schedule;
+    nodeRoles?: string[];
     children?: ReactNode;
 };
 
@@ -24,6 +25,7 @@ function ScanConfigParametersView({
     headingLevel,
     scanName,
     scanSchedule,
+    nodeRoles,
     children,
 }: ScanConfigParametersViewProps): ReactElement {
     return (
@@ -46,6 +48,14 @@ function ScanConfigParametersView({
                         {formatRecurringSchedule(scanSchedule)}
                     </DescriptionListDescription>
                 </DescriptionListGroup>
+                {nodeRoles && nodeRoles.length > 0 && (
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Node roles</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {nodeRoles.join(', ')}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                )}
                 {children}
             </DescriptionList>
         </Flex>

--- a/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
+++ b/ui/apps/platform/src/services/ComplianceScanConfigurationService.ts
@@ -41,6 +41,7 @@ type BaseComplianceScanConfigurationSettings = {
     scanSchedule: Schedule;
     description?: string;
     notifiers: NotifierConfiguration[];
+    nodeRoles?: string[];
 };
 
 export type ComplianceScanConfiguration = {


### PR DESCRIPTION
## Description

ACS previously hardcoded `["master", "worker"]` as node roles in every ScanSetting it generated for the Compliance Operator. This prevented scanning nodes with custom roles (e.g., `infra`, `control-plane`, `gpu`).

This change makes node roles configurable through the API and UI, with backward-compatible defaults (`["master", "worker"]`).

### Changes

**Proto layer:**
- Storage: reserved old `NodeRole` enum field (tag 9), added `repeated string node_roles` (tag 19)
- API: added `node_roles` field to `BaseComplianceScanConfigurationSettings`
- Internal API: added `node_roles` to `BaseScanSettings` for Central-Sensor communication

**Central:**
- Conversion layer: maps `node_roles` between API and storage, applies `["master", "worker"]` default when empty
- Validation: matches Compliance Operator rules (alphanumeric + hyphens, 1-39 chars, `@all` exclusive, rejects duplicates)
- Manager: passes `node_roles` through `buildScanConfigSensorMsg`
- Startup sync: includes `node_roles` in `SyncComplianceScanConfigRequest`

**Sensor:**
- Reads roles from Central request instead of hardcoding `["master", "worker"]`
- Falls back to `["master", "worker"]` when field is empty (backward compat with old Central)

**UI:**
- Node roles section in scan config wizard as a top-level section below Schedule (with its own heading and divider)
- Text input + label chips for adding/removing roles
- Not marked as required — helper text explains defaults apply when empty
- Inline validation error for invalid role names
- Displays node roles in config detail view and review step
- Default: `master`, `worker` pre-populated

### Coverage page

Node roles are intentionally not shown on the compliance coverage pages. Coverage answers "what passed/failed?" while node roles are a scan configuration input. Surfacing them on results pages would conflate configuration with outcomes and add visual noise without actionable value. Node roles are visible on the scan schedule detail page, one click from the coverage dropdown.

### Design decisions

- **Free-text `repeated string` over enum**: The Compliance Operator accepts arbitrary role strings. An enum would require an ACS release for each new role name.
- **Default in Central, fallback in Sensor**: Central applies defaults before DB persistence (clean source of truth). Sensor defaults as safety net for messages from old Central versions.
- **Proto tag 19 instead of reusing tag 9**: The old field used `NodeRole` enum (varint wire type); changing to string would break wire compatibility. Reserved tag 9 per proto best practices.
- **Optional field (not required)**: Node roles are pre-populated with `master` and `worker`. Users can override or clear them; empty defaults to `["master", "worker"]` server-side.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated OR update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above OR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

Unit tests added for:
- Node role validation (Central): empty, `@all`, mixed `@all`, invalid chars, duplicates, too long
- Node roles from request (Sensor): explicit roles, empty defaults, nil request, `@all`
- Existing service tests updated with `nodeRoles` field

### How I validated my change

Deployed to an OCP 4.22 cluster with Compliance Operator v1.9.1 and verified end-to-end.

**API tests** (curl against deployed Central `4.12.x-537-g9c2f276143`):

| Test | Input | ScanSetting on Cluster | Result |
|------|-------|----------------------|--------|
| Default (empty) | omitted | `["master","worker"]` | Pass |
| Worker + Infra | `["worker","infra"]` | `["worker","infra"]` | Pass |
| @all | `["@all"]` | `["@all"]` | Pass |
| Three roles | `["master","worker","control-plane"]` | `["master","worker","control-plane"]` | Pass |
| Custom gpu | `["gpu"]` (label added to node) | `["gpu"]` | Pass |
| UPDATE roles | `["control-plane","worker"]` | `["control-plane","worker"]` | Pass |
| LIST all configs | All show nodeRoles | n/a | Pass |
| @all+worker (invalid) | rejected with error | n/a | Pass |
| inv@lid (invalid) | rejected with error | n/a | Pass |
| Duplicates (invalid) | rejected with error | n/a | Pass |
| Remove node label | gpu label removed from node | No breakage | Pass |

**UI screenshots:**

Create wizard — Node roles as a top-level section below Schedule, with defaults pre-populated:

![create wizard](https://i.imgur.com/CwhTC7A.png)

Adding multiple roles (master, worker, infra, +1 more):

![multiple roles](https://i.imgur.com/sJEG9Ho.png)

Invalid role input error:

![invalid error](https://i.imgur.com/MpQI7CX.png)

Empty roles — no error, helper text explains defaults:

![empty roles](https://i.imgur.com/yzTXxUe.png)

Config detail view showing Node roles:

![detail view](https://i.imgur.com/0d61gNt.png)

_AI-assisted implementation._
