### PR TITLE
ROX-36076: trim scanner vuln bundles for nongroovy e2e tests

### DIFF
--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -223,7 +223,7 @@ class ComplianceE2eTest(BaseTest):
 
 
 class NonGroovyE2e(BaseTest):
-    TEST_TIMEOUT = 90 * 60
+    TEST_TIMEOUT = 120 * 60
     TEST_OUTPUT_DIR = "/tmp/e2e-test-logs"
 
     def run(self):

--- a/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
@@ -14,6 +14,9 @@ from post_tests import PostClusterTest, FinalPost
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
 os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "faster"
+# On GKE only ubi9 (RHEL) images are scanned with vuln assertions (delegated_scanning_test.go).
+# Matches ocp_vm_scanning_e2e_tests.py allowlist — drops alpine, debian, osv, ubuntu.
+os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "rhel-vex,stackrox-rhel-csaf,manual,epss,nvd"
 
 # delegated scanning support in the secured cluster
 os.environ["SENSOR_SCANNER_SUPPORT"] = "true"


### PR DESCRIPTION
## Description

The `gke-oldest-nongroovy-e2e-tests` job consistently times out at 90 minutes. Root cause: `scanner-v4-matcher` loads 9 vulnerability bundles (the CI default from tests/e2e/lib.sh) which takes ~50 minutes on the slow "oldest" GKE cluster, leaving only ~40 minutes for the ~42-minute test suite.

Only delegated_scanning_test.go asserts on actual vulnerability data, and on GKE (non-OpenShift) it only scans `ubi9/ubi-minimal` (RHEL) images — the nginx, httpd, and OCP-internal images are behind skipIfNotOpenShift guards. Other tests using prefetched images (nginx-*, ubuntu, busybox) test deployment, backup, proxy, and roxctl — none assert on scan results.

Restrict `SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST` to the same 5 bundles used by `ocp_vm_scanning_e2e_tests.py` (`rhel-vex`, `stackrox-rhel-csaf`, `manual`, `epss`, `nvd`). This mechanism was introduced in ROX-35684 and is already proven in production CI. Also bump `NonGroovyE2e.TEST_TIMEOUT` from `90` to `120` minutes as a safety net for inherently slow disk I/O on this cluster.

Partially generated by AI.
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI