### PR TITLE
chore: improve notifications from the Scanner Vulnerabilities workflow

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -513,7 +513,10 @@ jobs:
     - build-and-run
     - upload-definitions
     runs-on: ubuntu-latest
-    if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
+    # TEMPORARY (test-only, do not merge): simplified to `failure()` so this
+    # fires from a scratch branch/dry-run test dispatch. Real condition:
+    # if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
+    if: failure()
     permissions:
       checks: read
       actions: read
@@ -569,10 +572,11 @@ jobs:
         WORKFLOW: ${{ github.workflow }}
         REPO: ${{ github.repository }}
         SUMMARY: ${{ steps.annotations.outputs.summary }}
-        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        # TEMPORARY (test-only, do not merge): real secret is SLACK_ONCALL_SCANNER_WEBHOOK.
+        SLACK_WEBHOOK: ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
       run: |
         set -euo pipefail
-        text=$(printf '<%s|Workflow %s> failed in repository %s: Failed to update vulnerabilities\n%s' \
+        text=$(printf '[TEST - Please Ignore]\n\n*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Failed steps:*\n%s' \
             "$RUN_URL" "$WORKFLOW" "$REPO" "$SUMMARY")
         jq -n --arg text "$text" '{text: $text}' \
             | curl -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -575,7 +575,7 @@ jobs:
                 success) icon="✅" ;;
                 skipped) icon="⏭️" ;;
                 cancelled) icon="🚫" ;;
-                in_progress) icon="🟡" ;; 
+                in_progress) icon="🟡" ;;
                 failure | timed_out | action_required | neutral | stale | startup_failure) icon="❌" ;;
                 *) icon="❔" ;; # genuinely unrecognized future conclusion value
             esac

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -587,10 +587,14 @@ jobs:
         while IFS=$'\t' read -r job_name job_conclusion; do
             case "$job_conclusion" in
                 success) icon="✅" ;;
-                failure) icon="❌" ;;
                 skipped) icon="⏭️" ;;
                 cancelled) icon="🚫" ;;
-                *) icon="🟡" ;; # in_progress/null (eg. this job, still running)
+                in_progress) icon="🟡" ;; # null conclusion (eg. this job, still running)
+                # All other terminal, non-success conclusions GitHub can
+                # report for a job (per the Actions/Checks API): treat as
+                # failed rather than defaulting to "in progress".
+                failure | timed_out | action_required | neutral | stale | startup_failure) icon="❌" ;;
+                *) icon="❔" ;; # genuinely unrecognized future conclusion value
             esac
             job_status+="${icon} ${job_name}"$'\n'
         done < <(printf '%s' "$jobs_json" | jq -r '.jobs[] | [.name, (.conclusion // "in_progress")] | @tsv')
@@ -610,18 +614,30 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Send Slack notification on workflow failure
+      # Runs even if "Collect failure annotations" itself failed (eg. the
+      # GitHub API call for the job list errored) -- a degraded, generic
+      # message still reaches on-call in that case, rather than nothing at
+      # all.
+      if: always()
       env:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         WORKFLOW: ${{ github.workflow }}
         REPO: ${{ github.repository }}
         SUMMARY: ${{ steps.annotations.outputs.summary }}
         JOB_STATUS: ${{ steps.annotations.outputs.job_status }}
+        ANNOTATIONS_OUTCOME: ${{ steps.annotations.outcome }}
         SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC2016 # backticks below are a Slack code-block
         # delimiter, not shell command substitution.
-        text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Job Status:*\n```\n%s```\n*Failed steps:*\n```\n%s\n```' \
-            "$RUN_URL" "$WORKFLOW" "$REPO" "$JOB_STATUS" "$SUMMARY")
+        if [ "$ANNOTATIONS_OUTCOME" != "success" ]; then
+            text=$(printf ':warning: *Failed Workflow:* <%s|%s>\n*Repository:* %s\nCould not collect failure annotations for this run (the collection step itself failed) -- please check the workflow run directly for details.' \
+                "$RUN_URL" "$WORKFLOW" "$REPO")
+        else
+            text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Job Status:*\n```\n%s```\n*Failed steps:*\n```\n%s\n```' \
+                "$RUN_URL" "$WORKFLOW" "$REPO" "$JOB_STATUS" "$SUMMARY")
+        fi
         jq -n --arg text "$text" '{text: $text}' \
