### PR TITLE
test(e2e): bake watch interval into Central deploy config

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -523,6 +523,10 @@ function launch_central {
         ${ORCH_CMD} -n stackrox set env deploy/central MODULE_LOGLEVELS="${MODULE_LOGLEVELS}"
       fi
 
+      # Red Hat signing key bundle watcher needs a short poll interval for e2e tests
+      # (tests/redhat_signing_key_test.go); avoids a Central restart mid-test-suite.
+      ${ORCH_CMD} -n stackrox set env deploy/central ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s
+
       if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
         echo >&2 "ROX_MANAGED_CENTRAL=true is only supported in conjunction with OUTPUT_FORMAT=helm"
         exit 1

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -521,6 +521,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
     customize_envVars+=$'\n      - name: ROX_RISK_REPROCESSING_INTERVAL'
     customize_envVars+=$'\n        value: "15s"'
+    customize_envVars+=$'\n      - name: ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL'
+    customize_envVars+=$'\n        value: "5s"'
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_ENHANCEMENTS'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_REPORTING'

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -72,25 +72,24 @@ func (s *RedHatSigningKeySuite) SetupSuite() {
 	s.KubernetesSuite.SetupSuite()
 	s.conn = centralgrpc.GRPCConnectionToCentral(s.T())
 
-	// Set once for the whole suite instead of per sub-test: every sub-test
-	// needs the watcher to poll quickly, and each Central restart costs
-	// ~30s, so sharing this one restart across sub-tests instead of paying
-	// it twice per sub-test saves several minutes of suite time.
+	// e2e deploy scripts (tests/e2e/lib.sh, deploy/common/k8sbased.sh) already
+	// set watchIntervalEnv=shortWatchInterval on Central at deploy time, before
+	// any test runs, so every sub-test gets fast polling without paying for a
+	// restart here. This call is a same-value no-op there (Kubernetes doesn't
+	// bump the pod template generation, so no rollout is triggered) - it only
+	// causes a real restart as a fallback for setups that deploy Central some
+	// other way (e.g. local dev, or a pre-existing cluster like the one used
+	// for manual verification) and haven't set this already.
+	//
+	// Deliberately no matching TearDownSuite: removing the env var again would
+	// undo the deploy-time optimization above and force a real restart just to
+	// restore a functionally-inert default (nothing else reads this interval),
+	// mirroring how e.g. ROX_RISK_REPROCESSING_INTERVAL is also never restored.
 	ns := namespaces.StackRox
 	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
 	defer cancel()
-	s.logf("Setting %s=%s on central for the whole suite", watchIntervalEnv, shortWatchInterval)
+	s.logf("Ensuring %s=%s on central for the whole suite", watchIntervalEnv, shortWatchInterval)
 	s.mustSetDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
-	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
-}
-
-// TearDownSuite reverts the watch-interval override applied in SetupSuite.
-func (s *RedHatSigningKeySuite) TearDownSuite() {
-	ns := namespaces.StackRox
-	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
-	defer cancel()
-	s.logf("Cleanup: removing %s env var", watchIntervalEnv)
-	s.mustDeleteDeploymentEnvVar(ctx, ns, "central", watchIntervalEnv)
 	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
 }
 


### PR DESCRIPTION
## Description

Central only reads `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL` once at startup, so `tests/redhat_signing_key_test.go`'s `SetupSuite` (from #22020) needs a Central restart (~29s) to shorten it for the test suite. This bakes the same value into Central's e2e deploy config instead, so it's already set on first boot and no restart is needed:

- `tests/e2e/lib.sh` - OCP nongroovy (operator/CR deploy path)
- `deploy/common/k8sbased.sh` - GKE nongroovy (kubectl deploy path)

These are the only two paths that ever deploy Central for a run including `TestRedHatSigningKey`; the Helm and roxie-compat deploy paths never run it, so they don't need the same change.

`SetupSuite`'s patch call is kept as a fallback for other contexts (local dev, ad hoc clusters): patching a Deployment env var to a value it already has doesn't bump the pod template generation, so it's a no-op wherever the deploy-time default is already in effect. `TearDownSuite` is dropped - unsetting the var would force a real restart just to undo a setting nothing else reads.

**Impact**: `TestRedHatSigningKey` suite runtime **259.79s → 200.88s** (live-validated on OCP 4.22), on top of the 460.02s → 259.79s already landed in #22020.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `go build`/`go vet`/`gofmt`/`shellcheck` all pass clean.
- Live-validated the mechanism on a real OCP 4.22 cluster: pre-set the env var to simulate the deploy-time default, confirmed `SetupSuite`'s patch causes no restart (identical Deployment generation and pod before/after), and ran the full suite (200.88s, all 7 sub-tests pass).
- Not yet done: the deploy scripts themselves haven't been exercised by CI, only their simulated effect - this PR's own e2e runs are the first real test of these exact lines.
