### PR TITLE
ROX-35889: fix OpenShift SCC for monitoring chart

### DIFF
--- a/deploy/charts/monitoring/Chart.lock
+++ b/deploy/charts/monitoring/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 0.20.1
 digest: sha256:4efdfc4b2132dedad382ceafad1003437d4c64227881731d046e24cc9f143b26
-generated: "2022-09-22T16:51:51.884579+02:00"
+generated: "2026-07-22T13:50:00.884405+02:00"

--- a/deploy/charts/monitoring/README.md
+++ b/deploy/charts/monitoring/README.md
@@ -7,12 +7,25 @@ INTERNAL USE ONLY. Deploys Prometheus, Grafana, Alertmanager, and kube-state-met
 ```bash
 export PAGERDUTY_INTEGRATION_KEY=dummy   # required; real key for PagerDuty
 helm dependency update deploy/charts/monitoring
+# ${PAGERDUTY_INTEGRATION_KEY} in values.yaml needs envsubst, or pass --set below.
+envsubst < deploy/charts/monitoring/values.yaml > /tmp/monitoring-values.yaml
 helm upgrade --install monitoring deploy/charts/monitoring \
   -n stackrox --create-namespace \
-  -f deploy/charts/monitoring/values.yaml
+  -f /tmp/monitoring-values.yaml
 ```
 
-`PAGERDUTY_INTEGRATION_KEY` is substituted into the Alertmanager config. Use a dummy value when you do not need real paging.
+Or without `envsubst`:
+
+```bash
+helm upgrade --install monitoring deploy/charts/monitoring \
+  -n stackrox --create-namespace \
+  -f deploy/charts/monitoring/values.yaml \
+  --set "alertmanager.config.receivers[0].pagerduty_configs[0].service_key=${PAGERDUTY_INTEGRATION_KEY}"
+```
+
+`enableMonitoringPSPs` defaults to `false` (PSPs are gone on current clusters). Set `--set enableMonitoringPSPs=true` only on clusters that still expose the PodSecurityPolicy API.
+
+On OpenShift, if Helm reports an `imagePullSecrets` conflict on a ServiceAccount (OpenShift's image-registry controller vs Helm server-side apply), retry with `--force-conflicts`.
 
 Roxie can install the same chart as add-on release `roxie-addon-monitoring` via `central.availableAddOns.monitoring`.
 
@@ -36,3 +49,4 @@ Prometheus defaults to a `2Gi` memory request, no memory limit, and a `1000m` CP
 - Prefer `nonroot-v2` over `anyuid`: least privilege, namespace-scoped `use` bindings only.
 - Prefer parent `values.yaml` overrides over forking the upstream alertmanager / kube-state-metrics charts.
 - Pod-level `runAsUser` on Alertmanager covers the configmap-reload sidecar, which has no container `securityContext` upstream.
+- Docker Hub `imagePullSecrets` (`stackrox`) are set on Pods, not ServiceAccounts, so OpenShift's SA dockercfg controller does not fight Helm on upgrade.

--- a/deploy/charts/monitoring/README.md
+++ b/deploy/charts/monitoring/README.md
@@ -7,25 +7,17 @@ INTERNAL USE ONLY. Deploys Prometheus, Grafana, Alertmanager, and kube-state-met
 ```bash
 export PAGERDUTY_INTEGRATION_KEY=dummy   # required; real key for PagerDuty
 helm dependency update deploy/charts/monitoring
-# ${PAGERDUTY_INTEGRATION_KEY} in values.yaml needs envsubst, or pass --set below.
-envsubst < deploy/charts/monitoring/values.yaml > /tmp/monitoring-values.yaml
-helm upgrade --install monitoring deploy/charts/monitoring \
-  -n stackrox --create-namespace \
-  -f /tmp/monitoring-values.yaml
-```
-
-Or without `envsubst`:
-
-```bash
 helm upgrade --install monitoring deploy/charts/monitoring \
   -n stackrox --create-namespace \
   -f deploy/charts/monitoring/values.yaml \
   --set "alertmanager.config.receivers[0].pagerduty_configs[0].service_key=${PAGERDUTY_INTEGRATION_KEY}"
 ```
 
+`values.yaml` still contains `${PAGERDUTY_INTEGRATION_KEY}` for classic deploy `envsubst`. For raw Helm, override it with `--set` as above (use a dummy value when you do not need real paging).
+
 `enableMonitoringPSPs` defaults to `false` (PSPs are gone on current clusters). Set `--set enableMonitoringPSPs=true` only on clusters that still expose the PodSecurityPolicy API.
 
-On OpenShift, if Helm reports an `imagePullSecrets` conflict on a ServiceAccount (OpenShift's image-registry controller vs Helm server-side apply), retry with `--force-conflicts`.
+On OpenShift, Helm may fail an upgrade with a ServiceAccount `imagePullSecrets` conflict (OpenShift's image-registry controller vs Helm server-side apply). With Helm 4, retry with `--force-conflicts`. With Helm 3, uninstall and reinstall the release instead (or delete the conflicting ServiceAccount and retry the upgrade).
 
 Roxie can install the same chart as add-on release `roxie-addon-monitoring` via `central.availableAddOns.monitoring`.
 

--- a/deploy/charts/monitoring/README.md
+++ b/deploy/charts/monitoring/README.md
@@ -29,17 +29,7 @@ Do not set alertmanager / kube-state-metrics `nameOverride` or `fullnameOverride
 
 ## Resources
 
-Default Prometheus container requests/limits are `512Mi`/`1Gi` memory. For smaller or contended workers:
-
-```yaml
-resources:
-  requests:
-    memory: "256Mi"
-    cpu: "100m"
-  limits:
-    memory: "512Mi"
-    cpu: "250m"
-```
+Prometheus defaults to a `2Gi` memory request, no memory limit, and a `1000m` CPU limit. Fixed memory limits OOMKill this chart under normal scrape load; omit that limit and let the process grow. Set `resources.limits.memory` in values if you need a hard cap.
 
 ## Design notes
 

--- a/deploy/charts/monitoring/README.md
+++ b/deploy/charts/monitoring/README.md
@@ -1,15 +1,48 @@
 # StackRox Monitoring Chart
 
-This Helm chart is for StackRox Monitoring. INTERNAL USE ONLY.
+INTERNAL USE ONLY. Deploys Prometheus, Grafana, Alertmanager, and kube-state-metrics for StackRox development and debugging.
 
-Run the following command to render this chart:
-- for Helm v2
+## Install
+
+```bash
+export PAGERDUTY_INTEGRATION_KEY=dummy   # required; real key for PagerDuty
+helm dependency update deploy/charts/monitoring
+helm upgrade --install monitoring deploy/charts/monitoring \
+  -n stackrox --create-namespace \
+  -f deploy/charts/monitoring/values.yaml
 ```
-helm dependency update ./monitoring
-helm install --name monitoring ./monitoring
+
+`PAGERDUTY_INTEGRATION_KEY` is substituted into the Alertmanager config. Use a dummy value when you do not need real paging.
+
+Roxie can install the same chart as add-on release `roxie-addon-monitoring` via `central.availableAddOns.monitoring`.
+
+## OpenShift
+
+When the cluster exposes `security.openshift.io/v1/SecurityContextConstraints`, the chart:
+
+1. Creates a namespace Role that allows `use` of SCC `nonroot-v2`.
+2. Binds that Role to the chart ServiceAccounts: `monitoring`, `<release>-alertmanager`, and `<release>-kube-state-metrics`.
+
+Subchart pods use UID/GID `1000`/`2000` (same as the parent monitoring Deployment) so they satisfy `nonroot-v2` without needing `anyuid`. On vanilla Kubernetes the SCC Role/RoleBinding is not rendered.
+
+Do not set alertmanager / kube-state-metrics `nameOverride` or `fullnameOverride` unless you also update the SCC RoleBinding subjects in `templates/00-serviceaccount.yaml` to match the generated ServiceAccount names.
+
+## Resources
+
+Default Prometheus container requests/limits are `512Mi`/`1Gi` memory. For smaller or contended workers:
+
+```yaml
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "250m"
 ```
-- for Helm v3
-```
-helm dependency update ./monitoring
-helm install monitoring ./monitoring
-```
+
+## Design notes
+
+- Prefer `nonroot-v2` over `anyuid`: least privilege, namespace-scoped `use` bindings only.
+- Prefer parent `values.yaml` overrides over forking the upstream alertmanager / kube-state-metrics charts.
+- Pod-level `runAsUser` on Alertmanager covers the configmap-reload sidecar, which has no container `securityContext` upstream.

--- a/deploy/charts/monitoring/templates/00-serviceaccount.yaml
+++ b/deploy/charts/monitoring/templates/00-serviceaccount.yaml
@@ -34,8 +34,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: use-monitoring-scc
+# Bind every ServiceAccount this chart creates so alertmanager and
+# kube-state-metrics can use nonroot-v2 (restricted-v2 rejects their UIDs).
 subjects:
 - kind: ServiceAccount
   name: monitoring
-  namespace: {{.Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ printf "%s-alertmanager" .Release.Name | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: {{ printf "%s-kube-state-metrics" .Release.Name | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
 {{- end}}

--- a/deploy/charts/monitoring/templates/00-serviceaccount.yaml
+++ b/deploy/charts/monitoring/templates/00-serviceaccount.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: stackrox
-imagePullSecrets:
-- name: stackrox
 ---
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
 ---

--- a/deploy/charts/monitoring/templates/deployment.yaml
+++ b/deploy/charts/monitoring/templates/deployment.yaml
@@ -46,6 +46,12 @@ spec:
                     operator: DoesNotExist
       {{- end}}
       serviceAccount: monitoring
+      # Docker Hub auth for grafana/prometheus (higher rate limits than anonymous).
+      # Kept on the Pod, not the ServiceAccount: on OpenShift the image-registry
+      # controller also writes SA imagePullSecrets, which conflicts with Helm
+      # server-side apply on upgrades.
+      imagePullSecrets:
+      - name: stackrox
       # The uid and gid are set to make `/var/prometheus` writable. See https://github.com/prometheus/prometheus/issues/5976.
       securityContext:
         runAsUser: 1000

--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -44,6 +44,35 @@ kube-state-metrics:
     runAsNonRoot: true
     runAsUser: 1000
     runAsGroup: 2000
+  # autoscaling/v2beta2 is gone on current clusters; the default HPA collector
+  # only produces "requested resource not found" log spam.
+  collectors:
+    - certificatesigningrequests
+    - configmaps
+    - cronjobs
+    - daemonsets
+    - deployments
+    - endpoints
+    - ingresses
+    - jobs
+    - limitranges
+    - mutatingwebhookconfigurations
+    - namespaces
+    - networkpolicies
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - poddisruptionbudgets
+    - pods
+    - replicasets
+    - replicationcontrollers
+    - resourcequotas
+    - secrets
+    - services
+    - statefulsets
+    - storageclasses
+    - validatingwebhookconfigurations
+    - volumeattachments
 
 alertmanager:
   persistence:
@@ -61,6 +90,9 @@ alertmanager:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
+  # configmap-reload pulls from Docker Hub; same Hub auth as the parent pod.
+  imagePullSecrets:
+    - name: stackrox
   config:
     receivers:
       - name: pagerduty-notifications
@@ -72,4 +104,6 @@ alertmanager:
   configmapReload:
     enabled: true
 
-enableMonitoringPSPs: ${MONITORING_ENABLE_PSP}
+# PSPs are removed from modern Kubernetes/OpenShift/GKE. Classic deploy can
+# still enable them with --set enableMonitoringPSPs=true when the API exists.
+enableMonitoringPSPs: false

--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -3,15 +3,15 @@ prometheusImage: prom/prometheus:v2.34.0
 password: stackrox
 anonymousAdminAccess: true
 
-# Modest defaults for shared/dev clusters. Raise for long-retention Prometheus
-# workloads; see README for a smaller profile.
+# No memory limit: scrape/compaction spikes OOMKill under fixed caps on real
+# clusters. Request reserves scheduler headroom; the process may use more.
+# Keep a CPU limit so Prometheus cannot starve other pods when busy.
 resources:
   requests:
-    memory: "512Mi"
-    cpu: "200m"
-  limits:
-    memory: "1Gi"
+    memory: "2Gi"
     cpu: "500m"
+  limits:
+    cpu: "1000m"
 
 exposure:
   port: 443

--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -3,13 +3,15 @@ prometheusImage: prom/prometheus:v2.34.0
 password: stackrox
 anonymousAdminAccess: true
 
+# Modest defaults for shared/dev clusters. Raise for long-retention Prometheus
+# workloads; see README for a smaller profile.
 resources:
   requests:
+    memory: "512Mi"
+    cpu: "200m"
+  limits:
     memory: "1Gi"
     cpu: "500m"
-  limits:
-    memory: "2Gi"
-    cpu: "1000m"
 
 exposure:
   port: 443
@@ -27,10 +29,38 @@ cadvisorMetricRelabelConfigs: []
 
 kube-state-metrics:
   releaseNamespace: true
+  # Align with the parent monitoring Deployment UIDs. Upstream defaults use
+  # 65534 (nobody), which OpenShift restricted-v2 rejects when the SA lacks
+  # a broader SCC; with nonroot-v2 these UIDs remain valid non-root values.
+  securityContext:
+    enabled: true
+    runAsUser: 1000
+    runAsGroup: 2000
+    fsGroup: 2000
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 2000
 
 alertmanager:
   persistence:
     enabled: false
+  # Pod-level runAsUser covers the configmap-reload sidecar, which has no
+  # container securityContext in the upstream chart.
+  podSecurityContext:
+    fsGroup: 2000
+    runAsUser: 1000
+    runAsNonRoot: true
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 2000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
   config:
     receivers:
       - name: pagerduty-notifications


### PR DESCRIPTION
## Description

Fixes OpenShift installs of the internal `deploy/charts/monitoring` chart ([ROX-35889](https://issues.redhat.com/browse/ROX-35889)). Discovered during testing of https://github.com/stackrox/roxie/pull/252.

### Problems

- When installing, Helm reported a successful install, but the Alertmanager and kube-state-metrics pods never became Ready.
- Those subchart pods (prometheus, grafana, alertmanager) run as UID and fsGroup `65534` by default. OpenShift `restricted-v2` rejects that identity because it is outside the namespace UID range.
- Only the parent `monitoring` ServiceAccount was allowed to use SCC `nonroot-v2`. The Alertmanager and kube-state-metrics ServiceAccounts were not, so admission never selected a compatible SCC.
- The Prometheus container was OOMKilled under fixed memory limits. With no memory limit it settled around 5Gi RSS on the test cluster.
- A raw `helm` install failed when `${MONITORING_ENABLE_PSP}` was left unsubstituted, because Helm treated that string as true and rendered a PodSecurityPolicy that modern clusters no longer have.
- OpenShift's image-registry controller writes `imagePullSecrets` on ServiceAccounts. Helm server-side apply also manages that field, which caused upgrade conflicts.
- kube-state-metrics repeatedly logged failures for `autoscaling/v2beta2` HorizontalPodAutoscaler, an API that current clusters no longer serve.
- The chart still used Helm v2-style `requirements.lock` while declaring Chart.yaml `apiVersion: v2`, which triggers Helm warnings.

### Approach
- Bind `<release>-alertmanager` and `<release>-kube-state-metrics` to the existing namespace-scoped `nonroot-v2` Role
- Override subchart securityContexts to UID/GID `1000`/`2000` (aligned with the parent Deployment); Alertmanager pod-level `runAsUser` covers the configmap-reload sidecar
- Prometheus: `2Gi` memory request, no memory limit, keep `1000m` CPU limit
- Default `enableMonitoringPSPs: false`
- Put Docker Hub `imagePullSecrets: stackrox` on Pods (not the monitoring SA) to keep Hub auth without SA field-manager conflicts
- Drop the kube-state-metrics `horizontalpodautoscalers` collector
- Migrate `requirements.lock` → `Chart.lock`
- Expand the chart README (envsubst / `--set`, OpenShift `--force-conflicts`)


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

Internal-only deploy chart; no product docs/CHANGELOG.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

Internal engineer tooling chart (not product GA surface).

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

No chart unit/e2e harness for this internal chart; validated manually on OpenShift.

### How I validated my change

- `helm template` with and without OpenShift API capabilities (SCC RoleBinding gated; no PSP when default false)
- Fresh install / upgrade of release `test-monitoring` on OpenShift cluster
- Confirmed Ready: `monitoring`, `test-monitoring-alertmanager-0`, `test-monitoring-kube-state-metrics`
- Prometheus no longer OOMKilled; RSS ~5Gi with no memory limit
- Grafana/Prometheus logs healthy aside from minor/non-blocking noise
- Used `--force-conflicts` once for residual kube-state-metrics SA `imagePullSecrets` SSA conflict (upstream chart always emits that field)

Partially generated by AI.

#### Manual testing steps and results

1. `helm uninstall test-monitoring` (old release)
2. `helm upgrade --install` from stackrox3 chart (`--force-conflicts`, PSP off, dummy PagerDuty key)
3. Checked pods Ready + SCC / securityContext / resources

##### Checks

| Check | How | Result |
| --- | --- | --- |
| Install succeeds | `helm -n stackrox list` → `deployed` | pass |
| monitoring Ready | `kubectl get deploy monitoring` → `1/1` | pass |
| alertmanager Ready | `kubectl get sts …-alertmanager` → `1/1` | pass |
| kube-state-metrics Ready | `kubectl get deploy …-kube-state-metrics` → `1/1` | pass |
| Subchart SCC = `nonroot-v2` | pod annotation `openshift.io/scc` | pass (AM + KSM) |
| SAs bound to `nonroot-v2` | `RoleBinding/monitoring-use-scc` subjects | pass (3 SAs) |
| UID/fsGroup `1000`/`2000` | pod/container `securityContext` | pass |
| No mem limit / `2Gi` request | deploy prometheus resources; `top` ~5Gi | pass |
| No PSP rendered | no `PodSecurityPolicy` object | pass |
| Pull secret on Pod, not SA | deploy `imagePullSecrets`; SA has dockercfg only | pass |
| No HPA collector | KSM `--resources=` omits `horizontalpodautoscalers` | pass |

**Note:** Alertmanager has no Grafana UI / Route (`exposure: none`). ClusterIP `:9093` only; use port-forward to open the AM UI.


[ROX-35889]: https://redhat.atlassian.net/browse/ROX-35889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