### PR TITLE
ROX-35710: Fix Risk Secrets page assertion

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/secrets.test.ts
+++ b/ui/apps/platform/cypress/integration/risk/secrets.test.ts
@@ -2,7 +2,7 @@ import withAuth from '../../helpers/basicAuth';
 import { hasFeatureFlag } from '../../helpers/features';
 import { interceptAndWatchRequests } from '../../helpers/request';
 import { sortByTableHeader } from '../../helpers/tableHelpers';
-import { assertCannotFindThePage, visit } from '../../helpers/visit';
+import { visit } from '../../helpers/visit';
 import navSelectors from '../../selectors/navigation';
 
 const listSecretsAlias = 'listSecrets';
@@ -96,7 +96,8 @@ describe('Risk - Secrets page', () => {
         it('should not render the Secrets page', () => {
             visit('/main/risk/secrets');
 
-            assertCannotFindThePage();
+            // Without the feature flag, 'secrets' is interpreted as a deployment ID and the page will show an error
+            cy.get('h2').contains(`deployment with id 'secrets' does not exist`);
         });
 
         it('should show Risk as a plain nav link, not an expandable section', () => {


### PR DESCRIPTION
## Description

Fixes broken assertion that fails during nightly CI runs.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Verify against staging, where the feature flag is off:
<img width="583" height="417" alt="image" src="https://github.com/user-attachments/assets/b716df6c-efaf-4fc1-abce-38028190329f" />

