### PR TITLE
ROX-35848: fetch KubeVirt CA on every handshake (roxagent)

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/tls.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls.go
@@ -25,10 +25,7 @@ const (
 	kubevirtCACID  = 2
 	kubevirtCAPort = 1
 
-	// defaultRefreshInterval is the staleness threshold that forces a
-	// handshake-triggered refetch (see CARefresher doc comment).
-	defaultRefreshInterval = 1 * time.Hour
-	defaultFetchTimeout    = 10 * time.Second
+	defaultFetchTimeout = 10 * time.Second
 
 	// gRPC method for the KubeVirt System.CABundle RPC.
 	// Proto: kubevirt.io/kubevirt/pkg/vsock/system/v1/system.proto
@@ -156,52 +153,27 @@ func extractBundleRaw(data []byte) ([]byte, error) {
 // virt-handler's client certificate during the VSOCK TLS handshake.
 //
 // KubeVirt's System.CABundle service is not always permanently available.
-// In VSOCK "global" mode it is: a single instance runs on CID 2/port 1 for
-// the lifetime of the node. In namespace-isolated ("local") mode -
-// introduced by KubeVirt VEP 222, see
+// In namespace-isolated VSOCK mode (KubeVirt VEP 222) the service exists
+// only for the duration of a virt-handler dial+handshake, so the fetch
+// must happen inside the handshake itself. See:
 // https://github.com/kubevirt/enhancements/blob/main/veps/sig-compute/222-vsock-netns-vep/vsock-netns-vep.md#change-4-on-demand-vsock-ca-service
-// and merged in https://github.com/kubevirt/kubevirt/pull/18067 - the
-// service exists only for the duration of a single virt-handler
-// dial+handshake (see pkg/virt-handler/vsock/{dial,servers,refcount}.go in
-// kubevirt/kubevirt) and is torn down immediately after. A fetch on any
-// independent schedule (a timer, or "once at startup") has no relationship
-// to that window and will, in practice, almost always miss it. The VEP
-// itself describes the intended fix: "This happens as part of the TLS
-// negotiation - no explicit synchronization between virt-handler and the
-// guest is needed", i.e. the fetch belongs inside the handshake, not
-// alongside it.
 //
-// CARefresher's cache is therefore populated reactively, and only
-// reactively: TLSConfig's GetConfigForClient callback calls
-// ensureFreshPool, which fetches inline, synchronously, as part of the
-// handshake itself - guaranteeing the fetch happens exactly when a window
-// (if one is needed at all) is open, because the incoming connection *is*
-// what opens it. This works unchanged in "global" mode too, since the
-// service is always reachable there.
-//
-// server.go's semaphore keeps ensureFreshPool single-caller in the
-// supported topology (one Sensor poller; see maxConcurrentConns). r.mu
-// still serializes every cache read/swap, so concurrent callers would
-// only pay for redundant fetches - never observe a corrupted pool.
+// ensureFreshPool fetches the CA on every handshake and falls back to the
+// cached pool when the fetch fails. This keeps the CA current across
+// rotations without requiring a separate cache-invalidation or retry
+// mechanism.
 type CARefresher struct {
-	mu        sync.RWMutex
-	pool      *x509.CertPool
-	fetchedAt time.Time
+	mu   sync.RWMutex
+	pool *x509.CertPool
 
-	interval     time.Duration
 	fetchTimeout time.Duration
 	fetchCA      func(ctx context.Context) ([]byte, error)
 }
 
-// NewCARefresher creates a refresher with an empty cache. There is no
-// separate warm-up step: the cache warms itself lazily on the first call
-// to TLSConfig's GetConfigForClient. An independent fetch attempt ahead of
-// a real handshake would have no relationship to KubeVirt's on-demand CA
-// window in namespace-isolated VSOCK mode anyway, so it would just be
-// wasted effort - see the CARefresher doc comment.
+// NewCARefresher creates a refresher with an empty cache. The cache
+// warms lazily on the first TLS handshake via GetConfigForClient.
 func NewCARefresher(opts ...CARefresherOption) *CARefresher {
 	r := &CARefresher{
-		interval:     defaultRefreshInterval,
 		fetchTimeout: defaultFetchTimeout,
 		fetchCA:      fetchKubeVirtCA,
 	}
@@ -225,38 +197,23 @@ func WithFetchFunc(f func(ctx context.Context) ([]byte, error)) CARefresherOptio
 	return func(r *CARefresher) { r.fetchCA = f }
 }
 
-// ensureFreshPool returns the cached CA pool if it is populated and not
-// older than r.interval, fetching a new one otherwise. See the CARefresher
-// doc comment for the single-caller assumption and how r.mu protects the
-// cache.
-//
-// A failed (re)fetch is not fatal as long as some pool - however stale - is
-// already cached: certificates signed by an old CA remain valid until they
-// individually expire, so serving the last known-good pool is strictly more
-// available than failing every handshake until the next successful fetch.
-// Only a cache that has never been populated even once - the state at boot,
-// before any fetch has ever succeeded - propagates the error, since there is
-// then truly nothing to validate a handshake against.
+// ensureFreshPool fetches a fresh CA on every call and falls back to
+// the cached pool when the fetch fails. Only a cold cache with no
+// prior successful fetch propagates the error.
 func (r *CARefresher) ensureFreshPool(ctx context.Context) (*x509.CertPool, error) {
-	if pool, ok := r.freshCachedPool(); ok {
-		return pool, nil
-	}
-
 	pool, err := r.fetchAndCachePool(ctx)
 	if err == nil {
 		return pool, nil
 	}
-	if stale, fetchedAt, ok := r.cachedPool(); ok {
-		log.Warnf("KubeVirt CA refresh failed, reusing last known-good CA (age: %v): %v",
-			time.Since(fetchedAt), err)
-		return stale, nil
+	if cached, ok := r.cachedPool(); ok {
+		log.Warnf("KubeVirt CA fetch failed, reusing cached pool: %v", err)
+		return cached, nil
 	}
-	return nil, err
+	return nil, fmt.Errorf("no CA pool cached and fetch failed: %w", err)
 }
 
 // fetchAndCachePool fetches a fresh CA bundle from KubeVirt, parses it, and
-// swaps it into the cache under r.mu's write lock. It returns the pool it
-// just wrote so the caller does not need a second locked read of r.pool.
+// swaps it into the cache under r.mu's write lock.
 func (r *CARefresher) fetchAndCachePool(ctx context.Context) (*x509.CertPool, error) {
 	// ctx belongs to the caller whose handshake triggered this fetch. If
 	// that handshake is torn down mid-fetch, ctx is cancelled - but the
@@ -278,67 +235,47 @@ func (r *CARefresher) fetchAndCachePool(ctx context.Context) (*x509.CertPool, er
 
 	concurrency.WithLock(&r.mu, func() {
 		r.pool = newPool
-		r.fetchedAt = time.Now()
 	})
 	log.Info("KubeVirt CA refreshed successfully")
 	return newPool, nil
 }
 
-// freshCachedPool returns the cached pool and true if it is populated and
-// not older than r.interval.
-func (r *CARefresher) freshCachedPool() (*x509.CertPool, bool) {
-	return concurrency.WithRLock2(&r.mu, func() (*x509.CertPool, bool) {
-		if r.pool == nil || time.Since(r.fetchedAt) >= r.interval {
-			return nil, false
-		}
-		return r.pool, true
-	})
-}
-
-// cachedPool returns the cached pool, the time it was fetched, and true if
-// it is populated, regardless of staleness. There is currently no maximum
-// age past which a cached pool stops being reused here - a stale pool is
-// always preferred over failing handshakes closed - so fetchedAt exists
-// purely for observability (see ensureFreshPool's fallback log line) rather
-// than to bound anything.
-func (r *CARefresher) cachedPool() (*x509.CertPool, time.Time, bool) {
+// cachedPool returns the cached pool and true if it is populated.
+// A stale pool is always preferred over failing handshakes.
+func (r *CARefresher) cachedPool() (*x509.CertPool, bool) {
 	type result struct {
-		pool      *x509.CertPool
-		fetchedAt time.Time
-		ok        bool
+		pool *x509.CertPool
+		ok   bool
 	}
 	res := concurrency.WithRLock1(&r.mu, func() result {
-		return result{pool: r.pool, fetchedAt: r.fetchedAt, ok: r.pool != nil}
+		return result{pool: r.pool, ok: r.pool != nil}
 	})
-	return res.pool, res.fetchedAt, res.ok
+	return res.pool, res.ok
 }
 
 // TLSConfig returns a *tls.Config that presents serverCert and validates
-// KubeVirt client certs. The returned config fetches a fresh CA pool on
-// each handshake via GetConfigForClient whenever the cache is empty or
-// stale - see the CARefresher doc comment for why this, not any
-// independent schedule, is what makes CA verification actually work in
-// namespace-isolated VSOCK mode.
+// KubeVirt client certs. GetConfigForClient fetches a fresh CA on every
+// handshake and returns a config with the latest ClientCAs.
+// Go's standard RequireAndVerifyClientCert handles verification.
 //
-// serverCert is baked in at construction time rather than left for the
-// caller to set on the returned config afterward, so there is no window in
-// which a config with no certificate could be handed to a listener.
+// SessionTicketsDisabled prevents TLS 1.2 session resumption from
+// skipping client certificate verification on reconnect.
 func (r *CARefresher) TLSConfig(serverCert tls.Certificate) *tls.Config {
-	return &tls.Config{
-		Certificates: []tls.Certificate{serverCert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS12,
-		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-			pool, err := r.ensureFreshPool(info.Context())
-			if err != nil {
-				return nil, fmt.Errorf("fetching KubeVirt CA for TLS handshake: %w", err)
-			}
-			return &tls.Config{
-				Certificates: []tls.Certificate{serverCert},
-				ClientAuth:   tls.RequireAndVerifyClientCert,
-				ClientCAs:    pool,
-				MinVersion:   tls.VersionTLS12,
-			}, nil
-		},
+	cfg := &tls.Config{
+		Certificates:           []tls.Certificate{serverCert},
+		ClientAuth:             tls.RequireAndVerifyClientCert,
+		MinVersion:             tls.VersionTLS12,
+		SessionTicketsDisabled: true,
 	}
+	cfg.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+		pool, err := r.ensureFreshPool(info.Context())
+		if err != nil {
+			return nil, fmt.Errorf("fetching KubeVirt CA for TLS handshake: %w", err)
+		}
+		c := cfg.Clone()
+		c.GetConfigForClient = nil
+		c.ClientCAs = pool
+		return c, nil
+	}
+	return cfg
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/tls_test.go
@@ -108,36 +108,12 @@ func TestCARefresher_InvalidPEM(t *testing.T) {
 
 	_, err := r.ensureFreshPool(context.Background())
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "no valid certificates")
-}
-
-func TestCARefresher_HandshakeFetchesOnColdCache(t *testing.T) {
-	caPEM, caCert, caKey := testCA(t)
-
-	var fetchCount atomic.Int32
-	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
-		fetchCount.Add(1)
-		return caPEM, nil
-	}))
-
-	// The cache starts out completely cold, mirroring roxagent immediately
-	// after boot in KubeVirt's namespace-isolated VSOCK mode, where the CA
-	// service does not exist until a real connection arrives. What's under
-	// test is that the handshake itself - not any independent warm-up -
-	// is what populates the cache.
-	serverCert := testServerCert(t)
-	clientCert := testLeafCert(t, caCert, caKey)
-	doTLSHandshake(t, r, serverCert, clientCert)
-
-	assert.Equal(t, int32(1), fetchCount.Load(), "the handshake should have triggered exactly one fetch")
+	assert.ErrorContains(t, err, "no CA pool cached and fetch failed")
 }
 
 func TestCARefresher_HandshakeFailsWhenCAServiceUnavailable(t *testing.T) {
 	caPEM, caCert, caKey := testCA(t)
 
-	// available toggles whether the fake CA service is reachable, modeling
-	// KubeVirt's on-demand System.CABundle service existing only for the
-	// duration of a virt-handler dial+handshake.
 	var available atomic.Bool
 	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
 		if !available.Load() {
@@ -146,50 +122,22 @@ func TestCARefresher_HandshakeFailsWhenCAServiceUnavailable(t *testing.T) {
 		return caPEM, nil
 	}))
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = ln.Close() }()
-
-	tlsCfg := r.TLSConfig(testServerCert(t))
+	serverCert := testServerCert(t)
 	clientCert := testLeafCert(t, caCert, caKey)
 	clientTLS := &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true}
 
