### PR TITLE
ROX-36048: add retry to TestDefaultIntegrationExists

### DIFF
--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stackrox/rox/pkg/namespaces"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	appsV1 "k8s.io/api/apps/v1"
@@ -139,28 +141,27 @@ func (s *RedHatSigningKeySuite) waitForIntegrationKeys(ctx context.Context, expe
 
 func (s *RedHatSigningKeySuite) TestDefaultIntegrationExists() {
 	t := s.T()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := s.listIntegrations(ctx)
-	s.Require().NoError(err, "listing signature integrations")
-
 	var matched int
-	for _, si := range resp.GetIntegrations() {
-		if si.GetId() != redHatIntegrationID {
-			continue
+	s.Require().EventuallyWithT(func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		resp, err := s.listIntegrations(ctx)
+		require.NoError(c, err, "listing signature integrations")
+		for _, si := range resp.GetIntegrations() {
+			if si.GetId() != redHatIntegrationID {
+				continue
+			}
+			matched = len(si.GetCosign().GetPublicKeys())
+			assert.Equal(c, "Red Hat", si.GetName())
+			assert.GreaterOrEqual(c, matched, 1, "expected at least one cosign public key")
+			for _, pk := range si.GetCosign().GetPublicKeys() {
+				assert.NotEmpty(c, pk.GetName(), "key name must not be empty")
+				assert.NotEmpty(c, pk.GetPublicKeyPemEnc(), "key PEM must not be empty")
+			}
+			break
 		}
-		matched = len(si.GetCosign().GetPublicKeys())
-		s.Assert().Equal("Red Hat", si.GetName())
-		s.Assert().GreaterOrEqual(matched, 1,
-			"expected at least one cosign public key")
-		for _, pk := range si.GetCosign().GetPublicKeys() {
-			s.Assert().NotEmpty(pk.GetName(), "key name must not be empty")
-			s.Assert().NotEmpty(pk.GetPublicKeyPemEnc(), "key PEM must not be empty")
-		}
-		break
-	}
-	s.Require().NotZero(matched, "Red Hat signature integration %q not found", redHatIntegrationID)
+		assert.NotZero(c, matched, "Red Hat signature integration %q not found", redHatIntegrationID)
+	}, 30*time.Second, 5*time.Second, "waiting for default Red Hat integration")
 	t.Logf("Red Hat integration found with %d key(s)", matched)
 }
 


### PR DESCRIPTION
## Description

This was the only subtest in RedHatSigningKeySuite making a direct gRPC call without retry. After PR #22020 moved the Central restart into SetupSuite, this became the first subtest to run post-restart. On OCP the route propagation delay exceeds the gRPC interceptor's 5-retry budget, causing intermittent Unavailable errors.

Use require.EventuallyWithT to retry with proper assertions, matching the pattern used in compliance_operator_test.go and ocp_dynamic_plugin_test.go.

Partially generated by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI