### PR TITLE
ROX-36018: fix race condition in TestRelay_UMHInteraction

### DIFF
--- a/compliance/virtualmachines/relay/relay_test.go
+++ b/compliance/virtualmachines/relay/relay_test.go
@@ -322,10 +322,9 @@ func (s *relayTestSuite) TestRelay_RateLimiting() {
 // TestRelay_UMHInteraction verifies the relay observes UMH signals and marks ACKs.
 func (s *relayTestSuite) TestRelay_UMHInteraction() {
 	done := concurrency.NewSignal()
+
 	mockIndexReportSender := &mockIndexReportSender{
-		failOnIndex:   -1,
-		done:          &done,
-		expectedCount: 1,
+		failOnIndex: -1,
 	}
 
 	mockIndexReportStream := &mockIndexReportStream{
@@ -336,6 +335,9 @@ func (s *relayTestSuite) TestRelay_UMHInteraction() {
 
 	umh := &mockUMH{
 		retryCh: make(chan string, 1),
+		onObserveSendingCb: func(_ string) {
+			done.Signal()
+		},
 	}
 
 	relay := New(mockIndexReportStream, mockIndexReportSender, umh, noThrottlingReportsPerMinute, testStaleAckThreshold)
@@ -348,14 +350,12 @@ func (s *relayTestSuite) TestRelay_UMHInteraction() {
 		errChan <- relay.Run(ctx)
 	}()
 
-	// Wait for the report to be sent.
 	select {
 	case <-done.Done():
 	case <-time.After(time.Second):
-		s.Fail("timeout waiting for report send")
+		s.Fail("timeout waiting for ObserveSending")
 	}
 
-	// Verify ObserveSending recorded the VSOCK ID.
 	var sends []string
 	concurrency.WithLock(&umh.mu, func() {
 		sends = append(sends, umh.sends...)
@@ -640,12 +640,13 @@ func (m *mockIndexReportSender) Send(_ context.Context, vmReport *v1.VMReport) e
 
 // mockUMH is a mock UnconfirmedMessageHandler for testing
 type mockUMH struct {
-	mu      sync.Mutex
-	acks    []string
-	nacks   []string
-	sends   []string
-	retryCh chan string
-	onACKCb func(resourceID string)
+	mu                 sync.Mutex
+	acks               []string
+	nacks              []string
+	sends              []string
+	retryCh            chan string
+	onACKCb            func(resourceID string)
+	onObserveSendingCb func(resourceID string)
 }
 
 func (m *mockUMH) HandleACK(resourceID string) {
@@ -666,9 +667,12 @@ func (m *mockUMH) HandleNACK(resourceID string) {
 }
 
 func (m *mockUMH) ObserveSending(resourceID string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.sends = append(m.sends, resourceID)
+	concurrency.WithLock(&m.mu, func() {
+		m.sends = append(m.sends, resourceID)
+		if m.onObserveSendingCb != nil {
+			m.onObserveSendingCb(resourceID)
+		}
+	})
 }
 
 func (m *mockUMH) RetryCommand() <-chan string {


### PR DESCRIPTION
## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

This is a non-conflicting cherry-pick of a change in `master` (fb67fc258ddf096fa06bdf25a8523a9ffbddbada).
