### PR TITLE
fix(ci): increase scanner-v4-matcher vuln readiness timeout to 3600s

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1592,7 +1592,7 @@ wait_for_scanner_V4() {
         info "Listing available storage classes:"
         kubectl describe storageclasses 2>/dev/null || true
 
-        matcher_max_seconds=${SCANNER_V4_VULN_READINESS_TIMEOUT:-2400}
+        matcher_max_seconds=${SCANNER_V4_VULN_READINESS_TIMEOUT:-3600}
         info "Waiting ${matcher_max_seconds}s for matcher vulnerability readiness..."
     fi
 


### PR DESCRIPTION
## Description

Increase the default `SCANNER_V4_VULN_READINESS_TIMEOUT` from 2400s (40 min) to 3600s (60 min).

Since [`6d5c27fa10`](https://github.com/stackrox/stackrox/commit/6d5c27fa10) enabled Scanner V4 for all e2e jobs on July 20, scanner-v4-matcher vulnerability store load times on master merge runs have ranged from 20 to 40 minutes, with one master timeout already on July 23. The 2400s budget provides zero margin.

Sampled master merge-gke-qa-e2e-tests since July 22 (before then, v4 matcher was running in https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-ocp-4-21-merge-vm-scanning-e2e-tests?buildId=2070006756120989696 and typically appeared to hit 24-30 minutes):

| Date (UTC) | Result | Matcher Load |
|------------|--------|-------------|
| 07-22 13:01 | PASS | 31m 42s |
| 07-22 19:11 | PASS | 34m 32s |
| 07-23 02:42 | PASS | 33m 40s |
| 07-23 15:17 | [**FAIL**](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/2080290945214976000) | **TIMEOUT** |
| 07-24 13:05 | PASS | 40m 1s |
| 07-25 06:23 | PASS | 25m 49s |
| 07-27 06:13 | PASS | 30m 13s |
| 07-27 19:49 | PASS | 20m 32s |
| 07-27 21:59 | PASS | 35m 10s |
| 07-28 11:02 | PASS | 33m 37s |
| 07-28 18:02 | PASS | 39m 57s |
| 07-29 00:08 | PASS | 24m 25s |
| 07-29 01:35 | PASS | 35m 17s |
| 07-29 10:23 | PASS | 23m 11s |
| 07-29 12:02 | PASS | 31m 34s |
| 07-29 12:33 | PASS | 23m 43s |
| 07-29 14:09 | PASS | 32m 50s |

Related: [ROX-35465](https://redhat.atlassian.net/browse/ROX-35465)

### How I validated my change

CI-only change (timeout constant). Validated by sampling 17 master merge-gke-qa-e2e-tests runs since Scanner V4 was enabled (July 20) — the data above shows load times consistently under 41 minutes, well within the new 3600s budget.


[ROX-35465]: https://redhat.atlassian.net/browse/ROX-35465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