-            | curl --fail --silent --show-error -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"
+            | curl --fail --silent --show-error --connect-timeout 10 --max-time 300 \
+                -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -316,7 +316,7 @@ jobs:
         done
 
         if [ "${#failures[@]}" -gt 0 ]; then
-            echo "::error::vulnerability bundle validation failed: ${#failures[@]} of ${#files[@]} source(s) broken"
+            echo "::error::vulnerability bundle validation failed: ${#failures[@]} of ${#files[@]} source(s) broken (affected source(s) will be missing from the published bundle; this does not block publishing)"
             printf '  - %s\n' "${failures[@]}"
             exit 1
         fi
@@ -565,10 +565,34 @@ jobs:
         # Keep the Slack message readable and within size limits.
         summary=$(printf '%s' "$summary" | head -c 3000)
 
+        # Per-job status overview (all jobs, not just failed ones), using
+        # icons matching GitHub's own status indicators, so readers can see
+        # at a glance whether eg. upload-definitions actually published
+        # despite a validation failure elsewhere.
+        job_status=""
+        while IFS=$'\t' read -r job_name job_conclusion; do
+            case "$job_conclusion" in
+                success) icon="✅" ;;
+                failure) icon="❌" ;;
+                skipped) icon="⏭️" ;;
+                cancelled) icon="🚫" ;;
+                *) icon="🟡" ;; # in_progress/null (eg. this job, still running)
+            esac
+            job_status+="${icon} ${job_name}"$'\n'
+        done < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
+            --jq '.jobs[] | [.name, (.conclusion // "in_progress")] | @tsv')
+
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
             echo "summary<<$EOF"
             echo "$summary"
+            echo "$EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+            echo "job_status<<$EOF"
+            echo "$job_status"
             echo "$EOF"
         } >> "$GITHUB_OUTPUT"
 
@@ -578,13 +602,14 @@ jobs:
         WORKFLOW: ${{ github.workflow }}
         REPO: ${{ github.repository }}
         SUMMARY: ${{ steps.annotations.outputs.summary }}
+        JOB_STATUS: ${{ steps.annotations.outputs.job_status }}
         # TEMPORARY (test-only, do not merge): real secret is SLACK_ONCALL_SCANNER_WEBHOOK.
         SLACK_WEBHOOK: ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC2016 # backticks below are a Slack code-block
         # delimiter, not shell command substitution.
-        text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Failed steps:*\n```\n%s\n```' \
-            "$RUN_URL" "$WORKFLOW" "$REPO" "$SUMMARY")
+        text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Job Status:*\n```\n%s```\n*Failed steps:*\n```\n%s\n```' \
+            "$RUN_URL" "$WORKFLOW" "$REPO" "$JOB_STATUS" "$SUMMARY")
         jq -n --arg text "$text" '{text: $text}' \
             | curl -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -535,6 +535,8 @@ jobs:
       run: |
         set -euo pipefail
 
+        # Rendered inside a Slack code block (see "Send Slack notification"),
+        # so job names are plain text here, not mrkdwn-bolded.
         summary=""
         while IFS=$'\t' read -r job_id job_name; do
             # Exclude the generic "Process completed with exit code N." annotation
@@ -542,18 +544,22 @@ jobs:
             messages=$(gh api "repos/${REPO}/check-runs/${job_id}/annotations" \
                 --jq '.[] | select(.annotation_level == "failure") | select(.message | test("^Process completed with exit code") | not) | .message' 2>/dev/null || true)
 
-            summary+=$'\n'"*${job_name}*:"$'\n'
+            # Blank line between job blocks (not before the first one) for
+            # readability when multiple jobs fail.
+            if [ -n "$summary" ]; then
+                summary+=$'\n\n'
+            fi
+            summary+="${job_name}:"$'\n'
             if [ -n "$messages" ]; then
                 summary+="$(printf '%s\n' "$messages" | sed 's/^/  - /')"
             else
                 summary+="  - (no detailed error annotations found; see the workflow run for details)"
             fi
-            summary+=$'\n'
         done < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
             --jq '.jobs[] | select(.conclusion == "failure") | [.id, .name] | @tsv')
 
         if [ -z "$summary" ]; then
-            summary=$'\n'"(no failed jobs found; see the workflow run for details)"
+            summary="(no failed jobs found; see the workflow run for details)"
         fi
 
         # Keep the Slack message readable and within size limits.
