### PR TITLE
ROX-35192: Fix scheme for vsockdialer WebSocket dial

### DIFF
--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -109,11 +109,10 @@ func buildWSURL(config *rest.Config, resource, namespace, name, subresource stri
 		return "", fmt.Errorf("parsing host: %w", err)
 	}
 
+	// Keep http/https: client-go's websocket RoundTripper rewrites to ws/wss
+	// itself and rejects a pre-rewritten wss/ws scheme with "unknown url scheme".
 	switch u.Scheme {
-	case "https":
-		u.Scheme = "wss"
-	case "http":
-		u.Scheme = "ws"
+	case "https", "http":
 	default:
 		return "", fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer_test.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer_test.go
@@ -19,13 +19,13 @@ func TestBuildWSURL(t *testing.T) {
 		wantURL string
 		wantErr string // substring to match against the error; empty means no error expected
 	}{
-		"should rewrite https to wss": {
+		"should keep https for client-go websocket RoundTripper": {
 			host:    "https://api.example.com:6443",
-			wantURL: "wss://api.example.com:6443/apis/subresources.kubevirt.io/v1/namespaces/ns1/virtualmachineinstances/vm-a/vsock?port=1024&tls=true",
+			wantURL: "https://api.example.com:6443/apis/subresources.kubevirt.io/v1/namespaces/ns1/virtualmachineinstances/vm-a/vsock?port=1024&tls=true",
 		},
-		"should rewrite http to ws": {
+		"should keep http for client-go websocket RoundTripper": {
 			host:    "http://localhost:8080",
-			wantURL: "ws://localhost:8080/apis/subresources.kubevirt.io/v1/namespaces/ns1/virtualmachineinstances/vm-a/vsock?port=1024&tls=true",
+			wantURL: "http://localhost:8080/apis/subresources.kubevirt.io/v1/namespaces/ns1/virtualmachineinstances/vm-a/vsock?port=1024&tls=true",
 		},
 		"should reject unsupported scheme": {
 			host:    "ftp://api.example.com",


### PR DESCRIPTION
## Description

client-go's websocket RoundTripper rewrites `http(s)` to `ws(s)` itself and rejects a pre-rewritten `wss` URL with `unknown url scheme: wss`. Sensor pull-mode scraping failed before reaching KubeVirt. Keep `https`/`http` in `buildWSURL` so `Negotiate` can rewrite the scheme.

Discovered when running e2e tests in https://github.com/stackrox/stackrox/pull/22032
Missed in #21434 when porting the fixes from the temporary PoC branch.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI
- e2e test in https://github.com/stackrox/stackrox/pull/22032 (which includes this fix)
- Manually on a cluster:

<details>
<summary><b>Manual verification: PASS</b> - pull-mode VSOCK WebSocket dial reaches roxagent GetReport</summary>


1. Start roxagent pull listener on the VM.

2. Wait for the next VMScraper poll cycle (~5 min), then check Sensor logs:
   `kubectl logs -n stackrox deployment/sensor --since=10m | grep VMScraper`
   → expect successful scrape, no dial scheme error
   ```
   VMScraper: about to poll 1 running VMs (concurrency=20)
   VMScraper: cycle done: 1/1 VMs scraped successfully in 64ms
   ```
   `kubectl logs -n stackrox deployment/sensor | grep -c 'unknown url scheme'` → `0`

3. Confirm roxagent received the pull over VSOCK+TLS (proves WebSocket dial reached the guest):
   `virtctl ssh ... --command "grep -E 'Accepted TLS|GetReport' /tmp/roxagent-serve.log | tail -5"`
   ```
   Accepted TLS connection from host(2):241433362 (version=0x0304, cipher=0x1301)
   GetReport: serving report (generation=1, packages=0)
   ```
   (0 packages here because `serve` used `/tmp/roxroot` without the systemd bind mounts; connectivity is what matters for this fix.)

</details>
