### PR TITLE
ROX-35910: add diagnostic logging for scanner-type fallback paths

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -48,11 +48,28 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	// XCCDF profile ID, so the compliance operator sets ComplianceScan.Spec.Profile to the profile's
 	// k8s object name instead. We must use the same value as ProfileId here so that BuildProfileRefID
 	// produces matching UUIDs on both the profile and the scan sides. The same pattern was applied to
-	// CEL-based tailored profiles in https://github.com/stackrox/stackrox/pull/19214 — see
+	// CEL-based tailored profiles in https://github.com/stackrox/stackrox/pull/21905 — see
 	// complianceoperatortailoredprofiles.go.
 	profileID := complianceProfile.ID
-	if complianceProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
+	switch scannerType := complianceProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; scannerType {
+	case string(v1alpha1.ScannerTypeCEL):
 		profileID = complianceProfile.Name
+		log.Debugf("Profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
+			complianceProfile.Name, profileID, complianceProfile.ID)
+	case string(v1alpha1.ScannerTypeOpenSCAP), "":
+		// OpenSCAP and unannotated profiles use the XCCDF content ID — no action needed.
+	default:
+		// Unknown scanner type: CO may have introduced a new type that also uses k8s name in
+		// ComplianceScan.Spec.Profile. If compliance coverage shows 0 results for this profile,
+		// check whether the scan's spec.profile matches the XCCDF ID or the k8s name and update
+		// this dispatcher accordingly.
+		log.Warnf("Profile %s has unrecognised scanner-type annotation %q: using XCCDF ID %q as ProfileId; "+
+			"if compliance coverage shows 0 results, this scanner type may need handling here",
+			complianceProfile.Name, scannerType, profileID)
+	}
+	if profileID == "" {
+		log.Warnf("Profile %s has an empty ProfileId; compliance coverage results will be missing for this profile",
+			complianceProfile.Name)
 	}
 
 	protoProfile := &storage.ComplianceOperatorProfile{

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles.go
@@ -54,8 +54,6 @@ func (c *ProfileDispatcher) ProcessEvent(obj, _ interface{}, action central.Reso
 	switch scannerType := complianceProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; scannerType {
 	case string(v1alpha1.ScannerTypeCEL):
 		profileID = complianceProfile.Name
-		log.Debugf("Profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
-			complianceProfile.Name, profileID, complianceProfile.ID)
 	case string(v1alpha1.ScannerTypeOpenSCAP), "":
 		// OpenSCAP and unannotated profiles use the XCCDF content ID — no action needed.
 	default:

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -75,18 +75,14 @@ func TestProfileDispatcher_CELProfileID(t *testing.T) {
 }
 
 // TestProfileDispatcher_NoAnnotation verifies that profiles with no scanner-type annotation
-// fall back to using the XCCDF content ID as ProfileId (same as OpenSCAP). Verified against a
-// live cluster (CO v1.9.1) that every parsed profile actually carries the annotation today —
-// the compliance operator's profileparser unconditionally sets scanner-type=OpenSCAP on every
-// XCCDF profile since v1.9.0, when the annotation was introduced alongside CEL support. This
-// case only applies to CO < v1.9.0, which predates the scanner-type mechanism entirely; it's
-// tested here purely as a defensive fallback, not as a realistic deployment scenario.
+// fall back to using the XCCDF content ID as ProfileId (same as OpenSCAP). This is a defensive
+// fallback for CO < 1.9, which predates the scanner-type annotation.
 func TestProfileDispatcher_NoAnnotation(t *testing.T) {
 	profile := &v1alpha1.Profile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ocp4-cis",
 			UID:  "some-uid",
-			// No annotations — simulates CO < v1.9.0, before scanner-type existed
+			// No annotations — simulates CO < 1.9, before scanner-type existed
 		},
 		ProfilePayload: v1alpha1.ProfilePayload{
 			ID: "xccdf_org.ssgproject.content_profile_cis",

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -75,13 +75,18 @@ func TestProfileDispatcher_CELProfileID(t *testing.T) {
 }
 
 // TestProfileDispatcher_NoAnnotation verifies that profiles with no scanner-type annotation
-// (the common case for pre-CEL content bundles) use the XCCDF content ID as ProfileId.
+// fall back to using the XCCDF content ID as ProfileId (same as OpenSCAP). Verified against a
+// live cluster (CO v1.9.1) that every parsed profile actually carries the annotation today —
+// the compliance operator's profileparser unconditionally sets scanner-type=OpenSCAP on every
+// XCCDF profile since v1.9.0, when the annotation was introduced alongside CEL support. This
+// case only applies to CO < v1.9.0, which predates the scanner-type mechanism entirely; it's
+// tested here purely as a defensive fallback, not as a realistic deployment scenario.
 func TestProfileDispatcher_NoAnnotation(t *testing.T) {
 	profile := &v1alpha1.Profile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ocp4-cis",
 			UID:  "some-uid",
-			// No annotations — normal for existing OpenSCAP content bundles
+			// No annotations — simulates CO < v1.9.0, before scanner-type existed
 		},
 		ProfilePayload: v1alpha1.ProfilePayload{
 			ID: "xccdf_org.ssgproject.content_profile_cis",

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -20,133 +20,74 @@ func profileToUnstructured(t *testing.T, p *v1alpha1.Profile) *unstructured.Unst
 	return &unstructured.Unstructured{Object: obj}
 }
 
-// TestProfileDispatcher_OpenSCAPProfileID verifies that OpenSCAP profiles use the XCCDF content ID
-// (complianceProfile.ID) as ProfileId, so that BuildProfileRefID matches the scan side.
-func TestProfileDispatcher_OpenSCAPProfileID(t *testing.T) {
-	profile := &v1alpha1.Profile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "ocp4-cis",
-			UID:  "some-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
-			},
+// TestProfileDispatcher_ProfileIDSelection verifies ProfileId selection for every scanner-type
+// annotation value, so that BuildProfileRefID produces matching UUIDs on both the profile and
+// the scan sides. Unrecognised scanner types and empty XCCDF IDs still produce a valid event
+// (not dropped) — the dispatcher only logs a Warn in those cases.
+func TestProfileDispatcher_ProfileIDSelection(t *testing.T) {
+	tests := map[string]struct {
+		scannerType   string
+		xccdfID       string
+		name          string
+		wantProfileID string
+	}{
+		"OpenSCAP uses XCCDF content ID": {
+			scannerType:   string(v1alpha1.ScannerTypeOpenSCAP),
+			xccdfID:       "xccdf_org.ssgproject.content_profile_cis",
+			name:          "ocp4-cis",
+			wantProfileID: "xccdf_org.ssgproject.content_profile_cis",
 		},
-		ProfilePayload: v1alpha1.ProfilePayload{
-			ID: "xccdf_org.ssgproject.content_profile_cis",
-		},
-	}
-
-	dispatcher := NewProfileDispatcher()
-	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "xccdf_org.ssgproject.content_profile_cis", v1Profile.GetProfileId())
-}
-
-// TestProfileDispatcher_CELProfileID verifies that CEL profiles use the k8s object name as
-// ProfileId, mirroring what ComplianceScan.Spec.Profile is set to by the compliance operator,
-// so that BuildProfileRefID produces matching UUIDs on both the profile and the scan sides.
-func TestProfileDispatcher_CELProfileID(t *testing.T) {
-	profile := &v1alpha1.Profile{
-		ObjectMeta: metav1.ObjectMeta{
-			// K8s name: what CO puts in ComplianceScan.Spec.Profile for CEL profiles
-			Name: "ocp4virt-cis-vm-extension",
-			UID:  "cel-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
-			},
-		},
-		ProfilePayload: v1alpha1.ProfilePayload{
+		"CEL uses k8s object name": {
+			scannerType: string(v1alpha1.ScannerTypeCEL),
 			// Short content ID — no XCCDF prefix — which CO does NOT use in spec.profile
-			ID: "cis-vm-extension",
+			xccdfID:       "cis-vm-extension",
+			name:          "ocp4virt-cis-vm-extension",
+			wantProfileID: "ocp4virt-cis-vm-extension",
+		},
+		"no annotation falls back to XCCDF ID (CO < 1.9)": {
+			scannerType:   "",
+			xccdfID:       "xccdf_org.ssgproject.content_profile_cis",
+			name:          "ocp4-cis",
+			wantProfileID: "xccdf_org.ssgproject.content_profile_cis",
+		},
+		"unrecognised scanner type falls back to XCCDF ID": {
+			scannerType:   "WASM", // hypothetical future type
+			xccdfID:       "xccdf_org.ssgproject.content_profile_future",
+			name:          "future-profile",
+			wantProfileID: "xccdf_org.ssgproject.content_profile_future",
+		},
+		"no XCCDF ID and no annotation yields empty ProfileId": {
+			scannerType:   "",
+			xccdfID:       "",
+			name:          "incomplete-profile",
+			wantProfileID: "",
 		},
 	}
 
-	dispatcher := NewProfileDispatcher()
-	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			profile := &v1alpha1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.name,
+					UID:  "some-uid",
+					Annotations: map[string]string{
+						v1alpha1.ScannerTypeAnnotation: tc.scannerType,
+					},
+				},
+				ProfilePayload: v1alpha1.ProfilePayload{
+					ID: tc.xccdfID,
+				},
+			}
 
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	// Must match what the scan dispatcher reads from ComplianceScan.Spec.Profile
-	assert.Equal(t, "ocp4virt-cis-vm-extension", v1Profile.GetProfileId())
-}
+			dispatcher := NewProfileDispatcher()
+			event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
 
-// TestProfileDispatcher_NoAnnotation verifies that profiles with no scanner-type annotation
-// fall back to using the XCCDF content ID as ProfileId (same as OpenSCAP). This is a defensive
-// fallback for CO < 1.9, which predates the scanner-type annotation.
-func TestProfileDispatcher_NoAnnotation(t *testing.T) {
-	profile := &v1alpha1.Profile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "ocp4-cis",
-			UID:  "some-uid",
-			// No annotations — simulates CO < 1.9, before scanner-type existed
-		},
-		ProfilePayload: v1alpha1.ProfilePayload{
-			ID: "xccdf_org.ssgproject.content_profile_cis",
-		},
+			require.NotNil(t, event)
+			require.NotEmpty(t, event.ForwardMessages)
+			v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+			assert.Equal(t, tc.wantProfileID, v1Profile.GetProfileId())
+		})
 	}