@@ -576,7 +582,9 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
       run: |
         set -euo pipefail
-        text=$(printf '[TEST - Please Ignore]\n\n*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Failed steps:*\n%s' \
+        # shellcheck disable=SC2016 # backticks below are a Slack code-block
+        # delimiter, not shell command substitution.
+        text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Failed steps:*\n```\n%s\n```' \
             "$RUN_URL" "$WORKFLOW" "$REPO" "$SUMMARY")
         jq -n --arg text "$text" '{text: $text}' \
             | curl -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -535,14 +535,31 @@ jobs:
       run: |
         set -euo pipefail
 
+        # Fetch the job list once (may span multiple pages; gh emits each
+        # page's JSON body back-to-back, which jq happily processes as a
+        # stream of documents below) and reuse it for both the job-status
+        # overview and the per-job failure summary, instead of querying this
+        # endpoint twice.
+        jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate)
+
         # Rendered inside a Slack code block (see "Send Slack notification"),
-        # so job names are plain text here, not mrkdwn-bolded.
+        # so job names are plain text here, not mrkdwn-bolded. Caps the
+        # number of messages shown per job so one very chatty failure can't
+        # blow out the whole Slack message -- truncated jobs get an explicit
+        # "... and N more" marker rather than being silently cut off.
+        max_messages_per_job=10
         summary=""
         while IFS=$'\t' read -r job_id job_name failed_step; do
             # Exclude the generic "Process completed with exit code N." annotation
             # that GitHub Actions auto-adds to every failed step -- it's noise here.
-            messages=$(gh api "repos/${REPO}/check-runs/${job_id}/annotations" \
-                --jq '.[] | select(.annotation_level == "failure") | select(.message | test("^Process completed with exit code") | not) | .message' 2>/dev/null || true)
+            # --paginate here too: a job with many broken sources can exceed
+            # the API's default 30-annotations-per-page limit.
+            if ! messages=$(gh api "repos/${REPO}/check-runs/${job_id}/annotations" --paginate \
+                --jq '.[] | select(.annotation_level == "failure") | select(.message | test("^Process completed with exit code") | not) | .message'); then
+                # Distinguish a real API failure from "no annotations found"
+                # (handled below) so the two aren't silently conflated.
+                messages="(failed to fetch annotations for this job via the GitHub API; see the workflow run directly for details)"
+            fi
 
             # Blank line between job blocks (not before the first one) for
             # readability when multiple jobs fail.
@@ -551,18 +568,22 @@ jobs:
             fi
             summary+="${job_name}: ${failed_step}"$'\n'
             if [ -n "$messages" ]; then
-                summary+="$(printf '%s\n' "$messages" | sed 's/^/  - /')"
+                total=$(printf '%s\n' "$messages" | grep -c .)
+                summary+="$(printf '%s\n' "$messages" | head -n "$max_messages_per_job" | sed 's/^/  - /')"
+                if [ "$total" -gt "$max_messages_per_job" ]; then
+                    summary+=$'\n'"  - ... and $((total - max_messages_per_job)) more (see the workflow run for full details)"
+                fi
             else
                 summary+="  - (no detailed error annotations found; see the workflow run for details)"
             fi
-        done < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
-            --jq '.jobs[] | select(.conclusion == "failure") | [.id, .name, ([.steps[]? | select(.conclusion == "failure") | .name][0] // "unknown step")] | @tsv')
+        done < <(printf '%s' "$jobs_json" | jq -r '.jobs[] | select(.conclusion == "failure") | [.id, .name, ([.steps[]? | select(.conclusion == "failure") | .name][0] // "unknown step")] | @tsv')
 
         if [ -z "$summary" ]; then
             summary="(no failed jobs found; see the workflow run for details)"
         fi
 
-        # Keep the Slack message readable and within size limits.
+        # Keep the Slack message readable and within size limits (safety net
+        # on top of the per-job cap above).
         summary=$(printf '%s' "$summary" | head -c 3000)
 
         # Per-job status overview (all jobs, not just failed ones), using
@@ -579,8 +600,7 @@ jobs:
                 *) icon="🟡" ;; # in_progress/null (eg. this job, still running)
             esac
             job_status+="${icon} ${job_name}"$'\n'
-        done < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
-            --jq '.jobs[] | [.name, (.conclusion // "in_progress")] | @tsv')
+        done < <(printf '%s' "$jobs_json" | jq -r '.jobs[] | [.name, (.conclusion // "in_progress")] | @tsv')
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {
@@ -612,4 +632,4 @@ jobs:
         text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Job Status:*\n```\n%s```\n*Failed steps:*\n```\n%s\n```' \
             "$RUN_URL" "$WORKFLOW" "$REPO" "$JOB_STATUS" "$SUMMARY")
         jq -n --arg text "$text" '{text: $text}' \
-            | curl -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"
+            | curl --fail --silent --show-error -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -513,8 +513,70 @@ jobs:
     - build-and-run
     - upload-definitions
     runs-on: ubuntu-latest
-    if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
+    # TEMPORARY (test-only, do not merge): simplified to `failure()` so this
+    # fires from a scratch branch/dry-run test dispatch. Real condition:
+    # if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
+    if: failure()
+    permissions:
+      checks: read
+      actions: read
     steps:
-    - name: Send Slack notification on workflow failure
+    - name: Collect failure annotations
+      # Pulls the ::error:: annotations from every failed job in this run
+      # so the Slack message below has enough context to triage without
+      # clicking into the run. Jobs with no annotations (eg. failures that
+      # don't emit ::error::) get a generic fallback line instead of being
+      # silently omitted.
+      id: annotations
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
       run: |
-        curl -X POST -H 'Content-type: application/json' --data '{"text":"<${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}|Workflow ${{ github.workflow }}> failed in repository ${{ github.repository }}: Failed to update vulnerabilities"}' ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        set -euo pipefail
+
+        summary=""
+        while IFS=$'\t' read -r job_id job_name; do
+            # Exclude the generic "Process completed with exit code N." annotation
+            # that GitHub Actions auto-adds to every failed step -- it's noise here.
+            messages=$(gh api "repos/${REPO}/check-runs/${job_id}/annotations" \
+                --jq '.[] | select(.annotation_level == "failure") | select(.message | test("^Process completed with exit code") | not) | .message' 2>/dev/null || true)
+
+            summary+=$'\n'"*${job_name}*:"$'\n'
+            if [ -n "$messages" ]; then
+                summary+="$(printf '%s\n' "$messages" | sed 's/^/  - /')"
+            else
+                summary+="  - (no detailed error annotations found; see the workflow run for details)"
+            fi
+            summary+=$'\n'
+        done < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
+            --jq '.jobs[] | select(.conclusion == "failure") | [.id, .name] | @tsv')
+
+        if [ -z "$summary" ]; then
+            summary=$'\n'"(no failed jobs found; see the workflow run for details)"
+        fi
+
+        # Keep the Slack message readable and within size limits.
+        summary=$(printf '%s' "$summary" | head -c 3000)
+
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        {
+            echo "summary<<$EOF"
+            echo "$summary"
+            echo "$EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Send Slack notification on workflow failure
+      env:
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        WORKFLOW: ${{ github.workflow }}
+        REPO: ${{ github.repository }}
+        SUMMARY: ${{ steps.annotations.outputs.summary }}
+        # TEMPORARY (test-only, do not merge): real secret is SLACK_ONCALL_SCANNER_WEBHOOK.
+        SLACK_WEBHOOK: ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
+      run: |
+        set -euo pipefail
+        text=$(printf '[TEST - Please Ignore]\n\n<%s|Workflow %s> failed in repository %s: Failed to update vulnerabilities\n%s' \
+            "$RUN_URL" "$WORKFLOW" "$REPO" "$SUMMARY")
+        jq -n --arg text "$text" '{text: $text}' \
+            | curl -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -520,10 +520,8 @@ jobs:
     steps:
     - name: Collect failure annotations
       # Pulls the ::error:: annotations from every failed job in this run
-      # so the Slack message below has enough context to triage without
-      # clicking into the run. Jobs with no annotations (eg. failures that
-      # don't emit ::error::) get a generic fallback line instead of being
-      # silently omitted.
+      # Jobs with no annotations (eg. failures that don't emit ::error::)
+      # get a generic fallback line instead of being silently omitted.
       id: annotations
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -532,11 +530,9 @@ jobs:
       run: |
         set -euo pipefail
 
-        # Fetch the job list once (may span multiple pages; gh emits each
-        # page's JSON body back-to-back, which jq happily processes as a
-        # stream of documents below) and reuse it for both the job-status
-        # overview and the per-job failure summary, instead of querying this
-        # endpoint twice.
+        # Fetch the job list (may span multiple pages; gh emits each
+        # page's JSON body back-to-back, which jq processes as a
+        # stream of documents below)
         jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate)
 
         # Rendered inside a Slack code block (see "Send Slack notification"),

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -538,7 +538,7 @@ jobs:
         # Rendered inside a Slack code block (see "Send Slack notification"),
         # so job names are plain text here, not mrkdwn-bolded.
         summary=""
