### PR TITLE
ROX-34488: verify sigstore bundle signatures via sigstore-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	github.com/sigstore/cosign/v3 v3.1.2
 	github.com/sigstore/rekor v1.5.3
 	github.com/sigstore/sigstore v1.10.8
+	github.com/sigstore/sigstore-go v1.2.1
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -405,7 +406,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.3.0 // indirect
-	github.com/sigstore/sigstore-go v1.2.1 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.1.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/sigstore/cosign/v3 v3.1.3
 	github.com/sigstore/rekor v1.5.3
 	github.com/sigstore/sigstore v1.10.9
+	github.com/sigstore/sigstore-go v1.2.2
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -407,7 +408,6 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.3.0 // indirect
-	github.com/sigstore/sigstore-go v1.2.2 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.1.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936 h1:foGzavPWwtoyBvjWyKJYDYsyzy+23iBV7NKTwdk+LRY=
-github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936/go.mod h1:ttKPnOepYt4LLzD+loXQ1rT6EmpyIYHro7TAJuIIlHo=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
 github.com/digitorus/pkcs7 v0.0.0-20230818184609-3a137a874352 h1:ge14PCmCvPjpMQMIAH7uKg0lrtNSOdpYsRXlwk3QbaE=

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -252,6 +252,7 @@ func transparencyLogsFromKeys(keys *cosign.TrustedTransparencyLogPubKeys) map[st
 	for logID, key := range keys.Keys {
 		idBytes, err := hex.DecodeString(logID)
 		if err != nil {
+			log.Warnf("Skipping transparency log key with malformed log ID %q: %v", logID, err)
 			continue
 		}
 		logs[logID] = &root.TransparencyLog{
@@ -333,7 +334,7 @@ func augmentTrustedMaterialWithSigChain(cosignOpts *cosign.CheckOpts, sig oci.Si
 		root.TrustedRootMediaType01,
 		augmented,
 		cosignOpts.TrustedMaterial.CTLogs(),
-		nil,
+		cosignOpts.TrustedMaterial.TimestampingAuthorities(),
 		cosignOpts.TrustedMaterial.RekorLogs(),
 	)
 	if err != nil {
@@ -486,7 +487,7 @@ func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opt
 	// doesn't chain to the configured/Fulcio root, missing SCT) and pins the exact
 	// signing key so only signatures from this key are accepted.
 	if cert.cert != nil {
-		chains, err := verify.VerifyLeafCertificate(cert.cert.NotBefore, cert.cert, opts.TrustedMaterial)
+		chains, err := verify.VerifyLeafCertificate(time.Now(), cert.cert, opts.TrustedMaterial)
 		if err != nil {
 			return opts, fmt.Errorf("validating configured certificate against trust root: %w", err)
 		}
@@ -562,7 +563,11 @@ func verifySigstoreBundle(ctx context.Context, sigstoreBundle []byte,
 	imageHash gcrv1.Hash, image *storage.Image, cosignOpts cosign.CheckOpts,
 ) ([]string, error) {
 	if cosignOpts.TrustedMaterial == nil {
-		return nil, errox.InvariantViolation.New("TrustedMaterial is required for sigstore bundle verification")
+		var err error
+		cosignOpts.TrustedMaterial, err = sigstoreTrustedRoot()
+		if err != nil {
+			return nil, fmt.Errorf("loading fallback trusted material for bundle verification: %w", err)
+		}
 	}
 
 	// sigstore-go requires at least one identity for cert-based verification.

--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -5,20 +5,25 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	rekorClient "github.com/sigstore/rekor/pkg/client"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
@@ -47,6 +52,16 @@ var (
 	errNoVerifiedReferences = errors.New("no verified references")
 	errUnverifiedBundle     = errors.New("unverified transparency log bundle")
 )
+
+// verifiableSignature holds signature data ready for verification. Exactly one of
+// the two fields is populated:
+//   - sigstoreBundle: raw sigstore bundle JSON, verified via verifySigstoreBundle (sigstore-go).
+//   - signature: reconstructed oci.Signature from decomposed SimpleSigning fields, verified via
+//     cosign.VerifyImageSignature.
+type verifiableSignature struct {
+	sigstoreBundle []byte
+	signature      oci.Signature
+}
 
 var once sync.Once
 
@@ -173,7 +188,7 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 		return storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, nil, errNoVerificationData
 	}
 
-	sigs, hash, err := retrieveVerificationDataFromImage(image)
+	vsigs, hash, err := retrieveVerificationDataFromImage(image)
 	if err != nil {
 		return getVerificationResultStatusFromErr(err), nil, err
 	}
@@ -200,9 +215,9 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 	var mutex sync.Mutex
 	var wg sync.WaitGroup
 	for _, opts := range c.verifierOpts {
-		for cnt, sig := range sigs {
+		for cnt, vsig := range vsigs {
 			wg.Go(func() {
-				verifierRefs, err := verifyImageSignature(ctx, sig, hash, image, opts)
+				verifierRefs, err := verifySignature(ctx, vsig.sigstoreBundle, vsig.signature, hash, image, opts)
 				mutex.Lock()
 				defer mutex.Unlock()
 				if err != nil {
@@ -212,7 +227,6 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 					)
 					return
 				}
-				// Successful verification. Keep the image references.
 				verifiedImageReferences.AddAll(verifierRefs...)
 			})
 		}
@@ -228,16 +242,131 @@ func (c *cosignSignatureVerifier) VerifySignature(ctx context.Context,
 	return storage.ImageSignatureVerificationResult_FAILED_VERIFICATION, nil, allVerifyErrs
 }
 
+// transparencyLogsFromKeys converts cosign's TrustedTransparencyLogPubKeys map into
+// sigstore-go TransparencyLog entries.
+func transparencyLogsFromKeys(keys *cosign.TrustedTransparencyLogPubKeys) map[string]*root.TransparencyLog {
+	if keys == nil || len(keys.Keys) == 0 {
+		return nil
+	}
+	logs := make(map[string]*root.TransparencyLog, len(keys.Keys))
+	for logID, key := range keys.Keys {
+		idBytes, err := hex.DecodeString(logID)
+		if err != nil {
+			continue
+		}
+		logs[logID] = &root.TransparencyLog{
+			ID:                idBytes,
+			PublicKey:         key.PubKey,
+			HashFunc:          crypto.SHA256,
+			SignatureHashFunc: crypto.SHA256,
+			// sigstore-go VerifySET rejects zero-value ValidityPeriodStart
+			// as "not set". Unix epoch is a non-zero sentinel meaning "always valid".
+			ValidityPeriodStart: time.Unix(0, 0),
+		}
+	}
+	return logs
+}
+
+// trustedMaterialFromTlogKeys builds a root.TrustedMaterial from the Rekor and CTLog keys
+// on CheckOpts. Returns nil if no custom keys are configured (verifySigstoreBundle will
+// fall back to the public Sigstore TUF root).
+func trustedMaterialFromTlogKeys(opts cosign.CheckOpts) (root.TrustedMaterial, error) {
+	rekorLogs := transparencyLogsFromKeys(opts.RekorPubKeys)
+	ctLogs := transparencyLogsFromKeys(opts.CTLogPubKeys)
+	if len(rekorLogs) == 0 && len(ctLogs) == 0 {
+		return nil, nil
+	}
+	tr, err := root.NewTrustedRoot(root.TrustedRootMediaType01, nil, ctLogs, nil, rekorLogs)
+	if err != nil {
+		return nil, fmt.Errorf("building trusted root from transparency log keys: %w", err)
+	}
+	return tr, nil
+}
+
+// trustedMaterialFromCertificateChain builds a root.TrustedMaterial from a custom certificate
+// chain. The last cert in the chain is treated as the root; the rest are intermediates.
+func trustedMaterialFromCertificateChain(chain []*x509.Certificate, opts cosign.CheckOpts) (root.TrustedMaterial, error) {
+	ca := &root.FulcioCertificateAuthority{
+		Root:          chain[len(chain)-1],
+		Intermediates: chain[:len(chain)-1],
+	}
+	return root.NewTrustedRoot(
+		root.TrustedRootMediaType01,
+		[]root.CertificateAuthority{ca},
+		transparencyLogsFromKeys(opts.CTLogPubKeys),
+		nil,
+		transparencyLogsFromKeys(opts.RekorPubKeys),
+	)
+}
+
+// augmentTrustedMaterialWithSigChain extracts intermediates from a SimpleSigning
+// signature's embedded certificate chain and merges them into the TrustedMaterial.
+// This is necessary because cosign's ValidateAndUnpackCertWithIntermediates ignores
+// sig.Chain() intermediates when TrustedMaterial is set, but the configured chain
+// may only contain the root CA (BYOPKI pattern where the signer provides the
+// intermediate chain).
+func augmentTrustedMaterialWithSigChain(cosignOpts *cosign.CheckOpts, sig oci.Signature) error {
+	sigChain, err := sig.Chain()
+	if err != nil || len(sigChain) <= 1 {
+		return err
+	}
+	sigIntermediates := sigChain[:len(sigChain)-1]
+
+	cas := cosignOpts.TrustedMaterial.FulcioCertificateAuthorities()
+	augmented := make([]root.CertificateAuthority, 0, len(cas))
+	for _, ca := range cas {
+		fca, ok := ca.(*root.FulcioCertificateAuthority)
+		if !ok {
+			augmented = append(augmented, ca)
+			continue
+		}
+		merged := &root.FulcioCertificateAuthority{
+			Root:                fca.Root,
+			Intermediates:       append(append([]*x509.Certificate{}, fca.Intermediates...), sigIntermediates...),
+			ValidityPeriodStart: fca.ValidityPeriodStart,
+			ValidityPeriodEnd:   fca.ValidityPeriodEnd,
+		}
+		augmented = append(augmented, merged)
+	}
+
+	tm, err := root.NewTrustedRoot(
+		root.TrustedRootMediaType01,
+		augmented,
+		cosignOpts.TrustedMaterial.CTLogs(),
+		nil,
+		cosignOpts.TrustedMaterial.RekorLogs(),
+	)
+	if err != nil {
+		return fmt.Errorf("rebuilding trusted material with signature intermediates: %w", err)
+	}
+	cosignOpts.TrustedMaterial = tm
+	return nil
+}
+
+// sigstoreTrustedRoot returns the public Sigstore trusted root from TUF.
+func sigstoreTrustedRoot() (root.TrustedMaterial, error) {
+	tr, err := cosign.TrustedRoot()
+	if err != nil {
+		return nil, fmt.Errorf("loading sigstore trusted root: %w", err)
+	}
+	return tr, nil
+}
+
 func (c *cosignSignatureVerifier) createVerifierOpts(ctx context.Context) error {
 	defaultOpts, err := c.defaultCosignCheckOpts(ctx)
 	if err != nil {
 		return errors.Wrap(err, "creating default cosign check opts")
 	}
 
+	// Build TrustedMaterial once from the tlog keys for public key verifiers.
+	publicKeyTrustedMaterial, err := trustedMaterialFromTlogKeys(defaultOpts)
+	if err != nil {
+		return err
+	}
+
 	var verifierErrs error
 	// Public key verifiers.
 	for _, key := range c.parsedPublicKeys {
-		// For now, only supporting SHA256 as algorithm.
 		v, err := signature.LoadVerifier(key, crypto.SHA256)
 		if err != nil {
 			verifierErrs = multierror.Append(verifierErrs, errors.Wrap(err, "creating verifier"))
@@ -245,6 +374,7 @@ func (c *cosignSignatureVerifier) createVerifierOpts(ctx context.Context) error 
 		}
 		opts := defaultOpts
 		opts.SigVerifier = v
+		opts.TrustedMaterial = publicKeyTrustedMaterial
 		c.verifierOpts = append(c.verifierOpts, opts)
 	}
 
@@ -317,9 +447,9 @@ func (c *cosignSignatureVerifier) defaultCosignCheckOpts(ctx context.Context) (c
 }
 
 func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opts cosign.CheckOpts) (cosign.CheckOpts, error) {
-	// Skip verifying the identities when the wildcard matching logic being used. This fixes an issue
-	// with verifying the identity which will yield an error when using the wildcard expressions _and_ the certificate
-	// to verify has no identities associated with it (i.e. within the BYOPKI use-case).
+	// Only set non-wildcard identities. CheckCertificatePolicy fails on BYOPKI certs
+	// that lack OIDC extensions. For the sigstore-go bundle path, verifySigstoreBundle
+	// injects wildcard identities when Identities is empty and SigVerifier is nil.
 	if cert.oidcIssuerExpr != ".*" && cert.identityExpr != ".*" {
 		opts.Identities = []cosign.Identity{{
 			IssuerRegExp:  cert.oidcIssuerExpr,
@@ -336,65 +466,87 @@ func cosignCheckOptsFromCert(ctx context.Context, cert certVerificationData, opt
 		}
 	}
 
-	// - If we have both cert and chain, we use both to verify the public key and the root.
-	// - If we only have the cert, we assume the fulcio trusted root.
-	// - If we only have the chain, we use this as the trusted root to verify certificates, if any.
-	// - If none is given, we set the fulcio roots.
-	switch {
-	case cert.cert != nil && len(cert.chain) > 0:
-		v, err := cosign.ValidateAndUnpackCertWithChain(cert.cert, cert.chain, &opts)
+	// Build TrustedMaterial: custom chain when provided, Sigstore (Fulcio) root otherwise.
+	// All certificate chain validation flows through TrustedMaterial — the legacy
+	// RootCerts/IntermediateCerts fields are not needed.
+	if len(cert.chain) > 0 {
+		opts.TrustedMaterial, err = trustedMaterialFromCertificateChain(cert.chain, opts)
 		if err != nil {
 			return opts, err
 		}
-		opts.SigVerifier = v
-		return opts, nil
-
-	case cert.cert != nil:
-		opts.RootCerts, err = fulcio.GetRoots()
+	} else {
+		opts.TrustedMaterial, err = sigstoreTrustedRoot()
 		if err != nil {
 			return opts, err
 		}
-		opts.IntermediateCerts, err = fulcio.GetIntermediates()
-		if err != nil {
-			return opts, err
-		}
-		v, err := cosign.ValidateAndUnpackCert(cert.cert, &opts)
-		if err != nil {
-			return opts, err
-		}
-		opts.SigVerifier = v
-		return opts, nil
-
-	case len(cert.chain) > 0:
-		pool := x509.NewCertPool()
-		for _, caCert := range cert.chain {
-			pool.AddCert(caCert)
-		}
-		opts.RootCerts = pool
-		return opts, nil
-
-	default:
-		opts.RootCerts, err = fulcio.GetRoots()
-		if err != nil {
-			return opts, err
-		}
-		return opts, nil
 	}
+
+	// When a leaf certificate is provided, validate it against TrustedMaterial and
+	// pin its public key as SigVerifier. This catches misconfigurations early (cert
+	// doesn't chain to the configured/Fulcio root, missing SCT) and pins the exact
+	// signing key so only signatures from this key are accepted.
+	if cert.cert != nil {
+		chains, err := verify.VerifyLeafCertificate(cert.cert.NotBefore, cert.cert, opts.TrustedMaterial)
+		if err != nil {
+			return opts, fmt.Errorf("validating configured certificate against trust root: %w", err)
+		}
+		if err := cosign.CheckCertificatePolicy(cert.cert, &opts); err != nil {
+			return opts, err
+		}
+		if !opts.IgnoreSCT {
+			contains, err := cosign.ContainsSCT(cert.cert.Raw)
+			if err != nil {
+				return opts, err
+			}
+			if !contains {
+				return opts, errors.New("certificate does not include required embedded SCT")
+			}
+			if err := verify.VerifySignedCertificateTimestamp(chains, 1, opts.TrustedMaterial); err != nil {
+				return opts, fmt.Errorf("verifying signed certificate timestamp: %w", err)
+			}
+		}
+		v, err := signature.LoadVerifier(cert.cert.PublicKey, crypto.SHA256)
+		if err != nil {
+			return opts, errors.Wrap(err, "loading verifier from certificate")
+		}
+		opts.SigVerifier = v
+	}
+
+	return opts, nil
 }
 
-func verifyImageSignature(ctx context.Context, signature oci.Signature,
+// verifySignature dispatches signature verification based on format:
+//   - Sigstore bundle: delegates to verifySigstoreBundle which uses cosign.VerifyNewBundle
+//     (sigstore-go). The bundle carries its own verification material (cert, tlog entry).
+//   - SimpleSigning: delegates to cosign.VerifyImageSignature which verifies the signature
+//     and rekor bundle (transparency log proof) from the decomposed proto fields.
+func verifySignature(ctx context.Context, sigstoreBundle []byte, sig oci.Signature,
 	imageHash gcrv1.Hash, image *storage.Image, cosignOpts cosign.CheckOpts,
 ) ([]string, error) {
-	// If there is no error during the verification, the signature was successfully verified
-	// as well as the claims.
-	bundleVerified, err := cosign.VerifyImageSignature(ctx, signature, imageHash, &cosignOpts)
+	// Verify DSSE Sigstore bundle.
+	if len(sigstoreBundle) > 0 {
+		return verifySigstoreBundle(ctx, sigstoreBundle, imageHash, image, cosignOpts)
+	}
+
+	// Verify SimpleSigning signature.
+	// cosign's ValidateAndUnpackCertWithIntermediates uses VerifyLeafCertificate when
+	// TrustedMaterial is set, which only considers CAs from the TrustedMaterial and
+	// ignores intermediates embedded in the signature. Merge them in so the chain
+	// builds correctly for BYOPKI setups where the configured chain is just the root.
+	if cosignOpts.TrustedMaterial != nil {
+		if err := augmentTrustedMaterialWithSigChain(&cosignOpts, sig); err != nil {
+			return nil, err
+		}
+	}
+	rekorVerified, err := cosign.VerifyImageSignature(ctx, sig, imageHash, &cosignOpts)
 	if err != nil {
 		return nil, err
 	}
-	if !bundleVerified && !cosignOpts.IgnoreTlog {
+	if !rekorVerified && !cosignOpts.IgnoreTlog {
 		return nil, errUnverifiedBundle
 	}
-	refs, err := getVerifiedImageReference(signature, image)
+
+	refs, err := getVerifiedImageReference(sig, image)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting verified image references")
 	}
@@ -402,6 +554,42 @@ func verifyImageSignature(ctx context.Context, signature oci.Signature,
 		return nil, errNoVerifiedReferences
 	}
 	return refs, nil
+}
+
+// verifySigstoreBundle verifies a sigstore bundle directly via cosign.VerifyNewBundle.
+// TrustedMaterial must be set by the caller (createVerifierOpts / cosignCheckOptsFromCert).
+func verifySigstoreBundle(ctx context.Context, sigstoreBundle []byte,
+	imageHash gcrv1.Hash, image *storage.Image, cosignOpts cosign.CheckOpts,
+) ([]string, error) {
+	if cosignOpts.TrustedMaterial == nil {
+		return nil, errox.InvariantViolation.New("TrustedMaterial is required for sigstore bundle verification")
+	}
+
+	// sigstore-go requires at least one identity for cert-based verification.
+	// cosignCheckOptsFromCert skips Identities for wildcard BYOPKI certs (they lack
+	// OIDC extensions that the legacy path would check), so inject them here.
+	if len(cosignOpts.Identities) == 0 && cosignOpts.SigVerifier == nil {
+		cosignOpts.Identities = []cosign.Identity{{SubjectRegExp: ".*", IssuerRegExp: ".*"}}
+	}
+
+	bundle := &sgbundle.Bundle{}
+	if err := bundle.UnmarshalJSON(sigstoreBundle); err != nil {
+		return nil, fmt.Errorf("unmarshalling sigstore bundle: %w", err)
+	}
+
+	digestBytes, err := hex.DecodeString(imageHash.Hex)
+	if err != nil {
+		return nil, fmt.Errorf("decoding image digest hex: %w", err)
+	}
+
+	artifactPolicy := verify.WithArtifactDigest(imageHash.Algorithm, digestBytes)
+	if _, err := cosign.VerifyNewBundle(ctx, &cosignOpts, artifactPolicy, bundle); err != nil {
+		return nil, err
+	}
+
+	// Sigstore bundles bind to the image digest, not a docker reference, so all
+	// names sharing the same digest are considered verified.
+	return getAllImageReferences(image), nil
 }
 
 // getVerificationResultStatusFromErr will map an error to a specific storage.ImageSignatureVerificationResult_Status.
@@ -433,7 +621,13 @@ func unmarshalRekorBundle(byteBundle []byte) (*bundle.RekorBundle, error) {
 	return rekorBundle, nil
 }
 
-func retrieveVerificationDataFromImage(image *storage.Image) ([]oci.Signature, gcrv1.Hash, error) {
+// retrieveVerificationDataFromImage reads stored signatures from the image proto and
+// prepares them for verification. Two storage formats are handled:
+//   - SigstoreBundle set: the raw bundle JSON is carried through for verifySigstoreBundle.
+//   - SigstoreBundle empty (legacy): the decomposed fields (RawSignature, SignaturePayload,
+//     CertPem, CertChainPem, RekorBundle) are reassembled into an oci.Signature for
+//     cosign.VerifyImageSignature.
+func retrieveVerificationDataFromImage(image *storage.Image) ([]verifiableSignature, gcrv1.Hash, error) {
 	imgSHA := imgUtils.GetSHA(image)
 	// If there is no digest associated with the image, we cannot safely do signature and claim verification.
 	if imgSHA == "" {
@@ -454,19 +648,29 @@ func retrieveVerificationDataFromImage(image *storage.Image) ([]oci.Signature, g
 			"invalid hashing algorithm %s used, only SHA256 is supported", hash.Algorithm)
 	}
 
-	// Each signature contains the base64 encoded version of it and the associated payload.
-	// In the future, this will also include potential rekor bundles for keyless verification.
-	signatures := make([]oci.Signature, 0, len(image.GetSignature().GetSignatures()))
+	vsigs := make([]verifiableSignature, 0, len(image.GetSignature().GetSignatures()))
 	for _, imgSig := range image.GetSignature().GetSignatures() {
 		if imgSig.GetCosign() == nil {
 			continue
 		}
-		b64Sig := base64.StdEncoding.EncodeToString(imgSig.GetCosign().GetRawSignature())
-		sigOpts := []static.Option{
-			static.WithCertChain(imgSig.GetCosign().GetCertPem(), imgSig.GetCosign().GetCertChainPem()),
+
+		cosignSig := imgSig.GetCosign()
+
+		// Sigstore bundle: carry the raw bundle for direct sigstore-go verification.
+		if len(cosignSig.GetSigstoreBundle()) > 0 {
+			vsigs = append(vsigs, verifiableSignature{
+				sigstoreBundle: cosignSig.GetSigstoreBundle(),
+			})
+			continue
 		}
 
-		rekorBundle, err := unmarshalRekorBundle(imgSig.GetCosign().GetRekorBundle())
+		// Legacy decomposed fields.
+		b64Sig := base64.StdEncoding.EncodeToString(cosignSig.GetRawSignature())
+		sigOpts := []static.Option{
+			static.WithCertChain(cosignSig.GetCertPem(), cosignSig.GetCertChainPem()),
+		}
+
+		rekorBundle, err := unmarshalRekorBundle(cosignSig.GetRekorBundle())
 		if err != nil {
 			log.Errorf("Failed to unmarshal rekor bundle for image %q: %s", image.GetName().GetFullName(), err)
 		}
@@ -474,19 +678,21 @@ func retrieveVerificationDataFromImage(image *storage.Image) ([]oci.Signature, g
 			sigOpts = append(sigOpts, static.WithBundle(rekorBundle))
 		}
 
-		sig, err := static.NewSignature(imgSig.GetCosign().GetSignaturePayload(), b64Sig, sigOpts...)
+		sig, err := static.NewSignature(cosignSig.GetSignaturePayload(), b64Sig, sigOpts...)
 		if err != nil {
 			return nil, gcrv1.Hash{}, errCorruptedSignature.CausedBy(err)
 		}
-		signatures = append(signatures, sig)
+		vsigs = append(vsigs, verifiableSignature{
+			signature: sig,
+		})
 	}
 
-	return signatures, hash, nil
+	return vsigs, hash, nil
 }
 
 // getVerifiedImageReferenceFromSignature retrieves the verified docker reference in the format of
-// <registry>/<repository> from the payload of the oci.Signature and filters out image names that are verified by
-// the docker reference using the image names associated with the storage.Image.
+// <registry>/<repository> from the payload of the SimpleSigning oci.Signature and filters out image
+// names that are verified by the docker reference using the image names associated with the storage.Image.
 func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([]string, error) {
 	payloadBytes, err := signature.Payload()
 	if err != nil {
@@ -530,6 +736,19 @@ func getVerifiedImageReference(signature oci.Signature, image *storage.Image) ([
 		}
 	}
 	return verifiedImageReferences, nil
+}
+
+func getAllImageReferences(image *storage.Image) []string {
+	imageNames := protoutils.SliceUnique(
+		append([]*storage.ImageName{image.GetName()}, image.GetNames()...),
+	)
+	refs := make([]string, 0, len(imageNames))
+	for _, n := range imageNames {
+		if fullName := n.GetFullName(); fullName != "" {
+			refs = append(refs, fullName)
+		}
+	}
+	return refs
 }
 
 func equalRegistryRepository(signatureIdentity, imageName string) (bool, error) {

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -809,9 +809,9 @@ func TestRetrieveVerificationDataFromImage_MixedFormats(t *testing.T) {
 	vsigs, _, err := retrieveVerificationDataFromImage(img)
 	require.NoError(t, err)
 	assert.Len(t, vsigs, 2)
-	assert.NotNil(t, vsigs[0].sig, "first signature should be SimpleSigning")
+	assert.NotNil(t, vsigs[0].signature, "first signature should be SimpleSigning")
 	assert.Empty(t, vsigs[0].sigstoreBundle)
-	assert.Nil(t, vsigs[1].sig, "second signature should be bundle-only")
+	assert.Nil(t, vsigs[1].signature, "second signature should be bundle-only")
 	assert.Equal(t, bundleJSON, vsigs[1].sigstoreBundle)
 }
 

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -2,11 +2,21 @@ package signatures
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
 	"os"
 	"testing"
 
+	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
+	"github.com/sigstore/cosign/v3/pkg/oci/static"
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/images/types"
@@ -901,4 +911,179 @@ func generateImageWithCosignSignature(imgString, b64Sig, b64SigPayload string,
 		},
 	}
 	return img, nil
+}
+
+func TestTransparencyLogsFromKeys(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	validLogID := hex.EncodeToString([]byte("valid-log-id-0123456789ab"))
+
+	cases := map[string]struct {
+		keys     *cosign.TrustedTransparencyLogPubKeys
+		expected int
+	}{
+		"nil keys returns nil": {
+			keys:     nil,
+			expected: 0,
+		},
+		"empty keys map returns nil": {
+			keys:     &cosign.TrustedTransparencyLogPubKeys{Keys: map[string]cosign.TransparencyLogPubKey{}},
+			expected: 0,
+		},
+		"valid key is converted": {
+			keys: &cosign.TrustedTransparencyLogPubKeys{
+				Keys: map[string]cosign.TransparencyLogPubKey{
+					validLogID: {PubKey: ecKey.Public()},
+				},
+			},
+			expected: 1,
+		},
+		"malformed hex log ID is skipped": {
+			keys: &cosign.TrustedTransparencyLogPubKeys{
+				Keys: map[string]cosign.TransparencyLogPubKey{
+					"not-valid-hex!": {PubKey: ecKey.Public()},
+				},
+			},
+			expected: 0,
+		},
+		"mixed valid and invalid log IDs": {
+			keys: &cosign.TrustedTransparencyLogPubKeys{
+				Keys: map[string]cosign.TransparencyLogPubKey{
+					validLogID:       {PubKey: ecKey.Public()},
+					"not-valid-hex!": {PubKey: ecKey.Public()},
+				},
+			},
+			expected: 1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := transparencyLogsFromKeys(tc.keys)
+			if tc.expected == 0 {
+				assert.Empty(t, result)
+				return
+			}
+			assert.Len(t, result, tc.expected)
+			for _, tl := range result {
+				assert.NotNil(t, tl.PublicKey)
+				assert.Equal(t, crypto.SHA256, tl.HashFunc)
+				assert.Equal(t, crypto.SHA256, tl.SignatureHashFunc)
+				assert.False(t, tl.ValidityPeriodStart.IsZero(), "ValidityPeriodStart must be non-zero for sigstore-go.")
+			}
+		})
+	}
+}
+
+func TestTrustedMaterialFromCertificateChain(t *testing.T) {
+	certPEM, err := os.ReadFile("testdata/cert.pem")
+	require.NoError(t, err)
+	chainPEM, err := os.ReadFile("testdata/chain.pem")
+	require.NoError(t, err)
+
+	parseCert := func(t *testing.T, pemData []byte) *x509.Certificate {
+		block, _ := pem.Decode(pemData)
+		require.NotNil(t, block)
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		return cert
+	}
+	leafCert := parseCert(t, certPEM)
+	rootCert := parseCert(t, chainPEM)
+
+	cases := map[string]struct {
+		chain                 []*x509.Certificate
+		expectedIntermediates int
+	}{
+		"single cert becomes root with no intermediates": {
+			chain:                 []*x509.Certificate{rootCert},
+			expectedIntermediates: 0,
+		},
+		"two certs: first is intermediate, last is root": {
+			chain:                 []*x509.Certificate{leafCert, rootCert},
+			expectedIntermediates: 1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tm, err := trustedMaterialFromCertificateChain(tc.chain, cosign.CheckOpts{})
+			require.NoError(t, err)
+			require.NotNil(t, tm)
+
+			cas := tm.FulcioCertificateAuthorities()
+			require.Len(t, cas, 1)
+			fca, ok := cas[0].(*root.FulcioCertificateAuthority)
+			require.True(t, ok)
+			assert.Equal(t, tc.chain[len(tc.chain)-1], fca.Root, "Last cert in chain should be root.")
+			assert.Len(t, fca.Intermediates, tc.expectedIntermediates)
+		})
+	}
+}
+
+func TestAugmentTrustedMaterialWithSigChain(t *testing.T) {
+	certPEM, err := os.ReadFile("testdata/cert.pem")
+	require.NoError(t, err)
+	chainPEM, err := os.ReadFile("testdata/chain.pem")
+	require.NoError(t, err)
+
+	parseCert := func(t *testing.T, pemData []byte) *x509.Certificate {
+		block, _ := pem.Decode(pemData)
+		require.NotNil(t, block)
+		cert, err := x509.ParseCertificate(block.Bytes)
+		require.NoError(t, err)
+		return cert
+	}
+	rootCert := parseCert(t, chainPEM)
+
+	// Build a TrustedMaterial with one CA that has only a root (no intermediates).
+	baseTM, err := root.NewTrustedRoot(
+		root.TrustedRootMediaType01,
+		[]root.CertificateAuthority{
+			&root.FulcioCertificateAuthority{Root: rootCert},
+		},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	t.Run("short chain is a no-op", func(t *testing.T) {
+		// Chain() returns only the root (1 cert) => no intermediates to add.
+		sig, err := static.NewSignature(nil, "", static.WithCertChain(certPEM, chainPEM))
+		require.NoError(t, err)
+
+		opts := &cosign.CheckOpts{TrustedMaterial: baseTM}
+		err = augmentTrustedMaterialWithSigChain(opts, sig)
+		assert.NoError(t, err)
+		// TrustedMaterial should be unchanged because chain has only 1 cert.
+		assert.Equal(t, baseTM, opts.TrustedMaterial)
+	})
+
+	t.Run("no chain is a no-op", func(t *testing.T) {
+		sig, err := static.NewSignature(nil, "")
+		require.NoError(t, err)
+
+		opts := &cosign.CheckOpts{TrustedMaterial: baseTM}
+		err = augmentTrustedMaterialWithSigChain(opts, sig)
+		assert.NoError(t, err)
+		assert.Equal(t, baseTM, opts.TrustedMaterial)
+	})
+
+	t.Run("multi-cert chain merges intermediates", func(t *testing.T) {
+		// Create a chain PEM with cert + root so Chain() returns 2 certs.
+		multiChainPEM := append(append([]byte{}, certPEM...), chainPEM...)
+		sig, err := static.NewSignature(nil, "", static.WithCertChain(certPEM, multiChainPEM))
+		require.NoError(t, err)
+
+		opts := &cosign.CheckOpts{TrustedMaterial: baseTM}
+		err = augmentTrustedMaterialWithSigChain(opts, sig)
+		require.NoError(t, err)
+
+		// The TrustedMaterial should now have the intermediate from the sig chain.
+		assert.NotEqual(t, baseTM, opts.TrustedMaterial, "TrustedMaterial should be replaced.")
+		cas := opts.TrustedMaterial.FulcioCertificateAuthorities()
+		require.Len(t, cas, 1)
+		fca, ok := cas[0].(*root.FulcioCertificateAuthority)
+		require.True(t, ok)
+		assert.Len(t, fca.Intermediates, 1, "One intermediate should be merged from sig chain.")
+	})
 }

--- a/pkg/signatures/cosign_sig_verifier_test.go
+++ b/pkg/signatures/cosign_sig_verifier_test.go
@@ -710,20 +710,21 @@ func TestRetrieveVerificationDataFromImage_Success(t *testing.T) {
 		b64CosignSignature, b64CosignSignaturePayload, nil, nil, nil)
 	require.NoError(t, err, "error creating image")
 
-	sigs, hash, err := retrieveVerificationDataFromImage(img)
+	vsigs, hash, err := retrieveVerificationDataFromImage(img)
 	require.NoError(t, err, "should not fail")
 
-	assert.Len(t, sigs, 1, "expected one signature")
-	sig := sigs[0]
-	b64sig, err := sig.Base64Signature()
+	assert.Len(t, vsigs, 1, "expected one signature")
+	vsig := vsigs[0]
+	b64sig, err := vsig.signature.Base64Signature()
 	require.NoError(t, err)
 	assert.Equal(t, b64CosignSignature, b64sig, "expected the base64 values of the signatures to match")
-	payload, err := sig.Payload()
+	payload, err := vsig.signature.Payload()
 	require.NoError(t, err)
 	expectedPayload, err := base64.StdEncoding.DecodeString(b64CosignSignaturePayload)
 	require.NoError(t, err)
 	assert.Equal(t, expectedPayload, payload, "expected the payloads of the signature to match")
 	assert.Equal(t, imgHash, hash.String(), "expected the hash to match the image's hash")
+	assert.Empty(t, vsig.sigstoreBundle)
 }
 
 func TestRetrieveVerificationDataFromImage_Failure(t *testing.T) {
@@ -752,6 +753,66 @@ func TestRetrieveVerificationDataFromImage_Failure(t *testing.T) {
 			assert.ErrorIs(t, err, c.err)
 		})
 	}
+}
+
+func TestRetrieveVerificationDataFromImage_SigstoreBundle(t *testing.T) {
+	imgHash := "sha256:3a4d57227f02243dfc8a2849ec4a116646bed293b9e93cbf9d4a673a28ef6345"
+	bundleJSON := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+
+	cimg, err := imgUtils.GenerateImageFromString("docker.io/nginx@" + imgHash)
+	require.NoError(t, err)
+	img := types.ToImage(cimg)
+	img.Signature = &storage.ImageSignature{
+		Signatures: []*storage.Signature{
+			{
+				Signature: &storage.Signature_Cosign{
+					Cosign: &storage.CosignSignature{
+						SigstoreBundle:  bundleJSON,
+						SignatureFormat: storage.CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE,
+					},
+				},
+			},
+		},
+	}
+
+	vsigs, hash, err := retrieveVerificationDataFromImage(img)
+	require.NoError(t, err)
+	assert.Len(t, vsigs, 1)
+	assert.Equal(t, bundleJSON, vsigs[0].sigstoreBundle)
+	assert.Nil(t, vsigs[0].signature)
+	assert.Equal(t, imgHash, hash.String())
+}
+
+func TestRetrieveVerificationDataFromImage_MixedFormats(t *testing.T) {
+	imgHash := "sha256:3a4d57227f02243dfc8a2849ec4a116646bed293b9e93cbf9d4a673a28ef6345"
+	bundleJSON := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+
+	img, err := generateImageWithCosignSignature("docker.io/nginx@"+imgHash,
+		"MEUCIDGMmJyxVKGPxvPk/QlRzMSGzcI8pYCy+MB7RTTpegzTAiEArssqWntVN8oJOMV0Aey0zhsNqRmEVQAY"+
+			"ZNkn8hkAnXI=",
+		"eyJjcml0aWNhbCI6eyJpZGVudGl0eSI6eyJkb2NrZXItcmVmZXJlbmNlIjoidHRsLnNoL2Q4ZDM4O"+
+			"TJkLTQ4YmQtNDY3MS1hNTQ2LTJlNzBhOTAwYjcwMiJ9LCJpbWFnZSI6eyJkb2NrZXItbWFuaWZlc3QtZGlnZXN0Ijoic2hhMjU2OmVlODli"+
+			"MDA1MjhmZjRmMDJmMjQwNWU0ZWUyMjE3NDNlYmMzZjhlOGRkMGJmZDVjNGMyMGEyZmEyYWFhN2VkZTMifSwidHlwZSI6ImNvc2lnbiBjb25"+
+			"0YWluZXIgaW1hZ2Ugc2lnbmF0dXJlIn0sIm9wdGlvbmFsIjpudWxsfQ==",
+		nil, nil, nil)
+	require.NoError(t, err)
+	// Add a second signature with a sigstore bundle.
+	img.GetSignature().Signatures = append(img.GetSignature().GetSignatures(), &storage.Signature{
+		Signature: &storage.Signature_Cosign{
+			Cosign: &storage.CosignSignature{
+				SigstoreBundle:  bundleJSON,
+				SignatureFormat: storage.CosignSignature_DEAD_SIMPLE_SIGNING_ENVELOPE,
+			},
+		},
+	})
+
+	vsigs, _, err := retrieveVerificationDataFromImage(img)
+	require.NoError(t, err)
+	assert.Len(t, vsigs, 2)
+	assert.NotNil(t, vsigs[0].sig, "first signature should be SimpleSigning")
+	assert.Empty(t, vsigs[0].sigstoreBundle)
+	assert.Nil(t, vsigs[1].sig, "second signature should be bundle-only")
+	assert.Equal(t, bundleJSON, vsigs[1].sigstoreBundle)
 }
 
 func TestEqualRegistryRepository(t *testing.T) {


### PR DESCRIPTION
## Description

Unify trust configuration around TrustedMaterial (sigstore-go's root.TrustedRoot) for both verification paths. The legacy RootCerts/IntermediateCerts fields on CheckOpts are replaced by TrustedMaterial built from the same verifier configuration (custom certificate chains, transparency log keys, or the public Sigstore root). This applies to SimpleSigning signatures verified via cosign.VerifyImageSignature as well as sigstore bundles verified via cosign.VerifyNewBundle, so both paths share the same trust root abstraction.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests in `cosign_sig_verifier_test.go` covering both SimpleSigning and sigstore bundle verification paths.