### PR TITLE
ci: avoid fetching all 1500+ remote branches on checkout

### DIFF
--- a/.github/workflows/audit-backport-prs.yml
+++ b/.github/workflows/audit-backport-prs.yml
@@ -48,11 +48,7 @@ jobs:
       issues: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
-        with:
-          fetch-depth: 1  # Need full history for git tag operations
 
-      - name: Fetch full history and tags for git describe
-        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # ratchet:actions/setup-python@v5
         with:

--- a/.github/workflows/audit-backport-prs.yml
+++ b/.github/workflows/audit-backport-prs.yml
@@ -49,8 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0  # Need full history for git tag operations
+          fetch-depth: 1  # Need full history for git tag operations
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # ratchet:actions/setup-python@v5
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,9 +37,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/handle-tagged-build
 
       - name: Compute build tag
@@ -169,9 +171,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -368,9 +372,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -399,9 +405,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -552,9 +560,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -32,9 +32,11 @@ jobs:
     - name: Checkout stackrox/stackrox
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -60,10 +62,12 @@ jobs:
     - name: Checkout previous released version
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ steps.get_previous_released_version.outputs.released_version }}
         path: .old-stackrox
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Run crd-schema-checker for platform operator
       run: |
         set -e

--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -66,8 +66,6 @@ jobs:
         ref: ${{ steps.get_previous_released_version.outputs.released_version }}
         path: .old-stackrox
 
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Run crd-schema-checker for platform operator
       run: |
         set -e

--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -52,10 +52,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -44,10 +44,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -125,9 +125,11 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/handle-tagged-build
     - name: Compute build tag
       id: build-tag

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -48,10 +48,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -196,10 +198,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -343,10 +347,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -52,10 +52,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         persist-credentials: false
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -45,14 +45,18 @@ jobs:
           repository: stackrox/acs-fleet-manager
           path: acs-fleet-manager
           ref: main
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Checkout stackrox/stackrox repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           repository: stackrox/stackrox
           ref: ${{ github.event.pull_request.head.sha }}
           path: stackrox
-          fetch-depth: 0
+          fetch-depth: 1
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v6
         with:

--- a/.github/workflows/emailsender-central-compatibility.yaml
+++ b/.github/workflows/emailsender-central-compatibility.yaml
@@ -46,8 +46,6 @@ jobs:
           path: acs-fleet-manager
           ref: main
           fetch-depth: 1
-      - name: Fetch full history and tags for git describe
-        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Checkout stackrox/stackrox repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
@@ -55,8 +53,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: stackrox
           fetch-depth: 1
-      - name: Fetch full history and tags for git describe
-        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v6
         with:

--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -61,11 +61,8 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
         ref: ${{ steps.pr-metadata.outputs.branch }}
-        fetch-depth: 1
         token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
 
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Configure Git
       run: |
         set -ex

--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -61,9 +61,11 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
         ref: ${{ steps.pr-metadata.outputs.branch }}
-        fetch-depth: 0
+        fetch-depth: 1
         token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Configure Git
       run: |
         set -ex

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Get PR image tag
         run: |
           MAIN_IMAGE_TAG="$(make --quiet --no-print-directory tag)"
@@ -48,9 +50,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Checkout workflow scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -28,8 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - id: is_release_check
         run: |
           source scripts/ci/lib.sh
@@ -45,8 +47,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Check scanner version
         run: |
           scripts/ci/lib.sh \
@@ -58,8 +62,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Check collector version
         run: |
           scripts/ci/lib.sh \
@@ -71,8 +77,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Check fact version
         run: |
           scripts/ci/lib.sh \
@@ -86,8 +94,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: cli-build
@@ -115,8 +125,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # ratchet:google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.GCLOUD_SERVICE_ACCOUNT_CI_ROX }}'
@@ -141,8 +153,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093' # ratchet:google-github-actions/auth@v3
         with:
           credentials_json: '${{ secrets.GCLOUD_SERVICE_ACCOUNT_CI_ROX }}'

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -27,8 +27,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/scanner-e2e-test.yaml
+++ b/.github/workflows/scanner-e2e-test.yaml
@@ -19,8 +19,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: "${{ github.event.pull_request.head.sha }}"
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Get tag
         run: |
           echo "tag=$(make --quiet --no-print-directory tag)" >> "$GITHUB_ENV"
@@ -47,9 +49,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: "${{ github.event.pull_request.head.sha }}"
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/scanner-nvd-update.yaml
+++ b/.github/workflows/scanner-nvd-update.yaml
@@ -101,8 +101,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         free-disk-space: 50
@@ -111,9 +113,11 @@ jobs:
     - name: Checkout specific reference
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Authenticate with test GCS bucket
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
@@ -148,8 +152,10 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
   upload-nvd-feeds:
     needs:
     - fetch-nvd-feeds
