### PR TITLE
For testing: Add sleep for manual restart-reschedule test

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -120,6 +120,14 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(ctx context.Context, req *Re
 		return
 	}
 
+	// TODO(charmik): Remove after manual testing. Sleep to simulate long-running report
+	// so central can be killed while report is in PREPARING state.
+	if req.ReportSnapshot.GetViewBasedVulnReportFilters() != nil {
+		log.Info("MANUAL TEST: Sleeping 2 minutes to simulate long-running VM report generation...")
+		time.Sleep(2 * time.Minute)
+		log.Info("MANUAL TEST: Sleep complete, continuing report generation.")
+	}
+
 	err = rg.generateReportAndNotify(ctx, req)
 	if err != nil {
 		rg.logAndUpsertError(ctx, err, req)

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -368,6 +368,18 @@ func (s *scheduler) queuePendingReports() {
 	}
 
 	for _, snap := range pendingReports {
+		// View-based reports have no associated report configuration, resource scope, or collection.
+		if snap.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
+			repRequest := &reportGen.ReportRequest{
+				ReportSnapshot: snap,
+			}
+			_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
+			if err != nil {
+				log.Errorf("Error rescheduling pending view-based report job '%s': %s", snap.GetReportId(), err)
+			}
+			continue
+		}
+
 		_, found, err := s.reportConfigDatastore.GetReportConfiguration(scheduledCtx, snap.GetReportConfigurationId())
 		if err != nil {
 			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -9,6 +9,7 @@ import (
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	reportGenMocks "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator/mocks"
 	snapshotMocks "github.com/stackrox/rox/central/reports/snapshot/datastore/mocks"
+	collectionMocks "github.com/stackrox/rox/central/resourcecollection/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -272,6 +273,74 @@ func TestCancelReportRequestReturnsFalseForUnknownReport(t *testing.T) {
 	cancelled, err := s.CancelReportRequest(context.Background(), "nonexistent-id")
 	assert.NoError(t, err)
 	assert.False(t, cancelled)
+}
+
+func TestQueuePendingReports(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockSnapshotStore := snapshotMocks.NewMockDataStore(ctrl)
+	mockReportConfigDS := mocks.NewMockDataStore(ctrl)
+	mockCollectionDS := collectionMocks.NewMockDataStore(ctrl)
+
+	viewBasedSnap := &storage.ReportSnapshot{
+		ReportId: "view-based-report-1",
+		Name:     "View Based Report",
+		Type:     storage.ReportSnapshot_VULNERABILITY,
+		ReportStatus: &storage.ReportStatus{
+			RunState:          storage.ReportStatus_PREPARING,
+			ReportRequestType: storage.ReportStatus_VIEW_BASED,
+		},
+		Filter: &storage.ReportSnapshot_ViewBasedVulnReportFilters{
+			ViewBasedVulnReportFilters: &storage.ViewBasedVulnerabilityReportFilters{
+				Query: "CVE Type:IMAGE_CVE",
+			},
+		},
+		Requester: &storage.SlimUser{Id: "user-1", Name: "user-1"},
+	}
+
+	configBasedSnap := &storage.ReportSnapshot{
+		ReportId:              "config-based-report-1",
+		ReportConfigurationId: "config-1",
+		Name:                  "Config Based Report",
+		Type:                  storage.ReportSnapshot_VULNERABILITY,
+		ReportStatus: &storage.ReportStatus{
+			RunState:          storage.ReportStatus_WAITING,
+			ReportRequestType: storage.ReportStatus_ON_DEMAND,
+		},
+		Filter: &storage.ReportSnapshot_VulnReportFilters{
+			VulnReportFilters: &storage.VulnerabilityReportFilters{},
+		},
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_CollectionId{CollectionId: "collection-1"},
+		},
+		Collection: &storage.CollectionSnapshot{Id: "collection-1", Name: "collection-1"},
+		Requester:  &storage.SlimUser{Id: "user-2", Name: "user-2"},
+	}
+
+	mockSnapshotStore.EXPECT().
+		SearchReportSnapshots(gomock.Any(), gomock.Any()).
+		Return([]*storage.ReportSnapshot{viewBasedSnap, configBasedSnap}, nil)
+
+	// View-based report should NOT trigger a config lookup.
+	// Config-based report should trigger a config lookup.
+	mockReportConfigDS.EXPECT().
+		GetReportConfiguration(gomock.Any(), "config-1").
+		Return(&storage.ReportConfiguration{Id: "config-1"}, true, nil)
+
+	mockCollectionDS.EXPECT().
+		Get(gomock.Any(), "collection-1").
+		Return(&storage.ResourceCollection{Id: "collection-1"}, true, nil)
+
+	// Both should be updated via resubmission.
+	mockSnapshotStore.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, cronScheduler, nil)
+	s.queuePendingReports()
+
+	assert.Equal(t, 2, s.reportRequestsQueue.Len())
 }
 
 func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {


### PR DESCRIPTION
## Description

Adds a 2-minute sleep in the VM report generator for view-based reports, right after the
status transitions to PREPARING. This gives time to kill the central pod while a report
is in-flight to manually verify that the reschedule fix from #21713 works correctly.

**Not for merge** — test-only throwaway branch stacked on #21713.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual test: trigger a VM report, observe PREPARING status and sleep log line, kill central pod,
verify report reschedules and completes after restart.