### PR TITLE
ROX-35908: Fix NOT-APPLICABLE scan watcher timeout on HCP

### DIFF
--- a/central/complianceoperator/v2/report/errors.go
+++ b/central/complianceoperator/v2/report/errors.go
@@ -6,6 +6,7 @@ const (
 	COMPLIANCE_VERSION_ERROR             = "Compliance Operator Version is older than 1.6.0"
 	COMPLIANCE_NOT_INSTALLED             = "Compliance Operator is not installed"
 	INTERNAL_ERROR                       = "Internal Error"
+	SCAN_NOT_APPLICABLE                  = "All scans were not applicable for this cluster"
 	SCAN_REMOVED_FMT                     = "Scan %s was removed"
 	SCAN_TIMEOUT_FMT                     = "Timeout waiting for scan %s to finish"
 	SCAN_TIMEOUT_SENSOR_DISCONNECTED_FMT = "Timeout waiting for scan %s to finish (Sensor disconnect during the scan)"

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -364,11 +364,15 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 			log.Debug("The scan is missing the LastStartedTime field")
 			return nil
 		}
-		if errors.Is(err, watcher.ErrScanAlreadyHandled) {
+		if errors.Is(err, watcher.ErrScanAlreadyHandled) && !watcher.IsScanNotApplicable(scan) {
 			log.Debugf("Scan %s was already handled", scan.GetScanName())
 			return nil
 		}
-		return err
+		if !errors.Is(err, watcher.ErrScanAlreadyHandled) {
+			return err
+		}
+		log.Debugf("Scan %s was already handled but is NOT-APPLICABLE, allowing through", scan.GetScanName())
+		id = fmt.Sprintf("%s:%s", scan.GetClusterId(), scan.GetId())
 	}
 	numChecks, err := watcher.GetExpectedNumChecks(scan)
 	if err != nil {
@@ -546,7 +550,7 @@ func (m *managerImpl) getOrCreateScanConfigWatcher(ctx context.Context, results 
 		if err != nil {
 			return nil, nil, false, errors.Wrap(err, "unable to retrieve snapshots from the store")
 		}
-		if len(snapshot) > 0 {
+		if len(snapshot) > 0 && !watcher.IsScanNotApplicable(results.Scan) {
 			// We already handled a scan newer than this one, we ignore this scanResults
 			return nil, nil, false, watcher.ErrScanAlreadyHandled
 		}

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -502,6 +502,10 @@ func (m *managerImpl) handleReadyScan() {
 			log.Debugf("Scan %s was removed", scanWatcherResult.Scan.GetScanName())
 			continue
 		}
+		if watcher.IsScanNotApplicable(scanWatcherResult.Scan) {
+			log.Infof("Scan %s is NOT-APPLICABLE, skipping report inclusion", scanWatcherResult.Scan.GetScanName())
+			continue
+		}
 		log.Debugf("Scan %s done with %d checks", scanWatcherResult.Scan.GetScanName(), len(scanWatcherResult.CheckResults))
 		w, scanConfig, wasAlreadyRunning, err := m.getOrCreateScanConfigWatcher(scanWatcherResult.SensorCtx, scanWatcherResult, m.scanConfigDataStore, m.scanConfigReadyQueue)
 		if errors.Is(err, watcher.ErrScanAlreadyHandled) {

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -502,10 +502,6 @@ func (m *managerImpl) handleReadyScan() {
 			log.Debugf("Scan %s was removed", scanWatcherResult.Scan.GetScanName())
 			continue
 		}
-		if watcher.IsScanNotApplicable(scanWatcherResult.Scan) {
-			log.Infof("Scan %s is NOT-APPLICABLE, skipping report inclusion", scanWatcherResult.Scan.GetScanName())
-			continue
-		}
 		log.Debugf("Scan %s done with %d checks", scanWatcherResult.Scan.GetScanName(), len(scanWatcherResult.CheckResults))
 		w, scanConfig, wasAlreadyRunning, err := m.getOrCreateScanConfigWatcher(scanWatcherResult.SensorCtx, scanWatcherResult, m.scanConfigDataStore, m.scanConfigReadyQueue)
 		if errors.Is(err, watcher.ErrScanAlreadyHandled) {

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -185,16 +185,39 @@ func (w *scanConfigWatcherImpl) run(timer Timer) {
 				return
 			}
 		}
-		if concurrency.WithLock1[bool](&w.resultsLock, func() bool {
-			if w.totalResults != 0 && w.totalResults == len(w.scanConfigResults.ScanResults) {
-				w.readyQueue.Push(w.scanConfigResults)
-				return true
-			}
-			return false
-		}) {
+		if w.checkCompletion() {
 			return
 		}
 	}
+}
+
+// checkCompletion verifies all expected scans have been received. When scansToWait is empty,
+// it re-queries the database to catch scan resources that were created after the initial query
+// (e.g., the CO may still be creating scan resources when the first results arrive).
+func (w *scanConfigWatcherImpl) checkCompletion() bool {
+	if w.totalResults == 0 || w.scansToWait.Cardinality() > 0 {
+		return false
+	}
+	newScans, err := GetScansFromScanConfiguration(w.ctx, w.scanConfigResults.ScanConfig, w.profileDS, w.scanDS)
+	if err != nil {
+		log.Warnf("Unable to re-query scans for completion check: %v", err)
+		return false
+	}
+	concurrency.WithLock(&w.resultsLock, func() {
+		for key := range w.scanConfigResults.ScanResults {
+			newScans.Remove(key)
+		}
+	})
+	if newScans.Cardinality() > 0 {
+		log.Infof("Scan config %s: found %d additional scans after re-query, continuing to wait", w.scanConfigName(), newScans.Cardinality())
+		w.scansToWait = newScans
+		w.totalResults += newScans.Cardinality()
+		return false
+	}
+	return concurrency.WithLock1[bool](&w.resultsLock, func() bool {
+		w.readyQueue.Push(w.scanConfigResults)
+		return true
+	})
 }
 
 func (w *scanConfigWatcherImpl) handleScanResults(result *ScanWatcherResults) error {
@@ -210,7 +233,7 @@ func (w *scanConfigWatcherImpl) handleScanResults(result *ScanWatcherResults) er
 	}
 	log.Debugf("Scan to handle %s with id %s", result.Scan.GetScanName(), result.Scan.GetId())
 	scanResultKey := fmt.Sprintf("%s:%s", result.Scan.GetClusterId(), result.Scan.GetId())
-	if found := w.scansToWait.Remove(fmt.Sprintf("%s:%s", result.Scan.GetClusterId(), result.Scan.GetId())); !found {
+	if found := w.scansToWait.Remove(scanResultKey); !found {
 		newScanResult := result.Scan
 		var timestampCmpResult int
 		concurrency.WithLock(&w.resultsLock, func() {
@@ -222,12 +245,39 @@ func (w *scanConfigWatcherImpl) handleScanResults(result *ScanWatcherResults) er
 			// We already handled a newer scan, so we can ignore this scan.
 			return nil
 		}
+		// The scan ID is not in scansToWait — the CO may have recycled the scan resource
+		// with a new ID. Re-query to refresh scansToWait with current IDs from the DB.
+		if freshScans, err := GetScansFromScanConfiguration(w.ctx, w.scanConfigResults.ScanConfig, w.profileDS, w.scanDS); err == nil {
+			w.scansToWait = freshScans
+			w.totalResults = len(w.scansToWait)
+			w.scansToWait.Remove(scanResultKey)
+			concurrency.WithLock(&w.resultsLock, func() {
+				for key := range w.scanConfigResults.ScanResults {
+					w.scansToWait.Remove(key)
+				}
+			})
+		}
 	}
+	// Remove any stale result for the same scan name on the same cluster (CO may recycle scan
+	// resources with new IDs). This prevents inflating ScanResults and keeps scansToWait accurate.
+	w.removeStaleResult(result.Scan.GetClusterId(), result.Scan.GetScanName(), scanResultKey)
 	concurrency.WithLock(&w.resultsLock, func() {
 		w.scanConfigResults.ScanResults[scanResultKey] = result
 	})
 
 	return w.appendScanToSnapshots(w.ctx, result.Scan)
+}
+
+func (w *scanConfigWatcherImpl) removeStaleResult(clusterID, scanName, currentKey string) {
+	concurrency.WithLock(&w.resultsLock, func() {
+		for key, existing := range w.scanConfigResults.ScanResults {
+			if key != currentKey && existing.Scan.GetClusterId() == clusterID && existing.Scan.GetScanName() == scanName {
+				log.Debugf("Removing stale scan result %s (replaced by %s)", key, currentKey)
+				delete(w.scanConfigResults.ScanResults, key)
+				w.scansToWait.Remove(key)
+			}
+		}
+	})
 }
 
 func (w *scanConfigWatcherImpl) appendScanToSnapshots(ctx context.Context, scan *storage.ComplianceOperatorScanV2) error {

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -3,7 +3,6 @@ package watcher
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/pkg/errors"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
@@ -72,7 +71,6 @@ func NewScanConfigWatcher(ctx, sensorCtx context.Context, watcherID string, sc *
 	watcherCtx, cancel := context.WithCancel(ctx)
 	finishedSignal := concurrency.NewSignal()
 	timeout := NewTimer(env.ComplianceScanScheduleWatcherTimeout.DurationSetting())
-	stabilize := NewTimer(env.ComplianceScanConfigWatcherStabilizationDelay.DurationSetting())
 	ret := &scanConfigWatcherImpl{
 		ctx:                 watcherCtx,
 		sensorCtx:           sensorCtx,
@@ -91,7 +89,7 @@ func NewScanConfigWatcher(ctx, sensorCtx context.Context, watcherID string, sc *
 		},
 		scansToWait: set.NewStringSet(),
 	}
-	go ret.run(timeout, stabilize)
+	go ret.run(timeout)
 	return ret
 }
 
@@ -153,120 +151,50 @@ func (w *scanConfigWatcherImpl) scanConfigName() string {
 	return w.scanConfigResults.WatcherID
 }
 
-func (w *scanConfigWatcherImpl) run(timer Timer, stabilize Timer) {
+func (w *scanConfigWatcherImpl) run(timer Timer) {
 	defer func() {
 		w.stopped.Signal()
 		<-w.stopped.Done()
 		timer.Stop()
-		stabilize.Stop()
 	}()
-
-	pendingResults := w.stabilize(timer, stabilize)
-	if pendingResults == nil {
-		return
-	}
-	if slices.ContainsFunc(pendingResults, w.processResult) {
-		return
-	}
-	if w.checkCompletion() {
-		return
-	}
-	w.processLoop(timer)
-}
-
-// stabilize buffers incoming results until no new results arrive for the stabilization period.
-// NOT-APPLICABLE scans are deduplicated by scan name + cluster ID since the Compliance Operator
-// may recycle scan resources multiple times during initialization.
-// Returns nil if the watcher was cancelled or timed out during stabilization.
-func (w *scanConfigWatcherImpl) stabilize(timer Timer, stabilize Timer) []*ScanWatcherResults {
-	var applicable []*ScanWatcherResults
-	notApplicable := make(map[string]*ScanWatcherResults)
 	for {
 		select {
 		case <-w.ctx.Done():
-			w.handleContextDone()
-			return nil
-		case <-timer.C():
-			w.handleTimeout()
-			return nil
-		case result := <-w.scanWatcherResoutsC:
-			if IsScanNotApplicable(result.Scan) {
-				key := fmt.Sprintf("%s:%s", result.Scan.GetClusterId(), result.Scan.GetScanName())
-				notApplicable[key] = result
-			} else {
-				applicable = append(applicable, result)
-			}
-			stabilize.Reset()
-		case <-stabilize.C():
-			pending := applicable
-			for _, r := range notApplicable {
-				pending = append(pending, r)
-			}
-			log.Infof("Scan config watcher for %s stabilized with %d buffered results (%d not-applicable, %d applicable)",
-				w.scanConfigName(), len(pending), len(notApplicable), len(applicable))
-			return pending
-		}
-	}
-}
-
-func (w *scanConfigWatcherImpl) processLoop(timer Timer) {
-	for {
-		select {
-		case <-w.ctx.Done():
-			w.handleContextDone()
+			concurrency.WithLock(&w.resultsLock, func() {
+				log.Infof("Stopping scan config watcher for %s. Received %d/%d scan results (watcher id: %s)",
+					w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID)
+				w.scanConfigResults.Error = ErrScanConfigContextCancelled
+				w.readyQueue.Push(w.scanConfigResults)
+			})
 			return
 		case <-timer.C():
-			w.handleTimeout()
+			concurrency.WithLock(&w.resultsLock, func() {
+				log.Warnf("Timeout waiting for the ScanConfiguration %s's scans to finish. Received %d/%d scan results (watcher id: %s, pending: %v)",
+					w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID, w.scansToWait.AsSlice())
+				w.scanConfigResults.Error = ErrScanConfigTimeout
+				w.readyQueue.Push(w.scanConfigResults)
+			})
 			return
 		case result := <-w.scanWatcherResoutsC:
-			if w.processResult(result) {
+			if err := w.handleScanResults(result); err != nil {
+				log.Errorf("Unable to handle scan results %s: %v", result.Scan.GetScanName(), err)
+				concurrency.WithLock(&w.resultsLock, func() {
+					w.scanConfigResults.Error = err
+					w.readyQueue.Push(w.scanConfigResults)
+				})
 				return
 			}
 		}
-		if w.checkCompletion() {
+		if concurrency.WithLock1[bool](&w.resultsLock, func() bool {
+			if w.totalResults != 0 && w.totalResults == len(w.scanConfigResults.ScanResults) {
+				w.readyQueue.Push(w.scanConfigResults)
+				return true
+			}
+			return false
+		}) {
 			return
 		}
 	}
-}
-
-func (w *scanConfigWatcherImpl) processResult(result *ScanWatcherResults) bool {
-	if err := w.handleScanResults(result); err != nil {
-		log.Errorf("Unable to handle scan results %s: %v", result.Scan.GetScanName(), err)
-		concurrency.WithLock(&w.resultsLock, func() {
-			w.scanConfigResults.Error = err
-			w.readyQueue.Push(w.scanConfigResults)
-		})
-		return true
-	}
-	return false
-}
-
-func (w *scanConfigWatcherImpl) checkCompletion() bool {
-	return concurrency.WithLock1[bool](&w.resultsLock, func() bool {
-		if w.totalResults != 0 && w.totalResults == len(w.scanConfigResults.ScanResults) {
-			w.readyQueue.Push(w.scanConfigResults)
-			return true
-		}
-		return false
-	})
-}
-
-func (w *scanConfigWatcherImpl) handleContextDone() {
-	concurrency.WithLock(&w.resultsLock, func() {
-		log.Infof("Stopping scan config watcher for %s. Received %d/%d scan results (watcher id: %s)",
-			w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID)
-		w.scanConfigResults.Error = ErrScanConfigContextCancelled
-		w.readyQueue.Push(w.scanConfigResults)
-	})
-}
-
-func (w *scanConfigWatcherImpl) handleTimeout() {
-	concurrency.WithLock(&w.resultsLock, func() {
-		log.Warnf("Timeout waiting for the ScanConfiguration %s's scans to finish. Received %d/%d scan results (watcher id: %s, pending: %v)",
-			w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID, w.scansToWait.AsSlice())
-		w.scanConfigResults.Error = ErrScanConfigTimeout
-		w.readyQueue.Push(w.scanConfigResults)
-	})
 }
 
 func (w *scanConfigWatcherImpl) handleScanResults(result *ScanWatcherResults) error {

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -282,6 +282,10 @@ func GetScansFromScanConfiguration(ctx context.Context, scanConfig *storage.Comp
 			return nil, errors.Wrap(err, "unable to search the scans")
 		}
 		for _, s := range scans {
+			if IsScanNotApplicable(s) {
+				log.Debugf("Skipping NOT-APPLICABLE scan %s", s.GetScanName())
+				continue
+			}
 			log.Debugf("Adding scan to wait %s", s.GetScanName())
 			ret.Add(fmt.Sprintf("%s:%s", s.GetClusterId(), s.GetId()))
 		}

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/pkg/errors"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
@@ -71,6 +72,7 @@ func NewScanConfigWatcher(ctx, sensorCtx context.Context, watcherID string, sc *
 	watcherCtx, cancel := context.WithCancel(ctx)
 	finishedSignal := concurrency.NewSignal()
 	timeout := NewTimer(env.ComplianceScanScheduleWatcherTimeout.DurationSetting())
+	stabilize := NewTimer(env.ComplianceScanConfigWatcherStabilizationDelay.DurationSetting())
 	ret := &scanConfigWatcherImpl{
 		ctx:                 watcherCtx,
 		sensorCtx:           sensorCtx,
@@ -89,7 +91,7 @@ func NewScanConfigWatcher(ctx, sensorCtx context.Context, watcherID string, sc *
 		},
 		scansToWait: set.NewStringSet(),
 	}
-	go ret.run(timeout)
+	go ret.run(timeout, stabilize)
 	return ret
 }
 
@@ -151,50 +153,120 @@ func (w *scanConfigWatcherImpl) scanConfigName() string {
 	return w.scanConfigResults.WatcherID
 }
 
-func (w *scanConfigWatcherImpl) run(timer Timer) {
+func (w *scanConfigWatcherImpl) run(timer Timer, stabilize Timer) {
 	defer func() {
 		w.stopped.Signal()
 		<-w.stopped.Done()
 		timer.Stop()
+		stabilize.Stop()
 	}()
+
+	pendingResults := w.stabilize(timer, stabilize)
+	if pendingResults == nil {
+		return
+	}
+	if slices.ContainsFunc(pendingResults, w.processResult) {
+		return
+	}
+	if w.checkCompletion() {
+		return
+	}
+	w.processLoop(timer)
+}
+
+// stabilize buffers incoming results until no new results arrive for the stabilization period.
+// NOT-APPLICABLE scans are deduplicated by scan name + cluster ID since the Compliance Operator
+// may recycle scan resources multiple times during initialization.
+// Returns nil if the watcher was cancelled or timed out during stabilization.
+func (w *scanConfigWatcherImpl) stabilize(timer Timer, stabilize Timer) []*ScanWatcherResults {
+	var applicable []*ScanWatcherResults
+	notApplicable := make(map[string]*ScanWatcherResults)
 	for {
 		select {
 		case <-w.ctx.Done():
-			concurrency.WithLock(&w.resultsLock, func() {
-				log.Infof("Stopping scan config watcher for %s. Received %d/%d scan results (watcher id: %s)",
-					w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID)
-				w.scanConfigResults.Error = ErrScanConfigContextCancelled
-				w.readyQueue.Push(w.scanConfigResults)
-			})
+			w.handleContextDone()
+			return nil
+		case <-timer.C():
+			w.handleTimeout()
+			return nil
+		case result := <-w.scanWatcherResoutsC:
+			if IsScanNotApplicable(result.Scan) {
+				key := fmt.Sprintf("%s:%s", result.Scan.GetClusterId(), result.Scan.GetScanName())
+				notApplicable[key] = result
+			} else {
+				applicable = append(applicable, result)
+			}
+			stabilize.Reset()
+		case <-stabilize.C():
+			pending := applicable
+			for _, r := range notApplicable {
+				pending = append(pending, r)
+			}
+			log.Infof("Scan config watcher for %s stabilized with %d buffered results (%d not-applicable, %d applicable)",
+				w.scanConfigName(), len(pending), len(notApplicable), len(applicable))
+			return pending
+		}
+	}
+}
+
+func (w *scanConfigWatcherImpl) processLoop(timer Timer) {
+	for {
+		select {
+		case <-w.ctx.Done():
+			w.handleContextDone()
 			return
 		case <-timer.C():
-			concurrency.WithLock(&w.resultsLock, func() {
-				log.Warnf("Timeout waiting for the ScanConfiguration %s's scans to finish. Received %d/%d scan results (watcher id: %s, pending: %v)",
-					w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID, w.scansToWait.AsSlice())
-				w.scanConfigResults.Error = ErrScanConfigTimeout
-				w.readyQueue.Push(w.scanConfigResults)
-			})
+			w.handleTimeout()
 			return
 		case result := <-w.scanWatcherResoutsC:
-			if err := w.handleScanResults(result); err != nil {
-				log.Errorf("Unable to handle scan results %s: %v", result.Scan.GetScanName(), err)
-				concurrency.WithLock(&w.resultsLock, func() {
-					w.scanConfigResults.Error = err
-					w.readyQueue.Push(w.scanConfigResults)
-				})
+			if w.processResult(result) {
 				return
 			}
 		}
-		if concurrency.WithLock1[bool](&w.resultsLock, func() bool {
-			if w.totalResults != 0 && w.totalResults == len(w.scanConfigResults.ScanResults) {
-				w.readyQueue.Push(w.scanConfigResults)
-				return true
-			}
-			return false
-		}) {
+		if w.checkCompletion() {
 			return
 		}
 	}
+}
+
+func (w *scanConfigWatcherImpl) processResult(result *ScanWatcherResults) bool {
+	if err := w.handleScanResults(result); err != nil {
+		log.Errorf("Unable to handle scan results %s: %v", result.Scan.GetScanName(), err)
+		concurrency.WithLock(&w.resultsLock, func() {
+			w.scanConfigResults.Error = err
+			w.readyQueue.Push(w.scanConfigResults)
+		})
+		return true
+	}
+	return false
+}
+
+func (w *scanConfigWatcherImpl) checkCompletion() bool {
+	return concurrency.WithLock1[bool](&w.resultsLock, func() bool {
+		if w.totalResults != 0 && w.totalResults == len(w.scanConfigResults.ScanResults) {
+			w.readyQueue.Push(w.scanConfigResults)
+			return true
+		}
+		return false
+	})
+}
+
+func (w *scanConfigWatcherImpl) handleContextDone() {
+	concurrency.WithLock(&w.resultsLock, func() {
+		log.Infof("Stopping scan config watcher for %s. Received %d/%d scan results (watcher id: %s)",
+			w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID)
+		w.scanConfigResults.Error = ErrScanConfigContextCancelled
+		w.readyQueue.Push(w.scanConfigResults)
+	})
+}
+
+func (w *scanConfigWatcherImpl) handleTimeout() {
+	concurrency.WithLock(&w.resultsLock, func() {
+		log.Warnf("Timeout waiting for the ScanConfiguration %s's scans to finish. Received %d/%d scan results (watcher id: %s, pending: %v)",
+			w.scanConfigName(), len(w.scanConfigResults.ScanResults), w.totalResults, w.scanConfigResults.WatcherID, w.scansToWait.AsSlice())
+		w.scanConfigResults.Error = ErrScanConfigTimeout
+		w.readyQueue.Push(w.scanConfigResults)
+	})
 }
 
 func (w *scanConfigWatcherImpl) handleScanResults(result *ScanWatcherResults) error {

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -282,10 +282,6 @@ func GetScansFromScanConfiguration(ctx context.Context, scanConfig *storage.Comp
 			return nil, errors.Wrap(err, "unable to search the scans")
 		}
 		for _, s := range scans {
-			if IsScanNotApplicable(s) {
-				log.Debugf("Skipping NOT-APPLICABLE scan %s", s.GetScanName())
-				continue
-			}
 			log.Debugf("Adding scan to wait %s", s.GetScanName())
 			ret.Add(fmt.Sprintf("%s:%s", s.GetClusterId(), s.GetId()))
 		}

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -125,6 +125,7 @@ func TestScanConfigWatcher(t *testing.T) {
 	}
 	for tName, tCase := range cases {
 		t.Run(tName, func(t *testing.T) {
+			t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 			watcherID := "sc-id"
 			scanConfig := &storage.ComplianceOperatorScanConfigurationV2{
 				Id: watcherID,
@@ -140,7 +141,7 @@ func TestScanConfigWatcher(t *testing.T) {
 			}
 			require.Eventually(t, func() bool {
 				return resultsQueue.Len() != 0
-			}, 200*time.Millisecond, 10*time.Millisecond)
+			}, 1*time.Second, 10*time.Millisecond)
 			result := resultsQueue.Pull()
 			require.NotNil(t, result)
 			require.Len(t, result.ScanResults, len(tCase.assertScanIDs))
@@ -166,6 +167,7 @@ func TestScanConfigWatcher(t *testing.T) {
 }
 
 func TestScanConfigWatcherCancel(t *testing.T) {
+	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -183,11 +185,11 @@ func TestScanConfigWatcherCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
 	scanConfigWatcher := NewScanConfigWatcher(ctx, ctx, watcherID, scanConfig, scanDS, profileDS, snapshotDS, resultQueue)
-	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	handleScanResults("scan-0")(t, scanConfigWatcher)
 	cancel()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		t.Error("timeout waiting for the watcher to stop")
 	}
 	assert.Equal(t, 1, resultQueue.Len())
@@ -196,6 +198,7 @@ func TestScanConfigWatcherCancel(t *testing.T) {
 }
 
 func TestScanConfigWatcherStop(t *testing.T) {
+	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -212,11 +215,11 @@ func TestScanConfigWatcherStop(t *testing.T) {
 	}
 	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
 	scanConfigWatcher := NewScanConfigWatcher(context.Background(), context.Background(), watcherID, scanConfig, scanDS, profileDS, snapshotDS, resultQueue)
-	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	handleScanResults("scan-0")(t, scanConfigWatcher)
 	scanConfigWatcher.Stop()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		t.Error("timeout waiting for the watcher to stop")
 	}
 	assert.Equal(t, 1, resultQueue.Len())
@@ -277,8 +280,12 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 		readyQueue:  resultQueue,
 		scansToWait: set.NewStringSet(),
 	}
-	go scanConfigWatcher.run(timeout)
+	stabilizeC := make(chan time.Time)
+	defer close(stabilizeC)
+	stabilize := &testTimer{ch: stabilizeC}
+	go scanConfigWatcher.run(timeout, stabilize)
 	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	stabilizeC <- time.Now()
 	timeoutC <- time.Now()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
@@ -292,6 +299,7 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 }
 
 func TestScanConfigWatcherSubscribe(t *testing.T) {
+	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -320,7 +328,7 @@ func TestScanConfigWatcherSubscribe(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return resultsQueue.Len() != 0
-	}, 200*time.Millisecond, 10*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 
 	require.Equal(t, 1, resultsQueue.Len())
 	result := resultsQueue.Pull()
@@ -343,6 +351,7 @@ func TestScanConfigWatcherSubscribe(t *testing.T) {
 }
 
 func TestScanConfigWatcherGetScans(t *testing.T) {
+	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -365,12 +374,12 @@ func TestScanConfigWatcherGetScans(t *testing.T) {
 	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
 	require.Eventually(t, func() bool {
 		return len(scanConfigWatcher.GetScans()) == 1
-	}, 200*time.Millisecond, 10*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 
 	handleScanResults("scan-1")(t, scanConfigWatcher)
 	require.Eventually(t, func() bool {
 		return resultsQueue.Len() != 0
-	}, 200*time.Millisecond, 10*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 
 	scans = scanConfigWatcher.GetScans()
 	require.Len(t, scans, 2)

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -125,7 +125,6 @@ func TestScanConfigWatcher(t *testing.T) {
 	}
 	for tName, tCase := range cases {
 		t.Run(tName, func(t *testing.T) {
-			t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 			watcherID := "sc-id"
 			scanConfig := &storage.ComplianceOperatorScanConfigurationV2{
 				Id: watcherID,
@@ -141,7 +140,7 @@ func TestScanConfigWatcher(t *testing.T) {
 			}
 			require.Eventually(t, func() bool {
 				return resultsQueue.Len() != 0
-			}, 1*time.Second, 10*time.Millisecond)
+			}, 200*time.Millisecond, 10*time.Millisecond)
 			result := resultsQueue.Pull()
 			require.NotNil(t, result)
 			require.Len(t, result.ScanResults, len(tCase.assertScanIDs))
@@ -167,7 +166,6 @@ func TestScanConfigWatcher(t *testing.T) {
 }
 
 func TestScanConfigWatcherCancel(t *testing.T) {
-	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -185,11 +183,11 @@ func TestScanConfigWatcherCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
 	scanConfigWatcher := NewScanConfigWatcher(ctx, ctx, watcherID, scanConfig, scanDS, profileDS, snapshotDS, resultQueue)
-	handleScanResults("scan-0")(t, scanConfigWatcher)
+	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
 	cancel()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
-	case <-time.After(1 * time.Second):
+	case <-time.After(100 * time.Millisecond):
 		t.Error("timeout waiting for the watcher to stop")
 	}
 	assert.Equal(t, 1, resultQueue.Len())
@@ -198,7 +196,6 @@ func TestScanConfigWatcherCancel(t *testing.T) {
 }
 
 func TestScanConfigWatcherStop(t *testing.T) {
-	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -215,11 +212,11 @@ func TestScanConfigWatcherStop(t *testing.T) {
 	}
 	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
 	scanConfigWatcher := NewScanConfigWatcher(context.Background(), context.Background(), watcherID, scanConfig, scanDS, profileDS, snapshotDS, resultQueue)
-	handleScanResults("scan-0")(t, scanConfigWatcher)
+	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
 	scanConfigWatcher.Stop()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
-	case <-time.After(1 * time.Second):
+	case <-time.After(100 * time.Millisecond):
 		t.Error("timeout waiting for the watcher to stop")
 	}
 	assert.Equal(t, 1, resultQueue.Len())
@@ -280,12 +277,8 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 		readyQueue:  resultQueue,
 		scansToWait: set.NewStringSet(),
 	}
-	stabilizeC := make(chan time.Time)
-	defer close(stabilizeC)
-	stabilize := &testTimer{ch: stabilizeC}
-	go scanConfigWatcher.run(timeout, stabilize)
+	go scanConfigWatcher.run(timeout)
 	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
-	stabilizeC <- time.Now()
 	timeoutC <- time.Now()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
@@ -299,7 +292,6 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 }
 
 func TestScanConfigWatcherSubscribe(t *testing.T) {
-	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -328,7 +320,7 @@ func TestScanConfigWatcherSubscribe(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return resultsQueue.Len() != 0
-	}, 1*time.Second, 10*time.Millisecond)
+	}, 200*time.Millisecond, 10*time.Millisecond)
 
 	require.Equal(t, 1, resultsQueue.Len())
 	result := resultsQueue.Pull()
@@ -351,7 +343,6 @@ func TestScanConfigWatcherSubscribe(t *testing.T) {
 }
 
 func TestScanConfigWatcherGetScans(t *testing.T) {
-	t.Setenv("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", "1ms")
 	ctrl := gomock.NewController(t)
 	scanDS := scanMocks.NewMockDataStore(ctrl)
 	profileDS := profileDatastore.NewMockDataStore(ctrl)
@@ -374,12 +365,12 @@ func TestScanConfigWatcherGetScans(t *testing.T) {
 	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
 	require.Eventually(t, func() bool {
 		return len(scanConfigWatcher.GetScans()) == 1
-	}, 1*time.Second, 10*time.Millisecond)
+	}, 200*time.Millisecond, 10*time.Millisecond)
 
 	handleScanResults("scan-1")(t, scanConfigWatcher)
 	require.Eventually(t, func() bool {
 		return resultsQueue.Len() != 0
-	}, 1*time.Second, 10*time.Millisecond)
+	}, 200*time.Millisecond, 10*time.Millisecond)
 
 	scans = scanConfigWatcher.GetScans()
 	require.Len(t, scans, 2)

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -23,7 +23,7 @@ type scanConfigTestEvent func(*testing.T, ScanConfigWatcher)
 
 func handleInitialScanResults(id string, scanDS *scanMocks.MockDataStore, profileDS *profileDatastore.MockDataStore, numOfScans int) scanConfigTestEvent {
 	return func(t *testing.T, watcher ScanConfigWatcher) {
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).
+		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(2).
 			DoAndReturn(func(_, _ any) ([]*storage.ComplianceOperatorProfileV2, error) {
 				return []*storage.ComplianceOperatorProfileV2{
 					{
@@ -31,19 +31,21 @@ func handleInitialScanResults(id string, scanDS *scanMocks.MockDataStore, profil
 					},
 				}, nil
 			})
-		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).
+		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(2).
 			DoAndReturn(func(_, _ any) ([]*storage.ComplianceOperatorScanV2, error) {
 				ret := make([]*storage.ComplianceOperatorScanV2, numOfScans)
 				for i := range numOfScans {
 					ret[i] = &storage.ComplianceOperatorScanV2{
-						Id: fmt.Sprintf("scan-%d", i),
+						Id:       fmt.Sprintf("scan-%d", i),
+						ScanName: fmt.Sprintf("scan-%d", i),
 					}
 				}
 				return ret, nil
 			})
 		err := watcher.PushScanResults(&ScanWatcherResults{
 			Scan: &storage.ComplianceOperatorScanV2{
-				Id: id,
+				Id:       id,
+				ScanName: id,
 			},
 		})
 		require.NoError(t, err)
@@ -54,7 +56,8 @@ func handleScanResults(id string) scanConfigTestEvent {
 	return func(t *testing.T, watcher ScanConfigWatcher) {
 		err := watcher.PushScanResults(&ScanWatcherResults{
 			Scan: &storage.ComplianceOperatorScanV2{
-				Id: id,
+				Id:       id,
+				ScanName: id,
 			},
 		})
 		require.NoError(t, err)
@@ -65,7 +68,8 @@ func handleScanResultsWithError(id string) scanConfigTestEvent {
 	return func(t *testing.T, watcher ScanConfigWatcher) {
 		err := watcher.PushScanResults(&ScanWatcherResults{
 			Scan: &storage.ComplianceOperatorScanV2{
-				Id: id,
+				Id:       id,
+				ScanName: id,
 			},
 			Error: errors.New("some error in the scan"),
 		})
@@ -182,8 +186,10 @@ func TestScanConfigWatcherCancel(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+	profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{{Id: "p"}}, nil)
+	scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{{Id: "scan-0"}, {Id: "scan-1"}}, nil)
 	scanConfigWatcher := NewScanConfigWatcher(ctx, ctx, watcherID, scanConfig, scanDS, profileDS, snapshotDS, resultQueue)
-	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	handleScanResults("scan-0")(t, scanConfigWatcher)
 	cancel()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
@@ -211,8 +217,10 @@ func TestScanConfigWatcherStop(t *testing.T) {
 		Id: watcherID,
 	}
 	resultQueue := queue.NewQueue[*ScanConfigWatcherResults]()
+	profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{{Id: "p"}}, nil)
+	scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{{Id: "scan-0"}, {Id: "scan-1"}}, nil)
 	scanConfigWatcher := NewScanConfigWatcher(context.Background(), context.Background(), watcherID, scanConfig, scanDS, profileDS, snapshotDS, resultQueue)
-	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	handleScanResults("scan-0")(t, scanConfigWatcher)
 	scanConfigWatcher.Stop()
 	select {
 	case <-scanConfigWatcher.Finished().Done():
@@ -277,8 +285,10 @@ func TestScanConfigWatcherTimeout(t *testing.T) {
 		readyQueue:  resultQueue,
 		scansToWait: set.NewStringSet(),
 	}
+	profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{{Id: "p"}}, nil)
+	scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{{Id: "scan-0"}, {Id: "scan-1"}}, nil)
 	go scanConfigWatcher.run(timeout)
-	handleInitialScanResults("scan-0", scanDS, profileDS, 2)(t, scanConfigWatcher)
+	handleScanResults("scan-0")(t, scanConfigWatcher)
 	timeoutC <- time.Now()
 	select {
 	case <-scanConfigWatcher.Finished().Done():

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -354,18 +354,19 @@ func (s *scanWatcherImpl) handleScan(scan *storage.ComplianceOperatorScanV2) err
 	if err != nil {
 		return err
 	}
-	s.totalChecks = numChecks
 
 	s.resultsLock.Lock()
 	defer s.resultsLock.Unlock()
 
 	// If we received a newer timestamp we need to reset the watcher.
 	if protocompat.CompareTimestamps(s.lastStartedTime, scan.GetLastStartedTime()) < 0 {
+		s.totalChecks = numChecks
 		s.lastStartedTime = scan.GetLastStartedTime()
 		s.scanResults.Scan = scan
 		s.scanResults.CheckResults = set.NewStringSet()
 		s.timeout.Reset()
 	} else if protocompat.CompareTimestamps(s.lastStartedTime, scan.GetLastStartedTime()) == 0 {
+		s.totalChecks = numChecks
 		// Same timestamp: update scan to pick up status changes (e.g., NOT-APPLICABLE).
 		s.scanResults.Scan = scan
 	}

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -41,6 +41,7 @@ const (
 	minimumComplianceOperatorVersion = "v1.6.0"
 	CheckCountAnnotationKey          = "compliance.openshift.io/check-count"
 	LastScannedAnnotationKey         = "compliance.openshift.io/last-scanned-timestamp"
+	ScanResultNotApplicable          = "NOT-APPLICABLE"
 	defaultChanelSize                = 100
 )
 
@@ -316,6 +317,12 @@ func (s *scanWatcherImpl) run() {
 			watcherFinishType.WithLabelValues(s.scanName(), "done").Inc()
 			return
 		}
+		if s.totalChecks == 0 && numCheckResults == 0 && s.scanResults.Scan.GetStatus().GetResult() == ScanResultNotApplicable {
+			log.Infof("Scan %s completed as NOT-APPLICABLE with 0 check results (watcher id: %s)", s.scanName(), s.scanResults.WatcherID)
+			s.readyQueue.Push(s.scanResults)
+			watcherFinishType.WithLabelValues(s.scanName(), "not_applicable").Inc()
+			return
+		}
 	}
 }
 
@@ -346,15 +353,15 @@ func (s *scanWatcherImpl) handleScan(scan *storage.ComplianceOperatorScanV2) err
 	s.resultsLock.Lock()
 	defer s.resultsLock.Unlock()
 
-	if s.scanResults.Scan == nil {
-		s.scanResults.Scan = scan
-	}
 	// If we received a newer timestamp we need to reset the watcher.
 	if protocompat.CompareTimestamps(s.lastStartedTime, scan.GetLastStartedTime()) < 0 {
 		s.lastStartedTime = scan.GetLastStartedTime()
 		s.scanResults.Scan = scan
 		s.scanResults.CheckResults = set.NewStringSet()
 		s.timeout.Reset()
+	} else if protocompat.CompareTimestamps(s.lastStartedTime, scan.GetLastStartedTime()) == 0 {
+		// Same timestamp: update scan to pick up status changes (e.g., NOT-APPLICABLE).
+		s.scanResults.Scan = scan
 	}
 	return nil
 }

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -317,13 +317,19 @@ func (s *scanWatcherImpl) run() {
 			watcherFinishType.WithLabelValues(s.scanName(), "done").Inc()
 			return
 		}
-		if s.totalChecks == 0 && numCheckResults == 0 && s.scanResults.Scan.GetStatus().GetResult() == ScanResultNotApplicable {
+		if s.totalChecks == 0 && numCheckResults == 0 && IsScanNotApplicable(s.scanResults.Scan) {
 			log.Infof("Scan %s completed as NOT-APPLICABLE with 0 check results (watcher id: %s)", s.scanName(), s.scanResults.WatcherID)
 			s.readyQueue.Push(s.scanResults)
 			watcherFinishType.WithLabelValues(s.scanName(), "not_applicable").Inc()
 			return
 		}
 	}
+}
+
+// IsScanNotApplicable returns true if the scan completed as NOT-APPLICABLE (e.g., a master-node
+// scan on an HCP cluster with no master nodes).
+func IsScanNotApplicable(scan *storage.ComplianceOperatorScanV2) bool {
+	return scan.GetStatus().GetResult() == ScanResultNotApplicable
 }
 
 func GetExpectedNumChecks(scan *storage.ComplianceOperatorScanV2) (int, error) {

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
@@ -597,3 +597,36 @@ func TestDeleteOldResults(t *testing.T) {
 		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
 	})
 }
+
+func TestIsScanNotApplicable(t *testing.T) {
+	cases := map[string]struct {
+		scan     *storage.ComplianceOperatorScanV2
+		expected bool
+	}{
+		"nil scan": {
+			scan:     nil,
+			expected: false,
+		},
+		"nil status": {
+			scan:     &storage.ComplianceOperatorScanV2{},
+			expected: false,
+		},
+		"empty result": {
+			scan:     &storage.ComplianceOperatorScanV2{Status: &storage.ScanStatus{Result: ""}},
+			expected: false,
+		},
+		"NON-COMPLIANT result": {
+			scan:     &storage.ComplianceOperatorScanV2{Status: &storage.ScanStatus{Result: "NON-COMPLIANT"}},
+			expected: false,
+		},
+		"NOT-APPLICABLE result": {
+			scan:     &storage.ComplianceOperatorScanV2{Status: &storage.ScanStatus{Result: ScanResultNotApplicable}},
+			expected: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsScanNotApplicable(tc.scan))
+		})
+	}
+}

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
@@ -51,6 +51,35 @@ func handleScanWithAnnotation(id, checkCount string, startTime *protocompat.Time
 	}
 }
 
+func handleScanNotApplicable(id string, startTime *protocompat.Timestamp) func(*testing.T, ScanWatcher) {
+	return func(t *testing.T, scanWatcher ScanWatcher) {
+		err := scanWatcher.PushScan(&storage.ComplianceOperatorScanV2{
+			Id:              id,
+			Annotations:     map[string]string{CheckCountAnnotationKey: "0"},
+			LastStartedTime: startTime,
+			Status: &storage.ScanStatus{
+				Phase:  "DONE",
+				Result: ScanResultNotApplicable,
+			},
+		})
+		require.NoError(t, err)
+	}
+}
+
+func handleScanNotApplicableNoAnnotation(id string, startTime *protocompat.Timestamp) func(*testing.T, ScanWatcher) {
+	return func(t *testing.T, scanWatcher ScanWatcher) {
+		err := scanWatcher.PushScan(&storage.ComplianceOperatorScanV2{
+			Id:              id,
+			LastStartedTime: startTime,
+			Status: &storage.ScanStatus{
+				Phase:  "DONE",
+				Result: ScanResultNotApplicable,
+			},
+		})
+		require.NoError(t, err)
+	}
+}
+
 func handleResult(id string, startTime *protocompat.Timestamp) func(*testing.T, ScanWatcher) {
 	return func(t *testing.T, scanWatcher ScanWatcher) {
 		err := scanWatcher.PushCheckResult(&storage.ComplianceOperatorCheckResultV2{
@@ -140,6 +169,28 @@ func TestScanWatcher(t *testing.T) {
 			assertScanID:    "id-1",
 			assertResultIDs: []string{"id-1", "id-2"},
 		},
+		"scan not-applicable with zero check-count annotation": {
+			events: []testEvent{
+				handleScanNotApplicable("id-1", timestampNow),
+			},
+			assertScanID:    "id-1",
+			assertResultIDs: []string{},
+		},
+		"scan not-applicable without check-count annotation": {
+			events: []testEvent{
+				handleScanNotApplicableNoAnnotation("id-1", timestampNow),
+			},
+			assertScanID:    "id-1",
+			assertResultIDs: []string{},
+		},
+		"scan -> scan not-applicable (two-step update)": {
+			events: []testEvent{
+				handleScan("id-1", timestampNow),
+				handleScanNotApplicable("id-1", timestampNow),
+			},
+			assertScanID:    "id-1",
+			assertResultIDs: []string{},
+		},
 	}
 	for tName, tCase := range cases {
 		t.Run(tName, func(t *testing.T) {
@@ -155,7 +206,9 @@ func TestScanWatcher(t *testing.T) {
 			}, 200*time.Millisecond, 10*time.Millisecond)
 			result := resultQueue.Pull()
 			require.NotNil(t, result)
+			assert.NoError(t, result.Error)
 			assert.Equal(t, tCase.assertScanID, result.Scan.GetId())
+			assert.Equal(t, len(tCase.assertResultIDs), len(result.CheckResults))
 			for _, checkID := range tCase.assertResultIDs {
 				found := false
 				for checkResult := range result.CheckResults {

--- a/central/complianceoperator/v2/report/manager/watcher/validator.go
+++ b/central/complianceoperator/v2/report/manager/watcher/validator.go
@@ -17,8 +17,10 @@ func ValidateScanConfigResults(ctx context.Context, results *ScanConfigWatcherRe
 	failedClusters := make(map[string]*report.FailedCluster)
 	errList := errorhelpers.NewErrorList("failed clusters")
 	clustersWithResults := set.NewStringSet()
+	clustersNotApplicable := set.NewStringSet()
 	for key, scanResult := range results.ScanResults {
 		if IsScanNotApplicable(scanResult.Scan) {
+			clustersNotApplicable.Add(scanResult.Scan.GetClusterId())
 			delete(results.ScanResults, key)
 			continue
 		}
@@ -41,6 +43,14 @@ func ValidateScanConfigResults(ctx context.Context, results *ScanConfigWatcherRe
 	if len(results.ScanConfig.GetClusters()) > len(clustersWithResults) {
 		for _, cluster := range results.ScanConfig.GetClusters() {
 			if clustersWithResults.Contains(cluster.GetClusterId()) {
+				continue
+			}
+			if clustersNotApplicable.Contains(cluster.GetClusterId()) {
+				failedClusters[cluster.GetClusterId()] = &report.FailedCluster{
+					ClusterId: cluster.GetClusterId(),
+					Reasons:   []string{report.SCAN_NOT_APPLICABLE},
+				}
+				errList.AddError(errors.New(fmt.Sprintf("cluster %s: all scans not applicable", cluster.GetClusterId())))
 				continue
 			}
 			clusterInfo := ValidateClusterHealth(ctx, cluster.GetClusterId(), integrationDataStore)

--- a/central/complianceoperator/v2/report/manager/watcher/validator.go
+++ b/central/complianceoperator/v2/report/manager/watcher/validator.go
@@ -17,7 +17,11 @@ func ValidateScanConfigResults(ctx context.Context, results *ScanConfigWatcherRe
 	failedClusters := make(map[string]*report.FailedCluster)
 	errList := errorhelpers.NewErrorList("failed clusters")
 	clustersWithResults := set.NewStringSet()
-	for _, scanResult := range results.ScanResults {
+	for key, scanResult := range results.ScanResults {
+		if IsScanNotApplicable(scanResult.Scan) {
+			delete(results.ScanResults, key)
+			continue
+		}
 		clustersWithResults.Add(scanResult.Scan.GetClusterId())
 		failedClusterInfo, isInstallationError := ValidateScanResults(ctx, scanResult, integrationDataStore)
 		if failedClusterInfo == nil {

--- a/central/complianceoperator/v2/report/manager/watcher/validator_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/validator_test.go
@@ -62,6 +62,36 @@ func TestValidateScanConfigResults(t *testing.T) {
 			checkScanResultsCount:    true,
 			expectedScanResultsCount: 1,
 		},
+		"cluster with only not-applicable scans is flagged": {
+			results: func() *ScanConfigWatcherResults {
+				return &ScanConfigWatcherResults{
+					ScanResults: map[string]*ScanWatcherResults{
+						"cluster-0:master-scan": {
+							Scan: &storage.ComplianceOperatorScanV2{
+								ClusterId: "cluster-0",
+								ScanName:  "master-scan",
+								Status:    &storage.ScanStatus{Result: ScanResultNotApplicable},
+							},
+						},
+					},
+					ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{
+						Clusters: []*storage.ComplianceOperatorScanConfigurationV2_Cluster{
+							{ClusterId: "cluster-0"},
+						},
+					},
+				}
+			}(),
+			expectFn: withExpectCall(nil),
+			expectedFailedClusters: map[string]*report.FailedCluster{
+				"cluster-0": {
+					ClusterId: "cluster-0",
+					Reasons:   []string{report.SCAN_NOT_APPLICABLE},
+				},
+			},
+			expectedError:            true,
+			checkScanResultsCount:    true,
+			expectedScanResultsCount: 0,
+		},
 		"two failed clusters": {
 			results: getScanConfigResults(2, 2, 0, 1, nil),
 			expectFn: withExpectCall(func(ds *mocksComplianceIntegrationDS.MockDataStore) {

--- a/central/complianceoperator/v2/report/manager/watcher/validator_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/validator_test.go
@@ -32,16 +32,35 @@ func withExpectCall(fn func(*mocksComplianceIntegrationDS.MockDataStore)) func(*
 func TestValidateScanConfigResults(t *testing.T) {
 	ctx := t.Context()
 	cases := map[string]struct {
-		results                *ScanConfigWatcherResults
-		expectFn               func(*mocksComplianceIntegrationDS.MockDataStore)
-		expectedFailedClusters map[string]*report.FailedCluster
-		expectedError          bool
-		expectedExactError     error
+		results                  *ScanConfigWatcherResults
+		expectFn                 func(*mocksComplianceIntegrationDS.MockDataStore)
+		expectedFailedClusters   map[string]*report.FailedCluster
+		expectedError            bool
+		expectedExactError       error
+		expectedScanResultsCount int
+		checkScanResultsCount    bool
 	}{
 		"no error": {
 			results:                getScanConfigResults(2, 0, 0, 1, nil),
 			expectFn:               withExpectCall(nil),
 			expectedFailedClusters: make(map[string]*report.FailedCluster),
+		},
+		"not-applicable scans are removed from results": {
+			results: func() *ScanConfigWatcherResults {
+				r := getScanConfigResults(1, 0, 0, 1, nil)
+				r.ScanResults["cluster-0:not-applicable-scan"] = &ScanWatcherResults{
+					Scan: &storage.ComplianceOperatorScanV2{
+						ClusterId: "cluster-0",
+						ScanName:  "not-applicable-scan",
+						Status:    &storage.ScanStatus{Result: ScanResultNotApplicable},
+					},
+				}
+				return r
+			}(),
+			expectFn:                 withExpectCall(nil),
+			expectedFailedClusters:   make(map[string]*report.FailedCluster),
+			checkScanResultsCount:    true,
+			expectedScanResultsCount: 1,
 		},
 		"two failed clusters": {
 			results: getScanConfigResults(2, 2, 0, 1, nil),
@@ -154,6 +173,9 @@ func TestValidateScanConfigResults(t *testing.T) {
 				if tCase.expectedExactError != nil {
 					assert.ErrorIs(tt, err, tCase.expectedExactError)
 				}
+			}
+			if tCase.checkScanResultsCount {
+				assert.Equal(tt, tCase.expectedScanResultsCount, len(tCase.results.ScanResults))
 			}
 		})
 	}

--- a/pkg/env/compliance_operator.go
+++ b/pkg/env/compliance_operator.go
@@ -22,6 +22,12 @@ var (
 	// The default is 45 mins.
 	ComplianceScanScheduleWatcherTimeout = registerDurationSetting("ROX_COMPLIANCE_SCAN_SCHEDULE_WATCHER_TIMEOUT", 45*time.Minute)
 
+	// ComplianceScanConfigWatcherStabilizationDelay is the debounce period for the ScanConfigWatcher.
+	// After receiving the first scan result, the watcher buffers results and waits for this duration
+	// of inactivity before processing them. This gives the Compliance Operator time to create all
+	// scan resources before GetScansFromScanConfiguration queries the database.
+	ComplianceScanConfigWatcherStabilizationDelay = registerDurationSetting("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", 30*time.Second)
+
 	// ComplianceMaxNumberOfErrorsInReport defines the max number of errors that a report will store. This is done to avoid overwhelming the UI with many errors.
 	// The default is 4
 	ComplianceMaxNumberOfErrorsInReport = RegisterIntegerSetting("ROX_COMPLIANCE_MAX_NUMBER_OF_ERRORS_IN_REPORT", 4)

--- a/pkg/env/compliance_operator.go
+++ b/pkg/env/compliance_operator.go
@@ -22,12 +22,6 @@ var (
 	// The default is 45 mins.
 	ComplianceScanScheduleWatcherTimeout = registerDurationSetting("ROX_COMPLIANCE_SCAN_SCHEDULE_WATCHER_TIMEOUT", 45*time.Minute)
 
-	// ComplianceScanConfigWatcherStabilizationDelay is the debounce period for the ScanConfigWatcher.
-	// After receiving the first scan result, the watcher buffers results and waits for this duration
-	// of inactivity before processing them. This gives the Compliance Operator time to create all
-	// scan resources before GetScansFromScanConfiguration queries the database.
-	ComplianceScanConfigWatcherStabilizationDelay = registerDurationSetting("ROX_COMPLIANCE_SCAN_CONFIG_WATCHER_STABILIZATION_DELAY", 30*time.Second)
-
 	// ComplianceMaxNumberOfErrorsInReport defines the max number of errors that a report will store. This is done to avoid overwhelming the UI with many errors.
 	// The default is 4
 	ComplianceMaxNumberOfErrorsInReport = RegisterIntegerSetting("ROX_COMPLIANCE_MAX_NUMBER_OF_ERRORS_IN_REPORT", 4)


### PR DESCRIPTION
## Description

### Problem 1: NOT-APPLICABLE scans timeout on HCP clusters

On HCP clusters with no master nodes, compliance node-profile scans (e.g., `ocp4-stig-node`) create both master and worker `ComplianceScan` CRs. The master scan finishes immediately as `NOT-APPLICABLE` with 0 check results, but Central's scan watcher could never detect this -- it always timed out after 40 minutes, blocking the entire report and marking the cluster as failed.

**Root cause:** The scan watcher completion condition (`totalChecks != 0 && totalChecks == numCheckResults`) is impossible when `totalChecks == 0`. The watcher also never inspected the scan's `Status.Result` field.

**Fix:**
- Recognize NOT-APPLICABLE scans as legitimately complete (0 expected checks, 0 received, status confirms it)
- Update the scan object on same-timestamp updates to pick up status transitions from the CO
- Only assign `totalChecks` inside the timestamp comparison branches to prevent older scan events from overwriting it
- Allow NOT-APPLICABLE scans to bypass the `ErrScanAlreadyHandled` check so they can participate in re-triggered scan cycles

### Problem 2: ScanConfigWatcher premature completion race

Fixing problem 1 exposed a race: NOT-APPLICABLE scans complete instantly and can trigger the ScanConfigWatcher before the CO has finished creating all scan resources. `GetScansFromScanConfiguration` queries the DB at that moment and gets an incomplete picture, causing premature report generation. Additionally, the CO recycles scan resources (delete + recreate with new IDs) during initialization, which creates stale entries in the tracking sets.

**Fix:**
- Re-query `GetScansFromScanConfiguration` on completion to catch scan resources created after the initial query
- When a scan result arrives with an ID not in `scansToWait` (CO recycled the resource), re-query to refresh `scansToWait` with current IDs, removing already-handled scans
- Deduplicate stale scan results in `ScanResults` by `clusterID:scanName` when the CO recycles a scan resource with a new ID

### NOT-APPLICABLE scan handling in reports

- NOT-APPLICABLE scans are filtered from report data in `ValidateScanConfigResults` -- they produce no report content
- Clusters with only NOT-APPLICABLE scans are flagged with "All scans were not applicable for this cluster" instead of the misleading "Internal Error"
- NOT-APPLICABLE scans still participate in ScanConfigWatcher coordination (count toward `totalResults`)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All unit tests pass for watcher and manager packages
- Tested manually on a cluster with 2 secured clusters (1 HCP without master nodes, 1 normal with master+worker) using node profiles (`ocp4-stig-node`, `ocp4-bsi-node`)
- Verified first scan cycle generates a single correct report
- Verified re-triggered scans generate correct reports without duplicate WAITING snapshots
- Verified NOT-APPLICABLE scans are excluded from report CSV content
- Verified clusters with only NOT-APPLICABLE scans are flagged appropriately
