### PR TITLE
ROX-35697: store newly issued sensor cert expiry

### DIFF
--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/x509utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -129,6 +130,7 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		return errors.Errorf("unable to generate a pipeline for cluster %q", cluster.GetId())
 	}
 
+	var issuedCertExpiry *storage.ClusterCertExpiryStatus
 	if sensorSupportsHello {
 		installInfo, err := telemetry.FetchInstallInfo(context.Background(), s.installation)
 		utils.Should(err)
@@ -183,6 +185,7 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 			if err != nil {
 				return errors.Wrap(err, "converting typed service certificate set to file map")
 			}
+			issuedCertExpiry = sensorCertExpiryFromCertSet(certificateSet)
 			return nil
 		}); err != nil {
 			log.Errorf("Could not include certificate bundle in sensor hello message: %s.", err)
@@ -223,11 +226,20 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		log.Infof("Cleared init artifact ID (%s) of newly created cluster %s.", clusterInitArtifactId, cluster.GetName())
 	}
 
-	if expiryStatus, err := getCertExpiryStatus(identity); err != nil {
-		notBefore, notAfter := identity.ValidityPeriod()
-		log.Warnf("Failed to convert expiry status of sensor cert (NotBefore: %v, Expiry: %v) from cluster %s to proto: %v.",
-			notBefore, notAfter, cluster.GetId(), err)
-	} else if expiryStatus != nil {
+	// Prefer the expiry of the newly issued cert (what sensor will use going forward)
+	// over the TLS handshake cert (what sensor connected with), so that the stored
+	// expiry matches the cert in the k8s secret.
+	expiryStatus := issuedCertExpiry
+	if expiryStatus == nil {
+		var err error
+		expiryStatus, err = getCertExpiryStatus(identity)
+		if err != nil {
+			notBefore, notAfter := identity.ValidityPeriod()
+			log.Warnf("Failed to convert expiry status of sensor cert (NotBefore: %v, Expiry: %v) from cluster %s to proto: %v.",
+				notBefore, notAfter, cluster.GetId(), err)
+		}
+	}
+	if expiryStatus != nil {
 		if err := s.clusters.UpdateClusterCertExpiryStatus(clusterDSSAC, cluster.GetId(), expiryStatus); err != nil {
 			log.Warnf("Failed to update cluster expiry status for cluster %s: %v.", cluster.GetId(), err)
 		}
@@ -242,6 +254,34 @@ func isCARotationSupported(sensorHello *central.SensorHello) bool {
 	capabilities := sliceutils.FromStringSlice[centralsensor.SensorCapability](sensorHello.GetCapabilities()...)
 	capSet := set.NewSet(capabilities...)
 	return capSet.Contains(centralsensor.SensorCARotationSupported)
+}
+
+func sensorCertExpiryFromCertSet(certSet *storage.TypedServiceCertificateSet) *storage.ClusterCertExpiryStatus {
+	for _, sc := range certSet.GetServiceCerts() {
+		if sc.GetServiceType() != storage.ServiceType_SENSOR_SERVICE {
+			continue
+		}
+		certs, err := x509utils.ConvertPEMTox509Certs(sc.GetCert().GetCertPem())
+		if err != nil || len(certs) == 0 {
+			log.Warnf("Failed to parse newly issued sensor cert PEM: %v", err)
+			return nil
+		}
+		cert := certs[0]
+		status := &storage.ClusterCertExpiryStatus{}
+		expiryTS, err := protocompat.ConvertTimeToTimestampOrError(cert.NotAfter)
+		if err != nil {
+			log.Warnf("Failed to convert sensor cert NotAfter to proto timestamp: %v", err)
+			return nil
+		}
+		status.SensorCertExpiry = expiryTS
+		if !cert.NotBefore.IsZero() {
+			if nbTS, err := protocompat.ConvertTimeToTimestampOrError(cert.NotBefore); err == nil {
+				status.SensorCertNotBefore = nbTS
+			}
+		}
+		return status
+	}
+	return nil
 }
 
 func getCertExpiryStatus(identity authn.Identity) (*storage.ClusterCertExpiryStatus, error) {


### PR DESCRIPTION
## Description

Central was storing the sensor cert expiry from the TLS handshake certificate (cert N), but then immediately issuing a new certificate (cert N+1) and sending it to sensor. The k8s `tls-cert-sensor` secret contains cert N+1, but Central stored cert N's expiry.

Due to cfssl's `time.Now().Round(time.Minute)` in `FillTemplate`, these two certs' `NotAfter` values can differ by exactly 1 minute when issued near a minute boundary. This caused `ClustersTest."Test cluster status has cert expiry"` to fail intermittently on OCP 5.0 FIPS e2e tests (and potentially on any CRS-based cluster).

The fix extracts the sensor cert's `NotAfter` from the newly issued certificate set and uses that for the stored `sensorCertExpiry`, falling back to the TLS identity expiry if cert issuance failed. This ensures the stored expiry matches the cert sensor will use going forward.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validated by triggering ocp-5-0 FIPS e2e rehearsal jobs on openshift/release PR #82054. The existing `ClustersTest` serves as the regression test — it uses strict equality (`==`) for cert expiry comparison, so any future timing mismatch will still be caught. Awaiting CI results.