### PR TITLE
ROX-33524: allow DEFAULT origin in CanModifyResource

### DIFF
--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	permissionsUtils "github.com/stackrox/rox/pkg/auth/permissions/utils"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/k8sutil"
@@ -47,9 +48,9 @@ var log = logging.LoggerForModule()
 // extension-apiserver-authentication ConfigMap (same CA that signs Prometheus client
 // certs). A ConfigMap watcher keeps the CA current across rotations.
 //
-// All seeded objects use IMPERATIVE origin. Ideally they would be DEFAULT
-// (non-user-modifiable), but the auth provider datastore rejects non-IMPERATIVE
-// origins through the normal creation path (see CanModifyResource).
+// The auth provider uses DEFAULT origin (not user-modifiable). Other seeded
+// objects (role, permission set, access scope, group) use IMPERATIVE origin
+// so operators can adjust them.
 func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registry, roleDS roleDataStore.DataStore, groupDS groupDataStore.DataStore) {
 	if !tlsconfig.OpenShiftTLSConfigured() {
 		return
@@ -65,7 +66,9 @@ func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registr
 		ensureAccessScope(ctx, roleDS)
 		ensurePermissionSet(ctx, roleDS)
 		ensureRole(ctx, roleDS)
-		ensureAuthProvider(ctx, registry, caPEM)
+		// Auth provider uses DEFAULT origin — needs a context that allows it.
+		defaultCtx := declarativeconfig.WithModifyDefaultResource(ctx)
+		ensureAuthProvider(defaultCtx, registry, caPEM)
 		ensureGroup(ctx, groupDS)
 	}
 
@@ -218,6 +221,7 @@ func ensureAuthProvider(ctx context.Context, registry authproviders.Registry, ca
 		authproviders.WithEnabled(true),
 		authproviders.WithActive(true),
 		authproviders.WithVisibility(storage.Traits_HIDDEN),
+		authproviders.WithOrigin(storage.Traits_DEFAULT),
 		authproviders.WithConfig(map[string]string{
 			userpki.ConfigKeys: caPEM,
 		}),

--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -48,8 +48,8 @@ var log = logging.LoggerForModule()
 // extension-apiserver-authentication ConfigMap (same CA that signs Prometheus client
 // certs). A ConfigMap watcher keeps the CA current across rotations.
 //
-// The auth provider uses DEFAULT origin (not user-modifiable). Other seeded
-// objects (role, permission set, access scope, group) use IMPERATIVE origin
+// The auth provider and access scope use DEFAULT origin (not user-modifiable).
+// Other seeded objects (role, permission set, group) use IMPERATIVE origin
 // so operators can adjust them.
 func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registry, roleDS roleDataStore.DataStore, groupDS groupDataStore.DataStore) {
 	if !tlsconfig.OpenShiftTLSConfigured() {
@@ -63,11 +63,12 @@ func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registr
 	}
 
 	onCA := func(caPEM string) {
-		ensureAccessScope(ctx, roleDS)
+		// Access scope uses DEFAULT origin — tied to the operator-managed label.
+		defaultCtx := declarativeconfig.WithModifyDefaultResource(ctx)
+		ensureAccessScope(defaultCtx, roleDS)
 		ensurePermissionSet(ctx, roleDS)
 		ensureRole(ctx, roleDS)
-		// Auth provider uses DEFAULT origin — needs a context that allows it.
-		defaultCtx := declarativeconfig.WithModifyDefaultResource(ctx)
+		// Auth provider also uses DEFAULT origin.
 		ensureAuthProvider(defaultCtx, registry, caPEM)
 		ensureGroup(ctx, groupDS)
 	}
@@ -150,6 +151,9 @@ func ensureAccessScope(ctx context.Context, roleDS roleDataStore.DataStore) {
 		Id:          accessScopeID,
 		Name:        accessScopeName,
 		Description: "Scoped to clusters labeled stackrox.io/central-colocated (set automatically by the operator)",
+		Traits: &storage.Traits{
+			Origin: storage.Traits_DEFAULT,
+		},
 		Rules: &storage.SimpleAccessScope_Rules{
 			ClusterLabelSelectors: []*storage.SetBasedLabelSelector{
 				{

--- a/central/auth/openshift/metrics_auth.go
+++ b/central/auth/openshift/metrics_auth.go
@@ -3,8 +3,10 @@ package openshift
 import (
 	"context"
 
+	"github.com/stackrox/rox/central/globaldb"
 	groupDataStore "github.com/stackrox/rox/central/group/datastore"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
+	postgresSimpleAccessScopeStore "github.com/stackrox/rox/central/role/store/simpleaccessscope/postgres"
 	"github.com/stackrox/rox/central/tlsconfig"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
@@ -44,17 +46,29 @@ var log = logging.LoggerForModule()
 // SeedMetricsAuthProvider ensures that the userpki auth provider, permission set, role,
 // and group mapping required for OpenShift Prometheus to scrape /metrics exist.
 //
-// The auth provider uses the Kubernetes client CA from the
-// extension-apiserver-authentication ConfigMap (same CA that signs Prometheus client
-// certs). A ConfigMap watcher keeps the CA current across rotations.
+// The access scope, permission set, and role have static content with no dependency on
+// the client CA, so they are seeded unconditionally at startup. The auth provider's
+// config and the group's auth-provider reference, however, need the Kubernetes client CA
+// from the extension-apiserver-authentication ConfigMap (same CA that signs Prometheus
+// client certs), which may not be available yet; a ConfigMap watcher keeps the CA current
+// across rotations.
 //
-// The auth provider and access scope use DEFAULT origin (not user-modifiable).
-// Other seeded objects (role, permission set, group) use IMPERATIVE origin
-// so operators can adjust them.
+// The access scope uses DEFAULT origin (not user-modifiable) and is seeded the same way
+// as the other built-in DEFAULT access scopes (Unrestricted, Deny All): an idempotent
+// upsert straight to the underlying store, self-healing across restarts and upgrades.
+// The auth provider and group also use DEFAULT origin: the group can't be repointed to a
+// different role or deleted, which in turn keeps the role permanently referenced so it
+// can't be deleted either. Role and permission set use IMPERATIVE origin so operators can
+// still adjust their permissions or which access scope the role grants; they are only
+// created if missing, never overwritten.
 func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registry, roleDS roleDataStore.DataStore, groupDS groupDataStore.DataStore) {
 	if !tlsconfig.OpenShiftTLSConfigured() {
 		return
 	}
+
+	seedAccessScope(ctx)
+	ensurePermissionSet(ctx, roleDS)
+	ensureRole(ctx, roleDS)
 
 	clientset, err := newK8sClient()
 	if err != nil {
@@ -63,12 +77,8 @@ func SeedMetricsAuthProvider(ctx context.Context, registry authproviders.Registr
 	}
 
 	onCA := func(caPEM string) {
-		// Access scope uses DEFAULT origin — tied to the operator-managed label.
+		// Auth provider uses DEFAULT origin.
 		defaultCtx := declarativeconfig.WithModifyDefaultResource(ctx)
-		ensureAccessScope(defaultCtx, roleDS)
-		ensurePermissionSet(ctx, roleDS)
-		ensureRole(ctx, roleDS)
-		// Auth provider also uses DEFAULT origin.
 		ensureAuthProvider(defaultCtx, registry, caPEM)
 		ensureGroup(ctx, groupDS)
 	}
@@ -139,14 +149,13 @@ func refreshCA(ctx context.Context, registry authproviders.Registry, provider au
 	}
 }
 
-func ensureAccessScope(ctx context.Context, roleDS roleDataStore.DataStore) {
-	if _, exists, err := roleDS.GetAccessScope(ctx, accessScopeID); err != nil {
-		log.Warnf("Failed to check OpenShift metrics access scope: %v", err)
-		return
-	} else if exists {
-		return
-	}
-
+// seedAccessScope upserts the OpenShift metrics access scope directly into the
+// underlying store, the same way the built-in DEFAULT access scopes (Unrestricted, Deny
+// All) are seeded in central/role/datastore/singleton.go. This keeps the scope's content
+// always in sync with the code (self-healing across restarts and upgrades) without going
+// through the datastore's DEFAULT-origin write protection, which is meant to guard
+// against API callers, not this kind of internal, static, boot-time seeding.
+func seedAccessScope(ctx context.Context) {
 	scope := &storage.SimpleAccessScope{
 		Id:          accessScopeID,
 		Name:        accessScopeName,
@@ -167,8 +176,9 @@ func ensureAccessScope(ctx context.Context, roleDS roleDataStore.DataStore) {
 			},
 		},
 	}
-	if err := roleDS.AddAccessScope(ctx, scope); err != nil {
-		log.Warnf("Failed to create OpenShift metrics access scope: %v", err)
+	store := postgresSimpleAccessScopeStore.New(globaldb.GetPostgres())
+	if err := store.Upsert(ctx, scope); err != nil {
+		log.Warnf("Failed to seed OpenShift metrics access scope: %v", err)
 	}
 }
 
@@ -253,10 +263,15 @@ func ensureGroup(ctx context.Context, groupDS groupDataStore.DataStore) {
 			AuthProviderId: authProviderID,
 			Key:            "name",
 			Value:          cn,
+			Traits: &storage.Traits{
+				Origin: storage.Traits_DEFAULT,
+			},
 		},
 		RoleName: roleName,
 	}
-	if err := groupDS.Add(ctx, group); err != nil {
+	// Group uses DEFAULT origin so a user can't repoint or delete the mapping and thereby
+	// orphan (and delete) the role out from under it.
+	if err := groupDS.Add(declarativeconfig.WithModifyDefaultResource(ctx), group); err != nil {
 		log.Warnf("Failed to create OpenShift metrics group: %v", err)
 	}
 }

--- a/central/auth/openshift/metrics_auth_pg_test.go
+++ b/central/auth/openshift/metrics_auth_pg_test.go
@@ -1,0 +1,49 @@
+//go:build sql_integration
+
+package openshift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/central/globaldb"
+	postgresSimpleAccessScopeStore "github.com/stackrox/rox/central/role/store/simpleaccessscope/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedAccessScope(t *testing.T) {
+	pgTest := pgtest.ForT(t)
+	require.NotNil(t, pgTest)
+	defer pgTest.Close()
+	globaldb.SetPostgresTest(t, pgTest.DB)
+
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Access)))
+
+	seedAccessScope(ctx)
+
+	store := postgresSimpleAccessScopeStore.New(pgTest.DB)
+	stored, found, err := store.Get(ctx, accessScopeID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, accessScopeName, stored.GetName())
+	assert.Equal(t, storage.Traits_DEFAULT, stored.GetTraits().GetOrigin())
+	require.Len(t, stored.GetRules().GetClusterLabelSelectors(), 1)
+	req := stored.GetRules().GetClusterLabelSelectors()[0].GetRequirements()[0]
+	assert.Equal(t, centralServicesLabelKey, req.GetKey())
+	assert.Equal(t, storage.SetBasedLabelSelector_EXISTS, req.GetOp())
+
+	// Re-seeding is idempotent, matching the boot-time self-healing behavior.
+	seedAccessScope(ctx)
+	stored, found, err = store.Get(ctx, accessScopeID)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, accessScopeName, stored.GetName())
+}

--- a/central/auth/openshift/metrics_auth_pg_test.go
+++ b/central/auth/openshift/metrics_auth_pg_test.go
@@ -37,7 +37,7 @@ func TestSeedAccessScope(t *testing.T) {
 	assert.Equal(t, storage.Traits_DEFAULT, stored.GetTraits().GetOrigin())
 	require.Len(t, stored.GetRules().GetClusterLabelSelectors(), 1)
 	req := stored.GetRules().GetClusterLabelSelectors()[0].GetRequirements()[0]
-	assert.Equal(t, centralServicesLabelKey, req.GetKey())
+	assert.Equal(t, centralColocatedLabelKey, req.GetKey())
 	assert.Equal(t, storage.SetBasedLabelSelector_EXISTS, req.GetOp())
 
 	// Re-seeding is idempotent, matching the boot-time self-healing behavior.

--- a/central/auth/openshift/metrics_auth_test.go
+++ b/central/auth/openshift/metrics_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	providerMocks "github.com/stackrox/rox/pkg/auth/authproviders/mocks"
 	"github.com/stackrox/rox/pkg/auth/authproviders/userpki"
+	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"go.uber.org/mock/gomock"
 )
 
@@ -25,8 +26,6 @@ func TestSeed_FirstBoot_CreatesAllObjects(t *testing.T) {
 	registry, roleDS, groupDS := setupMocks(t)
 	ctx := context.Background()
 
-	roleDS.EXPECT().GetAccessScope(gomock.Any(), accessScopeID).Return(nil, false, nil)
-	roleDS.EXPECT().AddAccessScope(gomock.Any(), gomock.Any()).Return(nil)
 	roleDS.EXPECT().GetPermissionSet(gomock.Any(), permissionSetID).Return(nil, false, nil)
 	roleDS.EXPECT().AddPermissionSet(gomock.Any(), gomock.Any()).Return(nil)
 	roleDS.EXPECT().GetRole(gomock.Any(), roleName).Return(nil, false, nil)
@@ -48,7 +47,6 @@ func TestSeed_FirstBoot_CreatesAllObjects(t *testing.T) {
 			return nil
 		})
 
-	ensureAccessScope(ctx, roleDS)
 	ensurePermissionSet(ctx, roleDS)
 	ensureRole(ctx, roleDS)
 	ensureAuthProvider(ctx, registry, testCAPEM)
@@ -86,7 +84,6 @@ func TestSeed_PartialRecovery_PermissionSetExists_RoleMissing(t *testing.T) {
 	registry, roleDS, groupDS := setupMocks(t)
 	ctx := context.Background()
 
-	roleDS.EXPECT().GetAccessScope(gomock.Any(), accessScopeID).Return(&storage.SimpleAccessScope{}, true, nil)
 	roleDS.EXPECT().GetPermissionSet(gomock.Any(), permissionSetID).Return(&storage.PermissionSet{}, true, nil)
 	roleDS.EXPECT().GetRole(gomock.Any(), roleName).Return(nil, false, nil)
 	roleDS.EXPECT().AddRole(gomock.Any(), gomock.Any()).Return(nil)
@@ -95,10 +92,28 @@ func TestSeed_PartialRecovery_PermissionSetExists_RoleMissing(t *testing.T) {
 	groupDS.EXPECT().GetFiltered(gomock.Any(), gomock.Any()).Return(nil, nil)
 	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).Return(nil)
 
-	ensureAccessScope(ctx, roleDS)
 	ensurePermissionSet(ctx, roleDS)
 	ensureRole(ctx, roleDS)
 	ensureAuthProvider(ctx, registry, testCAPEM)
+	ensureGroup(ctx, groupDS)
+}
+
+func TestSeed_Group_IsDefaultOriginAndImmutable(t *testing.T) {
+	_, _, groupDS := setupMocks(t)
+	ctx := context.Background()
+
+	groupDS.EXPECT().GetFiltered(gomock.Any(), gomock.Any()).Return(nil, nil)
+	groupDS.EXPECT().Add(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(addCtx context.Context, group *storage.Group) error {
+			if group.GetProps().GetTraits().GetOrigin() != storage.Traits_DEFAULT {
+				t.Errorf("expected group to use DEFAULT origin, got %v", group.GetProps().GetTraits().GetOrigin())
+			}
+			if !declarativeconfig.CanModifyResource(addCtx, group.GetProps()) {
+				t.Error("expected ensureGroup to pass a context that can modify DEFAULT-origin resources")
+			}
+			return nil
+		})
+
 	ensureGroup(ctx, groupDS)
 }
 
@@ -112,27 +127,4 @@ func TestSeed_SubsequentBoot_GroupExists_NotOverwritten(t *testing.T) {
 	}}, nil)
 
 	ensureGroup(ctx, groupDS)
