### PR TITLE
ROX-35967: [backport release-4.11] Fix view-based reports stuck in PREPARING

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -117,6 +117,10 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 		return
 	}
 
+	// TODO(charmik): Remove this sleep. Added to simulate a long-running report job for testing restart recovery.
+	log.Warn("Sleeping 2 minutes to simulate long-running report generation...")
+	time.Sleep(2 * time.Minute)
+
 	err = rg.generateReportAndNotify(req)
 	if err != nil {
 		rg.logAndUpsertError(err, req)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -117,10 +117,6 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 		return
 	}
 
-	// TODO(charmik): Remove this sleep. Added to simulate a long-running report job for testing restart recovery.
-	log.Warn("Sleeping 2 minutes to simulate long-running report generation...")
-	time.Sleep(2 * time.Minute)
-
 	err = rg.generateReportAndNotify(req)
 	if err != nil {
 		rg.logAndUpsertError(err, req)

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -332,6 +332,18 @@ func (s *scheduler) queuePendingReports() {
 	}
 
 	for _, snap := range pendingReports {
+		// View-based reports have no associated report configuration, resource scope, or collection.
+		if snap.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
+			repRequest := &reportGen.ReportRequest{
+				ReportSnapshot: snap,
+			}
+			_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
+			if err != nil {
+				log.Errorf("Error rescheduling pending view-based report job '%s': %s", snap.GetReportId(), err)
+			}
+			continue
+		}
+
 		_, found, err := s.reportConfigDatastore.GetReportConfiguration(scheduledCtx, snap.GetReportConfigurationId())
 		if err != nil {
 			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -4,7 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/central/reports/config/datastore/mocks"
+	snapshotMocks "github.com/stackrox/rox/central/reports/snapshot/datastore/mocks"
+	collectionMocks "github.com/stackrox/rox/central/resourcecollection/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	"gopkg.in/robfig/cron.v2"
 )
 
@@ -75,4 +80,72 @@ func TestFindPreviousFireTimeReturnsZeroWhenNoFireInWindow(t *testing.T) {
 	// Now is March 1, 2027 (non-leap year). Feb 29 doesn't exist, so no fire in window.
 	previousFire := findPreviousFireTime(schedule, time.Date(2027, 3, 1, 0, 0, 0, 0, loc))
 	assert.True(t, previousFire.IsZero(), "Expected zero time when no fire exists in lookback window")
+}
+
+func TestQueuePendingReports(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockSnapshotStore := snapshotMocks.NewMockDataStore(ctrl)
+	mockReportConfigDS := mocks.NewMockDataStore(ctrl)
+	mockCollectionDS := collectionMocks.NewMockDataStore(ctrl)
+
+	viewBasedSnap := &storage.ReportSnapshot{
+		ReportId: "view-based-report-1",
+		Name:     "View Based Report",
+		Type:     storage.ReportSnapshot_VULNERABILITY,
+		ReportStatus: &storage.ReportStatus{
+			RunState:          storage.ReportStatus_PREPARING,
+			ReportRequestType: storage.ReportStatus_VIEW_BASED,
+		},
+		Filter: &storage.ReportSnapshot_ViewBasedVulnReportFilters{
+			ViewBasedVulnReportFilters: &storage.ViewBasedVulnerabilityReportFilters{
+				Query: "CVE Type:IMAGE_CVE",
+			},
+		},
+		Requester: &storage.SlimUser{Id: "user-1", Name: "user-1"},
+	}
+
+	configBasedSnap := &storage.ReportSnapshot{
+		ReportId:              "config-based-report-1",
+		ReportConfigurationId: "config-1",
+		Name:                  "Config Based Report",
+		Type:                  storage.ReportSnapshot_VULNERABILITY,
+		ReportStatus: &storage.ReportStatus{
+			RunState:          storage.ReportStatus_WAITING,
+			ReportRequestType: storage.ReportStatus_ON_DEMAND,
+		},
+		Filter: &storage.ReportSnapshot_VulnReportFilters{
+			VulnReportFilters: &storage.VulnerabilityReportFilters{},
+		},
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_CollectionId{CollectionId: "collection-1"},
+		},
+		Collection: &storage.CollectionSnapshot{Id: "collection-1", Name: "collection-1"},
+		Requester:  &storage.SlimUser{Id: "user-2", Name: "user-2"},
+	}
+
+	mockSnapshotStore.EXPECT().
+		SearchReportSnapshots(gomock.Any(), gomock.Any()).
+		Return([]*storage.ReportSnapshot{viewBasedSnap, configBasedSnap}, nil)
+
+	// View-based report should NOT trigger a config lookup.
+	// Config-based report should trigger a config lookup.
+	mockReportConfigDS.EXPECT().
+		GetReportConfiguration(gomock.Any(), "config-1").
+		Return(&storage.ReportConfiguration{Id: "config-1"}, true, nil)
+
+	mockCollectionDS.EXPECT().
+		Get(gomock.Any(), "collection-1").
+		Return(&storage.ResourceCollection{Id: "collection-1"}, true, nil)
+
+	// Both should be updated via resubmission.
+	mockSnapshotStore.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, cronScheduler, nil)
+	s.queuePendingReports()
+
+	assert.Equal(t, 2, s.reportRequestsQueue.Len())
 }


### PR DESCRIPTION
## Description

Backport of #21713 to release-4.11.

After Central restarts, the report scheduler reschedules unfinished report jobs via
`queuePendingReports()`. View-based reports don't have an associated report configuration
(empty config ID), so the lookup fails and the job is skipped — leaving it permanently
stuck in PREPARING state and blocking the user from scheduling new reports.

The fix checks `ReportRequestType == VIEW_BASED` at the top of the loop and requeues
these reports directly, bypassing the config, resource scope, and collection lookups
that don't apply to them.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Added `TestQueuePendingReports` unit test
- Manually tested by starting a view-based report on a scale cluster and killing the Central pod before the report was generated. After Central restarted, it successfully rescheduled and ran that report job.