### PR TITLE
ROX-35848: force KubeVirt CA refetch on client verify failure

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -83,12 +83,20 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() { srv.Serve(ctx, ln); close(serveDone) }()
+	// cancel/serveDone must run even if the select times out and calls
+	// t.Fatal; otherwise the accept-loop goroutine outlives the test.
+	defer func() {
+		cancel()
+		<-serveDone
+	}()
 
 	// A stalled peer: opens the TCP connection but never sends a TLS
 	// ClientHello (or anything else). That peer wins the single semaphore
 	// slot; serveConn then blocks in HandshakeContext off the accept loop.
 	stalled, err := net.Dial("tcp", ln.Addr().String())
 	require.NoError(t, err)
+	// Close before cancel (defer LIFO) so the handshake goroutine unblocks
+	// without waiting out connDeadline.
 	defer func() { _ = stalled.Close() }()
 
 	// A second peer must still be accepted, handshaked, and answered with
@@ -123,10 +131,4 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	case <-time.After(5 * time.Second):
 		t.Fatal("second connection was not answered promptly; accept loop is likely blocked by the stalled peer")
 	}
-
-	// Unblock the stalled connection's server-side handshake goroutine
-	// immediately, rather than waiting out connDeadline, so the test stays fast.
-	_ = stalled.Close()
-	cancel()
-	<-serveDone
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -65,6 +65,14 @@ func TestServeAcceptLoop(t *testing.T) {
 // every other connection - including the legitimate one - for as long as
 // the stalled peer stayed connected. The handshake must run off the accept
 // loop so Accept() only ever blocks on Accept() itself.
+//
+// With maxConcurrentConns=1, the stalled peer is accepted first and holds
+// the semaphore for the duration of its (never-completing) handshake, so
+// the second peer always takes the rejectConn path and receives
+// ERROR_CODE_BUSY. That is enough to prove Accept() kept running: a blocked
+// accept loop would never handshake the second peer or write BUSY.
+// The client must only ReadFrame here - writing a request races rejectConn's
+// close-after-BUSY and flakes with broken pipe on Linux.
 func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing.T) {
 	handler := NewHandler(&ReportCache{}, "test")
 	srv := NewServer(handler, &tls.Config{Certificates: []tls.Certificate{testServerCert(t)}})
@@ -77,15 +85,14 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	go func() { srv.Serve(ctx, ln); close(serveDone) }()
 
 	// A stalled peer: opens the TCP connection but never sends a TLS
-	// ClientHello (or anything else). Before the fix, the server's
-	// HandshakeContext call for this connection would block Serve's single
-	// accept loop indefinitely, since it has no deadline of its own.
+	// ClientHello (or anything else). That peer wins the single semaphore
+	// slot; serveConn then blocks in HandshakeContext off the accept loop.
 	stalled, err := net.Dial("tcp", ln.Addr().String())
 	require.NoError(t, err)
 	defer func() { _ = stalled.Close() }()
 
-	// A well-behaved peer must still be accepted and served promptly,
-	// despite the stalled connection still being open.
+	// A second peer must still be accepted, handshaked, and answered with
+	// BUSY promptly while the stalled peer remains connected.
 	// require inside a non-test goroutine only stops that goroutine (via
 	// runtime.Goexit), not the test itself, so failures here use assert with
 	// an early return instead.
@@ -98,25 +105,23 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 		}
 		defer func() { _ = clientConn.Close() }()
 
-		req, _ := proto.Marshal(&pb.VMServiceRequest{Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}}})
-		if !assert.NoError(t, vsockframing.WriteFrame(clientConn, req)) {
-			return
-		}
 		respData, readErr := vsockframing.ReadFrame(clientConn, 1<<20)
-		if !assert.NoError(t, readErr) {
+		if !assert.NoError(t, readErr, "rejected peer should receive framed BUSY before the server closes") {
 			return
 		}
 		var resp pb.VMServiceResponse
 		if !assert.NoError(t, proto.Unmarshal(respData, &resp)) {
 			return
 		}
-		assert.NotNil(t, resp.GetError(), "expected NOT_READY, but any response at all proves the loop wasn't blocked")
+		if assert.NotNil(t, resp.GetError()) {
+			assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
+		}
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("well-behaved connection was not served promptly; accept loop is likely blocked by the stalled peer")
+		t.Fatal("second connection was not answered promptly; accept loop is likely blocked by the stalled peer")
 	}
 
 	// Unblock the stalled connection's server-side handshake goroutine

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -83,8 +83,6 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() { srv.Serve(ctx, ln); close(serveDone) }()
-	// cancel/serveDone must run even if the select times out and calls
-	// t.Fatal; otherwise the accept-loop goroutine outlives the test.
 	defer func() {
 		cancel()
 		<-serveDone
@@ -99,36 +97,22 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	// without waiting out connDeadline.
 	defer func() { _ = stalled.Close() }()
 
-	// A second peer must still be accepted, handshaked, and answered with
-	// BUSY promptly while the stalled peer remains connected.
-	// require inside a non-test goroutine only stops that goroutine (via
-	// runtime.Goexit), not the test itself, so failures here use assert with
-	// an early return instead.
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		clientConn, dialErr := tls.Dial("tcp", ln.Addr().String(), &tls.Config{InsecureSkipVerify: true})
-		if !assert.NoError(t, dialErr) {
-			return
-		}
-		defer func() { _ = clientConn.Close() }()
-
-		respData, readErr := vsockframing.ReadFrame(clientConn, 1<<20)
-		if !assert.NoError(t, readErr, "rejected peer should receive framed BUSY before the server closes") {
-			return
-		}
-		var resp pb.VMServiceResponse
-		if !assert.NoError(t, proto.Unmarshal(respData, &resp)) {
-			return
-		}
-		if assert.NotNil(t, resp.GetError()) {
-			assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
-		}
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("second connection was not answered promptly; accept loop is likely blocked by the stalled peer")
+	// Second peer on the test goroutine (same style as TestServeAcceptLoop).
+	// NetDialer.Timeout bounds dial+TLS handshake: if Accept were blocked,
+	// TCP can still complete from the backlog, but the handshake would hang.
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 5 * time.Second},
+		Config:    &tls.Config{InsecureSkipVerify: true},
 	}
+	clientConn, err := dialer.DialContext(ctx, "tcp", ln.Addr().String())
+	require.NoError(t, err, "second peer should be accepted promptly; accept loop may be blocked")
+	defer func() { _ = clientConn.Close() }()
+
+	require.NoError(t, clientConn.SetDeadline(time.Now().Add(5*time.Second)))
+	respData, err := vsockframing.ReadFrame(clientConn, 1<<20)
+	require.NoError(t, err, "rejected peer should receive framed BUSY before the server closes")
+	var resp pb.VMServiceResponse
+	require.NoError(t, proto.Unmarshal(respData, &resp))
+	require.NotNil(t, resp.GetError())
+	assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/tls.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls.go
@@ -331,23 +331,6 @@ func (r *CARefresher) cachedPool() (*x509.CertPool, time.Time, bool) {
 	return res.pool, res.fetchedAt, res.ok
 }
 
