### PR TITLE
ROX-35910: use ScannerTypeAnnotation for CEL TailoredProfile detection

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -65,13 +65,18 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	}
 
 	// The compliance operator sets ComplianceScan.Spec.Profile to the tailored profile's
-	// k8s name (not its XCCDF Status.ID) when the tailored profile contains custom rules
-	// (annotation compliance.openshift.io/tailored-profile-contains-custom-rules=true, see
-	// https://github.com/ComplianceAsCode/compliance-operator/blob/197c942793f0f0ef81ca39e4e9082271218b8b42/pkg/controller/scansettingbinding/scansettingbinding_controller.go#L555-L563
-	// for details). We must use the same value as ProfileId so that BuildProfileRefID
-	// produces matching UUIDs on both the profile and the scan sides.
+	// k8s name (not its XCCDF Status.ID) for any CEL-based tailored profile
+	// (annotation compliance.openshift.io/scanner-type=CEL). This covers:
+	//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
+	//   - TPs with CEL-typed rules but no CustomRules (ScannerTypeAnnotation only)
+	//   - TPs extending a CEL base profile (inherit ScannerTypeAnnotation from base)
+	// See https://github.com/ComplianceAsCode/compliance-operator/pull/19214 for the
+	// original CustomRuleProfileAnnotation-based fix and the PR that introduced the
+	// broader ScannerTypeAnnotation check in CO's scansettingbinding controller.
+	// We must use the same value as ProfileId so that BuildProfileRefID produces
+	// matching UUIDs on both the profile and the scan sides.
 	profileID := tailoredProfile.Status.ID
-	if tailoredProfile.GetAnnotations()[v1alpha1.CustomRuleProfileAnnotation] == "true" {
+	if tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
 		profileID = tailoredProfile.GetName()
 	}
 

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -161,6 +161,68 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	}, ruleNames)
 }
 
+// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
+// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
+func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tp-openscap",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
+}
+
+// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
+// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
+// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
+//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
+//   - TPs with CEL-typed rules but no CustomRules
+//   - TPs extending a CEL base profile
+func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cel-tp",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			// CO sets a generated ID, but scan.Profile uses the k8s name for CEL TPs
+			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
+}
+
 // TestProcessEvent_StoresTailoredProfileMetadata tests that all metadata fields are stored
 // from the tailored profile itself, rather than from the base profile it extends.
 func TestProcessEvent_StoresTailoredProfileMetadata(t *testing.T) {


### PR DESCRIPTION
## Description

Follow-up to #21904 (CEL profile fix) for coherence.

When the compliance operator annotates a TailoredProfile as CEL-based, it sets **both** `compliance.openshift.io/scanner-type=CEL` and `compliance.openshift.io/tailored-profile-contains-custom-rules=true` for TPs with CustomRules. The previous check used only `CustomRuleProfileAnnotation`, which is equivalent for that case but misses two newer CO scenarios:

- **TP with CEL-typed rules but no CustomRules**: gets `ScannerTypeAnnotation=CEL` only (no `CustomRuleProfileAnnotation`)
- **TP extending a CEL base profile**: inherits `ScannerTypeAnnotation=CEL` from the base

In newer CO versions (including v1.9.x running in the field), the SSB controller uses `hasCustomRule(tp) || isCELObject(tp)` (where `isCELObject` checks `ScannerTypeAnnotation`) to decide `scan.Profile = tp.GetName()`. Our dispatcher should do the same.

This change aligns `complianceoperatortailoredprofiles.go` with the approach already taken for regular Profiles in #21904 — both now use `ScannerTypeAnnotation`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit tests added for explicit OpenSCAP (uses `Status.ID`) and CEL (uses k8s name) cases. Build and full dispatcher test suite pass clean.