### PR TITLE
ROX-35910: add observability for scanner-type divergence in TP dispatcher

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -40,7 +40,10 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		return nil
 	}
 
-	if tailoredProfile.Status.ID == "" {
+	if tailoredProfile.Status.ID == "" &&
+		tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] != string(v1alpha1.ScannerTypeCEL) {
+		// CEL-based TPs may legitimately have no XCCDF Status.ID; we use the k8s name instead.
+		// Non-CEL TPs without a Status.ID are not yet ready (CO hasn't processed them).
 		log.Warnf("Tailored profile %s does not have an ID. Skipping...", tailoredProfile.Name)
 		return nil
 	}
@@ -75,9 +78,19 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	// broader ScannerTypeAnnotation check in CO's scansettingbinding controller.
 	// We must use the same value as ProfileId so that BuildProfileRefID produces
 	// matching UUIDs on both the profile and the scan sides.
-	profileID := tailoredProfile.Status.ID
-	if tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
+	var profileID string
+	switch scannerType := tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; {
+	case scannerType == string(v1alpha1.ScannerTypeCEL):
 		profileID = tailoredProfile.GetName()
+		log.Debugf("Tailored profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
+			tailoredProfile.GetName(), profileID, tailoredProfile.Status.ID)
+	case scannerType == string(v1alpha1.ScannerTypeOpenSCAP), scannerType == "":
+		profileID = tailoredProfile.Status.ID
+	default:
+		profileID = tailoredProfile.Status.ID
+		log.Warnf("Tailored profile %s has unrecognised scanner-type annotation %q: using XCCDF ID %q as ProfileId; "+
+			"if compliance coverage shows 0 results, this scanner type may need handling here",
+			tailoredProfile.GetName(), scannerType, profileID)
 	}
 
 	protoProfile := &storage.ComplianceOperatorProfile{

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -243,7 +243,8 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped
+// TestProcessEvent_NoStatusID tests that non-CEL TPs without a Status.ID are skipped
+// (not yet processed by CO).
 func TestProcessEvent_NoStatusID(t *testing.T) {
 	tp := &v1alpha1.TailoredProfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -264,6 +265,65 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	assert.Nil(t, event)
+}
+
+// TestProcessEvent_CELTPWithNoStatusID verifies that a CEL-based TP is not skipped when
+// Status.ID is empty. CEL TPs use the k8s name as ProfileId, so Status.ID is not required.
+func TestProcessEvent_CELTPWithNoStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cel-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			// Status.ID intentionally empty — CO may not set it for CEL TPs
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event, "CEL TP without Status.ID should not be skipped")
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
+}
+
+// TestProcessEvent_UnknownScannerType verifies that a TP with an unrecognised scanner-type
+// falls back to Status.ID as ProfileId (so the dispatcher doesn't silently break).
+func TestProcessEvent_UnknownScannerType(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "future-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_future-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Falls back to Status.ID — a Warn log is emitted by the dispatcher
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_future-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped


### PR DESCRIPTION
## Description

Stacked on #21965. Same observability improvements applied to `complianceoperatortailoredprofiles.go`:

- `Warn` on unrecognised scanner-type annotation (forward-compat guard)
- `Debug` when CEL branch is taken (for cross-referencing with scan dispatcher)
- CEL TP with empty `Status.ID` is no longer skipped — CEL TPs use k8s name, so `Status.ID` is irrelevant

## User-facing documentation

- [x] update is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests: CEL TP without Status.ID passes through; unknown scanner type falls back to Status.ID.