-
-	dispatcher := NewProfileDispatcher()
-	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "xccdf_org.ssgproject.content_profile_cis", v1Profile.GetProfileId())
-}
-
-// TestProfileDispatcher_UnknownScannerType verifies that a profile with an unrecognised scanner-type
-// falls back to the XCCDF ID (a Warn log is emitted; the dispatcher does not break).
-func TestProfileDispatcher_UnknownScannerType(t *testing.T) {
-	profile := &v1alpha1.Profile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "future-profile",
-			UID:  "some-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
-			},
-		},
-		ProfilePayload: v1alpha1.ProfilePayload{
-			ID: "xccdf_org.ssgproject.content_profile_future",
-		},
-	}
-
-	dispatcher := NewProfileDispatcher()
-	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	// Falls back to XCCDF ID — a Warn log is emitted by the dispatcher
-	assert.Equal(t, "xccdf_org.ssgproject.content_profile_future", v1Profile.GetProfileId())
-}
-
-// TestProfileDispatcher_EmptyProfileID verifies that a profile with no XCCDF content ID and no
-// scanner-type annotation still produces a valid event (not dropped), with an empty ProfileId.
-// This exercises the empty-ProfileId Warn path in the dispatcher.
-func TestProfileDispatcher_EmptyProfileID(t *testing.T) {
-	profile := &v1alpha1.Profile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "incomplete-profile",
-			UID:  "some-uid",
-			// No annotations, no XCCDF ID — malformed or in-progress profile
-		},
-		ProfilePayload: v1alpha1.ProfilePayload{
-			ID: "",
-		},
-	}
-
-	dispatcher := NewProfileDispatcher()
-	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	// The dispatcher does not drop the event — it logs a Warn and proceeds.
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "", v1Profile.GetProfileId())
 }
 
 // TestProfileDispatcher_CELProfileID_V2 verifies the V2 event also carries the k8s name as ProfileId.

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -74,6 +74,80 @@ func TestProfileDispatcher_CELProfileID(t *testing.T) {
 	assert.Equal(t, "ocp4virt-cis-vm-extension", v1Profile.GetProfileId())
 }
 
