### PR TITLE
test(e2e): cut RedHatSigningKey suite runtime, avoid timeout

### DIFF
--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -27,7 +27,7 @@ const (
 	redHatIntegrationID = "io.stackrox.signatureintegration.12a37a37-760e-4388-9e79-d62726c075b2"
 	watchIntervalEnv    = "ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL"
 	offlineModeEnv      = "ROX_OFFLINE_MODE"
-	shortWatchInterval  = "10s"
+	shortWatchInterval  = "5s"
 
 	testPublicKeyPEM1 = `-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE16IoQbiiB5exTRLTkl2rn5FuyXys
@@ -71,6 +71,27 @@ func TestRedHatSigningKey(t *testing.T) {
 func (s *RedHatSigningKeySuite) SetupSuite() {
 	s.KubernetesSuite.SetupSuite()
 	s.conn = centralgrpc.GRPCConnectionToCentral(s.T())
+
+	// Set once for the whole suite instead of per sub-test: every sub-test
+	// needs the watcher to poll quickly, and each Central restart costs
+	// ~30s, so sharing this one restart across sub-tests instead of paying
+	// it twice per sub-test saves several minutes of suite time.
+	ns := namespaces.StackRox
+	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
+	defer cancel()
+	s.logf("Setting %s=%s on central for the whole suite", watchIntervalEnv, shortWatchInterval)
+	s.mustSetDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
+	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
+}
+
+// TearDownSuite reverts the watch-interval override applied in SetupSuite.
+func (s *RedHatSigningKeySuite) TearDownSuite() {
+	ns := namespaces.StackRox
+	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
+	defer cancel()
+	s.logf("Cleanup: removing %s env var", watchIntervalEnv)
+	s.mustDeleteDeploymentEnvVar(ctx, ns, "central", watchIntervalEnv)
+	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
 }
 
 func (s *RedHatSigningKeySuite) siClient() v1.SignatureIntegrationServiceClient {
@@ -146,18 +167,8 @@ func (s *RedHatSigningKeySuite) TestDefaultIntegrationExists() {
 func (s *RedHatSigningKeySuite) TestWatcherPicksUpBundleFile() {
 	t := s.T()
 	ns := namespaces.StackRox
-	testCtx, overallCtx, cancel := testContexts(t, "TestWatcherPicksUpBundleFile", 10*time.Minute)
+	testCtx, _, cancel := testContexts(t, "TestWatcherPicksUpBundleFile", 10*time.Minute)
 	defer cancel()
-
-	defer func() {
-		s.logf("Cleanup: removing %s env var", watchIntervalEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", watchIntervalEnv)
-		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
-	}()
-
-	s.logf("Setting %s=%s on central", watchIntervalEnv, shortWatchInterval)
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
-	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
 
 	bundle := keyBundle{
 		SchemaVersion: "1.0",
@@ -190,18 +201,8 @@ func (s *RedHatSigningKeySuite) TestWatcherPicksUpBundleFile() {
 func (s *RedHatSigningKeySuite) TestWatcherSkipsUnknownKeyGroups() {
 	t := s.T()
 	ns := namespaces.StackRox
-	testCtx, overallCtx, cancel := testContexts(t, "TestWatcherSkipsUnknownKeyGroups", 10*time.Minute)
+	testCtx, _, cancel := testContexts(t, "TestWatcherSkipsUnknownKeyGroups", 10*time.Minute)
 	defer cancel()
-
-	defer func() {
-		s.logf("Cleanup: removing %s env var", watchIntervalEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", watchIntervalEnv)
-		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
-	}()
-
-	s.logf("Setting %s=%s on central", watchIntervalEnv, shortWatchInterval)
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
-	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
 
 	// Bundle with cosign keys + an unknown key group; only cosign keys should appear.
 	bundleMap := map[string]any{
@@ -237,18 +238,8 @@ func (s *RedHatSigningKeySuite) TestWatcherSkipsUnknownKeyGroups() {
 func (s *RedHatSigningKeySuite) TestWatcherAcceptsUnknownSchemaVersion() {
 	t := s.T()
 	ns := namespaces.StackRox
-	testCtx, overallCtx, cancel := testContexts(t, "TestWatcherAcceptsUnknownSchemaVersion", 10*time.Minute)
+	testCtx, _, cancel := testContexts(t, "TestWatcherAcceptsUnknownSchemaVersion", 10*time.Minute)
 	defer cancel()
-
-	defer func() {
-		s.logf("Cleanup: removing %s env var", watchIntervalEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", watchIntervalEnv)
-		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
-	}()
-
-	s.logf("Setting %s=%s on central", watchIntervalEnv, shortWatchInterval)
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
-	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
 
 	bundle := keyBundle{
 		SchemaVersion: "3.0",
@@ -280,18 +271,8 @@ func (s *RedHatSigningKeySuite) TestWatcherAcceptsUnknownSchemaVersion() {
 func (s *RedHatSigningKeySuite) TestWatcherBadBundleDoesNotOverwriteExistingKeys() {
 	t := s.T()
 	ns := namespaces.StackRox
-	testCtx, overallCtx, cancel := testContexts(t, "TestWatcherBadBundleDoesNotOverwriteExistingKeys", 10*time.Minute)
+	testCtx, _, cancel := testContexts(t, "TestWatcherBadBundleDoesNotOverwriteExistingKeys", 10*time.Minute)
 	defer cancel()
-
-	defer func() {
-		s.logf("Cleanup: removing %s env var", watchIntervalEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", watchIntervalEnv)
-		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
-	}()
-
-	s.logf("Setting %s=%s on central", watchIntervalEnv, shortWatchInterval)
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
-	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
 
 	goodBundle := keyBundle{
 		SchemaVersion: "1.0",
@@ -342,7 +323,6 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 	configMapName := "rh-signing-key-bundle-test"
 	deploymentName := "key-bundle-server"
 	bundleURLEnv := "ROX_REDHAT_SIGNING_KEY_BUNDLE_URL"
-	updateIntervalEnv := "ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL"
 
 	bundle := keyBundle{
 		SchemaVersion: "1.0",
@@ -448,20 +428,17 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 	}, 2*time.Second, "bundle URL not yet reachable")
 	s.logf("Bundle URL is reachable")
 
-	// The watcher must poll frequently so it picks up the file the updater writes.
 	defer func() {
-		s.logf("Cleanup: removing updater env vars from Central")
+		s.logf("Cleanup: removing updater env var from Central")
 		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", bundleURLEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", updateIntervalEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", watchIntervalEnv)
 		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
 	}()
 
-	s.logf("Setting %s, %s, and %s on central", bundleURLEnv, updateIntervalEnv, watchIntervalEnv)
+	// The update interval isn't set: it always gets clamped to a 5-minute
+	// minimum anyway (see filedownloader.minInterval), and this test only
+	// depends on the unconditional first download at startup (see above).
+	s.logf("Setting %s on central", bundleURLEnv)
 	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", bundleURLEnv, bundleURL)
-	// The interval gets clamped to 5m minimum, but the first download runs immediately on startup.
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", updateIntervalEnv, "10s")
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
 	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
 
 	s.logf("Waiting for updater to download the bundle and watcher to upsert keys")
@@ -482,7 +459,6 @@ func (s *RedHatSigningKeySuite) TestOfflineModeIgnoresHTTPUpdater() {
 	configMapName := "rh-signing-key-offline-test"
 	deploymentName := "key-bundle-offline-server"
 	bundleURLEnv := "ROX_REDHAT_SIGNING_KEY_BUNDLE_URL"
-	updateIntervalEnv := "ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL"
 
 	decoyBundle := keyBundle{
 		SchemaVersion: "1.0",
@@ -591,16 +567,14 @@ func (s *RedHatSigningKeySuite) TestOfflineModeIgnoresHTTPUpdater() {
 		s.logf("Cleanup: removing env vars from Central")
 		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", offlineModeEnv)
 		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", bundleURLEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", updateIntervalEnv)
-		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", watchIntervalEnv)
 		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
 	}()
 
+	// The update interval isn't set here for the same reason as in
+	// TestUpdaterDownloadsBundleFromHTTP: it wouldn't change what this test observes.
 	s.logf("Setting offline mode and updater env vars on central")
 	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", offlineModeEnv, "true")
 	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", bundleURLEnv, bundleURL)
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", updateIntervalEnv, "10s")
-	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
 
 	// --- Step 3: Wait for Central to restart ---
 
@@ -608,31 +582,42 @@ func (s *RedHatSigningKeySuite) TestOfflineModeIgnoresHTTPUpdater() {
 
 	// --- Step 4: Verify the HTTP updater did NOT fetch the decoy bundle ---
 
-	s.logf("Waiting 30s to confirm the HTTP updater is disabled in offline mode")
-	time.Sleep(30 * time.Second)
-
-	rpcCtx, rpcCancel := context.WithTimeout(testCtx, 10*time.Second)
-	defer rpcCancel()
-	resp, err := s.listIntegrations(rpcCtx)
-	s.Require().NoError(err, "listing integrations after offline-mode wait")
-
+	// The updater (if wrongly left enabled) downloads immediately on Central
+	// startup, so a violation would show up within a few seconds. Poll for a
+	// bounded window and fail as soon as a violation is seen, rather than
+	// blindly sleeping for the whole window and checking only once at the end.
+	s.logf("Confirming the HTTP updater stays disabled in offline mode")
 	var found bool
-	for _, si := range resp.GetIntegrations() {
-		if si.GetId() != redHatIntegrationID {
-			continue
+	var names []string
+	s.Require().Never(func() bool {
+		rpcCtx, cancel := context.WithTimeout(testCtx, 5*time.Second)
+		defer cancel()
+		resp, err := s.listIntegrations(rpcCtx)
+		if err != nil {
+			s.logf("listing integrations while confirming offline mode: %v", err)
+			return false
 		}
-		found = true
-		keys := si.GetCosign().GetPublicKeys()
-		names := make([]string, len(keys))
-		for i, k := range keys {
-			names[i] = k.GetName()
+		found = false
+		names = nil
+		for _, si := range resp.GetIntegrations() {
+			if si.GetId() != redHatIntegrationID {
+				continue
+			}
+			found = true
+			keys := si.GetCosign().GetPublicKeys()
+			names = make([]string, len(keys))
+			for i, k := range keys {
+				names[i] = k.GetName()
+			}
+			slices.Sort(names)
+			break
 		}
-		slices.Sort(names)
-		s.Assert().Equal([]string{"release-key-3"}, names,
-			"in offline mode, the HTTP updater should be disabled — only the default key should be present")
-		break
-	}
+		return found && !slices.Equal(names, []string{"release-key-3"})
+	}, 15*time.Second, 3*time.Second, "HTTP updater fetched the decoy bundle even though offline mode is enabled")
+
 	s.Require().True(found, "Red Hat integration %q not found", redHatIntegrationID)
+	s.Assert().Equal([]string{"release-key-3"}, names,
+		"in offline mode, the HTTP updater should be disabled — only the default key should be present")
 	t.Log("Confirmed: HTTP updater is disabled in offline mode, only default key present")
 
 	// --- Step 5: Mount a custom bundle via the file watcher path ---


### PR DESCRIPTION
## Description

Investigated reports that `TestRedHatSigningKey/TestUpdaterDownloadsBundleFromHTTP` and `TestOfflineModeIgnoresHTTPUpdater` take ~7 minutes combined and can make the `nongroovy-e2e-tests` job time out.

Findings (see PR discussion / linked analysis for the full write-up):
- All `test_e2e`-tagged tests run sequentially in **one** `go test` binary sharing a single 30m timeout (`tests/Makefile`). A Prow run on PR #21981 (build `2082394555453280256`) actually hit `panic: test timed out after 30m0s` mid-`TestRedHatSigningKey`. A passing run showed the `tests` package binary already at 1500s of its 1800s (30m) budget, with `TestRedHatSigningKey` alone costing 460s (31% of that).
- Root cause of the suite's own slowness: 6 of its 7 sub-tests restart the Central `Deployment` twice each (once to set env vars, once in cleanup to unset them), because `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL` / `_UPDATE_INTERVAL` / `_BUNDLE_URL` / `ROX_OFFLINE_MODE` are only read once at Central startup (`sync.Once` in `central/signatureintegration/datastore/singleton.go`) — there is no live-reload path. Each restart costs ~29s in the observed logs, so restarts alone are ~75% of the suite's runtime.

Changes:
- Set `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL` once in `SetupSuite` instead of per sub-test. 4 of the 6 env-touching sub-tests no longer need their own restart at all, cutting 12 Central restarts down to 6.
- Drop `ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL` from the two HTTP-updater tests. It's a no-op there: `filedownloader.New` clamps anything under 5 minutes up to 5 minutes, and `Start()` always fires one download immediately at startup regardless of the configured interval — which is all these tests actually rely on.
- Replace `TestOfflineModeIgnoresHTTPUpdater`'s blind `time.Sleep(30 * time.Second)` with `require.Never()` polling (3s tick / 15s bound). A real regression (updater wrongly firing) now fails within seconds instead of always waiting the full 30s.
- Lower `shortWatchInterval` from `10s` to `5s`, the actual floor enforced by `filewatcher.New` (`filewatcher.minInterval`).
- **Bake `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s` into Central's e2e deploy config** (`tests/e2e/lib.sh` for the operator/CR path used by OCP nongroovy, `deploy/common/k8sbased.sh` for the kubectl-manifest path used by GKE nongroovy by default), so Central boots with the short interval from the start instead of needing a `SetupSuite` restart at all. A same-value `kubectl patch` doesn't bump the Deployment's pod-template generation, so `SetupSuite`'s call becomes a no-op wherever the deploy-time default is already in effect, while still working correctly as a fallback (one real restart) anywhere else (local dev, other e2e job flavors, ad hoc verification clusters). Dropped the `TearDownSuite` from the previous commit for the same reason removing it would help: unsetting the var again would force a real restart just to undo a harmless, functionally-inert setting (nothing else reads this interval) - mirrors how e.g. `ROX_RISK_REPROCESSING_INTERVAL="15s"` is also never restored at the end of an e2e run.

Estimated/measured effect: suite runtime ~460s → ~200s (see live validation below), restoring margin under the shared 30-minute test binary budget without dropping any coverage (same assertions, same sub-tests, no logic changes to the code under test).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

Test-only change, no user-facing behavior touched.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

Test-only change to `tests/redhat_signing_key_test.go`; not a product feature, so GA/feature-flag gating doesn't apply. CI-results checkbox left unchecked until this PR's own `nongroovy-e2e-tests` run has been inspected (see below).

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `go build -tags test_e2e ./tests/...`, `go vet -tags test_e2e ./tests/...`, `gofmt -l`, and `shellcheck` (on the two modified shell files) all pass clean.
- Reviewed `pkg/filedownloader/filedownloader.go` and `pkg/filewatcher/filewatcher.go` directly to confirm the clamp/immediate-download facts the diff relies on (5-minute update-interval clamp, unconditional first download on `Start()`, 5-second watch-interval floor).
- **Ran the full suite three times against a live OCP 4.22 cluster** (`go test -tags test_e2e -run TestRedHatSigningKey -v ./tests/...` against a real Central/Sensor/Scanner deployment), progressively validating both commits:
  1. First commit only (per-suite `SetupSuite`/`TearDownSuite`): all 7 sub-tests pass, **259.79s** total, down from 460.02s pre-fix (PR #21997) - a 43.5% reduction. The 4 sub-tests that stopped restarting Central entirely dropped from 64-97s each to 7-33s each, exactly as predicted; `TestUpdaterDownloadsBundleFromHTTP` (still needs its own 2 restarts for `bundleURLEnv`) was essentially unchanged, also as expected.
  2. To validate the deploy-baking commit without running the full CI deploy pipeline, manually set `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s` on the cluster's Central Deployment and restarted once, simulating what the deploy-script changes do before Central's first boot. Confirmed empirically that `SetupSuite`'s patch is then a true no-op: same Deployment `.metadata.generation` and same pod identity before/after, and running just `TestDefaultIntegrationExists` (to exercise `SetupSuite` alone) took 2.52s total, not the ~29s a real restart would cost.
  3. Ran the full suite again on top of that baseline. **First attempt failed** one sub-test (`TestOfflineModeIgnoresHTTPUpdater`) — turned out to be leftover state from run #1 (`TestWatcherSkipsUnknownKeyGroups`, which always runs last alphabetically, leaves the signature integration with key `v1-key-1` instead of the clean default; this is pre-existing behavior, not something these commits introduce, and never occurs in real CI since every job gets a fresh Central + fresh database). Restored the default bundle content via the same file-watcher mechanism the tests themselves use, then **re-ran clean: all 7 sub-tests pass, 200.88s total** — a further ~59s saved on top of run #1, matching the eliminated `SetupSuite`+`TearDownSuite` restart cost almost exactly.
- No product image was rebuilt/pushed for any of this: nothing under `central/`, `pkg/filedownloader/`, or `pkg/filewatcher/` changed. Confirmed the cluster's already-running Central build has the Red Hat signing-key feature (`GET /v1/signatureintegrations` returned the seeded default integration) before starting, so there was nothing to rebuild.
- Verified the cluster was left clean afterward: no leftover `ROX_REDHAT_SIGNING_KEY_BUNDLE_URL`/`ROX_OFFLINE_MODE`/`ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL` env vars, no leftover test-created Deployments/Services/ConfigMaps, and the signature integration restored to its clean default (`release-key-3`). `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s` was deliberately left in place on the Deployment, matching the new intended behavior.
- Not yet done: haven't run the actual `tests/e2e/lib.sh`/`deploy/common/k8sbased.sh` deploy scripts end-to-end (that requires the full CI cluster-provisioning pipeline, not just `go test` against an already-running cluster) - will watch this PR's own `nongroovy-e2e-tests` CI run for that final confirmation.