-	dial := func() error {
-		serverErr := make(chan error, 1)
-		go func() {
-			conn, err := ln.Accept()
-			if err != nil {
-				serverErr <- err
-				return
-			}
-			tlsConn := tls.Server(conn, tlsCfg)
-			err = tlsConn.Handshake()
-			_ = tlsConn.Close()
-			serverErr <- err
-		}()
-
-		clientConn, dialErr := tls.Dial("tcp", ln.Addr().String(), clientTLS)
-		if dialErr == nil {
-			_ = clientConn.Close()
-		}
-		return <-serverErr
-	}
-
-	// CA service "closed": the handshake must fail, not fall back to some
-	// stale/empty pool.
 	available.Store(false)
-	assert.Error(t, dial(), "handshake should fail while the CA service is unavailable")
+	assert.Error(t, dialTLS(t, r, serverCert, clientTLS), "handshake should fail while the CA service is unavailable")
 
-	// CA service "open": the very next handshake must succeed, with no
-	// independent warm-up ever having occurred.
 	available.Store(true)
-	assert.NoError(t, dial(), "handshake should succeed once the CA service becomes available")
+	assert.NoError(t, dialTLS(t, r, serverCert, clientTLS), "handshake should succeed once the CA service becomes available")
 }
 
 // TestCARefresher_ConcurrentHandshakesEachGetValidPool calls
 // ensureFreshPool directly from several goroutines at once, bypassing
 // server.go's semaphore (which limits the agent to one in-flight
