### PR TITLE
ROX-36074,ROX-34591,ROX-31441,ROX-30083: add @Retry to createNewPolicy

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/PolicyService.groovy
@@ -1,6 +1,7 @@
 package services
 
 import groovy.util.logging.Slf4j
+import io.stackrox.annotations.Retry
 import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.api.v1.PolicyServiceGrpc
 import io.stackrox.proto.api.v1.PolicyServiceOuterClass
@@ -23,21 +24,14 @@ class PolicyService extends BaseService {
         return getPolicyClient().listPolicies(query).policiesList
     }
 
+    @Retry
     static String createNewPolicy(PolicyOuterClass.Policy policy) {
-        String policyID = ""
-
-        try {
-            policyID = getPolicyClient().postPolicy(
-                    PolicyServiceOuterClass.PostPolicyRequest.newBuilder().
-                            setPolicy(policy).
-                            setEnableStrictValidation(true).
-                            build()
-            ).getId()
-        } catch (Exception e) {
-            log.error("error creating new policy", e)
-        }
-
-        return policyID
+        return getPolicyClient().postPolicy(
+                PolicyServiceOuterClass.PostPolicyRequest.newBuilder().
+                        setPolicy(policy).
+                        setEnableStrictValidation(true).
+                        build()
+        ).getId()
     }
 
     static PolicyOuterClass.Policy createAndFetchPolicy(PolicyOuterClass.Policy policy) {

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -872,7 +872,7 @@ class ComplianceTest extends BaseSpecification {
         def policyGroup = PolicyGroup.newBuilder()
                 .setFieldName("Environment Variable")
                 .setBooleanOperator(PolicyOuterClass.BooleanOperator.AND)
-        policyGroup.addAllValues([PolicyValue.newBuilder().setValue(".*SECRET.*=.*").build()])
+        policyGroup.addAllValues([PolicyValue.newBuilder().setValue("RAW=.*SECRET.*=").build()])
 
         def policyId = PolicyService.createNewPolicy(PolicyOuterClass.Policy.newBuilder()
                 .setName("XYZ Compliance Secrets")

--- a/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/PolicyConfigurationTest.groovy
@@ -700,8 +700,8 @@ class PolicyConfigurationTest extends BaseSpecification {
     @Tag("BAT")
     @Tag("SMOKE")
     def "Verify env var policy configuration for source #envVarSource fails validation"() {
-        expect:
-        assert !PolicyService.createNewPolicy(Policy.newBuilder()
+        when:
+        PolicyService.createNewPolicy(Policy.newBuilder()
                         .setName("TestEnvironmentPolicy")
                         .setDescription("TestEnvironment")
                         .setRationale("TestEnvironment")
@@ -717,6 +717,9 @@ class PolicyConfigurationTest extends BaseSpecification {
                                                         .setValue("KEY=VALUE")
                                                         .build()).build())
                         ).build())
+
+        then:
+        thrown(Exception)
 
         where:
         "Data inputs are :"


### PR DESCRIPTION
## Description

`PolicyService.createNewPolicy` silently swallowed all exceptions (including transient gRPC UNAVAILABLE errors) and returned an empty string. This caused recurring CI flakes in `ImageSignatureVerificationTest/initializationError`.

Replace the try/catch-and-swallow pattern with `@Retry`, matching the established pattern used by 10+ other service classes (AlertService, GroupService, SecretService, etc.). Update the one negative test in PolicyConfigurationTest that relied on the empty-string-on-failure behavior to use Spock's thrown() instead.

Partially generated by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