-// parseClientCerts parses the raw ASN.1 certificates presented by a TLS
-// peer, as passed to tls.Config.VerifyPeerCertificate.
-func parseClientCerts(rawCerts [][]byte) ([]*x509.Certificate, error) {
-	if len(rawCerts) == 0 {
-		return nil, errors.New("tls: client certificate required")
-	}
-	certs := make([]*x509.Certificate, len(rawCerts))
-	for i, asn1Data := range rawCerts {
-		cert, err := x509.ParseCertificate(asn1Data)
-		if err != nil {
-			return nil, fmt.Errorf("tls: failed to parse client certificate: %w", err)
-		}
-		certs[i] = cert
-	}
-	return certs, nil
-}
-
 // verifyClientCertChain verifies certs[0] (the leaf) against pool, treating
 // any remaining certs as intermediates.
 func verifyClientCertChain(pool *x509.CertPool, certs []*x509.Certificate) error {
@@ -373,15 +356,19 @@ func verifyClientCertChain(pool *x509.CertPool, certs []*x509.Certificate) error
 // back to the stale pool, since that pool already failed verification;
 // unlike ensureFreshPool, which can.
 //
+// certs is tls.ConnectionState.PeerCertificates, already parsed by
+// crypto/tls during the handshake regardless of ClientAuth mode.
+//
 // The forced fetch itself is rate-limited (forceFetchLimiter): a peer that
 // keeps presenting an invalid cert can trigger this path on demand, so
 // without a cooldown it could repeatedly hammer virt-handler's CABundle
 // service. While the cooldown is active, this skips the fetch and returns
 // the original verify error, noting that the retry was skipped.
-func (r *CARefresher) verifyPeerCertificate(ctx context.Context, rawCerts [][]byte) error {
-	certs, err := parseClientCerts(rawCerts)
-	if err != nil {
-		return err
+func (r *CARefresher) verifyPeerCertificate(ctx context.Context, certs []*x509.Certificate) error {
+	// Belt-and-suspenders: RequireAnyClientCert already makes crypto/tls
+	// reject an empty certificate list before VerifyConnection runs.
+	if len(certs) == 0 {
+		return errors.New("client certificate required")
 	}
 
 	pool, _, _ := r.cachedPool()
@@ -416,19 +403,21 @@ func (r *CARefresher) verifyPeerCertificate(ctx context.Context, rawCerts [][]by
 // which a config with no certificate could be handed to a listener.
 //
 // This function's own return value (the "outer" config) is deliberately
-// unusable on its own: RequireAndVerifyClientCert with no ClientCAs can
-// never accept a client cert. That's a safety net for one documented edge
-// case in crypto/tls.Config: if GetConfigForClient ever returned (nil,
-// nil), Go would use this config directly instead. That never happens
-// today, so the fallback is unreachable in practice - but if it ever were
-// reached, rejecting every client is the safe failure mode.
+// unusable for KubeVirt's certs: with ClientCAs nil, RequireAndVerifyClientCert
+// falls back to the system root CA pool, which never contains KubeVirt's
+// self-managed CA, so no cert virt-handler presents can pass here. That's
+// a safety net for one documented edge case in crypto/tls.Config: if
+// GetConfigForClient ever returned (nil, nil), Go would use this config
+// directly instead. That never happens today, so the fallback is
+// unreachable in practice.
 //
 // Every real handshake instead uses the config GetConfigForClient returns
 // below: a clone of the outer config with ClientAuth switched to
-// RequireAnyClientCert and VerifyPeerCertificate set. That switch is
-// required: with RequireAndVerifyClientCert, Go checks the client cert against
-// ClientCAs *before* calling VerifyPeerCertificate, so a stale pool would fail
-// the handshake before the force-refresh retry in verifyPeerCertificate ever got a chance to run.
+// RequireAnyClientCert and VerifyConnection set. That switch is required:
+// with RequireAndVerifyClientCert, Go checks the client cert against
+// ClientCAs *before* any verification callback runs, so a stale pool would
+// fail the handshake before the force-refresh retry in verifyPeerCertificate
+// ever got a chance to run.
 //
 // SessionTicketsDisabled forces a full handshake on every connection, so a
 // resumed session can never skip re-checking the client cert.
@@ -440,16 +429,16 @@ func (r *CARefresher) TLSConfig(serverCert tls.Certificate) *tls.Config {
 		SessionTicketsDisabled: true,
 	}
 	cfg.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-		ctx := info.Context() // captured once; reused below by ensureFreshPool and VerifyPeerCertificate
+		ctx := info.Context() // captured once; reused below by ensureFreshPool and VerifyConnection
 		if _, err := r.ensureFreshPool(ctx); err != nil {
 			return nil, fmt.Errorf("fetching KubeVirt CA for TLS handshake: %w", err)
 		}
 		clientCfg := cfg.Clone()
 		clientCfg.GetConfigForClient = nil              // clone copies the callback; clear to avoid recursion
-		clientCfg.ClientAuth = tls.RequireAnyClientCert // verification happens in VerifyPeerCertificate below, not here
+		clientCfg.ClientAuth = tls.RequireAnyClientCert // verification happens in VerifyConnection below, not here
 		clientCfg.ClientCAs = nil
-		clientCfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			return r.verifyPeerCertificate(ctx, rawCerts)
+		clientCfg.VerifyConnection = func(state tls.ConnectionState) error {
+			return r.verifyPeerCertificate(ctx, state.PeerCertificates)
 		}
 		return clientCfg, nil
 	}

--- a/compliance/virtualmachines/roxagent/vsockserver/tls.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls.go
@@ -257,6 +257,11 @@ func (r *CARefresher) ensureFreshPool(ctx context.Context) (*x509.CertPool, erro
 // fetchAndCachePool fetches a fresh CA bundle from KubeVirt, parses it, and
 // swaps it into the cache under r.mu's write lock. It returns the pool it
 // just wrote so the caller does not need a second locked read of r.pool.
+//
+// Shared by ensureFreshPool (age-gated refresh, falls back to a stale pool
+// on fetch failure) and verifyPeerCertificate (forced refresh on a
+// client-cert verify failure, no stale fallback) - see their doc comments
+// for what each does when the fetch itself fails.
 func (r *CARefresher) fetchAndCachePool(ctx context.Context) (*x509.CertPool, error) {
 	// ctx belongs to the caller whose handshake triggered this fetch. If
 	// that handshake is torn down mid-fetch, ctx is cancelled - but the
@@ -313,6 +318,69 @@ func (r *CARefresher) cachedPool() (*x509.CertPool, time.Time, bool) {
 	return res.pool, res.fetchedAt, res.ok
 }
 
+// parseClientCerts parses the raw ASN.1 certificates presented by a TLS
+// peer, as passed to tls.Config.VerifyPeerCertificate.
+func parseClientCerts(rawCerts [][]byte) ([]*x509.Certificate, error) {
+	if len(rawCerts) == 0 {
+		return nil, errors.New("tls: client certificate required")
+	}
+	certs := make([]*x509.Certificate, len(rawCerts))
+	for i, asn1Data := range rawCerts {
+		cert, err := x509.ParseCertificate(asn1Data)
+		if err != nil {
+			return nil, fmt.Errorf("tls: failed to parse client certificate: %w", err)
+		}
+		certs[i] = cert
+	}
+	return certs, nil
+}
+
+// verifyClientCertChain verifies certs[0] (the leaf) against pool, treating
+// any remaining certs as intermediates.
+func verifyClientCertChain(pool *x509.CertPool, certs []*x509.Certificate) error {
+	if pool == nil {
+		return errors.New("tls: no KubeVirt CA pool available")
+	}
+	intermediates := x509.NewCertPool()
+	for _, cert := range certs[1:] {
+		intermediates.AddCert(cert)
+	}
+	_, err := certs[0].Verify(x509.VerifyOptions{
+		Roots:         pool,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	return err
+}
+
+// verifyPeerCertificate verifies the client cert against the cached CA
+// pool, force-fetching CABundle (bypassing the age gate) and retrying once
+// on failure - so a hard CA cutover self-heals within one handshake
+// instead of waiting out the age gate. A failed forced fetch never falls
+// back to the stale pool, since that pool already failed verification;
+// unlike ensureFreshPool, which can.
+func (r *CARefresher) verifyPeerCertificate(ctx context.Context, rawCerts [][]byte) error {
+	certs, err := parseClientCerts(rawCerts)
+	if err != nil {
+		return err
+	}
+
+	pool, _, _ := r.cachedPool()
+	verifyErr := verifyClientCertChain(pool, certs)
+	if verifyErr == nil {
+		return nil
+	}
+
+	newPool, fetchErr := r.fetchAndCachePool(ctx)
+	if fetchErr != nil {
+		return fmt.Errorf("verifying client certificate: %w (KubeVirt CA re-fetch failed: %v)", verifyErr, fetchErr)
+	}
+	if err := verifyClientCertChain(newPool, certs); err != nil {
+		return fmt.Errorf("verifying client certificate after KubeVirt CA refresh: %w", err)
+	}
+	return nil
+}
+
 // TLSConfig returns a *tls.Config that presents serverCert and validates
 // KubeVirt client certs. The returned config fetches a fresh CA pool on
 // each handshake via GetConfigForClient whenever the cache is empty or
@@ -323,22 +391,44 @@ func (r *CARefresher) cachedPool() (*x509.CertPool, time.Time, bool) {
 // serverCert is baked in at construction time rather than left for the
 // caller to set on the returned config afterward, so there is no window in
 // which a config with no certificate could be handed to a listener.
+//
+// This function's own return value (the "outer" config) is deliberately
+// unusable on its own: RequireAndVerifyClientCert with no ClientCAs can
+// never accept a client cert. That's a safety net for one documented edge
+// case in crypto/tls.Config: if GetConfigForClient ever returned (nil,
+// nil), Go would use this config directly instead. That never happens
+// today, so the fallback is unreachable in practice - but if it ever were
+// reached, rejecting every client is the safe failure mode.
+//
+// Every real handshake instead uses the config GetConfigForClient returns
+// below: a clone of the outer config with ClientAuth switched to
+// RequireAnyClientCert and VerifyPeerCertificate set. That switch is
+// required: with RequireAndVerifyClientCert, Go checks the client cert against
+// ClientCAs *before* calling VerifyPeerCertificate, so a stale pool would fail
+// the handshake before the force-refresh retry in verifyPeerCertificate ever got a chance to run.
+//
+// SessionTicketsDisabled forces a full handshake on every connection, so a
+// resumed session can never skip re-checking the client cert.
 func (r *CARefresher) TLSConfig(serverCert tls.Certificate) *tls.Config {
-	return &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS12,
-		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-			pool, err := r.ensureFreshPool(info.Context())
-			if err != nil {
-				return nil, fmt.Errorf("fetching KubeVirt CA for TLS handshake: %w", err)
-			}
-			return &tls.Config{
-				Certificates: []tls.Certificate{serverCert},
-				ClientAuth:   tls.RequireAndVerifyClientCert,
-				ClientCAs:    pool,
-				MinVersion:   tls.VersionTLS12,
-			}, nil
-		},
+	cfg := &tls.Config{
+		Certificates:           []tls.Certificate{serverCert},
+		ClientAuth:             tls.RequireAndVerifyClientCert,
+		MinVersion:             tls.VersionTLS12,
+		SessionTicketsDisabled: true,
 	}
+	cfg.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+		ctx := info.Context() // captured once; reused below by ensureFreshPool and VerifyPeerCertificate
+		if _, err := r.ensureFreshPool(ctx); err != nil {
+			return nil, fmt.Errorf("fetching KubeVirt CA for TLS handshake: %w", err)
+		}
+		clientCfg := cfg.Clone()
+		clientCfg.GetConfigForClient = nil              // clone copies the callback; clear to avoid recursion
+		clientCfg.ClientAuth = tls.RequireAnyClientCert // verification happens in VerifyPeerCertificate below, not here
+		clientCfg.ClientCAs = nil
+		clientCfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			return r.verifyPeerCertificate(ctx, rawCerts)
+		}
+		return clientCfg, nil
+	}
+	return cfg
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/tls.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -29,6 +30,13 @@ const (
 	// handshake-triggered refetch (see CARefresher doc comment).
 	defaultRefreshInterval = 1 * time.Hour
 	defaultFetchTimeout    = 10 * time.Second
+
+	// defaultForceFetchCooldown throttles the forced refetch in
+	// verifyPeerCertificate, which a peer can trigger on demand by
+	// repeatedly presenting an invalid client cert. Deliberately generous:
+	// legitimate dials happen at most every 1-5 minutes, so even this
+	// leaves a wide margin.
+	defaultForceFetchCooldown = 2 * time.Second
 
 	// gRPC method for the KubeVirt System.CABundle RPC.
 	// Proto: kubevirt.io/kubevirt/pkg/vsock/system/v1/system.proto
@@ -191,6 +199,10 @@ type CARefresher struct {
 	interval     time.Duration
 	fetchTimeout time.Duration
 	fetchCA      func(ctx context.Context) ([]byte, error)
+
+	// forceFetchLimiter throttles verifyPeerCertificate's forced-refetch
+	// path only; the age-gated path via ensureFreshPool is untouched.
+	forceFetchLimiter *rate.Limiter
 }
 
 // NewCARefresher creates a refresher with an empty cache. There is no
@@ -201,9 +213,10 @@ type CARefresher struct {
 // wasted effort - see the CARefresher doc comment.
 func NewCARefresher(opts ...CARefresherOption) *CARefresher {
 	r := &CARefresher{
-		interval:     defaultRefreshInterval,
-		fetchTimeout: defaultFetchTimeout,
-		fetchCA:      fetchKubeVirtCA,
+		interval:          defaultRefreshInterval,
+		fetchTimeout:      defaultFetchTimeout,
+		fetchCA:           fetchKubeVirtCA,
+		forceFetchLimiter: rate.NewLimiter(rate.Every(defaultForceFetchCooldown), 1),
 	}
 	for _, o := range opts {
 		o(r)
@@ -359,6 +372,12 @@ func verifyClientCertChain(pool *x509.CertPool, certs []*x509.Certificate) error
 // instead of waiting out the age gate. A failed forced fetch never falls
 // back to the stale pool, since that pool already failed verification;
 // unlike ensureFreshPool, which can.
+//
+// The forced fetch itself is rate-limited (forceFetchLimiter): a peer that
+// keeps presenting an invalid cert can trigger this path on demand, so
+// without a cooldown it could repeatedly hammer virt-handler's CABundle
+// service. While the cooldown is active, this skips the fetch and returns
+// the original verify error, noting that the retry was skipped.
 func (r *CARefresher) verifyPeerCertificate(ctx context.Context, rawCerts [][]byte) error {
 	certs, err := parseClientCerts(rawCerts)
 	if err != nil {
@@ -371,9 +390,13 @@ func (r *CARefresher) verifyPeerCertificate(ctx context.Context, rawCerts [][]by
 		return nil
 	}
 
+	if !r.forceFetchLimiter.Allow() {
+		return fmt.Errorf("verifying client certificate: %w; must re-fetch KubeVirt CA, but was rate-limited", verifyErr)
+	}
+
 	newPool, fetchErr := r.fetchAndCachePool(ctx)
 	if fetchErr != nil {
-		return fmt.Errorf("verifying client certificate: %w (KubeVirt CA re-fetch failed: %v)", verifyErr, fetchErr)
+		return fmt.Errorf("verifying client certificate: %w; must re-fetch KubeVirt CA, but re-fetch also failed: %w", verifyErr, fetchErr)
 	}
 	if err := verifyClientCertChain(newPool, certs); err != nil {
 		return fmt.Errorf("verifying client certificate after KubeVirt CA refresh: %w", err)

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -373,6 +373,98 @@ func TestCARefresher_OverlapBundleTrustsBothOldAndNewCA(t *testing.T) {
 	doTLSHandshake(t, r, serverCert, newClientCert)
 }
 
+// TestCARefresher_HardCutover_ForcesRefetchWhileCacheFresh covers KubeVirt
+// hard CA cutover: the cache is still within the age gate (so ensureFreshPool
+// would not refetch), but the peer presents a leaf signed by the new CA.
+// The handshake must force a CABundle fetch and succeed on the first attempt.
+//
+// Acceptance criterion (ROX-35848): simulated rotation with a fresh cache —
+// the first handshake after rotation force-fetches and succeeds.
+func TestCARefresher_HardCutover_ForcesRefetchWhileCacheFresh(t *testing.T) {
+	ca1PEM, ca1Cert, ca1Key := testCA(t)
+	ca2PEM, ca2Cert, ca2Key := testCA(t)
+
+	var fetchCount atomic.Int32
+	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+		n := fetchCount.Add(1)
+		if n == 1 {
+			return ca1PEM, nil
+		}
+		return ca2PEM, nil
+	}))
+
+	_, err := r.ensureFreshPool(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int32(1), fetchCount.Load())
+	// Deliberately do NOT zero r.fetchedAt — cache must still be "fresh".
+
+	serverCert := testServerCert(t)
+	newClientCert := testLeafCert(t, ca2Cert, ca2Key)
+	doTLSHandshake(t, r, serverCert, newClientCert)
+
+	assert.Equal(t, int32(2), fetchCount.Load(),
+		"verify failure against the cached CA must force exactly one refetch")
+
+	// Forced fetch replaces the pool; old leaves must no longer verify.
+	oldClientCert := testLeafCert(t, ca1Cert, ca1Key)
+	doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+}
+
+// TestCARefresher_HardCutover_ForceRefetchFailureKeepsRejecting proves the
+// force path does not fall back to the stale pool: that pool already
+// failed to verify the peer once, so reusing it would just accept the same
+// unverifiable peer.
+//
+// Acceptance criterion (ROX-35848): a forced fetch failure does not accept
+// the peer.
+func TestCARefresher_HardCutover_ForceRefetchFailureKeepsRejecting(t *testing.T) {
+	ca1PEM, _, _ := testCA(t)
+	_, ca2Cert, ca2Key := testCA(t)
+
+	var fetchCount atomic.Int32
+	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+		n := fetchCount.Add(1)
+		if n == 1 {
+			return ca1PEM, nil
+		}
+		return nil, assert.AnError
+	}))
+
+	_, err := r.ensureFreshPool(context.Background())
+	require.NoError(t, err)
+
+	serverCert := testServerCert(t)
+	newClientCert := testLeafCert(t, ca2Cert, ca2Key)
+	doTLSHandshakeFails(t, r, serverCert, newClientCert)
+	assert.Equal(t, int32(2), fetchCount.Load(), "verify failure must still attempt a forced refetch")
+}
+
+// TestCARefresher_FreshCache_SecondHandshakeDoesNotRefetch locks case 1:
+// after a successful warm, a still-fresh cache must not hit CABundle again
+// on the next successful handshake.
+//
+// Acceptance criterion (ROX-35848): the happy path still uses the cache —
+// no fetch on every handshake.
+func TestCARefresher_FreshCache_SecondHandshakeDoesNotRefetch(t *testing.T) {
+	caPEM, caCert, caKey := testCA(t)
+
+	var fetchCount atomic.Int32
+	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+		fetchCount.Add(1)
+		return caPEM, nil
+	}))
+
+	serverCert := testServerCert(t)
+	clientCert := testLeafCert(t, caCert, caKey)
+
+	doTLSHandshake(t, r, serverCert, clientCert)
+	require.Equal(t, int32(1), fetchCount.Load())
+
+	doTLSHandshake(t, r, serverCert, clientCert)
+	assert.Equal(t, int32(1), fetchCount.Load(),
+		"successful verify against a fresh cache must not refetch")
+}
+
 func TestCARefresher_TLSHandshake(t *testing.T) {
 	caPEM, caCert, caKey := testCA(t)
 
@@ -385,17 +477,29 @@ func TestCARefresher_TLSHandshake(t *testing.T) {
 	doTLSHandshake(t, r, serverCert, clientCert)
 }
 
+// TestCARefresher_TLSHandshake_WrongCA proves a peer that verifies against
+// neither the old nor a freshly-refetched CA still fails, after exactly one
+// forced retry.
+//
+// Acceptance criterion (ROX-35848): a peer that verifies against neither the
+// old nor the new CA still fails, with only a single forced retry.
 func TestCARefresher_TLSHandshake_WrongCA(t *testing.T) {
 	caPEM, _, _ := testCA(t)
 	_, wrongCACert, wrongCAKey := testCA(t)
 
+	var fetchCount atomic.Int32
 	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) { return caPEM, nil }),
+		WithFetchFunc(func(context.Context) ([]byte, error) {
+			fetchCount.Add(1)
+			return caPEM, nil
+		}),
 	)
 
 	serverCert := testServerCert(t)
 	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
 	doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+	// Cold ensureFreshPool + one forced refetch after verify failure.
+	assert.Equal(t, int32(2), fetchCount.Load())
 }
 
 // doTLSHandshake performs a full TLS handshake between a server using the

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
@@ -394,6 +395,8 @@ func TestCARefresher_HardCutover_ForcesRefetchWhileCacheFresh(t *testing.T) {
 		}
 		return ca2PEM, nil
 	}))
