### PR TITLE
ROX-35860: adds legacy scanner feature flag to installer

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -148,6 +148,13 @@ spec:
         - name: ROX_SCANNER_V4
           value: "true"
         {{- end }}
+        {{- if ._rox._scannerEnabled }}
+        - name: ROX_LEGACY_SCANNER
+          value: "true"
+        {{- else }}
+        - name: ROX_LEGACY_SCANNER
+          value: "false"
+        {{- end }}
         [<- end >]
         {{- include "srox.envVars" (list . "deployment" "central" "central") | nindent 8 }}
         volumeMounts:

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -148,7 +148,7 @@ spec:
         - name: ROX_SCANNER_V4
           value: "true"
         {{- end }}
-        {{- if ._rox._scannerEnabled }}
+        {{- if ._rox._legacyScannerEnabled }}
         - name: ROX_LEGACY_SCANNER
           value: "true"
         {{- else }}

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -294,6 +294,8 @@
   {{ include "srox.scannerInit" (list $ $scannerCfg) }}
 {{ end }}
 
+{{ $_ := set $._rox "_scannerEnabled" (not $scannerCfg.disable) }}
+
 {{/*
    ScannerV4 setup.
   */}}

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -294,7 +294,7 @@
   {{ include "srox.scannerInit" (list $ $scannerCfg) }}
 {{ end }}
 
-{{ $_ := set $._rox "_scannerEnabled" (not $scannerCfg.disable) }}
+{{ $_ := set $._rox "_legacyScannerEnabled" (not $scannerCfg.disable) }}
 
 {{/*
    ScannerV4 setup.

--- a/operator/tests/central/central-misc/080-assert-non-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-non-openshift.yaml
@@ -49,6 +49,8 @@ spec:
               value: "operator"
             - name: ROX_SCANNER_V4
               value: "true"
+            - name: ROX_LEGACY_SCANNER
+              value: "true"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/central-misc/080-assert-openshift.yaml
+++ b/operator/tests/central/central-misc/080-assert-openshift.yaml
@@ -53,6 +53,8 @@ spec:
               value: "operator"
             - name: ROX_SCANNER_V4
               value: "true"
+            - name: ROX_LEGACY_SCANNER
+              value: "true"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/central-misc/081-assert-non-openshift.yaml
+++ b/operator/tests/central/central-misc/081-assert-non-openshift.yaml
@@ -45,6 +45,8 @@ spec:
               value: "operator"
             - name: ROX_SCANNER_V4
               value: "true"
+            - name: ROX_LEGACY_SCANNER
+              value: "true"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/operator/tests/central/central-misc/081-assert-openshift.yaml
+++ b/operator/tests/central/central-misc/081-assert-openshift.yaml
@@ -49,6 +49,8 @@ spec:
               value: "operator"
             - name: ROX_SCANNER_V4
               value: "true"
+            - name: ROX_LEGACY_SCANNER
+              value: "true"
             - name: NO_PROXY
               valueFrom:
                 secretKeyRef:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -111,6 +111,22 @@ tests:
   expect: |
     envVars(.deployments.central; "central") | assertThat(has("ROX_TENANT_ID") == false)
 
+- name: ROX_LEGACY_SCANNER should be true by default
+  expect: |
+    envVars(.deployments.central; "central")["ROX_LEGACY_SCANNER"] | assertThat(. == "true")
+
+- name: ROX_LEGACY_SCANNER should be false when scanner is disabled
+  set:
+    scanner.disable: true
+  expect: |
+    envVars(.deployments.central; "central")["ROX_LEGACY_SCANNER"] | assertThat(. == "false")
+
+- name: ROX_LEGACY_SCANNER should be true when scanner is explicitly enabled
+  set:
+    scanner.disable: false
+  expect: |
+    envVars(.deployments.central; "central")["ROX_LEGACY_SCANNER"] | assertThat(. == "true")
+
 - name: Central deployment has secure container security context
   expect: |
     container(.deployments["central"]; "central") | .securityContext.allowPrivilegeEscalation | assertThat(. == false)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds legacy scanner feature flag support to installer, allowing users to be able to turn off ScannerV2 functionality and deployment artifacts from the installer.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Prereqs:
* Get image from this PR: `4.12.x-547-gc9615ee8b8`

Test default and without passing anything:
* `roxie deploy -t 4.12.x-547-gc9615ee8b8`
```
oc get deployment -n acs-central central -o yaml | yq '.spec.template.spec.containers[].env[] | select(.name=="ROX_LEGACY_SCANNER")'
name: ROX_LEGACY_SCANNER
value: "true"
```
* `roxie teardown`

Test explicit disabling:
* `roxie deploy --tag 4.12.x-547-gc9615ee8b8 --set central.spec.scanner.scannerComponent=Disabled`
```
oc get deployment -n acs-central central -o yaml | yq '.spec.template.spec.containers[].env[] | select(.name=="ROX_LEGACY_SCANNER")'
name: ROX_LEGACY_SCANNER
value: "false"
```
* `roxie teardown`

Test explicit enabling:
* `roxie deploy --tag 4.12.x-547-gc9615ee8b8 --set central.spec.scanner.scannerComponent=Enabled`
```
oc get deployment -n acs-central central -o yaml | yq '.spec.template.spec.containers[].env[] | select(.name=="ROX_LEGACY_SCANNER")'
name: ROX_LEGACY_SCANNER
value: "true"
```
* `roxie teardown`