### PR TITLE
ROX-35910: use k8s name as ProfileId for CEL compliance profiles

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -44,9 +44,20 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	// useful for the deduping from sensor.
 	uid := string(complianceProfile.UID)
 
+	// Profiles using the CEL scanner (annotation compliance.openshift.io/scanner-type=CEL) have no
+	// XCCDF profile ID, so the compliance operator sets ComplianceScan.Spec.Profile to the profile's
+	// k8s object name instead. We must use the same value as ProfileId here so that BuildProfileRefID
+	// produces matching UUIDs on both the profile and the scan sides. The same pattern was applied to
+	// CEL-based tailored profiles in https://github.com/stackrox/stackrox/pull/19214 — see
+	// complianceoperatortailoredprofiles.go.
+	profileID := complianceProfile.ID
+	if complianceProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
+		profileID = complianceProfile.Name
+	}
+
 	protoProfile := &storage.ComplianceOperatorProfile{
 		Id:          uid,
-		ProfileId:   complianceProfile.ID,
+		ProfileId:   profileID,
 		Name:        complianceProfile.Name,
 		Labels:      complianceProfile.Labels,
 		Annotations: complianceProfile.Annotations,
@@ -71,7 +82,7 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	if centralcaps.Has(centralsensor.ComplianceV2Integrations) {
 		protoProfile := &central.ComplianceOperatorProfileV2{
 			Id:             uid,
-			ProfileId:      complianceProfile.ID,
+			ProfileId:      profileID,
 			Name:           complianceProfile.Name,
 			ProfileVersion: complianceProfile.Version,
 			Labels:         complianceProfile.Labels,

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -1,0 +1,105 @@
+package dispatchers
+
+import (
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func profileToUnstructured(t *testing.T, p *v1alpha1.Profile) *unstructured.Unstructured {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(p)
+	require.NoError(t, err)
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// TestProfileDispatcher_OpenSCAPProfileID verifies that OpenSCAP profiles use the XCCDF content ID
+// (complianceProfile.ID) as ProfileId, so that BuildProfileRefID matches the scan side.
+func TestProfileDispatcher_OpenSCAPProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp4-cis",
+			UID:  "some-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_cis",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_org.ssgproject.content_profile_cis", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_CELProfileID verifies that CEL profiles use the k8s object name as
+// ProfileId, mirroring what ComplianceScan.Spec.Profile is set to by the compliance operator,
+// so that BuildProfileRefID produces matching UUIDs on both the profile and the scan sides.
+func TestProfileDispatcher_CELProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			// K8s name: what CO puts in ComplianceScan.Spec.Profile for CEL profiles
+			Name: "ocp4virt-cis-vm-extension",
+			UID:  "cel-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			// Short content ID — no XCCDF prefix — which CO does NOT use in spec.profile
+			ID: "cis-vm-extension",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what the scan dispatcher reads from ComplianceScan.Spec.Profile
+	assert.Equal(t, "ocp4virt-cis-vm-extension", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_CELProfileID_V2 verifies the V2 event also carries the k8s name as ProfileId.
+func TestProfileDispatcher_CELProfileID_V2(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp4virt-cis-vm-extension",
+			UID:  "cel-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "cis-vm-extension",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.Len(t, event.ForwardMessages, 2)
+
+	v2Profile := event.ForwardMessages[1].GetComplianceOperatorProfileV2()
+	require.NotNil(t, v2Profile)
+	assert.Equal(t, "ocp4virt-cis-vm-extension", v2Profile.GetProfileId())
+	assert.Equal(t, central.ComplianceOperatorProfileV2_PROFILE, v2Profile.GetOperatorKind())
+}


### PR DESCRIPTION
## Description

CEL profiles have no XCCDF ID. The compliance operator deliberately sets `ComplianceScan.Spec.Profile` to the k8s object name for CEL profiles (e.g. `ocp4virt-cis-vm-extension`), while `complianceProfile.ID` contains only the short content ID (e.g. `cis-vm-extension`). This caused `BuildProfileRefID` to produce different UUIDs on the profile and scan sides, breaking the SQL JOIN in the coverage view — 0 checks shown for any CEL profile.

The identical root cause was already fixed for tailored profiles with custom rules in `complianceoperatortailoredprofiles.go`. This PR applies the same pattern to `complianceoperatorprofiles.go`: when the `compliance.openshift.io/scanner-type` annotation is `CEL`, use `complianceProfile.Name` as `ProfileId` instead of `complianceProfile.ID`, in both V1 and V2 proto blocks.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Deployed the patched sensor to `ga-ocp4-cron` and ran a scan against the `ocp4virt-cis-vm-extension` CEL profile.

**Before fix:**
```json
GET /v2/compliance/scan/stats/profiles/ocp4virt-cis-vm-extension
{"scanStats":[],"totalCount":0}
```

**After fix:**
```json
{"scanStats":[{"checkStats":[...,{"count":5,"status":"ERROR"}],"profileName":"ocp4virt-cis-vm-extension",...}],"totalCount":1}
```

Coverage UI screenshot confirms all 5 checks visible for the cluster.