### PR TITLE
ROX-27910: Disable rollback strategy in operator

### DIFF
--- a/operator/internal/reconciler/reconciler_factory.go
+++ b/operator/internal/reconciler/reconciler_factory.go
@@ -94,6 +94,7 @@ func SetupReconcilerWithManager(mgr ctrl.Manager, gvk schema.GroupVersionKind, c
 				return confighash.NewPodTemplateAnnotationPostRenderer(kubeClient, obj, renderCache)
 			},
 		),
+		client.WithFailureRollbacks(false),
 	}
 
 	actionClientGetter, err := client.NewActionClientGetter(actionConfigGetter, opts...)

--- a/operator/internal/reconciler/reconciler_factory.go
+++ b/operator/internal/reconciler/reconciler_factory.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/helm/charts"
 	"github.com/stackrox/rox/pkg/images/defaults"
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/postrender"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -94,6 +95,7 @@ func SetupReconcilerWithManager(mgr ctrl.Manager, gvk schema.GroupVersionKind, c
 				return confighash.NewPodTemplateAnnotationPostRenderer(kubeClient, obj, renderCache)
 			},
 		),
+		client.AppendUpgradeFailureRollbackOptions(DisableForceOnRollback),
 	}
 
 	actionClientGetter, err := client.NewActionClientGetter(actionConfigGetter, opts...)
@@ -124,6 +126,31 @@ func SetupReconcilerWithManager(mgr ctrl.Manager, gvk schema.GroupVersionKind, c
 	if err := r.SetupWithManager(mgr); err != nil {
 		return errors.Wrapf(err, "unable to setup %s reconciler", gvk)
 	}
+	return nil
+}
+
+// DisableForceOnRollback overrides the helm-operator's hardcoded rollback.Force=true
+// which causes Helm to replace resources (PUT) instead of patching them.
+//
+// The default Force=true setting breaks rollback for immutable resources like PVCs,
+// leading to an infinite reconcile loop of the form
+//
+//	   trigger reconciliation
+//	-> failure
+//	-> trigger rollback
+//	-> failure
+//	-> back to square one.
+//
+// on reconciliation failures.
+//
+// With Force=false, no PUT is used to rollback resources, instead a diff between
+// the resource versions is computed and, if non-empty, patched during rollback.
+//
+// For (mostly) immutable resources, such das PVCs, the Force=false setting restores
+// rollback functionality -- as long as there is no subtantial diff between the
+// resources versions.
+func DisableForceOnRollback(rollback *action.Rollback) error {
+	rollback.Force = false
 	return nil
 }
 

