### PR TITLE
ROX-35124: Use GetVM endpoint for VM details

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx
@@ -20,7 +20,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 import useURLStringUnion from 'hooks/useURLStringUnion';
-import { getVirtualMachine } from 'services/VirtualMachineService';
+import { getVM, getVirtualMachine } from 'services/VirtualMachineService';
 
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { detailsTabValues } from '../../types';
@@ -33,9 +33,11 @@ import {
     CVSS_SORT_FIELD,
 } from '../../utils/sortFields';
 import VirtualMachinePageHeader from './VirtualMachinePageHeader';
+import VirtualMachinePageHeaderLegacy from './VirtualMachinePageHeaderLegacy';
 import VirtualMachinePageComponents from './VirtualMachinePageComponents';
 import VirtualMachinePageComponentsLegacy from './VirtualMachinePageComponentsLegacy';
 import VirtualMachinePageDetails from './VirtualMachinePageDetails';
+import VirtualMachinePageDetailsLegacy from './VirtualMachinePageDetailsLegacy';
 import VirtualMachinePageVulnerabilities from './VirtualMachinePageVulnerabilities';
 import VirtualMachinePageVulnerabilitiesLegacy from './VirtualMachinePageVulnerabilitiesLegacy';
 
@@ -76,12 +78,25 @@ function VirtualMachinePage() {
         onSort: () => urlPagination.setPage(1, 'replace'),
     });
 
