### PR TITLE
ROX-35968: [backport release-4.10] Fix view-based reports stuck in PREPARING

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -117,6 +117,10 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 		return
 	}
 
+	// TODO(charmik): Remove this sleep. Added to simulate a long-running report job for testing restart recovery.
+	log.Warn("Sleeping 2 minutes to simulate long-running report generation...")
+	time.Sleep(2 * time.Minute)
+
 	err = rg.generateReportAndNotify(req)
 	if err != nil {
 		rg.logAndUpsertError(err, req)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -117,10 +117,6 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 		return
 	}
 
-	// TODO(charmik): Remove this sleep. Added to simulate a long-running report job for testing restart recovery.
-	log.Warn("Sleeping 2 minutes to simulate long-running report generation...")
-	time.Sleep(2 * time.Minute)
-
 	err = rg.generateReportAndNotify(req)
 	if err != nil {
 		rg.logAndUpsertError(err, req)

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -331,6 +331,18 @@ func (s *scheduler) queuePendingReports() {
 	}
 
 	for _, snap := range pendingReports {
+		// View-based reports have no associated report configuration, resource scope, or collection.
+		if snap.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
+			repRequest := &reportGen.ReportRequest{
+				ReportSnapshot: snap,
+			}
+			_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
+			if err != nil {
+				log.Errorf("Error rescheduling pending view-based report job '%s': %s", snap.GetReportId(), err)
+			}
+			continue
+		}
+
 		_, found, err := s.reportConfigDatastore.GetReportConfiguration(scheduledCtx, snap.GetReportConfigurationId())
 		if err != nil {
 			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)


### PR DESCRIPTION
## Description

Backport of #21713 to release-4.10.

After Central restarts, the report scheduler reschedules unfinished report jobs via
`queuePendingReports()`. View-based reports don't have an associated report configuration
(empty config ID), so the lookup fails and the job is skipped — leaving it permanently
stuck in PREPARING state and blocking the user from scheduling new reports.

The fix checks `ReportRequestType == VIEW_BASED` at the top of the loop and requeues
these reports directly, bypassing the config, resource scope, and collection lookups
that don't apply to them.

Note: the test file `scheduler_impl_test.go` does not exist on release-4.10, so only
the production code change is included.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Cherry-pick of merged #21713. Unit tests validated on master.
- Manually tested by starting a view-based report on a scale cluster and killing the Central pod before the report was generated. After Central restarted, it successfully rescheduled and ran that report job.