-// connection) to exercise the defensive path when multiple connections are established in parallel.
+// connection) to exercise the defensive path when multiple connections are
+// established in parallel.
 func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		caPEM, caCert, caKey := testCA(t)
@@ -198,7 +146,7 @@ func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 		fetchesMayProceed := concurrency.NewSignal()
 		r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
 			fetchCount.Add(1)
-			fetchesMayProceed.Wait() // block until the test says all callers have arrived
+			fetchesMayProceed.Wait()
 			return caPEM, nil
 		}))
 
@@ -215,11 +163,9 @@ func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 			}()
 		}
 
-		synctest.Wait() // Wait until all callers are blocked on fetchesMayProceed.Wait
+		synctest.Wait()
 		fetchesMayProceed.Signal()
 
-		// A leaf cert signed by the fetched CA must verify against every
-		// pool handed back. Corrupted pool would fail this assertion.
 		leaf := testLeafCert(t, caCert, caKey)
 		leafCert, err := x509.ParseCertificate(leaf.Certificate[0])
 		require.NoError(t, err)
@@ -236,16 +182,15 @@ func TestCARefresher_ConcurrentHandshakesEachGetValidPool(t *testing.T) {
 		}
 		assert.GreaterOrEqual(t, fetchCount.Load(), int32(1), "at least one caller must have triggered a fetch")
 
