### PR TITLE
fix(reprocessor): CI template DB flake

### DIFF
--- a/central/reprocessor/reprocessor_test.go
+++ b/central/reprocessor/reprocessor_test.go
@@ -26,93 +26,84 @@ import (
 )
 
 func TestImagesWithSignaturesQuery(t *testing.T) {
-	testutils.MustUpdateFeature(t, features.FlattenImageData, false)
-
 	testCtx := sac.WithAllAccess(context.Background())
 
 	testingDB := pgtest.ForT(t)
 	pool := testingDB.DB
 	defer pool.Close()
 
-	imageDS := imageDatastore.NewWithPostgres(imagePostgresV2.New(pool, false, concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
-
-	imgWithSignature := fixtures.GetImage()
-	imgWithoutSignature := fixtures.GetImageWithUniqueComponents(10)
-
 	oneHourAgo := time.Now().Add(-1 * time.Hour)
 	oneMinuteAgo := time.Now().Add(-1 * time.Minute)
+
 	const imgWithSignatureID = "sha256:image-with-signature"
 	const imgWithoutSignatureID = "sha256:image-without-signature"
 
-	imgWithSignature.Id = imgWithSignatureID
-	imgWithSignature.Signature = &storage.ImageSignature{
-		Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneHourAgo),
-	}
-	imgWithoutSignature.Id = imgWithoutSignatureID
+	t.Run("V1", func(t *testing.T) {
+		testutils.MustUpdateFeature(t, features.FlattenImageData, false)
 
-	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
-	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithoutSignature))
+		imageDS := imageDatastore.NewWithPostgres(imagePostgresV2.New(pool, false, concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
 
-	results, err := imageDS.Search(testCtx, imagesWithSignaturesQuery)
-	assert.NoError(t, err)
+		imgWithSignature := fixtures.GetImage()
+		imgWithoutSignature := fixtures.GetImageWithUniqueComponents(10)
 
-	require.Len(t, results, 1)
-	assert.Equal(t, results[0].ID, imgWithSignatureID)
+		imgWithSignature.Id = imgWithSignatureID
+		imgWithSignature.Signature = &storage.ImageSignature{
+			Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneHourAgo),
+		}
+		imgWithoutSignature.Id = imgWithoutSignatureID
 
-	imgWithSignature.Signature = &storage.ImageSignature{
-		Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneMinuteAgo),
-	}
-	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
+		require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
+		require.NoError(t, imageDS.UpsertImage(testCtx, imgWithoutSignature))
 
-	results, err = imageDS.Search(testCtx, imagesWithSignaturesQuery)
-	assert.NoError(t, err)
+		results, err := imageDS.Search(testCtx, imagesWithSignaturesQuery)
+		assert.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, results[0].ID, imgWithSignatureID)
 
-	require.Len(t, results, 1)
-	assert.Equal(t, results[0].ID, imgWithSignatureID)
-}
+		imgWithSignature.Signature = &storage.ImageSignature{
+			Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneMinuteAgo),
+		}
+		require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
 
-func TestImagesWithSignaturesQueryV2(t *testing.T) {
-	testutils.MustUpdateFeature(t, features.FlattenImageData, true)
+		results, err = imageDS.Search(testCtx, imagesWithSignaturesQuery)
+		assert.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, results[0].ID, imgWithSignatureID)
+	})
 
-	testCtx := sac.WithAllAccess(context.Background())
+	t.Run("V2", func(t *testing.T) {
+		testutils.MustUpdateFeature(t, features.FlattenImageData, true)
 
-	testingDB := pgtest.ForT(t)
-	pool := testingDB.DB
-	defer pool.Close()
+		imageDS := imageV2Datastore.NewWithPostgres(imageV2PG.New(pool, false, concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
 
-	imageDS := imageV2Datastore.NewWithPostgres(imageV2PG.New(pool, false, concurrency.NewKeyFence()), nil, ranking.ImageRanker(), ranking.ComponentRanker())
+		imgWithSignature := fixtures.GetImageV2()
+		imgWithoutSignature := fixtures.GetImageV2WithUniqueComponents(10)
 
-	imgWithSignature := fixtures.GetImageV2()
-	imgWithoutSignature := fixtures.GetImageV2WithUniqueComponents(10)
+		imgWithSignatureID := utils.NewImageV2ID(imgWithSignature.GetName(), imgWithSignatureID)
+		imgWithoutSignatureID := utils.NewImageV2ID(imgWithoutSignature.GetName(), imgWithoutSignatureID)
 
-	oneHourAgo := time.Now().Add(-1 * time.Hour)
-	oneMinuteAgo := time.Now().Add(-1 * time.Minute)
-	imgWithSignatureID := utils.NewImageV2ID(imgWithSignature.GetName(), "sha256:image-with-signature")
-	imgWithoutSignatureID := utils.NewImageV2ID(imgWithoutSignature.GetName(), "sha256:image-without-signature")
+		imgWithSignature.Id = imgWithSignatureID
+		imgWithSignature.Signature = &storage.ImageSignature{
+			Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneHourAgo),
+		}
+		imgWithoutSignature.Id = imgWithoutSignatureID
 
-	imgWithSignature.Id = imgWithSignatureID
-	imgWithSignature.Signature = &storage.ImageSignature{
-		Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneHourAgo),
-	}
-	imgWithoutSignature.Id = imgWithoutSignatureID
+		require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
+		require.NoError(t, imageDS.UpsertImage(testCtx, imgWithoutSignature))
 
-	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
-	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithoutSignature))
+		results, err := imageDS.Search(testCtx, imagesWithSignaturesQuery)
+		assert.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, results[0].ID, imgWithSignatureID)
 
-	results, err := imageDS.Search(testCtx, imagesWithSignaturesQuery)
-	assert.NoError(t, err)
+		imgWithSignature.Signature = &storage.ImageSignature{
+			Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneMinuteAgo),
+		}
+		require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
 
-	require.Len(t, results, 1)
-	assert.Equal(t, results[0].ID, imgWithSignatureID)
-
-	imgWithSignature.Signature = &storage.ImageSignature{
-		Fetched: protocompat.ConvertTimeToTimestampOrNil(&oneMinuteAgo),
-	}
-	require.NoError(t, imageDS.UpsertImage(testCtx, imgWithSignature))
-
-	results, err = imageDS.Search(testCtx, imagesWithSignaturesQuery)
-	assert.NoError(t, err)
-
-	require.Len(t, results, 1)
-	assert.Equal(t, results[0].ID, imgWithSignatureID)
+		results, err = imageDS.Search(testCtx, imagesWithSignaturesQuery)
+		assert.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, results[0].ID, imgWithSignatureID)
+	})
 }


### PR DESCRIPTION
## Description

In CI, `pgtest.ForT` creates a shared template DB via `sync.Once` that captures feature flag state from the first test. `TestImagesWithSignaturesQuery (V1)` ran first and disabled `FlattenImageData`, which excluded `images_v2` tables from the template. The subsequent `TestImagesWithSignaturesQueryV2` then failed with:
```go
relation images_v2_layers does not exist
```

Merge the two top-level test functions into a single test with V1/V2 subtests. `pgtest.ForT` is now called before any feature flag toggle, so the template is created with the default state (`FlattenImageData enabled`), and both subtests get a complete schema.

Refs:
- https://github.com/stackrox/stackrox/pull/17104
- https://github.com/stackrox/stackrox/pull/10908
- #21486
- https://github.com/stackrox/stackrox/actions/runs/30354487935/job/90259450526?pr=21682

Partially generated by AI

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

```
CI=true go test -tags sql_integration ./central/reprocessor/... -count 1 -v
```
