### PR TITLE
fix(CI): register ImageV2 loader in GraphQL benchmark tests

### DIFF
--- a/central/graphql/handler/handler_benchmark_test.go
+++ b/central/graphql/handler/handler_benchmark_test.go
@@ -153,7 +153,8 @@ func getGraphQLServer(testHelper *testutils.ExportServicePostgresTestHelper) (*h
 	resolver := resolvers.NewMock()
 	resolver.DeploymentDataStore = testHelper.Deployments
 	resolver.ImageDataStore = testHelper.Images
-	// Override Deployment and Image loader to avoid panics
+	resolver.ImageV2DataStore = testHelper.ImagesV2
+	// Override Deployment, Image, and ImageV2 loaders to avoid panics
 	deploymentFactory := func() interface{} {
 		return loaders.NewDeploymentLoader(resolver.DeploymentDataStore, testHelper.DeploymentView)
 	}
@@ -162,6 +163,10 @@ func getGraphQLServer(testHelper *testutils.ExportServicePostgresTestHelper) (*h
 		return loaders.NewImageLoader(resolver.ImageDataStore, testHelper.ImageView)
 	}
 	loaders.RegisterTypeFactory(reflect.TypeFor[storage.Image](), imageFactory)
+	imageV2Factory := func() interface{} {
+		return loaders.NewImageV2Loader(testHelper.ImagesV2, testHelper.ImageView)
+	}
+	loaders.RegisterTypeFactory(reflect.TypeFor[storage.ImageV2](), imageV2Factory)
 	ourSchema, err := graphql.ParseSchema(schema, resolver)
 	if err != nil {
 		return nil, err

--- a/central/graphql/handler/handler_benchmark_test.go
+++ b/central/graphql/handler/handler_benchmark_test.go
@@ -207,8 +207,14 @@ func prepareGraphQLCall(
 func consumeResponse(b *testing.B, resp *http.Response) {
 	defer func() { assert.NoError(b, resp.Body.Close()) }()
 	assert.Equal(b, http.StatusOK, resp.StatusCode)
-	_, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	assert.NoError(b, err)
+	var result struct {
+		Errors []json.RawMessage `json:"errors"`
+	}
+	if assert.NoError(b, json.Unmarshal(body, &result)) {
+		assert.Empty(b, result.Errors, "GraphQL response contained errors")
+	}
 }
 
 func getGraphQLBenchmark(


### PR DESCRIPTION
## Description

`BenchmarkImageExport` and `BenchmarkDeploymentWithImageExport` panic with a nil pointer dereference
because `getGraphQLServer` does not register an `ImageV2Loader` factory. With `FlattenImageData`
enabled by default, `Images()` dispatches to `ImageV2s()`, which uses `GetImageV2Loader()`.
Without this registration, the V2 loader falls back to the `init()`-registered singleton factory
(`central/graphql/resolvers/loaders/images_v2.go:18`) which calls `globaldb.GetPostgres()` -- nil
in test environments. That causes a nil pointer dereference in `tracedQuery`
(`pkg/search/postgres/common.go:888`).

The panic was not caught by CI because the graphql-go library recovers the panic and returns it as
an error in the GraphQL JSON response (HTTP 200). The benchmark's `consumeResponse` checked the
status code but discarded the body without inspecting the `errors` field. A new assertion on the
response `errors` field ensures future regressions fail CI instead of silently logging panics.

The fix registers an `ImageV2Loader` factory (using the test helper's `ImagesV2` datastore and
`ImageView`) and sets `resolver.ImageV2DataStore`, matching the existing pattern for `Deployment`
and `Image` loaders.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran all three benchmarks locally and confirmed:
- `BenchmarkImageExport` -- PASS, no errors
- `BenchmarkDeploymentWithImageExport` -- PASS, no errors
- `BenchmarkDeploymentExport` -- PASS, no errors