-		finalPool, _, ok := r.cachedPool()
+		finalPool, ok := r.cachedPool()
 		require.True(t, ok, "cache must be populated after concurrent fetches complete")
 		require.NotNil(t, finalPool)
 	})
 }
 
-// TestCARefresher_Refresh proves that a stale cache is picked up and fully
-// rotated by the handshake path itself - there is no background loop left
-// to drive a second fetch, so ensureFreshPool being called from
-// GetConfigForClient during a real handshake is the only thing that can.
+// TestCARefresher_Refresh proves that every handshake fetches the latest
+// CA. When the CA service starts returning a new bundle, the very next
+// handshake picks it up and the old CA is fully rotated out.
 func TestCARefresher_Refresh(t *testing.T) {
 	ca1PEM, ca1Cert, ca1Key := testCA(t)
 	ca2PEM, ca2Cert, ca2Key := testCA(t)
@@ -260,30 +205,23 @@ func TestCARefresher_Refresh(t *testing.T) {
 			return ca2PEM, nil
 		}),
 	)
-	// Warm the cache with CA1 via a direct call.
+
 	_, err := r.ensureFreshPool(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, int32(1), callCount.Load())
 
-	// Force cache stale.
-	r.fetchedAt = time.Time{}
-
-	// The second CA is now active, fetched by the handshake below.
 	serverCert := testServerCert(t)
 	clientCert := testLeafCert(t, ca2Cert, ca2Key)
 	doTLSHandshake(t, r, serverCert, clientCert)