+	// Long cooldown so the second handshake stays rate-limited without wall-clock races.
+	r.forceFetchLimiter = rate.NewLimiter(rate.Every(time.Hour), 1)
 
 	_, err := r.ensureFreshPool(context.Background())
 	require.NoError(t, err)
@@ -441,6 +444,7 @@ func TestCARefresher_HardCutover_ForceRefetchFailureKeepsRejecting(t *testing.T)
 	newClientCert := testLeafCert(t, ca2Cert, ca2Key)
 	err = doTLSHandshakeFails(t, r, serverCert, newClientCert)
 	require.Error(t, err)
+	assert.ErrorContains(t, err, "must re-fetch KubeVirt CA, but re-fetch also failed")
 	assert.Equal(t, int32(2), fetchCount.Load(), "verify failure must still attempt a forced refetch")
 }
 
@@ -524,6 +528,8 @@ func TestCARefresher_ForceFetchCooldown_SkipsRepeatedRefetch(t *testing.T) {
 			return caPEM, nil
 		}),
 	)
+	// Long cooldown so the second handshake stays rate-limited without wall-clock races.
+	r.forceFetchLimiter = rate.NewLimiter(rate.Every(time.Hour), 1)
 
 	serverCert := testServerCert(t)
 	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -278,7 +278,9 @@ func TestCARefresher_Refresh(t *testing.T) {
 	// refresher bug that unioned pools instead of replacing them would pass
 	// unnoticed without this assertion.
 	oldClientCert := testLeafCert(t, ca1Cert, ca1Key)
-	doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+	err = doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "verifying client certificate after KubeVirt CA refresh")
 }
 
 // TestCARefresher_RefreshFailure_KeepsOldCA proves that a failed refetch,
