### PR TITLE
ROX-35977: Migrate compliance output channel to pub sub

### DIFF
--- a/sensor/common/compliance/command_handler.go
+++ b/sensor/common/compliance/command_handler.go
@@ -18,9 +18,10 @@ type CommandHandler interface {
 }
 
 // NewCommandHandler returns a new instance of a CommandHandler using the input image and Orchestrator.
-func NewCommandHandler(complianceService Service) CommandHandler {
+func NewCommandHandler(complianceService Service, pubSubDispatcher common.PubSubDispatcher) CommandHandler {
 	return &commandHandlerImpl{
-		service: complianceService,
+		service:          complianceService,
+		pubSubDispatcher: pubSubDispatcher,
 
 		commands: make(chan *central.ScrapeCommand),
 		updates:  make(chan *message.ExpiringMessage),

--- a/sensor/common/compliance/command_handler_impl.go
+++ b/sensor/common/compliance/command_handler_impl.go
@@ -10,10 +10,12 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
 var (
@@ -24,7 +26,8 @@ type commandHandlerImpl struct {
 	commands chan *central.ScrapeCommand
 	updates  chan *message.ExpiringMessage
 
-	service Service
+	service          Service
+	pubSubDispatcher common.PubSubDispatcher
 
 	scrapeIDToState map[string]*scrapeState
 
@@ -41,6 +44,16 @@ func (c *commandHandlerImpl) ResponsesC() <-chan *message.ExpiringMessage {
 }
 
 func (c *commandHandlerImpl) Start() error {
+	if features.SensorInternalPubSub.Enabled() && c.pubSubDispatcher != nil {
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceCommandHandlerReturnConsumer,
+			pubsub.ComplianceReturnTopic,
+			pubsub.ComplianceReturnLane,
+			c.handleComplianceReturnEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance command handler return consumer")
+		}
+	}
 	go c.run()
 	return nil
 }
@@ -113,11 +126,24 @@ func (c *commandHandlerImpl) run() {
 				c.stopper.Flow().StopWithError(errors.New("compliance return input closed"))
 				return
 			}
-			if updates := c.commitResult(result); len(updates) > 0 {
-				c.sendUpdates(updates)
-			}
+			c.handleComplianceReturn(result)
 		}
 	}
+}
+
+func (c *commandHandlerImpl) handleComplianceReturn(result *compliance.ComplianceReturn) {
+	if updates := c.commitResult(result); len(updates) > 0 {
+		c.sendUpdates(updates)
+	}
+}
+
+func (c *commandHandlerImpl) handleComplianceReturnEvent(event pubsub.Event) error {
+	returnEvent, ok := event.(*ComplianceReturnEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	c.handleComplianceReturn(returnEvent.Return)
+	return nil
 }
 
 func (c *commandHandlerImpl) runCommand(command *central.ScrapeCommand) []*central.ScrapeUpdate {

--- a/sensor/common/compliance/command_handler_pubsub_test.go
+++ b/sensor/common/compliance/command_handler_pubsub_test.go
@@ -1,0 +1,66 @@
+package compliance
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/compliance"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+)
+
+type wrongEvent struct{}
+
+func (*wrongEvent) Topic() pubsub.Topic { return pubsub.DefaultTopic }
+func (*wrongEvent) Lane() pubsub.LaneID { return pubsub.DefaultLane }
+
+func newTestComplianceReturnDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ComplianceReturnLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+func (s *CommandHandlerTestSuite) TestPubSubComplianceReturnDelivered() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestComplianceReturnDispatcher(t)
+	defer dispatcher.Stop()
+	s.cHandler.pubSubDispatcher = dispatcher
+
+	outputChan := make(chan *compliance.ComplianceReturn)
+	defer close(outputChan)
+	s.startCommandHandler(outputChan)
+
+	s.startScrape("foo", []string{"node1", "node2"})
+	s.getScrapeUpdate()
+
+	require.NoError(t, dispatcher.Publish(&ComplianceReturnEvent{Return: &compliance.ComplianceReturn{
+		NodeName: "node1",
+		ScrapeId: "foo",
+	}}))
+
+	select {
+	case <-s.cHandler.updates:
+	case <-time.After(2 * time.Second):
+		s.Require().Fail("timed out waiting for update via pubsub")
+	}
+}
+
+func (s *CommandHandlerTestSuite) TestHandleComplianceReturnEventWrongType() {
+	outputChan := make(chan *compliance.ComplianceReturn)
+	defer close(outputChan)
+	s.startCommandHandler(outputChan)
+
+	err := s.cHandler.handleComplianceReturnEvent(&wrongEvent{})
+	s.Require().Error(err)
+}

--- a/sensor/common/compliance/compliance_return_event.go
+++ b/sensor/common/compliance/compliance_return_event.go
@@ -1,0 +1,19 @@
+package compliance
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/compliance"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// ComplianceReturnEvent carries a ComplianceReturn result relayed from a compliance gRPC node.
+type ComplianceReturnEvent struct {
+	Return *compliance.ComplianceReturn
+}
+
+func (e *ComplianceReturnEvent) Topic() pubsub.Topic {
+	return pubsub.ComplianceReturnTopic
+}
+
+func (e *ComplianceReturnEvent) Lane() pubsub.LaneID {
+	return pubsub.ComplianceReturnLane
+}

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -243,7 +243,13 @@ func (s *serviceImpl) Communicate(server sensor.ComplianceService_CommunicateSer
 		switch t := msg.GetMsg().(type) {
 		case *sensor.MsgFromCompliance_Return:
 			log.Infof("Received compliance return from %q", msg.GetNode())
-			s.output <- t.Return
+			if features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil {
+				if err := s.pubSubDispatcher.Publish(&ComplianceReturnEvent{Return: t.Return}); err != nil {
+					logging.GetRateLimitedLogger().ErrorL("compliance-return-publish", "Failed to publish compliance return event: %v", err)
+				}
+			} else {
+				s.output <- t.Return
+			}
 		case *sensor.MsgFromCompliance_AuditEvents:
 			// if we are offline we do not send more audit logs to the manager nor the detector.
 			// Upon reconnection Central will sync the last state and Sensor will request to Compliance to start

--- a/sensor/common/compliance/service_impl_pubsub_test.go
+++ b/sensor/common/compliance/service_impl_pubsub_test.go
@@ -1,0 +1,76 @@
+package compliance
+
+import (
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/compliance"
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *complianceServiceSuite) TestComplianceReturnLegacyPath() {
+	s.T().Setenv(features.SensorInternalPubSub.EnvVar(), "false")
+
+	s.Require().NoError(s.stream.Send(&sensor.MsgFromCompliance{
+		Msg: &sensor.MsgFromCompliance_Return{
+			Return: &compliance.ComplianceReturn{NodeName: "node1", ScrapeId: "foo"},
+		},
+	}))
+
+	select {
+	case result := <-s.srv.output:
+		s.Require().Equal("foo", result.GetScrapeId())
+	case <-time.After(2 * time.Second):
+		s.Fail("expected compliance return on legacy output channel")
+	}
+}
+
+func (s *complianceServiceSuite) TestComplianceReturnPubSubPath() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ComplianceReturnLane),
+		},
+	))
+	require.NoError(t, err)
+	defer dispatcher.Stop()
+
+	received := make(chan *ComplianceReturnEvent, 1)
+	require.NoError(t, dispatcher.RegisterConsumerToLane(
+		pubsub.ComplianceCommandHandlerReturnConsumer,
+		pubsub.ComplianceReturnTopic,
+		pubsub.ComplianceReturnLane,
+		func(event pubsub.Event) error {
+			evt, ok := event.(*ComplianceReturnEvent)
+			s.Require().True(ok)
+			received <- evt
+			return nil
+		},
+	))
+	s.srv.pubSubDispatcher = dispatcher
+
+	s.Require().NoError(s.stream.Send(&sensor.MsgFromCompliance{
+		Msg: &sensor.MsgFromCompliance_Return{
+			Return: &compliance.ComplianceReturn{NodeName: "node1", ScrapeId: "foo"},
+		},
+	}))
+
+	select {
+	case evt := <-received:
+		s.Require().Equal("foo", evt.Return.GetScrapeId())
+	case <-time.After(2 * time.Second):
+		s.Fail("expected compliance return event via pubsub")
+	}
+
+	select {
+	case <-s.srv.output:
+		s.Fail("unexpected message on legacy output channel while pubsub is enabled")
+	default:
+	}
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,7 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	ComplianceCommandHandlerReturnConsumer
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		ComplianceCommandHandlerReturnConsumer: "ComplianceCommandHandlerReturn",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	ComplianceReturnLane
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		ComplianceReturnLane:           "ComplianceReturn",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	ComplianceReturnTopic
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		ComplianceReturnTopic:           "ComplianceReturn",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,7 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.ComplianceReturnLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -159,7 +159,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	admCtrlMsgForwarder := admissioncontroller.NewAdmCtrlMsgForwarder(admCtrlSettingsMgr, pipeline)
 
 	imageService := image.NewService(clusterID, imageCache, storeProvider.Registries(), storeProvider.RegistryMirrors())