-	assert.Equal(t, int32(2), callCount.Load(), "the stale handshake should have triggered exactly one refetch")
+	assert.Equal(t, int32(2), callCount.Load(), "handshake must trigger a fresh fetch")
 
-	// The first CA was fully rotated out (not merely appended to): a
-	// refresher bug that unioned pools instead of replacing them would pass
-	// unnoticed without this assertion.
 	oldClientCert := testLeafCert(t, ca1Cert, ca1Key)
-	doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+	err = doTLSHandshakeFails(t, r, serverCert, oldClientCert)
+	require.Error(t, err)
 }
 
-// TestCARefresher_RefreshFailure_KeepsOldCA proves that a failed refetch,
-// triggered by a stale-cache handshake, falls back to the last known-good
-// CA rather than failing the handshake outright.
+// TestCARefresher_RefreshFailure_KeepsOldCA proves that a failed fetch
+// falls back to the cached pool rather than failing the handshake.
 func TestCARefresher_RefreshFailure_KeepsOldCA(t *testing.T) {
 	caPEM, caCert, caKey := testCA(t)
 
@@ -297,64 +235,20 @@ func TestCARefresher_RefreshFailure_KeepsOldCA(t *testing.T) {
 			return nil, assert.AnError
 		}),
 	)
-	// Warm the cache with the original CA via a direct call.
+
 	_, err := r.ensureFreshPool(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, int32(1), callCount.Load())
 
-	// Force cache stale.
-	r.fetchedAt = time.Time{}
-
-	// Original CA should still work.
 	serverCert := testServerCert(t)
 	clientCert := testLeafCert(t, caCert, caKey)
 	doTLSHandshake(t, r, serverCert, clientCert)
-	assert.Equal(t, int32(2), callCount.Load(), "the stale handshake should have attempted a refetch")
-}
-
-// TestCARefresher_StaleCacheTriggersRefetchDuringHandshake proves the
-// minimal case: a stale cache is refetched by ensureFreshPool being called
-// from GetConfigForClient during a real handshake. TestCARefresher_Refresh
-// covers the same mechanism plus full CA rotation (old CA fully replaced,
-// not unioned with the new one).
-func TestCARefresher_StaleCacheTriggersRefetchDuringHandshake(t *testing.T) {
-	ca1PEM, _, _ := testCA(t)
-	ca2PEM, ca2Cert, ca2Key := testCA(t)
-
-	var fetchCount atomic.Int32
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) {
-			if fetchCount.Add(1) == 1 {
-				return ca1PEM, nil
-			}
-			return ca2PEM, nil
-		}),
-	)
-	// Warm the cache with CA1 via a direct call.
-	_, err := r.ensureFreshPool(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, int32(1), fetchCount.Load())
-
-	// Force cache stale.
-	r.fetchedAt = time.Time{}
-
-	// The next handshake presents a CA2-signed client cert. It can only
-	// succeed if the handshake path itself noticed the staleness and
-	// fetched a replacement pool inline.
-	serverCert := testServerCert(t)
-	clientCert := testLeafCert(t, ca2Cert, ca2Key)
-	doTLSHandshake(t, r, serverCert, clientCert)
-
-	assert.Equal(t, int32(2), fetchCount.Load(), "the stale handshake should have triggered exactly one refetch")
+	assert.Equal(t, int32(2), callCount.Load(), "fetch was attempted despite failure")
 }
 
 // TestCARefresher_OverlapBundleTrustsBothOldAndNewCA models KubeVirt's real
 // rotation behavior: during the overlap window, the CA service returns a