@@ -407,7 +409,9 @@ func TestCARefresher_HardCutover_ForcesRefetchWhileCacheFresh(t *testing.T) {
 
 	// Forced fetch replaces the pool; old leaves must no longer verify.
 	oldClientCert := testLeafCert(t, ca1Cert, ca1Key)
-	doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+	err = doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "must re-fetch KubeVirt CA, but was rate-limited")
 }
 
 // TestCARefresher_HardCutover_ForceRefetchFailureKeepsRejecting proves the
@@ -435,7 +439,8 @@ func TestCARefresher_HardCutover_ForceRefetchFailureKeepsRejecting(t *testing.T)
 
 	serverCert := testServerCert(t)
 	newClientCert := testLeafCert(t, ca2Cert, ca2Key)
-	doTLSHandshakeFails(t, r, serverCert, newClientCert)
+	err = doTLSHandshakeFails(t, r, serverCert, newClientCert)
+	require.Error(t, err)
 	assert.Equal(t, int32(2), fetchCount.Load(), "verify failure must still attempt a forced refetch")
 }
 
@@ -497,9 +502,42 @@ func TestCARefresher_TLSHandshake_WrongCA(t *testing.T) {
 
 	serverCert := testServerCert(t)
 	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
-	doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+	err := doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "verifying client certificate after KubeVirt CA refresh")
 	// Cold ensureFreshPool + one forced refetch after verify failure.
 	assert.Equal(t, int32(2), fetchCount.Load())