-        while IFS=$'\t' read -r job_id job_name; do
+        while IFS=$'\t' read -r job_id job_name failed_step; do
             # Exclude the generic "Process completed with exit code N." annotation
             # that GitHub Actions auto-adds to every failed step -- it's noise here.
             messages=$(gh api "repos/${REPO}/check-runs/${job_id}/annotations" \
@@ -549,14 +549,14 @@ jobs:
             if [ -n "$summary" ]; then
                 summary+=$'\n\n'
             fi
-            summary+="${job_name}:"$'\n'
+            summary+="${job_name}: ${failed_step}"$'\n'
             if [ -n "$messages" ]; then
                 summary+="$(printf '%s\n' "$messages" | sed 's/^/  - /')"
             else
                 summary+="  - (no detailed error annotations found; see the workflow run for details)"
             fi
         done < <(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
-            --jq '.jobs[] | select(.conclusion == "failure") | [.id, .name] | @tsv')
+            --jq '.jobs[] | select(.conclusion == "failure") | [.id, .name, ([.steps[]? | select(.conclusion == "failure") | .name][0] // "unknown step")] | @tsv')
 
         if [ -z "$summary" ]; then
             summary="(no failed jobs found; see the workflow run for details)"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -513,10 +513,7 @@ jobs:
     - build-and-run
     - upload-definitions
     runs-on: ubuntu-latest
-    # TEMPORARY (test-only, do not merge): simplified to `failure()` so this
-    # fires from a scratch branch/dry-run test dispatch. Real condition:
-    # if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
-    if: failure()
+    if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
     permissions:
       checks: read
       actions: read
@@ -623,8 +620,7 @@ jobs:
         REPO: ${{ github.repository }}
         SUMMARY: ${{ steps.annotations.outputs.summary }}
         JOB_STATUS: ${{ steps.annotations.outputs.job_status }}
-        # TEMPORARY (test-only, do not merge): real secret is SLACK_ONCALL_SCANNER_WEBHOOK.
-        SLACK_WEBHOOK: ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
       run: |
         set -euo pipefail
         # shellcheck disable=SC2016 # backticks below are a Slack code-block

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -559,7 +559,7 @@ jobs:
             else
                 summary+="  - (no detailed error annotations found; see the workflow run for details)"
             fi
-        done < <(printf '%s' "$jobs_json" | jq -r '.jobs[] | select(.conclusion == "failure") | [.id, .name, ([.steps[]? | select(.conclusion == "failure") | .name][0] // "unknown step")] | @tsv')
+        done < <(printf '%s' "$jobs_json" | jq -r '.jobs[] | select(.conclusion | IN("failure","timed_out","action_required","neutral","stale","startup_failure")) | [.id, .name, ([.steps[]? | select(.conclusion | IN("failure","timed_out","action_required","neutral","stale","startup_failure")) | .name][0] // "unknown step")] | @tsv')
 
         if [ -z "$summary" ]; then
             summary="(no failed jobs found; see the workflow run for details)"
@@ -621,6 +621,10 @@ jobs:
             text=$(printf '*Failed Workflow:* <%s|%s>\n*Repository:* %s\n*Job Status:*\n```\n%s```\n*Failed steps:*\n```\n%s\n```' \
                 "$RUN_URL" "$WORKFLOW" "$REPO" "$JOB_STATUS" "$SUMMARY")
         fi
+        # --retry-all-errors means a slow-but-eventually-successful post could be
+        # retried and sent twice; unlikely in practice, but possible.
         jq -n --arg text "$text" '{text: $text}' \
-            | curl --fail --silent --show-error --connect-timeout 10 --max-time 300 \
+            | curl --fail --silent --show-error \
+                --retry 3 --retry-all-errors --retry-delay 5 \
+                --connect-timeout 10 --max-time 300 \
                 -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -575,8 +575,7 @@ jobs:
                 success) icon="✅" ;;
                 skipped) icon="⏭️" ;;
                 cancelled) icon="🚫" ;;