-// bundle containing *both* the old and new CA concatenated (not a hard swap
-// from one to the other), specifically so nothing already holding an
-// old-CA-signed cert breaks mid-rotation. AppendCertsFromPEM and
-// x509.CertPool both natively support multiple CAs in one bundle, so this is
-// mostly a regression/documentation test rather than new capability.
+// bundle containing *both* the old and new CA concatenated.
 func TestCARefresher_OverlapBundleTrustsBothOldAndNewCA(t *testing.T) {
 	oldCAPEM, oldCACert, oldCAKey := testCA(t)
 	newCAPEM, newCACert, newCAKey := testCA(t)
@@ -373,34 +267,96 @@ func TestCARefresher_OverlapBundleTrustsBothOldAndNewCA(t *testing.T) {
 	doTLSHandshake(t, r, serverCert, newClientCert)
 }
 
-func TestCARefresher_TLSHandshake(t *testing.T) {
+// TestCARefresher_HardCutover covers KubeVirt hard CA cutover: the CA
+// service starts serving a new CA bundle while the cache still holds the
+// old one. The always-fetch approach means the very next handshake picks
+// up the new CA without any retry logic.
+//
+// Acceptance criterion (ROX-35848): simulated rotation — the first
+// handshake after rotation succeeds immediately.
+func TestCARefresher_HardCutover(t *testing.T) {
+	ca1PEM, ca1Cert, ca1Key := testCA(t)
+	ca2PEM, ca2Cert, ca2Key := testCA(t)
+
+	var fetchCount atomic.Int32
+	r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+		n := fetchCount.Add(1)
+		if n == 1 {
+			return ca1PEM, nil
+		}
+		return ca2PEM, nil
+	}))
+
+	serverCert := testServerCert(t)
+
+	client1 := testLeafCert(t, ca1Cert, ca1Key)
+	doTLSHandshake(t, r, serverCert, client1)
+	require.Equal(t, int32(1), fetchCount.Load())
+
+	client2 := testLeafCert(t, ca2Cert, ca2Key)
+	doTLSHandshake(t, r, serverCert, client2)
+	assert.Equal(t, int32(2), fetchCount.Load(),
+		"handshake after CA rotation fetches the new CA and succeeds immediately")
+
+	// Old CA must no longer verify — proves replacement, not union.
+	err := doTLSHandshakeFails(t, r, serverCert, client1)
+	require.Error(t, err)
+}
+
+// TestCARefresher_TLSHandshake_ClientCertScenarios covers how the first
+// handshake against a cold cache resolves for different client certificate
+// presentations. Every case fetches the CA exactly once via
+// GetConfigForClient; Go's standard RequireAndVerifyClientCert handles
+// verification — there is no custom retry.
+func TestCARefresher_TLSHandshake_ClientCertScenarios(t *testing.T) {
 	caPEM, caCert, caKey := testCA(t)
-
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) { return caPEM, nil }),
-	)
-
-	serverCert := testServerCert(t)
-	clientCert := testLeafCert(t, caCert, caKey)
-	doTLSHandshake(t, r, serverCert, clientCert)
-}
-
-func TestCARefresher_TLSHandshake_WrongCA(t *testing.T) {
-	caPEM, _, _ := testCA(t)
 	_, wrongCACert, wrongCAKey := testCA(t)
+	correctLeaf := testLeafCert(t, caCert, caKey)
+	wrongLeaf := testLeafCert(t, wrongCACert, wrongCAKey)
 
-	r := NewCARefresher(
-		WithFetchFunc(func(context.Context) ([]byte, error) { return caPEM, nil }),
-	)
+	tests := map[string]struct {
+		clientTLS   *tls.Config
+		wantErr     bool
+		wantFetches int32
+	}{
+		"cert signed by the current CA succeeds": {
+			clientTLS:   &tls.Config{Certificates: []tls.Certificate{correctLeaf}, InsecureSkipVerify: true},
+			wantFetches: 1,
+		},
+		"cert signed by an unrelated CA fails": {
+			clientTLS:   &tls.Config{Certificates: []tls.Certificate{wrongLeaf}, InsecureSkipVerify: true},
+			wantErr:     true,
+			wantFetches: 1,
+		},
+		"no certificate is rejected": {
+			clientTLS:   &tls.Config{InsecureSkipVerify: true},
+			wantErr:     true,
+			wantFetches: 1,
+		},
+	}
 
-	serverCert := testServerCert(t)
-	wrongClientCert := testLeafCert(t, wrongCACert, wrongCAKey)
-	doTLSHandshakeFails(t, r, serverCert, wrongClientCert)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var fetchCount atomic.Int32
+			r := NewCARefresher(WithFetchFunc(func(context.Context) ([]byte, error) {
+				fetchCount.Add(1)
+				return caPEM, nil
+			}))
+
+			err := dialTLS(t, r, testServerCert(t), tc.clientTLS)
+			if !tc.wantErr {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			assert.Equal(t, tc.wantFetches, fetchCount.Load())
+		})
+	}
 }
 
