### PR TITLE
ROX: 35969: Fix image search not working for fields in images_layers lable

### DIFF
--- a/central/image/datastore/datastore_impl_flat_postgres_test.go
+++ b/central/image/datastore/datastore_impl_flat_postgres_test.go
@@ -210,6 +210,23 @@ func (s *ImageFlatPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 	s.NoError(err)
 	s.Len(results, 1)
 	s.Equal(newImage.GetId(), results[0].ID)
+
+	// Search by Dockerfile Instruction Keyword (from child table images_layers).
+	q = pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.DockerfileInstructionKeyword, "RUN").ProtoQuery()
+	results, err = s.datastore.Search(ctx, q)
+	s.NoError(err)
+	s.Len(results, 2)
+
+	// Count by Dockerfile Instruction Keyword.
+	count, err := s.datastore.Count(ctx, q)
+	s.NoError(err)
+	s.Equal(2, count)
+
+	// Search by Dockerfile Instruction Value.
+	q = pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.DockerfileInstructionValue, "apt-get").ProtoQuery()
+	results, err = s.datastore.Search(ctx, q)
+	s.NoError(err)
+	s.Len(results, 2)
 }
 
 func (s *ImageFlatPostgresDataStoreTestSuite) TestFixableWithPostgres() {
@@ -955,6 +972,14 @@ func getTestImage(id string) *storage.Image {
 							ScoreVersion: storage.EmbeddedVulnerability_V3,
 						},
 					},
+				},
+			},
+		},
+		Metadata: &storage.ImageMetadata{
+			V1: &storage.V1Metadata{
+				Layers: []*storage.ImageLayer{
+					{Instruction: "ADD", Value: "file:abc123 in /"},
+					{Instruction: "RUN", Value: "apt-get update && apt-get install -y curl"},
 				},
 			},
 		},

--- a/central/image/datastore/store/v2/postgres/gen.go
+++ b/central/image/datastore/store/v2/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.Image --search-category IMAGES --schema-only --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,DEPLOYMENTS,NAMESPACES,CLUSTERS
+//go:generate pg-table-bindings-wrapper --type=storage.Image --search-category IMAGES --schema-only --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,IMAGES,DEPLOYMENTS,NAMESPACES,CLUSTERS

--- a/pkg/postgres/schema/images.go
+++ b/pkg/postgres/schema/images.go
@@ -39,6 +39,7 @@ var (
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory_IMAGE_VULNERABILITIES_V2,
 			v1.SearchCategory_IMAGE_COMPONENTS_V2,
+			v1.SearchCategory_IMAGES,
 			v1.SearchCategory_DEPLOYMENTS,
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The old image store was deleted during dead code cleanup in 4.10 and recreated at `central/image/datastore/store/v2/postgres/gen.go` (ROX-31535). With this change, the `IMAGES` category was accidentally dropped from `--search-scope`. 

This prevented the BFS based join resolver in `pkg/search/postgres/joins.go` from reaching the images_layers child table (which has PrimaryCategory = `IMAGES`), silently returning 0 results for any query using `Dockerfile Instruction Keyword` and `Dockerfile Instruction Value` fields.

**Why it only affects child-table fields**: Fields on the parent images table (Image Name, etc.) are found at the BFS root without needing joins. Fields on external tables (CVE, Component, etc) work because their categories (`IMAGE_VULNERABILITIES_V2`, `IMAGE_COMPONENTS_V2`, etc) are in the search scope. Only the `images_layers` child table was unreachable.

Changes:
  1. `central/image/datastore/store/v2/postgres/gen.go` — added `IMAGES` to `--search-scope`
  2. `pkg/postgres/schema/images.go` — regenerated (now includes `IMAGES` in search scope)
  3. `central/image/datastore/datastore_impl_flat_postgres_test.go` — added Dockerfile search/count assertions to TestSearchWithPostgres

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [X] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- Updated unit tests to check 
- Manually tested with ImageV2 disabled