-                in_progress) icon="🟡" ;; # null conclusion (eg. this job, still running)
-                # Other terminal conclusions (not success/skipped/cancelled) count as failed.
+                in_progress) icon="🟡" ;; 
                 failure | timed_out | action_required | neutral | stale | startup_failure) icon="❌" ;;
                 *) icon="❔" ;; # genuinely unrecognized future conclusion value
             esac

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -552,7 +552,7 @@ jobs:
             summary+="${job_name}: ${failed_step}"$'\n'
             if [ -n "$messages" ]; then
                 total=$(printf '%s\n' "$messages" | grep -c .)
-                summary+="$(printf '%s\n' "$messages" | head -n "$max_messages_per_job" | sed 's/^/  - /')"
+                summary+="$(printf '%s\n' "$messages" | sed -n "1,${max_messages_per_job}s/^/  - /p")"
                 if [ "$total" -gt "$max_messages_per_job" ]; then
                     summary+=$'\n'"  - ... and $((total - max_messages_per_job)) more (see the workflow run for full details)"
                 fi
@@ -566,7 +566,7 @@ jobs:
         fi
 
         # Safety-net truncation, on top of the per-job cap above.
-        summary=$(printf '%s' "$summary" | head -c 3000)
+        summary="${summary:0:3000}"
 
         # Status of every job (not just failed ones), icons matching GitHub's own.
         job_status=""
@@ -581,6 +581,8 @@ jobs:
             esac
             job_status+="${icon} ${job_name}"$'\n'
         done < <(printf '%s' "$jobs_json" | jq -r '.jobs[] | [.name, (.conclusion // "in_progress")] | @tsv')
+
+        job_status="${job_status:0:3000}"
 
         EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         {

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -519,9 +519,8 @@ jobs:
       actions: read
     steps:
     - name: Collect failure annotations
-      # Pulls the ::error:: annotations from every failed job in this run
-      # Jobs with no annotations (eg. failures that don't emit ::error::)
-      # get a generic fallback line instead of being silently omitted.
+      # Pulls ::error:: annotations from every failed job for the Slack
+      # message below; jobs with none get a generic fallback line.
       id: annotations
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -530,32 +529,23 @@ jobs:
       run: |
         set -euo pipefail
 
-        # Fetch the job list (may span multiple pages; gh emits each
-        # page's JSON body back-to-back, which jq processes as a
-        # stream of documents below)
+        # --paginate output is multiple JSON docs back-to-back; jq below
+        # handles that as a stream, no --slurp needed.
         jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate)
 
-        # Rendered inside a Slack code block (see "Send Slack notification"),
-        # so job names are plain text here, not mrkdwn-bolded. Caps the
-        # number of messages shown per job so one very chatty failure can't
-        # blow out the whole Slack message -- truncated jobs get an explicit
-        # "... and N more" marker rather than being silently cut off.
+        # Plain text: rendered inside a Slack code block, not mrkdwn.
         max_messages_per_job=10
         summary=""
         while IFS=$'\t' read -r job_id job_name failed_step; do
-            # Exclude the generic "Process completed with exit code N." annotation
-            # that GitHub Actions auto-adds to every failed step -- it's noise here.
-            # --paginate here too: a job with many broken sources can exceed
-            # the API's default 30-annotations-per-page limit.
+            # Exclude GitHub's generic "Process completed..." annotation (noise).
+            # --paginate: a job can have >30 annotations (API's page size).
             if ! messages=$(gh api "repos/${REPO}/check-runs/${job_id}/annotations" --paginate \
                 --jq '.[] | select(.annotation_level == "failure") | select(.message | test("^Process completed with exit code") | not) | .message'); then
-                # Distinguish a real API failure from "no annotations found"
-                # (handled below) so the two aren't silently conflated.
+                # Distinct fallback so an API failure isn't confused with "no annotations".
                 messages="(failed to fetch annotations for this job via the GitHub API; see the workflow run directly for details)"
             fi
 
-            # Blank line between job blocks (not before the first one) for
-            # readability when multiple jobs fail.
+            # Blank line between job blocks, but not before the first one.
             if [ -n "$summary" ]; then
                 summary+=$'\n\n'
             fi
@@ -575,14 +565,10 @@ jobs:
             summary="(no failed jobs found; see the workflow run for details)"
         fi
 