-// doTLSHandshake performs a full TLS handshake between a server using the
-// refresher's TLS config and a client presenting the given cert.
-func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) {
+// dialTLS runs a server using r's TLS config against a client dialing with
+// clientTLS, and returns the server side's handshake result.
+func dialTLS(t *testing.T, r *CARefresher, serverCert tls.Certificate, clientTLS *tls.Config) error {
 	t.Helper()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -422,52 +378,28 @@ func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Cer
 		serverErr <- err
 	}()
 
-	clientTLS := &tls.Config{
-		Certificates:       []tls.Certificate{clientCert},
-		InsecureSkipVerify: true,
-	}
-	clientConn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
-	require.NoError(t, err, "client dial should succeed")
-	_ = clientConn.Close()
-
-	require.NoError(t, <-serverErr, "server handshake should succeed")
-}
-
-// doTLSHandshakeFails performs a TLS handshake between a server using the
-// refresher's TLS config and a client presenting the given cert, and asserts
-// that the server-side handshake is rejected (e.g. because clientCert isn't
-// signed by any CA in the refresher's currently active pool).
-func doTLSHandshakeFails(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) {
-	t.Helper()
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer func() { _ = ln.Close() }()
-
-	tlsCfg := r.TLSConfig(serverCert)
-
-	serverErr := make(chan error, 1)
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			serverErr <- err
-			return
-		}
-		tlsConn := tls.Server(conn, tlsCfg)
-		serverErr <- tlsConn.Handshake()
-		_ = tlsConn.Close()
-	}()
-
-	clientTLS := &tls.Config{
-		Certificates:       []tls.Certificate{clientCert},
-		InsecureSkipVerify: true,
-	}
-	clientConn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
-	if err == nil {
+	clientConn, dialErr := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if dialErr == nil {
 		_ = clientConn.Close()
 	}
+	return <-serverErr
+}
 
