### PR TITLE
fix(ci): install EBS CSI driver addon for EKS e2e tests

### DIFF
--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -3,9 +3,146 @@
 """
 Run qa-tests-backend in an EKS cluster provided via automation-flavors/eks.
 """
+import json
 import os
+import subprocess
+import time
 from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import AutomationFlavorsCluster
+
+
+def install_ebs_csi_driver():
+    """Install AWS EBS CSI driver addon for EKS to enable PVC support.
+
+    Scanner V4 DB requires PVCs, but EKS clusters don't have the EBS CSI driver
+    by default. The gp2 StorageClass exists but its provisioner (kubernetes.io/aws-ebs)
+    is redirected to ebs.csi.aws.com via CSI migration, which isn't running without
+    this addon.
+    """
+    print("Installing AWS EBS CSI driver addon...")
+
+    # Get cluster name from kubectl context or CLUSTER_NAME env var
+    cluster_name = os.environ.get("CLUSTER_NAME")
+    if not cluster_name:
+        result = subprocess.run(
+            ["kubectl", "config", "current-context"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        context = result.stdout.strip()
+        # EKS contexts look like: arn:aws:eks:region:account:cluster/cluster-name
+        # or sometimes just cluster-name
+        if "/cluster/" in context:
+            cluster_name = context.split("/cluster/")[-1]
+        else:
+            cluster_name = context
+
+    print(f"Cluster name: {cluster_name}")
+
+    # Get AWS region
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
+    print(f"AWS region: {region}")
+
+    # Get node IAM role and attach EBS CSI policy
+    # First, get a node's IAM role
+    print("Getting node IAM role...")
+    result = subprocess.run(
+        ["kubectl", "get", "nodes", "-o", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    nodes = json.loads(result.stdout)
+    if not nodes.get("items"):
+        raise RuntimeError("No nodes found in cluster")
+
+    # Extract instance ID from first node's provider ID
+    # Provider ID format: aws:///zone/instance-id
+    provider_id = nodes["items"][0]["spec"]["providerID"]
+    instance_id = provider_id.split("/")[-1]
+    print(f"Node instance ID: {instance_id}")
+
+    # Get IAM instance profile
+    result = subprocess.run(
+        ["aws", "ec2", "describe-instances",
+         "--instance-ids", instance_id,
+         "--region", region,
+         "--query", "Reservations[0].Instances[0].IamInstanceProfile.Arn",
+         "--output", "text"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    instance_profile_arn = result.stdout.strip()
+    instance_profile_name = instance_profile_arn.split("/")[-1]
+    print(f"Instance profile: {instance_profile_name}")
+
+    # Get role name from instance profile
+    result = subprocess.run(
+        ["aws", "iam", "get-instance-profile",
+         "--instance-profile-name", instance_profile_name,
+         "--query", "InstanceProfile.Roles[0].RoleName",
+         "--output", "text"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    role_name = result.stdout.strip()
+    print(f"IAM role: {role_name}")
+
+    # Attach EBS CSI policy to role
+    print("Attaching EBS CSI policy to IAM role...")
+    subprocess.run(
+        ["aws", "iam", "attach-role-policy",
+         "--role-name", role_name,
+         "--policy-arn", "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"],
+        check=True,
+    )
+    print("Policy attached successfully")
+
+    # Install the EBS CSI driver addon
+    print("Creating EBS CSI driver addon...")
+    subprocess.run(
+        ["aws", "eks", "create-addon",
+         "--cluster-name", cluster_name,
+         "--addon-name", "aws-ebs-csi-driver",
+         "--region", region],
+        check=True,
+    )
+
+    # Wait for addon to become ACTIVE
+    print("Waiting for addon to become ACTIVE...")
+    max_attempts = 30
+    for attempt in range(max_attempts):
+        result = subprocess.run(
+            ["aws", "eks", "describe-addon",
+             "--cluster-name", cluster_name,
+             "--addon-name", "aws-ebs-csi-driver",
+             "--region", region,
+             "--query", "addon.status",
+             "--output", "text"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        status = result.stdout.strip()
+        print(f"Addon status: {status} (attempt {attempt + 1}/{max_attempts})")
+
+        if status == "ACTIVE":
+            print("EBS CSI driver addon is ACTIVE")
+            break
+        elif status in ["CREATE_FAILED", "DEGRADED"]:
+            raise RuntimeError(f"Addon installation failed with status: {status}")
+
+        time.sleep(10)
+    else:
+        raise RuntimeError("Addon installation timed out")
+
+    # Set storage class for Scanner V4 DB
+    os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "gp2"
+    print("EBS CSI driver installation complete")
+
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
@@ -13,5 +150,8 @@ os.environ["KUBERNETES_PROVIDER"] = "eks"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
+
+# Install EBS CSI driver before running tests
+install_ebs_csi_driver()
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

EKS clusters created by automation-flavors lack the AWS EBS CSI driver addon. Since Kubernetes 1.23, the in-tree `kubernetes.io/aws-ebs` provisioner is transparently redirected to `ebs.csi.aws.com` via CSI migration. Without the CSI driver running, PVCs stay Pending forever.

This became visible after PR #21503 enabled Scanner V4 globally — scanner-v4-db requires a PVC, and every EKS e2e run now fails before tests start.

Fix: add `install_ebs_csi_driver()` to `eks_qa_e2e_tests.py` that discovers the cluster, attaches `AmazonEBSCSIDriverPolicy` to the node IAM role, installs the `aws-ebs-csi-driver` addon, and waits for it to become active. Also sets `SCANNER_V4_DB_STORAGE_CLASS=gp2`.

Alternative approach being tested in parallel: PR using emptyDir for scanner-v4-db instead (branch `davdhacs/eks-scanner-v4-db-emptydir`). Also testing EBS CSI driver installation at cluster creation time in automation-flavors repo.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validation in progress — this PR exists to run the EKS e2e test (`/test eks-qa-e2e-tests`) and confirm scanner-v4-db PVCs provision successfully with the EBS CSI driver installed.