### PR TITLE
fix(ci): use emptyDir for scanner-v4-db on EKS e2e tests

### DIFF
--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -4,6 +4,7 @@
 Run qa-tests-backend in an EKS cluster provided via automation-flavors/eks.
 """
 import os
+import tempfile
 from base_qa_e2e_test import make_qa_e2e_test_runner
 from clusters import AutomationFlavorsCluster
 
@@ -13,5 +14,14 @@ os.environ["KUBERNETES_PROVIDER"] = "eks"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
+
+# Use emptyDir for scanner-v4-db since EKS clusters lack a PV provisioner
+# (no EBS CSI driver installed). For CI e2e tests, persistence isn't needed.
+values_file = tempfile.NamedTemporaryFile(
+    mode='w', suffix='.yaml', delete=False, prefix='eks-scanner-v4-'
+)
+values_file.write('scannerV4:\n  db:\n    persistence:\n      none: true\n')
+values_file.close()
+os.environ["ROX_CENTRAL_EXTRA_HELM_VALUES_FILE"] = values_file.name
 
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

EKS clusters created by automation-flavors lack the AWS EBS CSI driver addon. Since Kubernetes 1.23, CSI migration redirects the in-tree `kubernetes.io/aws-ebs` provisioner to `ebs.csi.aws.com`, which isn't running. Scanner-v4-db PVCs stay Pending forever.

This became visible after PR #21503 enabled Scanner V4 globally.

Fix: write a Helm values override file setting `scannerV4.db.persistence.none: true` and pass it via `ROX_CENTRAL_EXTRA_HELM_VALUES_FILE`. This gives scanner-v4-db an emptyDir volume, which is fine for ephemeral CI clusters. The mechanism already exists in `deploy/common/k8sbased.sh` (lines 484-488).

Alternative approach being tested in parallel: PR installing the EBS CSI driver addon (branch `davdhacs/eks-ebs-csi-addon`).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validation in progress — this PR exists to run the EKS e2e test (`/test eks-qa-e2e-tests`) and confirm scanner-v4-db starts successfully with emptyDir.