### PR TITLE
fix(compliance): prevent cascade ScanConfigWatcher after timeout

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -87,6 +87,21 @@ type managerImpl struct {
 	watchingScanConfigsLock sync.Mutex
 	// watchingScanConfigs a map holding the ScanConfigWatchers
 	watchingScanConfigs map[string]watcher.ScanConfigWatcher
+	// retiredScanConfigWatchers records, per scan configuration ID, when (Central's own
+	// clock) a ScanConfigWatcher last retired (e.g. timed out) after processing at
+	// least one scan for that configuration. getOrCreateScanConfigWatcher treats any
+	// scan arriving within retiredScanConfigWatcherGracePeriod of that retirement as a
+	// late arrival of the same cycle and skips creating a duplicate watcher for it,
+	// even when no report snapshot exists (e.g. no notifiers configured, see
+	// createAutomaticSnapshotAndSubscribe).
+	//
+	// This intentionally uses Central's own clock instead of comparing the scans' own
+	// self-reported LastStartedTime across clusters: in-cluster testing showed two
+	// clusters scanned "at the same time" for the same cycle can still differ by a
+	// second or more, which is enough to break a strict timestamp comparison and
+	// re-open the exact cascade this map exists to prevent. Guarded by
+	// watchingScanConfigsLock.
+	retiredScanConfigWatchers map[string]time.Time
 	// scanConfigReadyQueue holds the scan configurations that are ready to be reported
 	scanConfigReadyQueue *queue.Queue[*watcher.ScanConfigWatcherResults]
 
@@ -107,27 +122,28 @@ func New(scanConfigDS scanConfigurationDS.DataStore,
 	reportGen reportGen.ComplianceReportGenerator) Manager {
 	gmt := time.NewTicker(env.ComplianceScansRunningInParallelMetricObservationPeriod.DurationSetting())
 	return &managerImpl{
-		scanConfigDataStore:    scanConfigDS,
-		scanDataStore:          scanDataStore,
-		profileDataStore:       profileDataStore,
-		snapshotDataStore:      snapshotDatastore,
-		integrationDataStore:   complianceIntegration,
-		suiteDataStore:         suiteDataStore,
-		bindingsDataStore:      bindingsDataStore,
-		checkResultDataStore:   checkResultDataStore,
-		stopper:                concurrency.NewStopper(),
-		runningReportConfigs:   make(map[string]*reportRequest, maxRequests),
-		reportRequests:         make(chan *reportRequest, maxRequests),
-		concurrencySem:         semaphore.NewWeighted(int64(env.ReportExecutionMaxConcurrency.IntegerSetting())),
-		reportGen:              reportGen,
-		automaticReportingCtx:  sac.WithAllAccess(context.Background()),
-		watchingScans:          make(map[string]watcher.ScanWatcher),
-		watchingScansStartTime: make(map[string]time.Time),
-		readyQueue:             queue.NewQueue[*watcher.ScanWatcherResults](),
-		watchingScanConfigs:    make(map[string]watcher.ScanConfigWatcher),
-		scanConfigReadyQueue:   queue.NewQueue[*watcher.ScanConfigWatcherResults](),
-		metricsTicker:          gmt,
-		metricsTickerC:         gmt.C,
+		scanConfigDataStore:       scanConfigDS,
+		scanDataStore:             scanDataStore,
+		profileDataStore:          profileDataStore,
+		snapshotDataStore:         snapshotDatastore,
+		integrationDataStore:      complianceIntegration,
+		suiteDataStore:            suiteDataStore,
+		bindingsDataStore:         bindingsDataStore,
+		checkResultDataStore:      checkResultDataStore,
+		stopper:                   concurrency.NewStopper(),
+		runningReportConfigs:      make(map[string]*reportRequest, maxRequests),
+		reportRequests:            make(chan *reportRequest, maxRequests),
+		concurrencySem:            semaphore.NewWeighted(int64(env.ReportExecutionMaxConcurrency.IntegerSetting())),
+		reportGen:                 reportGen,
+		automaticReportingCtx:     sac.WithAllAccess(context.Background()),
+		watchingScans:             make(map[string]watcher.ScanWatcher),
+		watchingScansStartTime:    make(map[string]time.Time),
+		readyQueue:                queue.NewQueue[*watcher.ScanWatcherResults](),
+		watchingScanConfigs:       make(map[string]watcher.ScanConfigWatcher),
+		retiredScanConfigWatchers: make(map[string]time.Time),
+		scanConfigReadyQueue:      queue.NewQueue[*watcher.ScanConfigWatcherResults](),
+		metricsTicker:             gmt,
+		metricsTickerC:            gmt.C,
 	}
 }
 
@@ -505,6 +521,8 @@ func (m *managerImpl) handleReadyScan() {
 		log.Debugf("Scan %s done with %d checks", scanWatcherResult.Scan.GetScanName(), len(scanWatcherResult.CheckResults))
 		w, scanConfig, wasAlreadyRunning, err := m.getOrCreateScanConfigWatcher(scanWatcherResult.SensorCtx, scanWatcherResult, m.scanConfigDataStore, m.scanConfigReadyQueue)
 		if errors.Is(err, watcher.ErrScanAlreadyHandled) {
+			log.Debugf("Scan config for scan %s was already handled by a previous ScanConfigWatcher, skipping",
+				scanWatcherResult.Scan.GetScanName())
 			continue
 		}
 		if err != nil {
@@ -533,11 +551,20 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 	if sc == nil {
 		return nil, nil, false, errors.Errorf("ScanConfiguration not found for scan %s", results.Scan.GetScanName())
 	}
-	w, watcherIsRunning := concurrency.WithLock2[watcher.ScanConfigWatcher, bool](&m.watchingScanConfigsLock, func() (watcher.ScanConfigWatcher, bool) {
+	w, watcherIsRunning, retiredAt := concurrency.WithLock3[watcher.ScanConfigWatcher, bool, time.Time](&m.watchingScanConfigsLock, func() (watcher.ScanConfigWatcher, bool, time.Time) {
 		w, watcherIsRunning := m.watchingScanConfigs[sc.GetId()]
-		return w, watcherIsRunning
+		return w, watcherIsRunning, m.retiredScanConfigWatchers[sc.GetId()]
 	})
 	if !watcherIsRunning {
+		if !retiredAt.IsZero() && time.Since(retiredAt) < retiredScanConfigWatcherGracePeriod() {
+			// A ScanConfigWatcher already retired (e.g. timed out) recently after
+			// processing at least one scan for this scan configuration. Treat this scan
+			// as a late arrival of that same cycle rather than spinning up a second
+			// watcher for it. This check does not depend on a report snapshot existing,
+			// so it also covers scan configurations with no notifiers configured, unlike
+			// the snapshot search below.
+			return nil, nil, false, watcher.ErrScanAlreadyHandled
+		}
 		query := search.NewQueryBuilder().
 			AddExactMatches(search.ComplianceOperatorScanConfig, sc.GetId()).
 			AddTimeRangeField(search.ComplianceOperatorScanLastStartedTime, results.Scan.GetLastStartedTime().AsTime(), timestamp.InfiniteFuture.GoTime()).
@@ -548,7 +575,9 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 		}
 		if len(snapshot) > 0 {
 			// A snapshot for this scan configuration already exists for this time range,
-			// meaning a prior ScanConfigWatcher already processed this scan cycle.
+			// meaning a prior ScanConfigWatcher already processed this scan cycle. This is
+			// a defense-in-depth backstop for the (rare) case where retiredScanConfigWatchers
+			// lost the in-memory record, e.g. across a Central restart.
 			return nil, nil, false, watcher.ErrScanAlreadyHandled
 		}
 		log.Debugf("Starting config watcher %s", sc.GetId())
@@ -558,6 +587,23 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 		})
 	}
 	return w, sc, watcherIsRunning, nil
+}
+
+// retiredScanConfigWatcherGracePeriod returns how long after a ScanConfigWatcher
+// retires a newly-arriving scan is still considered a late arrival of the same cycle
+// (see retiredScanConfigWatchers).
+//
+// An individual scan can legitimately still be in flight for up to
+// ComplianceScanWatcherTimeout from whenever its own ScanWatcher started, independent
+// of when the scan configuration's watcher started counting down. Since the scan
+// configuration watcher's own timeout (ComplianceScanScheduleWatcherTimeout) can fire
+// as soon as it is created -- i.e. as early as when the very first scan of the cycle
+// arrives -- the worst-case gap between the scan config watcher retiring and a slower
+// sibling scan's own watcher finally timing out is bounded by the sum of both
+// durations. In-cluster testing confirmed that using either timeout alone does not
+// consistently leave enough margin and lets the cascade this exists to prevent through.
+func retiredScanConfigWatcherGracePeriod() time.Duration {
+	return env.ComplianceScanScheduleWatcherTimeout.DurationSetting() + env.ComplianceScanWatcherTimeout.DurationSetting()
 }
 
 // createAutomaticSnapshotAndSubscribe creates a snapshot for an automatic report (not on-demand)
@@ -608,6 +654,12 @@ func (m *managerImpl) handleReadyScanConfig() {
 			scanConfigWatcherResult.ScanConfig.GetScanConfigName(), len(scanConfigWatcherResult.ScanResults), len(scanConfigWatcherResult.ReportSnapshot), scanConfigWatcherResult.Error)
 		concurrency.WithLock(&m.watchingScanConfigsLock, func() {
 			delete(m.watchingScanConfigs, scanConfigWatcherResult.WatcherID)
+			// Only record a retirement if at least one scan was actually processed: if
+			// none were, there is no already-succeeded data a duplicate watcher could
+			// endanger, so a late scan is free to start a fresh watcher.
+			if len(scanConfigWatcherResult.ScanResults) > 0 {
+				m.retiredScanConfigWatchers[scanConfigWatcherResult.WatcherID] = time.Now()
+			}
 		})
 		if err := watcher.DeleteOldResultsFromMissingScans(m.automaticReportingCtx, scanConfigWatcherResult, m.profileDataStore, m.scanDataStore, m.checkResultDataStore); err != nil {
 			log.Errorf("unable to delete old CheckResults: %v", err)

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/queue"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -48,6 +49,15 @@ type reportRequest struct {
 	notificationMethod storage.ComplianceOperatorReportStatus_NotificationMethod
 	clusterData        map[string]*report.ClusterData
 	numFailedClusters  int
+}
+
+// retiredScanConfigWatcherInfo is recorded when a ScanConfigWatcher retires; see
+// managerImpl.retiredScanConfigWatchers.
+type retiredScanConfigWatcherInfo struct {
+	retiredAt time.Time
+	// missingScans holds the "clusterID:scanID" identities that were still
+	// outstanding when the watcher retired.
+	missingScans set.StringSet
 }
 
 type managerImpl struct {
@@ -87,21 +97,28 @@ type managerImpl struct {
 	watchingScanConfigsLock sync.Mutex
 	// watchingScanConfigs a map holding the ScanConfigWatchers
 	watchingScanConfigs map[string]watcher.ScanConfigWatcher
-	// retiredScanConfigWatchers records, per scan configuration ID, when (Central's own
-	// clock) a ScanConfigWatcher last retired (e.g. timed out) after processing at
-	// least one scan for that configuration. getOrCreateScanConfigWatcher treats any
-	// scan arriving within retiredScanConfigWatcherGracePeriod of that retirement as a
-	// late arrival of the same cycle and skips creating a duplicate watcher for it,
-	// even when no report snapshot exists (e.g. no notifiers configured, see
-	// createAutomaticSnapshotAndSubscribe).
+	// retiredScanConfigWatchers records, per scan configuration ID, the scans that were
+	// still outstanding ("clusterID:scanID", the same identity used as ScanResults
+	// map keys) when a ScanConfigWatcher last retired (e.g. timed out) after
+	// processing at least one scan for that configuration, together with when (Central's
+	// own clock) that happened. getOrCreateScanConfigWatcher treats a scan arriving
+	// within retiredScanConfigWatcherGracePeriod of that retirement as a late arrival of
+	// the same cycle -- and skips creating a duplicate watcher for it, even when no
+	// report snapshot exists (e.g. no notifiers configured, see
+	// createAutomaticSnapshotAndSubscribe) -- only if it is one of the recorded
+	// outstanding scans.
 	//
-	// This intentionally uses Central's own clock instead of comparing the scans' own
+	// Matching by scan identity, rather than only by elapsed time, matters: a bare
+	// time-based guard cannot tell a late arrival of the retired cycle apart from a
+	// scan belonging to a genuinely new cycle (e.g. the scan configuration manually
+	// re-run shortly after the timeout) and would silently drop the latter's results
+	// too. Matching by identity also does not depend on comparing the scans' own
 	// self-reported LastStartedTime across clusters: in-cluster testing showed two
 	// clusters scanned "at the same time" for the same cycle can still differ by a
 	// second or more, which is enough to break a strict timestamp comparison and
 	// re-open the exact cascade this map exists to prevent. Guarded by
 	// watchingScanConfigsLock.
-	retiredScanConfigWatchers map[string]time.Time
+	retiredScanConfigWatchers map[string]retiredScanConfigWatcherInfo
 	// scanConfigReadyQueue holds the scan configurations that are ready to be reported
 	scanConfigReadyQueue *queue.Queue[*watcher.ScanConfigWatcherResults]
 
@@ -140,7 +157,7 @@ func New(scanConfigDS scanConfigurationDS.DataStore,
 		watchingScansStartTime:    make(map[string]time.Time),
 		readyQueue:                queue.NewQueue[*watcher.ScanWatcherResults](),
 		watchingScanConfigs:       make(map[string]watcher.ScanConfigWatcher),
-		retiredScanConfigWatchers: make(map[string]time.Time),
+		retiredScanConfigWatchers: make(map[string]retiredScanConfigWatcherInfo),
 		scanConfigReadyQueue:      queue.NewQueue[*watcher.ScanConfigWatcherResults](),
 		metricsTicker:             gmt,
 		metricsTickerC:            gmt.C,
@@ -551,18 +568,23 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 	if sc == nil {
 		return nil, nil, false, errors.Errorf("ScanConfiguration not found for scan %s", results.Scan.GetScanName())
 	}
-	w, watcherIsRunning, retiredAt := concurrency.WithLock3[watcher.ScanConfigWatcher, bool, time.Time](&m.watchingScanConfigsLock, func() (watcher.ScanConfigWatcher, bool, time.Time) {
+	w, watcherIsRunning, retiredInfo := concurrency.WithLock3[watcher.ScanConfigWatcher, bool, retiredScanConfigWatcherInfo](&m.watchingScanConfigsLock, func() (watcher.ScanConfigWatcher, bool, retiredScanConfigWatcherInfo) {
 		w, watcherIsRunning := m.watchingScanConfigs[sc.GetId()]
 		return w, watcherIsRunning, m.retiredScanConfigWatchers[sc.GetId()]
 	})
 	if !watcherIsRunning {
-		if !retiredAt.IsZero() && time.Since(retiredAt) < retiredScanConfigWatcherGracePeriod() {
-			// A ScanConfigWatcher already retired (e.g. timed out) recently after
-			// processing at least one scan for this scan configuration. Treat this scan
-			// as a late arrival of that same cycle rather than spinning up a second
-			// watcher for it. This check does not depend on a report snapshot existing,
-			// so it also covers scan configurations with no notifiers configured, unlike
-			// the snapshot search below.
+		scanKey := fmt.Sprintf("%s:%s", results.Scan.GetClusterId(), results.Scan.GetId())
+		if !retiredInfo.retiredAt.IsZero() && retiredInfo.missingScans.Contains(scanKey) &&
+			time.Since(retiredInfo.retiredAt) < retiredScanConfigWatcherGracePeriod() {
+			// A ScanConfigWatcher already retired (e.g. timed out) recently while still
+			// waiting for exactly this scan. Treat it as a late arrival of that same
+			// cycle rather than spinning up a second watcher for it. Matching by scan
+			// identity (not just elapsed time) means a genuinely new cycle for the same
+			// scan configuration -- e.g. a manual re-run shortly after the timeout,
+			// which uses a different scan -- is not mistaken for a late arrival and
+			// silently dropped. This check does not depend on a report snapshot
+			// existing, so it also covers scan configurations with no notifiers
+			// configured, unlike the snapshot search below.
 			return nil, nil, false, watcher.ErrScanAlreadyHandled
 		}
 		query := search.NewQueryBuilder().
@@ -604,6 +626,23 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 // consistently leave enough margin and lets the cascade this exists to prevent through.
 func retiredScanConfigWatcherGracePeriod() time.Duration {
 	return env.ComplianceScanScheduleWatcherTimeout.DurationSetting() + env.ComplianceScanWatcherTimeout.DurationSetting()
+}
+
+// computeMissingScans returns the "clusterID:scanID" identities that were expected for
+// the scan configuration but are not present in the given results. This mirrors the
+// computation watcher.DeleteOldResultsFromMissingScans performs (called right after
+// this, from handleReadyScanConfig); the small amount of duplicated work is a deliberate
+// simplification to avoid restructuring that function's signature just to share it.
+func (m *managerImpl) computeMissingScans(ctx context.Context, result *watcher.ScanConfigWatcherResults) set.StringSet {
+	scans, err := watcher.GetScansFromScanConfiguration(ctx, result.ScanConfig, m.profileDataStore, m.scanDataStore)
+	if err != nil {
+		log.Warnf("unable to compute missing scans for scan config %s: %v", result.ScanConfig.GetScanConfigName(), err)
+		return nil
+	}
+	for _, scanResult := range result.ScanResults {
+		scans.Remove(fmt.Sprintf("%s:%s", scanResult.Scan.GetClusterId(), scanResult.Scan.GetId()))
+	}
+	return scans
 }
 
 // createAutomaticSnapshotAndSubscribe creates a snapshot for an automatic report (not on-demand)
@@ -652,13 +691,21 @@ func (m *managerImpl) handleReadyScanConfig() {
 	for scanConfigWatcherResult := range m.scanConfigReadyQueue.Seq(m.stopper.LowLevel().GetStopRequestSignal()) {
 		log.Infof("Scan config %s completed with %d scans, %d reports, error: %v",
 			scanConfigWatcherResult.ScanConfig.GetScanConfigName(), len(scanConfigWatcherResult.ScanResults), len(scanConfigWatcherResult.ReportSnapshot), scanConfigWatcherResult.Error)
+		// Only record a retirement if at least one scan was actually processed: if none
+		// were, there is no already-succeeded data a duplicate watcher could endanger,
+		// so a late scan is free to start a fresh watcher. Computed outside the lock
+		// since it queries the datastores.
+		var missingScans set.StringSet
+		if len(scanConfigWatcherResult.ScanResults) > 0 {
+			missingScans = m.computeMissingScans(m.automaticReportingCtx, scanConfigWatcherResult)
+		}
 		concurrency.WithLock(&m.watchingScanConfigsLock, func() {
 			delete(m.watchingScanConfigs, scanConfigWatcherResult.WatcherID)
-			// Only record a retirement if at least one scan was actually processed: if
-			// none were, there is no already-succeeded data a duplicate watcher could
-			// endanger, so a late scan is free to start a fresh watcher.
 			if len(scanConfigWatcherResult.ScanResults) > 0 {
-				m.retiredScanConfigWatchers[scanConfigWatcherResult.WatcherID] = time.Now()
+				m.retiredScanConfigWatchers[scanConfigWatcherResult.WatcherID] = retiredScanConfigWatcherInfo{
+					retiredAt:    time.Now(),
+					missingScans: missingScans,
+				}
 			}
 		})
 		if err := watcher.DeleteOldResultsFromMissingScans(m.automaticReportingCtx, scanConfigWatcherResult, m.profileDataStore, m.scanDataStore, m.checkResultDataStore); err != nil {

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -539,7 +539,7 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 	})
 	if !watcherIsRunning {
 		query := search.NewQueryBuilder().
-			AddExactMatches(search.ComplianceOperatorScanRef, results.Scan.GetScanRefId()).
+			AddExactMatches(search.ComplianceOperatorScanConfig, sc.GetId()).
 			AddTimeRangeField(search.ComplianceOperatorScanLastStartedTime, results.Scan.GetLastStartedTime().AsTime(), timestamp.InfiniteFuture.GoTime()).
 			ProtoQuery()
 		snapshot, err := m.snapshotDataStore.SearchSnapshots(m.automaticReportingCtx, query)
@@ -547,10 +547,11 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 			return nil, nil, false, errors.Wrap(err, "unable to retrieve snapshots from the store")
 		}
 		if len(snapshot) > 0 {
-			// We already handled a scan newer than this one, we ignore this scanResults
+			// A snapshot for this scan configuration already exists for this time range,
+			// meaning a prior ScanConfigWatcher already processed this scan cycle.
 			return nil, nil, false, watcher.ErrScanAlreadyHandled
 		}
-		log.Debugf("Staring config watcher %s", sc.GetId())
+		log.Debugf("Starting config watcher %s", sc.GetId())
 		concurrency.WithLock(&m.watchingScanConfigsLock, func() {
 			w = watcher.NewScanConfigWatcher(m.automaticReportingCtx, ctx, sc.GetId(), sc, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, queue)
 			m.watchingScanConfigs[sc.GetId()] = w

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -58,6 +58,13 @@ type retiredScanConfigWatcherInfo struct {
 	// missingScans holds the "clusterID:scanID" identities that were still
 	// outstanding when the watcher retired.
 	missingScans set.StringSet
+	// latestScanStartTime is the latest LastStartedTime among the scans that
+	// actually reported to the retired watcher. It serves as the reference
+	// timestamp for the cycle: a late arrival of the same cycle will have a
+	// LastStartedTime close to this value (within cross-cluster scheduling
+	// skew), while a rerun's LastStartedTime will typically be newer (CO
+	// sets a fresh StartTimestamp each time it processes a rescan).
+	latestScanStartTime time.Time
 }
 
 type managerImpl struct {
@@ -101,23 +108,35 @@ type managerImpl struct {
 	// still outstanding ("clusterID:scanID", the same identity used as ScanResults
 	// map keys) when a ScanConfigWatcher last retired (e.g. timed out) after
 	// processing at least one scan for that configuration, together with when (Central's
-	// own clock) that happened. getOrCreateScanConfigWatcher treats a scan arriving
-	// within retiredScanConfigWatcherGracePeriod of that retirement as a late arrival of
-	// the same cycle -- and skips creating a duplicate watcher for it, even when no
-	// report snapshot exists (e.g. no notifiers configured, see
-	// createAutomaticSnapshotAndSubscribe) -- only if it is one of the recorded
-	// outstanding scans.
+	// own clock) that happened and the latest LastStartedTime among the scans that
+	// actually reported.
 	//
-	// Matching by scan identity, rather than only by elapsed time, matters: a bare
-	// time-based guard cannot tell a late arrival of the retired cycle apart from a
-	// scan belonging to a genuinely new cycle (e.g. the scan configuration manually
-	// re-run shortly after the timeout) and would silently drop the latter's results
-	// too. Matching by identity also does not depend on comparing the scans' own
-	// self-reported LastStartedTime across clusters: in-cluster testing showed two
-	// clusters scanned "at the same time" for the same cycle can still differ by a
-	// second or more, which is enough to break a strict timestamp comparison and
-	// re-open the exact cascade this map exists to prevent. Guarded by
-	// watchingScanConfigsLock.
+	// getOrCreateScanConfigWatcher treats a scan as a late arrival of the same cycle
+	// and skips creating a duplicate watcher for it -- even when no report snapshot
+	// exists (e.g. no notifiers configured, see createAutomaticSnapshotAndSubscribe)
+	// -- only if ALL of the following are true:
+	//
+	//  1. Identity match: the incoming scan's "clusterID:scanID" is one of the
+	//     recorded outstanding scans. This prevents a genuinely new scan (e.g. a
+	//     cluster/profile added to the config) from being suppressed.
+	//
+	//  2. Timestamp tolerance: the incoming scan's own LastStartedTime is within
+	//     lastStartedTimeTolerance() of the reference timestamp. This catches the
+	//     common case where a rerun is triggered after the watcher times out: the
+	//     rerun's LastStartedTime is substantially newer than the reference. It does
+	//     NOT reliably catch a rerun triggered while the watcher was still running
+	//     (the rerun's timestamp could be close to the original cycle's). This check
+	//     is necessary because reruns reuse the exact same ComplianceScan K8s object
+	//     (same UID → same scanID → same identity): both CO's scheduled rerunner and
+	//     StackRox's manual "Run Now" fetch the existing object by name, set a rescan
+	//     annotation, and Update() it — never Create(). Identity alone cannot tell
+	//     a late arrival apart from a rerun.
+	//
+	//  3. Elapsed-time TTL: Central's clock hasn't moved past
+	//     retiredScanConfigWatcherGracePeriod() since the retirement. This prevents
+	//     stale entries from suppressing scans indefinitely.
+	//
+	// Guarded by watchingScanConfigsLock.
 	retiredScanConfigWatchers map[string]retiredScanConfigWatcherInfo
 	// scanConfigReadyQueue holds the scan configurations that are ready to be reported
 	scanConfigReadyQueue *queue.Queue[*watcher.ScanConfigWatcherResults]
@@ -574,17 +593,25 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 	})
 	if !watcherIsRunning {
 		scanKey := fmt.Sprintf("%s:%s", results.Scan.GetClusterId(), results.Scan.GetId())
-		if !retiredInfo.retiredAt.IsZero() && retiredInfo.missingScans.Contains(scanKey) &&
-			time.Since(retiredInfo.retiredAt) < retiredScanConfigWatcherGracePeriod() {
-			// A ScanConfigWatcher already retired (e.g. timed out) recently while still
-			// waiting for exactly this scan. Treat it as a late arrival of that same
-			// cycle rather than spinning up a second watcher for it. Matching by scan
-			// identity (not just elapsed time) means a genuinely new cycle for the same
-			// scan configuration -- e.g. a manual re-run shortly after the timeout,
-			// which uses a different scan -- is not mistaken for a late arrival and
-			// silently dropped. This check does not depend on a report snapshot
-			// existing, so it also covers scan configurations with no notifiers
-			// configured, unlike the snapshot search below.
+		incomingStartTime := results.Scan.GetLastStartedTime().AsTime()
+		if !retiredInfo.retiredAt.IsZero() &&
+			retiredInfo.missingScans.Contains(scanKey) &&
+			time.Since(retiredInfo.retiredAt) < retiredScanConfigWatcherGracePeriod() &&
+			!retiredInfo.latestScanStartTime.IsZero() &&
+			!incomingStartTime.IsZero() &&
+			absDuration(incomingStartTime.Sub(retiredInfo.latestScanStartTime)) <= lastStartedTimeTolerance() {
+			// All three conditions for the dedup guard are met (see
+			// retiredScanConfigWatchers doc comment for why all three matter):
+			//  1. Identity: this scan was one of the missing scans when the watcher retired.
+			//  2. Timestamp: its LastStartedTime is close to the retired cycle's reference
+			//     timestamp, so it's from the same scheduling cycle, not a rerun (which
+			//     would have a substantially newer timestamp).
+			//  3. TTL: the retirement was recent enough to still be relevant.
+			log.Debugf("Suppressing late scan %s for scan config %s (retired %s ago, start time delta %s, tolerance %s)",
+				scanKey, sc.GetId(),
+				time.Since(retiredInfo.retiredAt),
+				absDuration(incomingStartTime.Sub(retiredInfo.latestScanStartTime)),
+				lastStartedTimeTolerance())
 			return nil, nil, false, watcher.ErrScanAlreadyHandled
 		}
 		query := search.NewQueryBuilder().
@@ -626,6 +653,37 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 // consistently leave enough margin and lets the cascade this exists to prevent through.
 func retiredScanConfigWatcherGracePeriod() time.Duration {
 	return env.ComplianceScanScheduleWatcherTimeout.DurationSetting() + env.ComplianceScanWatcherTimeout.DurationSetting()
+}
+
+// lastStartedTimeTolerance returns the maximum allowed difference between an incoming
+// scan's LastStartedTime and the retired cycle's reference timestamp for the scan to be
+// considered a late arrival of the same cycle (as opposed to a rerun).
+//
+// The value is ComplianceScanScheduleWatcherTimeout / 3. This is much larger than
+// realistic cross-cluster scheduling skew (~seconds), so legitimate late arrivals from
+// the same cycle are always within tolerance.
+//
+// For reruns triggered after the watcher times out (the common case: a human notices the
+// timeout and clicks "Run Now"), the gap between the original cycle's timestamps and the
+// rerun's is at least ComplianceScanScheduleWatcherTimeout, so the tolerance provides a
+// 3× safety margin.
+//
+// Caveat: a rerun triggered while the watcher is still running (before timeout) can have
+// a LastStartedTime close to the original cycle's, falling within tolerance. In that
+// case the timestamp check does not help and the rerun may be suppressed if it also
+// matches by identity and arrives after the watcher retires. This is an accepted
+// limitation; the identity check (condition 1) and the TTL (condition 3) narrow the
+// window further, and check results are persisted independently at the pipeline level
+// regardless of this guard's decision.
+func lastStartedTimeTolerance() time.Duration {
+	return env.ComplianceScanScheduleWatcherTimeout.DurationSetting() / 3
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
 }
 
 // computeMissingScans returns the "clusterID:scanID" identities that were expected for
@@ -696,15 +754,22 @@ func (m *managerImpl) handleReadyScanConfig() {
 		// so a late scan is free to start a fresh watcher. Computed outside the lock
 		// since it queries the datastores.
 		var missingScans set.StringSet
+		var latestScanStartTime time.Time
 		if len(scanConfigWatcherResult.ScanResults) > 0 {
 			missingScans = m.computeMissingScans(m.automaticReportingCtx, scanConfigWatcherResult)
+			for _, scanResult := range scanConfigWatcherResult.ScanResults {
+				if t := scanResult.Scan.GetLastStartedTime().AsTime(); t.After(latestScanStartTime) {
+					latestScanStartTime = t
+				}
+			}
 		}
 		concurrency.WithLock(&m.watchingScanConfigsLock, func() {
 			delete(m.watchingScanConfigs, scanConfigWatcherResult.WatcherID)
 			if len(scanConfigWatcherResult.ScanResults) > 0 {
 				m.retiredScanConfigWatchers[scanConfigWatcherResult.WatcherID] = retiredScanConfigWatcherInfo{
-					retiredAt:    time.Now(),
-					missingScans: missingScans,
+					retiredAt:           time.Now(),
+					missingScans:        missingScans,
+					latestScanStartTime: latestScanStartTime,
 				}
 			}
 		})

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -433,6 +433,212 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 	}
 }
 
+// TestGetOrCreateScanConfigWatcherRetiredGuard covers the getOrCreateScanConfigWatcher
+// dedup guard for late-arriving scans after a ScanConfigWatcher has retired (e.g. timed
+// out). It specifically covers scan configurations without notifiers, where no report
+// snapshot is ever created, so the snapshot-based check alone cannot detect that the
+// cycle was already handled (see ROX-34779 / PR #22000).
+//
+// The guard is time-based (Central's own clock), not a comparison of the scans' own
+// self-reported LastStartedTime: in-cluster testing showed two clusters scanning "at
+// the same time" for the same cycle can still differ by a second or more, which broke
+// an earlier, timestamp-comparison-based version of this guard in practice.
+func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherRetiredGuard() {
+	scWithNotifiers := getTestScanConfig()
+	scNoNotifiers := scWithNotifiers.CloneVT()
+	scNoNotifiers.Notifiers = nil
+
+	gracePeriod := retiredScanConfigWatcherGracePeriod()
+
+	tests := map[string]struct {
+		scanConfig          *storage.ComplianceOperatorScanConfigurationV2
+		retiredAt           time.Time
+		snapshotSearchCalls int
+		snapshotsFound      []*storage.ComplianceOperatorReportSnapshotV2
+		expectHandled       bool
+	}{
+		"no notifiers, no retired record, no snapshot: starts a new watcher": {
+			scanConfig:          scNoNotifiers,
+			snapshotSearchCalls: 1,
+		},
+		"no notifiers, retired very recently: already handled without a DB search": {
+			scanConfig:          scNoNotifiers,
+			retiredAt:           time.Now(),
+			snapshotSearchCalls: 0,
+			expectHandled:       true,
+		},
+		"no notifiers, retired just under one grace period ago: already handled without a DB search": {
+			scanConfig:          scNoNotifiers,
+			retiredAt:           time.Now().Add(-gracePeriod + time.Second),
+			snapshotSearchCalls: 0,
+			expectHandled:       true,
+		},
+		"no notifiers, retired more than one grace period ago: falls through to a new watcher": {
+			scanConfig:          scNoNotifiers,
+			retiredAt:           time.Now().Add(-gracePeriod - time.Second),
+			snapshotSearchCalls: 1,
+		},
+		"notifiers configured, no retired record, snapshot exists: already handled (defense in depth)": {
+			scanConfig:          scWithNotifiers,
+			snapshotSearchCalls: 1,
+			snapshotsFound:      []*storage.ComplianceOperatorReportSnapshotV2{{}},
+			expectHandled:       true,
+		},
+	}
+
+	for name, tc := range tests {
+		m.Run(name, func() {
+			ctrl := gomock.NewController(m.T())
+			scanConfigDS := scanConfigurationDS.NewMockDataStore(ctrl)
+			snapshotDS := snapshotMocks.NewMockDataStore(ctrl)
+			generator := reportGen.NewMockComplianceReportGenerator(ctrl)
+
+			scanConfigDS.EXPECT().GetScanConfigurationByName(gomock.Any(), gomock.Eq(tc.scanConfig.GetScanConfigName())).
+				Times(1).Return(tc.scanConfig, nil)
+			snapshotDS.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).
+				Times(tc.snapshotSearchCalls).Return(tc.snapshotsFound, nil)
+
+			manager := New(scanConfigDS, m.scanDataStore, m.profileDataStore, snapshotDS, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, generator)
+			managerImplementation, ok := manager.(*managerImpl)
+			require.True(m.T(), ok)
+			if !tc.retiredAt.IsZero() {
+				managerImplementation.retiredScanConfigWatchers[tc.scanConfig.GetId()] = tc.retiredAt
+			}
+
+			results := &watcher.ScanWatcherResults{
+				Scan: &storage.ComplianceOperatorScanV2{
+					ScanConfigName:  tc.scanConfig.GetScanConfigName(),
+					LastStartedTime: protocompat.TimestampNow(),
+				},
+			}
+			w, returnedSC, wasAlreadyRunning, err := managerImplementation.getOrCreateScanConfigWatcher(
+				context.Background(), results, scanConfigDS, managerImplementation.scanConfigReadyQueue)
+
+			if tc.expectHandled {
+				assert.ErrorIs(m.T(), err, watcher.ErrScanAlreadyHandled)
+				assert.Nil(m.T(), w)
+				concurrency.WithLock(&managerImplementation.watchingScanConfigsLock, func() {
+					assert.Len(m.T(), managerImplementation.watchingScanConfigs, 0)
+				})
+			} else {
+				require.NoError(m.T(), err)
+				require.NotNil(m.T(), w)
+				assert.False(m.T(), wasAlreadyRunning)
+				assert.Equal(m.T(), tc.scanConfig.GetId(), returnedSC.GetId())
+				w.Stop()
+			}
+		})
+	}
+}
+
+// TestGetOrCreateScanConfigWatcherAlreadyRunning covers the fast path where a watcher is
+// already running for the scan configuration: neither the retired-record check nor the
+// snapshot search should be consulted.
+func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherAlreadyRunning() {
+	sc := getTestScanConfig()
+	m.scanConfigDataStore.EXPECT().GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
+		Times(1).Return(sc, nil)
+	// No SearchSnapshots expectation: it must not be called while a watcher is running.
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	managerImplementation, ok := manager.(*managerImpl)
+	require.True(m.T(), ok)
+	existing := &stubScanConfigWatcher{}
+	concurrency.WithLock(&managerImplementation.watchingScanConfigsLock, func() {
+		managerImplementation.watchingScanConfigs[sc.GetId()] = existing
+	})
+
+	results := &watcher.ScanWatcherResults{
+		Scan: &storage.ComplianceOperatorScanV2{
+			ScanConfigName:  sc.GetScanConfigName(),
+			LastStartedTime: protocompat.TimestampNow(),
+		},
+	}
+	w, _, wasAlreadyRunning, err := managerImplementation.getOrCreateScanConfigWatcher(
+		context.Background(), results, m.scanConfigDataStore, managerImplementation.scanConfigReadyQueue)
+	require.NoError(m.T(), err)
+	assert.True(m.T(), wasAlreadyRunning)
+	assert.Same(m.T(), watcher.ScanConfigWatcher(existing), w)
+}
+
+// TestHandleReadyScanConfigRecordsRetirement verifies that when a ScanConfigWatcher
+// retires (success, timeout, or cancellation) having processed at least one scan,
+// handleReadyScanConfig records the retirement time (Central's own clock), keyed by
+// scan configuration ID. This is what allows getOrCreateScanConfigWatcher to recognize
+// late scans from the same cycle without depending on a report snapshot (see
+// TestGetOrCreateScanConfigWatcherRetiredGuard). If no scan was ever processed, no
+// retirement is recorded, since there is no already-succeeded data to protect.
+func (m *ManagerTestSuite) TestHandleReadyScanConfigRecordsRetirement() {
+	sc := getTestScanConfig()
+
+	// No profiles reported for the scan config, so GetScansFromScanConfiguration (and thus
+	// DeleteOldResultsFromMissingScans) returns an empty set and no further datastore calls
+	// are made.
+	m.profileDataStore.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorProfileV2{}, nil)
+	m.reportGen.EXPECT().Stop().AnyTimes()
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	manager.Start()
+	m.T().Cleanup(manager.Stop)
+	managerImplementation, ok := manager.(*managerImpl)
+	require.True(m.T(), ok)
+
+	beforePush := time.Now()
+	result := &watcher.ScanConfigWatcherResults{
+		WatcherID:  sc.GetId(),
+		ScanConfig: sc,
+		ScanResults: map[string]*watcher.ScanWatcherResults{
+			"cluster-1:scan-1": {Scan: &storage.ComplianceOperatorScanV2{LastStartedTime: protocompat.TimestampNow()}},
+		},
+		Error: watcher.ErrScanConfigTimeout,
+	}
+	managerImplementation.scanConfigReadyQueue.Push(result)
+
+	m.Assert().Eventually(func() bool {
+		return concurrency.WithLock1[bool](&managerImplementation.watchingScanConfigsLock, func() bool {
+			retiredAt, ok := managerImplementation.retiredScanConfigWatchers[sc.GetId()]
+			return ok && !retiredAt.Before(beforePush)
+		})
+	}, 2*time.Second, 10*time.Millisecond, "expected retiredScanConfigWatchers to record the retirement time")
+}
+
+// TestHandleReadyScanConfigDoesNotRecordRetirementWithoutScans verifies that no
+// retirement is recorded when a ScanConfigWatcher retires without ever having
+// processed a scan (e.g. it timed out immediately): there is nothing for a duplicate
+// watcher to endanger in that case, so late scans should be free to start fresh.
+func (m *ManagerTestSuite) TestHandleReadyScanConfigDoesNotRecordRetirementWithoutScans() {
+	sc := getTestScanConfig()
+	m.profileDataStore.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorProfileV2{}, nil)
+	m.reportGen.EXPECT().Stop().AnyTimes()
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	manager.Start()
+	m.T().Cleanup(manager.Stop)
+	managerImplementation, ok := manager.(*managerImpl)
+	require.True(m.T(), ok)
+
+	result := &watcher.ScanConfigWatcherResults{
+		WatcherID:   sc.GetId(),
+		ScanConfig:  sc,
+		ScanResults: map[string]*watcher.ScanWatcherResults{},
+		Error:       watcher.ErrScanConfigTimeout,
+	}
+	managerImplementation.scanConfigReadyQueue.Push(result)
+
+	m.Assert().Eventually(func() bool {
+		return concurrency.WithLock1[bool](&managerImplementation.watchingScanConfigsLock, func() bool {
+			_, watcherStillTracked := managerImplementation.watchingScanConfigs[sc.GetId()]
+			return !watcherStillTracked
+		})
+	}, 2*time.Second, 10*time.Millisecond, "expected the watcher to be removed")
+	concurrency.WithLock(&managerImplementation.watchingScanConfigsLock, func() {
+		_, ok := managerImplementation.retiredScanConfigWatchers[sc.GetId()]
+		assert.False(m.T(), ok, "expected no retirement to be recorded when no scans were processed")
+	})
+}
+
 func (m *ManagerTestSuite) TestHandleScan() {
 	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
 		Return(

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -439,20 +440,27 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 // snapshot is ever created, so the snapshot-based check alone cannot detect that the
 // cycle was already handled (see ROX-34779 / PR #22000).
 //
-// The guard is time-based (Central's own clock), not a comparison of the scans' own
-// self-reported LastStartedTime: in-cluster testing showed two clusters scanning "at
-// the same time" for the same cycle can still differ by a second or more, which broke
-// an earlier, timestamp-comparison-based version of this guard in practice.
+// The guard matches by scan identity (clusterID:scanID) within a grace period measured
+// on Central's own clock, not by comparing the scans' own self-reported LastStartedTime
+// (in-cluster testing showed two clusters scanning "at the same time" for the same
+// cycle can still differ by a second or more, which broke an earlier,
+// timestamp-comparison-based version of this guard) and not by elapsed time alone
+// (which cannot tell a late arrival of the retired cycle apart from a scan belonging to
+// a genuinely new/re-triggered cycle -- see the "different scan" case below, found by a
+// CodeRabbit review of this PR).
 func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherRetiredGuard() {
 	scWithNotifiers := getTestScanConfig()
 	scNoNotifiers := scWithNotifiers.CloneVT()
 	scNoNotifiers.Notifiers = nil
 
 	gracePeriod := retiredScanConfigWatcherGracePeriod()
+	const incomingClusterID = "cluster-2"
+	const incomingScanID = "scan-2"
+	incomingScanKey := fmt.Sprintf("%s:%s", incomingClusterID, incomingScanID)
 
 	tests := map[string]struct {
 		scanConfig          *storage.ComplianceOperatorScanConfigurationV2
-		retiredAt           time.Time
+		retiredInfo         retiredScanConfigWatcherInfo
 		snapshotSearchCalls int
 		snapshotsFound      []*storage.ComplianceOperatorReportSnapshotV2
 		expectHandled       bool
@@ -461,21 +469,38 @@ func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherRetiredGuard() {
 			scanConfig:          scNoNotifiers,
 			snapshotSearchCalls: 1,
 		},
-		"no notifiers, retired very recently: already handled without a DB search": {
-			scanConfig:          scNoNotifiers,
-			retiredAt:           time.Now(),
+		"no notifiers, retired very recently with this scan missing: already handled without a DB search": {
+			scanConfig: scNoNotifiers,
+			retiredInfo: retiredScanConfigWatcherInfo{
+				retiredAt:    time.Now(),
+				missingScans: set.NewStringSet(incomingScanKey),
+			},
 			snapshotSearchCalls: 0,
 			expectHandled:       true,
 		},
-		"no notifiers, retired just under one grace period ago: already handled without a DB search": {
-			scanConfig:          scNoNotifiers,
-			retiredAt:           time.Now().Add(-gracePeriod + time.Second),
+		"no notifiers, retired just under one grace period ago with this scan missing: already handled without a DB search": {
+			scanConfig: scNoNotifiers,
+			retiredInfo: retiredScanConfigWatcherInfo{
+				retiredAt:    time.Now().Add(-gracePeriod + time.Second),
+				missingScans: set.NewStringSet(incomingScanKey),
+			},
 			snapshotSearchCalls: 0,
 			expectHandled:       true,
 		},
-		"no notifiers, retired more than one grace period ago: falls through to a new watcher": {
-			scanConfig:          scNoNotifiers,
-			retiredAt:           time.Now().Add(-gracePeriod - time.Second),
+		"no notifiers, retired more than one grace period ago with this scan missing: falls through to a new watcher": {
+			scanConfig: scNoNotifiers,
+			retiredInfo: retiredScanConfigWatcherInfo{
+				retiredAt:    time.Now().Add(-gracePeriod - time.Second),
+				missingScans: set.NewStringSet(incomingScanKey),
+			},
+			snapshotSearchCalls: 1,
+		},
+		"no notifiers, retired recently but this scan was not one it was missing (e.g. a re-triggered cycle): falls through to a new watcher": {
+			scanConfig: scNoNotifiers,
+			retiredInfo: retiredScanConfigWatcherInfo{
+				retiredAt:    time.Now(),
+				missingScans: set.NewStringSet("cluster-3:scan-3"),
+			},
 			snapshotSearchCalls: 1,
 		},
 		"notifiers configured, no retired record, snapshot exists: already handled (defense in depth)": {
@@ -501,13 +526,15 @@ func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherRetiredGuard() {
 			manager := New(scanConfigDS, m.scanDataStore, m.profileDataStore, snapshotDS, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, generator)
 			managerImplementation, ok := manager.(*managerImpl)
 			require.True(m.T(), ok)
-			if !tc.retiredAt.IsZero() {
-				managerImplementation.retiredScanConfigWatchers[tc.scanConfig.GetId()] = tc.retiredAt
+			if !tc.retiredInfo.retiredAt.IsZero() {
+				managerImplementation.retiredScanConfigWatchers[tc.scanConfig.GetId()] = tc.retiredInfo
 			}
 
 			results := &watcher.ScanWatcherResults{
 				Scan: &storage.ComplianceOperatorScanV2{
 					ScanConfigName:  tc.scanConfig.GetScanConfigName(),
+					ClusterId:       incomingClusterID,
+					Id:              incomingScanID,
 					LastStartedTime: protocompat.TimestampNow(),
 				},
 			}
@@ -563,19 +590,32 @@ func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherAlreadyRunning() {
 
 // TestHandleReadyScanConfigRecordsRetirement verifies that when a ScanConfigWatcher
 // retires (success, timeout, or cancellation) having processed at least one scan,
-// handleReadyScanConfig records the retirement time (Central's own clock), keyed by
-// scan configuration ID. This is what allows getOrCreateScanConfigWatcher to recognize
-// late scans from the same cycle without depending on a report snapshot (see
-// TestGetOrCreateScanConfigWatcherRetiredGuard). If no scan was ever processed, no
-// retirement is recorded, since there is no already-succeeded data to protect.
+// handleReadyScanConfig records the retirement time (Central's own clock) and the set
+// of scans that were still missing, keyed by scan configuration ID. This is what allows
+// getOrCreateScanConfigWatcher to recognize late scans from the same cycle without
+// depending on a report snapshot (see TestGetOrCreateScanConfigWatcherRetiredGuard). If
+// no scan was ever processed, no retirement is recorded, since there is no
+// already-succeeded data to protect.
 func (m *ManagerTestSuite) TestHandleReadyScanConfigRecordsRetirement() {
 	sc := getTestScanConfig()
 
-	// No profiles reported for the scan config, so GetScansFromScanConfiguration (and thus
-	// DeleteOldResultsFromMissingScans) returns an empty set and no further datastore calls
-	// are made.
+	// The scan configuration expects two scans (one profile, matched to two clusters);
+	// only "cluster-1:scan-1" is reported as received below, so "cluster-2:scan-2"
+	// should end up recorded as missing.
 	m.profileDataStore.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).AnyTimes().
-		Return([]*storage.ComplianceOperatorProfileV2{}, nil)
+		Return([]*storage.ComplianceOperatorProfileV2{{ProfileRefId: "profile-ref-1"}}, nil)
+	m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanV2{
+			{ClusterId: "cluster-1", Id: "scan-1"},
+			{ClusterId: "cluster-2", Id: "scan-2"},
+		}, nil)
+	// DeleteOldResultsFromMissingScans (called right after computeMissingScans, from
+	// handleReadyScanConfig) independently looks up and deletes results for the same
+	// missing scan; satisfy that downstream call too.
+	m.scanDataStore.EXPECT().GetScan(gomock.Any(), gomock.Eq("scan-2")).AnyTimes().
+		Return(&storage.ComplianceOperatorScanV2{ClusterId: "cluster-2", Id: "scan-2", ScanRefId: "scan-ref-2"}, true, nil)
+	m.checkResultDataStore.EXPECT().DeleteOldResults(gomock.Any(), gomock.Any(), gomock.Eq("scan-ref-2"), gomock.Eq(true)).AnyTimes().
+		Return(nil)
 	m.reportGen.EXPECT().Stop().AnyTimes()
 
 	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
@@ -589,7 +629,7 @@ func (m *ManagerTestSuite) TestHandleReadyScanConfigRecordsRetirement() {
 		WatcherID:  sc.GetId(),
 		ScanConfig: sc,
 		ScanResults: map[string]*watcher.ScanWatcherResults{
-			"cluster-1:scan-1": {Scan: &storage.ComplianceOperatorScanV2{LastStartedTime: protocompat.TimestampNow()}},
+			"cluster-1:scan-1": {Scan: &storage.ComplianceOperatorScanV2{ClusterId: "cluster-1", Id: "scan-1", LastStartedTime: protocompat.TimestampNow()}},
 		},
 		Error: watcher.ErrScanConfigTimeout,
 	}
@@ -597,10 +637,12 @@ func (m *ManagerTestSuite) TestHandleReadyScanConfigRecordsRetirement() {
 
 	m.Assert().Eventually(func() bool {
 		return concurrency.WithLock1[bool](&managerImplementation.watchingScanConfigsLock, func() bool {
-			retiredAt, ok := managerImplementation.retiredScanConfigWatchers[sc.GetId()]
-			return ok && !retiredAt.Before(beforePush)
+			info, ok := managerImplementation.retiredScanConfigWatchers[sc.GetId()]
+			return ok && !info.retiredAt.Before(beforePush) &&
+				info.missingScans.Contains("cluster-2:scan-2") &&
+				!info.missingScans.Contains("cluster-1:scan-1")
 		})
-	}, 2*time.Second, 10*time.Millisecond, "expected retiredScanConfigWatchers to record the retirement time")
+	}, 2*time.Second, 10*time.Millisecond, "expected retiredScanConfigWatchers to record the retirement time and the missing scan")
 }
 
 // TestHandleReadyScanConfigDoesNotRecordRetirementWithoutScans verifies that no

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -438,73 +438,104 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 // dedup guard for late-arriving scans after a ScanConfigWatcher has retired (e.g. timed
 // out). It specifically covers scan configurations without notifiers, where no report
 // snapshot is ever created, so the snapshot-based check alone cannot detect that the
-// cycle was already handled (see ROX-34779 / PR #22000).
+// cycle was already handled.
 //
-// The guard matches by scan identity (clusterID:scanID) within a grace period measured
-// on Central's own clock, not by comparing the scans' own self-reported LastStartedTime
-// (in-cluster testing showed two clusters scanning "at the same time" for the same
-// cycle can still differ by a second or more, which broke an earlier,
-// timestamp-comparison-based version of this guard) and not by elapsed time alone
-// (which cannot tell a late arrival of the retired cycle apart from a scan belonging to
-// a genuinely new/re-triggered cycle -- see the "different scan" case below, found by a
-// CodeRabbit review of this PR).
+// The guard requires identity match (clusterID:scanID), timestamp tolerance
+// (LastStartedTime close to the retired cycle's reference), and an elapsed-time TTL.
+// See the retiredScanConfigWatchers doc comment in manager_impl.go for rationale.
 func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherRetiredGuard() {
 	scWithNotifiers := getTestScanConfig()
 	scNoNotifiers := scWithNotifiers.CloneVT()
 	scNoNotifiers.Notifiers = nil
 
 	gracePeriod := retiredScanConfigWatcherGracePeriod()
+	tolerance := lastStartedTimeTolerance()
 	const incomingClusterID = "cluster-2"
 	const incomingScanID = "scan-2"
 	incomingScanKey := fmt.Sprintf("%s:%s", incomingClusterID, incomingScanID)
 
+	// cycleStartTime simulates when the retired cycle's scans ran.
+	cycleStartTime := time.Now().Add(-10 * time.Minute)
+	cycleStartProto, err := protocompat.ConvertTimeToTimestampOrError(cycleStartTime)
+	require.NoError(m.T(), err)
+
+	// rerunStartTime simulates a rerun: same scan identity but LastStartedTime
+	// substantially newer than the retired cycle (more than tolerance away).
+	rerunStartTime := cycleStartTime.Add(tolerance + 5*time.Minute)
+	rerunStartProto, err := protocompat.ConvertTimeToTimestampOrError(rerunStartTime)
+	require.NoError(m.T(), err)
+
 	tests := map[string]struct {
 		scanConfig          *storage.ComplianceOperatorScanConfigurationV2
 		retiredInfo         retiredScanConfigWatcherInfo
+		incomingStartTime   *protocompat.Timestamp
 		snapshotSearchCalls int
 		snapshotsFound      []*storage.ComplianceOperatorReportSnapshotV2
 		expectHandled       bool
 	}{
 		"no notifiers, no retired record, no snapshot: starts a new watcher": {
 			scanConfig:          scNoNotifiers,
+			incomingStartTime:   cycleStartProto,
 			snapshotSearchCalls: 1,
 		},
-		"no notifiers, retired very recently with this scan missing: already handled without a DB search": {
+		"no notifiers, retired very recently with this scan missing and matching timestamp: already handled": {
 			scanConfig: scNoNotifiers,
 			retiredInfo: retiredScanConfigWatcherInfo{
-				retiredAt:    time.Now(),
-				missingScans: set.NewStringSet(incomingScanKey),
+				retiredAt:           time.Now(),
+				missingScans:        set.NewStringSet(incomingScanKey),
+				latestScanStartTime: cycleStartTime,
 			},
+			incomingStartTime:   cycleStartProto,
 			snapshotSearchCalls: 0,
 			expectHandled:       true,
 		},
-		"no notifiers, retired just under one grace period ago with this scan missing: already handled without a DB search": {
+		"no notifiers, retired just under one grace period ago with matching timestamp: already handled": {
 			scanConfig: scNoNotifiers,
 			retiredInfo: retiredScanConfigWatcherInfo{
-				retiredAt:    time.Now().Add(-gracePeriod + time.Second),
-				missingScans: set.NewStringSet(incomingScanKey),
+				retiredAt:           time.Now().Add(-gracePeriod + time.Second),
+				missingScans:        set.NewStringSet(incomingScanKey),
+				latestScanStartTime: cycleStartTime,
 			},
+			incomingStartTime:   cycleStartProto,
 			snapshotSearchCalls: 0,
 			expectHandled:       true,
 		},
-		"no notifiers, retired more than one grace period ago with this scan missing: falls through to a new watcher": {
+		"no notifiers, retired more than one grace period ago: falls through (TTL expired)": {
 			scanConfig: scNoNotifiers,
 			retiredInfo: retiredScanConfigWatcherInfo{
-				retiredAt:    time.Now().Add(-gracePeriod - time.Second),
-				missingScans: set.NewStringSet(incomingScanKey),
+				retiredAt:           time.Now().Add(-gracePeriod - time.Second),
+				missingScans:        set.NewStringSet(incomingScanKey),
+				latestScanStartTime: cycleStartTime,
 			},
+			incomingStartTime:   cycleStartProto,
 			snapshotSearchCalls: 1,
 		},
-		"no notifiers, retired recently but this scan was not one it was missing (e.g. a re-triggered cycle): falls through to a new watcher": {
+		"no notifiers, retired recently but different identity: falls through (new scan)": {
 			scanConfig: scNoNotifiers,
 			retiredInfo: retiredScanConfigWatcherInfo{
-				retiredAt:    time.Now(),
-				missingScans: set.NewStringSet("cluster-3:scan-3"),
+				retiredAt:           time.Now(),
+				missingScans:        set.NewStringSet("cluster-3:scan-3"),
+				latestScanStartTime: cycleStartTime,
 			},
+			incomingStartTime:   cycleStartProto,
+			snapshotSearchCalls: 1,
+		},
+		"no notifiers, retired recently, same identity, but LastStartedTime much newer (rerun): falls through": {
+			// This is the key scenario: a manual rerun reuses the same K8s object
+			// (same UID → same scanID → same identity), but its LastStartedTime is
+			// substantially newer. The timestamp tolerance check must let it through.
+			scanConfig: scNoNotifiers,
+			retiredInfo: retiredScanConfigWatcherInfo{
+				retiredAt:           time.Now(),
+				missingScans:        set.NewStringSet(incomingScanKey),
+				latestScanStartTime: cycleStartTime,
+			},
+			incomingStartTime:   rerunStartProto,
 			snapshotSearchCalls: 1,
 		},
 		"notifiers configured, no retired record, snapshot exists: already handled (defense in depth)": {
 			scanConfig:          scWithNotifiers,
+			incomingStartTime:   cycleStartProto,
 			snapshotSearchCalls: 1,
 			snapshotsFound:      []*storage.ComplianceOperatorReportSnapshotV2{{}},
 			expectHandled:       true,
@@ -530,12 +561,16 @@ func (m *ManagerTestSuite) TestGetOrCreateScanConfigWatcherRetiredGuard() {
 				managerImplementation.retiredScanConfigWatchers[tc.scanConfig.GetId()] = tc.retiredInfo
 			}
 
+			startTime := tc.incomingStartTime
+			if startTime == nil {
+				startTime = protocompat.TimestampNow()
+			}
 			results := &watcher.ScanWatcherResults{
 				Scan: &storage.ComplianceOperatorScanV2{
 					ScanConfigName:  tc.scanConfig.GetScanConfigName(),
 					ClusterId:       incomingClusterID,
 					Id:              incomingScanID,
-					LastStartedTime: protocompat.TimestampNow(),
+					LastStartedTime: startTime,
 				},
 			}
 			w, returnedSC, wasAlreadyRunning, err := managerImplementation.getOrCreateScanConfigWatcher(
@@ -624,12 +659,16 @@ func (m *ManagerTestSuite) TestHandleReadyScanConfigRecordsRetirement() {
 	managerImplementation, ok := manager.(*managerImpl)
 	require.True(m.T(), ok)
 
+	scanStartTime := time.Now().Add(-5 * time.Minute)
+	scanStartProto, err := protocompat.ConvertTimeToTimestampOrError(scanStartTime)
+	require.NoError(m.T(), err)
+
 	beforePush := time.Now()
 	result := &watcher.ScanConfigWatcherResults{
 		WatcherID:  sc.GetId(),
 		ScanConfig: sc,
 		ScanResults: map[string]*watcher.ScanWatcherResults{
-			"cluster-1:scan-1": {Scan: &storage.ComplianceOperatorScanV2{ClusterId: "cluster-1", Id: "scan-1", LastStartedTime: protocompat.TimestampNow()}},
+			"cluster-1:scan-1": {Scan: &storage.ComplianceOperatorScanV2{ClusterId: "cluster-1", Id: "scan-1", LastStartedTime: scanStartProto}},
 		},
 		Error: watcher.ErrScanConfigTimeout,
 	}
@@ -640,9 +679,10 @@ func (m *ManagerTestSuite) TestHandleReadyScanConfigRecordsRetirement() {
 			info, ok := managerImplementation.retiredScanConfigWatchers[sc.GetId()]
 			return ok && !info.retiredAt.Before(beforePush) &&
 				info.missingScans.Contains("cluster-2:scan-2") &&
-				!info.missingScans.Contains("cluster-1:scan-1")
+				!info.missingScans.Contains("cluster-1:scan-1") &&
+				absDuration(info.latestScanStartTime.Sub(scanStartTime)) < time.Second
 		})
-	}, 2*time.Second, 10*time.Millisecond, "expected retiredScanConfigWatchers to record the retirement time and the missing scan")
+	}, 2*time.Second, 10*time.Millisecond, "expected retiredScanConfigWatchers to record the retirement time, missing scan, and latest scan start time")
 }
 
 // TestHandleReadyScanConfigDoesNotRecordRetirementWithoutScans verifies that no


### PR DESCRIPTION
## Description

When a `ScanConfigWatcher` times out, it is removed from `watchingScanConfigs`. A late-arriving scan result for the same cycle then re-enters `getOrCreateScanConfigWatcher`, which finds no active watcher and creates a **second** one. That second watcher only receives the stragglers, times out itself, and `DeleteOldResultsFromMissingScans` deletes check results for every scan/cluster that had already succeeded under the first watcher. Customer central logs from ROX-34779 show exactly this: two timeouts for the same `weeklyscan` cycle (21/27 then 3/27), the second wiping all 9 clusters' data.

**Fix**: when a `ScanConfigWatcher` retires after processing at least one scan, record its retirement in an in-memory `retiredScanConfigWatchers` map. `getOrCreateScanConfigWatcher` suppresses creating a duplicate watcher for an incoming scan only if **all three** conditions hold:

1. **Identity match**: the incoming `clusterID:scanID` was one of the scans still outstanding when the watcher retired.
2. **Timestamp tolerance**: the incoming scan's `LastStartedTime` is within `ComplianceScanScheduleWatcherTimeout / 3` of the latest `LastStartedTime` among the scans that reported to the retired watcher. This catches the common case where a rerun is triggered after the watcher times out: CO sets a fresh `StartTimestamp`, so the rerun's `LastStartedTime` is substantially newer than the reference. Caveat: a rerun triggered while the watcher was still running can have a `LastStartedTime` close to the original cycle's, falling within tolerance — the timestamp check does not help in that case, and the rerun may be suppressed if it also matches by identity and arrives after retirement. Check results are persisted independently at the pipeline level regardless.
3. **Elapsed-time TTL**: less than `ComplianceScanScheduleWatcherTimeout + ComplianceScanWatcherTimeout` has elapsed since the retirement (prevents stale entries from lingering forever).

The existing snapshot-based search (`SearchSnapshots` by `ComplianceOperatorScanConfig`) is kept as a defense-in-depth backstop for the rare case where the in-memory record is lost (e.g. Central restart). This matters because scan configs with no notifiers never produce a snapshot (`createAutomaticSnapshotAndSubscribe` returns `ErrNoNotifiersConfigured` before creating one).

**Why all three checks are needed**: identity alone cannot distinguish a late arrival from a rerun — reruns reuse the exact same `ComplianceScan` K8s object (`Get` + annotate + `Update`, never `Create`; the UID flows unchanged through the pipeline as the scan's `Id`). Elapsed time alone cannot distinguish a late arrival from a genuinely new cycle. The timestamp tolerance catches the common post-timeout rerun case where the gap is large.

**Scope**: this prevents the *cascade* (duplicate watcher creation) that turns a partial timeout into a full wipe. It does not change `DeleteOldResultsFromMissingScans` itself — see PR #20904 for that complementary fix.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

Unit tests cover the retired-record guard (with and without notifiers, at the grace-period boundary, same identity with matching timestamp vs newer timestamp for rerun), the already-running fast path, retirement recording including `latestScanStartTime`, and the "no scans processed" case.

### How I validated my change

- Unit tests pass including `-race`.
- **In-cluster** (ga-ocp4-cron + ga-ocp4-cron-2, 2-cluster/1-profile/no-notifier scan config, `ROX_COMPLIANCE_SCAN_SCHEDULE_WATCHER_TIMEOUT=3m ROX_COMPLIANCE_SCAN_WATCHER_TIMEOUT=8m`):
  - **Cascade prevention**: sensor disconnected on cluster 2 → ScanConfigWatcher timeout (1/3) → late scan watcher timeouts → no second ScanConfigWatcher created → cluster 1's 89 check results intact.
  - **Rerun not dropped**: sensor disconnected → timeout → reconnect → manual rerun via `POST .../run` within the grace period → new ScanConfigWatcher created (rerun's `LastStartedTime` was outside the tolerance of the retired cycle's reference timestamp) → 89 check results per cluster after rerun.