--- a/operator/tests/reconcile/reconcile_suite_test.go
+++ b/operator/tests/reconcile/reconcile_suite_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	versionTestutils "github.com/stackrox/rox/pkg/version/testutils"
 	"go.uber.org/zap/zapcore"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,18 +22,22 @@ import (
 var (
 	testEnv *envtest.Environment
 	cfg     *rest.Config
+	testT   *testing.T
 	gvk     = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestApp"}
 )
 
 func TestReconcileExtensions(t *testing.T) {
+	testT = t
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Reconcile Extensions Suite")
 }
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
+	versionTestutils.SetExampleVersion(testT)
 	testEnv = &envtest.Environment{
 		AttachControlPlaneOutput: false, // set to true to see kube-apiserver and etcd logs
+		CRDDirectoryPaths:        []string{"../../config/crd/bases"},
 	}
 
 	var err error

--- a/operator/tests/reconcile/reconcile_suite_test.go
+++ b/operator/tests/reconcile/reconcile_suite_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	versionTestutils "github.com/stackrox/rox/pkg/version/testutils"
 	"go.uber.org/zap/zapcore"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,10 +23,12 @@ import (
 var (
 	testEnv *envtest.Environment
 	cfg     *rest.Config
+	testT   *testing.T
 	gvk     = schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestApp"}
 )
 
 func TestReconcileExtensions(t *testing.T) {
+	testT = t
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Reconcile Extensions Suite")
 }
@@ -33,8 +36,10 @@ func TestReconcileExtensions(t *testing.T) {
 var _ = BeforeSuite(func() {
 	prefixedLogger := newPrefixedLogger("\t", GinkgoWriter)
 	logf.SetLogger(zap.New(zap.WriteTo(prefixedLogger), zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
+	versionTestutils.SetExampleVersion(testT)
 	testEnv = &envtest.Environment{
 		AttachControlPlaneOutput: false, // set to true to see kube-apiserver and etcd logs
+		CRDDirectoryPaths:        []string{"../../config/crd/bases"},
 	}
 
 	var err error

--- a/operator/tests/reconcile/reconcile_suite_test.go
+++ b/operator/tests/reconcile/reconcile_suite_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,7 +30,7 @@ func TestReconcileExtensions(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
 	testEnv = &envtest.Environment{
 		AttachControlPlaneOutput: false, // set to true to see kube-apiserver and etcd logs
 	}

--- a/operator/tests/reconcile/reconcile_suite_test.go
+++ b/operator/tests/reconcile/reconcile_suite_test.go
@@ -2,11 +2,13 @@ package reconcile
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,7 +31,8 @@ func TestReconcileExtensions(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	prefixedLogger := newPrefixedLogger("\t", GinkgoWriter)
+	logf.SetLogger(zap.New(zap.WriteTo(prefixedLogger), zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
 	testEnv = &envtest.Environment{
 		AttachControlPlaneOutput: false, // set to true to see kube-apiserver and etcd logs
 	}
@@ -100,4 +103,20 @@ func BuildTestCR(gvk schema.GroupVersionKind) *unstructured.Unstructured {
 		"helm.sdk.operatorframework.io/uninstall-description": "test uninstall description",
 	})
 	return obj
+}
+
+type prefixedLogger struct {
+	prefix []byte
+	writer io.Writer
+}
+
+func (p *prefixedLogger) Write(data []byte) (int, error) {
+	return p.writer.Write(append(p.prefix, data...))
+}
+
+func newPrefixedLogger(prefix string, writer io.Writer) io.Writer {
+	return &prefixedLogger{
+		prefix: []byte(prefix),
+		writer: writer,
+	}
 }

--- a/operator/tests/reconcile/rollback_test.go
+++ b/operator/tests/reconcile/rollback_test.go
@@ -1,0 +1,179 @@
+package reconcile
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stackrox/rox/image"
+	platform "github.com/stackrox/rox/operator/api/v1alpha1"
+	centralTranslation "github.com/stackrox/rox/operator/internal/central/values/translation"
+	stackroxReconciler "github.com/stackrox/rox/operator/internal/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+var _ = Describe("Rolling back after failed upgrade", func() {
+	const (
+		centralName = "test-central"
+		namespace   = "default"
+	)
+
+	var (
+		mgr    manager.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		s := runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+		Expect(platform.AddToScheme(s)).To(Succeed())
+
+		var err error
+		mgr, err = manager.New(cfg, manager.Options{
+			Scheme:  s,
+			Metrics: server.Options{BindAddress: "0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		translator := centralTranslation.New(mgr.GetClient())
+		Expect(stackroxReconciler.SetupReconcilerWithManager(
+			mgr, platform.CentralGVK, image.CentralServicesChartPrefix,
+			translator, nil,
+		)).To(Succeed())
+
+		ctx, cancel = context.WithCancel(context.Background())
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(ctx)).To(Succeed())
+		}()
+	})
+
+	AfterEach(func() {
+		By("cleaning up Central CR")
+		central := &platform.Central{}
+		objKey := types.NamespacedName{Namespace: namespace, Name: centralName}
+		if err := mgr.GetAPIReader().Get(ctx, objKey, central); err == nil {
+			central.SetFinalizers([]string{})
+			_ = mgr.GetClient().Update(ctx, central)
+			err = mgr.GetClient().Delete(ctx, central)
+			if err != nil && !apiErrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		By("cleaning up PVCs")
+		pvcList := &corev1.PersistentVolumeClaimList{}
+		if err := mgr.GetAPIReader().List(ctx, pvcList, ctrlClient.InNamespace(namespace)); err == nil {
+			for i := range pvcList.Items {
+				_ = mgr.GetClient().Delete(ctx, &pvcList.Items[i])
+			}
+		}
+
+		By("cleaning up PVs")
+		pvList := &corev1.PersistentVolumeList{}
+		if err := mgr.GetAPIReader().List(ctx, pvList); err == nil {
+			for i := range pvList.Items {
+				_ = mgr.GetClient().Delete(ctx, &pvList.Items[i])
+			}
+		}
+
+		cancel()
+	})
+
+	It("should roll back successfully after a failed upgrade when bound PVCs exist", func() {
+		By("creating a Central CR with Scanner V4 enabled")
+		central := &platform.Central{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      centralName,
+				Namespace: namespace,
+			},
+			Spec: platform.CentralSpec{
+				ScannerV4: &platform.ScannerV4Spec{
+					ScannerComponent: new(platform.ScannerV4ComponentEnabled),
+				},
+			},
+		}
+		Expect(mgr.GetClient().Create(ctx, central)).To(Succeed())
+
+		By("waiting for initial install to complete")
+		Eventually(func(g Gomega) {
+			c := &platform.Central{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, c)).To(Succeed())
+
+			releaseFailed := c.GetCondition(platform.ConditionReleaseFailed)
+			irreconcilable := c.GetCondition(platform.ConditionIrreconcilable)
+
+			g.Expect(releaseFailed).NotTo(BeNil(), "ReleaseFailed condition should be set")
+			g.Expect(string(releaseFailed.Status)).To(Equal(string(platform.StatusFalse)),
+				"ReleaseFailed should be False after successful install")
+			g.Expect(irreconcilable).NotTo(BeNil(), "Irreconcilable condition should be set")
+			g.Expect(string(irreconcilable.Status)).To(Equal(string(platform.StatusFalse)),
+				"Irreconcilable should be False after successful install")
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("simulating PVC binding by setting spec.volumeName")
+		pvc := &corev1.PersistentVolumeClaim{}
+		Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+			Namespace: namespace, Name: "scanner-v4-db",
+		}, pvc)).To(Succeed())
+		pvc.Spec.VolumeName = "fake-pv"
+		Expect(mgr.GetClient().Update(ctx, pvc)).To(Succeed())
+
+		By("applying an invalid overlay to trigger upgrade failure")
+		Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+			Namespace: namespace, Name: centralName,
+		}, central)).To(Succeed())
+		central.Spec.Overlays = []*platform.K8sObjectOverlay{
+			{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "scanner-v4-matcher-config",
+				Patches: []*platform.K8sObjectOverlayPatch{
+					{
+						Path:  `data.config\.yaml`,
+						Value: "matcher:\n  vulnerabilities_url: \"https://bad\"", // This will be unmarshalled as a map.
+					},
+				},
+			},
+		}
+		Expect(mgr.GetClient().Update(ctx, central)).To(Succeed())
+
+		By("waiting for upgrade failure with successful rollback")
+		Eventually(func(g Gomega) {
+			c := &platform.Central{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, c)).To(Succeed())
+
+			releaseFailed := c.GetCondition(platform.ConditionReleaseFailed)
+			g.Expect(releaseFailed).NotTo(BeNil(), "ReleaseFailed condition should exist")
+			g.Expect(string(releaseFailed.Status)).To(Equal(string(platform.StatusTrue)),
+				"ReleaseFailed should be True after failed upgrade")
+			g.Expect(releaseFailed.Message).NotTo(ContainSubstring("rollback failed"),
+				"Rollback should succeed with Force=false; got: %s", releaseFailed.Message)
+
+			// Reduce log noise.
+			messageTruncated := releaseFailed.Message[:min(len(releaseFailed.Message), 100)] + " [...]"
+			GinkgoWriter.Printf("ReleaseFailed condition: status=%s, reason=%s, message='%s'\n",
+				releaseFailed.Status, releaseFailed.Reason, messageTruncated)
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("verifying PVC is still intact")
+		Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+			Namespace: namespace, Name: "scanner-v4-db",
+		}, pvc)).To(Succeed())
+		Expect(pvc.Spec.VolumeName).To(Equal("fake-pv"))
+	})
+})

