### PR TITLE
ROX-35910: add observability for scanner-type divergence in compliance profile dispatchers

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -44,9 +44,37 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	// useful for the deduping from sensor.
 	uid := string(complianceProfile.UID)
 
+	// Profiles using the CEL scanner (annotation compliance.openshift.io/scanner-type=CEL) have no
+	// XCCDF profile ID, so the compliance operator sets ComplianceScan.Spec.Profile to the profile's
+	// k8s object name instead. We must use the same value as ProfileId here so that BuildProfileRefID
+	// produces matching UUIDs on both the profile and the scan sides. The same pattern was applied to
+	// CEL-based tailored profiles in https://github.com/stackrox/stackrox/pull/19214 — see
+	// complianceoperatortailoredprofiles.go.
+	profileID := complianceProfile.ID
+	switch scannerType := complianceProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; scannerType {
+	case string(v1alpha1.ScannerTypeCEL):
+		profileID = complianceProfile.Name
+		log.Debugf("Profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
+			complianceProfile.Name, profileID, complianceProfile.ID)
+	case string(v1alpha1.ScannerTypeOpenSCAP), "":
+		// OpenSCAP and unannotated profiles use the XCCDF content ID — no action needed.
+	default:
+		// Unknown scanner type: CO may have introduced a new type that also uses k8s name in
+		// ComplianceScan.Spec.Profile. If compliance coverage shows 0 results for this profile,
+		// check whether the scan's spec.profile matches the XCCDF ID or the k8s name and update
+		// this dispatcher accordingly.
+		log.Warnf("Profile %s has unrecognised scanner-type annotation %q: using XCCDF ID %q as ProfileId; "+
+			"if compliance coverage shows 0 results, this scanner type may need handling here",
+			complianceProfile.Name, scannerType, profileID)
+	}
+	if profileID == "" {
+		log.Warnf("Profile %s has an empty ProfileId; compliance coverage results will be missing for this profile",
+			complianceProfile.Name)
+	}
+
 	protoProfile := &storage.ComplianceOperatorProfile{
 		Id:          uid,
-		ProfileId:   complianceProfile.ID,
+		ProfileId:   profileID,
 		Name:        complianceProfile.Name,
 		Labels:      complianceProfile.Labels,
 		Annotations: complianceProfile.Annotations,
@@ -71,7 +99,7 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	if centralcaps.Has(centralsensor.ComplianceV2Integrations) {
 		protoProfile := &central.ComplianceOperatorProfileV2{
 			Id:             uid,
-			ProfileId:      complianceProfile.ID,
+			ProfileId:      profileID,
 			Name:           complianceProfile.Name,
 			ProfileVersion: complianceProfile.Version,
 			Labels:         complianceProfile.Labels,

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -1,0 +1,130 @@
+package dispatchers
+
+import (
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func profileToUnstructured(t *testing.T, p *v1alpha1.Profile) *unstructured.Unstructured {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(p)
+	require.NoError(t, err)
+	return &unstructured.Unstructured{Object: obj}
+}
+
+// TestProfileDispatcher_OpenSCAPProfileID verifies that OpenSCAP profiles use the XCCDF content ID
+// (complianceProfile.ID) as ProfileId, so that BuildProfileRefID matches the scan side.
+func TestProfileDispatcher_OpenSCAPProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp4-cis",
+			UID:  "some-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_cis",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_org.ssgproject.content_profile_cis", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_CELProfileID verifies that CEL profiles use the k8s object name as
+// ProfileId, mirroring what ComplianceScan.Spec.Profile is set to by the compliance operator,
+// so that BuildProfileRefID produces matching UUIDs on both the profile and the scan sides.
+func TestProfileDispatcher_CELProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			// K8s name: what CO puts in ComplianceScan.Spec.Profile for CEL profiles
+			Name: "ocp4virt-cis-vm-extension",
+			UID:  "cel-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			// Short content ID — no XCCDF prefix — which CO does NOT use in spec.profile
+			ID: "cis-vm-extension",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what the scan dispatcher reads from ComplianceScan.Spec.Profile
+	assert.Equal(t, "ocp4virt-cis-vm-extension", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_UnknownScannerType verifies that a profile with an unrecognised scanner-type
+// falls back to the XCCDF ID (a Warn log is emitted; the dispatcher does not break).
+func TestProfileDispatcher_UnknownScannerType(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "future-profile",
+			UID:  "some-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_future",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Falls back to XCCDF ID — a Warn log is emitted by the dispatcher
+	assert.Equal(t, "xccdf_org.ssgproject.content_profile_future", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_CELProfileID_V2 verifies the V2 event also carries the k8s name as ProfileId.
+func TestProfileDispatcher_CELProfileID_V2(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp4virt-cis-vm-extension",
+			UID:  "cel-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "cis-vm-extension",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.Len(t, event.ForwardMessages, 2)
+
+	v2Profile := event.ForwardMessages[1].GetComplianceOperatorProfileV2()
+	require.NotNil(t, v2Profile)
+	assert.Equal(t, "ocp4virt-cis-vm-extension", v2Profile.GetProfileId())
+	assert.Equal(t, central.ComplianceOperatorProfileV2_PROFILE, v2Profile.GetOperatorKind())
+}

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -65,13 +65,18 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	}
 
 	// The compliance operator sets ComplianceScan.Spec.Profile to the tailored profile's
-	// k8s name (not its XCCDF Status.ID) when the tailored profile contains custom rules
-	// (annotation compliance.openshift.io/tailored-profile-contains-custom-rules=true, see
-	// https://github.com/ComplianceAsCode/compliance-operator/blob/197c942793f0f0ef81ca39e4e9082271218b8b42/pkg/controller/scansettingbinding/scansettingbinding_controller.go#L555-L563
-	// for details). We must use the same value as ProfileId so that BuildProfileRefID
-	// produces matching UUIDs on both the profile and the scan sides.
+	// k8s name (not its XCCDF Status.ID) for any CEL-based tailored profile
+	// (annotation compliance.openshift.io/scanner-type=CEL). This covers:
+	//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
+	//   - TPs with CEL-typed rules but no CustomRules (ScannerTypeAnnotation only)
+	//   - TPs extending a CEL base profile (inherit ScannerTypeAnnotation from base)
+	// See https://github.com/ComplianceAsCode/compliance-operator/pull/19214 for the
+	// original CustomRuleProfileAnnotation-based fix and the PR that introduced the
+	// broader ScannerTypeAnnotation check in CO's scansettingbinding controller.
+	// We must use the same value as ProfileId so that BuildProfileRefID produces
+	// matching UUIDs on both the profile and the scan sides.
 	profileID := tailoredProfile.Status.ID
-	if tailoredProfile.GetAnnotations()[v1alpha1.CustomRuleProfileAnnotation] == "true" {
+	if tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
 		profileID = tailoredProfile.GetName()
 	}
 

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -40,7 +40,10 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		return nil
 	}
 
-	if tailoredProfile.Status.ID == "" {
+	if tailoredProfile.Status.ID == "" &&
+		tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] != string(v1alpha1.ScannerTypeCEL) {
+		// CEL-based TPs may legitimately have no XCCDF Status.ID; we use the k8s name instead.
+		// Non-CEL TPs without a Status.ID are not yet ready (CO hasn't processed them).
 		log.Warnf("Tailored profile %s does not have an ID. Skipping...", tailoredProfile.Name)
 		return nil
 	}
@@ -75,9 +78,19 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	// broader ScannerTypeAnnotation check in CO's scansettingbinding controller.
 	// We must use the same value as ProfileId so that BuildProfileRefID produces
 	// matching UUIDs on both the profile and the scan sides.
-	profileID := tailoredProfile.Status.ID
-	if tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
+	var profileID string
+	switch scannerType := tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; {
+	case scannerType == string(v1alpha1.ScannerTypeCEL):
 		profileID = tailoredProfile.GetName()
+		log.Debugf("Tailored profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
+			tailoredProfile.GetName(), profileID, tailoredProfile.Status.ID)
+	case scannerType == string(v1alpha1.ScannerTypeOpenSCAP), scannerType == "":
+		profileID = tailoredProfile.Status.ID
+	default:
+		profileID = tailoredProfile.Status.ID
+		log.Warnf("Tailored profile %s has unrecognised scanner-type annotation %q: using XCCDF ID %q as ProfileId; "+
+			"if compliance coverage shows 0 results, this scanner type may need handling here",
+			tailoredProfile.GetName(), scannerType, profileID)
 	}
 
 	protoProfile := &storage.ComplianceOperatorProfile{

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -243,7 +243,8 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped
+// TestProcessEvent_NoStatusID tests that non-CEL TPs without a Status.ID are skipped
+// (not yet processed by CO).
 func TestProcessEvent_NoStatusID(t *testing.T) {
 	tp := &v1alpha1.TailoredProfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -264,6 +265,65 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	assert.Nil(t, event)
+}
+
+// TestProcessEvent_CELTPWithNoStatusID verifies that a CEL-based TP is not skipped when
+// Status.ID is empty. CEL TPs use the k8s name as ProfileId, so Status.ID is not required.
+func TestProcessEvent_CELTPWithNoStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cel-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			// Status.ID intentionally empty — CO may not set it for CEL TPs
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event, "CEL TP without Status.ID should not be skipped")
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
+}
+
+// TestProcessEvent_UnknownScannerType verifies that a TP with an unrecognised scanner-type
+// falls back to Status.ID as ProfileId (so the dispatcher doesn't silently break).
+func TestProcessEvent_UnknownScannerType(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "future-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_future-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Falls back to Status.ID — a Warn log is emitted by the dispatcher
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_future-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped


### PR DESCRIPTION
## Description

Follow-up to #21904 and #21905. The compliance coverage join relies on `BuildProfileRefID` producing identical UUIDs from the profile dispatcher and the scan dispatcher. If they diverge, the result is always the same silent symptom: 0 checks shown. This adds targeted logs to make such divergence detectable without a code change.

**Edge cases that are now observable:**

- **Unknown scanner type** (`Warn`): if CO introduces a new scanner type that also uses the k8s name in `ComplianceScan.Spec.Profile` (e.g. a hypothetical future type), the dispatcher falls back to XCCDF ID, causing a mismatch. The Warn log names the unknown type and the profile, making root cause obvious.
- **Empty ProfileId after selection** (`Warn`): if `complianceProfile.ID` is empty for a non-CEL profile, `BuildProfileRefID` silently produces a wrong UUID. Now surfaced.
- **CEL scanner detected** (`Debug`): confirms the k8s-name branch was taken, with both the name and the XCCDF ID logged for cross-referencing.

**Also fixes a latent issue in the TP dispatcher:** the `Status.ID == """ guard skipped CEL TPs that had no XCCDF Status.ID, even though CEL TPs use the k8s name and don't need Status.ID. Now CEL TPs without Status.ID are allowed through.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests (unknown scanner type fallback, CEL TP without Status.ID)

### How I validated my change

Unit tests pass. Build clean.