+// TestProfileDispatcher_NoAnnotation verifies that profiles with no scanner-type annotation
+// (the common case for pre-CEL content bundles) use the XCCDF content ID as ProfileId.
+func TestProfileDispatcher_NoAnnotation(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp4-cis",
+			UID:  "some-uid",
+			// No annotations — normal for existing OpenSCAP content bundles
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_cis",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_org.ssgproject.content_profile_cis", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_UnknownScannerType verifies that a profile with an unrecognised scanner-type
+// falls back to the XCCDF ID (a Warn log is emitted; the dispatcher does not break).
+func TestProfileDispatcher_UnknownScannerType(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "future-profile",
+			UID:  "some-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_future",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Falls back to XCCDF ID — a Warn log is emitted by the dispatcher
+	assert.Equal(t, "xccdf_org.ssgproject.content_profile_future", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_EmptyProfileID verifies that a profile with no XCCDF content ID and no
+// scanner-type annotation still produces a valid event (not dropped), with an empty ProfileId.
+// This exercises the empty-ProfileId Warn path in the dispatcher.
+func TestProfileDispatcher_EmptyProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "incomplete-profile",
+			UID:  "some-uid",
+			// No annotations, no XCCDF ID — malformed or in-progress profile
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	// The dispatcher does not drop the event — it logs a Warn and proceeds.
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "", v1Profile.GetProfileId())
+}
+
 // TestProfileDispatcher_CELProfileID_V2 verifies the V2 event also carries the k8s name as ProfileId.
 func TestProfileDispatcher_CELProfileID_V2(t *testing.T) {
 	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorprofiles_test.go
@@ -20,30 +20,70 @@ func profileToUnstructured(t *testing.T, p *v1alpha1.Profile) *unstructured.Unst
 	return &unstructured.Unstructured{Object: obj}
 }
 
-// TestProfileDispatcher_ProfileIDSelection verifies ProfileId selection for every scanner-type
-// annotation value, so that BuildProfileRefID produces matching UUIDs on both the profile and
-// the scan sides. Unrecognised scanner types and empty XCCDF IDs still produce a valid event
-// (not dropped) — the dispatcher only logs a Warn in those cases.
-func TestProfileDispatcher_ProfileIDSelection(t *testing.T) {
+// TestProfileDispatcher_OpenSCAPProfileID verifies that OpenSCAP profiles use the XCCDF content ID
+// (complianceProfile.ID) as ProfileId, so that BuildProfileRefID matches the scan side.
+func TestProfileDispatcher_OpenSCAPProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ocp4-cis",
+			UID:  "some-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_cis",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_org.ssgproject.content_profile_cis", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_CELProfileID verifies that CEL profiles use the k8s object name as
+// ProfileId, mirroring what ComplianceScan.Spec.Profile is set to by the compliance operator,
+// so that BuildProfileRefID produces matching UUIDs on both the profile and the scan sides.
+func TestProfileDispatcher_CELProfileID(t *testing.T) {
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			// K8s name: what CO puts in ComplianceScan.Spec.Profile for CEL profiles
+			Name: "ocp4virt-cis-vm-extension",
+			UID:  "cel-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			// Short content ID — no XCCDF prefix — which CO does NOT use in spec.profile
+			ID: "cis-vm-extension",
+		},
+	}
+
+	dispatcher := NewProfileDispatcher()
+	event := dispatcher.ProcessEvent(profileToUnstructured(t, profile), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	v1Profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what the scan dispatcher reads from ComplianceScan.Spec.Profile
+	assert.Equal(t, "ocp4virt-cis-vm-extension", v1Profile.GetProfileId())
+}
+
+// TestProfileDispatcher_FallbackCases verifies the fallback ProfileId paths added for
+// observability: no annotation, an unrecognised scanner type, and a missing XCCDF ID. In every
+// case the dispatcher still emits a valid event (never drops it) and logs a Warn.
+func TestProfileDispatcher_FallbackCases(t *testing.T) {
 	tests := map[string]struct {
 		scannerType   string
 		xccdfID       string
 		name          string
 		wantProfileID string
 	}{
-		"OpenSCAP uses XCCDF content ID": {
-			scannerType:   string(v1alpha1.ScannerTypeOpenSCAP),
-			xccdfID:       "xccdf_org.ssgproject.content_profile_cis",
-			name:          "ocp4-cis",
-			wantProfileID: "xccdf_org.ssgproject.content_profile_cis",
-		},
-		"CEL uses k8s object name": {
-			scannerType: string(v1alpha1.ScannerTypeCEL),
-			// Short content ID — no XCCDF prefix — which CO does NOT use in spec.profile
-			xccdfID:       "cis-vm-extension",
-			name:          "ocp4virt-cis-vm-extension",
-			wantProfileID: "ocp4virt-cis-vm-extension",
-		},
 		"no annotation falls back to XCCDF ID (CO < 1.9)": {
 			scannerType:   "",
 			xccdfID:       "xccdf_org.ssgproject.content_profile_cis",

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -82,8 +82,6 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	switch scannerType := tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; {
 	case scannerType == string(v1alpha1.ScannerTypeCEL):
 		profileID = tailoredProfile.GetName()
-		log.Debugf("Tailored profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
-			tailoredProfile.GetName(), profileID, tailoredProfile.Status.ID)
 	case scannerType == string(v1alpha1.ScannerTypeOpenSCAP), scannerType == "":
 		profileID = tailoredProfile.Status.ID
 	default:

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -76,10 +76,10 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	// We must use the same value as ProfileId so that BuildProfileRefID produces
 	// matching UUIDs on both the profile and the scan sides.
 	var profileID string
-	switch scannerType := tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; {
-	case scannerType == string(v1alpha1.ScannerTypeCEL):
+	switch scannerType := tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; scannerType {
+	case string(v1alpha1.ScannerTypeCEL):
 		profileID = tailoredProfile.GetName()
-	case scannerType == string(v1alpha1.ScannerTypeOpenSCAP), scannerType == "":
+	case string(v1alpha1.ScannerTypeOpenSCAP), "":
 		profileID = tailoredProfile.Status.ID
 	default:
 		profileID = tailoredProfile.Status.ID

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -40,7 +40,10 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		return nil
 	}
 
-	if tailoredProfile.Status.ID == "" {
+	if tailoredProfile.Status.ID == "" &&
+		tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] != string(v1alpha1.ScannerTypeCEL) {
+		// CEL-based TPs may legitimately have no XCCDF Status.ID; we use the k8s name instead.
+		// Non-CEL TPs without a Status.ID are not yet ready (CO hasn't processed them).
 		log.Warnf("Tailored profile %s does not have an ID. Skipping...", tailoredProfile.Name)
 		return nil
 	}
@@ -75,9 +78,19 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	// broader ScannerTypeAnnotation check in CO's scansettingbinding controller.
 	// We must use the same value as ProfileId so that BuildProfileRefID produces
 	// matching UUIDs on both the profile and the scan sides.
-	profileID := tailoredProfile.Status.ID
-	if tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] == string(v1alpha1.ScannerTypeCEL) {
+	var profileID string
+	switch scannerType := tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation]; {
+	case scannerType == string(v1alpha1.ScannerTypeCEL):
 		profileID = tailoredProfile.GetName()
+		log.Debugf("Tailored profile %s uses CEL scanner: using k8s name %q as ProfileId instead of XCCDF ID %q",
+			tailoredProfile.GetName(), profileID, tailoredProfile.Status.ID)
+	case scannerType == string(v1alpha1.ScannerTypeOpenSCAP), scannerType == "":
+		profileID = tailoredProfile.Status.ID
+	default:
+		profileID = tailoredProfile.Status.ID
+		log.Warnf("Tailored profile %s has unrecognised scanner-type annotation %q: using XCCDF ID %q as ProfileId; "+
+			"if compliance coverage shows 0 results, this scanner type may need handling here",
+			tailoredProfile.GetName(), scannerType, profileID)
 	}
 
 	protoProfile := &storage.ComplianceOperatorProfile{

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -40,10 +40,7 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		return nil
 	}
 
-	if tailoredProfile.Status.ID == "" &&
-		tailoredProfile.GetAnnotations()[v1alpha1.ScannerTypeAnnotation] != string(v1alpha1.ScannerTypeCEL) {
-		// CEL-based TPs may legitimately have no XCCDF Status.ID; we use the k8s name instead.
-		// Non-CEL TPs without a Status.ID are not yet ready (CO hasn't processed them).
+	if tailoredProfile.Status.ID == "" {
 		log.Warnf("Tailored profile %s does not have an ID. Skipping...", tailoredProfile.Name)
 		return nil
 	}

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -161,67 +161,67 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
-// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
-func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tp-openscap",
-			UID:  "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
-			},
+// TestProcessEvent_TailoredProfileIDSelection verifies ProfileId selection for every scanner-type
+// annotation value, so that BuildProfileRefID produces matching UUIDs on both the profile and
+// the scan sides. CEL-based TPs use the k8s object name (which covers TPs with CustomRules, TPs
+// with CEL-typed rules but no CustomRules, and TPs extending a CEL base profile — the compliance
+// operator sets ComplianceScan.Spec.Profile to the k8s name for all three). An unrecognised
+// scanner type still produces a valid event (not dropped) — the dispatcher only logs a Warn.
+func TestProcessEvent_TailoredProfileIDSelection(t *testing.T) {
+	tests := map[string]struct {
+		scannerType   string
+		statusID      string
+		name          string
+		wantProfileID string
+	}{
+		"OpenSCAP TP uses Status.ID": {
+			scannerType:   string(v1alpha1.ScannerTypeOpenSCAP),
+			statusID:      "xccdf_compliance.openshift.io_profile_tp-openscap",
+			name:          "tp-openscap",
+			wantProfileID: "xccdf_compliance.openshift.io_profile_tp-openscap",
 		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		"CEL TP uses k8s object name": {
+			scannerType:   string(v1alpha1.ScannerTypeCEL),
+			statusID:      "xccdf_compliance.openshift.io_profile_my-cel-tp",
+			name:          "my-cel-tp",
+			wantProfileID: "my-cel-tp",
 		},
-		Status: v1alpha1.TailoredProfileStatus{
-			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
-}
-
-// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
-// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
-// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
-//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
-//   - TPs with CEL-typed rules but no CustomRules
-//   - TPs extending a CEL base profile
-func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-cel-tp",
-			UID:  "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
-			State: "READY",
+		"unrecognised scanner type falls back to Status.ID": {
+			scannerType:   "WASM", // hypothetical future type
+			statusID:      "xccdf_compliance.openshift.io_profile_future-tp",
+			name:          "future-tp",
+			wantProfileID: "xccdf_compliance.openshift.io_profile_future-tp",
 		},
 	}
 
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tp := &v1alpha1.TailoredProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.name,
+					UID:  "tp-uid",
+					Annotations: map[string]string{
+						v1alpha1.ScannerTypeAnnotation: tc.scannerType,
+					},
+				},
+				Spec: v1alpha1.TailoredProfileSpec{
+					EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+				},
+				Status: v1alpha1.TailoredProfileStatus{
+					ID:    tc.statusID,
+					State: "READY",
+				},
+			}
 
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
-	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
+			dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+			event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+			require.NotNil(t, event)
+			require.NotEmpty(t, event.ForwardMessages)
+			profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+			assert.Equal(t, tc.wantProfileID, profile.GetProfileId())
+		})
+	}
 }
 
 // TestProcessEvent_StoresTailoredProfileMetadata tests that all metadata fields are stored
@@ -327,37 +327,6 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	assert.Nil(t, event)
-}
-
-// TestProcessEvent_UnknownScannerType verifies that a TP with an unrecognised scanner-type
-// falls back to Status.ID as ProfileId (so the dispatcher doesn't silently break).
-func TestProcessEvent_UnknownScannerType(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "future-tp",
-			Namespace: "openshift-compliance",
-			UID:       "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			ID:    "xccdf_compliance.openshift.io_profile_future-tp",
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	// Falls back to Status.ID — a Warn log is emitted by the dispatcher
-	assert.Equal(t, "xccdf_compliance.openshift.io_profile_future-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -76,69 +76,6 @@ func toUnstructured(t *testing.T, tp *v1alpha1.TailoredProfile) *unstructured.Un
 	return &unstructured.Unstructured{Object: unstructuredObj}
 }
 
-// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
-// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
-func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tp-openscap",
-			UID:  "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
-}
-
-// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
-// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
-// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
-//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
-//   - TPs with CEL-typed rules but no CustomRules
-//   - TPs extending a CEL base profile
-func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-cel-tp",
-			UID:  "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	require.NotEmpty(t, event.ForwardMessages)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
-	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
-}
-
 // TestProcessEvent_ExtendsProfile tests rule computation and metadata handling when extending a base profile:
 // - effective rules = base rules - disabled rules + enabled rules
 // - labels, annotations, description parsed from tailored profile
