### PR TITLE
ROX-35843: Fix stalled-handshake accept-loop test flake

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -83,12 +83,20 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() { srv.Serve(ctx, ln); close(serveDone) }()
+	// cancel/serveDone must run even if the select times out and calls
+	// t.Fatal; otherwise the accept-loop goroutine outlives the test.
+	defer func() {
+		cancel()
+		<-serveDone
+	}()
 
 	// A stalled peer: opens the TCP connection but never sends a TLS
 	// ClientHello (or anything else). That peer wins the single semaphore
 	// slot; serveConn then blocks in HandshakeContext off the accept loop.
 	stalled, err := net.Dial("tcp", ln.Addr().String())
 	require.NoError(t, err)
+	// Close before cancel (defer LIFO) so the handshake goroutine unblocks
+	// without waiting out connDeadline.
 	defer func() { _ = stalled.Close() }()
 
 	// A second peer must still be accepted, handshaked, and answered with
@@ -123,10 +131,4 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	case <-time.After(5 * time.Second):
 		t.Fatal("second connection was not answered promptly; accept loop is likely blocked by the stalled peer")
 	}
-
-	// Unblock the stalled connection's server-side handshake goroutine
-	// immediately, rather than waiting out connDeadline, so the test stays fast.
-	_ = stalled.Close()
-	cancel()
-	<-serveDone
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -65,6 +65,14 @@ func TestServeAcceptLoop(t *testing.T) {
 // every other connection - including the legitimate one - for as long as
 // the stalled peer stayed connected. The handshake must run off the accept
 // loop so Accept() only ever blocks on Accept() itself.
+//
+// With maxConcurrentConns=1, the stalled peer is accepted first and holds
+// the semaphore for the duration of its (never-completing) handshake, so
+// the second peer always takes the rejectConn path and receives
+// ERROR_CODE_BUSY. That is enough to prove Accept() kept running: a blocked
+// accept loop would never handshake the second peer or write BUSY.
+// The client must only ReadFrame here - writing a request races rejectConn's
+// close-after-BUSY and flakes with broken pipe on Linux.
 func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing.T) {
 	handler := NewHandler(&ReportCache{}, "test")
 	srv := NewServer(handler, &tls.Config{Certificates: []tls.Certificate{testServerCert(t)}})
@@ -77,15 +85,14 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	go func() { srv.Serve(ctx, ln); close(serveDone) }()
 
 	// A stalled peer: opens the TCP connection but never sends a TLS
-	// ClientHello (or anything else). Before the fix, the server's
-	// HandshakeContext call for this connection would block Serve's single
-	// accept loop indefinitely, since it has no deadline of its own.
+	// ClientHello (or anything else). That peer wins the single semaphore
+	// slot; serveConn then blocks in HandshakeContext off the accept loop.
 	stalled, err := net.Dial("tcp", ln.Addr().String())
 	require.NoError(t, err)
 	defer func() { _ = stalled.Close() }()
 
-	// A well-behaved peer must still be accepted and served promptly,
-	// despite the stalled connection still being open.
+	// A second peer must still be accepted, handshaked, and answered with
+	// BUSY promptly while the stalled peer remains connected.
 	// require inside a non-test goroutine only stops that goroutine (via
 	// runtime.Goexit), not the test itself, so failures here use assert with
 	// an early return instead.
@@ -98,25 +105,23 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 		}
 		defer func() { _ = clientConn.Close() }()
 
-		req, _ := proto.Marshal(&pb.VMServiceRequest{Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}}})
-		if !assert.NoError(t, vsockframing.WriteFrame(clientConn, req)) {
-			return
-		}
 		respData, readErr := vsockframing.ReadFrame(clientConn, 1<<20)
-		if !assert.NoError(t, readErr) {
+		if !assert.NoError(t, readErr, "rejected peer should receive framed BUSY before the server closes") {
 			return
 		}
 		var resp pb.VMServiceResponse
 		if !assert.NoError(t, proto.Unmarshal(respData, &resp)) {
 			return
 		}
-		assert.NotNil(t, resp.GetError(), "expected NOT_READY, but any response at all proves the loop wasn't blocked")
+		if assert.NotNil(t, resp.GetError()) {
+			assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
+		}
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("well-behaved connection was not served promptly; accept loop is likely blocked by the stalled peer")
+		t.Fatal("second connection was not answered promptly; accept loop is likely blocked by the stalled peer")
 	}
 
 	// Unblock the stalled connection's server-side handshake goroutine

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -83,8 +83,6 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	serveDone := make(chan struct{})
 	go func() { srv.Serve(ctx, ln); close(serveDone) }()