-	complianceCommandHandler := compliance.NewCommandHandler(complianceService)
+	complianceCommandHandler := compliance.NewCommandHandler(complianceService, internalMessageDispatcher)
 
 	// Create Process Pipeline
 	indicators := make(chan *message.ExpiringMessage, queue.ScaleSizeOnNonDefault(env.ProcessIndicatorBufferSize))


### PR DESCRIPTION
## Description

  Migrates the compliance service's `output` channel — which carries `ComplianceReturn` results relayed from compliance gRPC nodes — from a raw Go
  channel to PubSub, behind `ROX_SENSOR_PUBSUB`.

  This is a `[compliance][inner]` migration: producer (`serviceImpl.Communicate()`) and consumer (`commandHandlerImpl.run()`) both live in
  `sensor/common/compliance`, so the new `ComplianceReturnEvent` type is defined directly in that package rather than in a shared `events` subpackage —
  nothing else needs to import it.

  **What changed:**
  - Added `ComplianceReturnEvent` (`compliance_return_event.go`) plus
  `ComplianceReturnTopic`/`ComplianceReturnLane`/`ComplianceCommandHandlerReturnConsumer` registry entries, wired into the production dispatcher in
  `pubsub.go`.
  - `serviceImpl.Communicate()`: when the FF is enabled, publishes a `ComplianceReturnEvent` instead of writing to the `output` channel — mirrors the
  existing `AuditLogEvent` dual-path already in this method.
  - `commandHandlerImpl`: extracted `handleComplianceReturn()` so the legacy `Output()` select case and the new PubSub callback
  (`handleComplianceReturnEvent`, with a concrete type assertion) share the same commit/send logic. `Start()` registers the PubSub consumer when the FF
  is enabled.
  - `NewCommandHandler` now takes a `common.PubSubDispatcher`, wired from `internalMessageDispatcher` in `sensor.go`.

  **Out of scope:** `commandHandlerImpl.run()`'s `commands` channel (ScrapeCommand from Central) is untouched — that's a separate
  `[compliance][central-in]` migration. In PubSub mode, the `Output()` select case is simply never hit since the producer stops writing to it; no need to
  nil it out.

  🤖 This change was partially generated with the assistance of AI.
  
  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**
  is not needed

  ## Testing and quality

  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is
  gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - Added tests covering both the legacy and PubSub-enabled paths on the producer side (`service_impl_pubsub_test.go`) and consumer side
  (`command_handler_pubsub_test.go`), plus a wrong-event-type case for the new PubSub callback.