+}
+
+// TestCARefresher_ForceFetchCooldown_SkipsRepeatedRefetch proves the forced
+// refetch in verifyPeerCertificate is rate-limited: a second verify failure
+// arriving right after the first must not trigger another fetch, and must
+// still fail (with the original verify error, not a new fetch attempt).
+func TestCARefresher_ForceFetchCooldown_SkipsRepeatedRefetch(t *testing.T) {
+	caPEM, _, _ := testCA(t)
+	_, wrongCACert, wrongCAKey := testCA(t)
+
+	var fetchCount atomic.Int32
+	r := NewCARefresher(
+		WithFetchFunc(func(context.Context) ([]byte, error) {
+			fetchCount.Add(1)
+			return caPEM, nil
+		}),
+	)
+
+	serverCert := testServerCert(t)
+	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
+
+	err := doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "verifying client certificate after KubeVirt CA refresh")
+	require.Equal(t, int32(2), fetchCount.Load(), "cold ensureFreshPool + one forced refetch")
+
+	err = doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "must re-fetch KubeVirt CA, but was rate-limited")
+	assert.Equal(t, int32(2), fetchCount.Load(),
+		"a verify failure inside the forced-refetch cooldown must not trigger another fetch")
 }
 
 // doTLSHandshake performs a full TLS handshake between a server using the
@@ -537,11 +575,8 @@ func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Cer
 	require.NoError(t, <-serverErr, "server handshake should succeed")
 }
 
-// doTLSHandshakeFails performs a TLS handshake between a server using the
-// refresher's TLS config and a client presenting the given cert, and asserts
-// that the server-side handshake is rejected (e.g. because clientCert isn't
-// signed by any CA in the refresher's currently active pool).
-func doTLSHandshakeFails(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) {
+// doTLSHandshakeFails is doTLSHandshake for the rejection path.
+func doTLSHandshakeFails(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) error {
 	t.Helper()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -571,7 +606,9 @@ func doTLSHandshakeFails(t *testing.T, r *CARefresher, serverCert, clientCert tl
 		_ = clientConn.Close()
 	}
 
-	assert.Error(t, <-serverErr, "server handshake should fail")
+	handshakeErr := <-serverErr
+	assert.Error(t, handshakeErr, "server handshake should fail")
+	return handshakeErr
 }
 
 func TestExtractBundleRaw(t *testing.T) {

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -112,27 +112,6 @@ func TestCARefresher_InvalidPEM(t *testing.T) {
 	assert.ErrorContains(t, err, "no valid certificates")
 }
 
-func TestCARefresher_HandshakeFetchesOnColdCache(t *testing.T) {
-	caPEM, caCert, caKey := testCA(t)
-
-	var fetchCount atomic.Int32
-	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
-		fetchCount.Add(1)
-		return caPEM, nil
-	}))
-
-	// The cache starts out completely cold, mirroring roxagent immediately
-	// after boot in KubeVirt's namespace-isolated VSOCK mode, where the CA
-	// service does not exist until a real connection arrives. What's under
-	// test is that the handshake itself - not any independent warm-up -
-	// is what populates the cache.
-	serverCert := testServerCert(t)
-	clientCert := testLeafCert(t, caCert, caKey)
-	doTLSHandshake(t, r, serverCert, clientCert)
-
-	assert.Equal(t, int32(1), fetchCount.Load(), "the handshake should have triggered exactly one fetch")
-}
-
 func TestCARefresher_HandshakeFailsWhenCAServiceUnavailable(t *testing.T) {
 	caPEM, caCert, caKey := testCA(t)
 
@@ -147,44 +126,19 @@ func TestCARefresher_HandshakeFailsWhenCAServiceUnavailable(t *testing.T) {
 		return caPEM, nil
 	}))
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = ln.Close() }()
-
-	tlsCfg := r.TLSConfig(testServerCert(t))
+	serverCert := testServerCert(t)
 	clientCert := testLeafCert(t, caCert, caKey)
 	clientTLS := &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true}
-
-	dial := func() error {
-		serverErr := make(chan error, 1)
-		go func() {
-			conn, err := ln.Accept()
-			if err != nil {
-				serverErr <- err
-				return
-			}
-			tlsConn := tls.Server(conn, tlsCfg)
-			err = tlsConn.Handshake()
-			_ = tlsConn.Close()
-			serverErr <- err
-		}()
-
-		clientConn, dialErr := tls.Dial("tcp", ln.Addr().String(), clientTLS)
-		if dialErr == nil {
-			_ = clientConn.Close()
-		}
-		return <-serverErr
-	}
 
 	// CA service "closed": the handshake must fail, not fall back to some
 	// stale/empty pool.
 	available.Store(false)
-	assert.Error(t, dial(), "handshake should fail while the CA service is unavailable")
+	assert.Error(t, dialTLS(t, r, serverCert, clientTLS), "handshake should fail while the CA service is unavailable")
 
 	// CA service "open": the very next handshake must succeed, with no
 	// independent warm-up ever having occurred.
 	available.Store(true)
-	assert.NoError(t, dial(), "handshake should succeed once the CA service becomes available")
+	assert.NoError(t, dialTLS(t, r, serverCert, clientTLS), "handshake should succeed once the CA service becomes available")
 }
 
 // TestCARefresher_ConcurrentHandshakesEachGetValidPool calls
@@ -315,42 +269,6 @@ func TestCARefresher_RefreshFailure_KeepsOldCA(t *testing.T) {
 	assert.Equal(t, int32(2), callCount.Load(), "the stale handshake should have attempted a refetch")
 }
 