-	assert.Error(t, <-serverErr, "server handshake should fail")
+// doTLSHandshake performs a full TLS handshake between a server using the
+// refresher's TLS config and a client presenting the given cert.
+func doTLSHandshake(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) {
+	t.Helper()
+	clientTLS := &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true}
+	require.NoError(t, dialTLS(t, r, serverCert, clientTLS), "server handshake should succeed")
+}
+
+// doTLSHandshakeFails is doTLSHandshake for the rejection path.
+func doTLSHandshakeFails(t *testing.T, r *CARefresher, serverCert, clientCert tls.Certificate) error {
+	t.Helper()
+	clientTLS := &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true}
+	err := dialTLS(t, r, serverCert, clientTLS)
+	assert.Error(t, err, "server handshake should fail")
+	return err
 }
 
 func TestExtractBundleRaw(t *testing.T) {
@@ -511,15 +443,13 @@ func TestExtractBundleRaw(t *testing.T) {
 			wantRaw: payload,
 		},
 		"truncated tag (mid-varint cutoff)": {
-			// 0x80 has its continuation bit set but no follow-up byte, so
-			// ConsumeTag's underlying varint read can never terminate.
 			input:      []byte{0x80},
 			wantErrMsg: "malformed KubeVirt Bundle response",
 		},
 		"malformed bytes field: length prefix exceeds remaining data": {
 			input: append(
 				protowire.AppendVarint(protowire.AppendTag(nil, 1, protowire.BytesType), 100),
-				[]byte{0x01, 0x02}..., // far fewer than the 100 bytes the length prefix claims
+				[]byte{0x01, 0x02}...,
 			),
 			wantErrMsg: "malformed protobuf bytes field",
 		},


### PR DESCRIPTION
## Description

The roxagent can fetch the KubeVirt CA only when a new connection arrives. Before this PR, that fetch was gated by a 1-hour cache-staleness interval: if the CA rotated mid-interval while the cached CA still looked "fresh" by age alone, every handshake kept failing until the timer elapsed — up to an hour later.

This PR closes that gap by fetching the CA on every TLS handshake via `GetConfigForClient`. When the fetch fails, the cached pool is used as fallback. Go's standard `RequireAndVerifyClientCert` handles verification — the fresh CA is already in place before the client certificate is checked, so no custom verify-retry logic is needed.

`SessionTicketsDisabled: true` prevents TLS 1.2 session resumption from skipping client certificate verification on reconnect.

Supersedes #21845. See this comment chain for context: https://github.com/stackrox/stackrox/pull/21845#discussion_r3638312123

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

Internal roxagent TLS behavior fix, no user-facing change.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

**Unit tests**: All 19 tests pass:

```
=== RUN   TestCARefresher_InvalidPEM                          --- PASS
=== RUN   TestCARefresher_HandshakeFailsWhenCAServiceUnavailable --- PASS
=== RUN   TestCARefresher_ConcurrentHandshakesEachGetValidPool --- PASS
=== RUN   TestCARefresher_Refresh                             --- PASS
=== RUN   TestCARefresher_RefreshFailure_KeepsOldCA           --- PASS
=== RUN   TestCARefresher_OverlapBundleTrustsBothOldAndNewCA  --- PASS
=== RUN   TestCARefresher_HardCutover                         --- PASS
=== RUN   TestCARefresher_TLSHandshake_ClientCertScenarios    --- PASS
=== RUN   TestExtractBundleRaw                                --- PASS
ok  github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver  0.774s
```

Key scenarios covered:
- `HardCutover`: CA rotates, next handshake fetches fresh CA and succeeds immediately
- `RefreshFailure_KeepsOldCA`: failed fetch falls back to cached pool
- `ConcurrentHandshakesEachGetValidPool`: concurrent handshakes each trigger independent fetches
- `TLSHandshake_ClientCertScenarios`: correct CA succeeds, wrong CA rejected (1 fetch, no retry), no cert rejected

**E2E test on a real VM** (OCP 4.22, KubeVirt 1.8.4, RHEL 9.8 VM on `ga-ocp4-cron` cluster):

Built roxagent from this branch and deployed to a real VM. Connected via the KubeVirt VSOCK subresource WebSocket API.

### 1) Baseline — CA fetch + TLS accept + report served

```
tls.go:239: Info: KubeVirt CA refreshed successfully
server.go:185: Info: Accepted TLS connection from host(2):1691811820 (version=0x0304, cipher=0x1301)
protocol.go:188: Info: GetReport: serving report (generation=1, packages=982)
```

CA at this point: `CN=kubevirt.io@1785231639` (fingerprint `16:25:85:5A:...`)

### 2) Hard CA cutover

Deleted `kubevirt-ca` secret; virt-operator regenerated a new CA within 1s:
```
# Before: CN=kubevirt.io@1785231639  sha256=16:25:85:5A:...
# After:  CN=kubevirt.io@1785239817  sha256=FE:BF:78:CB:...
```
Verified virt-handler's projected volume mount updated to show the new issuer before reconnecting.

### 3) Post-cutover connection — fetches new CA, succeeds immediately

```
tls.go:239: Info: KubeVirt CA refreshed successfully
server.go:185: Info: Accepted TLS connection from host(2):1691811821 (version=0x0304, cipher=0x1301)
protocol.go:188: Info: GetReport: serving report (generation=1, packages=982)
```

The second "KubeVirt CA refreshed successfully" at 08:00:28 (3m45s after the baseline at 07:56:43) fetched the **new** CA (`@1785239817`) — well under any 1h age gate. `ensureFreshPool` fetches on every handshake, so the rotated CA was picked up on the very first post-cutover connection. Report served successfully.

**Verdict: PASS.** The exact failure mode this PR addresses (hard CA cutover while cache is fresh) self-heals on the first handshake.