### PR TITLE
chore(deps): bump Go from 1.26.3 to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.26.3
+go 1.26.5
 
 require (
 	cloud.google.com/go/artifactregistry v1.26.0


### PR DESCRIPTION
## Description

Bump Go version from 1.26.3 to 1.26.5 to fix stdlib CVEs flagged in GovCloud FedRAMP compliance scans (30-day SLA from 2026-08-03).

Fixed CVEs:
- CVE-2026-42504 (MIME DoS, IMPORTANT)
- CVE-2026-39822 (stdlib, IMPORTANT)
- CVE-2026-27145 (stdlib, IMPORTANT)
- CVE-2026-42505 (stdlib, MODERATE)
- CVE-2026-42507 (stdlib, MODERATE)

Related tickets: ROX-36083, ROX-36084, ROX-36085, ROX-36086

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Go patch version bump only — no API or behavioral changes. CI validation is sufficient.