### PR TITLE
POC - DO NOT REVIEW: Auto-detect Lightspeed via OLSConfig CRD

### DIFF
--- a/central/deployment/service/service_impl.go
+++ b/central/deployment/service/service_impl.go
@@ -302,14 +302,14 @@ func (s *serviceImpl) GetDeploymentRiskSummary(ctx context.Context, request *v1.
 
 	clusterID := riskResp.GetDeployment().GetClusterId()
 
-	host, info := s.lightspeedStore.Get(clusterID)
-	if host == "" {
+	_, info := s.lightspeedStore.Get(clusterID)
+	if info == nil || (!info.GetIsReady() && !info.GetIsAutoDetected()) {
 		return nil, errox.InvalidArgs.New("Lightspeed is not configured for this cluster")
 	}
-	if info != nil && !info.GetIsReady() {
+	if !info.GetIsReady() {
 		return nil, errox.ResourceExhausted.Newf("Lightspeed is not ready: %s", info.GetStatusError())
 	}
-	if info != nil && !info.GetHasQueryAccess() {
+	if !info.GetHasQueryAccess() {
 		return nil, errox.NotAuthorized.Newf("Sensor lacks Lightspeed access: %s", info.GetStatusError())
 	}
 

--- a/central/lightspeed/DESIGN.md
+++ b/central/lightspeed/DESIGN.md
@@ -50,12 +50,22 @@ Sensor already has an auto-mounted service account token and can reach
 cluster-local services. This follows the existing `DeploymentEnhancement`
 pattern where Central sends requests to Sensor for cluster-local operations.
 
-## Why user-configured host instead of auto-detection?
+## Auto-detection via OLSConfig CRD
 
-Lightspeed deployment names and namespaces can be customized by the operator
-configuration (`OLSConfig` CR). Rather than guessing deployment names, we let
-the user provide the service URL. Sensor validates it using Lightspeed's
-`/readiness` and `/authorized` endpoints.
+Sensor auto-detects Lightspeed by checking for the `OLSConfig` CRD
+(`ols.openshift.io/v1alpha1`). On each health-check tick:
+1. Discovery API: does `ols.openshift.io/v1alpha1` exist?
+2. Dynamic client: any `OLSConfig` CRs? (name is not assumed — could be
+   anything, not just "cluster")
+3. Typed client: find services with label
+   `app.kubernetes.io/part-of=openshift-lightspeed`
+4. Construct the URL from the service's name, namespace, and first port
+
+Manual host configuration from Central takes precedence. When
+`LightspeedConfig{host: ""}` is sent, auto-detection resumes.
+
+The `LightspeedInfo` message includes `is_auto_detected: true` when the host
+was discovered via the CRD rather than configured manually.
 
 ## Authentication
 

--- a/central/lightspeed/service/service_impl.go
+++ b/central/lightspeed/service/service_impl.go
@@ -93,6 +93,7 @@ func (s *serviceImpl) GetLightspeedConfig(_ context.Context, req *v1.ResourceByI
 		resp.IsReady = info.GetIsReady()
 		resp.HasQueryAccess = info.GetHasQueryAccess()
 		resp.StatusError = info.GetStatusError()
+		resp.IsAutoDetected = info.GetIsAutoDetected()
 	}
 	return resp, nil
 }

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -938,6 +938,8 @@ function launch_sensor {
       if [[ "${LIGHTSPEED_ENABLED:-false}" == "true" ]]; then
         echo "Enable Lightspeed integration"
         extra_helm_config+=(--set "lightspeed.enabled=true")
+        ${KUBE_COMMAND:-kubectl} label namespace "${sensor_namespace}" \
+          network.openshift.io/policy-group=ingress --overwrite 2>/dev/null || true
       fi
 
       if [[ -n "$CI" ]]; then

--- a/generated/api/v1/lightspeed_service.pb.go
+++ b/generated/api/v1/lightspeed_service.pb.go
@@ -80,6 +80,7 @@ type GetLightspeedConfigResponse struct {
 	IsReady        bool                   `protobuf:"varint,2,opt,name=is_ready,json=isReady,proto3" json:"is_ready,omitempty"`
 	HasQueryAccess bool                   `protobuf:"varint,3,opt,name=has_query_access,json=hasQueryAccess,proto3" json:"has_query_access,omitempty"`
 	StatusError    string                 `protobuf:"bytes,4,opt,name=status_error,json=statusError,proto3" json:"status_error,omitempty"`
+	IsAutoDetected bool                   `protobuf:"varint,5,opt,name=is_auto_detected,json=isAutoDetected,proto3" json:"is_auto_detected,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -142,6 +143,13 @@ func (x *GetLightspeedConfigResponse) GetStatusError() string {
 	return ""
 }
 
+func (x *GetLightspeedConfigResponse) GetIsAutoDetected() bool {
+	if x != nil {
+		return x.IsAutoDetected
+	}
+	return false
+}
+
 var File_api_v1_lightspeed_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_lightspeed_service_proto_rawDesc = "" +
@@ -150,12 +158,13 @@ const file_api_v1_lightspeed_service_proto_rawDesc = "" +
 	"\x1aConfigureLightspeedRequest\x12\x1d\n" +
 	"\n" +
 	"cluster_id\x18\x01 \x01(\tR\tclusterId\x12\x12\n" +
-	"\x04host\x18\x02 \x01(\tR\x04host\"\x99\x01\n" +
+	"\x04host\x18\x02 \x01(\tR\x04host\"\xc3\x01\n" +
 	"\x1bGetLightspeedConfigResponse\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x19\n" +
 	"\bis_ready\x18\x02 \x01(\bR\aisReady\x12(\n" +
 	"\x10has_query_access\x18\x03 \x01(\bR\x0ehasQueryAccess\x12!\n" +
-	"\fstatus_error\x18\x04 \x01(\tR\vstatusError2\x84\x02\n" +
+	"\fstatus_error\x18\x04 \x01(\tR\vstatusError\x12(\n" +
+	"\x10is_auto_detected\x18\x05 \x01(\bR\x0eisAutoDetected2\x84\x02\n" +
 	"\x11LightspeedService\x12x\n" +
 	"\x13ConfigureLightspeed\x12\x1e.v1.ConfigureLightspeedRequest\x1a\t.v1.Empty\"6\x82\xd3\xe4\x93\x020:\x01*\x1a+/v1/clusters/{cluster_id}/lightspeed-config\x12u\n" +
 	"\x13GetLightspeedConfig\x12\x10.v1.ResourceByID\x1a\x1f.v1.GetLightspeedConfigResponse\"+\x82\xd3\xe4\x93\x02%\x12#/v1/clusters/{id}/lightspeed-configB'\n" +

--- a/generated/api/v1/lightspeed_service.swagger.json
+++ b/generated/api/v1/lightspeed_service.swagger.json
@@ -141,6 +141,9 @@
         },
         "statusError": {
           "type": "string"
+        },
+        "isAutoDetected": {
+          "type": "boolean"
         }
       }
     }

--- a/generated/api/v1/lightspeed_service_vtproto.pb.go
+++ b/generated/api/v1/lightspeed_service_vtproto.pb.go
@@ -47,6 +47,7 @@ func (m *GetLightspeedConfigResponse) CloneVT() *GetLightspeedConfigResponse {
 	r.IsReady = m.IsReady
 	r.HasQueryAccess = m.HasQueryAccess
 	r.StatusError = m.StatusError
+	r.IsAutoDetected = m.IsAutoDetected
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -96,6 +97,9 @@ func (this *GetLightspeedConfigResponse) EqualVT(that *GetLightspeedConfigRespon
 		return false
 	}
 	if this.StatusError != that.StatusError {
+		return false
+	}
+	if this.IsAutoDetected != that.IsAutoDetected {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -185,6 +189,16 @@ func (m *GetLightspeedConfigResponse) MarshalToSizedBufferVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.IsAutoDetected {
+		i--
+		if m.IsAutoDetected {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
 	if len(m.StatusError) > 0 {
 		i -= len(m.StatusError)
 		copy(dAtA[i:], m.StatusError)
@@ -259,6 +273,9 @@ func (m *GetLightspeedConfigResponse) SizeVT() (n int) {
 	l = len(m.StatusError)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.IsAutoDetected {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -512,6 +529,26 @@ func (m *GetLightspeedConfigResponse) UnmarshalVT(dAtA []byte) error {
 			}
 			m.StatusError = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IsAutoDetected", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IsAutoDetected = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -798,6 +835,26 @@ func (m *GetLightspeedConfigResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.StatusError = stringValue
 			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IsAutoDetected", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IsAutoDetected = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/internalapi/central/lightspeed.pb.go
+++ b/generated/internalapi/central/lightspeed.pb.go
@@ -75,6 +75,7 @@ type LightspeedInfo struct {
 	IsReady        bool                   `protobuf:"varint,2,opt,name=is_ready,json=isReady,proto3" json:"is_ready,omitempty"`
 	HasQueryAccess bool                   `protobuf:"varint,3,opt,name=has_query_access,json=hasQueryAccess,proto3" json:"has_query_access,omitempty"`
 	StatusError    string                 `protobuf:"bytes,4,opt,name=status_error,json=statusError,proto3" json:"status_error,omitempty"`
+	IsAutoDetected bool                   `protobuf:"varint,5,opt,name=is_auto_detected,json=isAutoDetected,proto3" json:"is_auto_detected,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -135,6 +136,13 @@ func (x *LightspeedInfo) GetStatusError() string {
 		return x.StatusError
 	}
 	return ""
+}
+
+func (x *LightspeedInfo) GetIsAutoDetected() bool {
+	if x != nil {
+		return x.IsAutoDetected
+	}
+	return false
 }
 
 // LightspeedQueryRequest is sent from Central to Sensor to query Lightspeed.
@@ -265,12 +273,13 @@ const file_internalapi_central_lightspeed_proto_rawDesc = "" +
 	"\n" +
 	"$internalapi/central/lightspeed.proto\x12\acentral\"&\n" +
 	"\x10LightspeedConfig\x12\x12\n" +
-	"\x04host\x18\x01 \x01(\tR\x04host\"\x8c\x01\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\"\xb6\x01\n" +
 	"\x0eLightspeedInfo\x12\x12\n" +
 	"\x04host\x18\x01 \x01(\tR\x04host\x12\x19\n" +
 	"\bis_ready\x18\x02 \x01(\bR\aisReady\x12(\n" +
 	"\x10has_query_access\x18\x03 \x01(\bR\x0ehasQueryAccess\x12!\n" +
-	"\fstatus_error\x18\x04 \x01(\tR\vstatusError\"a\n" +
+	"\fstatus_error\x18\x04 \x01(\tR\vstatusError\x12(\n" +
+	"\x10is_auto_detected\x18\x05 \x01(\bR\x0eisAutoDetected\"a\n" +
 	"\x16LightspeedQueryRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05query\x18\x02 \x01(\tR\x05query\x12!\n" +

--- a/generated/internalapi/central/lightspeed_vtproto.pb.go
+++ b/generated/internalapi/central/lightspeed_vtproto.pb.go
@@ -46,6 +46,7 @@ func (m *LightspeedInfo) CloneVT() *LightspeedInfo {
 	r.IsReady = m.IsReady
 	r.HasQueryAccess = m.HasQueryAccess
 	r.StatusError = m.StatusError
+	r.IsAutoDetected = m.IsAutoDetected
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -130,6 +131,9 @@ func (this *LightspeedInfo) EqualVT(that *LightspeedInfo) bool {
 		return false
 	}
 	if this.StatusError != that.StatusError {
+		return false
+	}
+	if this.IsAutoDetected != that.IsAutoDetected {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -261,6 +265,16 @@ func (m *LightspeedInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.IsAutoDetected {
+		i--
+		if m.IsAutoDetected {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
 	}
 	if len(m.StatusError) > 0 {
 		i -= len(m.StatusError)
@@ -440,6 +454,9 @@ func (m *LightspeedInfo) SizeVT() (n int) {
 	l = len(m.StatusError)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.IsAutoDetected {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -705,6 +722,26 @@ func (m *LightspeedInfo) UnmarshalVT(dAtA []byte) error {
 			}
 			m.StatusError = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IsAutoDetected", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IsAutoDetected = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1249,6 +1286,26 @@ func (m *LightspeedInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.StatusError = stringValue
 			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IsAutoDetected", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IsAutoDetected = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-lightspeed-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-lightspeed-rbac.yaml
@@ -1,6 +1,5 @@
 {{- include "srox.init" . -}}
 
-{{- if ._rox.lightspeed.enabled }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -17,4 +16,3 @@ roleRef:
   kind: ClusterRole
   name: lightspeed-operator-query-access
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/image/templates/sensor/kubernetes/sensor.sh
+++ b/image/templates/sensor/kubernetes/sensor.sh
@@ -97,6 +97,10 @@ if [[ -f "$DIR/sensor-compliance-rbac.yaml" ]]; then
     echo "Creating sensor compliance RBAC roles..."
     ${KUBE_COMMAND} apply -f "$DIR/sensor-compliance-rbac.yaml"
 fi
+if [[ -f "$DIR/sensor-lightspeed-rbac.yaml" ]]; then
+    echo "Creating sensor Lightspeed RBAC roles..."
+    ${KUBE_COMMAND} apply -f "$DIR/sensor-lightspeed-rbac.yaml"
+fi
 echo "Creating sensor network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/sensor-netpol.yaml" || exit 1
 

--- a/image/templates/sensor/openshift/sensor.sh
+++ b/image/templates/sensor/openshift/sensor.sh
@@ -35,6 +35,10 @@ if [[ -f "$DIR/sensor-compliance-rbac.yaml" ]]; then
     echo "Creating sensor compliance RBAC roles..."
     ${KUBE_COMMAND} apply -f "$DIR/sensor-compliance-rbac.yaml"
 fi
+if [[ -f "$DIR/sensor-lightspeed-rbac.yaml" ]]; then
+    echo "Creating sensor Lightspeed RBAC roles..."
+    ${KUBE_COMMAND} apply -f "$DIR/sensor-lightspeed-rbac.yaml"
+fi
 echo "Creating sensor network policies..."
 ${KUBE_COMMAND} apply -f "$DIR/sensor-netpol.yaml"
 

--- a/proto/api/v1/lightspeed_service.proto
+++ b/proto/api/v1/lightspeed_service.proto
@@ -19,6 +19,7 @@ message GetLightspeedConfigResponse {
   bool is_ready = 2;
   bool has_query_access = 3;
   string status_error = 4;
+  bool is_auto_detected = 5;
 }
 
 service LightspeedService {

--- a/proto/internalapi/central/lightspeed.proto
+++ b/proto/internalapi/central/lightspeed.proto
@@ -17,6 +17,7 @@ message LightspeedInfo {
   bool is_ready = 2;
   bool has_query_access = 3;
   string status_error = 4;
+  bool is_auto_detected = 5;
 }
 
 // LightspeedQueryRequest is sent from Central to Sensor to query Lightspeed.

--- a/sensor/kubernetes/lightspeed/updater.go
+++ b/sensor/kubernetes/lightspeed/updater.go
@@ -15,6 +15,11 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	sensorUtils "github.com/stackrox/rox/sensor/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -27,8 +32,15 @@ var (
 	log = logging.LoggerForModule()
 )
 
+var olsConfigGVR = schema.GroupVersionResource{
+	Group:    "ols.openshift.io",
+	Version:  "v1alpha1",
+	Resource: "olsconfigs",
+}
+
 // NewUpdater returns a sensor component that periodically checks Lightspeed endpoint health.
-func NewUpdater(updateInterval time.Duration) *updaterImpl {
+// It auto-detects Lightspeed via the OLSConfig CRD when no manual host is configured.
+func NewUpdater(k8sClient kubernetes.Interface, dynamicClient dynamic.Interface, updateInterval time.Duration) *updaterImpl {
 	if updateInterval == 0 {
 		updateInterval = defaultInterval
 	}
@@ -36,6 +48,8 @@ func NewUpdater(updateInterval time.Duration) *updaterImpl {
 	updateTicker.Stop()
 
 	return &updaterImpl{
+		k8sClient:      k8sClient,
+		dynamicClient:  dynamicClient,
 		updateInterval: updateInterval,
 		response:       make(chan *message.ExpiringMessage),
 		stopSig:        concurrency.NewSignal(),
@@ -52,14 +66,17 @@ func NewUpdater(updateInterval time.Duration) *updaterImpl {
 }
 
 type updaterImpl struct {
+	k8sClient      kubernetes.Interface
+	dynamicClient  dynamic.Interface
 	updateTicker   *time.Ticker
 	updateInterval time.Duration
 	response       chan *message.ExpiringMessage
 	stopSig        concurrency.Signal
 	httpClient     *http.Client
 
-	mutex sync.RWMutex
-	host  string
+	mutex      sync.RWMutex
+	manualHost string // set by Central via ProcessMessage
+	autoHost   string // set by OLSConfig CRD auto-detection
 }
 
 func (u *updaterImpl) Name() string {
@@ -102,20 +119,44 @@ func (u *updaterImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor
 	}
 
 	u.mutex.Lock()
-	u.host = config.GetHost()
+	u.manualHost = config.GetHost()
 	u.mutex.Unlock()
 
-	log.Infof("Lightspeed config updated: host=%s", config.GetHost())
+	log.Infof("Lightspeed manual config updated: host=%s", config.GetHost())
 	return nil
 }
 
+// GetHost returns the effective host: manual config takes precedence over auto-detected.
 func (u *updaterImpl) GetHost() string {
 	u.mutex.RLock()
 	defer u.mutex.RUnlock()
-	return u.host
+	if u.manualHost != "" {
+		return u.manualHost
+	}
+	return u.autoHost
+}
+
+func (u *updaterImpl) isAutoDetected() bool {
+	u.mutex.RLock()
+	defer u.mutex.RUnlock()
+	return u.manualHost == "" && u.autoHost != ""
+}
+
+func (u *updaterImpl) setAutoHost(host string) {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+	if u.autoHost != host {
+		if host != "" {
+			log.Infof("Auto-detected Lightspeed service: %s", host)
+		} else if u.autoHost != "" {
+			log.Info("Lightspeed service no longer detected")
+		}
+		u.autoHost = host
+	}
 }
 
 func (u *updaterImpl) run(tickerC <-chan time.Time) {
+	u.detectLightspeedHost()
 	if responseSent := u.checkHealthAndSendResponse(); !responseSent {
 		return
 	}
@@ -123,6 +164,7 @@ func (u *updaterImpl) run(tickerC <-chan time.Time) {
 	for {
 		select {
 		case <-tickerC:
+			u.detectLightspeedHost()
 			if responseSent := u.checkHealthAndSendResponse(); !responseSent {
 				return
 			}
@@ -130,6 +172,51 @@ func (u *updaterImpl) run(tickerC <-chan time.Time) {
 			return
 		}
 	}
+}
+
+func (u *updaterImpl) detectLightspeedHost() {
+	ctx := concurrency.AsContext(&u.stopSig)
+
+	hasAPI, err := sensorUtils.HasAPI(u.k8sClient, "ols.openshift.io/v1alpha1", "OLSConfig")
+	if err != nil {
+		log.Debugf("Failed to check for OLSConfig API: %v", err)
+		u.setAutoHost("")
+		return
+	}
+	if !hasAPI {
+		u.setAutoHost("")
+		return
+	}
+
+	list, err := u.dynamicClient.Resource(olsConfigGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Debugf("Failed to list OLSConfig CRs: %v", err)
+		u.setAutoHost("")
+		return
+	}
+	if len(list.Items) == 0 {
+		u.setAutoHost("")
+		return
+	}
+
+	services, err := u.k8sClient.CoreV1().Services("").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/part-of=openshift-lightspeed",
+	})
+	if err != nil || len(services.Items) == 0 {
+		log.Debugf("OLSConfig exists but no Lightspeed service found: %v", err)
+		u.setAutoHost("")
+		return
+	}
+
+	svc := services.Items[0]
+	if len(svc.Spec.Ports) == 0 {
+		log.Warn("Lightspeed service found but has no ports")
+		u.setAutoHost("")
+		return
+	}
+
+	host := fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
+	u.setAutoHost(host)
 }
 
 func (u *updaterImpl) checkHealthAndSendResponse() bool {
@@ -154,6 +241,7 @@ func (u *updaterImpl) checkHealthAndSendResponse() bool {
 
 func (u *updaterImpl) getLightspeedInfo() *central.LightspeedInfo {
 	host := u.GetHost()
+	autoDetected := u.isAutoDetected()
 	if host == "" {
 		return &central.LightspeedInfo{
 			Host:           "",
@@ -163,7 +251,8 @@ func (u *updaterImpl) getLightspeedInfo() *central.LightspeedInfo {
 	}
 
 	info := &central.LightspeedInfo{
-		Host: host,
+		Host:           host,
+		IsAutoDetected: autoDetected,
 	}
 
 	// Check readiness endpoint

--- a/sensor/kubernetes/lightspeed/updater.go
+++ b/sensor/kubernetes/lightspeed/updater.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/pods"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -74,9 +75,10 @@ type updaterImpl struct {
 	stopSig        concurrency.Signal
 	httpClient     *http.Client
 
-	mutex      sync.RWMutex
-	manualHost string // set by Central via ProcessMessage
-	autoHost   string // set by OLSConfig CRD auto-detection
+	mutex                 sync.RWMutex
+	manualHost            string // set by Central via ProcessMessage
+	autoHost              string // set by OLSConfig CRD auto-detection
+	namespaceLabelApplied bool
 }
 
 func (u *updaterImpl) Name() string {
@@ -217,6 +219,43 @@ func (u *updaterImpl) detectLightspeedHost() {
 
 	host := fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
 	u.setAutoHost(host)
+	u.ensureNamespaceLabel(ctx)
+}
+
+const ingressPolicyLabel = "network.openshift.io/policy-group"
+
+func (u *updaterImpl) ensureNamespaceLabel(ctx context.Context) {
+	if u.namespaceLabelApplied {
+		return
+	}
+
+	ns := pods.GetPodNamespace()
+	if ns == "" {
+		return
+	}
+
+	nsObj, err := u.k8sClient.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if err != nil {
+		log.Debugf("Failed to get namespace %s: %v", ns, err)
+		return
+	}
+
+	if nsObj.Labels[ingressPolicyLabel] == "ingress" {
+		u.namespaceLabelApplied = true
+		return
+	}
+
+	if nsObj.Labels == nil {
+		nsObj.Labels = make(map[string]string)
+	}
+	nsObj.Labels[ingressPolicyLabel] = "ingress"
+
+	if _, err := u.k8sClient.CoreV1().Namespaces().Update(ctx, nsObj, metav1.UpdateOptions{}); err != nil {
+		log.Warnf("Failed to label namespace %s for Lightspeed network access: %v", ns, err)
+		return
+	}
+	log.Infof("Labeled namespace %s with %s=ingress for Lightspeed network access", ns, ingressPolicyLabel)
+	u.namespaceLabelApplied = true
 }
 
 func (u *updaterImpl) checkHealthAndSendResponse() bool {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -215,7 +215,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	coInfoUpdater := complianceoperator.NewInfoUpdater(cfg.k8sClient.Kubernetes(), 0, &coReadySignal)
 	components = append(components, coInfoUpdater, complianceoperator.NewRequestHandler(cfg.k8sClient.Dynamic(), coInfoUpdater, &coReadySignal))
 
-	lightspeedUpdater := lightspeed.NewUpdater(0)
+	lightspeedUpdater := lightspeed.NewUpdater(cfg.k8sClient.Kubernetes(), cfg.k8sClient.Dynamic(), 0)
 	lightspeedQuerier := lightspeed.NewQuerier(lightspeedUpdater)
 	components = append(components, lightspeedUpdater, lightspeedQuerier)
 


### PR DESCRIPTION
## Description

Adds auto-detection of OpenShift Lightspeed to the Sensor updater. Instead of requiring manual host configuration via the API, Sensor now periodically checks for the `OLSConfig` CRD (`ols.openshift.io/v1alpha1`) and discovers the Lightspeed service by label selector.

**Detection flow (each 30s tick):**
1. Discovery API: does `ols.openshift.io/v1alpha1` exist?
2. Dynamic client: any `OLSConfig` CRs? (name not assumed — form allows changing it)
3. Typed client: find services with label `app.kubernetes.io/part-of=openshift-lightspeed`
4. Construct URL from service name/namespace/port

Manual host config from Central still takes precedence over auto-detection. Sending an empty host clears the override and auto-detection resumes.

A new `is_auto_detected` field on `LightspeedInfo` and `GetLightspeedConfigResponse` lets Central/UI distinguish between manually configured and auto-detected hosts.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Prototype — will validate on OpenShift cluster with Lightspeed operator installed.