@@ -222,6 +159,69 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 		"ocp4-api-server-encryption-provider-cipher",
 		"ocp4-audit-log-forwarding-enabled",
 	}, ruleNames)
+}
+
+// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
+// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
+func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tp-openscap",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
+}
+
+// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
+// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
+// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
+//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
+//   - TPs with CEL-typed rules but no CustomRules
+//   - TPs extending a CEL base profile
+func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cel-tp",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_StoresTailoredProfileMetadata tests that all metadata fields are stored

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -76,6 +76,69 @@ func toUnstructured(t *testing.T, tp *v1alpha1.TailoredProfile) *unstructured.Un
 	return &unstructured.Unstructured{Object: unstructuredObj}
 }
 
+// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
+// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
+func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tp-openscap",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
+}
+
+// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
+// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
+// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
+//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
+//   - TPs with CEL-typed rules but no CustomRules
+//   - TPs extending a CEL base profile
+func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cel-tp",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
+}
+
 // TestProcessEvent_ExtendsProfile tests rule computation and metadata handling when extending a base profile:
 // - effective rules = base rules - disabled rules + enabled rules
 // - labels, annotations, description parsed from tailored profile
@@ -161,68 +224,6 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
-// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
-func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tp-openscap",
-			UID:  "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
-}
-
-// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
-// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
-// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
-//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
-//   - TPs with CEL-typed rules but no CustomRules
-//   - TPs extending a CEL base profile
-func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-cel-tp",
-			UID:  "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			// CO sets a generated ID, but scan.Profile uses the k8s name for CEL TPs
-			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
-	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
-}
-
 // TestProcessEvent_StoresTailoredProfileMetadata tests that all metadata fields are stored
 // from the tailored profile itself, rather than from the base profile it extends.
 func TestProcessEvent_StoresTailoredProfileMetadata(t *testing.T) {
@@ -305,7 +306,8 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped
+// TestProcessEvent_NoStatusID tests that non-CEL TPs without a Status.ID are skipped
+// (not yet processed by CO).
 func TestProcessEvent_NoStatusID(t *testing.T) {
 	tp := &v1alpha1.TailoredProfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -326,6 +328,67 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	assert.Nil(t, event)
+}
+
+// TestProcessEvent_CELTPWithNoStatusID verifies that a CEL-based TP is not skipped when
+// Status.ID is empty. CEL TPs use the k8s name as ProfileId, so Status.ID is not required.
+func TestProcessEvent_CELTPWithNoStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cel-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			// Status.ID intentionally empty — CO may not set it for CEL TPs
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event, "CEL TP without Status.ID should not be skipped")
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
+}
+
+// TestProcessEvent_UnknownScannerType verifies that a TP with an unrecognised scanner-type
+// falls back to Status.ID as ProfileId (so the dispatcher doesn't silently break).
+func TestProcessEvent_UnknownScannerType(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "future-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_future-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Falls back to Status.ID — a Warn log is emitted by the dispatcher
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_future-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -306,8 +306,7 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_NoStatusID tests that non-CEL TPs without a Status.ID are skipped
-// (not yet processed by CO).
+// TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped
 func TestProcessEvent_NoStatusID(t *testing.T) {
 	tp := &v1alpha1.TailoredProfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -328,36 +327,6 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	assert.Nil(t, event)
-}
-
-// TestProcessEvent_CELTPWithNoStatusID verifies that a CEL-based TP is not skipped when
-// Status.ID is empty. CEL TPs use the k8s name as ProfileId, so Status.ID is not required.
-func TestProcessEvent_CELTPWithNoStatusID(t *testing.T) {
-	tp := &v1alpha1.TailoredProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-cel-tp",
-			Namespace: "openshift-compliance",
-			UID:       "tp-uid",
-			Annotations: map[string]string{
-				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
-			},
-		},
-		Spec: v1alpha1.TailoredProfileSpec{
-			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
-		},
-		Status: v1alpha1.TailoredProfileStatus{
-			// Status.ID intentionally empty — CO may not set it for CEL TPs
-			State: "READY",
-		},
-	}
-
-	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
-
-	require.NotNil(t, event, "CEL TP without Status.ID should not be skipped")
-	require.NotEmpty(t, event.ForwardMessages)
-	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_UnknownScannerType verifies that a TP with an unrecognised scanner-type

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -161,67 +161,68 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	}, ruleNames)
 }
 
