### PR TITLE
ROX-36084: bump Go from 1.26.3 to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.26.3
+go 1.26.5
 
 require (
 	cloud.google.com/go/artifactregistry v1.25.0


### PR DESCRIPTION
## Description

Backport of #22090 to release-4.11.

Bumps Go from 1.26.3 to 1.26.5 to fix CVE-2026-42504, CVE-2026-39822, CVE-2026-27145, CVE-2026-42505, and CVE-2026-42507.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Dependency-only change (go directive). CI will validate compatibility.