### PR TITLE
fix(tests): fix roxctl bats test flakes and silent failures

### DIFF
--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -57,7 +57,7 @@ roxctl-development-cmd() {
     _uname="$(luname)"
     _goarch="$(go env GOARCH)"
     mkdir -p "$tmp_roxctl"
-    make -s "roxctl_${_uname}-${_goarch}" GOTAGS='' 2>&3
+    make -s "roxctl_${_uname}-${_goarch}" GOTAGS='' >&3 2>&3
     mv "bin/${_uname}_${_goarch}/roxctl" "${tmp_roxctl}/roxctl-dev"
   fi
   echo "${tmp_roxctl}/roxctl-dev"
@@ -74,7 +74,7 @@ roxctl-release-cmd() {
     _uname="$(luname)"
     _goarch="$(go env GOARCH)"
     mkdir -p "$tmp_roxctl"
-    make -s "roxctl_${_uname}-${_goarch}" GOTAGS='release' 2>&3
+    make -s "roxctl_${_uname}-${_goarch}" GOTAGS='release' >&3 2>&3
     mv "bin/${_uname}_${_goarch}/roxctl" "${tmp_roxctl}/roxctl-release"
   fi
   echo "${tmp_roxctl}/roxctl-release"

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive-dummy.expect.tcl
@@ -24,9 +24,15 @@ if {[llength $argv] != 2} {
 spawn {*}"$binary" central generate interactive
 
 expect "Path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
-expect "Read templates from local filesystem*:*: " { send "\n" }
-expect "Path to helm templates on your local filesystem*:*: " { send "\n" }
-expect "PEM cert bundle file*: " { send "\n" }
+# Debug flags only appear in development builds (guarded by !buildinfo.ReleaseBuild)
+expect {
+  "Read templates from local filesystem*:*: " { send "\n"
+    expect "Path to helm templates on your local filesystem*:*: " { send "\n" }
+    expect "PEM cert bundle file*: " { send "\n" }
+  }
+  "PEM cert bundle file*: " { send "\n" }
+}
+expect "Disable the administrator password*: " { send "\n" }
 expect "Create PodSecurityPolicy resources*:*: " { send "\n" }
 expect "Administrator password*:*: " { send "\n" }
 expect "Orchestrator (k8s, openshift)*: " { send "k8s\n" }

--- a/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
+++ b/tests/roxctl/bats-tests/local/expect/flavor-interactive.expect.tcl
@@ -34,9 +34,14 @@ if {[llength $argv] != 4} {
 spawn {*}"$binary" central generate interactive
 
 expect "Path to the backup bundle from which to restore keys and certificates*: " { send "\n" }
-expect "Read templates from local filesystem*:*: " { send "\n" }
-expect "Path to helm templates on your local filesystem*:*: " { send "\n" }
-expect "PEM cert bundle file*: " { send "\n" }
+# Debug flags only appear in development builds (guarded by !buildinfo.ReleaseBuild)
+expect {
+  "Read templates from local filesystem*:*: " { send "\n"
+    expect "Path to helm templates on your local filesystem*:*: " { send "\n" }
+    expect "PEM cert bundle file*: " { send "\n" }
+  }
+  "PEM cert bundle file*: " { send "\n" }
+}
 expect "Disable the administrator password*: " { send "\n" }
 expect "Create PodSecurityPolicy resources*:*: " { send "\n" }
 expect "Administrator password*:*: " { send "\n" }


### PR DESCRIPTION
## Description

Three bugs in the roxctl interactive bats tests causing flakes and silent test failures:

1. **make stdout contamination** (`helpers.bash`): `roxctl-*-cmd` functions only redirected make's stderr to fd3, leaving stdout unredirected. Any Makefile target that echoes to stdout contaminates the binary path captured by `$()`, causing the expect script to try executing garbage. Fix: `>&3 2>&3`.

2. **Missing `disable-admin-password` prompt** (`flavor-interactive-dummy.expect.tcl`): The flag was added in Jun 2024 (commit 7ffb3bf6ec) but the dummy expect script was never updated. Each missing prompt causes a 10s timeout cascade, and the test "passes" without exercising the interactive flow. Fix: add the missing expect line.

3. **Debug flags expected in release builds** (both expect scripts): `--debug` and `--debug-path` flags are guarded by `!buildinfo.ReleaseBuild`, so they only appear in dev builds. Both expect scripts expected them unconditionally, causing 20s of wasted timeouts per release test. Fix: use TCL expect branching to handle both build types.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI `local-roxctl-tests` job — the fixes address the root causes of intermittent failures on tests 19, 23-25 in `central-generate-interactive-flavors.bats`.