-// TestProcessEvent_TailoredProfileIDSelection verifies ProfileId selection for every scanner-type
-// annotation value, so that BuildProfileRefID produces matching UUIDs on both the profile and
-// the scan sides. CEL-based TPs use the k8s object name (which covers TPs with CustomRules, TPs
-// with CEL-typed rules but no CustomRules, and TPs extending a CEL base profile — the compliance
-// operator sets ComplianceScan.Spec.Profile to the k8s name for all three). An unrecognised
-// scanner type still produces a valid event (not dropped) — the dispatcher only logs a Warn.
-func TestProcessEvent_TailoredProfileIDSelection(t *testing.T) {
-	tests := map[string]struct {
-		scannerType   string
-		statusID      string
-		name          string
-		wantProfileID string
-	}{
-		"OpenSCAP TP uses Status.ID": {
-			scannerType:   string(v1alpha1.ScannerTypeOpenSCAP),
-			statusID:      "xccdf_compliance.openshift.io_profile_tp-openscap",
-			name:          "tp-openscap",
-			wantProfileID: "xccdf_compliance.openshift.io_profile_tp-openscap",
+// TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID verifies that OpenSCAP TPs use Status.ID
+// as ProfileId, matching what the scan dispatcher reads from ComplianceScan.Spec.Profile.
+func TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tp-openscap",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeOpenSCAP),
+			},
 		},
-		"CEL TP uses k8s object name": {
-			scannerType:   string(v1alpha1.ScannerTypeCEL),
-			statusID:      "xccdf_compliance.openshift.io_profile_my-cel-tp",
-			name:          "my-cel-tp",
-			wantProfileID: "my-cel-tp",
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
 		},
-		"unrecognised scanner type falls back to Status.ID": {
-			scannerType:   "WASM", // hypothetical future type
-			statusID:      "xccdf_compliance.openshift.io_profile_future-tp",
-			name:          "future-tp",
-			wantProfileID: "xccdf_compliance.openshift.io_profile_future-tp",
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_tp-openscap",
+			State: "READY",
 		},
 	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			tp := &v1alpha1.TailoredProfile{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: tc.name,
-					UID:  "tp-uid",
-					Annotations: map[string]string{
-						v1alpha1.ScannerTypeAnnotation: tc.scannerType,
-					},
-				},
-				Spec: v1alpha1.TailoredProfileSpec{
-					EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
-				},
-				Status: v1alpha1.TailoredProfileStatus{
-					ID:    tc.statusID,
-					State: "READY",
-				},
-			}
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
-			dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
-			event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_tp-openscap", profile.GetProfileId())
+}
 
