### PR TITLE
fix(CI): Bump workflow reference to latest commit

### DIFF
--- a/.github/workflows/create-clusters.yml
+++ b/.github/workflows/create-clusters.yml
@@ -64,7 +64,7 @@ jobs:
   clusters:
     name: Setup demo clusters
     needs: trim-cluster-names
-    uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@88282091b8f367ba43514d4b82da50c108820421 # ratchet:stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
+    uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@43bb707aa4f32ead5bfb8d5ab11fb409f971ffc8 # ratchet:stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
     secrets: inherit
     with:
       version: ${{github.event.inputs.version}}

--- a/.github/workflows/create-clusters.yml
+++ b/.github/workflows/create-clusters.yml
@@ -64,7 +64,7 @@ jobs:
   clusters:
     name: Setup demo clusters
     needs: trim-cluster-names
-    uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@4efb76aa74694b9ee55e95c4ead57fdf50d79ddf # ratchet:stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
+    uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@88282091b8f367ba43514d4b82da50c108820421 # ratchet:stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
     secrets: inherit
     with:
       version: ${{github.event.inputs.version}}


### PR DESCRIPTION
## Description

Bump workflow reference, after CI failures such as
https://github.com/stackrox/stackrox/actions/runs/30620224704/job/91133563738

The new workflow version installs the roxie CLI.

## User-facing documentation

nothing

## Testing and quality

nothing

### Automated testing

nothing

### How I validated my change

Need to dispatch a new job.
