### PR TITLE
ROX-35932: adds AI workload central API service

### DIFF
--- a/central/aiworkload/service/service.go
+++ b/central/aiworkload/service/service.go
@@ -1,0 +1,11 @@
+package service
+
+import (
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/pkg/grpc"
+)
+
+type Service interface {
+	grpc.APIService
+	v2.AIWorkloadServiceServer
+}

--- a/central/aiworkload/service/service_impl.go
+++ b/central/aiworkload/service/service_impl.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	aiWorkloadDataStore "github.com/stackrox/rox/central/aiworkload/datastore"
+	"github.com/stackrox/rox/central/convert/storagetov2"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/grpc/authz"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
+	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
+	"google.golang.org/grpc"
+)
+
+const defaultPageSize = 100
+
+var authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
+	user.With(permissions.View(resources.AIWorkload)): {
+		"/v2.AIWorkloadService/GetAIWorkload",
+		"/v2.AIWorkloadService/ListAIWorkloads",
+	},
+})
+
+type serviceImpl struct {
+	v2.UnimplementedAIWorkloadServiceServer
+	datastore aiWorkloadDataStore.DataStore
+}
+
+func New(datastore aiWorkloadDataStore.DataStore) Service {
+	return &serviceImpl{datastore: datastore}
+}
+
+func (s *serviceImpl) RegisterServiceServer(server *grpc.Server) {
+	v2.RegisterAIWorkloadServiceServer(server, s)
+}
+
+func (s *serviceImpl) RegisterServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return v2.RegisterAIWorkloadServiceHandler(ctx, mux, conn)
+}
+
+func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, authorizer.Authorized(ctx, fullMethodName)
+}
+
+func (s *serviceImpl) GetAIWorkload(ctx context.Context, req *v2.GetAIWorkloadRequest) (*v2.AIWorkload, error) {
+	workload, found, err := s.datastore.GetAIWorkload(ctx, req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errox.NotFound.Newf("AI workload %q not found", req.GetId())
+	}
+	return storagetov2.AIWorkload(workload), nil
+}
+
+func (s *serviceImpl) ListAIWorkloads(ctx context.Context, req *v2.ListAIWorkloadsRequest) (*v2.ListAIWorkloadsResponse, error) {
+	searchQuery, err := search.ParseQuery(req.GetQuery().GetQuery(), search.MatchAllIfEmpty())
+	if err != nil {
+		return nil, err
+	}
+
+	countQuery := searchQuery.CloneVT()
+	count, err := s.datastore.CountAIWorkloads(ctx, countQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	paginated.FillPaginationV2(searchQuery, req.GetQuery().GetPagination(), defaultPageSize)
+	workloads, err := s.datastore.SearchRawAIWorkloads(ctx, searchQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*v2.AIWorkload, 0, len(workloads))
+	for _, w := range workloads {
+		result = append(result, storagetov2.AIWorkload(w))
+	}
+	return &v2.ListAIWorkloadsResponse{
+		AiWorkloads: result,
+		TotalCount:  int32(count),
+	}, nil
+}

--- a/central/aiworkload/service/service_impl_test.go
+++ b/central/aiworkload/service/service_impl_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	aiWorkloadDSMocks "github.com/stackrox/rox/central/aiworkload/datastore/mocks"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetAIWorkload(t *testing.T) {
+	tests := map[string]struct {
+		setupMocks   func(*aiWorkloadDSMocks.MockDataStore)
+		request      *v2.GetAIWorkloadRequest
+		expectsError bool
+		validate     func(t *testing.T, result *v2.AIWorkload)
+	}{
+		"returns workload when found": {
+			setupMocks: func(ds *aiWorkloadDSMocks.MockDataStore) {
+				ds.EXPECT().GetAIWorkload(gomock.Any(), "test-id").Return(&storage.AIWorkload{
+					Id:          "test-id",
+					Name:        "test-model",
+					Namespace:   "ai-project",
+					ModelFormat: "vLLM",
+				}, true, nil)
+			},
+			request: &v2.GetAIWorkloadRequest{Id: "test-id"},
+			validate: func(t *testing.T, result *v2.AIWorkload) {
+				assert.Equal(t, "test-id", result.GetId())
+				assert.Equal(t, "test-model", result.GetName())
+				assert.Equal(t, "vLLM", result.GetModelFormat())
+			},
+		},
+		"returns not found error when missing": {
+			setupMocks: func(ds *aiWorkloadDSMocks.MockDataStore) {
+				ds.EXPECT().GetAIWorkload(gomock.Any(), "missing-id").Return(nil, false, nil)
+			},
+			request:      &v2.GetAIWorkloadRequest{Id: "missing-id"},
+			expectsError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ds := aiWorkloadDSMocks.NewMockDataStore(ctrl)
+			tc.setupMocks(ds)
+
+			svc := &serviceImpl{datastore: ds}
+			result, err := svc.GetAIWorkload(context.Background(), tc.request)
+			if tc.expectsError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				tc.validate(t, result)
+			}
+		})
+	}
+}
+
+func TestListAIWorkloads(t *testing.T) {
+	tests := map[string]struct {
+		setupMocks func(*aiWorkloadDSMocks.MockDataStore)
+		request    *v2.ListAIWorkloadsRequest
+		validate   func(t *testing.T, result *v2.ListAIWorkloadsResponse)
+	}{
+		"returns workloads": {
+			setupMocks: func(ds *aiWorkloadDSMocks.MockDataStore) {
+				ds.EXPECT().CountAIWorkloads(gomock.Any(), gomock.Any()).Return(2, nil)
+				ds.EXPECT().SearchRawAIWorkloads(gomock.Any(), gomock.Any()).Return([]*storage.AIWorkload{
+					{Id: "1", Name: "model-a", ModelFormat: "vLLM"},
+					{Id: "2", Name: "model-b", ModelFormat: "pytorch"},
+				}, nil)
+			},
+			request: &v2.ListAIWorkloadsRequest{},
+			validate: func(t *testing.T, result *v2.ListAIWorkloadsResponse) {
+				assert.Equal(t, int32(2), result.GetTotalCount())
+				require.Len(t, result.GetAiWorkloads(), 2)
+				assert.Equal(t, "model-a", result.GetAiWorkloads()[0].GetName())
+				assert.Equal(t, "model-b", result.GetAiWorkloads()[1].GetName())
+			},
+		},
+		"returns empty list": {
+			setupMocks: func(ds *aiWorkloadDSMocks.MockDataStore) {
+				ds.EXPECT().CountAIWorkloads(gomock.Any(), gomock.Any()).Return(0, nil)
+				ds.EXPECT().SearchRawAIWorkloads(gomock.Any(), gomock.Any()).Return(nil, nil)
+			},
+			request: &v2.ListAIWorkloadsRequest{},
+			validate: func(t *testing.T, result *v2.ListAIWorkloadsResponse) {
+				assert.Equal(t, int32(0), result.GetTotalCount())
+				assert.Empty(t, result.GetAiWorkloads())
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ds := aiWorkloadDSMocks.NewMockDataStore(ctrl)
+			tc.setupMocks(ds)
+
+			svc := &serviceImpl{datastore: ds}
+			result, err := svc.ListAIWorkloads(context.Background(), tc.request)
+			require.NoError(t, err)
+			tc.validate(t, result)
+		})
+	}
+}

