### PR TITLE
ROX-35123: Add RawQuery filter to GetVMCVEDetail

### DIFF
--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -476,13 +476,23 @@ func (s *serviceImpl) GetVMCVEDetail(ctx context.Context, request *v2.GetVMCVEDe
 		return nil, status.Errorf(codes.NotFound, "CVE %q not found", request.GetCveId())
 	}
 	cve := cves[0]
-	severityCounts, err := s.cveView.CountBySeverity(ctx, cveFilter)
+
+	viewFilter := cveFilter.CloneVT()
+	if request.GetQuery().GetQuery() != "" {
+		additionalQuery, err := search.ParseQuery(request.GetQuery().GetQuery())
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing input query")
+		}
+		viewFilter = search.ConjunctionQuery(viewFilter, additionalQuery)
+	}
+
+	severityCounts, err := s.cveView.CountBySeverity(ctx, viewFilter)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get affected VM count.
-	affectedVMIDs, err := s.cveView.GetVMIDs(ctx, cveFilter.CloneVT())
+	affectedVMIDs, err := s.cveView.GetVMIDs(ctx, viewFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -513,9 +513,10 @@ func TestGetVMCVEDetail(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		request       *v2.GetVMCVEDetailRequest
-		setupMock     func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView)
-		expectedError string
+		request        *v2.GetVMCVEDetailRequest
+		setupMock      func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView)
+		expectedError  string
+		expectedResult *v2.VMCVEDetail
 	}{
 		"empty cve_id": {
 			request: &v2.GetVMCVEDetailRequest{
@@ -550,6 +551,49 @@ func TestGetVMCVEDetail(t *testing.T) {
 				}, nil, nil)
 			},
 		},
+		"successful detail with query": {
+			request: &v2.GetVMCVEDetailRequest{
+				CveId: "CVE-2024-1234",
+				Query: &v2.RawQuery{Query: "Severity:CRITICAL_VULNERABILITY_SEVERITY"},
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+					CriticalSeverityCount: 2,
+				}, nil)
+				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return([]string{"vm-1"}, nil)
+				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(5, nil)
+				mockVM.EXPECT().GetManyVirtualMachines(ctx, []string{"vm-1"}).Return([]*storage.VirtualMachineV2{
+					{Id: "vm-1", GuestOs: "rhel-9"},
+				}, nil, nil)
+			},
+			expectedResult: &v2.VMCVEDetail{
+				AffectedVmCount:      1,
+				TotalVmCount:         5,
+				AffectedGuestOsCount: 1,
+				VmSeverityCounts: storagetov2.SeverityCountsToProto(&commonViews.ResourceCountByImageCVESeverity{
+					CriticalSeverityCount: 2,
+				}),
+			},
+		},
+		"query filters out all results but CVE detail still loads": {
+			request: &v2.GetVMCVEDetailRequest{
+				CveId: "CVE-2024-1234",
+				Query: &v2.RawQuery{Query: "Severity:CRITICAL_VULNERABILITY_SEVERITY"},
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{}, nil)
+				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return(nil, nil)
+				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(5, nil)
+			},
+			expectedResult: &v2.VMCVEDetail{
+				AffectedVmCount:      0,
+				TotalVmCount:         5,
+				AffectedGuestOsCount: 0,
+				VmSeverityCounts:     storagetov2.SeverityCountsToProto(&commonViews.ResourceCountByImageCVESeverity{}),
+			},
+		},
 	}
 
 	for name, tt := range tests {
@@ -581,7 +625,14 @@ func TestGetVMCVEDetail(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, result)
+				require.NotNil(t, result)
+				assert.Equal(t, "CVE-2024-1234", result.GetCve())
+				if tt.expectedResult != nil {
+					assert.Equal(t, tt.expectedResult.GetAffectedVmCount(), result.GetAffectedVmCount())
+					assert.Equal(t, tt.expectedResult.GetTotalVmCount(), result.GetTotalVmCount())
+					assert.Equal(t, tt.expectedResult.GetAffectedGuestOsCount(), result.GetAffectedGuestOsCount())
+					protoassert.Equal(t, tt.expectedResult.GetVmSeverityCounts(), result.GetVmSeverityCounts())
+				}
 			}
 		})
 	}