-	// cancel/serveDone must run even if the select times out and calls
-	// t.Fatal; otherwise the accept-loop goroutine outlives the test.
 	defer func() {
 		cancel()
 		<-serveDone
@@ -99,36 +97,22 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	// without waiting out connDeadline.
 	defer func() { _ = stalled.Close() }()
 
-	// A second peer must still be accepted, handshaked, and answered with
-	// BUSY promptly while the stalled peer remains connected.
-	// require inside a non-test goroutine only stops that goroutine (via
-	// runtime.Goexit), not the test itself, so failures here use assert with
-	// an early return instead.
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		clientConn, dialErr := tls.Dial("tcp", ln.Addr().String(), &tls.Config{InsecureSkipVerify: true})
-		if !assert.NoError(t, dialErr) {
-			return
-		}
-		defer func() { _ = clientConn.Close() }()
-
-		respData, readErr := vsockframing.ReadFrame(clientConn, 1<<20)
-		if !assert.NoError(t, readErr, "rejected peer should receive framed BUSY before the server closes") {
-			return
-		}
-		var resp pb.VMServiceResponse
-		if !assert.NoError(t, proto.Unmarshal(respData, &resp)) {
-			return
-		}
-		if assert.NotNil(t, resp.GetError()) {
-			assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
-		}
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("second connection was not answered promptly; accept loop is likely blocked by the stalled peer")
+	// Second peer on the test goroutine (same style as TestServeAcceptLoop).
+	// NetDialer.Timeout bounds dial+TLS handshake: if Accept were blocked,
+	// TCP can still complete from the backlog, but the handshake would hang.
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 5 * time.Second},
+		Config:    &tls.Config{InsecureSkipVerify: true},
 	}
+	clientConn, err := dialer.DialContext(ctx, "tcp", ln.Addr().String())
+	require.NoError(t, err, "second peer should be accepted promptly; accept loop may be blocked")
+	defer func() { _ = clientConn.Close() }()
+
+	require.NoError(t, clientConn.SetDeadline(time.Now().Add(5*time.Second)))
+	respData, err := vsockframing.ReadFrame(clientConn, 1<<20)
+	require.NoError(t, err, "rejected peer should receive framed BUSY before the server closes")
+	var resp pb.VMServiceResponse
+	require.NoError(t, proto.Unmarshal(respData, &resp))
+	require.NotNil(t, resp.GetError())
+	assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
 }


### PR DESCRIPTION
## Description

`TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections` flaked on Linux with `broken pipe` on `WriteFrame` (ROX-35843). Flake has not been observed locally on Mac.

This test assumes, that the agent (which accepts only one request in parallel), can be blocked, if a malicious client connects to it and never finishes the handshake. In that case, we want to make sure that a second caller is not waiting forever (=agent's timeout) to get the `ERROR_CODE_BUSY`.

In this test, the second client still behaved like a normal client on that path: it opened a connection and immediately wrote it's request (get_report). As the connection would never be accepted properly (if would be opened only to reply BUSY), that write often raced the close and failed with `broken pipe`.

Fix: after TLS dial, only `ReadFrame` and assert `ERROR_CODE_BUSY`. That still proves Accept is not blocked, without racing close-after-BUSY.

This PR is test-only.

The same write-vs-close-after-BUSY ordering can hit production Sensor (write request, then read) on a busy reject.
Consequence is mostly wrong classification in logs/metrics (transport error instead of `ERROR_CODE_BUSY`); the scrape fails either way and retries on the next poll. 📓 Expect a small follow-up so Sensor surfaces busy distinctly.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI - previously failed this test on Linux (`broken pipe` on write after BUSY close); this change targets that failure mode.
- Local Linux stress via podman (Go 1.26.3), 200 iterations:

```bash
podman run --rm -v "$PWD":/src -w /src docker.io/library/golang:1.26.3 \
  go test ./compliance/virtualmachines/roxagent/vsockserver/ \
  -run 'TestServeAcceptLoop' -count=200
```