### PR TITLE
fix(ci): wire SCANNER_V4_DB_PERSISTENCE_NONE env var

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -477,6 +477,10 @@ function launch_central {
         helm_args+=(-f "${COMMON_DIR}/ci-values.yaml")
       fi
 
+      if [[ -n "${SCANNER_V4_DB_PERSISTENCE_NONE}" ]]; then
+        helm_args+=(--set "scannerV4.db.persistence.none=true")
+      fi
+
       if [[ -n "${SCANNER_V4_DB_STORAGE_CLASS}" ]]; then
         helm_args+=(--set "scannerV4.db.persistence.persistentVolumeClaim.storageClass=${SCANNER_V4_DB_STORAGE_CLASS}")
       fi

--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -14,4 +14,8 @@ os.environ["KUBERNETES_PROVIDER"] = "eks"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
+# EKS clusters lack the EBS CSI driver addon, so PVCs can't be provisioned.
+# Use emptyDir for scanner-v4-db since persistence isn't needed in CI.
+os.environ["SCANNER_V4_DB_PERSISTENCE_NONE"] = "true"
+
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

The Helm chart already supports `scannerV4.db.persistence.none: true` for emptyDir volumes (`_scanner-v4_volume.tpl`, line 33), but there was no env var to set it from deploy scripts — unlike central-db which has `CENTRAL_PERSISTENCE_NONE`.

This adds `SCANNER_V4_DB_PERSISTENCE_NONE` to `k8sbased.sh` (mirroring `CENTRAL_PERSISTENCE_NONE`) and sets it in the EKS e2e test script, since EKS clusters lack the EBS CSI driver addon and can't provision PVCs.

This is the cleanest of four parallel approaches being tested — the others install the CSI driver (PRs #21849, #353) or use a tempfile values override (#21850).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validation in progress — `/test eks-qa-e2e-tests` triggered to confirm scanner-v4-db starts with emptyDir via this env var.