-        # Keep the Slack message readable and within size limits (safety net
-        # on top of the per-job cap above).
+        # Safety-net truncation, on top of the per-job cap above.
         summary=$(printf '%s' "$summary" | head -c 3000)
 
-        # Per-job status overview (all jobs, not just failed ones), using
-        # icons matching GitHub's own status indicators, so readers can see
-        # at a glance whether eg. upload-definitions actually published
-        # despite a validation failure elsewhere.
+        # Status of every job (not just failed ones), icons matching GitHub's own.
         job_status=""
         while IFS=$'\t' read -r job_name job_conclusion; do
             case "$job_conclusion" in
@@ -590,9 +576,7 @@ jobs:
                 skipped) icon="⏭️" ;;
                 cancelled) icon="🚫" ;;
                 in_progress) icon="🟡" ;; # null conclusion (eg. this job, still running)
-                # All other terminal, non-success conclusions GitHub can
-                # report for a job (per the Actions/Checks API): treat as
-                # failed rather than defaulting to "in progress".
+                # Other terminal conclusions (not success/skipped/cancelled) count as failed.
                 failure | timed_out | action_required | neutral | stale | startup_failure) icon="❌" ;;
                 *) icon="❔" ;; # genuinely unrecognized future conclusion value
             esac
@@ -614,10 +598,8 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Send Slack notification on workflow failure
-      # Runs even if "Collect failure annotations" itself failed (eg. the
-      # GitHub API call for the job list errored) -- a degraded, generic
-      # message still reaches on-call in that case, rather than nothing at
-      # all.
+      # Runs even if "Collect failure annotations" failed, so a degraded
+      # message still reaches on-call instead of nothing at all.
       if: always()
       env:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -513,10 +513,7 @@ jobs:
     - build-and-run
     - upload-definitions
     runs-on: ubuntu-latest
-    # TEMPORARY (test-only, do not merge): simplified to `failure()` so this
-    # fires from a scratch branch/dry-run test dispatch. Real condition:
-    # if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
-    if: failure()
+    if: ${{ failure() && github.ref_name == 'master' && (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') }}
     permissions:
       checks: read
       actions: read
@@ -572,11 +569,10 @@ jobs:
         WORKFLOW: ${{ github.workflow }}
         REPO: ${{ github.repository }}
         SUMMARY: ${{ steps.annotations.outputs.summary }}
-        # TEMPORARY (test-only, do not merge): real secret is SLACK_ONCALL_SCANNER_WEBHOOK.
-        SLACK_WEBHOOK: ${{ secrets.SLACK_CI_INTEGRATION_TESTING_WEBHOOK }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
       run: |
         set -euo pipefail
-        text=$(printf '[TEST - Please Ignore]\n\n<%s|Workflow %s> failed in repository %s: Failed to update vulnerabilities\n%s' \
+        text=$(printf '<%s|Workflow %s> failed in repository %s: Failed to update vulnerabilities\n%s' \
             "$RUN_URL" "$WORKFLOW" "$REPO" "$SUMMARY")
         jq -n --arg text "$text" '{text: $text}' \
             | curl -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK"


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Rewrites the `send-notification` job in `scanner-versioned-definitions-update.yaml`
so Slack failure alerts actually say what broke, instead of one static
"Failed to update vulnerabilities" line. The new message includes:

- a per-job status overview (icons matching GitHub's own job-status icons)
- which step failed in each failed job, plus the real `::error::` messages
  for it (pulled from the run's check-run annotations)

Notes:
- The "Send Slack notification" step runs with `if: always()` and checks
  the outcome of the annotation-collection step. If that step itself fails
  (e.g. API error), a degraded but still-informative message is sent
  instead of nothing at all.
- Per-job error messages are capped (10 messages/job, ~3000 chars total)
  with a "...and N more" marker, to avoid an oversized/truncated Slack
  message.
- The Slack `curl` call intentionally has no `--retry`, to avoid the risk
  of posting the same failure notification twice.


## User-facing documentation

- [X] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [X] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [X] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [X] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

This is N/A since it is a github actiosn workflow.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- Local testing `bash/jq` commands
- Triggered the real workflow via `workflow_dispatch` to send the message to the #acs-slack-ci-integration-testing channel. Here is a sample message: https://redhat-internal.slack.com/archives/C068WMY4SEQ/p1784840370084269