-// TestCARefresher_StaleCacheTriggersRefetchDuringHandshake proves the
-// minimal case: a stale cache is refetched by ensureFreshPool being called
-// from GetConfigForClient during a real handshake. TestCARefresher_Refresh
-// covers the same mechanism plus full CA rotation (old CA fully replaced,
-// not unioned with the new one).
-func TestCARefresher_StaleCacheTriggersRefetchDuringHandshake(t *testing.T) {
-	ca1PEM, _, _ := testCA(t)
-	ca2PEM, ca2Cert, ca2Key := testCA(t)
-
-	var fetchCount atomic.Int32
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) {
-			if fetchCount.Add(1) == 1 {
-				return ca1PEM, nil
-			}
-			return ca2PEM, nil
-		}),
-	)
-	// Warm the cache with CA1 via a direct call.
-	_, err := r.ensureFreshPool(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, int32(1), fetchCount.Load())
-
-	// Force cache stale.
-	r.fetchedAt = time.Time{}
-
-	// The next handshake presents a CA2-signed client cert. It can only
-	// succeed if the handshake path itself noticed the staleness and
-	// fetched a replacement pool inline.
-	serverCert := testServerCert(t)
-	clientCert := testLeafCert(t, ca2Cert, ca2Key)
-	doTLSHandshake(t, r, serverCert, clientCert)
-
-	assert.Equal(t, int32(2), fetchCount.Load(), "the stale handshake should have triggered exactly one refetch")
-}
-
 // TestCARefresher_OverlapBundleTrustsBothOldAndNewCA models KubeVirt's real
 // rotation behavior: during the overlap window, the CA service returns a
 // bundle containing *both* the old and new CA concatenated (not a hard swap
@@ -474,81 +392,137 @@ func TestCARefresher_FreshCache_SecondHandshakeDoesNotRefetch(t *testing.T) {
 		"successful verify against a fresh cache must not refetch")
 }
 
-func TestCARefresher_TLSHandshake(t *testing.T) {
-	caPEM, caCert, caKey := testCA(t)
-
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) { return caPEM, nil }),
-	)
-
-	serverCert := testServerCert(t)
-	clientCert := testLeafCert(t, caCert, caKey)
-	doTLSHandshake(t, r, serverCert, clientCert)
-}
-
-// TestCARefresher_TLSHandshake_WrongCA proves a peer that verifies against
-// neither the old nor a freshly-refetched CA still fails, after exactly one
+// TestCARefresher_TLSHandshake_ClientCertScenarios covers how the very
+// first handshake against a cold cache resolves for different client
+// certificate presentations. Every case fetches the CA exactly once via
+// GetConfigForClient before the client's certificate is ever inspected;
+// the "wrong CA" case fetches a second time via verifyPeerCertificate's
 // forced retry.
 //
 // Acceptance criterion (ROX-35848): a peer that verifies against neither the
 // old nor the new CA still fails, with only a single forced retry.
-func TestCARefresher_TLSHandshake_WrongCA(t *testing.T) {
-	caPEM, _, _ := testCA(t)
+func TestCARefresher_TLSHandshake_ClientCertScenarios(t *testing.T) {
+	caPEM, caCert, caKey := testCA(t)
 	_, wrongCACert, wrongCAKey := testCA(t)
+	correctLeaf := testLeafCert(t, caCert, caKey)
+	wrongLeaf := testLeafCert(t, wrongCACert, wrongCAKey)
 
-	var fetchCount atomic.Int32
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) {
-			fetchCount.Add(1)
-			return caPEM, nil
-		}),
-	)
+	tests := map[string]struct {
+		clientTLS *tls.Config
+		wantErr   bool
+		// wantErrMsg, if set, is asserted with ErrorContains; leave empty to
+		// only require that some error occurred (e.g. wording owned by
+		// crypto/tls itself, not this package).
+		wantErrMsg  string
+		wantFetches int32
+	}{
+		"cert signed by the current CA succeeds": {
+			clientTLS:   &tls.Config{Certificates: []tls.Certificate{correctLeaf}, InsecureSkipVerify: true},
+			wantFetches: 1,
+		},
+		"cert signed by an unrelated CA fails after one forced retry": {
+			clientTLS:   &tls.Config{Certificates: []tls.Certificate{wrongLeaf}, InsecureSkipVerify: true},
+			wantErr:     true,
+			wantErrMsg:  "verifying client certificate after KubeVirt CA refresh",
+			wantFetches: 2,
+		},
+		"no certificate is rejected by crypto/tls before verifyPeerCertificate runs": {
+			clientTLS:   &tls.Config{InsecureSkipVerify: true},
+			wantErr:     true,
+			wantFetches: 1,
+		},
+	}
 
-	serverCert := testServerCert(t)
-	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
-	err := doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "verifying client certificate after KubeVirt CA refresh")
-	// Cold ensureFreshPool + one forced refetch after verify failure.
-	assert.Equal(t, int32(2), fetchCount.Load())
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var fetchCount atomic.Int32
+			r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+				fetchCount.Add(1)
+				return caPEM, nil
+			}))
+
+			err := dialTLS(t, r, testServerCert(t), tc.clientTLS)
+			if !tc.wantErr {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tc.wantErrMsg != "" {
+					assert.ErrorContains(t, err, tc.wantErrMsg)
+				}
+			}
+			assert.Equal(t, tc.wantFetches, fetchCount.Load())
+		})
+	}
 }
 
-// TestCARefresher_ForceFetchCooldown_SkipsRepeatedRefetch proves the forced
-// refetch in verifyPeerCertificate is rate-limited: a second verify failure
-// arriving right after the first must not trigger another fetch, and must
-// still fail (with the original verify error, not a new fetch attempt).
-func TestCARefresher_ForceFetchCooldown_SkipsRepeatedRefetch(t *testing.T) {
-	caPEM, _, _ := testCA(t)
-	_, wrongCACert, wrongCAKey := testCA(t)
+// TestCARefresher_ForceFetchCooldown proves the forced refetch in
+// verifyPeerCertificate is rate-limited, and that the limit is a cooldown
+// rather than a permanent lockout: a second verify failure inside the
+// cooldown window is rejected without a new fetch, while one arriving after
+// the cooldown elapses triggers another forced fetch.
+func TestCARefresher_ForceFetchCooldown(t *testing.T) {
+	tests := map[string]struct {
+		// limiter overrides forceFetchLimiter; nil keeps defaultForceFetchCooldown,
+		// which this test then has to really wait out.
+		limiter        *rate.Limiter
+		wait           time.Duration
+		wantSecondMsg  string
+		wantFetchCount int32
+	}{
+		"repeated failure inside the cooldown is rate-limited, not re-fetched": {
+			limiter:        rate.NewLimiter(rate.Every(time.Hour), 1),
+			wantSecondMsg:  "must re-fetch KubeVirt CA, but was rate-limited",
+			wantFetchCount: 2,
+		},
+		"failure after the cooldown elapses triggers another forced fetch": {
+			wait:           defaultForceFetchCooldown + 500*time.Millisecond,
+			wantSecondMsg:  "verifying client certificate after KubeVirt CA refresh",
+			wantFetchCount: 3,
+		},
+	}
 
-	var fetchCount atomic.Int32
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) {
-			fetchCount.Add(1)
-			return caPEM, nil
-		}),
-	)
-	// Long cooldown so the second handshake stays rate-limited without wall-clock races.
-	r.forceFetchLimiter = rate.NewLimiter(rate.Every(time.Hour), 1)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			caPEM, _, _ := testCA(t)
+			_, wrongCACert, wrongCAKey := testCA(t)
 
-	serverCert := testServerCert(t)
-	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
+			var fetchCount atomic.Int32
+			r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+				fetchCount.Add(1)
+				return caPEM, nil
+			}))
+			if tc.limiter != nil {
+				r.forceFetchLimiter = tc.limiter
+			}
 
-	err := doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "verifying client certificate after KubeVirt CA refresh")
-	require.Equal(t, int32(2), fetchCount.Load(), "cold ensureFreshPool + one forced refetch")
+			serverCert := testServerCert(t)
+			wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
 