--- a/operator/tests/reconcile/rollback_test.go
+++ b/operator/tests/reconcile/rollback_test.go
@@ -1,0 +1,210 @@
+package reconcile
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stackrox/rox/image"
+	platform "github.com/stackrox/rox/operator/api/v1alpha1"
+	centralTranslation "github.com/stackrox/rox/operator/internal/central/values/translation"
+	stackroxReconciler "github.com/stackrox/rox/operator/internal/reconciler"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+var _ = Describe("Upgrade failure with rollbacks disabled", func() {
+	const (
+		centralName = "test-central"
+		namespace   = "default"
+	)
+
+	var (
+		mgr    manager.Manager
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		s := runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+		Expect(platform.AddToScheme(s)).To(Succeed())
+
+		var err error
+		mgr, err = manager.New(cfg, manager.Options{
+			Scheme:  s,
+			Metrics: server.Options{BindAddress: "0"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		translator := centralTranslation.New(mgr.GetClient())
+		Expect(stackroxReconciler.SetupReconcilerWithManager(
+			mgr, platform.CentralGVK, image.CentralServicesChartPrefix,
+			translator, nil,
+		)).To(Succeed())
+
+		ctx, cancel = context.WithCancel(context.Background())
+		go func() {
+			defer GinkgoRecover()
+			Expect(mgr.Start(ctx)).To(Succeed())
+		}()
+	})
+
+	AfterEach(func() {
+		By("cleaning up Central CR")
+		central := &platform.Central{}
+		objKey := types.NamespacedName{Namespace: namespace, Name: centralName}
+		if err := mgr.GetAPIReader().Get(ctx, objKey, central); err == nil {
+			central.SetFinalizers([]string{})
+			_ = mgr.GetClient().Update(ctx, central)
+			err = mgr.GetClient().Delete(ctx, central)
+			if err != nil && !apiErrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		By("cleaning up PVCs")
+		pvcList := &corev1.PersistentVolumeClaimList{}
+		if err := mgr.GetAPIReader().List(ctx, pvcList, ctrlClient.InNamespace(namespace)); err == nil {
+			for i := range pvcList.Items {
+				_ = mgr.GetClient().Delete(ctx, &pvcList.Items[i])
+			}
+		}
+
+		By("cleaning up PVs")
+		pvList := &corev1.PersistentVolumeList{}
+		if err := mgr.GetAPIReader().List(ctx, pvList); err == nil {
+			for i := range pvList.Items {
+				_ = mgr.GetClient().Delete(ctx, &pvList.Items[i])
+			}
+		}
+
+		cancel()
+	})
+
+	It("should not attempt rollback after a failed upgrade, preserving PVCs", func() {
+		pvcName := types.NamespacedName{
+			Namespace: namespace, Name: "scanner-v4-db",
+		}
+		By("creating a Central CR with Scanner V4 enabled")
+		central := &platform.Central{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      centralName,
+				Namespace: namespace,
+			},
+			Spec: platform.CentralSpec{
+				ScannerV4: &platform.ScannerV4Spec{
+					ScannerComponent: new(platform.ScannerV4ComponentEnabled),
+				},
+			},
+		}
+		Expect(mgr.GetClient().Create(ctx, central)).To(Succeed())
+
+		By("waiting for initial install to complete")
+		Eventually(func(g Gomega) {
+			c := &platform.Central{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, c)).To(Succeed())
+
+			g.Expect(c.GetCondition(platform.ConditionDeployed)).To(
+				SatisfyAll(Not(BeNil()), HaveField("Status", Equal(platform.StatusTrue))),
+				"Deployed condition should be True after successful install")
+		}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+		By("simulating PVC binding by setting spec.volumeName")
+		Eventually(func(g Gomega) {
+			pvc := &corev1.PersistentVolumeClaim{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, pvcName, pvc)).To(Succeed())
+			pvc.Spec.VolumeName = "fake-pv"
+			g.Expect(mgr.GetClient().Update(ctx, pvc)).To(Succeed())
+		}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+		By("applying an invalid overlay to trigger upgrade failure")
+		Eventually(func(g Gomega) {
+			c := &platform.Central{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, c)).To(Succeed())
+			c.Spec.Overlays = []*platform.K8sObjectOverlay{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "scanner-v4-matcher-config",
+					Patches: []*platform.K8sObjectOverlayPatch{
+						{
+							Path:  `data.config\.yaml`,
+							Value: "matcher:\n  vulnerabilities_url: \"https://bad\"", // This will be unmarshalled as a map.
+						},
+					},
+				},
+			}
+			g.Expect(mgr.GetClient().Update(ctx, c)).To(Succeed())
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		By("waiting for upgrade failure without rollback attempt")
+		Eventually(func(g Gomega) {
+			c := &platform.Central{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, c)).To(Succeed())
+
+			releaseFailed := c.GetCondition(platform.ConditionReleaseFailed)
+			irreconcilable := c.GetCondition(platform.ConditionIrreconcilable)
+
+			g.Expect(releaseFailed).To(SatisfyAll(Not(BeNil()), HaveField("Status", Equal(platform.StatusTrue))),
+				"ReleaseFailed condition should be True")
+			g.Expect(releaseFailed.Message).NotTo(ContainSubstring("rollback"),
+				"No rollback should be attempted; got: %s", releaseFailed.Message)
+			g.Expect(irreconcilable).To(SatisfyAll(Not(BeNil()), HaveField("Status", Equal(platform.StatusTrue))),
+				"Irreconcilable condition should be True")
+
+			messageTruncated := releaseFailed.Message[:min(len(releaseFailed.Message), 100)] + " [...]"
+			GinkgoWriter.Printf("ReleaseFailed condition: status=%s, reason=%s, message='%s'\n",
+				releaseFailed.Status, releaseFailed.Reason, messageTruncated)
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		By("repairing the custom resource, which failed reconciliation")
+		Eventually(func() error {
+			if err := mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, central); err != nil {
+				return err
+			}
+			central.Spec.Overlays = []*platform.K8sObjectOverlay{}
+			return mgr.GetClient().Update(ctx, central)
+		}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+		By("waiting for reconciliation to succeed again")
+		Eventually(func(g Gomega) {
+			c := &platform.Central{}
+			g.Expect(mgr.GetAPIReader().Get(ctx, types.NamespacedName{
+				Namespace: namespace, Name: centralName,
+			}, c)).To(Succeed())
+
+			releaseFailed := c.GetCondition(platform.ConditionReleaseFailed)
+			irreconcilable := c.GetCondition(platform.ConditionIrreconcilable)
+
+			g.Expect(c.GetCondition(platform.ConditionDeployed)).To(
+				SatisfyAll(Not(BeNil()), HaveField("Status", Equal(platform.StatusTrue))),
+				"Deployed condition should be True again")
+			g.Expect(releaseFailed).To(SatisfyAny(BeNil(), HaveField("Status", Equal(platform.StatusFalse))),
+				"ReleaseFailed condition should be nil or False")
+			g.Expect(irreconcilable).To(SatisfyAny(BeNil(), HaveField("Status", Equal(platform.StatusFalse))),
+				"Irreconcilable condition should be nil or False")
+		}, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("verifying PVC is still intact")
+		pvc := &corev1.PersistentVolumeClaim{}
+		Expect(mgr.GetAPIReader().Get(ctx, pvcName, pvc)).To(Succeed())
+		Expect(pvc.Spec.VolumeName).To(Equal("fake-pv"))
+	})
+})


### PR DESCRIPTION
## Description

Disable Helm rollbacks on failed upgrades in the operator reconciler. When an upgrade fails, the operator now leaves the release in the failed state instead of attempting a rollback, which seems to be the more sensible approach.

The operator's reconciliation loop will keep retrying, so a transient failure self-heals and a permanent failure is surfaced via `ReleaseFailed`/`Irreconcilable` conditions for the user to fix.

## User-facing documentation

- [x] CHANGELOG.md update not needed, because in most cases this shouldn't effectively change the situation: previously a rollback was attempted and the system ended up in an irreconcilable state. Now no rollback is attempted and the system ends up in an irreconcilable state.
- [x] documentation PR: I don't think changes are needed, because AFAIK we don't currently document technical details about how the operator behaves in case of reconciliation errors.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added integration tests

### How I validated my change

Envtest-based integration test (`rollback_test.go`) exercises the full reconciliation loop: installs a Central CR, triggers an upgrade failure via an invalid overlay, verifies no rollback is attempted, repairs the CR, and confirms PVCs survive the cycle.
