### PR TITLE
fix(compliance): cancel watcher context on exit

### DIFF
--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -196,6 +196,7 @@ func (w *scanConfigWatcherImpl) scanConfigName() string {
 
 func (w *scanConfigWatcherImpl) run(timer Timer) {
 	defer func() {
+		w.cancel()
 		w.stopped.Signal()
 		<-w.stopped.Done()
 		timer.Stop()

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -270,6 +270,7 @@ func (s *scanWatcherImpl) scanName() string {
 
 func (s *scanWatcherImpl) run() {
 	defer func() {
+		s.cancel()
 		s.stopped.Signal()
 		<-s.stopped.Done()
 		s.timeout.Stop()


### PR DESCRIPTION
## Description

Both `scanWatcherImpl.run()` and `scanConfigWatcherImpl.run()` push to their ready queue on timeout/completion and return, but never cancel their context. This leaves `w.ctx`/`s.ctx` alive after the goroutine exits.

`PushScanResults` and `PushCheckResult` use a select on the channel and `ctx.Done()`. With the context still alive, a late caller blocks forever on the dead channel (nobody reads it after `run()` returns) and `ctx.Done()` never fires. This is a goroutine leak.

There is also a race window between `run()` returning (pushing to the ready queue) and `handleReadyScanConfig`/`handleReadyScan` removing the watcher from the active map. A late scan arriving in this window finds the dead watcher, calls `PushScanResults`, and the goroutine deadlocks.

**Fix**: call `cancel()` in the defer of `run()` before signaling `stopped`. This ensures `PushScanResults`/`PushCheckResult` return an error immediately ("The watcher is stopped") instead of blocking.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

One-line additions to existing defer blocks. All existing tests pass.

### How I validated my change

- Unit tests pass (`go test ./central/complianceoperator/v2/report/manager/...`)
- Code review confirms both `cancel` functions are stored at construction time (`context.WithCancel`) and are safe to call multiple times
