### PR TITLE
ROX-27690: add exceptions to feature flag test

### DIFF
--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	// skipFeatures is a list of feature flags to ignore in comparisons, these
+	// flags may intentionally differ from the defaults.
+	skipFeatures = map[string]bool{
+		// Scanner V4 is enabled/disabled at install time, when Scanner V4 is
+		// installed the value will differ from the default.
+		features.ScannerV4.EnvVar(): true,
+		// Legacy Scanner is enabled/disabled at install time, when the legacy
+		// scanner is installed the value will differ from the default.
+		features.LegacyScanner.EnvVar(): true,
+	}
+)
+
 func TestFeatureFlagSettings(t *testing.T) {
 	if os.Getenv("ORCHESTRATOR_FLAVOR") == "openshift" {
 		t.Skip("Skipping on OCP: ci_export uses cci-export which does not set shell variables, causing systemic mismatch between test runner and Central")
@@ -30,6 +43,10 @@ func TestFeatureFlagSettings(t *testing.T) {
 
 	expectedFlagVals := make(map[string]bool)
 	for _, flag := range features.Flags {
+		if skipFeatures[flag.EnvVar()] {
+			continue
+		}
+
 		// For non-release builds, test that feature flag settings match the local environment;
 		// for release builds, test that they match the defaults.
 		expectedVal := flag.Enabled()
@@ -45,6 +62,10 @@ func TestFeatureFlagSettings(t *testing.T) {
 
 	actualFlagVals := make(map[string]bool)
 	for _, flag := range featureFlags.GetFeatureFlags() {
+		if skipFeatures[flag.GetEnvVar()] {
+			continue
+		}
+
 		actualFlagVals[flag.GetEnvVar()] = flag.GetEnabled()
 	}
 


### PR DESCRIPTION
## Description

After enabling Scanner V4 in CI, various nightly tests were failing because the SCANNER_V4 feature flag value did not match the default (in release builds) - this adds the feature flags set by the installer for Scanner V4 and the legacy scanner to a skip list.

Examples:

- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-gke-latest-nongroovy-e2e-tests/2079366802852286464
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-gke-nongroovy-e2e-tests/2079366803024252928
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-gke-oldest-nongroovy-e2e-tests/2079366804412567552

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing



- [x] modified existing tests

### How I validated my change

Unit test