-}
-
-func TestSeed_AccessScope_HasLabelSelector(t *testing.T) {
-	_, roleDS, _ := setupMocks(t)
-	ctx := context.Background()
-
-	roleDS.EXPECT().GetAccessScope(gomock.Any(), accessScopeID).Return(nil, false, nil)
-	roleDS.EXPECT().AddAccessScope(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, scope *storage.SimpleAccessScope) error {
-			if len(scope.GetRules().GetClusterLabelSelectors()) == 0 {
-				t.Error("access scope has no cluster label selectors")
-			}
-			req := scope.GetRules().GetClusterLabelSelectors()[0].GetRequirements()[0]
-			if req.GetKey() != centralColocatedLabelKey {
-				t.Errorf("expected label key %q, got %q", centralColocatedLabelKey, req.GetKey())
-			}
-			if req.GetOp() != storage.SetBasedLabelSelector_EXISTS {
-				t.Errorf("expected operator EXISTS, got %v", req.GetOp())
-			}
-			return nil
-		})
-
-	ensureAccessScope(ctx, roleDS)
 }

--- a/pkg/auth/authproviders/provider_options.go
+++ b/pkg/auth/authproviders/provider_options.go
@@ -166,3 +166,18 @@ func WithVisibility(visibility storage.Traits_Visibility) ProviderOption {
 		return nil
 	}
 }