-	err = doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "must re-fetch KubeVirt CA, but was rate-limited")
-	assert.Equal(t, int32(2), fetchCount.Load(),
-		"a verify failure inside the forced-refetch cooldown must not trigger another fetch")
+			err := doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+			require.Error(t, err)
+			require.Equal(t, int32(2), fetchCount.Load(), "cold ensureFreshPool + one forced refetch")
+
+			if tc.wait > 0 {
+				// Can't use synctest: dialTLS uses a real TCP loopback
+				// socket, and synctest never treats network I/O as durably
+				// blocked.
+				time.Sleep(tc.wait)
+			}
+
+			err = doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.wantSecondMsg)
+			assert.Equal(t, tc.wantFetchCount, fetchCount.Load())
+		})
+	}
 }
 
-// doTLSHandshake performs a full TLS handshake between a server using the
-// refresher's TLS config and a client presenting the given cert.
-func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) {
+// dialTLS runs a server using r's TLS config against a client dialing with
+// clientTLS, and returns the server side's handshake result. It is the
+// shared plumbing under doTLSHandshake, doTLSHandshakeFails, and any test
+// that needs a client TLS config dialTLS itself can't assume (e.g. one
+// presenting no certificate at all).
+func dialTLS(t *testing.T, r *CARefresher, serverCert tls.Certificate, clientTLS *tls.Config) error {
 	t.Helper()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -570,51 +544,28 @@ func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Cer
 		serverErr <- err
 	}()
 
-	clientTLS := &tls.Config{
-		Certificates:       []tls.Certificate{clientCert},
-		InsecureSkipVerify: true,
+	clientConn, dialErr := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if dialErr == nil {
+		_ = clientConn.Close()
 	}
-	clientConn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
-	require.NoError(t, err, "client dial should succeed")
-	_ = clientConn.Close()
+	return <-serverErr
+}
 
-	require.NoError(t, <-serverErr, "server handshake should succeed")
+// doTLSHandshake performs a full TLS handshake between a server using the
+// refresher's TLS config and a client presenting the given cert.
+func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) {
+	t.Helper()
+	clientTLS := &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true}
+	require.NoError(t, dialTLS(t, r, serverCert, clientTLS), "server handshake should succeed")
 }
 
 // doTLSHandshakeFails is doTLSHandshake for the rejection path.
 func doTLSHandshakeFails(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) error {
 	t.Helper()
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = ln.Close() }()
-
-	tlsCfg := r.TLSConfig(serverCert)
-
-	serverErr := make(chan error, 1)
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			serverErr <- err
-			return
-		}
-		tlsConn := tls.Server(conn, tlsCfg)
-		serverErr <- tlsConn.Handshake()
-		_ = tlsConn.Close()
-	}()
-
-	clientTLS := &tls.Config{
-		Certificates:       []tls.Certificate{clientCert},
-		InsecureSkipVerify: true,
-	}
-	clientConn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
-	if err == nil {
-		_ = clientConn.Close()
-	}
-
-	handshakeErr := <-serverErr
-	assert.Error(t, handshakeErr, "server handshake should fail")
-	return handshakeErr
+	clientTLS := &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true}
+	err := dialTLS(t, r, serverCert, clientTLS)
+	assert.Error(t, err, "server handshake should fail")
+	return err
 }
 
 func TestExtractBundleRaw(t *testing.T) {


### PR DESCRIPTION
## Description

The roxagent can fetch the KubeVirt CA only when a new connection arrives to it. This happens:
1. Before this PR:
    1. When the internal 1h timer elapsed and new connection from Sensor arrived
2. In this PR:
    1. (same as before) When the internal 1h timer elapsed and new connection from Sensor arrived,
    2. OR when the certificate expired and new connection from Sensor arrived,

Roxagent now force-refetches the KubeVirt CA bundle on a VSOCK TLS client-cert verify failure, bypassing the usual 1-hour cache-staleness gate, and retries verification once in the same handshake:

1. Verify client-cert for incoming VSOCK connection (if passes: continue, if fails then...) 
2. Fetch new CA form KubeVirt
3. Verify again (same as step 1). Return error on failure, store the new CA on success.

The KubeVirt replaces the old CA in one go - there is no no old+new overlap bundle. 
The connections would fail the verification, If the CA rotation happens in the middle of the 1hr interval while the agent's cached CA still looked "fresh" by looking only at the age gate. 
Nothing except cache age ever triggered a refetch on the agent, so every handshake kept failing until the timer elapsed, up to an hour later. This PR closes that gap.

The per-handshake TLS config now uses `RequireAnyClientCert` plus a custom `VerifyPeerCertificate`, instead of `RequireAndVerifyClientCert` with `ClientCAs`.  That swap is required, other wise `RequireAndVerifyClientCert` would reject the stale-pool mismatch before the retry logic ever got a chance to run. 

Extra defense (may be seen as YAGNI violation): The outer `tls.Config` keeps `RequireAndVerifyClientCert` with no `ClientCAs`, which acts as a fail-closed fallback for the `GetConfigForClient` `(nil, nil)` case. This is unreachable in practice, but safe if it ever happened. 

A forced-fetch failure does not fall back to the stale pool, since that pool just failed verification against this peer. The existing age-gated `ensureFreshPool` path is unchanged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

Internal `roxagent` TLS behavior fix, no user-facing change. The VSOCK pull-mode ADR (`stackrox/architecture-decision-records#41`) does need a follow-up update to describe this behavior once this PR is merged, tracked separately and not blocking this PR.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Manual verification on a real cluster:

1. Deploy this branch's `roxagent` against a VM on a real OpenShift/CNV cluster; confirm a normal Sensor → virt-handler → roxagent scrape succeeds and the CA pool gets cached (fresh, well under 1h old). For this verification round only, also temporarily lower `defaultRefreshInterval` in a local build from 1h to something more manageable, e.g. 5m — not a change shipped in this PR, just what keeps the before/after timing in step 4 practical to observe in one sitting.
5. Force a hard CA cutover deterministically: delete the `kubevirt-ca` secret in the KubeVirt install namespace (`kubectl delete secret kubevirt-ca -n <kubevirt-namespace>`). `virt-operator` regenerates a brand-new CA immediately and re-signs virt-handler's certs with it, with no overlap with the old CA — a real hard cutover, not the scheduled `caOverlapInterval`-based rotation (already covered by `TestCARefresher_OverlapBundleTrustsBothOldAndNewCA`). TBD whether this needs any extra nudge to propagate to virt-handler immediately versus on its own reconcile cadence; confirm during the actual run and adjust these notes.
6. Well before the 1h age gate would fire on its own, trigger another scrape.
7. Before this fix: expect that handshake to fail (unknown authority), and to keep failing on every scrape until the 1h gate elapses.
8. After this fix: expect that very next handshake to succeed, with roxagent's logs showing a CA refetch firing immediately off the verify failure rather than the 1h tick.
9. Negative control: confirm a peer that verifies against neither CA is still rejected, with exactly one forced retry — not zero (a silent bypass) and not more than one (a retry loop).
   1. Generate a third, throwaway CA and a leaf certificate signed by it, unrelated to both the pre- and post-cutover KubeVirt CAs from steps 1–2.
   4. Present that leaf cert to roxagent's TLS listener in place of virt-handler's real client cert — e.g. dial the guest's VSOCK CID directly with a small TLS client, bypassing the KubeVirt subresource API (same kind of direct-dial plumbing as `vsock-tls-namespace-isolation-issue.md` §4.4's trigger program). TBD whether cluster network policy allows this from outside virt-handler; confirm during the run.
   5. Pass criteria (both must hold): the handshake fails on the client side with a certificate-verification error, not a connection-level error; and roxagent's log shows exactly one additional forced-refetch line between the connection attempt and the final rejection.
   6. Fallback if direct VSOCK dialing isn't feasible on this cluster: record `TestCARefresher_TLSHandshake_WrongCA` (already green in CI) as the check of record for this case instead of a live-cluster injection, and say so explicitly when reporting results.