@@ -159,9 +165,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.ref }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: nvd-feeds
@@ -188,9 +196,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.ref }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: nvd-api

--- a/.github/workflows/scanner-nvd-update.yaml
+++ b/.github/workflows/scanner-nvd-update.yaml
@@ -151,11 +151,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
-      with:
-        fetch-depth: 1
 
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
   upload-nvd-feeds:
     needs:
     - fetch-nvd-feeds

--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -23,10 +23,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 1
-
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Create matrix
       id: output-matrix
       run: |

--- a/.github/workflows/scanner-offline-bundle-update.yaml
+++ b/.github/workflows/scanner-offline-bundle-update.yaml
@@ -23,8 +23,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Create matrix
       id: output-matrix
       run: |

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -52,7 +52,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Parse VULNERABILITY_BUNDLE_VERSION
       id: set-versions
       env:
@@ -111,8 +113,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Download NVD PR
       if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-nvd')
       run: |
@@ -211,8 +215,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         free-disk-space: 50
@@ -221,9 +227,11 @@ jobs:
     - name: Checkout specific reference
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ env.ROX_GIT_REF }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Download NVD
       uses: ./.github/actions/download-artifact-with-retry
       with:
@@ -336,8 +344,10 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
   build-upload-pr-vulnerabilities:
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
     needs:
@@ -357,8 +367,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         free-disk-space: 50
@@ -367,9 +379,11 @@ jobs:
     - name: Checkout specific reference
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - name: Authenticate with test GCS bucket
       if: github.event_name == 'pull_request'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
@@ -426,8 +440,10 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
   upload-definitions:
     needs:
     - build-and-run
@@ -437,8 +453,10 @@ jobs:
     # Checkout to run ./.github/actions/download-artifact-with-retry
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
       with:
         # Vulnerability bundles are named `artifact_${{ env.SCANNER_BUNDLE_VERSION }}`.

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -343,11 +343,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
-      with:
-        fetch-depth: 1
 
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
   build-upload-pr-vulnerabilities:
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pr-update-scanner-vulns')
     needs:
@@ -439,11 +435,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       if: always()
-      with:
-        fetch-depth: 1
 
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
   upload-definitions:
     needs:
     - build-and-run
@@ -452,11 +444,7 @@ jobs:
     steps:
     # Checkout to run ./.github/actions/download-artifact-with-retry
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
-      with:
-        fetch-depth: 1
 
-    - name: Fetch full history and tags for git describe
-      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
       with:
         # Vulnerability bundles are named `artifact_${{ env.SCANNER_BUNDLE_VERSION }}`.

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -32,9 +32,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -59,9 +61,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Fetch full history and tags for git describe
+      run: git fetch --unshallow --tags --no-recurse-submodules origin
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
@@ -102,9 +106,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           free-disk-space: '30'
@@ -295,9 +301,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}

--- a/.github/workflows/tagged-ci.yaml
+++ b/.github/workflows/tagged-ci.yaml
@@ -13,8 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.ref_name }}
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - name: Slack
         env:
           RELEASE_WORKFLOW_NOTIFY_WEBHOOK: ${{ secrets.RELEASE_WORKFLOW_NOTIFY_WEBHOOK }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -471,9 +471,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Fetch full history and tags for git describe
+        run: git fetch --unshallow --tags --no-recurse-submodules origin
       - uses: ./.github/actions/job-preamble
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}


### PR DESCRIPTION
## Description

Most workflow jobs used `fetch-depth: 0` solely to get enough git history for `git describe --tags` (used by `make tag`). With 1500+ branches in the repo, `actions/checkout` translates `fetch-depth: 0` into `+refs/heads/*:refs/remotes/origin/*`, pulling every remote branch on every job.

Replace with `fetch-depth: 1` (shallow clone of the target ref only) followed by `git fetch --unshallow --tags --no-recurse-submodules origin` which deepens only the current branch and fetches all tags. This gives `git describe` everything it needs without touching the other 1499 branches.

Skipped files that legitimately need all branches: finish-release, start-release, and update_*_periodic workflows that iterate over or push to multiple branches.

Second commit removes unshallow steps from workflows that never use `git describe` or `make tag` (cleanup checkouts, formatting workflows, audit scripts).

20 files, 51 instances changed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests — CI itself is the test. The change is self-validating: if the shallow checkout + unshallow step breaks `git describe` or any downstream build logic, the affected workflow jobs will fail.

### How I validated my change

- All workflow YAML files parse as valid YAML after the transformation.
- The only remaining `fetch-depth: 0` instances are in the intentionally skipped files (release and periodic-update workflows).
- The `git fetch --unshallow --tags` command is well-documented to deepen only refs that were previously shallow (i.e., the current branch), not all remote branches.
- CI results on this PR will serve as the primary validation.