--- a/generated/api/v2/virtual_machine_v2_service.pb.go
+++ b/generated/api/v2/virtual_machine_v2_service.pb.go
@@ -2088,6 +2088,7 @@ func (x *VMCVEDetail) GetTopCvss() float32 {
 type GetVMCVEDetailRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CveId         string                 `protobuf:"bytes,1,opt,name=cve_id,json=cveId,proto3" json:"cve_id,omitempty"`
+	Query         *RawQuery              `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2127,6 +2128,13 @@ func (x *GetVMCVEDetailRequest) GetCveId() string {
 		return x.CveId
 	}
 	return ""
+}
+
+func (x *GetVMCVEDetailRequest) GetQuery() *RawQuery {
+	if x != nil {
+		return x.Query
+	}
+	return nil
 }
 
 type VMCVEAffectedVMRow struct {
@@ -2494,9 +2502,10 @@ const file_api_v2_virtual_machine_v2_service_proto_rawDesc = "" +
 	"\x17affected_guest_os_count\x18\t \x01(\x05R\x14affectedGuestOsCount\x12E\n" +
 	"\x12vm_severity_counts\x18\n" +
 	" \x01(\v2\x17.v2.VulnCountBySeverityR\x10vmSeverityCounts\x12\x19\n" +
-	"\btop_cvss\x18\v \x01(\x02R\atopCvss\".\n" +
+	"\btop_cvss\x18\v \x01(\x02R\atopCvss\"R\n" +
 	"\x15GetVMCVEDetailRequest\x12\x15\n" +
-	"\x06cve_id\x18\x01 \x01(\tR\x05cveId\"\x81\x02\n" +
+	"\x06cve_id\x18\x01 \x01(\tR\x05cveId\x12\"\n" +
+	"\x05query\x18\x02 \x01(\v2\f.v2.RawQueryR\x05query\"\x81\x02\n" +
 	"\x12VMCVEAffectedVMRow\x12\x13\n" +
 	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x17\n" +
 	"\avm_name\x18\x02 \x01(\tR\x06vmName\x125\n" +
@@ -2658,34 +2667,35 @@ var file_api_v2_virtual_machine_v2_service_proto_depIdxs = []int32{
 	38, // 42: v2.VMCVEDetail.published_on:type_name -> google.protobuf.Timestamp
 	38, // 43: v2.VMCVEDetail.first_discovered:type_name -> google.protobuf.Timestamp
 	6,  // 44: v2.VMCVEDetail.vm_severity_counts:type_name -> v2.VulnCountBySeverity
-	40, // 45: v2.VMCVEAffectedVMRow.severity:type_name -> v2.VulnerabilitySeverity
-	39, // 46: v2.ListVMCVEAffectedVMsRequest.query:type_name -> v2.RawQuery
-	32, // 47: v2.ListVMCVEAffectedVMsResponse.vms:type_name -> v2.VMCVEAffectedVMRow
-	18, // 48: v2.VirtualMachineV2Service.GetVM:input_type -> v2.GetVMRequest
-	20, // 49: v2.VirtualMachineV2Service.GetVMVulnSummary:input_type -> v2.GetVMVulnSummaryRequest
-	22, // 50: v2.VirtualMachineV2Service.ListVMCVEsByVM:input_type -> v2.ListVMCVEsByVMRequest
-	25, // 51: v2.VirtualMachineV2Service.GetVMCVEComponents:input_type -> v2.GetVMCVEComponentsRequest
-	28, // 52: v2.VirtualMachineV2Service.ListVMComponents:input_type -> v2.ListVMComponentsRequest
-	9,  // 53: v2.VirtualMachineV2Service.ListVMs:input_type -> v2.ListVMsRequest
-	12, // 54: v2.VirtualMachineV2Service.ListVMCVEs:input_type -> v2.ListVMCVEsRequest
-	14, // 55: v2.VirtualMachineV2Service.GetVMDashboardCounts:input_type -> v2.VMDashboardCountsRequest
-	31, // 56: v2.VirtualMachineV2Service.GetVMCVEDetail:input_type -> v2.GetVMCVEDetailRequest
-	33, // 57: v2.VirtualMachineV2Service.ListVMCVEAffectedVMs:input_type -> v2.ListVMCVEAffectedVMsRequest
-	17, // 58: v2.VirtualMachineV2Service.GetVM:output_type -> v2.VMDetail
-	19, // 59: v2.VirtualMachineV2Service.GetVMVulnSummary:output_type -> v2.VMVulnSummary
-	23, // 60: v2.VirtualMachineV2Service.ListVMCVEsByVM:output_type -> v2.ListVMCVEsByVMResponse
-	26, // 61: v2.VirtualMachineV2Service.GetVMCVEComponents:output_type -> v2.GetVMCVEComponentsResponse
-	29, // 62: v2.VirtualMachineV2Service.ListVMComponents:output_type -> v2.ListVMComponentsResponse
-	10, // 63: v2.VirtualMachineV2Service.ListVMs:output_type -> v2.ListVMsResponse
-	13, // 64: v2.VirtualMachineV2Service.ListVMCVEs:output_type -> v2.ListVMCVEsResponse
-	15, // 65: v2.VirtualMachineV2Service.GetVMDashboardCounts:output_type -> v2.VMDashboardCountsResponse
-	30, // 66: v2.VirtualMachineV2Service.GetVMCVEDetail:output_type -> v2.VMCVEDetail
-	34, // 67: v2.VirtualMachineV2Service.ListVMCVEAffectedVMs:output_type -> v2.ListVMCVEAffectedVMsResponse
-	58, // [58:68] is the sub-list for method output_type
-	48, // [48:58] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	39, // 45: v2.GetVMCVEDetailRequest.query:type_name -> v2.RawQuery
+	40, // 46: v2.VMCVEAffectedVMRow.severity:type_name -> v2.VulnerabilitySeverity
+	39, // 47: v2.ListVMCVEAffectedVMsRequest.query:type_name -> v2.RawQuery
+	32, // 48: v2.ListVMCVEAffectedVMsResponse.vms:type_name -> v2.VMCVEAffectedVMRow
+	18, // 49: v2.VirtualMachineV2Service.GetVM:input_type -> v2.GetVMRequest
+	20, // 50: v2.VirtualMachineV2Service.GetVMVulnSummary:input_type -> v2.GetVMVulnSummaryRequest
+	22, // 51: v2.VirtualMachineV2Service.ListVMCVEsByVM:input_type -> v2.ListVMCVEsByVMRequest
+	25, // 52: v2.VirtualMachineV2Service.GetVMCVEComponents:input_type -> v2.GetVMCVEComponentsRequest
+	28, // 53: v2.VirtualMachineV2Service.ListVMComponents:input_type -> v2.ListVMComponentsRequest
+	9,  // 54: v2.VirtualMachineV2Service.ListVMs:input_type -> v2.ListVMsRequest
+	12, // 55: v2.VirtualMachineV2Service.ListVMCVEs:input_type -> v2.ListVMCVEsRequest
+	14, // 56: v2.VirtualMachineV2Service.GetVMDashboardCounts:input_type -> v2.VMDashboardCountsRequest
+	31, // 57: v2.VirtualMachineV2Service.GetVMCVEDetail:input_type -> v2.GetVMCVEDetailRequest
+	33, // 58: v2.VirtualMachineV2Service.ListVMCVEAffectedVMs:input_type -> v2.ListVMCVEAffectedVMsRequest
+	17, // 59: v2.VirtualMachineV2Service.GetVM:output_type -> v2.VMDetail
+	19, // 60: v2.VirtualMachineV2Service.GetVMVulnSummary:output_type -> v2.VMVulnSummary
+	23, // 61: v2.VirtualMachineV2Service.ListVMCVEsByVM:output_type -> v2.ListVMCVEsByVMResponse
+	26, // 62: v2.VirtualMachineV2Service.GetVMCVEComponents:output_type -> v2.GetVMCVEComponentsResponse
+	29, // 63: v2.VirtualMachineV2Service.ListVMComponents:output_type -> v2.ListVMComponentsResponse
+	10, // 64: v2.VirtualMachineV2Service.ListVMs:output_type -> v2.ListVMsResponse
+	13, // 65: v2.VirtualMachineV2Service.ListVMCVEs:output_type -> v2.ListVMCVEsResponse
+	15, // 66: v2.VirtualMachineV2Service.GetVMDashboardCounts:output_type -> v2.VMDashboardCountsResponse
+	30, // 67: v2.VirtualMachineV2Service.GetVMCVEDetail:output_type -> v2.VMCVEDetail
+	34, // 68: v2.VirtualMachineV2Service.ListVMCVEAffectedVMs:output_type -> v2.ListVMCVEAffectedVMsResponse
+	59, // [59:69] is the sub-list for method output_type
+	49, // [49:59] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_virtual_machine_v2_service_proto_init() }

--- a/generated/api/v2/virtual_machine_v2_service.pb.gw.go
+++ b/generated/api/v2/virtual_machine_v2_service.pb.gw.go
@@ -393,6 +393,8 @@ func local_request_VirtualMachineV2Service_GetVMDashboardCounts_0(ctx context.Co
 	return msg, metadata, err
 }
 
+var filter_VirtualMachineV2Service_GetVMCVEDetail_0 = &utilities.DoubleArray{Encoding: map[string]int{"cve_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+
 func request_VirtualMachineV2Service_GetVMCVEDetail_0(ctx context.Context, marshaler runtime.Marshaler, client VirtualMachineV2ServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetVMCVEDetailRequest
@@ -409,6 +411,12 @@ func request_VirtualMachineV2Service_GetVMCVEDetail_0(ctx context.Context, marsh
 	protoReq.CveId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "cve_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_VirtualMachineV2Service_GetVMCVEDetail_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := client.GetVMCVEDetail(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -427,6 +435,12 @@ func local_request_VirtualMachineV2Service_GetVMCVEDetail_0(ctx context.Context,
 	protoReq.CveId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "cve_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_VirtualMachineV2Service_GetVMCVEDetail_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := server.GetVMCVEDetail(ctx, &protoReq)
 	return msg, metadata, err

--- a/generated/api/v2/virtual_machine_v2_service.swagger.json
+++ b/generated/api/v2/virtual_machine_v2_service.swagger.json
@@ -116,6 +116,57 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "query.query",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "query.pagination.limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "query.pagination.offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "query.pagination.sortOption.field",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "query.pagination.sortOption.reversed",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "query.pagination.sortOption.aggregateBy.aggrFunc",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "UNSET",
+              "COUNT",
+              "MIN",
+              "MAX"
+            ],
+            "default": "UNSET"
+          },
+          {
+            "name": "query.pagination.sortOption.aggregateBy.distinct",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "tags": [

--- a/generated/api/v2/virtual_machine_v2_service_vtproto.pb.go
+++ b/generated/api/v2/virtual_machine_v2_service_vtproto.pb.go
@@ -610,6 +610,7 @@ func (m *GetVMCVEDetailRequest) CloneVT() *GetVMCVEDetailRequest {
 	}
 	r := new(GetVMCVEDetailRequest)
 	r.CveId = m.CveId
+	r.Query = m.Query.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1542,6 +1543,9 @@ func (this *GetVMCVEDetailRequest) EqualVT(that *GetVMCVEDetailRequest) bool {
 		return false
 	}
 	if this.CveId != that.CveId {
+		return false
+	}
+	if !this.Query.EqualVT(that.Query) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3407,6 +3411,16 @@ func (m *GetVMCVEDetailRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Query != nil {
+		size, err := m.Query.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.CveId) > 0 {
 		i -= len(m.CveId)
 		copy(dAtA[i:], m.CveId)
@@ -4289,6 +4303,10 @@ func (m *GetVMCVEDetailRequest) SizeVT() (n int) {
 	_ = l
 	l = len(m.CveId)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Query != nil {
+		l = m.Query.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -9158,6 +9176,42 @@ func (m *GetVMCVEDetailRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.CveId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &RawQuery{}
+			}
+			if err := m.Query.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -14576,6 +14630,42 @@ func (m *GetVMCVEDetailRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.CveId = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &RawQuery{}
+			}
+			if err := m.Query.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/proto/api/v2/virtual_machine_v2_service.proto
+++ b/proto/api/v2/virtual_machine_v2_service.proto
@@ -260,6 +260,7 @@ message VMCVEDetail {
 
 message GetVMCVEDetailRequest {
   string cve_id = 1;
+  RawQuery query = 2;
 }
 
 // ─── Endpoint 10: ListVMCVEAffectedVMs ───


### PR DESCRIPTION
## Description

Add `RawQuery` filter to `GetVMCVEDetail`

The single CVE detail page has a widget that shows severity counts, affected VM
count, and affected guest OS count. These counts need to update based on user
filters (e.g. by VM name or severity), but `GetVMCVEDetail` didn't accept a
query parameter so the counts were always unfiltered.

Notes:
- Uses a split query approach so CVE details always load even when the filter matches nothing. The CVE lookup is unfiltered, the counts use the conjoined filter.
- Adding the field to the existing request message (alongside `cve_id`) highlights the benefit of
nested params for backwards compatibility (even though this feature was in early stages).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

**Before the change** (query param is silently ignored):

```bash
# With VM name filter (ignored by old code, returns both VMs)
curl -sk -u admin:$PASS \
  "$CENTRAL/v2/virtualmachines/cves/CVE-2015-1197?query.query=Virtual+Machine+Name:rhel9-1"
```
```json
{
  "cve": "CVE-2015-1197",
  "affectedVmCount": 2,
  "totalVmCount": 2,
  "affectedGuestOsCount": 1,
  "vmSeverityCounts": {
    "low": {"total": 2, "fixable": 0}
  },
  "topCvss": 2.1
}
```

**After the change** (query param filters the counts):

```bash
# Without query (unchanged behavior, both VMs counted)
curl -sk -u admin:$PASS \
  "$CENTRAL/v2/virtualmachines/cves/CVE-2015-1197"
```
```json
{
  "cve": "CVE-2015-1197",
  "affectedVmCount": 2,
  "totalVmCount": 2,
  "affectedGuestOsCount": 1,
  "vmSeverityCounts": {
    "low": {"total": 2, "fixable": 0}
  },
  "topCvss": 2.1
}
```

```bash
# With VM name filter (counts scoped to rhel9-1 only)
curl -sk -u admin:$PASS \
  "$CENTRAL/v2/virtualmachines/cves/CVE-2015-1197?query.query=Virtual+Machine+Name:rhel9-1"
```
```json
{
  "cve": "CVE-2015-1197",
  "affectedVmCount": 1,
  "totalVmCount": 2,
  "affectedGuestOsCount": 1,
  "vmSeverityCounts": {
    "low": {"total": 1, "fixable": 0}
  },
  "topCvss": 2.1
}
```

`affectedVmCount` drops from 2 to 1 and `vmSeverityCounts.low.total` drops from
2 to 1.