--- a/central/aiworkload/service/singleton.go
+++ b/central/aiworkload/service/singleton.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"github.com/stackrox/rox/central/aiworkload/datastore"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	once sync.Once
+	as   Service
+)
+
+func initialize() {
+	as = New(datastore.Singleton())
+}
+
+func Singleton() Service {
+	once.Do(initialize)
+	return as
+}

--- a/central/main.go
+++ b/central/main.go
@@ -16,6 +16,7 @@ import (
 	administrationUsageDataStore "github.com/stackrox/rox/central/administration/usage/datastore/securedunits"
 	administrationUsageInjector "github.com/stackrox/rox/central/administration/usage/injector"
 	administrationUsageService "github.com/stackrox/rox/central/administration/usage/service"
+	aiworkloadService "github.com/stackrox/rox/central/aiworkload/service"
 	alertDatastore "github.com/stackrox/rox/central/alert/datastore"
 	alertService "github.com/stackrox/rox/central/alert/service"
 	apitokenDS "github.com/stackrox/rox/central/apitoken/datastore"
@@ -503,6 +504,10 @@ func servicesToRegister() []pkgGRPC.APIService {
 		} else {
 			servicesToRegister = append(servicesToRegister, virtualmachineService.Singleton())
 		}
+	}
+
+	if features.AIWorkloads.Enabled() {
+		servicesToRegister = append(servicesToRegister, aiworkloadService.Singleton())
 	}
 
 	if features.BaseImageDetection.Enabled() {


### PR DESCRIPTION
## Description

Exposes the stored AI workload data to external consumers. Adds a read-only gRPC/REST service with GET /v2/aiworkloads (search/filter/paginate) and GET /v2/aiworkloads/{id}. Both endpoints require View(AIWorkload) permission. The service is conditionally registered behind the feature flag so it has zero impact when disabled.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