-    const fetchVirtualMachine = useCallback(
+    const fetchVirtualMachineLegacy = useCallback(
         () => getVirtualMachine(virtualMachineId),
         [virtualMachineId]
     );
+    const {
+        data: virtualMachineLegacy,
+        isLoading: isLoadingLegacy,
+        error: errorLegacy,
+    } = useRestQuery(fetchVirtualMachineLegacy);
 
-    const { data: virtualMachine, isLoading, error } = useRestQuery(fetchVirtualMachine);
+    const fetchVirtualMachine = useCallback(() => getVM(virtualMachineId), [virtualMachineId]);
+    const {
+        data: virtualMachineDetail,
+        isLoading: isLoadingEnhanced,
+        error: errorEnhanced,
+    } = useRestQuery(fetchVirtualMachine);
+
+    const isLoading = isEnhancedDataModelEnabled ? isLoadingEnhanced : isLoadingLegacy;
+    const error = isEnhancedDataModelEnabled ? errorEnhanced : errorLegacy;
 
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
@@ -89,7 +104,9 @@ function VirtualMachinePage() {
     const componentsTabKey = detailsTabValues[4];
     const detailsTabKey = detailsTabValues[1];
 
-    const virtualMachineName = virtualMachine?.name;
+    const virtualMachineName = isEnhancedDataModelEnabled
+        ? virtualMachineDetail?.name
+        : virtualMachineLegacy?.name;
 
     function onTabChange(value: string | number) {
         if (value === componentsTabKey) {
@@ -122,11 +139,19 @@ function VirtualMachinePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection>
-                <VirtualMachinePageHeader
-                    virtualMachine={virtualMachine}
-                    isLoading={isLoading}
-                    error={error}
-                />
+                {isEnhancedDataModelEnabled ? (
+                    <VirtualMachinePageHeader
+                        virtualMachineDetail={virtualMachineDetail}
+                        isLoading={isLoading}
+                        error={error}
+                    />
+                ) : (
+                    <VirtualMachinePageHeaderLegacy
+                        virtualMachine={virtualMachineLegacy}
+                        isLoading={isLoading}
+                        error={error}
+                    />
+                )}
             </PageSection>
             <PageSection padding={{ default: 'noPadding' }}>
                 <Tabs
@@ -180,9 +205,9 @@ function VirtualMachinePage() {
                             />
                         ) : (
                             <VirtualMachinePageVulnerabilitiesLegacy
-                                virtualMachine={virtualMachine}
-                                isLoadingVirtualMachine={isLoading}
-                                errorVirtualMachine={error}
+                                virtualMachine={virtualMachineLegacy}
+                                isLoadingVirtualMachine={isLoadingLegacy}
+                                errorVirtualMachine={errorLegacy}
                                 urlSearch={urlSearch}
                                 urlSorting={urlSorting}
                                 urlPagination={urlPagination}
@@ -196,9 +221,9 @@ function VirtualMachinePage() {
                             <VirtualMachinePageComponents virtualMachineId={virtualMachineId} />
                         ) : (
                             <VirtualMachinePageComponentsLegacy
-                                virtualMachine={virtualMachine}
-                                isLoadingVirtualMachine={isLoading}
-                                errorVirtualMachine={error}
+                                virtualMachine={virtualMachineLegacy}
+                                isLoadingVirtualMachine={isLoadingLegacy}
+                                errorVirtualMachine={errorLegacy}
                                 urlSearch={urlSearch}
                                 urlSorting={urlSorting}
                                 urlPagination={urlPagination}
@@ -208,7 +233,17 @@ function VirtualMachinePage() {
                 )}
                 {activeTabKey === detailsTabKey && (
                     <TabContent id={DETAILS_TAB_ID}>
-                        <VirtualMachinePageDetails virtualMachine={virtualMachine} />
+                        {isEnhancedDataModelEnabled ? (
+                            virtualMachineDetail && (
+                                <VirtualMachinePageDetails
+                                    virtualMachineDetail={virtualMachineDetail}
+                                />
+                            )
+                        ) : (
+                            <VirtualMachinePageDetailsLegacy
+                                virtualMachine={virtualMachineLegacy}
+                            />
+                        )}
                     </TabContent>
                 )}
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetails.tsx
@@ -22,17 +22,8 @@ export type VirtualMachinePageDetailsProps = {
 };
 
 function VirtualMachinePageDetails({ virtualMachineDetail }: VirtualMachinePageDetailsProps) {
-    const {
-        state,
-        agentStatus,
-        guestOs,
-        lastUpdated,
-        latestScan,
-        facts,
-        vsockCid,
-        labels,
-        annotations,
-    } = virtualMachineDetail;
+    const { state, agentStatus, guestOs, lastUpdated, latestScan, facts, labels, annotations } =
+        virtualMachineDetail;
 
     return (
         <PageSection isFilled padding={{ default: 'padding' }}>
@@ -81,7 +72,7 @@ function VirtualMachinePageDetails({ virtualMachineDetail }: VirtualMachinePageD
                             <DescriptionListGroup>
                                 <DescriptionListTerm>Top CVSS</DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    {latestScan.topCvss || '-'}
+                                    {latestScan.topCvss ?? '-'}
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </>
@@ -109,10 +100,6 @@ function VirtualMachinePageDetails({ virtualMachineDetail }: VirtualMachinePageD
                         <DescriptionListDescription>
                             {facts.bootOrder || '-'}
                         </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>Vsock CID</DescriptionListTerm>
-                        <DescriptionListDescription>{vsockCid || '-'}</DescriptionListDescription>
                     </DescriptionListGroup>
                 </DescriptionList>
                 <ExpandableLabelSection toggleText="Labels" labels={recordToLabelArray(labels)} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetails.tsx
@@ -3,54 +3,124 @@ import {
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
+    Flex,
     PageSection,
 } from '@patternfly/react-core';
-import capitalize from 'lodash/capitalize';
 
-import type { VirtualMachine } from 'services/VirtualMachineService';
+import type { VMDetail } from 'services/VirtualMachineService';
+import { getDateTime } from 'utils/dateUtils';
+
+import ExpandableLabelSection from '../../components/ExpandableLabelSection';
+import { agentStatusDisplayMap, stateDisplayMap } from './virtualMachineUtils';
+
+function recordToLabelArray(record: Record<string, string>): { key: string; value: string }[] {
+    return Object.entries(record).map(([key, value]) => ({ key, value }));
+}
 
 export type VirtualMachinePageDetailsProps = {
-    virtualMachine: VirtualMachine | undefined;
+    virtualMachineDetail: VMDetail;
 };
 
-function VirtualMachinePageDetails({ virtualMachine }: VirtualMachinePageDetailsProps) {
-    const facts = virtualMachine?.facts ?? {};
+function VirtualMachinePageDetails({ virtualMachineDetail }: VirtualMachinePageDetailsProps) {
+    const {
+        state,
+        agentStatus,
+        guestOs,
+        lastUpdated,
+        latestScan,
+        facts,
+        vsockCid,
+        labels,
+        annotations,
+    } = virtualMachineDetail;
+
     return (
-        <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'padding' }}>
-            <DescriptionList>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Status</DescriptionListTerm>
-                    <DescriptionListDescription>
-                        {capitalize(virtualMachine?.state)}
-                    </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Operating System</DescriptionListTerm>
-                    <DescriptionListDescription>{facts.guestOS || '-'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>IP Addresses</DescriptionListTerm>
-                    <DescriptionListDescription>
-                        {facts.ipAddresses || '-'}
-                    </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Node</DescriptionListTerm>
-                    <DescriptionListDescription>{facts.nodeName || '-'}</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Pods</DescriptionListTerm>
-                    <DescriptionListDescription>
-                        {facts.activePods || '-'}
-                    </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Boot Order</DescriptionListTerm>
-                    <DescriptionListDescription>
-                        {facts.bootOrder || '-'}
-                    </DescriptionListDescription>
-                </DescriptionListGroup>
-            </DescriptionList>
+        <PageSection isFilled padding={{ default: 'padding' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
+                <DescriptionList columnModifier={{ default: '1Col', lg: '2Col' }}>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Status</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {stateDisplayMap[state] ?? state}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Agent Status</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {agentStatusDisplayMap[agentStatus] ?? agentStatus}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Operating System</DescriptionListTerm>
+                        <DescriptionListDescription>{guestOs || '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                    {lastUpdated && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Last Updated</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {getDateTime(lastUpdated)}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                    {latestScan && (
+                        <>
+                            {latestScan.scanTime && (
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>Last Scan Time</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        {getDateTime(latestScan.scanTime)}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+                            )}
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Scan OS</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {latestScan.scanOs || '-'}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>Top CVSS</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {latestScan.topCvss || '-'}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </>
+                    )}
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Node</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {facts.nodeName || '-'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>IP Addresses</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {facts.ipAddresses || '-'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Pods</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {facts.activePods || '-'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Boot Order</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {facts.bootOrder || '-'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Vsock CID</DescriptionListTerm>
+                        <DescriptionListDescription>{vsockCid || '-'}</DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+                <ExpandableLabelSection toggleText="Labels" labels={recordToLabelArray(labels)} />
+                <ExpandableLabelSection
+                    toggleText="Annotations"
+                    labels={recordToLabelArray(annotations)}
+                />
+            </Flex>
         </PageSection>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetailsLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageDetailsLegacy.tsx
@@ -1,0 +1,58 @@
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    PageSection,
+} from '@patternfly/react-core';
+import capitalize from 'lodash/capitalize';
+
+import type { VirtualMachine } from 'services/VirtualMachineService';
+
+export type VirtualMachinePageDetailsLegacyProps = {
+    virtualMachine: VirtualMachine | undefined;
+};
+
+function VirtualMachinePageDetailsLegacy({ virtualMachine }: VirtualMachinePageDetailsLegacyProps) {
+    const facts = virtualMachine?.facts ?? {};
+    return (
+        <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'padding' }}>
+            <DescriptionList>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Status</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {capitalize(virtualMachine?.state)}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Operating System</DescriptionListTerm>
+                    <DescriptionListDescription>{facts.guestOS || '-'}</DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>IP Addresses</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {facts.ipAddresses || '-'}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Node</DescriptionListTerm>
+                    <DescriptionListDescription>{facts.nodeName || '-'}</DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Pods</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {facts.activePods || '-'}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Boot Order</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {facts.bootOrder || '-'}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+            </DescriptionList>
+        </PageSection>
+    );
+}
+
+export default VirtualMachinePageDetailsLegacy;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeaderLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeaderLegacy.tsx
@@ -1,23 +1,23 @@
 import { Alert, Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
 
-import type { VMDetail } from 'services/VirtualMachineService';
+import TechnologyPreviewLabel from 'Components/PatternFly/PreviewLabel/TechnologyPreviewLabel';
+import type { VirtualMachine } from 'services/VirtualMachineService';
 import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
-import { agentStatusDisplayMap, stateDisplayMap } from './virtualMachineUtils';
 
-export type VirtualMachinePageHeaderProps = {
-    virtualMachineDetail: VMDetail | undefined;
+export type VirtualMachinePageHeaderLegacyProps = {
+    virtualMachine: VirtualMachine | undefined;
     isLoading: boolean;
     error: Error | undefined;
 };
 
-function VirtualMachinePageHeader({
-    virtualMachineDetail,
+function VirtualMachinePageHeaderLegacy({
+    virtualMachine,
     isLoading,
     error,
-}: VirtualMachinePageHeaderProps) {
+}: VirtualMachinePageHeaderLegacyProps) {
     if (isLoading) {
         return (
             <HeaderLoadingSkeleton
@@ -40,29 +40,29 @@ function VirtualMachinePageHeader({
         );
     }
 
-    if (!virtualMachineDetail) {
+    if (!virtualMachine) {
         return null;
     }
 
-    const { name, clusterName, namespace, state, agentStatus, latestScan, guestOs } =
-        virtualMachineDetail;
-
     return (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
-            <Title headingLevel="h1">{name}</Title>
+            <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                <Title headingLevel="h1">{virtualMachine.name}</Title>
+                <TechnologyPreviewLabel />
+            </Flex>
             <LabelGroup numLabels={5}>
                 <Label>
-                    In: {clusterName}/{namespace}
+                    In: {virtualMachine.clusterName}/{virtualMachine.namespace}
                 </Label>
-                <Label>Status: {stateDisplayMap[state] ?? state}</Label>
-                <Label>Agent: {agentStatusDisplayMap[agentStatus] ?? agentStatus}</Label>
-                {latestScan?.scanTime && (
-                    <Label>Scan time: {getDateTime(latestScan.scanTime)}</Label>
+                {virtualMachine.scan?.scanTime && (
+                    <Label>Scan time: {getDateTime(virtualMachine.scan.scanTime)}</Label>
                 )}
-                {guestOs && <Label>Guest OS: {guestOs}</Label>}
+                {virtualMachine?.facts?.guestOS && (
+                    <Label>Guest OS: {virtualMachine.facts.guestOS}</Label>
+                )}
             </LabelGroup>
         </Flex>
     );
 }
 
-export default VirtualMachinePageHeader;
+export default VirtualMachinePageHeaderLegacy;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageLegacy.tsx
@@ -15,15 +15,26 @@ import {
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
 import useURLStringUnion from 'hooks/useURLStringUnion';
-import { getVM } from 'services/VirtualMachineService';
+import { getVirtualMachine } from 'services/VirtualMachineService';
 
+import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { detailsTabValues } from '../../types';
 import { getOverviewPagePath } from '../../utils/searchUtils';
-import VirtualMachinePageHeader from './VirtualMachinePageHeader';
-import VirtualMachinePageComponents from './VirtualMachinePageComponents';
-import VirtualMachinePageDetails from './VirtualMachinePageDetails';
-import VirtualMachinePageVulnerabilities from './VirtualMachinePageVulnerabilities';
+import {
+    COMPONENT_SORT_FIELD,
+    CVE_EPSS_PROBABILITY_SORT_FIELD,
+    CVE_SEVERITY_SORT_FIELD,
+    CVE_SORT_FIELD,
+    CVSS_SORT_FIELD,
+} from '../../utils/sortFields';
+import VirtualMachinePageHeaderLegacy from './VirtualMachinePageHeaderLegacy';
+import VirtualMachinePageComponentsLegacy from './VirtualMachinePageComponentsLegacy';
+import VirtualMachinePageDetailsLegacy from './VirtualMachinePageDetailsLegacy';
+import VirtualMachinePageVulnerabilitiesLegacy from './VirtualMachinePageVulnerabilitiesLegacy';
 
 const VULNERABILITIES_TAB_ID = 'vulnerabilities-tab-content';
 const COMPONENTS_TAB_ID = 'components-tab-content';
@@ -33,11 +44,36 @@ const virtualMachineCveOverviewPath = getOverviewPagePath('VirtualMachine', {
     entityTab: 'VirtualMachine',
 });
 
-function VirtualMachinePage() {
-    const { virtualMachineId } = useParams() as { virtualMachineId: string };
+const sortFields = [
+    COMPONENT_SORT_FIELD,
+    CVE_EPSS_PROBABILITY_SORT_FIELD,
+    CVE_SORT_FIELD,
+    CVE_SEVERITY_SORT_FIELD,
+    CVSS_SORT_FIELD,
+];
 
-    const fetchVirtualMachine = useCallback(() => getVM(virtualMachineId), [virtualMachineId]);
-    const { data: virtualMachineDetail, isLoading, error } = useRestQuery(fetchVirtualMachine);
+const defaultComponentsSortOption = { field: COMPONENT_SORT_FIELD, direction: 'asc' } as const;
+
+const defaultVulnerabilitiesSortOption = {
+    field: CVE_SEVERITY_SORT_FIELD,
+    direction: 'desc',
+} as const;
+
+function VirtualMachinePageLegacy() {
+    const { virtualMachineId } = useParams() as { virtualMachineId: string };
+    const urlPagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const urlSearch = useURLSearch();
+    const urlSorting = useURLSort({
+        sortFields,
+        defaultSortOption: defaultVulnerabilitiesSortOption,
+        onSort: () => urlPagination.setPage(1, 'replace'),
+    });
+
+    const fetchVirtualMachine = useCallback(
+        () => getVirtualMachine(virtualMachineId),
+        [virtualMachineId]
+    );
+    const { data: virtualMachine, isLoading, error } = useRestQuery(fetchVirtualMachine);
 
     const [activeTabKey, setActiveTabKey] = useURLStringUnion('detailsTab', detailsTabValues);
 
@@ -46,21 +82,26 @@ function VirtualMachinePage() {
     const detailsTabKey = detailsTabValues[1];
 
     function onTabChange(value: string | number) {
+        if (value === componentsTabKey) {
+            urlSorting.setSortOption(defaultComponentsSortOption);
+        } else {
+            urlSorting.setSortOption(defaultVulnerabilitiesSortOption);
+        }
         setActiveTabKey(value);
+        urlPagination.setPage(1, 'replace');
+        urlSearch.setSearchFilter({});
     }
 
     return (
         <>
-            <PageTitle
-                title={`Virtual Machine CVEs - Virtual Machine ${virtualMachineDetail?.name}`}
-            />
+            <PageTitle title={`Virtual Machine CVEs - Virtual Machine ${virtualMachine?.name}`} />
             <PageSection>
                 <Breadcrumb>
                     <BreadcrumbItemLink to={virtualMachineCveOverviewPath}>
                         Virtual Machines
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>
-                        {virtualMachineDetail?.name ?? (
+                        {virtualMachine?.name ?? (
                             <Skeleton
                                 screenreaderText="Loading Virtual Machine name"
                                 width="200px"
@@ -71,8 +112,8 @@ function VirtualMachinePage() {
             </PageSection>
             <Divider component="div" />
             <PageSection>
-                <VirtualMachinePageHeader
-                    virtualMachineDetail={virtualMachineDetail}
+                <VirtualMachinePageHeaderLegacy
+                    virtualMachine={virtualMachine}
                     isLoading={isLoading}
                     error={error}
                 />
@@ -123,21 +164,31 @@ function VirtualMachinePage() {
             >
                 {activeTabKey === vulnTabKey && (
                     <TabContent id={VULNERABILITIES_TAB_ID}>
-                        <VirtualMachinePageVulnerabilities virtualMachineId={virtualMachineId} />
+                        <VirtualMachinePageVulnerabilitiesLegacy
+                            virtualMachine={virtualMachine}
+                            isLoadingVirtualMachine={isLoading}
+                            errorVirtualMachine={error}
+                            urlSearch={urlSearch}
+                            urlSorting={urlSorting}
+                            urlPagination={urlPagination}
+                        />
                     </TabContent>
                 )}
                 {activeTabKey === componentsTabKey && (
                     <TabContent id={COMPONENTS_TAB_ID}>
-                        <VirtualMachinePageComponents virtualMachineId={virtualMachineId} />
+                        <VirtualMachinePageComponentsLegacy
+                            virtualMachine={virtualMachine}
+                            isLoadingVirtualMachine={isLoading}
+                            errorVirtualMachine={error}
+                            urlSearch={urlSearch}
+                            urlSorting={urlSorting}
+                            urlPagination={urlPagination}
+                        />
                     </TabContent>
                 )}
                 {activeTabKey === detailsTabKey && (
                     <TabContent id={DETAILS_TAB_ID}>
-                        {virtualMachineDetail && (
-                            <VirtualMachinePageDetails
-                                virtualMachineDetail={virtualMachineDetail}
-                            />
-                        )}
+                        <VirtualMachinePageDetailsLegacy virtualMachine={virtualMachine} />
                     </TabContent>
                 )}
             </PageSection>
@@ -145,4 +196,4 @@ function VirtualMachinePage() {
     );
 }
 
-export default VirtualMachinePage;
+export default VirtualMachinePageLegacy;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/virtualMachineUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/virtualMachineUtils.ts
@@ -1,0 +1,12 @@
+import type { AgentStatus, VirtualMachineV2State } from 'services/VirtualMachineService';
+
+export const stateDisplayMap: Record<VirtualMachineV2State, string> = {
+    VM_STATE_UNKNOWN: 'Unknown',
+    VM_STATE_STOPPED: 'Stopped',
+    VM_STATE_RUNNING: 'Running',
+};
+
+export const agentStatusDisplayMap: Record<AgentStatus, string> = {
+    AGENT_STATUS_UNKNOWN: 'Unknown',
+    AGENT_STATUS_ACTIVE: 'Active',
+};

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCvesPage.tsx
@@ -4,14 +4,20 @@ import { PageSection } from '@patternfly/react-core';
 import PageNotFound from 'Components/PageNotFound';
 import PageTitle from 'Components/PageTitle';
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import VirtualMachineCvesOverviewPage from './Overview/VirtualMachineCvesOverviewPage';
 import VirtualMachineCvePage from './VirtualMachineCve/VirtualMachineCvePage';
 import VirtualMachinePage from './VirtualMachine/VirtualMachinePage';
+import VirtualMachinePageLegacy from './VirtualMachine/VirtualMachinePageLegacy';
 
 function VirtualMachineCvesPage() {
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForIntegration = hasReadAccess('Integration');
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isEnhancedDataModelEnabled = isFeatureFlagEnabled(
+        'ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL'
+    );
 
     return (
         <>
@@ -19,7 +25,16 @@ function VirtualMachineCvesPage() {
             <Routes>
                 <Route index element={<VirtualMachineCvesOverviewPage />} />
                 <Route path="cves/:cveId" element={<VirtualMachineCvePage />} />
-                <Route path="virtualmachines/:virtualMachineId" element={<VirtualMachinePage />} />
+                <Route
+                    path="virtualmachines/:virtualMachineId"
+                    element={
+                        isEnhancedDataModelEnabled ? (
+                            <VirtualMachinePage />
+                        ) : (
+                            <VirtualMachinePageLegacy />
+                        )
+                    }
+                />
                 <Route
                     path="*"
                     element={

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -5,7 +5,6 @@ import type { SearchQueryOptions } from 'types/search';
 import { applyRegexSearchModifiers } from 'utils/searchUtils';
 
 import { buildNestedRawQueryParams } from './ComplianceCommon';
-import { applyRegexSearchModifiers } from 'utils/searchUtils';
 
 // Legacy API (v2/virtualmachines)
 

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -5,6 +5,7 @@ import type { SearchQueryOptions } from 'types/search';
 import { applyRegexSearchModifiers } from 'utils/searchUtils';
 
 import { buildNestedRawQueryParams } from './ComplianceCommon';
+import { applyRegexSearchModifiers } from 'utils/searchUtils';
 
 // Legacy API (v2/virtualmachines)
 

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -288,7 +288,5 @@ export function listVMComponents(
 }
 
 export function getVM(vmId: string): Promise<VMDetail> {
-    return axios
-        .get<VMDetail>(`/v2/virtualmachines/vms/${vmId}`)
-        .then((response) => response.data);
+    return axios.get<VMDetail>(`/v2/virtualmachines/vms/${vmId}`).then((response) => response.data);
 }

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -179,6 +179,49 @@ export type ListVMComponentsResponse = {
     totalCount: number;
 };
 
+export type VirtualMachineV2State = 'VM_STATE_UNKNOWN' | 'VM_STATE_STOPPED' | 'VM_STATE_RUNNING';
+
+export type VMScanNote =
+    | 'VM_SCAN_NOTE_UNSET'
+    | 'VM_SCAN_NOTE_OS_UNKNOWN'
+    | 'VM_SCAN_NOTE_OS_UNSUPPORTED';
+
+export type VMNote =
+    | 'VM_NOTE_MISSING_METADATA'
+    | 'VM_NOTE_MISSING_SCAN_DATA'
+    | 'VM_NOTE_MISSING_SIGNATURE'
+    | 'VM_NOTE_MISSING_SIGNATURE_VERIFICATION_DATA'
+    | 'VM_NOTE_MISSING_SCANNER'
+    | 'VM_NOTE_SCAN_FAILED';
+
+export type AgentStatus = 'AGENT_STATUS_UNKNOWN' | 'AGENT_STATUS_ACTIVE';
+
+export type VMScanInfo = {
+    scanId: string;
+    scanOs: string;
+    scanTime?: string;
+    topCvss: number;
+    scanNotes: VMScanNote[];
+};
+
+export type VMDetail = {
+    id: string;
+    name: string;
+    namespace: string;
+    clusterId: string;
+    clusterName: string;
+    guestOs: string;
+    state: VirtualMachineV2State;
+    lastUpdated?: string;
+    facts: Record<string, string>;
+    annotations: Record<string, string>;
+    labels: Record<string, string>;
+    vsockCid: number;
+    notes: VMNote[];
+    latestScan?: VMScanInfo;
+    agentStatus: AgentStatus;
+};
+
 export function listVMs({
     sortOption,
     page,
@@ -241,5 +284,11 @@ export function listVMComponents(
     });
     return axios
         .get<ListVMComponentsResponse>(`/v2/virtualmachines/${vmId}/components?${params}`)
+        .then((response) => response.data);
+}
+
+export function getVM(vmId: string): Promise<VMDetail> {
+    return axios
+        .get<VMDetail>(`/v2/virtualmachines/vms/${vmId}`)
         .then((response) => response.data);
 }


### PR DESCRIPTION
## Description

When `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL` is enabled, the VM detail page header and details tab now use the `GetVM` v2 endpoint.

**Details tab:**
- Uses `VMDetail` response type instead of legacy `VirtualMachine`
- Note: `annotations`, `labels`, and `agentStatus` exist in the API proto but are not yet populated by the backend converter. 

**Header:**
- Uses `VMDetail` for cluster/namespace, scan time, and guest OS
- Adds VM state and agent status labels
- Removes `TechnologyPreviewLabel` from enhanced header

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified enhanced detail page renders all fields from `VMDetail` response
- Verified legacy pages remain unchanged when feature flag is off

<img width="2149" height="1159" alt="Screenshot 2026-07-20 at 12 36 26 PM" src="https://github.com/user-attachments/assets/9fa6174b-877f-4327-b2d2-f027359f0417" />

