### PR TITLE
refactor(sensor): remove unused deployment config detection code

### DIFF
--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -25,8 +24,7 @@ import (
 )
 
 const (
-	openshiftEncodedDeploymentConfigAnnotation = `openshift.io/encoded-deployment-config`
-	appArmorAnnotationTemplate                 = `container.apparmor.security.beta.kubernetes.io/%s`
+	appArmorAnnotationTemplate = `container.apparmor.security.beta.kubernetes.io/%s`
 )
 
 var (
@@ -72,31 +70,10 @@ func NewDeploymentFromStaticResource(obj interface{}, deploymentType, clusterID,
 		}
 	}
 
-	// This only applies to OpenShift
-	if encDeploymentConfig, ok := objMeta.GetLabels()[openshiftEncodedDeploymentConfigAnnotation]; ok {
-		newMeta, newKind, err := extractDeploymentConfig(encDeploymentConfig)
-		if err != nil {
-			log.Error(err)
-		} else {
-			objMeta, kind = newMeta, newKind
-		}
-	}
-
 	wrap := newWrap(objMeta, kind, clusterID, registryOverride)
 	wrap.populateFields(obj)
 	return wrap.Deployment, nil
 
-}
-
-func extractDeploymentConfig(encodedDeploymentConfig string) (metav1.Object, string, error) {
-	// Anonymous struct that only contains the fields we are interested in (note: json.Unmarshal silently ignores
-	// fields that are not in the destination object).
-	dc := struct {
-		metav1.TypeMeta
-		MetaData metav1.ObjectMeta `json:"metadata"`
-	}{}
-	err := json.Unmarshal([]byte(encodedDeploymentConfig), &dc)
-	return &dc.MetaData, dc.Kind, err
 }
 
 func newWrap(meta metav1.Object, kind, clusterID, registryOverride string) *DeploymentWrap {

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	v1listers "k8s.io/client-go/listers/core/v1"
 )
@@ -289,7 +290,19 @@ func (w *deploymentWrap) getPods(hierarchy references.ParentHierarchy, labelSele
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list pods")
 	}
-	return filterOnOwners(hierarchy, w.Id, pods), nil
+	owned := filterOnOwners(hierarchy, w.Id, pods)
+	if len(owned) > 0 {
+		return owned, nil
+	}
+	// Fallback: the label selector didn't match any owned pods. This can happen
+	// when the selector diverges from actual pod labels (e.g., OpenShift overrides
+	// the deploymentconfig label on pods to match the DC name). List all pods in
+	// the namespace and filter by ownership only.
+	allPods, err := lister.Pods(w.Namespace).List(labels.Everything())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list pods for ownership fallback")
+	}
+	return filterOnOwners(hierarchy, w.Id, allPods), nil
 }
 
 func (w *deploymentWrap) populateDataFromPods(localImages set.StringSet, pods ...*v1.Pod) {

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -1360,3 +1360,108 @@ func (l *mockPodLister) List(_ labels.Selector) ([]*v1.Pod, error) {
 func (l *mockPodLister) Pods(_ string) v1listers.PodNamespaceLister {
 	return l
 }
+
+type selectorAwarePodLister struct {
+	v1listers.PodLister
+	v1listers.PodNamespaceLister
+	pods []*v1.Pod
+}
+
+func (l *selectorAwarePodLister) List(sel labels.Selector) ([]*v1.Pod, error) {
+	var matched []*v1.Pod
+	for _, p := range l.pods {
+		if sel.Matches(labels.Set(p.Labels)) {
+			matched = append(matched, p)
+		}
+	}
+	return matched, nil
+}
+
+func (l *selectorAwarePodLister) Pods(_ string) v1listers.PodNamespaceLister {
+	return l
+}
+
+func TestGetPodsOwnershipFallback(t *testing.T) {
+	dcUID := "dc-uid-123"
+	rcUID := "rc-uid-456"
+
+	hierarchy := references.NewParentHierarchy()
+	// RC is child of DC
+	hierarchy.AddManually(rcUID, dcUID)
+
+	ownedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-owned",
+			Namespace: "namespace",
+			UID:       "pod-uid-1",
+			Labels:    map[string]string{"app": "test", "deploymentconfig": "actual-dc-name"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "ReplicationController",
+					Name:       "test-rc",
+					UID:        types.UID(rcUID),
+				},
+			},
+		},
+	}
+	hierarchy.Add(ownedPod)
+
+	unownedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-unowned",
+			Namespace: "namespace",
+			UID:       "pod-uid-2",
+			Labels:    map[string]string{"app": "unrelated"},
+		},
+	}
+
+	cases := map[string]struct {
+		selector     *metav1.LabelSelector
+		pods         []*v1.Pod
+		expectedPods []string
+	}{
+		"labels match - finds pod by selector": {
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test", "deploymentconfig": "actual-dc-name"},
+			},
+			pods:         []*v1.Pod{ownedPod, unownedPod},
+			expectedPods: []string{"pod-owned"},
+		},
+		"labels mismatch - falls back to ownership": {
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test", "deploymentconfig": "wrong-name"},
+			},
+			pods:         []*v1.Pod{ownedPod, unownedPod},
+			expectedPods: []string{"pod-owned"},
+		},
+		"no owned pods at all - returns empty": {
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test", "deploymentconfig": "wrong-name"},
+			},
+			pods:         []*v1.Pod{unownedPod},
+			expectedPods: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			wrap := &deploymentWrap{
+				Deployment: &storage.Deployment{
+					Id:        dcUID,
+					Namespace: "namespace",
+				},
+			}
+			lister := &selectorAwarePodLister{pods: tc.pods}
+
+			pods, err := wrap.getPods(hierarchy, tc.selector, lister)
+			require.NoError(t, err)
+
+			var podNames []string
+			for _, p := range pods {
+				podNames = append(podNames, p.Name)
+			}
+			assert.Equal(t, tc.expectedPods, podNames)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Backport to release-4.9.

Removes dead code from the deployment resource detection path that has been unreachable since 2018 due to a label/annotation mismatch introduced during a refactoring. Additionally improves pod discovery in the deployment update path by falling back to ownership-based matching when the label selector yields no results, which handles cases where pod labels diverge from the deployment selector (e.g., OpenShift override of `deploymentconfig` label).

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests

### How I validated my change

- Verified that DeploymentConfigs continue to show up correctly in ACS after the dead code removal
- Verified that DeploymentConfigs with mismatched selectors now have image digests populated
- Tested with local-sensor against an OCP cluster