### PR TITLE
ROX-35299: tighten VSOCK preflight to require PodRunning

### DIFF
--- a/tests/vmhelpers/cluster_preflight.go
+++ b/tests/vmhelpers/cluster_preflight.go
@@ -192,7 +192,8 @@ func VirtHandlerHostVsockVolumesLookUsable(ctx context.Context, t testing.TB, k8
 		}
 		for i := range pods.Items {
 			pod := &pods.Items[i]
-			phaseReady := pod.Status.Phase == coreV1.PodRunning || pod.Status.Phase == coreV1.PodPending
+			// Waiting for PodRunning, as PodPending pods may declare hostPath volumes that aren't mounted yet.
+			phaseReady := pod.Status.Phase == coreV1.PodRunning
 			if !phaseReady {
 				fmt.Fprintf(&diag, "namespace %q pod %q: phase=%q\n", ns, pod.Name, pod.Status.Phase)
 			}

--- a/tests/vmhelpers/cluster_preflight_test.go
+++ b/tests/vmhelpers/cluster_preflight_test.go
@@ -222,6 +222,15 @@ func TestVirtHandlerHostVsockVolumesLookUsable(t *testing.T) {
 			require.Truef(t, ok, "expected %s to pass preflight; diagnostics: %s", hostPath, diag)
 		})
 	}
+
+	t.Run("pending pod is considered not usable", func(t *testing.T) {
+		t.Parallel()
+		client := kubefake.NewSimpleClientset(
+			makeVirtHandlerPod("openshift-cnv", "virt-handler-1", coreV1.PodPending, "/dev/vhost-vsock"),
+		)
+		ok, diag := VirtHandlerHostVsockVolumesLookUsable(context.Background(), t, client, "openshift-cnv")
+		require.Falsef(t, ok, "expected pending pod to fail preflight; diagnostics: %s", diag)
+	})
 }
 
 func TestVerifyClusterVSOCKReadyPhases_ShouldGivePhaseTwoAFreshTimeoutAfterSlowPhaseOne(t *testing.T) {


### PR DESCRIPTION
## Description

`VirtHandlerHostVsockVolumesLookUsable` treated a `Pending` virt-handler pod as evidence that VSOCK hostPath plumbing was usable.
However,  pending pod's hostPath volumes are only declared in its spec, not yet mounted. That let the preflight pass before VSOCK was actually ready, pushing the real failure downstream to the next step, where it's harder to triage.

This tightens the check to require `PodRunning`. The check already runs inside a polling loop, so this doesn't introduce flakiness: a still-pending pod just fails the current poll iteration and the loop retries until the pod is actually running.

Fixes ROX-35299 (origin: CodeRabbit review on PR #21292).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added regression tests

### How I validated my change

CI e2e tests are running:
```
/test ocp-4-21-vm-scanning-e2e-tests
/test ocp-4-22-vm-scanning-e2e-tests
```