### PR TITLE
ROX-35472: Use enhanced api for vm4vm components table

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
@@ -1,6 +1,6 @@
 // If you're adding a new attribute, make sure to add it to "imageComponentAttributes" as well
 
-import { sourceTypeLabels, sourceTypes } from 'types/image.proto';
+import { sourceTypeLabels, sourceTypes } from 'Containers/Vulnerabilities/constants';
 import type { CompoundSearchFilterAttribute } from '../types';
 
 export const Name: CompoundSearchFilterAttribute = {
@@ -16,9 +16,10 @@ export const Source: CompoundSearchFilterAttribute = {
     searchTerm: 'Component Source',
     inputType: 'select',
     inputProps: {
-        options: sourceTypes.map((sourceType) => {
-            return { label: sourceTypeLabels[sourceType], value: sourceType };
-        }),
+        options: sourceTypes.map((sourceType) => ({
+            label: sourceTypeLabels[sourceType],
+            value: sourceType,
+        })),
     },
 };
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/virtualMachine.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/virtualMachine.ts
@@ -1,4 +1,4 @@
-import type { CompoundSearchFilterAttribute } from '../types';
+import type { CompoundSearchFilterAttribute, SelectSearchFilterAttribute } from '../types';
 
 export const VirtualMachineCVEName: CompoundSearchFilterAttribute = {
     displayName: 'Name',
@@ -19,6 +19,25 @@ export const VirtualMachineComponentVersion: CompoundSearchFilterAttribute = {
     filterChipLabel: 'Virtual machine component version',
     searchTerm: 'Component Version',
     inputType: 'text',
+};
+
+export const VirtualMachineComponentSource: SelectSearchFilterAttribute = {
+    displayName: 'Source',
+    filterChipLabel: 'Virtual machine component source',
+    searchTerm: 'Component Source',
+    inputType: 'select',
+    inputProps: {
+        options: [
+            { label: 'OS', value: 'OS' },
+            { label: 'Python', value: 'PYTHON' },
+            { label: 'Java', value: 'JAVA' },
+            { label: 'Ruby', value: 'RUBY' },
+            { label: 'Node.js', value: 'NODEJS' },
+            { label: 'Go', value: 'GO' },
+            { label: '.NET Core Runtime', value: 'DOTNETCORERUNTIME' },
+            { label: 'Infrastructure', value: 'INFRASTRUCTURE' },
+        ],
+    },
 };
 
 export const VirtualMachineID: CompoundSearchFilterAttribute = {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/virtualMachine.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/virtualMachine.ts
@@ -1,3 +1,4 @@
+import { sourceTypeLabels, sourceTypes } from 'Containers/Vulnerabilities/constants';
 import type { CompoundSearchFilterAttribute, SelectSearchFilterAttribute } from '../types';
 
 export const VirtualMachineCVEName: CompoundSearchFilterAttribute = {
@@ -27,16 +28,10 @@ export const VirtualMachineComponentSource: SelectSearchFilterAttribute = {
     searchTerm: 'Component Source',
     inputType: 'select',
     inputProps: {
-        options: [
-            { label: 'OS', value: 'OS' },
-            { label: 'Python', value: 'PYTHON' },
-            { label: 'Java', value: 'JAVA' },
-            { label: 'Ruby', value: 'RUBY' },
-            { label: 'Node.js', value: 'NODEJS' },
-            { label: 'Go', value: 'GO' },
-            { label: '.NET Core Runtime', value: 'DOTNETCORERUNTIME' },
-            { label: 'Infrastructure', value: 'INFRASTRUCTURE' },
-        ],
+        options: sourceTypes.map((sourceType) => ({
+            label: sourceTypeLabels[sourceType],
+            value: sourceType,
+        })),
     },
 };
 

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -304,9 +304,9 @@ describe(Cypress.spec.relative, () => {
         cy.get(imageComponenSourceSelectItems).eq(1).should('have.text', 'Python');
         cy.get(imageComponenSourceSelectItems).eq(2).should('have.text', 'Java');
         cy.get(imageComponenSourceSelectItems).eq(3).should('have.text', 'Ruby');
-        cy.get(imageComponenSourceSelectItems).eq(4).should('have.text', 'Node js');
+        cy.get(imageComponenSourceSelectItems).eq(4).should('have.text', 'Node.js');
         cy.get(imageComponenSourceSelectItems).eq(5).should('have.text', 'Go');
-        cy.get(imageComponenSourceSelectItems).eq(6).should('have.text', 'Dotnet Core Runtime');
+        cy.get(imageComponenSourceSelectItems).eq(6).should('have.text', '.NET Core Runtime');
         cy.get(imageComponenSourceSelectItems).eq(7).should('have.text', 'Infrastructure');
 
         cy.get(imageComponenSourceSelectItems).eq(1).click();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx
@@ -1,5 +1,6 @@
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import { sourceTypeLabels } from '../../constants';
 import type { CveComponentRow } from '../aggregateUtils';
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
 import FixedByVersion from '../../components/FixedByVersion';
@@ -32,7 +33,7 @@ function VirtualMachineComponentsTable({ components }: VirtualMachineComponentsT
                             <Td dataLabel="Advisory">
                                 <AdvisoryLinkOrText advisory={advisory} />
                             </Td>
-                            <Td dataLabel="Type">{sourceType}</Td>
+                            <Td dataLabel="Type">{sourceTypeLabels[sourceType]}</Td>
                         </Tr>
                     );
                 })}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx
@@ -34,6 +34,7 @@ import {
 } from '../../utils/sortFields';
 import VirtualMachinePageHeader from './VirtualMachinePageHeader';
 import VirtualMachinePageComponents from './VirtualMachinePageComponents';
+import VirtualMachinePageComponentsLegacy from './VirtualMachinePageComponentsLegacy';
 import VirtualMachinePageDetails from './VirtualMachinePageDetails';
 import VirtualMachinePageVulnerabilities from './VirtualMachinePageVulnerabilities';
 import VirtualMachinePageVulnerabilitiesLegacy from './VirtualMachinePageVulnerabilitiesLegacy';
@@ -191,14 +192,18 @@ function VirtualMachinePage() {
                 )}
                 {activeTabKey === componentsTabKey && (
                     <TabContent id={COMPONENTS_TAB_ID}>
-                        <VirtualMachinePageComponents
-                            virtualMachine={virtualMachine}
-                            isLoadingVirtualMachine={isLoading}
-                            errorVirtualMachine={error}
-                            urlSearch={urlSearch}
-                            urlSorting={urlSorting}
-                            urlPagination={urlPagination}
-                        />
+                        {isEnhancedDataModelEnabled ? (
+                            <VirtualMachinePageComponents virtualMachineId={virtualMachineId} />
+                        ) : (
+                            <VirtualMachinePageComponentsLegacy
+                                virtualMachine={virtualMachine}
+                                isLoadingVirtualMachine={isLoading}
+                                errorVirtualMachine={error}
+                                urlSearch={urlSearch}
+                                urlSorting={urlSorting}
+                                urlPagination={urlPagination}
+                            />
+                        )}
                     </TabContent>
                 )}
                 {activeTabKey === detailsTabKey && (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageComponents.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageComponents.tsx
@@ -23,9 +23,8 @@ import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import { listVMComponents } from 'services/VirtualMachineService';
 import type { VMComponentScanStatus } from 'services/VirtualMachineService';
+import { DEFAULT_VM_PAGE_SIZE, sourceTypeLabels } from '../../constants';
 import { getTableUIState } from 'utils/getTableUIState';
-
-import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { virtualMachineComponentSearchFilterConfig } from '../../searchFilterConfig';
 import { scanStatuses } from '../../types';
 import { COMPONENT_SORT_FIELD } from '../../utils/sortFields';
@@ -90,11 +89,6 @@ function VirtualMachinePageComponents({ virtualMachineId }: VirtualMachinePageCo
         setPage(1);
     };
 
-    const onSearchScanStatus: OnSearchCallback = (payload) => {
-        setSearchFilter(updateSearchFilter(searchFilter, payload));
-        setPage(1);
-    };
-
     const colSpan = 4;
 
     return (
@@ -109,7 +103,7 @@ function VirtualMachinePageComponents({ virtualMachineId }: VirtualMachinePageCo
                     <SearchFilterSelectInclusive
                         attribute={attributeForScanStatus}
                         isSeparate
-                        onSearch={onSearchScanStatus}
+                        onSearch={onSearch}
                         searchFilter={searchFilter}
                     />
                     <ToolbarGroup className="pf-v6-u-w-100">
@@ -135,7 +129,7 @@ function VirtualMachinePageComponents({ virtualMachineId }: VirtualMachinePageCo
                 borders={tableState.type === 'COMPLETE'}
                 variant="compact"
                 aria-live="polite"
-                aria-busy={false}
+                aria-busy={isLoading}
             >
                 <Thead>
                     <Tr>
@@ -165,7 +159,9 @@ function VirtualMachinePageComponents({ virtualMachineId }: VirtualMachinePageCo
                                         {scanStatusDisplayMap[componentRow.scanStatus] ??
                                             componentRow.scanStatus}
                                     </Td>
-                                    <Td dataLabel="Source">{componentRow.source}</Td>
+                                    <Td dataLabel="Source">
+                                        {sourceTypeLabels[componentRow.source]}
+                                    </Td>
                                 </Tr>
                             ))}
                         </Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageComponents.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageComponents.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback } from 'react';
 import {
     PageSection,
     Pagination,
@@ -6,6 +6,7 @@ import {
     ToolbarContent,
     ToolbarGroup,
 } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
@@ -15,22 +16,27 @@ import type {
 } from 'Components/CompoundSearchFilter/types';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
-import type { UseURLPaginationResult } from 'hooks/useURLPagination';
-import type { UseUrlSearchReturn } from 'hooks/useURLSearch';
-import type { UseURLSortResult } from 'hooks/useURLSort';
-import type { VirtualMachine } from 'services/VirtualMachineService';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import { listVMComponents } from 'services/VirtualMachineService';
+import type { VMComponentScanStatus } from 'services/VirtualMachineService';
 import { getTableUIState } from 'utils/getTableUIState';
 
-import {
-    applyVirtualMachineComponentsTableFilters,
-    applyVirtualMachineComponentsTableSort,
-    getVirtualMachineComponentsTableData,
-} from '../aggregateUtils';
+import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { virtualMachineComponentSearchFilterConfig } from '../../searchFilterConfig';
 import { scanStatuses } from '../../types';
-import VirtualMachineComponentsPageTable from './VirtualMachineComponentsPageTable';
+import { COMPONENT_SORT_FIELD } from '../../utils/sortFields';
 
-export const attributeForScanStatus: SelectSearchFilterAttribute = {
+const sortFields = [COMPONENT_SORT_FIELD];
+
+const defaultSortOption = { field: COMPONENT_SORT_FIELD, direction: 'asc' } as const;
+
+const searchFilterConfig = [virtualMachineComponentSearchFilterConfig];
+
+const attributeForScanStatus: SelectSearchFilterAttribute = {
     displayName: 'Scan status',
     filterChipLabel: 'Scan status',
     searchTerm: 'Scan Status',
@@ -40,67 +46,37 @@ export const attributeForScanStatus: SelectSearchFilterAttribute = {
     },
 };
 
-export type VirtualMachinePageComponentsProps = {
-    virtualMachine: VirtualMachine | undefined;
-    isLoadingVirtualMachine: boolean;
-    errorVirtualMachine: Error | undefined;
-    urlSearch: UseUrlSearchReturn;
-    urlSorting: UseURLSortResult;
-    urlPagination: UseURLPaginationResult;
+const scanStatusDisplayMap: Record<VMComponentScanStatus, string> = {
+    SCANNED: 'Scanned',
+    NOT_SCANNED: 'Not scanned',
+    SCAN_PENDING: 'Scan pending',
+    CPE_MISSING: 'CPE missing',
+    REPO_UNKNOWN: 'Repo unknown',
 };
 
-const searchFilterConfig = [virtualMachineComponentSearchFilterConfig];
+export type VirtualMachinePageComponentsProps = {
+    virtualMachineId: string;
+};
 
-function VirtualMachinePageComponents({
-    virtualMachine,
-    isLoadingVirtualMachine,
-    errorVirtualMachine,
-    urlSearch,
-    urlSorting,
-    urlPagination,
-}: VirtualMachinePageComponentsProps) {
-    const { searchFilter, setSearchFilter } = urlSearch;
-    const { page, perPage, setPage, setPerPage } = urlPagination;
-    const { sortOption, getSortParams } = urlSorting;
+function VirtualMachinePageComponents({ virtualMachineId }: VirtualMachinePageComponentsProps) {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+        onSort: () => setPage(1),
+    });
 
-    const virtualMachineComponentsTableData = useMemo(
-        () => getVirtualMachineComponentsTableData(virtualMachine),
-        [virtualMachine]
+    const fetchComponents = useCallback(
+        () => listVMComponents(virtualMachineId, { searchFilter, page, perPage, sortOption }),
+        [virtualMachineId, searchFilter, page, perPage, sortOption]
     );
-
-    const filteredVirtualMachineComponentsTableData = useMemo(
-        () =>
-            applyVirtualMachineComponentsTableFilters(
-                virtualMachineComponentsTableData,
-                searchFilter
-            ),
-        [virtualMachineComponentsTableData, searchFilter]
-    );
-
-    const sortedVirtualMachineComponentsTableData = useMemo(
-        () =>
-            applyVirtualMachineComponentsTableSort(
-                filteredVirtualMachineComponentsTableData,
-                Array.isArray(sortOption) ? sortOption[0].field : sortOption.field,
-                Array.isArray(sortOption) ? sortOption[0].reversed : sortOption.reversed
-            ),
-        [filteredVirtualMachineComponentsTableData, sortOption]
-    );
-
-    const paginatedVirtualMachineComponentsTableData = useMemo(() => {
-        const totalRows = sortedVirtualMachineComponentsTableData.length;
-        const maxPage = Math.max(1, Math.ceil(totalRows / perPage) || 1);
-        const safePage = Math.min(page, maxPage);
-
-        const start = (safePage - 1) * perPage;
-        const end = start + perPage;
-        return sortedVirtualMachineComponentsTableData.slice(start, end);
-    }, [sortedVirtualMachineComponentsTableData, page, perPage]);
+    const { data, isLoading, error } = useRestQuery(fetchComponents);
 
     const tableState = getTableUIState({
-        isLoading: isLoadingVirtualMachine,
-        data: paginatedVirtualMachineComponentsTableData,
-        error: errorVirtualMachine,
+        isLoading,
+        data: data?.components ?? [],
+        error,
         searchFilter,
     });
 
@@ -118,6 +94,8 @@ function VirtualMachinePageComponents({
         setSearchFilter(updateSearchFilter(searchFilter, payload));
         setPage(1);
     };
+
+    const colSpan = 4;
 
     return (
         <PageSection isFilled>
@@ -145,7 +123,7 @@ function VirtualMachinePageComponents({
                 </ToolbarContent>
             </Toolbar>
             <Pagination
-                itemCount={filteredVirtualMachineComponentsTableData.length}
+                itemCount={data?.totalCount ?? 0}
                 perPage={perPage}
                 page={page}
                 onSetPage={(_, newPage) => setPage(newPage)}
@@ -153,11 +131,47 @@ function VirtualMachinePageComponents({
                     setPerPage(newPerPage);
                 }}
             />
-            <VirtualMachineComponentsPageTable
-                tableState={tableState}
-                getSortParams={getSortParams}
-                onClearFilters={onClearFilters}
-            />
+            <Table
+                borders={tableState.type === 'COMPLETE'}
+                variant="compact"
+                aria-live="polite"
+                aria-busy={false}
+            >
+                <Thead>
+                    <Tr>
+                        <Th sort={getSortParams(COMPONENT_SORT_FIELD)}>Name</Th>
+                        <Th>Version</Th>
+                        <Th>Status</Th>
+                        <Th>Source</Th>
+                    </Tr>
+                </Thead>
+                <TbodyUnified
+                    tableState={tableState}
+                    colSpan={colSpan}
+                    errorProps={{
+                        title: 'There was an error loading results',
+                    }}
+                    emptyProps={{
+                        message: 'No components were detected for this virtual machine',
+                    }}
+                    filteredEmptyProps={{ onClearFilters }}
+                    renderer={({ data }) => (
+                        <Tbody>
+                            {data.map((componentRow) => (
+                                <Tr key={componentRow.id}>
+                                    <Td dataLabel="Name">{componentRow.name}</Td>
+                                    <Td dataLabel="Version">{componentRow.version}</Td>
+                                    <Td dataLabel="Status">
+                                        {scanStatusDisplayMap[componentRow.scanStatus] ??
+                                            componentRow.scanStatus}
+                                    </Td>
+                                    <Td dataLabel="Source">{componentRow.source}</Td>
+                                </Tr>
+                            ))}
+                        </Tbody>
+                    )}
+                />
+            </Table>
         </PageSection>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageComponentsLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageComponentsLegacy.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from 'react';
+import {
+    PageSection,
+    Pagination,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+} from '@patternfly/react-core';
+
+import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
+import type {
+    OnSearchCallback,
+    SelectSearchFilterAttribute,
+} from 'Components/CompoundSearchFilter/types';
+import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
+import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { UseUrlSearchReturn } from 'hooks/useURLSearch';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { VirtualMachine } from 'services/VirtualMachineService';
+import { getTableUIState } from 'utils/getTableUIState';
+
+import {
+    applyVirtualMachineComponentsTableFilters,
+    applyVirtualMachineComponentsTableSort,
+    getVirtualMachineComponentsTableData,
+} from '../aggregateUtils';
+import { virtualMachineComponentLegacySearchFilterConfig } from '../../searchFilterConfig';
+import { scanStatuses } from '../../types';
+import VirtualMachineComponentsPageTable from './VirtualMachineComponentsPageTable';
+
+export const attributeForScanStatus: SelectSearchFilterAttribute = {
+    displayName: 'Scan status',
+    filterChipLabel: 'Scan status',
+    searchTerm: 'Scan Status',
+    inputType: 'select',
+    inputProps: {
+        options: scanStatuses.map((label) => ({ label, value: label })),
+    },
+};
+
+export type VirtualMachinePageComponentsLegacyProps = {
+    virtualMachine: VirtualMachine | undefined;
+    isLoadingVirtualMachine: boolean;
+    errorVirtualMachine: Error | undefined;
+    urlSearch: UseUrlSearchReturn;
+    urlSorting: UseURLSortResult;
+    urlPagination: UseURLPaginationResult;
+};
+
+const searchFilterConfig = [virtualMachineComponentLegacySearchFilterConfig];
+
+function VirtualMachinePageComponentsLegacy({
+    virtualMachine,
+    isLoadingVirtualMachine,
+    errorVirtualMachine,
+    urlSearch,
+    urlSorting,
+    urlPagination,
+}: VirtualMachinePageComponentsLegacyProps) {
+    const { searchFilter, setSearchFilter } = urlSearch;
+    const { page, perPage, setPage, setPerPage } = urlPagination;
+    const { sortOption, getSortParams } = urlSorting;
+
+    const virtualMachineComponentsTableData = useMemo(
+        () => getVirtualMachineComponentsTableData(virtualMachine),
+        [virtualMachine]
+    );
+
+    const filteredVirtualMachineComponentsTableData = useMemo(
+        () =>
+            applyVirtualMachineComponentsTableFilters(
+                virtualMachineComponentsTableData,
+                searchFilter
+            ),
+        [virtualMachineComponentsTableData, searchFilter]
+    );
+
+    const sortedVirtualMachineComponentsTableData = useMemo(
+        () =>
+            applyVirtualMachineComponentsTableSort(
+                filteredVirtualMachineComponentsTableData,
+                Array.isArray(sortOption) ? sortOption[0].field : sortOption.field,
+                Array.isArray(sortOption) ? sortOption[0].reversed : sortOption.reversed
+            ),
+        [filteredVirtualMachineComponentsTableData, sortOption]
+    );
+
+    const paginatedVirtualMachineComponentsTableData = useMemo(() => {
+        const totalRows = sortedVirtualMachineComponentsTableData.length;
+        const maxPage = Math.max(1, Math.ceil(totalRows / perPage) || 1);
+        const safePage = Math.min(page, maxPage);
+
+        const start = (safePage - 1) * perPage;
+        const end = start + perPage;
+        return sortedVirtualMachineComponentsTableData.slice(start, end);
+    }, [sortedVirtualMachineComponentsTableData, page, perPage]);
+
+    const tableState = getTableUIState({
+        isLoading: isLoadingVirtualMachine,
+        data: paginatedVirtualMachineComponentsTableData,
+        error: errorVirtualMachine,
+        searchFilter,
+    });
+
+    function onClearFilters() {
+        setSearchFilter({});
+        setPage(1);
+    }
+
+    const onSearch: OnSearchCallback = (payload) => {
+        setSearchFilter(updateSearchFilter(searchFilter, payload));
+        setPage(1);
+    };
+
+    const onSearchScanStatus: OnSearchCallback = (payload) => {
+        setSearchFilter(updateSearchFilter(searchFilter, payload));
+        setPage(1);
+    };
+
+    return (
+        <PageSection isFilled>
+            <Toolbar>
+                <ToolbarContent>
+                    <CompoundSearchFilter
+                        config={searchFilterConfig}
+                        searchFilter={searchFilter}
+                        onSearch={onSearch}
+                    />
+                    <SearchFilterSelectInclusive
+                        attribute={attributeForScanStatus}
+                        isSeparate
+                        onSearch={onSearchScanStatus}
+                        searchFilter={searchFilter}
+                    />
+                    <ToolbarGroup className="pf-v6-u-w-100">
+                        <CompoundSearchFilterLabels
+                            attributesSeparateFromConfig={[attributeForScanStatus]}
+                            config={searchFilterConfig}
+                            searchFilter={searchFilter}
+                            onFilterChange={setSearchFilter}
+                        />
+                    </ToolbarGroup>
+                </ToolbarContent>
+            </Toolbar>
+            <Pagination
+                itemCount={filteredVirtualMachineComponentsTableData.length}
+                perPage={perPage}
+                page={page}
+                onSetPage={(_, newPage) => setPage(newPage)}
+                onPerPageSelect={(_, newPerPage) => {
+                    setPerPage(newPerPage);
+                }}
+            />
+            <VirtualMachineComponentsPageTable
+                tableState={tableState}
+                getSortParams={getSortParams}
+                onClearFilters={onClearFilters}
+            />
+        </PageSection>
+    );
+}
+
+export default VirtualMachinePageComponentsLegacy;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilitiesLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilitiesLegacy.tsx
@@ -22,7 +22,7 @@ import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayo
 import VirtualMachineScanScopeAlert from '../components/VirtualMachineScanScopeAlert';
 import {
     virtualMachineCVESearchFilterConfig,
-    virtualMachineComponentSearchFilterConfig,
+    virtualMachineComponentLegacySearchFilterConfig,
 } from '../../searchFilterConfig';
 import {
     getHiddenSeverities,
@@ -47,7 +47,7 @@ export type VirtualMachinePageVulnerabilitiesLegacyProps = {
 
 const searchFilterConfig = [
     virtualMachineCVESearchFilterConfig,
-    virtualMachineComponentSearchFilterConfig,
+    virtualMachineComponentLegacySearchFilterConfig,
 ];
 
 function VirtualMachinePageVulnerabilitiesLegacy({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/constants.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/constants.ts
@@ -1,1 +1,30 @@
+import type { SourceType as ImageSourceType } from 'types/image.proto';
+import type { SourceType as ScanComponentSourceType } from 'types/scanComponent.proto';
+
 export const DEFAULT_VM_PAGE_SIZE = 20;
+
+// Display labels
+
+export type SourceType = ImageSourceType | ScanComponentSourceType;
+
+export const sourceTypes: readonly SourceType[] = [
+    'OS',
+    'PYTHON',
+    'JAVA',
+    'RUBY',
+    'NODEJS',
+    'GO',
+    'DOTNETCORERUNTIME',
+    'INFRASTRUCTURE',
+] as const;
+
+export const sourceTypeLabels: Record<SourceType, string> = Object.freeze({
+    OS: 'OS',
+    PYTHON: 'Python',
+    JAVA: 'Java',
+    RUBY: 'Ruby',
+    NODEJS: 'Node.js',
+    GO: 'Go',
+    DOTNETCORERUNTIME: '.NET Core Runtime',
+    INFRASTRUCTURE: 'Infrastructure',
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -42,6 +42,7 @@ import { platformCVEAttributes } from 'Components/CompoundSearchFilter/attribute
 import {
     VirtualMachineCVEName,
     VirtualMachineComponentName,
+    VirtualMachineComponentSource,
     VirtualMachineComponentVersion,
     VirtualMachineID,
     VirtualMachineName,
@@ -129,10 +130,20 @@ export const virtualMachineCVESearchFilterConfig: CompoundSearchFilterEntity = {
     attributes: [VirtualMachineCVEName],
 };
 
-export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEntity = {
+export const virtualMachineComponentLegacySearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Virtual machine component',
     searchCategory: 'SEARCH_UNSET', // we don't have autocomplete for virtual machines
     attributes: [VirtualMachineComponentName, VirtualMachineComponentVersion],
+};
+
+export const virtualMachineComponentSearchFilterConfig: CompoundSearchFilterEntity = {
+    displayName: 'Virtual machine component',
+    searchCategory: 'SEARCH_UNSET',
+    attributes: [
+        VirtualMachineComponentName,
+        VirtualMachineComponentVersion,
+        VirtualMachineComponentSource,
+    ],
 };
 
 export const virtualMachinesClusterSearchFilterConfig: CompoundSearchFilterEntity = {

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -1,9 +1,10 @@
 import axios from 'services/instance';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
-import type { ScanComponent } from 'types/scanComponent.proto';
+import type { ScanComponent, SourceType } from 'types/scanComponent.proto';
 import type { SearchQueryOptions } from 'types/search';
 import { applyRegexSearchModifiers } from 'utils/searchUtils';
 import { buildNestedRawQueryParams } from './ComplianceCommon';
+import { applyRegexSearchModifiers } from 'utils/searchUtils';
 
 // Legacy API (v2/virtualmachines)
 
@@ -156,6 +157,28 @@ export type ListVMCVEsByVMResponse = {
     totalCount: number;
 };
 
+export type VMComponentScanStatus =
+    | 'NOT_SCANNED'
+    | 'SCAN_PENDING'
+    | 'CPE_MISSING'
+    | 'REPO_UNKNOWN'
+    | 'SCANNED';
+
+export type VMComponentRow = {
+    id: string;
+    name: string;
+    version: string;
+    source: SourceType;
+    scanStatus: VMComponentScanStatus;
+    lastScanned?: string;
+    cveCount: number;
+};
+
+export type ListVMComponentsResponse = {
+    components: VMComponentRow[];
+    totalCount: number;
+};
+
 export function listVMs({
     sortOption,
     page,
@@ -203,5 +226,20 @@ export function listVMCVEsByVM(
     });
     return axios
         .get<ListVMCVEsByVMResponse>(`/v2/virtualmachines/${vmId}/cves?${params}`)
+        .then((response) => response.data);
+}
+
+export function listVMComponents(
+    vmId: string,
+    { searchFilter, page, perPage, sortOption }: SearchQueryOptions
+): Promise<ListVMComponentsResponse> {
+    const params = buildNestedRawQueryParams({
+        page,
+        perPage,
+        searchFilter: applyRegexSearchModifiers(searchFilter ?? {}),
+        sortOption,
+    });
+    return axios
+        .get<ListVMComponentsResponse>(`/v2/virtualmachines/${vmId}/components?${params}`)
         .then((response) => response.data);
 }

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -3,8 +3,8 @@ import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { ScanComponent, SourceType } from 'types/scanComponent.proto';
 import type { SearchQueryOptions } from 'types/search';
 import { applyRegexSearchModifiers } from 'utils/searchUtils';
+
 import { buildNestedRawQueryParams } from './ComplianceCommon';
-import { applyRegexSearchModifiers } from 'utils/searchUtils';
 
 // Legacy API (v2/virtualmachines)
 

--- a/ui/apps/platform/src/types/image.proto.ts
+++ b/ui/apps/platform/src/types/image.proto.ts
@@ -20,26 +20,12 @@ export type WatchedImage = {
     name: string;
 };
 
-export const sourceTypes = [
-    'OS',
-    'PYTHON',
-    'JAVA',
-    'RUBY',
-    'NODEJS',
-    'GO',
-    'DOTNETCORERUNTIME',
-    'INFRASTRUCTURE',
-] as const;
-
-export const sourceTypeLabels: Record<SourceType, string> = {
-    OS: 'OS',
-    PYTHON: 'Python',
-    JAVA: 'Java',
-    RUBY: 'Ruby',
-    NODEJS: 'Node js',
-    GO: 'Go',
-    DOTNETCORERUNTIME: 'Dotnet Core Runtime',
-    INFRASTRUCTURE: 'Infrastructure',
-};
-
-export type SourceType = (typeof sourceTypes)[number];
+export type SourceType =
+    | 'OS'
+    | 'PYTHON'
+    | 'JAVA'
+    | 'RUBY'
+    | 'NODEJS'
+    | 'GO'
+    | 'DOTNETCORERUNTIME'
+    | 'INFRASTRUCTURE';


### PR DESCRIPTION
## Description

Converts the VM components tab to use the `ListVMComponents` API endpoint for server side sorting, filtering, and pagination when the `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL` feature flag is enabled. The previous client side implementation is preserved as `VirtualMachinePageComponentsLegacy`.

Also adds a Source column and Source filter (inside CompoundSearchFilter) to the enhanced component table.

**Note:** The Scan Status filter is currently not working for the enhanced table. The backend `VirtualMachineComponentV2` proto has no `search:` tag on the `notes` field, so the query is silently ignored. I create a bug ticket to get this resolved.


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Manually tested components tab with feature flag enabled and disabled
- Verified server side pagination, sorting by name, and filtering by component name/version/source works

<img width="2149" height="1159" alt="Screenshot 2026-07-20 at 11 42 29 AM" src="https://github.com/user-attachments/assets/a26a3d52-731b-442f-b57a-dc1970716e23" />