+
+// WithOrigin sets the origin for the auth provider.
+func WithOrigin(origin storage.Traits_Origin) ProviderOption {
+	return func(pr *providerImpl) error {
+		if pr.storedInfo == nil {
+			return errox.InvariantViolation.CausedBy("no storage data for auth provider")
+		}
+		if pr.storedInfo.GetTraits() != nil {
+			pr.storedInfo.Traits.Origin = origin
+		} else {
+			pr.storedInfo.Traits = &storage.Traits{Origin: origin}
+		}
+		return nil
+	}
+}

--- a/pkg/declarativeconfig/context.go
+++ b/pkg/declarativeconfig/context.go
@@ -10,6 +10,7 @@ type originCheckerKey struct{}
 
 const allowOnlyDeclarativeOperations = 0
 const allowModifyDeclarativeOrImperative = 1
+const allowDefaultOperations = 2
 
 // WithModifyDeclarativeResource returns a context that is a child of the given context and allows to modify
 // proto messages with the traits origin == DECLARATIVE.
@@ -21,6 +22,13 @@ func WithModifyDeclarativeResource(ctx context.Context) context.Context {
 // proto messages with the traits origin == DECLARATIVE or DECLARATIVE_ORPHANED or IMPERATIVE
 func WithModifyDeclarativeOrImperative(ctx context.Context) context.Context {
 	return context.WithValue(ctx, originCheckerKey{}, allowModifyDeclarativeOrImperative)
+}
+
+// WithModifyDefaultResource returns a context that allows creating and modifying
+// proto messages with the traits origin == DEFAULT. This is intended for internal
+// seeding of system-managed objects that should not be user-modifiable.
+func WithModifyDefaultResource(ctx context.Context) context.Context {
+	return context.WithValue(ctx, originCheckerKey{}, allowDefaultOperations)
 }
 
 // ResourceWithTraits is a common interface for proto messages containing storage.Traits.
@@ -37,11 +45,14 @@ func HasModifyDeclarativeResourceKey(ctx context.Context) bool {
 
 // CanModifyResource returns whether context holder is allowed to modify resource.
 func CanModifyResource(ctx context.Context, resource ResourceWithTraits) bool {
-	if ctx.Value(originCheckerKey{}) == allowOnlyDeclarativeOperations {
+	switch ctx.Value(originCheckerKey{}) {
+	case allowOnlyDeclarativeOperations:
 		return IsDeclarativeOrigin(resource)
-	}
-	if ctx.Value(originCheckerKey{}) == allowModifyDeclarativeOrImperative {
+	case allowModifyDeclarativeOrImperative:
 		return IsDeclarativeOrigin(resource) || IsImperativeOrigin(resource) || IsEphemeralOrigin(resource)
+	case allowDefaultOperations:
+		return IsDefaultOrigin(resource)
+	default:
+		return IsImperativeOrigin(resource) || IsEphemeralOrigin(resource)
 	}
-	return IsImperativeOrigin(resource) || IsEphemeralOrigin(resource)
 }

--- a/pkg/declarativeconfig/context_test.go
+++ b/pkg/declarativeconfig/context_test.go
@@ -24,6 +24,7 @@ func TestContext(t *testing.T) {
 	ctx := context.Background()
 	declarativeCtx := WithModifyDeclarativeResource(ctx)
 	declarativeOrImperativeCtx := WithModifyDeclarativeOrImperative(ctx)
+	defaultCtx := WithModifyDefaultResource(ctx)
 	// 1.1. empty context can modify imperative origin
 	assert.True(t, CanModifyResource(ctx, imperativeResource))
 	// 1.2. empty context can modify ephemeral origin
@@ -48,4 +49,10 @@ func TestContext(t *testing.T) {
 	assert.True(t, CanModifyResource(declarativeOrImperativeCtx, ephemeralResource))
 	// 9. context.WithModifyDeclarativeOrImperative can't modify default origin
 	assert.False(t, CanModifyResource(declarativeOrImperativeCtx, defaultResource))
+	// 10. context.WithModifyDefaultResource can modify default origin
+	assert.True(t, CanModifyResource(defaultCtx, defaultResource))
+	// 11.1. context.WithModifyDefaultResource can't modify imperative origin
+	assert.False(t, CanModifyResource(defaultCtx, imperativeResource))
+	// 11.2. context.WithModifyDefaultResource can't modify declarative origin
+	assert.False(t, CanModifyResource(defaultCtx, declarativeResource))
 }

--- a/pkg/declarativeconfig/origin.go
+++ b/pkg/declarativeconfig/origin.go
@@ -28,3 +28,8 @@ func IsEphemeralOrigin(resource ResourceWithTraits) bool {
 func IsImperativeOrigin(resource ResourceWithTraits) bool {
 	return resource.GetTraits().GetOrigin() == storage.Traits_IMPERATIVE
 }
+
+// IsDefaultOrigin returns whether origin of resource is default or not.
+func IsDefaultOrigin(resource ResourceWithTraits) bool {
+	return resource.GetTraits().GetOrigin() == storage.Traits_DEFAULT
+}


### PR DESCRIPTION
## Description

`CanModifyResource` in `pkg/declarativeconfig` only recognized IMPERATIVE, DECLARATIVE, and EPHEMERAL origins. DEFAULT-origin objects could only be created by bypassing the datastore layer entirely (direct Postgres store writes in `central/role/datastore/singleton.go`).

This adds a `WithModifyDefaultResource` context variant so internal seeding code can create and update DEFAULT-origin objects through the normal datastore path. Without this, the OpenShift metrics auth provider had to use IMPERATIVE origin, making it user-deletable.

**Alternative considered:** using DECLARATIVE or EPHEMERAL origin to get through the gate. Both have wrong semantics (DECLARATIVE = config-managed; EPHEMERAL = hidden from UI listings).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Existing `pkg/declarativeconfig` unit tests pass — the new context variant doesn't affect existing IMPERATIVE/DECLARATIVE/EPHEMERAL behavior.
- Tested on a live OpenShift cluster: auth provider is created with DEFAULT origin and the CA watcher successfully updates it on rotation.
<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21785**
    * **PR #21789**
      * **PR #21887** 👈
<!-- GHIT dependencies end -->