### PR TITLE
ROX-35969: [backport release-4.10] Fix image search for images_layers fields

### DIFF
--- a/central/image/datastore/datastore_impl_flat_postgres_test.go
+++ b/central/image/datastore/datastore_impl_flat_postgres_test.go
@@ -194,6 +194,23 @@ func (s *ImageFlatPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 	s.NoError(err)
 	s.Len(results, 1)
 	s.Equal(newImage.GetId(), results[0].ID)
+
+	// Search by Dockerfile Instruction Keyword (from child table images_layers).
+	q = pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.DockerfileInstructionKeyword, "RUN").ProtoQuery()
+	results, err = s.datastore.Search(ctx, q)
+	s.NoError(err)
+	s.Len(results, 2)
+
+	// Count by Dockerfile Instruction Keyword.
+	count, err := s.datastore.Count(ctx, q)
+	s.NoError(err)
+	s.Equal(2, count)
+
+	// Search by Dockerfile Instruction Value.
+	q = pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.DockerfileInstructionValue, "apt-get").ProtoQuery()
+	results, err = s.datastore.Search(ctx, q)
+	s.NoError(err)
+	s.Len(results, 2)
 }
 
 func (s *ImageFlatPostgresDataStoreTestSuite) TestFixableWithPostgres() {
@@ -620,6 +637,14 @@ func getTestImage(id string) *storage.Image {
 							ScoreVersion: storage.EmbeddedVulnerability_V3,
 						},
 					},
+				},
+			},
+		},
+		Metadata: &storage.ImageMetadata{
+			V1: &storage.V1Metadata{
+				Layers: []*storage.ImageLayer{
+					{Instruction: "ADD", Value: "file:abc123 in /"},
+					{Instruction: "RUN", Value: "apt-get update && apt-get install -y curl"},
 				},
 			},
 		},

--- a/central/image/datastore/store/v2/postgres/gen.go
+++ b/central/image/datastore/store/v2/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.Image --search-category IMAGES --schema-only --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,DEPLOYMENTS,NAMESPACES,CLUSTERS
+//go:generate pg-table-bindings-wrapper --type=storage.Image --search-category IMAGES --schema-only --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,IMAGES,DEPLOYMENTS,NAMESPACES,CLUSTERS

--- a/pkg/postgres/schema/images.go
+++ b/pkg/postgres/schema/images.go
@@ -39,6 +39,7 @@ var (
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory_IMAGE_VULNERABILITIES_V2,
 			v1.SearchCategory_IMAGE_COMPONENTS_V2,
+			v1.SearchCategory_IMAGES,
 			v1.SearchCategory_DEPLOYMENTS,
 			v1.SearchCategory_NAMESPACES,
 			v1.SearchCategory_CLUSTERS,


### PR DESCRIPTION
## Description

Backport of #21988 (ROX-35969) to release-4.10.

The v2 image store was missing `IMAGES` from its `--search-scope`, preventing the BFS join resolver from reaching the `images_layers` child table. This caused queries using `Dockerfile Instruction Keyword` and `Dockerfile Instruction Value` fields to silently return 0 results.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `TestImageFlatDataStoreWithPostgres/TestSearchWithPostgres` passes with new Dockerfile search assertions