### PR TITLE
ROX-35845: drop flaky VM e2e compliance ACK equality

### DIFF
--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -53,7 +53,7 @@ type pipelineMetricsSnapshot struct {
 // assertPipelineMetrics scrapes compliance and sensor metrics, retrying until
 // all pipeline assertions pass or the timeout expires.
 // vmNodeName must be non-empty so compliance metrics are scoped to the VM's local collector pod.
-func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string, before, midpoint pipelineMetricsSnapshot) {
+func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string, before pipelineMetricsSnapshot) {
 	tt, ok := t.(*testing.T)
 	require.True(t, ok, "assertPipelineMetrics requires *testing.T")
 
@@ -72,7 +72,7 @@ func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.T
 		if !assert.NoError(ct, err, "scrape pipeline metrics") {
 			return
 		}
-		assertPipeline(ct, before, midpoint, after)
+		assertPipeline(ct, before, after)
 	}, metricsTimeout, metricsPoll)
 }
 
@@ -152,63 +152,24 @@ func assertMetricZeroOrAbsentDelta(t *assert.CollectT, before, after testmetrics
 		name, formatMetricObservation(beforeObs), formatMetricObservation(afterObs), got)
 }
 
-func metricDelta(before, after testmetrics.Metrics, name string, labels ...string) float64 {
-	afterObs := metricObservationFor(after, name, labels...)
-	beforeObs := metricObservationFor(before, name, labels...)
-	return afterObs.valueOrZero() - beforeObs.valueOrZero()
-}
-
-type metricPhaseDeltas struct {
-	firstRun float64
-	rescan   float64
-	total    float64
-}
-
-func metricPhaseDeltasFor(before, midpoint, after testmetrics.Metrics, name string, labels ...string) metricPhaseDeltas {
-	return metricPhaseDeltas{
-		firstRun: metricDelta(before, midpoint, name, labels...),
-		rescan:   metricDelta(midpoint, after, name, labels...),
-		total:    metricDelta(before, after, name, labels...),
-	}
-}
-
-// assertPipeline verifies the two-report scenario using three metric snapshots:
-// baseline before the first roxagent run, midpoint after the first report is
-// visible in Central and just before rescan, and final after the rescan path
-// completes. The main contract is that two ACKs make it all the way back to
-// compliance; the other metrics help localize failures when that contract is not met.
-func assertPipeline(t *assert.CollectT, before, midpoint, after pipelineMetricsSnapshot) {
+// assertPipeline verifies the two-report scenario using baseline and final metric
+// snapshots. Sensor ACK and compliance ingress must move by at least two (the two
+// roxagent runs); error/backpressure counters must stay flat. Exact equality on the
+// compliance ACK counter is intentionally not asserted: UMH retries under slow ACK
+// RTT inflate that shared cumulative metric even when the scan path is healthy.
+func assertPipeline(t *assert.CollectT, before, after pipelineMetricsSnapshot) {
 	complianceBefore := before.compliance
-	complianceMidpoint := midpoint.compliance
 	complianceAfter := after.compliance
 	sensorBefore := before.sensor
-	sensorMidpoint := midpoint.sensor
 	sensorAfter := after.sensor
 
-	const complianceACKMetric = "rox_compliance_virtual_machine_index_acks_from_sensor_total"
 	const sensorACKMetric = "rox_sensor_virtual_machine_index_report_acks_received_total"
 	const complianceIngressMetric = "rox_compliance_virtual_machine_relay_index_reports_received_total"
-
-	complianceACKDeltas := metricPhaseDeltasFor(complianceBefore, complianceMidpoint, complianceAfter, complianceACKMetric, "action", "ACK")
-	sensorACKDeltas := metricPhaseDeltasFor(sensorBefore, sensorMidpoint, sensorAfter, sensorACKMetric, "action", "ACK")
-	complianceIngressDeltas := metricPhaseDeltasFor(complianceBefore, complianceMidpoint, complianceAfter, complianceIngressMetric)
-
-	// Primary end-to-end assertion: the two roxagent runs in this test should
-	// yield exactly two ACKs returning from Sensor to compliance.
-	assert.Equalf(t, float64(2), complianceACKDeltas.total,
-		"%s delta should be 2; compliance ACKs firstRun=%.0f rescan=%.0f total=%.0f; "+
-			"sensor ACKs firstRun=%.0f rescan=%.0f total=%.0f; "+
-			"compliance relay ingress firstRun=%.0f rescan=%.0f total=%.0f",
-		complianceACKMetric,
-		complianceACKDeltas.firstRun, complianceACKDeltas.rescan, complianceACKDeltas.total,
-		sensorACKDeltas.firstRun, sensorACKDeltas.rescan, sensorACKDeltas.total,
-		complianceIngressDeltas.firstRun, complianceIngressDeltas.rescan, complianceIngressDeltas.total)
 
 	// Breadcrumbs: use "at least 2" because this test sends two reports, so a
 	// healthy path should move these counters by at least two, but they are also
 	// shared cumulative metrics that may legitimately observe extra activity
-	// (for example retries or other VM traffic). Requiring equality here would
-	// make the diagnostics more flaky than the primary compliance ACK check.
+	// (for example retries or other VM traffic).
 	assertMetricDeltaAtLeast(t, sensorBefore, sensorAfter, 2,
 		sensorACKMetric, "action", "ACK")
 	assertMetricDeltaAtLeast(t, complianceBefore, complianceAfter, 2,
@@ -216,8 +177,6 @@ func assertPipeline(t *assert.CollectT, before, midpoint, after pipelineMetricsS
 
 	// Happy-path guardrails: none of the known error or backpressure counters
 	// should move during the two-report scenario.
-	assertMetricZeroOrAbsentDelta(t, complianceBefore, complianceAfter,
-		"rox_compliance_virtual_machine_index_acks_from_sensor_total", "action", "NACK")
 	assertMetricZeroOrAbsentDelta(t, complianceBefore, complianceAfter,
 		"rox_compliance_virtual_machine_relay_index_reports_sent_total", "failed", "true")
 	assertMetricZeroOrAbsentDelta(t, complianceBefore, complianceAfter,

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -24,7 +24,6 @@ func (s *VMScanningSuite) TestScanPipeline() {
 		s.T().Run(vm.Name, func(t *testing.T) {
 			var first *v2.VirtualMachine
 			var metricsBefore pipelineMetricsSnapshot
-			var metricsMidpoint pipelineMetricsSnapshot
 			metricsChecksEnabled := true
 			roxagentOK := false
 
@@ -85,18 +84,6 @@ func (s *VMScanningSuite) TestScanPipeline() {
 					"scan.operating_system should be populated via Sensor DiscoveredData")
 			})
 
-			// Snapshot metrics after the first report is fully visible in Central and
-			// before kicking off the rescan. This is used for diagnostics without
-			// making the midpoint another strict gate.
-			if ok := t.Run("MetricsMidpoint", func(t *testing.T) {
-				if !metricsChecksEnabled {
-					t.Skip("skipping: baseline metric scrape failed")
-				}
-				metricsMidpoint = s.mustScrapePipelineMetrics(s.ctx, t, vm.NodeName)
-			}); !ok {
-				metricsChecksEnabled = false
-			}
-
 			beforeTime := s.mustGetScanTimestamp(first.GetId())
 			var rescan *v2.VirtualMachine
 
@@ -126,7 +113,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				if !metricsChecksEnabled {
 					t.Skip("metric prerequisite scrape failed earlier in this VM scenario")
 				}
-				s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore, metricsMidpoint)
+				s.assertPipelineMetrics(s.ctx, t, vm.NodeName, metricsBefore)
 			})
 
 			t.Run("ConsistencyCheck", func(t *testing.T) {


### PR DESCRIPTION
## Description

Nightly `TestVMScanning/TestScanPipeline/*/PipelineMetrics` flakes when UMH (Unconfirmed Message Handler) retries under slow ACK round trip `rox_compliance_virtual_machine_index_acks_from_sensor_total` above the exact expected delta of 2, even though vsock sends 2 messages and Central scan checks pass 
```
rox_compliance_virtual_machine_index_acks_from_sensor_total delta should be 2; compliance ACKs firstRun=2 rescan=3 total=5; sensor ACKs firstRun=2 rescan=5 total=7; compliance relay ingress firstRun=1 rescan=1 total=2
```
(example: [build 2079728900513992704](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-ocp-4-22-ocp-vm-scanning-e2e-tests/2079728900513992704)).

This PR removes the exact compliance ACK `== 2` primary assertion (and the matching compliance NACK zero-delta), plus the midpoint snapshot that existed only to diagnose that check. 
Sensor ACK and compliance ingress still require `>= 2`; the other error/backpressure guards stay.

**This is a temporary mitigation.** The acknowledgement path will be rewritten as part of implementing the new vsock pull mode for VM scanning; once Sensor is the only ACK recipient and that pipeline is in place, these metrics assertions should be redesigned or replaced rather than tightened again on the current compliance ACK counters.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] Ran VM scanning e2e CI (`ocp-vm-scanning-e2e-tests`) on the PR (and will monitor nightlies afterwards)
    - ✅ https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21872/pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests/2079829006512820224
    - ✅ https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21872/pull-ci-stackrox-stackrox-master-ocp-4-22-vm-scanning-e2e-tests/2079829030403575808 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified VM scanning pipeline metric validation by comparing baseline and final results.
  * Updated checks to verify required metric increases across the complete scanning scenario.
  * Retained safeguards ensuring error and backpressure metrics remain unchanged or absent.
  * Removed intermediate metric snapshot handling from the scanning test flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->