-			require.NotNil(t, event)
-			require.NotEmpty(t, event.ForwardMessages)
-			profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
-			assert.Equal(t, tc.wantProfileID, profile.GetProfileId())
-		})
+// TestProcessEvent_CELTailoredProfileUsesK8sName verifies that CEL TPs use the k8s object name
+// as ProfileId. The compliance operator sets ComplianceScan.Spec.Profile to the k8s name for
+// any CEL-based TP (ScannerTypeAnnotation=CEL). This covers:
+//   - TPs with CustomRules (also have CustomRuleProfileAnnotation=true)
+//   - TPs with CEL-typed rules but no CustomRules
+//   - TPs extending a CEL base profile
+func TestProcessEvent_CELTailoredProfileUsesK8sName(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-cel-tp",
+			UID:  "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: string(v1alpha1.ScannerTypeCEL),
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-cel-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			// CO sets a generated ID, but scan.Profile uses the k8s name for CEL TPs
+			ID:    "xccdf_compliance.openshift.io_profile_my-cel-tp",
+			State: "READY",
+		},
 	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Must match what CO puts in ComplianceScan.Spec.Profile for CEL TPs
+	assert.Equal(t, "my-cel-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_StoresTailoredProfileMetadata tests that all metadata fields are stored
@@ -327,6 +328,37 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	assert.Nil(t, event)
+}
+
+// TestProcessEvent_UnknownScannerType verifies that a TP with an unrecognised scanner-type
+// falls back to Status.ID as ProfileId (so the dispatcher doesn't silently break).
+func TestProcessEvent_UnknownScannerType(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "future-tp",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Annotations: map[string]string{
+				v1alpha1.ScannerTypeAnnotation: "WASM", // hypothetical future type
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_future-tp",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+	// Falls back to Status.ID — a Warn log is emitted by the dispatcher
+	assert.Equal(t, "xccdf_compliance.openshift.io_profile_future-tp", profile.GetProfileId())
 }
 
 // TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped


### PR DESCRIPTION
## Description

Follow-up to #21904 and #21905. The compliance coverage join relies on `BuildProfileRefID` producing identical UUIDs from the profile dispatcher and the scan dispatcher. Divergence always manifests as 0 checks shown with no indication of cause, and #21904/#21905 fixed the two scanner types CO has today (OpenSCAP, CEL) with no such log. This PR does not change behavior — it adds visibility into fallback paths that were already silently taken, so a future divergence (or a CO scanner type this dispatcher does not yet know about) shows up in logs instead of just as an unexplained 0-results coverage page.

**Code changes to both `complianceoperatorprofiles.go` and `complianceoperatortailoredprofiles.go`:**

- `Warn` on unrecognised scanner-type annotation: if CO introduces a new scanner type that also uses the k8s name in `ComplianceScan.Spec.Profile`, the dispatcher falls back to the XCCDF ID exactly as it already did for any non-CEL annotation — the fallback itself is unchanged, only now it logs. This path is currently unreachable (CO only ever sets `OpenSCAP` or `CEL`).
- `Warn` when `profileID` is empty after selection (`complianceoperatorprofiles.go` only — structurally impossible in the TP dispatcher, see below): the event was already being sent with an empty `ProfileId` in this case before this PR; `BuildProfileRefID` with an empty string silently produces a wrong UUID. Now surfaced.

Every line here is provably behavior-preserving: traced by hand against every possible `scanner-type` annotation value, the resulting `ProfileId` is identical to what the pre-existing `if`/`else` produced. No field sent to Central changes, no event is dropped or added.

**Test coverage:** `TestProfileDispatcher_FallbackCases` (table-driven, 3 cases: no annotation, unrecognised annotation, empty XCCDF ID) and `TestProcessEvent_UnknownScannerType` (single case for the TP dispatcher — only one new branch there) cover the new log paths. Pre-existing `TestProfileDispatcher_OpenSCAPProfileID`/`_CELProfileID` and `TestProcessEvent_OpenSCAPTailoredProfileUsesStatusID`/`_CELTailoredProfileUsesK8sName` (from #21904/#21905) are unchanged.

**Note on the no-annotation fallback case:** verified against two live clusters (ga-ocp4-cron, ga-ocp4-cron-2, CO v1.9.1) that every profile carries the scanner-type annotation today (78/78 on each). Traced to compliance-operator profileparser.go, which has unconditionally set `scanner-type=OpenSCAP` on every parsed XCCDF profile since v1.9.0. The no-annotation code path only matters for CO < 1.9 — a defensive fallback, not a realistic deployment scenario today.

**Why no empty-ProfileId Warn in the TP dispatcher:** the pre-existing `Status.ID == ""` guard (unchanged by this PR) establishes `Status.ID != ""` for every TP that reaches the profileID switch, so `profileID` can never be empty there — adding the same check would be dead code.

## Scope note

An earlier version of this PR also relaxed the `Status.ID == ""` guard for CEL-annotated TPs, based on the claim that CEL TPs may legitimately lack a `Status.ID`. That claim does not hold: `updateTailoredProfileStatusReady` in compliance-operator (the only place `Ready` state is set) always sets `Status.ID` atomically in the same status update, for CEL and OpenSCAP TPs alike. A CEL TP with empty `Status.ID` is either mid-reconcile (self-corrects) or permanently stuck in an error state — forwarding the latter to Central would reproduce the exact "0 results, no obvious cause" symptom this effort exists to fix. That change has been reverted and split out; it needs its own PR with a corrected approach (e.g. checking `Status.State` instead of `Status.ID`) before shipping.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests: fallback-case coverage (no annotation, unknown scanner type, empty ProfileId) across both dispatchers