#### Manual test report - isolated roxagent test (without sensor)

<details>

<summary><b>Manual verification (cluster2): PASS</b> — hard KubeVirt CA cutover force-refetch + wrong-CA negative control (dialer path; no Sensor scraper in this image)</summary>


**Setup:** Sensor scraper is not in this image, so scrapes were driven by a small VSOCK TLS dialer inside the node-local `virt-handler` pod using the real `kubevirt-virt-handler-vsock-client-certs` leaf (same mTLS path Sensor would use; no `GetReport` framing). 
Forced kubevirt CA refresh with: `kubectl delete secret kubevirt-ca -n openshift-cnv`. Agent times below are guest EDT (UTC−4).

**How to read:** each step states what must be true for PASS, then the log/command output that proves it.

### 1) Baseline — cold CA fetch + TLS accept

*Must see:* listen on :818, one `KubeVirt CA refreshed successfully`, then `Accepted TLS connection`.

```
16:05:36  Listening on VSOCK port 818 (pull mode)
16:05:53  KubeVirt CA refreshed successfully
16:05:53  Accepted TLS connection from host(2):893664158
```

Dialer: `TLS_HANDSHAKE_SUCCESS`. Protocol `EOF` after accept is expected (dialer sends no `GetReport`).

### 2) Hard CA cutover — new CA, re-signed client leaf

*Must see:* CA fingerprint/subject change; vsock client issuer matches the **new** CA (not an overlap bundle).

```
# before  sha256=25:AC:DC:B7:…:48:FC  CN=kubevirt.io@1784663985
# after   sha256=13:06:67:D9:…:91:B4  CN=kubevirt.io@1784664370
# client  issuer=CN=kubevirt.io@1784664370  (openssl verify vs new CA → OK)
```

Wait until the virt-handler projected mount matches the new secret before the next dial (a dial with a stale mount accepts against the old cached CA and does **not** exercise cutover).

### 3) Post-cutover handshake — force-refetch while cache still fresh

*Must see:* a **second** `KubeVirt CA refreshed successfully` well under the 1h age gate, then `Accepted TLS`. Here Δ ≈ 47s (16:05:53 → 16:06:40), so this cannot be `ensureFreshPool`'s age gate; it is verify-fail → force-refetch → retry-success.

```
16:06:40  KubeVirt CA refreshed successfully
16:06:40  Accepted TLS connection from host(2):893664160
```

### 4) Negative control — wrong CA rejected; one forced refetch; retry rate-limited

Throwaway CA + `clientAuth` leaf (unrelated to either KubeVirt CA). Dialer (Sensor imitation) post-handshake read surfaces TLS 1.3's server alert.

*Must see:* client `tls: bad certificate`; server rejects **after** one forced refetch; immediate second dial is rate-limited (no second refetch; refresh count +1 only).

```
# dialer (both attempts)
post-handshake read: remote error: tls: bad certificate

# agent
16:07:37  KubeVirt CA refreshed successfully
16:07:37  TLS handshake … failed: verifying client certificate after KubeVirt CA refresh: x509: certificate signed by unknown authority
16:07:38  TLS handshake … failed: … unknown authority; must re-fetch KubeVirt CA, but was rate-limited
# CA-refresh count across the pair: 4 → 5
```

### 5) Good peer still works afterward

```
16:07:40  Accepted TLS connection from host(2):893664166
```

**Verdict: PASS.** Full write-up (method, dialer source, discarded false-positive dial): see working notes / `pr-21845-smoke-test-report.md`. For the same scenarios with Sensor's VMScraper from #21369 in the path (including `GetReport`), see the companion spoiler.

</details>

#### Manual test report - roxagent & Sensor (deployed from the PoC branch)

<details>
<summary><b>Manual verification (cluster2) with Sensor scraper from #21369: PASS</b> — same CA cutover scenarios, real Sensor → virt-handler → roxagent <code>GetReport</code></summary>


**Setup:** Same cluster/VM as the dialer-path run. Sensor swapped to the PoC branch to include VMScraper (Scraper not merged yet). Agent binary and Central stayed on #21845 (`4.12.x-555-g5fa10fab9b`) - mixed stack on purpose. Scraper poll temporarily set to `ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL=30s` (default 5m). Agent restarted so the CA cache started cold. Sensor logs are UTC; agent journal is guest EDT (UTC−4).

**How to read:** each step states what must be true for PASS, then the log output that proves it.

### 1) Baseline — Sensor scrapes end-to-end (TLS + GetReport), CA cached

*Must see:* Sensor `1/1 VMs scraped successfully`; agent `KubeVirt CA refreshed successfully` + `Accepted TLS` + `GetReport: serving report`.

```
# sensor (UTC)
20:30:13  VMScraper: about to poll 1 running VMs
20:30:13  VMScraper: cycle done: 1/1 VMs scraped successfully in 90ms

# agent (EDT)
16:30:13  KubeVirt CA refreshed successfully
16:30:13  Accepted TLS connection from host(2):893664169
16:30:13  GetReport: serving report (generation=1, packages=982)
```

### 2) Hard CA cutover - new kubevirt CA, re-signed client leaf, mount refreshed

*Must see:* CA fingerprint/subject change; vsock client issuer matches the **new** CA; virt-handler projected mount matches the secret before the next scrape.

```
# before  sha256=13:06:67:D9:…:91:B4  CN=kubevirt.io@1784664370
# after   sha256=9F:5C:32:02:…:C4:07  CN=kubevirt.io@1784665838
# client  issuer=CN=kubevirt.io@1784665838  (verify vs new CA → OK; mount_match=yes)
```

### 3) Next Sensor scrape — force-refetch while cache still fresh + GetReport

*Must see:* a **second** `KubeVirt CA refreshed successfully` well under the 1h age gate, Sensor still `1/1 scraped successfully`, agent serves `GetReport`. Here Δ = 30s (16:30:13 → 16:30:43), so this cannot be the age gate.

```
# sensor (UTC)
20:30:43  VMScraper: cycle done: 1/1 VMs scraped successfully in 88ms

# agent (EDT)
16:30:43  KubeVirt CA refreshed successfully
16:30:43  Accepted TLS connection from host(2):893664170
16:30:43  GetReport: unchanged (generation=1, last_known_generation=1)
```

### 4) Negative control - wrong CA rejected; one forced refetch; retry rate-limited

Same throwaway leaf + virt-handler dialer as the dialer-path run (⚠️ Sensor cannot present a wrong cert).

*Must see:* client `tls: bad certificate`; server rejects after one forced refetch; immediate second dial rate-limited (refresh count +1 only).

```
# dialer (both attempts)
post-handshake read: remote error: tls: bad certificate

# agent
16:31:09  KubeVirt CA refreshed successfully
16:31:09  TLS handshake … failed: verifying client certificate after KubeVirt CA refresh: x509: certificate signed by unknown authority
16:31:10  TLS handshake … failed: … unknown authority; must re-fetch KubeVirt CA, but was rate-limited
# CA-refresh count across the pair: 7 → 8
```

### 5) Sensor still scrapes afterward

```
# sensor
20:31:13  VMScraper: cycle done: 1/1 VMs scraped successfully in 53ms

# agent
16:31:13  Accepted TLS connection …
16:31:13  GetReport: unchanged (generation=1, last_known_generation=1)
```

**Verdict: PASS.** Full write-up: `pr-21845-smoke-test-report-with-sensor-21369.md`. Dialer source / method notes: companion dialer-path report.

</details>

