### PR TITLE
ROX-35685: pull-mode roxagent gets repo-to-CPE mapping via Sensor

### DIFF
--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
@@ -20,15 +21,15 @@ const (
 // the VM filesystem and publishing results to cache, independent of how the
 // cached report is served over VSOCK. Kept separate from Server/CARefresher
 // wiring in runServe so its retry/backoff policy is easier to reason about
-// and test on its own. Scanning does not make a network call; the downloader
-// built by newMappingDownloader keeps the mapping file fresh independently,
-// on its own schedule, so only the schedule for the next rescan attempt is
-// retried here, not the scan itself.
+// and test on its own. Scanning does not make a network call; provider
+// keeps the mapping file fresh independently, on its own schedule, so only
+// the schedule for the next rescan attempt is retried here, not the scan
+// itself.
 type rescanner struct {
-	cache           *vsockserver.ReportCache
-	hostPath        string
-	mappingFilePath string
-	interval        time.Duration
+	cache    *vsockserver.ReportCache
+	hostPath string
+	provider vsockserver.MappingProvider
+	interval time.Duration
 
 	// scanFn defaults to the package scan function; tests override it to
 	// inject failures. factsFn defaults to the package discoverFacts
@@ -41,17 +42,33 @@ type rescanner struct {
 	scanFn   func(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, error)
 	factsFn  func(hostPath string) map[string]string
 	newDelay func(d time.Duration) <-chan time.Time
+
+	// wake lets OnMappingChanged nudge Run into scanning immediately
+	// instead of waiting out the rest of the current interval. Buffered
+	// so a callback that fires while Run is mid-scan is not lost.
+	wake chan struct{}
 }
 
-func newRescanner(cache *vsockserver.ReportCache, hostPath, mappingFilePath string, interval time.Duration) *rescanner {
+func newRescanner(cache *vsockserver.ReportCache, hostPath string, provider vsockserver.MappingProvider, interval time.Duration) *rescanner {
 	return &rescanner{
-		cache:           cache,
-		hostPath:        hostPath,
-		mappingFilePath: mappingFilePath,
-		interval:        interval,
-		scanFn:          scan,
-		factsFn:         discoverFacts,
-		newDelay:        time.After,
+		cache:    cache,
+		hostPath: hostPath,
+		provider: provider,
+		interval: interval,
+		scanFn:   scan,
+		factsFn:  discoverFacts,
+		newDelay: time.After,
+		wake:     make(chan struct{}, 1),
+	}
+}
+
+// OnMappingChanged is the updater's onChange callback: it schedules an
+// immediate scan attempt by waking Run's loop, coalescing with any
+// already-pending wake so a burst of changes only triggers one extra scan.
+func (r *rescanner) OnMappingChanged() {
+	select {
+	case r.wake <- struct{}{}:
+	default:
 	}
 }
 
@@ -67,22 +84,61 @@ func (r *rescanner) Run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-r.wake:
+			if err := r.scanOnce(ctx); err != nil {
+				log.Errorf("Rescan triggered by mapping change failed: %v", err)
+			}
 		case <-delay:
-			log.Info("Starting rescan")
-			report, err := r.scanFn(ctx, r.hostPath, r.mappingFilePath)
-			if err != nil {
+			if err := r.scanOnce(ctx); err != nil {
 				retryIn := min(backoff, r.interval)
 				log.Errorf("Rescan failed: %v; trying again in %v", err, retryIn)
 				backoff = min(backoff*2, rescanRetryMaxBackoff)
 				delay = r.newDelay(retryIn)
 				continue
 			}
-			r.cache.SetReport(report, r.factsFn(r.hostPath))
-			log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
 			backoff = rescanRetryBaseBackoff
 			delay = r.newDelay(r.interval)
 		}
 	}
+}
+
+// scanOnce attempts one rescan, skipping it (returning nil, without calling
+// scanFn) if provider has no mapping ready yet. While a scan that does run
+// is in flight, provider is marked busy (when it implements ScanBusyGate)
+// so a concurrent Sync defers instead of racing the scan; that busy state
+// is cleared here on failure, but on success it is left for the Handler to
+// clear once the resulting report has actually been sent over VSOCK.
+func (r *rescanner) scanOnce(ctx context.Context) error {
+	if !r.provider.Ready() {
+		log.Info("Skipping rescan: repository-to-CPE mapping not yet available")
+		return nil
+	}
+
+	gate, hasGate := r.provider.(vsockserver.ScanBusyGate)
+	if hasGate {
+		gate.MarkScanBusy()
+	}
+
+	path, err := r.provider.Path()
+	if err != nil {
+		if hasGate {
+			gate.MarkScanIdleAndApplyPending()
+		}
+		return fmt.Errorf("resolving mapping file path: %w", err)
+	}
+
+	log.Info("Starting rescan")
+	report, err := r.scanFn(ctx, r.hostPath, path)
+	if err != nil {
+		if hasGate {
+			gate.MarkScanIdleAndApplyPending()
+		}
+		return err
+	}
+
+	r.cache.SetReport(report, r.factsFn(r.hostPath))
+	log.Infof("Rescan complete, report updated. Num packages: %d", len(report.GetContents().GetPackages()))
+	return nil
 }
 
 // runAsync starts Run in a goroutine and returns a channel that is closed

--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -102,12 +102,8 @@ func (r *rescanner) Run(ctx context.Context) {
 	}
 }
 
-// scanOnce attempts one rescan, skipping it (returning nil, without calling
-// scanFn) if provider has no mapping ready yet. While a scan that does run
-// is in flight, provider is marked busy (when it implements ScanBusyGate)
-// so a concurrent Sync defers instead of racing the scan; that busy state
-// is cleared here on failure, but on success it is left for the Handler to
-// clear once the resulting report has actually been sent over VSOCK.
+// scanOnce clears the busy gate itself only on failure; a successful scan
+// leaves that to the Handler, once the report has gone out over VSOCK.
 func (r *rescanner) scanOnce(ctx context.Context) error {
 	if !r.provider.Ready() {
 		log.Info("Skipping rescan: repository-to-CPE mapping not yet available")

--- a/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
@@ -9,9 +9,46 @@ import (
 
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
+)
+
+// fakeProvider is a vsockserver.MappingProvider test double for rescanner
+// tests; Hash/UpdatePath/Bytes are unused by rescanner and always zero.
+type fakeProvider struct {
+	ready   bool
+	path    string
+	pathErr error
+}
+
+func (f *fakeProvider) Ready() bool  { return f.ready }
+func (f *fakeProvider) Hash() string { return "" }
+func (f *fakeProvider) UpdatePath() pb.RepoCPEMappingUpdatePath {
+	return pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED
+}
+func (f *fakeProvider) Bytes() ([]byte, error) { return nil, errors.New("not implemented") }
+func (f *fakeProvider) Path() (string, error)  { return f.path, f.pathErr }
+
+var _ vsockserver.MappingProvider = (*fakeProvider)(nil)
+
+// fakeGatedProvider adds ScanBusyGate call tracking on top of fakeProvider,
+// mirroring SensorUpdater (gated) as opposed to URLUpdater (ungated) so
+// tests can verify scanOnce only invokes the gate for providers that
+// implement it.
+type fakeGatedProvider struct {
+	fakeProvider
+	busyCalls int
+	idleCalls int
+}
+
+func (f *fakeGatedProvider) MarkScanBusy()                { f.busyCalls++ }
+func (f *fakeGatedProvider) MarkScanIdleAndApplyPending() { f.idleCalls++ }
+
+var (
+	_ vsockserver.MappingProvider = (*fakeGatedProvider)(nil)
+	_ vsockserver.ScanBusyGate    = (*fakeGatedProvider)(nil)
 )
 
 // testRescanner returns a rescanner with a long default interval so tests
@@ -19,9 +56,13 @@ import (
 // factsFn is stubbed out so Run never exercises the real discoverFacts,
 // which - unlike scanFn - has no test-friendly no-op input; hostPath=""
 // resolves to real absolute host paths (e.g. "/etc/pki/entitlement"), not
-// a safe default.
-func testRescanner() *rescanner {
-	r := newRescanner(&vsockserver.ReportCache{}, "", "", time.Hour)
+// a safe default. provider defaults to always-ready when nil, so existing
+// tests that don't care about readiness are unaffected.
+func testRescanner(provider vsockserver.MappingProvider) *rescanner {
+	if provider == nil {
+		provider = &fakeProvider{ready: true}
+	}
+	r := newRescanner(&vsockserver.ReportCache{}, "", provider, time.Hour)
 	r.factsFn = func(string) map[string]string { return nil }
 	return r
 }
@@ -66,7 +107,7 @@ func (f *fakeTicker) lastReset() time.Duration {
 func TestRescanner_Run(t *testing.T) {
 	t.Run("should publish to cache on each tick", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			r := testRescanner()
+			r := testRescanner(nil)
 			ticker := newFakeTicker()
 			defer ticker.close()
 			r.newDelay = ticker.newDelay
@@ -101,7 +142,7 @@ func TestRescanner_Run(t *testing.T) {
 
 	t.Run("should retry sooner than the full interval after a failed rescan", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			r := testRescanner()
+			r := testRescanner(nil)
 			ticker := newFakeTicker()
 			defer ticker.close()
 			r.newDelay = ticker.newDelay
@@ -142,7 +183,7 @@ func TestRescanner_Run(t *testing.T) {
 
 	t.Run("should stop promptly when the context is cancelled", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			r := testRescanner()
+			r := testRescanner(nil)
 
 			ctx, cancel := context.WithCancel(t.Context())
 			stopped := r.runAsync(ctx)
@@ -153,6 +194,87 @@ func TestRescanner_Run(t *testing.T) {
 			// fails the test on deadlock automatically.
 			cancel()
 			<-stopped
+		})
+	})
+
+	t.Run("a periodic tick is a no-op when the mapping is not yet ready", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			r := testRescanner(&fakeProvider{ready: false})
+			ticker := newFakeTicker()
+			defer ticker.close()
+			r.newDelay = ticker.newDelay
+			var calls int
+			r.scanFn = func(context.Context, string, string) (*v4.IndexReport, error) {
+				calls++
+				return &v4.IndexReport{}, nil
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			stopped := r.runAsync(ctx)
+			defer func() {
+				cancel()
+				<-stopped
+			}()
+			synctest.Wait()
+
+			ticker.fire()
+			synctest.Wait()
+
+			assert.Zero(t, calls, "scanFn must not be called while the mapping provider isn't ready")
+		})
+	})
+
+	t.Run("OnMappingChanged triggers an immediate scan attempt", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			r := testRescanner(&fakeProvider{ready: true})
+			ticker := newFakeTicker()
+			defer ticker.close()
+			r.newDelay = ticker.newDelay
+			var calls int
+			r.scanFn = func(context.Context, string, string) (*v4.IndexReport, error) {
+				calls++
+				return &v4.IndexReport{}, nil
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			stopped := r.runAsync(ctx)
+			defer func() {
+				cancel()
+				<-stopped
+			}()
+			synctest.Wait() // Run is blocked waiting for the first tick
+
+			r.OnMappingChanged()
+			synctest.Wait()
+
+			assert.Equal(t, 1, calls, "OnMappingChanged should trigger a scan without waiting for the next tick")
+		})
+	})
+
+	t.Run("a failed scan clears busy via idle-and-apply-pending", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			provider := &fakeGatedProvider{fakeProvider: fakeProvider{ready: true}}
+			r := testRescanner(provider)
+			ticker := newFakeTicker()
+			defer ticker.close()
+			r.newDelay = ticker.newDelay
+			r.scanFn = func(context.Context, string, string) (*v4.IndexReport, error) {
+				return nil, errors.New("scan failed")
+			}
+
+			ctx, cancel := context.WithCancel(t.Context())
+			stopped := r.runAsync(ctx)
+			defer func() {
+				cancel()
+				<-stopped
+			}()
+			synctest.Wait()
+
+			ticker.fire()
+			synctest.Wait()
+
+			assert.Equal(t, 1, provider.busyCalls)
+			assert.Equal(t, 1, provider.idleCalls, "a failed scan must not leave a Sync stuck behind busy forever")
 		})
 	})
 }

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -66,7 +66,8 @@ func ServeCmd(ctx context.Context) *cobra.Command {
 	}
 	cmd.Flags().Uint32Var(&cfg.port, "port", 818, "VSOCK port to listen on")
 	cmd.Flags().StringVar(&cfg.hostPath, "host-path", "/", "Root filesystem path for indexing")
-	cmd.Flags().StringVar(&cfg.repoCPEURL, "repo-cpe-url", repoToCPEMappingURL, "Repository to CPE mapping URL")
+	cmd.Flags().StringVar(&cfg.repoCPEURL, "repo-cpe-url", "",
+		"Repository to CPE mapping URL. Empty (default) means Sensor pushes the mapping over VSOCK instead.")
 	cmd.Flags().DurationVar(&cfg.rescanInterval, "rescan-interval", 4*time.Hour,
 		fmt.Sprintf("Interval between rescans (range %v-%v)", minRescanInterval, maxRescanInterval))
 	cmd.Flags().DurationVar(&cfg.caFetchTimeout, "ca-fetch-timeout", 10*time.Second,
@@ -103,33 +104,40 @@ func (c serveConfig) validate() error {
 	return nil
 }
 
+// newRescannerAndProvider builds the rescanner and the mapping provider it
+// scans against: the URL-backed provider when repoCPEURL is set, the
+// Sensor-backed one (also usable as updater) otherwise. The rescanner is
+// constructed first, with a nil provider, so its OnMappingChanged callback
+// - passed to the provider's constructor below - has a live receiver even
+// if the provider invokes it synchronously during bootstrap (e.g. a valid
+// mapping already cached from a previous run); OnMappingChanged only
+// touches the rescanner's wake channel, never its provider field, so this
+// is safe regardless of ordering. urlUpdater is non-nil only in the
+// URL-backed case, for the caller to Start/Stop its download loop.
+func newRescannerAndProvider(cache *vsockserver.ReportCache, cfg serveConfig) (vmRescanner *rescanner, provider vsockserver.MappingProvider, updater vsockserver.MappingUpdater, urlUpdater *vsockserver.URLUpdater) {
+	vmRescanner = newRescanner(cache, cfg.hostPath, nil, cfg.rescanInterval)
+
+	if cfg.repoCPEURL != "" {
+		urlUpdater = vsockserver.NewURLUpdater(cfg.repoCPEURL, mappingCachePath, vmRescanner.OnMappingChanged)
+		provider = urlUpdater
+	} else {
+		sensorUpdater := vsockserver.NewSensorUpdater(mappingCachePath, "", vmRescanner.OnMappingChanged)
+		provider, updater = sensorUpdater, sensorUpdater
+	}
+	vmRescanner.provider = provider
+
+	return vmRescanner, provider, updater, urlUpdater
+}
+
 func runServe(ctx context.Context, cfg serveConfig) error {
 	if err := cfg.validate(); err != nil {
 		return err
 	}
 
-	// The mapping file must exist locally before the first scan can run:
-	// scan() never fetches it itself, so this initial fetch is mandatory.
-	// If it fails, startup fails rather than running a scan against no data.
-	// Start(ctx, true) blocks until that fetch completes, then keeps
-	// refreshing the file in the background.
-	mappingDownloader := newMappingDownloader(cfg.repoCPEURL, mappingCachePath,
-		logMappingDownloadResult(cfg.repoCPEURL, mappingCachePath))
-	if err := mappingDownloader.Start(ctx, true); err != nil {
-		return fmt.Errorf("initial repository-to-CPE mapping fetch: %w", err)
-	}
-
 	cache := &vsockserver.ReportCache{}
-	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
+	vmRescanner, provider, updater, urlUpdater := newRescannerAndProvider(cache, cfg)
 
-	report, err := scan(ctx, cfg.hostPath, mappingCachePath)
-	if err != nil {
-		return fmt.Errorf("initial scan: %w", err)
-	}
-	cache.SetReport(report, discoverFacts(cfg.hostPath))
-	log.Infof("Initial scan complete, report cached. Num packages: %d", len(report.GetContents().GetPackages()))
-
-	handler := vsockserver.NewHandler(cache, agentVersion)
+	handler := vsockserver.NewHandler(cache, agentVersion, provider, updater)
 
 	// TLS is mandatory: sensor always dials with TLS, so a plaintext agent is
 	// unreachable. The KubeVirt CA (served by virt-handler on CID 2, port 1)
@@ -154,6 +162,12 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	}
 	log.Infof("Listening on VSOCK port %d (pull mode)", cfg.port)
 
+	if urlUpdater != nil {
+		if err := urlUpdater.Start(ctx); err != nil {
+			return fmt.Errorf("starting repository-to-CPE mapping downloader: %w", err)
+		}
+	}
+
 	var wg sync.WaitGroup
 	wg.Go(func() { srv.Serve(ctx, ln) })
 	wg.Go(func() { vmRescanner.Run(ctx) })
@@ -161,31 +175,18 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	<-ctx.Done()
 	// Wait for Serve's graceful drain (in-flight connections) and the
 	// rescan loop to finish before returning, so the process doesn't exit
-	// mid-drain or mid-scan. mappingDownloader.Stop waits for its own
-	// background refresh loop the same way, once ctx is already done.
+	// mid-drain or mid-scan. urlUpdater.Stop waits for its own background
+	// refresh loop the same way, once ctx is already done.
 	wg.Wait()
-	mappingDownloader.Stop()
-	return nil
-}
-
-// logMappingDownloadResult logs a repository-to-CPE mapping download outcome and status of the local mapping file.
-func logMappingDownloadResult(url, cachePath string) func(err error, duration time.Duration) {
-	return func(err error, duration time.Duration) {
-		if err == nil {
-			log.Infof("Repository-to-CPE mapping file downloaded from %s in %s", url, duration)
-			return
-		}
-		if _, statErr := os.Stat(cachePath); statErr == nil {
-			log.Warnf("Repository-to-CPE mapping download failed after %s, scans keep using the previously cached file: %v", duration, err)
-			return
-		}
-		log.Errorf("Repository-to-CPE mapping download failed after %s, no cached file available: %v", duration, err)
+	if urlUpdater != nil {
+		urlUpdater.Stop()
 	}
+	return nil
 }
 
 // scan indexes the VM filesystem at hostPath, consulting the
 // repository-to-CPE mapping data cached at mappingFilePath.
-// The mapping downloader keeps mappingFilePath fresh independently.
+// The mapping provider keeps mappingFilePath fresh independently.
 func scan(ctx context.Context, hostPath, mappingFilePath string) (*v4.IndexReport, error) {
 	cfg := index.NodeIndexerConfig{
 		HostPath:            hostPath,

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -104,16 +104,9 @@ func (c serveConfig) validate() error {
 	return nil
 }
 
-// newRescannerAndProvider builds the rescanner and the mapping provider it
-// scans against: the URL-backed provider when repoCPEURL is set, the
-// Sensor-backed one (also usable as updater) otherwise. The rescanner is
-// constructed first, with a nil provider, so its OnMappingChanged callback
-// - passed to the provider's constructor below - has a live receiver even
-// if the provider invokes it synchronously during bootstrap (e.g. a valid
-// mapping already cached from a previous run); OnMappingChanged only
-// touches the rescanner's wake channel, never its provider field, so this
-// is safe regardless of ordering. urlUpdater is non-nil only in the
-// URL-backed case, for the caller to Start/Stop its download loop.
+// newRescannerAndProvider builds the rescanner and its mapping provider.
+// OnMappingChanged only touches the wake channel, so passing it to the
+// provider's constructor before provider is assigned below is safe.
 func newRescannerAndProvider(cache *vsockserver.ReportCache, cfg serveConfig) (vmRescanner *rescanner, provider vsockserver.MappingProvider, updater vsockserver.MappingUpdater, urlUpdater *vsockserver.URLUpdater) {
 	vmRescanner = newRescanner(cache, cfg.hostPath, nil, cfg.rescanInterval)
 

--- a/compliance/virtualmachines/roxagent/cmd/serve_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve_test.go
@@ -3,7 +3,11 @@ package cmd
 import (
 	"context"
 	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,13 +15,19 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // validMappingJSON is the minimal content repositorytocpe.ValidateMapping accepts.
-const validMappingJSON = `{"data":{}}`
+// otherValidMappingJSON is a distinct valid payload for tests that need two
+// different hashes (e.g. deferred-apply across a simulated scan).
+const (
+	validMappingJSON      = `{"data":{}}`
+	otherValidMappingJSON = `{"data":{"rhel-9-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:9"]}}}`
+)
 
 // waitTimeout/waitTick bound assert.Eventually polling for background
 // effects of a real (non-fake-clock) mapping update, e.g. onChange firing.
@@ -81,9 +91,17 @@ func TestNewRescannerAndProvider_NoMappingStaysIdle(t *testing.T) {
 	for name, repoCPEURL := range map[string]string{"Sensor-managed": "", "URL-managed": "https://example.invalid/repo-to-cpe.json"} {
 		t.Run(name, func(t *testing.T) {
 			withMappingCachePath(t)
-			_, provider, _, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{repoCPEURL: repoCPEURL})
+			vmRescanner, provider, _, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{repoCPEURL: repoCPEURL})
 
 			assert.False(t, provider.Ready(), "no cached mapping file must leave the provider not-Ready, not erroring")
+
+			var scanCalls int
+			vmRescanner.scanFn = func(context.Context, string, string) (*v4.IndexReport, error) {
+				scanCalls++
+				return &v4.IndexReport{}, nil
+			}
+			require.NoError(t, vmRescanner.scanOnce(t.Context()))
+			assert.Zero(t, scanCalls, "a not-Ready provider must never trigger a disk scan")
 		})
 	}
 }
@@ -108,7 +126,7 @@ func TestNewRescannerAndProvider_CallbackWiredAfterConstruction(t *testing.T) {
 // forget cache-persistence goroutine is real background I/O outside the
 // rescanner's own fake-clock-driven loop.
 func TestNewRescannerAndProvider_SyncKicksFirstScan(t *testing.T) {
-	withMappingCachePath(t)
+	cachePath := withMappingCachePath(t)
 	vmRescanner, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
 	require.False(t, provider.Ready())
 	require.NotNil(t, updater, "Sensor path must produce a non-nil updater")
@@ -136,6 +154,159 @@ func TestNewRescannerAndProvider_SyncKicksFirstScan(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return concurrency.WithLock1(&mu, func() int { return calls }) == 1
 	}, waitTimeout, waitTick, "a Sync-style mapping update should kick an immediate scan attempt")
+
+	// SensorUpdater.Update persists to disk via a fire-and-forget goroutine
+	// (see vsockserver.SensorUpdater.persistAndNotify), so the on-disk
+	// content lands independently of, and possibly after, the scan kick
+	// asserted above.
+	assert.Eventually(t, func() bool {
+		content, err := os.ReadFile(cachePath)
+		return err == nil && string(content) == validMappingJSON
+	}, waitTimeout, waitTick, "a synced mapping should also land in the on-disk cache")
+}
+
+// TestNewRescannerAndProvider_URLNeverSucceeds_StaysNotSensorManaged covers
+// a configured --repo-cpe-url that never produces a usable mapping: the
+// update path must stay URL, with no fallback to Sensor, even once the
+// downloader has actually attempted and failed a fetch. Log-level (ERROR
+// vs WARN) is not asserted here: the codebase has no lightweight log-
+// capture convention (see report), and URLUpdater.onDownloadComplete only
+// ever logs WARN today regardless of whether a mapping was ever
+// successfully fetched — see the task report for this gap.
+func TestNewRescannerAndProvider_URLNeverSucceeds_StaysNotSensorManaged(t *testing.T) {
+	withMappingCachePath(t)
+
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, provider, updater, urlUpdater := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{repoCPEURL: srv.URL})
+	require.Nil(t, updater)
+	require.NotNil(t, urlUpdater)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	require.NoError(t, urlUpdater.Start(ctx))
+	defer func() {
+		cancel()
+		urlUpdater.Stop()
+	}()
+
+	assert.Eventually(t, func() bool { return requests.Load() > 0 }, waitTimeout, waitTick,
+		"the downloader should have attempted at least one fetch against the configured URL")
+
+	assert.False(t, provider.Ready(), "a URL that never succeeds must never make the provider Ready")
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL, provider.UpdatePath(),
+		"a failing URL must not fall back to Sensor management")
+}
+
+// TestNewRescannerAndProvider_RestartSwitchesUpdatePath simulates an
+// operator adding or removing --repo-cpe-url between two agent restarts
+// that share the same on-disk mappingCachePath. Per the design, the
+// update path is re-derived purely from cfg.repoCPEURL on every restart,
+// never persisted; this table only pins that re-derivation, not whether
+// the previous updater's cached bytes get re-read (see report: cmd wires
+// both updaters to the same mappingCachePath file, so unlike the design's
+// "own cache file" wording, content bootstrapped by one updater is in
+// fact visible to the other after a switch).
+func TestNewRescannerAndProvider_RestartSwitchesUpdatePath(t *testing.T) {
+	tests := map[string]struct {
+		firstURL  string
+		secondURL string
+		wantFirst pb.RepoCPEMappingUpdatePath
+		wantAfter pb.RepoCPEMappingUpdatePath
+	}{
+		"adding --repo-cpe-url switches Sensor-managed to URL-managed": {
+			firstURL:  "",
+			secondURL: "https://example.invalid/repo-to-cpe.json",
+			wantFirst: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR,
+			wantAfter: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL,
+		},
+		"removing --repo-cpe-url switches URL-managed to Sensor-managed": {
+			firstURL:  "https://example.invalid/repo-to-cpe.json",
+			secondURL: "",
+			wantFirst: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL,
+			wantAfter: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			withMappingCachePath(t)
+
+			_, firstProvider, _, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{repoCPEURL: tt.firstURL})
+			require.Equal(t, tt.wantFirst, firstProvider.UpdatePath())
+
+			_, secondProvider, _, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{repoCPEURL: tt.secondURL})
+			assert.Equal(t, tt.wantAfter, secondProvider.UpdatePath(),
+				"a fresh restart must re-derive the update path from the current --repo-cpe-url, not remember the prior one")
+		})
+	}
+}
+
+// TestNewRescannerAndProvider_SensorSync_DefersUnderScanThenApplies covers
+// the cmd-level wiring for deferred apply: SensorUpdater's own deferred-
+// apply logic is unit-tested in vsockserver/sensor_updater_test.go, so this
+// only checks that newRescannerAndProvider's returned updater/provider
+// pair exposes that behavior end-to-end through the ScanBusyGate interface.
+func TestNewRescannerAndProvider_SensorSync_DefersUnderScanThenApplies(t *testing.T) {
+	cachePath := withMappingCachePath(t)
+	require.NoError(t, os.WriteFile(cachePath, []byte(validMappingJSON), 0o600))
+
+	_, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
+	require.True(t, provider.Ready(), "a pre-seeded Sensor cache must bootstrap the provider Ready")
+	require.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), provider.Hash())
+
+	gate, ok := updater.(vsockserver.ScanBusyGate)
+	require.True(t, ok, "the Sensor updater must implement ScanBusyGate")
+	gate.MarkScanBusy()
+
+	updated, err := updater.Update([]byte(otherValidMappingJSON))
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), provider.Hash(),
+		"the active mapping must stay the bootstrapped content while a scan is in flight")
+
+	gate.MarkScanIdleAndApplyPending()
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(otherValidMappingJSON)), provider.Hash(),
+		"the pending mapping should apply once the scan is marked idle")
+
+	// MarkScanIdleAndApplyPending's persist is also fire-and-forget; wait
+	// for it so the background write can't still be touching cachePath's
+	// directory when t.TempDir() cleans it up.
+	assert.Eventually(t, func() bool {
+		content, err := os.ReadFile(cachePath)
+		return err == nil && string(content) == otherValidMappingJSON
+	}, waitTimeout, waitTick, "the applied mapping should also land in the on-disk cache")
+}
+
+// TestNewRescannerAndProvider_SensorUpdate_InvalidContentKeepsLastGood
+// covers the cmd-level wiring only; SensorUpdater's own validation
+// behavior is unit-tested in vsockserver/sensor_updater_test.go.
+func TestNewRescannerAndProvider_SensorUpdate_InvalidContentKeepsLastGood(t *testing.T) {
+	cachePath := withMappingCachePath(t)
+	_, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
+
+	updated, err := updater.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	require.True(t, updated)
+	wantHash := provider.Hash()
+	// Drain the first Update's fire-and-forget persist before the test ends,
+	// so its background write can't still be touching cachePath's directory
+	// when t.TempDir() cleans it up.
+	assert.Eventually(t, func() bool {
+		content, err := os.ReadFile(cachePath)
+		return err == nil && string(content) == validMappingJSON
+	}, waitTimeout, waitTick, "the initial valid mapping should land in the on-disk cache")
+
+	updated, err = updater.Update([]byte(`{not valid json`))
+	assert.Error(t, err)
+	assert.False(t, updated)
+	assert.Equal(t, wantHash, provider.Hash(), "invalid content must not replace the last-known-good mapping")
 }
 
 // validServeConfig returns a serveConfig that passes validate(), so each

--- a/compliance/virtualmachines/roxagent/cmd/serve_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve_test.go
@@ -1,13 +1,142 @@
 package cmd
 
 import (
+	"context"
 	"crypto/x509"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// validMappingJSON is the minimal content repositorytocpe.ValidateMapping accepts.
+const validMappingJSON = `{"data":{}}`
+
+// waitTimeout/waitTick bound assert.Eventually polling for background
+// effects of a real (non-fake-clock) mapping update, e.g. onChange firing.
+const (
+	waitTimeout = 2 * time.Second
+	waitTick    = 10 * time.Millisecond
+)
+
+// withMappingCachePath points the package-level mappingCachePath at a fresh
+// file under a per-test temp dir, so tests never share state through it or
+// touch the real hardcoded path, and restores it afterward.
+func withMappingCachePath(t *testing.T) string {
+	t.Helper()
+	original := mappingCachePath
+	path := filepath.Join(t.TempDir(), "cache.json")
+	mappingCachePath = path
+	t.Cleanup(func() { mappingCachePath = original })
+	return path
+}
+
+func TestNewRescannerAndProvider_URLSelection(t *testing.T) {
+	withMappingCachePath(t)
+
+	tests := map[string]struct {
+		repoCPEURL     string
+		wantUpdatePath pb.RepoCPEMappingUpdatePath
+		wantUpdaterNil bool
+		wantURLUpdater bool
+	}{
+		"empty repo-cpe-url selects the Sensor-managed path": {
+			repoCPEURL:     "",
+			wantUpdatePath: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR,
+			wantUpdaterNil: false,
+			wantURLUpdater: false,
+		},
+		"non-empty repo-cpe-url selects the URL-managed path": {
+			repoCPEURL:     "https://example.invalid/repo-to-cpe.json",
+			wantUpdatePath: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL,
+			wantUpdaterNil: true,
+			wantURLUpdater: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg := serveConfig{repoCPEURL: tt.repoCPEURL}
+			_, provider, updater, urlUpdater := newRescannerAndProvider(&vsockserver.ReportCache{}, cfg)
+
+			assert.Equal(t, tt.wantUpdatePath, provider.UpdatePath())
+			assert.Equal(t, tt.wantUpdaterNil, updater == nil)
+			assert.Equal(t, tt.wantURLUpdater, urlUpdater != nil)
+		})
+	}
+}
+
+// TestNewRescannerAndProvider_NoMappingStaysIdle covers agent startup with
+// no mapping file present yet: the provider must report not-Ready instead
+// of treating a missing file as a fetch error, so runServe never attempts
+// a scan before a mapping actually arrives.
+func TestNewRescannerAndProvider_NoMappingStaysIdle(t *testing.T) {
+	for name, repoCPEURL := range map[string]string{"Sensor-managed": "", "URL-managed": "https://example.invalid/repo-to-cpe.json"} {
+		t.Run(name, func(t *testing.T) {
+			withMappingCachePath(t)
+			_, provider, _, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{repoCPEURL: repoCPEURL})
+
+			assert.False(t, provider.Ready(), "no cached mapping file must leave the provider not-Ready, not erroring")
+		})
+	}
+}
+
+// TestNewRescannerAndProvider_CallbackWiredAfterConstruction pins down the
+// construction order: the rescanner's provider field is only assigned
+// after the provider itself is built, but OnMappingChanged - already bound
+// to the rescanner - must be safe to call throughout, and the assignment
+// must have actually taken effect by the time construction returns.
+func TestNewRescannerAndProvider_CallbackWiredAfterConstruction(t *testing.T) {
+	withMappingCachePath(t)
+	vmRescanner, provider, _, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
+
+	assert.Same(t, provider, vmRescanner.provider, "the rescanner must observe the same provider instance constructed alongside it")
+	assert.NotPanics(t, vmRescanner.OnMappingChanged)
+}
+
+// TestNewRescannerAndProvider_SyncKicksFirstScan simulates a Sensor-pushed
+// mapping arriving (without any real VSOCK connection) and checks it wakes
+// the rescanner into an immediate scan attempt via the onChange wiring.
+// Runs on the real clock (not synctest): SensorUpdater.Update's fire-and-
+// forget cache-persistence goroutine is real background I/O outside the
+// rescanner's own fake-clock-driven loop.
+func TestNewRescannerAndProvider_SyncKicksFirstScan(t *testing.T) {
+	withMappingCachePath(t)
+	vmRescanner, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
+	require.False(t, provider.Ready())
+	require.NotNil(t, updater, "Sensor path must produce a non-nil updater")
+
+	var mu sync.Mutex
+	var calls int
+	vmRescanner.scanFn = func(context.Context, string, string) (*v4.IndexReport, error) {
+		concurrency.WithLock(&mu, func() { calls++ })
+		return &v4.IndexReport{}, nil
+	}
+	vmRescanner.factsFn = func(string) map[string]string { return nil }
+	vmRescanner.interval = time.Hour
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stopped := vmRescanner.runAsync(ctx)
+	defer func() {
+		cancel()
+		<-stopped
+	}()
+
+	updated, err := updater.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	assert.Eventually(t, func() bool {
+		return concurrency.WithLock1(&mu, func() int { return calls }) == 1
+	}, waitTimeout, waitTick, "a Sync-style mapping update should kick an immediate scan attempt")
+}
 
 // validServeConfig returns a serveConfig that passes validate(), so each
 // test case in TestRunServe_ValidatesFlags only needs to override the one

--- a/compliance/virtualmachines/roxagent/vsockserver/mapping.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/mapping.go
@@ -1,0 +1,29 @@
+package vsockserver
+
+import (
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+)
+
+// MappingProvider supplies the current repository-to-CPE mapping regardless
+// of which updater (Sensor-backed or URL-backed) owns it in this process.
+type MappingProvider interface {
+	Ready() bool
+	Hash() string
+	UpdatePath() pb.RepoCPEMappingUpdatePath
+	Bytes() ([]byte, error)
+	Path() (string, error)
+}
+
+// MappingUpdater accepts new mapping content pushed in over VSOCK. Only the
+// Sensor-backed updater implements this; a URL-backed agent's Handler keeps
+// its updater reference nil and rejects SyncRepoCPEMapping instead.
+type MappingUpdater interface {
+	Update(content []byte) (updated bool, err error)
+}
+
+// ScanBusyGate is implemented by the Sensor updater so rescanner/Handler
+// can defer active applies across an in-flight scan + GetReport send.
+type ScanBusyGate interface {
+	MarkScanBusy()
+	MarkScanIdleAndApplyPending()
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol.go
@@ -11,12 +11,14 @@ import (
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const maxRequestSize = 1 << 20 // 1 MiB
+// maxRequestSize must fit a synced repo-to-CPE mapping (up to MaxMappingBytes) plus envelope headroom, not just a GetReport request.
+const maxRequestSize = repositorytocpe.MaxMappingBytes + 1<<20
 
 // reportSnapshot is an immutable point-in-time view of the cached report state.
 type reportSnapshot struct {
@@ -78,6 +80,8 @@ func cloneFacts(in map[string]string) map[string]string {
 type Handler struct {
 	cache        *ReportCache
 	agentVersion string
+	provider     MappingProvider
+	updater      MappingUpdater
 	// epoch is seeded once per process lifetime and never persisted to VM
 	// disk. It lets Sensor (and this handler itself, via GetReportRequest's
 	// known_epoch) distinguish "this agent restarted" from "this agent's
@@ -87,9 +91,10 @@ type Handler struct {
 	epoch uint32
 }
 
-// NewHandler creates a protocol handler.
-func NewHandler(cache *ReportCache, agentVersion string) *Handler {
-	return &Handler{cache: cache, agentVersion: agentVersion, epoch: newEpoch()}
+// NewHandler creates a protocol handler. updater is nil for URL-managed
+// agents, so SyncRepoCPEMapping is rejected with MAPPING_NOT_SENSOR_MANAGED.
+func NewHandler(cache *ReportCache, agentVersion string, provider MappingProvider, updater MappingUpdater) *Handler {
+	return &Handler{cache: cache, agentVersion: agentVersion, provider: provider, updater: updater, epoch: newEpoch()}
 }
 
 // newEpoch derives a process-lifetime epoch value. Time-derived rather than
@@ -141,6 +146,12 @@ func (h *Handler) HandleConn(conn net.Conn) {
 	}
 	if err := vsockframing.WriteFrame(conn, respData); err != nil {
 		log.Errorf("Writing response frame: %v", err)
+		return
+	}
+	// Only now that the report for whatever scan may have been in flight has
+	// actually gone out is it safe to promote a Sync that arrived mid-scan.
+	if gate, ok := h.provider.(ScanBusyGate); ok {
+		gate.MarkScanIdleAndApplyPending()
 	}
 }
 
@@ -148,12 +159,19 @@ func (h *Handler) dispatch(req *pb.VMServiceRequest) *pb.VMServiceResponse {
 	switch req.GetMethod().(type) {
 	case *pb.VMServiceRequest_GetReport:
 		return h.handleGetReport(req.GetGetReport())
+	case *pb.VMServiceRequest_SyncRepoCpeMapping:
+		return h.handleSyncRepoCPEMapping(req.GetSyncRepoCpeMapping())
 	default:
 		return h.errorResponse(pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD, "unknown or unset method")
 	}
 }
 
 func (h *Handler) handleGetReport(req *pb.GetReportRequest) *pb.VMServiceResponse {
+	if !h.provider.Ready() {
+		log.Info("GetReport: no repo-to-CPE mapping available yet")
+		return h.errorResponse(pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED, "repository-to-CPE mapping not yet available")
+	}
+
 	snap := h.cache.snap.Load()
 	if snap == nil || snap.report == nil {
 		log.Info("GetReport: not ready (initial scan in progress)")
@@ -200,17 +218,39 @@ func (h *Handler) newResponseFromSnap(snap *reportSnapshot) *pb.VMServiceRespons
 		facts = cloneFacts(snap.facts)
 		gen = snap.generation
 	}
+	updatePath := h.provider.UpdatePath()
 	meta := &pb.ResponseMeta{
-		AgentVersion:     h.agentVersion,
-		ReportGeneration: gen,
-		SupportedMethods: []string{"get_report"},
-		Facts:            facts,
-		Epoch:            h.epoch,
+		AgentVersion:             h.agentVersion,
+		ReportGeneration:         gen,
+		SupportedMethods:         []string{"get_report", "sync_repo_cpe_mapping"},
+		Facts:                    facts,
+		Epoch:                    h.epoch,
+		RepoCpeMappingHash:       proto.String(h.provider.Hash()),
+		RepoCpeMappingUpdatePath: updatePath.Enum(),
 	}
 	if snap != nil && !snap.generatedAt.IsZero() {
 		meta.ReportGeneratedAt = timestamppb.New(snap.generatedAt)
 	}
 	return &pb.VMServiceResponse{Meta: meta}
+}
+
+// handleSyncRepoCPEMapping applies a Sensor-pushed mapping. URL-managed
+// agents (updater == nil) reject Sync outright; Update keeps the last-good
+// mapping on a validation failure, so an err here never leaves the agent
+// without a usable mapping.
+func (h *Handler) handleSyncRepoCPEMapping(req *pb.SyncRepoCPEMappingRequest) *pb.VMServiceResponse {
+	if h.updater == nil {
+		return h.errorResponse(pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED, "agent is URL-managed and does not accept pushed mappings")
+	}
+	updated, err := h.updater.Update(req.GetMapping())
+	if err != nil {
+		return h.errorResponse(pb.ErrorCode_ERROR_CODE_INTERNAL, fmt.Sprintf("invalid repository-to-CPE mapping: %v", err))
+	}
+	resp := h.newResponseFromSnap(h.cache.snap.Load())
+	resp.Result = &pb.VMServiceResponse_SyncRepoCpeMapping{
+		SyncRepoCpeMapping: &pb.SyncRepoCPEMappingResponse{Updated: updated},
+	}
+	return resp
 }
 
 func (h *Handler) errorResponse(code pb.ErrorCode, msg string) *pb.VMServiceResponse {

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol.go
@@ -236,8 +236,7 @@ func (h *Handler) newResponseFromSnap(snap *reportSnapshot) *pb.VMServiceRespons
 
 // handleSyncRepoCPEMapping applies a Sensor-pushed mapping. URL-managed
 // agents (updater == nil) reject Sync outright; Update keeps the last-good
-// mapping on a validation failure, so an err here never leaves the agent
-// without a usable mapping.
+// mapping on a validation failure.
 func (h *Handler) handleSyncRepoCPEMapping(req *pb.SyncRepoCPEMappingRequest) *pb.VMServiceResponse {
 	if h.updater == nil {
 		return h.errorResponse(pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED, "agent is URL-managed and does not accept pushed mappings")

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
@@ -1,8 +1,10 @@
 package vsockserver
 
 import (
+	"errors"
 	"net"
 	"testing"
+	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -11,6 +13,60 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+// fakeMappingProvider is a MappingProvider test double whose Ready/Hash/
+// UpdatePath are directly settable; Bytes/Path are unused by the Handler
+// and always error.
+type fakeMappingProvider struct {
+	ready      bool
+	hash       string
+	updatePath pb.RepoCPEMappingUpdatePath
+}
+
+func (f *fakeMappingProvider) Ready() bool                             { return f.ready }
+func (f *fakeMappingProvider) Hash() string                            { return f.hash }
+func (f *fakeMappingProvider) UpdatePath() pb.RepoCPEMappingUpdatePath { return f.updatePath }
+func (f *fakeMappingProvider) Bytes() ([]byte, error)                  { return nil, errors.New("not implemented") }
+func (f *fakeMappingProvider) Path() (string, error)                   { return "", errors.New("not implemented") }
+
+var _ MappingProvider = (*fakeMappingProvider)(nil)
+
+// fakeGatedProvider adds ScanBusyGate call tracking on top of
+// fakeMappingProvider, mirroring SensorUpdater (gated) as opposed to
+// URLUpdater (ungated) so tests can verify HandleConn only invokes the
+// gate for providers that implement it.
+type fakeGatedProvider struct {
+	fakeMappingProvider
+	busyCalls int
+	idleCalls int
+}
+
+func (f *fakeGatedProvider) MarkScanBusy()                { f.busyCalls++ }
+func (f *fakeGatedProvider) MarkScanIdleAndApplyPending() { f.idleCalls++ }
+
+var (
+	_ MappingProvider = (*fakeGatedProvider)(nil)
+	_ ScanBusyGate    = (*fakeGatedProvider)(nil)
+)
+
+// fakeMappingUpdater is a MappingUpdater test double that returns a fixed
+// (updated, err) pair and records the content it was called with.
+type fakeMappingUpdater struct {
+	updated bool
+	err     error
+	calls   [][]byte
+}
+
+func (f *fakeMappingUpdater) Update(content []byte) (bool, error) {
+	f.calls = append(f.calls, content)
+	return f.updated, f.err
+}
+
+var _ MappingUpdater = (*fakeMappingUpdater)(nil)
+
+// readyProvider is the default fakeMappingProvider for GetReport test
+// cases that aren't exercising mapping-readiness behavior itself.
+func readyProvider() *fakeMappingProvider { return &fakeMappingProvider{ready: true} }
 
 func sendAndReceive(t *testing.T, handler *Handler, req *pb.VMServiceRequest) *pb.VMServiceResponse {
 	t.Helper()
@@ -33,8 +89,9 @@ func sendAndReceive(t *testing.T, handler *Handler, req *pb.VMServiceRequest) *p
 func TestHandleRequest_GetReport(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
+	provider := &fakeMappingProvider{ready: true, hash: "mapping-hash", updatePath: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR}
 
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", provider, nil)
 	req := &pb.VMServiceRequest{
 		Meta:   &pb.RequestMeta{RequestId: "req-1", Capabilities: []string{"report_v1"}},
 		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{LastKnownGeneration: 0}},
@@ -52,14 +109,17 @@ func TestHandleRequest_GetReport(t *testing.T) {
 	assert.Equal(t, uint32(1), meta.GetReportGeneration())
 	assert.NotNil(t, meta.GetReportGeneratedAt())
 	assert.Contains(t, meta.GetSupportedMethods(), "get_report")
+	assert.Contains(t, meta.GetSupportedMethods(), "sync_repo_cpe_mapping")
 	assert.NotZero(t, meta.GetEpoch(), "epoch should be seeded on handler creation")
+	assert.Equal(t, "mapping-hash", meta.GetRepoCpeMappingHash())
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, meta.GetRepoCpeMappingUpdatePath())
 }
 
 func TestHandleRequest_GetReport_Unchanged(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
 
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 	req := &pb.VMServiceRequest{
 		Meta:   &pb.RequestMeta{RequestId: "req-2"},
 		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{LastKnownGeneration: 1}},
@@ -76,7 +136,7 @@ func TestHandleRequest_GetReport_UnchangedWhenKnownEpochMatches(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
 
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 	// Learn the handler's epoch from a first exchange (known_epoch=0, so
 	// Sensor has no cached epoch yet — falls back to generation-only).
 	firstResp := sendAndReceive(t, handler, &pb.VMServiceRequest{
@@ -112,7 +172,7 @@ func TestHandleRequest_GetReport_ServesFullReportOnKnownEpochMismatch(t *testing
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "post-restart-hash"}, nil)
 
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 	req := &pb.VMServiceRequest{
 		Meta: &pb.RequestMeta{RequestId: "req-epoch-mismatch"},
 		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
@@ -141,7 +201,7 @@ func TestHandleRequest_GetReport_UnchangedWhenKnownEpochZero(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
 
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 	req := &pb.VMServiceRequest{
 		Meta: &pb.RequestMeta{RequestId: "req-epoch-zero"},
 		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
@@ -161,7 +221,7 @@ func TestHandleRequest_GetReport_GenerationRegression(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "post-restart-hash"}, nil)
 
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 	req := &pb.VMServiceRequest{
 		Meta: &pb.RequestMeta{RequestId: "req-regression"},
 		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
@@ -179,7 +239,7 @@ func TestHandleRequest_GetReport_GenerationRegression(t *testing.T) {
 
 func TestHandleRequest_NotReady(t *testing.T) {
 	cache := &ReportCache{}
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 	req := &pb.VMServiceRequest{
 		Meta:   &pb.RequestMeta{RequestId: "req-3"},
 		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}},
@@ -195,7 +255,7 @@ func TestHandleRequest_NotReady(t *testing.T) {
 func TestHandleRequest_UnknownMethod(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "x"}, nil)
-	handler := NewHandler(cache, "test-1.0.0")
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
 
 	req := &pb.VMServiceRequest{
 		Meta: &pb.RequestMeta{RequestId: "req-4"},
@@ -207,4 +267,146 @@ func TestHandleRequest_UnknownMethod(t *testing.T) {
 	assert.Nil(t, resp.GetGetReport())
 	require.NotNil(t, resp.GetError())
 	assert.Equal(t, pb.ErrorCode_ERROR_CODE_UNKNOWN_METHOD, resp.GetError().GetCode())
+}
+
+func TestHandleRequest_GetReport_MappingRequired(t *testing.T) {
+	cache := &ReportCache{}
+	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
+	handler := NewHandler(cache, "test-1.0.0", &fakeMappingProvider{ready: false}, nil)
+
+	req := &pb.VMServiceRequest{
+		Meta:   &pb.RequestMeta{RequestId: "req-mapping-required"},
+		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}},
+	}
+
+	resp := sendAndReceive(t, handler, req)
+
+	assert.Nil(t, resp.GetGetReport())
+	require.NotNil(t, resp.GetError())
+	assert.Equal(t, pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED, resp.GetError().GetCode())
+}
+
+// TestHandleRequest_MetadataAlwaysPresentOnError pins down that an empty
+// mapping hash is still an explicitly-present optional field, not a nil
+// one Sensor would have to special-case.
+func TestHandleRequest_MetadataAlwaysPresentOnError(t *testing.T) {
+	cache := &ReportCache{}
+	handler := NewHandler(cache, "test-1.0.0", &fakeMappingProvider{ready: false}, nil)
+
+	req := &pb.VMServiceRequest{
+		Meta:   &pb.RequestMeta{RequestId: "req-meta-on-error"},
+		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}},
+	}
+
+	resp := sendAndReceive(t, handler, req)
+
+	require.NotNil(t, resp.GetError())
+	meta := resp.GetMeta()
+	require.NotNil(t, meta)
+	require.NotNil(t, meta.RepoCpeMappingHash, "hash must be present-but-empty, not nil")
+	assert.Empty(t, meta.GetRepoCpeMappingHash())
+	require.NotNil(t, meta.RepoCpeMappingUpdatePath)
+	assert.Contains(t, meta.GetSupportedMethods(), "sync_repo_cpe_mapping")
+}
+
+func TestHandleRequest_SyncRepoCPEMapping(t *testing.T) {
+	tests := map[string]struct {
+		updater     *fakeMappingUpdater
+		wantCode    pb.ErrorCode
+		wantUpdated bool
+	}{
+		"new mapping content is applied": {
+			updater:     &fakeMappingUpdater{updated: true},
+			wantUpdated: true,
+		},
+		"unchanged mapping content is a no-op": {
+			updater:     &fakeMappingUpdater{updated: false},
+			wantUpdated: false,
+		},
+		"oversize or otherwise invalid content is rejected as internal error": {
+			updater:  &fakeMappingUpdater{err: errors.New("mapping size exceeds cap")},
+			wantCode: pb.ErrorCode_ERROR_CODE_INTERNAL,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := &ReportCache{}
+			handler := NewHandler(cache, "test-1.0.0", readyProvider(), tt.updater)
+			req := &pb.VMServiceRequest{
+				Meta:   &pb.RequestMeta{RequestId: "req-sync"},
+				Method: &pb.VMServiceRequest_SyncRepoCpeMapping{SyncRepoCpeMapping: &pb.SyncRepoCPEMappingRequest{Mapping: []byte("content")}},
+			}
+
+			resp := sendAndReceive(t, handler, req)
+
+			if tt.wantCode != pb.ErrorCode_ERROR_CODE_UNSPECIFIED {
+				require.NotNil(t, resp.GetError())
+				assert.Equal(t, tt.wantCode, resp.GetError().GetCode())
+				assert.Nil(t, resp.GetSyncRepoCpeMapping())
+				return
+			}
+			require.NotNil(t, resp.GetSyncRepoCpeMapping())
+			assert.Equal(t, tt.wantUpdated, resp.GetSyncRepoCpeMapping().GetUpdated())
+			require.Len(t, tt.updater.calls, 1)
+			assert.Equal(t, []byte("content"), tt.updater.calls[0])
+		})
+	}
+}
+
+func TestHandleRequest_SyncRepoCPEMapping_NilUpdater_NotSensorManaged(t *testing.T) {
+	cache := &ReportCache{}
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
+	req := &pb.VMServiceRequest{
+		Meta:   &pb.RequestMeta{RequestId: "req-sync-url-managed"},
+		Method: &pb.VMServiceRequest_SyncRepoCpeMapping{SyncRepoCpeMapping: &pb.SyncRepoCPEMappingRequest{Mapping: []byte("content")}},
+	}
+
+	resp := sendAndReceive(t, handler, req)
+
+	assert.Nil(t, resp.GetSyncRepoCpeMapping())
+	require.NotNil(t, resp.GetError())
+	assert.Equal(t, pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED, resp.GetError().GetCode())
+}
+
+// TestHandleConn_MarksProviderIdleAfterEveryResponse covers the deferred-
+// apply path end-to-end: a rescanner marking the provider busy before a
+// scan (simulated here directly) must see it cleared once - and only once
+// - HandleConn has actually written the response for that round trip, so
+// a Sync that arrived mid-scan can finally be promoted.
+func TestHandleConn_MarksProviderIdleAfterEveryResponse(t *testing.T) {
+	cache := &ReportCache{}
+	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
+	provider := &fakeGatedProvider{fakeMappingProvider: fakeMappingProvider{ready: true}}
+	handler := NewHandler(cache, "test-1.0.0", provider, nil)
+
+	provider.MarkScanBusy()
+	req := &pb.VMServiceRequest{
+		Meta:   &pb.RequestMeta{RequestId: "req-deferred-apply"},
+		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}},
+	}
+
+	sendAndReceive(t, handler, req)
+
+	// HandleConn's post-write call happens after the client has already read
+	// the response (see sendAndReceive), so it may not have run yet here.
+	assert.Eventually(t, func() bool { return provider.idleCalls == 1 }, time.Second, time.Millisecond,
+		"idle-and-apply-pending must fire exactly once, after the response is sent")
+}
+
+// TestHandleConn_UngatedProviderNeverPanics covers a URL-managed agent's
+// provider, which does not implement ScanBusyGate: HandleConn's post-write
+// type assertion must be a silent no-op instead of a panic.
+func TestHandleConn_UngatedProviderNeverPanics(t *testing.T) {
+	cache := &ReportCache{}
+	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
+
+	req := &pb.VMServiceRequest{
+		Meta:   &pb.RequestMeta{RequestId: "req-ungated"},
+		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}},
+	}
+
+	resp := sendAndReceive(t, handler, req)
+	assert.NotNil(t, resp.GetGetReport())
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -1,0 +1,193 @@
+package vsockserver
+
+import (
+	"bytes"
+	"errors"
+	"os"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/filedownloader"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	_ MappingProvider = (*SensorUpdater)(nil)
+	_ MappingUpdater  = (*SensorUpdater)(nil)
+	_ ScanBusyGate    = (*SensorUpdater)(nil)
+)
+
+var errSensorMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
+
+// SensorUpdater is the MappingProvider/MappingUpdater/ScanBusyGate for an
+// agent whose mapping is pushed in over VSOCK via SyncRepoCPEMapping. It
+// defers applying a new mapping into active while busy is set, so an
+// in-flight VM-disk scan (and the GetReport response for it) never
+// observes the active mapping change mid-flight.
+type SensorUpdater struct {
+	active     []byte
+	activeHash string
+	cachePath  string
+	pending    []byte
+	busy       bool
+	onChange   func()
+	mu         sync.Mutex
+}
+
+// NewSensorUpdater seeds active from cachePath if it holds a validated
+// mapping, else from bundledPath if non-empty and validated, else stays
+// empty until the first Update. onChange must already be non-nil by the
+// time any bootstrap content is found, so construct dependents (e.g. the
+// rescanner) before calling this.
+func NewSensorUpdater(cachePath, bundledPath string, onChange func()) *SensorUpdater {
+	u := &SensorUpdater{cachePath: cachePath, onChange: onChange}
+	if u.bootstrapFrom(cachePath) || u.bootstrapFrom(bundledPath) {
+		if onChange != nil {
+			onChange()
+		}
+	}
+	return u
+}
+
+// bootstrapFrom seeds active/activeHash from path if it decodes as a valid
+// mapping. A no-op for an empty path, so the optional bundled seed can be
+// skipped by passing "". Reports whether it seeded active.
+func (u *SensorUpdater) bootstrapFrom(path string) bool {
+	if path == "" {
+		return false
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		log.Warnf("Ignoring invalid repo-to-CPE mapping at %q: %v", path, err)
+		return false
+	}
+	u.active = content
+	u.activeHash = repositorytocpe.HashMapping(content)
+	return true
+}
+
+// Ready reports whether a validated mapping is currently active.
+func (u *SensorUpdater) Ready() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.active) > 0
+}
+
+// Hash returns the active mapping's content hash, or "" if not Ready.
+func (u *SensorUpdater) Hash() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.activeHash
+}
+
+// UpdatePath reports this updater's mapping source for ResponseMeta.
+func (u *SensorUpdater) UpdatePath() pb.RepoCPEMappingUpdatePath {
+	return pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR
+}
+
+// Bytes returns a copy of the active mapping content.
+func (u *SensorUpdater) Bytes() ([]byte, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if len(u.active) == 0 {
+		return nil, errSensorMappingNotReady
+	}
+	out := make([]byte, len(u.active))
+	copy(out, u.active)
+	return out, nil
+}
+
+// Path returns cachePath after (re-)writing it with the active mapping, so
+// callers always get a file whose content matches Bytes() even if the
+// fire-and-forget persistence from the last apply has not landed yet.
+func (u *SensorUpdater) Path() (string, error) {
+	u.mu.Lock()
+	active := u.active
+	cachePath := u.cachePath
+	u.mu.Unlock()
+	if len(active) == 0 {
+		return "", errSensorMappingNotReady
+	}
+	if err := filedownloader.AtomicWriteFile(cachePath, active); err != nil {
+		return "", err
+	}
+	return cachePath, nil
+}
+
+// Update validates content and either applies it to active immediately or,
+// if a scan is in flight (busy), stages it as pending for
+// MarkScanIdleAndApplyPending to promote later. updated is false only when
+// content is invalid or already equal to the current active/pending
+// content; a validation error never touches state.
+func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		return false, err
+	}
+	hash := repositorytocpe.HashMapping(content)
+
+	u.mu.Lock()
+	if hash == u.activeHash || bytes.Equal(content, u.pending) {
+		u.mu.Unlock()
+		return false, nil
+	}
+	if u.busy {
+		u.pending = content
+		u.mu.Unlock()
+		log.Infof("SyncRepoCPEMapping: deferring apply of mapping (hash=%s) until the in-flight scan finishes", hash)
+		return true, nil
+	}
+	u.applyLocked(content, hash)
+	u.mu.Unlock()
+	u.persistAndNotify(content)
+	return true, nil
+}
+
+// MarkScanBusy marks a VM-disk scan in progress, so a concurrent Update
+// stages new content as pending instead of mutating active underneath it.
+func (u *SensorUpdater) MarkScanBusy() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.busy = true
+}
+
+// MarkScanIdleAndApplyPending clears busy and, if Update staged content
+// while busy, promotes it to active now that the scan (and its GetReport
+// response) has finished.
+func (u *SensorUpdater) MarkScanIdleAndApplyPending() {
+	u.mu.Lock()
+	u.busy = false
+	pending := u.pending
+	if pending == nil {
+		u.mu.Unlock()
+		return
+	}
+	u.pending = nil
+	u.applyLocked(pending, repositorytocpe.HashMapping(pending))
+	u.mu.Unlock()
+	u.persistAndNotify(pending)
+}
+
+// applyLocked sets active/activeHash to content/hash. Caller must hold mu.
+func (u *SensorUpdater) applyLocked(content []byte, hash string) {
+	u.active = content
+	u.activeHash = hash
+}
+
+// persistAndNotify writes content to cachePath in the background - a scan
+// or another Update must never block on disk I/O - then synchronously
+// fires onChange so the caller's later reads already see the new active
+// mapping.
+func (u *SensorUpdater) persistAndNotify(content []byte) {
+	cachePath := u.cachePath
+	go func() {
+		if err := filedownloader.AtomicWriteFile(cachePath, content); err != nil {
+			log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", cachePath, err)
+		}
+	}()
+	if u.onChange != nil {
+		u.onChange()
+	}
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/filedownloader"
 	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
@@ -100,10 +101,9 @@ func (u *SensorUpdater) Bytes() ([]byte, error) {
 // callers always get a file whose content matches Bytes() even if the
 // fire-and-forget persistence from the last apply has not landed yet.
 func (u *SensorUpdater) Path() (string, error) {
-	u.mu.Lock()
-	active := u.active
-	cachePath := u.cachePath
-	u.mu.Unlock()
+	active, cachePath := concurrency.WithLock2(&u.mu, func() ([]byte, string) {
+		return u.active, u.cachePath
+	})
 	if len(active) == 0 {
 		return "", errSensorMappingNotReady
 	}
@@ -122,19 +122,24 @@ func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 	}
 	hash := repositorytocpe.HashMapping(content)
 
-	u.mu.Lock()
-	if hash == u.activeHash || bytes.Equal(content, u.pending) {
-		u.mu.Unlock()
+	updated, deferred := concurrency.WithLock2(&u.mu, func() (bool, bool) {
+		if hash == u.activeHash || bytes.Equal(content, u.pending) {
+			return false, false
+		}
+		if u.busy {
+			u.pending = content
+			return true, true
+		}
+		u.applyLocked(content, hash)
+		return true, false
+	})
+	if !updated {
 		return false, nil
 	}
-	if u.busy {
-		u.pending = content
-		u.mu.Unlock()
+	if deferred {
 		log.Infof("SyncRepoCPEMapping: deferring apply of mapping (hash=%s) until the in-flight scan finishes", hash)
 		return true, nil
 	}
-	u.applyLocked(content, hash)
-	u.mu.Unlock()
 	u.persistAndNotify(content)
 	return true, nil
 }
@@ -151,17 +156,19 @@ func (u *SensorUpdater) MarkScanBusy() {
 // while busy, promotes it to active now that the scan (and its GetReport
 // response) has finished.
 func (u *SensorUpdater) MarkScanIdleAndApplyPending() {
-	u.mu.Lock()
-	u.busy = false
-	pending := u.pending
-	if pending == nil {
-		u.mu.Unlock()
-		return
+	pending := concurrency.WithLock1(&u.mu, func() []byte {
+		u.busy = false
+		pending := u.pending
+		if pending == nil {
+			return nil
+		}
+		u.pending = nil
+		u.applyLocked(pending, repositorytocpe.HashMapping(pending))
+		return pending
+	})
+	if pending != nil {
+		u.persistAndNotify(pending)
 	}
-	u.pending = nil
-	u.applyLocked(pending, repositorytocpe.HashMapping(pending))
-	u.mu.Unlock()
-	u.persistAndNotify(pending)
 }
 
 // applyLocked sets active/activeHash to content/hash. Caller must hold mu.

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -19,11 +19,9 @@ var (
 
 var errSensorMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
 
-// SensorUpdater is the MappingProvider/MappingUpdater/ScanBusyGate for an
-// agent whose mapping is pushed in over VSOCK via SyncRepoCPEMapping. It
-// defers applying a new mapping into active while busy is set, so an
-// in-flight VM-disk scan (and the GetReport response for it) never
-// observes the active mapping change mid-flight.
+// SensorUpdater applies repo-to-CPE mappings pushed in over VSOCK via
+// SyncRepoCPEMapping, deferring the apply while busy is set so an
+// in-flight scan's GetReport response never sees a mid-flight change.
 type SensorUpdater struct {
 	active     []byte
 	activeHash string
@@ -34,11 +32,9 @@ type SensorUpdater struct {
 	mu         sync.Mutex
 }
 
-// NewSensorUpdater seeds active from cachePath if it holds a validated
-// mapping, else from bundledPath if non-empty and validated, else stays
-// empty until the first Update. onChange must already be non-nil by the
-// time any bootstrap content is found, so construct dependents (e.g. the
-// rescanner) before calling this.
+// NewSensorUpdater seeds active from cachePath, else bundledPath, else
+// stays empty until the first Update. Construct onChange's dependents
+// (e.g. the rescanner) first, since it may fire during this call.
 func NewSensorUpdater(cachePath, bundledPath string, onChange func()) *SensorUpdater {
 	u := &SensorUpdater{cachePath: cachePath, onChange: onChange}
 	if u.bootstrapFrom(cachePath) || u.bootstrapFrom(bundledPath) {
@@ -117,11 +113,9 @@ func (u *SensorUpdater) Path() (string, error) {
 	return cachePath, nil
 }
 
-// Update validates content and either applies it to active immediately or,
-// if a scan is in flight (busy), stages it as pending for
-// MarkScanIdleAndApplyPending to promote later. updated is false only when
-// content is invalid or already equal to the current active/pending
-// content; a validation error never touches state.
+// Update applies content to active immediately, or stages it as pending
+// for MarkScanIdleAndApplyPending to promote later if a scan is in
+// flight (busy), so it never mutates active out from under that scan.
 func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 	if err := repositorytocpe.ValidateMapping(content); err != nil {
 		return false, err
@@ -176,10 +170,9 @@ func (u *SensorUpdater) applyLocked(content []byte, hash string) {
 	u.activeHash = hash
 }
 
-// persistAndNotify writes content to cachePath in the background - a scan
-// or another Update must never block on disk I/O - then synchronously
-// fires onChange so the caller's later reads already see the new active
-// mapping.
+// persistAndNotify writes content to cachePath in the background, then
+// synchronously fires onChange so the caller's later reads already see
+// the new active mapping.
 func (u *SensorUpdater) persistAndNotify(content []byte) {
 	cachePath := u.cachePath
 	go func() {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -1,0 +1,255 @@
+package vsockserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validMappingJSON = `{"data":{"rhel-8-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:8"]}}}`
+const otherValidMappingJSON = `{"data":{"rhel-9-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:9"]}}}`
+const invalidMappingJSON = `{not json`
+
+// waitTimeout/waitTick bound assert.Eventually polling for the
+// fire-and-forget cache-persistence goroutine shared by both updaters' tests.
+const (
+	waitTimeout = 2 * time.Second
+	waitTick    = 10 * time.Millisecond
+)
+
+// onChangeCounter is a test double for a MappingProvider's onChange
+// callback that records how many times it fired.
+type onChangeCounter struct {
+	count int
+}
+
+func (c *onChangeCounter) fn() { c.count++ }
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+}
+
+// waitForCacheContent polls cachePath for the persist goroutine an applied
+// Update starts in the background, so tests can drain it deterministically
+// instead of letting it race the tempdir's end-of-test cleanup.
+func waitForCacheContent(t *testing.T, cachePath, want string) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		b, err := os.ReadFile(cachePath)
+		return err == nil && string(b) == want
+	}, waitTimeout, waitTick, "expected %q to be persisted to %s", want, cachePath)
+}
+
+func TestNewSensorUpdater_EmptyStart_NotReady(t *testing.T) {
+	dir := t.TempDir()
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), "", counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Empty(t, u.Hash())
+	assert.Equal(t, 0, counter.count)
+
+	_, err := u.Bytes()
+	assert.Error(t, err)
+	_, err = u.Path()
+	assert.Error(t, err)
+}
+
+func TestNewSensorUpdater_BootstrapFromCache(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+	assert.Equal(t, 1, counter.count, "onChange should fire once for a valid bootstrap")
+}
+
+func TestNewSensorUpdater_BootstrapFromBundled_WhenNoCache(t *testing.T) {
+	dir := t.TempDir()
+	bundledPath := filepath.Join(dir, "bundled.json")
+	writeFile(t, bundledPath, validMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), bundledPath, counter.fn)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count)
+}
+
+func TestNewSensorUpdater_CacheTakesPrecedenceOverBundled(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	bundledPath := filepath.Join(dir, "bundled.json")
+	writeFile(t, cachePath, validMappingJSON)
+	writeFile(t, bundledPath, otherValidMappingJSON)
+
+	u := NewSensorUpdater(cachePath, bundledPath, func() {})
+
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b), "a valid cache must win over a valid bundled file")
+}
+
+func TestNewSensorUpdater_InvalidCacheFallsBackToBundled(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	bundledPath := filepath.Join(dir, "bundled.json")
+	writeFile(t, cachePath, invalidMappingJSON)
+	writeFile(t, bundledPath, validMappingJSON)
+
+	u := NewSensorUpdater(cachePath, bundledPath, func() {})
+
+	require.True(t, u.Ready())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+}
+
+func TestNewSensorUpdater_InvalidCacheNoBundled_NotReady(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, invalidMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Equal(t, 0, counter.count)
+}
+
+func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+
+	updated, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.True(t, updated)
+	assert.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count)
+	waitForCacheContent(t, cachePath, validMappingJSON)
+}
+
+func TestSensorUpdater_Update_NoOpWhenUnchanged(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	u := NewSensorUpdater(cachePath, "", func() {})
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	waitForCacheContent(t, cachePath, validMappingJSON)
+
+	updated, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.False(t, updated, "re-applying identical content must be a no-op")
+}
+
+func TestSensorUpdater_Update_RejectsInvalidKeepsLastGood(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	u := NewSensorUpdater(cachePath, "", func() {})
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	wantHash := u.Hash()
+	waitForCacheContent(t, cachePath, validMappingJSON)
+
+	updated, err := u.Update([]byte(invalidMappingJSON))
+	assert.Error(t, err)
+	assert.False(t, updated)
+	assert.Equal(t, wantHash, u.Hash(), "invalid content must not replace the last-good mapping")
+}
+
+func TestSensorUpdater_Update_OversizeRejected(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	oversized := make([]byte, repositorytocpe.MaxMappingBytes+1)
+
+	updated, err := u.Update(oversized)
+	assert.Error(t, err)
+	assert.False(t, updated)
+	assert.False(t, u.Ready())
+}
+
+func TestSensorUpdater_UpdateWhileBusy_DefersUntilIdle(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.count)
+	idleHash := u.Hash()
+	idleBytes, err := u.Bytes()
+	require.NoError(t, err)
+
+	u.MarkScanBusy()
+
+	updated, err := u.Update([]byte(otherValidMappingJSON))
+	require.NoError(t, err)
+	assert.True(t, updated, "a genuinely new candidate is reported as updated even while deferred")
+
+	// While busy, active content (and therefore Hash/Bytes) must not change:
+	// an in-flight scan may still be reading these values.
+	assert.Equal(t, idleHash, u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, idleBytes, b)
+	assert.Equal(t, 1, counter.count, "onChange must not fire for a deferred apply")
+
+	u.MarkScanIdleAndApplyPending()
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(otherValidMappingJSON)), u.Hash())
+	b, err = u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, otherValidMappingJSON, string(b))
+	assert.Equal(t, 2, counter.count, "onChange must fire once the pending mapping is promoted")
+	waitForCacheContent(t, cachePath, otherValidMappingJSON)
+}
+
+func TestSensorUpdater_UpdateWhileBusy_SameAsPending_NoOp(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	u.MarkScanBusy()
+
+	updated, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.True(t, updated)
+
+	updated, err = u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.False(t, updated, "re-staging identical pending content must be a no-op")
+}
+
+func TestSensorUpdater_MarkScanIdleAndApplyPending_NoPending_NoOp(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	counter := &onChangeCounter{}
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.count)
+	waitForCacheContent(t, cachePath, validMappingJSON)
+
+	u.MarkScanBusy()
+	u.MarkScanIdleAndApplyPending()
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count, "onChange must not fire when there is nothing pending to apply")
+}
+
+func TestSensorUpdater_UpdatePath_IsSensor(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, u.UpdatePath())
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -18,7 +18,7 @@ import (
 // rejects a second connection with an ERROR_CODE_BUSY response while the first
 // is still being handled, and that cancelling the context drains gracefully.
 func TestServeAcceptLoop(t *testing.T) {
-	handler := NewHandler(&ReportCache{}, "test")
+	handler := NewHandler(&ReportCache{}, "test", readyProvider(), nil)
 	srv := NewServer(handler, nil)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -74,7 +74,7 @@ func TestServeAcceptLoop(t *testing.T) {
 // The client must only ReadFrame here - writing a request races rejectConn's
 // close-after-BUSY and flakes with broken pipe on Linux.
 func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing.T) {
-	handler := NewHandler(&ReportCache{}, "test")
+	handler := NewHandler(&ReportCache{}, "test", readyProvider(), nil)
 	srv := NewServer(handler, &tls.Config{Certificates: []tls.Certificate{testServerCert(t)}})
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -1,0 +1,160 @@
+package vsockserver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/filedownloader"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// Retry/refresh policy for the periodic mapping download, mirroring
+// cmd.newMappingDownloader: WaitMin=5s with the default WaitMax=30s covers
+// four HTTP attempts (5+10+20=35s) within urlMappingClientTimeout.
+const (
+	urlMappingFetchRetryMax     = 3
+	urlMappingFetchRetryWaitMin = 5 * time.Second
+	urlMappingClientTimeout     = 2 * time.Minute
+	urlMappingRefreshInterval   = time.Hour
+)
+
+var _ MappingProvider = (*URLUpdater)(nil)
+
+var errURLMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
+
+// URLUpdater is the MappingProvider for an agent configured with a
+// mapping URL. It only implements MappingProvider: Handler keeps its
+// updater reference nil for URL-backed agents, since this mapping source
+// never accepts a Sensor-pushed Update.
+type URLUpdater struct {
+	downloader *filedownloader.Downloader
+	cachePath  string
+	active     []byte
+	activeHash string
+	onChange   func()
+	mu         sync.Mutex
+}
+
+// NewURLUpdater seeds active from cachePath if it holds a validated
+// mapping (e.g. left by a prior process's successful download), else
+// stays empty until the first successful fetch. There is no bundled-file
+// fallback: a URL-backed agent has exactly one mapping source.
+func NewURLUpdater(url, cachePath string, onChange func()) *URLUpdater {
+	u := &URLUpdater{cachePath: cachePath, onChange: onChange}
+	if u.bootstrap() && onChange != nil {
+		onChange()
+	}
+	u.downloader = filedownloader.New(url, cachePath, urlMappingRefreshInterval,
+		filedownloader.WithRequestTimeout(urlMappingClientTimeout),
+		filedownloader.WithRetryMax(urlMappingFetchRetryMax),
+		filedownloader.WithRetryWaitMin(urlMappingFetchRetryWaitMin),
+		filedownloader.WithOnComplete(u.onDownloadComplete),
+	)
+	return u
+}
+
+// bootstrap seeds active/activeHash from cachePath if it decodes as a
+// valid mapping. Reports whether it seeded active.
+func (u *URLUpdater) bootstrap() bool {
+	content, err := os.ReadFile(u.cachePath)
+	if err != nil {
+		return false
+	}
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		log.Warnf("Ignoring invalid repo-to-CPE mapping cache at %q: %v", u.cachePath, err)
+		return false
+	}
+	u.active = content
+	u.activeHash = repositorytocpe.HashMapping(content)
+	return true
+}
+
+// Start begins the periodic download loop in the background; agent
+// startup never blocks on a successful fetch.
+func (u *URLUpdater) Start(ctx context.Context) error {
+	return u.downloader.Start(ctx, false)
+}
+
+// Stop signals the download loop to stop and blocks until it exits.
+func (u *URLUpdater) Stop() {
+	u.downloader.Stop()
+}
+
+// Ready reports whether a validated mapping is currently active.
+func (u *URLUpdater) Ready() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.active) > 0
+}
+
+// Hash returns the active mapping's content hash, or "" if not Ready.
+func (u *URLUpdater) Hash() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.activeHash
+}
+
+// UpdatePath reports this updater's mapping source for ResponseMeta.
+func (u *URLUpdater) UpdatePath() pb.RepoCPEMappingUpdatePath {
+	return pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL
+}
+
+// Bytes returns a copy of the active mapping content.
+func (u *URLUpdater) Bytes() ([]byte, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if len(u.active) == 0 {
+		return nil, errURLMappingNotReady
+	}
+	out := make([]byte, len(u.active))
+	copy(out, u.active)
+	return out, nil
+}
+
+// Path returns cachePath, which the downloader already keeps in sync with
+// the active mapping via its own atomic writes.
+func (u *URLUpdater) Path() (string, error) {
+	u.mu.Lock()
+	ready := len(u.active) > 0
+	u.mu.Unlock()
+	if !ready {
+		return "", errURLMappingNotReady
+	}
+	return u.cachePath, nil
+}
+
+// onDownloadComplete is filedownloader's OnComplete callback. On a failed
+// fetch it only logs, keeping the last-good active mapping (if any). On a
+// successful fetch it re-reads cachePath (the callback carries no bytes)
+// and validates before promoting it to active, so a since-corrupted file
+// can never replace a good in-memory mapping.
+func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
+	if err != nil {
+		log.Warnf("Downloading repo-to-CPE mapping: %v", err)
+		return
+	}
+	content, err := os.ReadFile(u.cachePath)
+	if err != nil {
+		log.Warnf("Reading downloaded repo-to-CPE mapping at %q: %v", u.cachePath, err)
+		return
+	}
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		log.Warnf("Downloaded repo-to-CPE mapping failed validation, keeping last-good: %v", err)
+		return
+	}
+	hash := repositorytocpe.HashMapping(content)
+
+	u.mu.Lock()
+	unchanged := hash == u.activeHash
+	u.active = content
+	u.activeHash = hash
+	u.mu.Unlock()
+
+	if !unchanged && u.onChange != nil {
+		u.onChange()
+	}
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/filedownloader"
 	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
@@ -116,9 +117,9 @@ func (u *URLUpdater) Bytes() ([]byte, error) {
 // Path returns cachePath, which the downloader already keeps in sync with
 // the active mapping via its own atomic writes.
 func (u *URLUpdater) Path() (string, error) {
-	u.mu.Lock()
-	ready := len(u.active) > 0
-	u.mu.Unlock()
+	ready := concurrency.WithLock1(&u.mu, func() bool {
+		return len(u.active) > 0
+	})
 	if !ready {
 		return "", errURLMappingNotReady
 	}
@@ -144,11 +145,12 @@ func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	}
 	hash := repositorytocpe.HashMapping(content)
 
-	u.mu.Lock()
-	unchanged := hash == u.activeHash
-	u.active = content
-	u.activeHash = hash
-	u.mu.Unlock()
+	unchanged := concurrency.WithLock1(&u.mu, func() bool {
+		unchanged := hash == u.activeHash
+		u.active = content
+		u.activeHash = hash
+		return unchanged
+	})
 
 	if !unchanged && u.onChange != nil {
 		u.onChange()

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -27,9 +27,7 @@ var _ MappingProvider = (*URLUpdater)(nil)
 var errURLMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
 
 // URLUpdater is the MappingProvider for an agent configured with a
-// mapping URL. It only implements MappingProvider: Handler keeps its
-// updater reference nil for URL-backed agents, since this mapping source
-// never accepts a Sensor-pushed Update.
+// mapping URL; this mapping source never accepts a Sensor-pushed Update.
 type URLUpdater struct {
 	downloader *filedownloader.Downloader
 	cachePath  string
@@ -127,11 +125,9 @@ func (u *URLUpdater) Path() (string, error) {
 	return u.cachePath, nil
 }
 
-// onDownloadComplete is filedownloader's OnComplete callback. On a failed
-// fetch it only logs, keeping the last-good active mapping (if any). On a
-// successful fetch it re-reads cachePath (the callback carries no bytes)
-// and validates before promoting it to active, so a since-corrupted file
-// can never replace a good in-memory mapping.
+// onDownloadComplete is filedownloader's OnComplete callback: it logs and
+// keeps the last-good mapping on failure, or re-validates before promoting
+// on success, so a corrupted file can never replace a good mapping.
 func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	if err != nil {
 		log.Warnf("Downloading repo-to-CPE mapping: %v", err)

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
@@ -1,0 +1,133 @@
+package vsockserver
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dummyMappingURL is never dialed in these tests: NewURLUpdater's
+// constructor only builds the filedownloader.Downloader, and the actual
+// fetch is exercised indirectly via onDownloadComplete.
+const dummyMappingURL = "http://127.0.0.1:0/mapping.json"
+
+func TestNewURLUpdater_BootstrapFromCache(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+	path, err := u.Path()
+	require.NoError(t, err)
+	assert.Equal(t, cachePath, path)
+	assert.Equal(t, 1, counter.count, "onChange should fire once for a valid bootstrap")
+}
+
+func TestNewURLUpdater_NotReadyWithoutCache(t *testing.T) {
+	dir := t.TempDir()
+	counter := &onChangeCounter{}
+
+	u := NewURLUpdater(dummyMappingURL, filepath.Join(dir, "cache.json"), counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Empty(t, u.Hash())
+	assert.Equal(t, 0, counter.count)
+	_, err := u.Bytes()
+	assert.Error(t, err)
+	_, err = u.Path()
+	assert.Error(t, err)
+}
+
+func TestNewURLUpdater_InvalidCacheStaysNotReady_NoBundledFallback(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, invalidMappingJSON)
+	counter := &onChangeCounter{}
+
+	// The URL updater has no bundled-file parameter and no secondary
+	// source at all: an invalid cachePath must leave it not Ready, not
+	// fall back to anything else.
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Equal(t, 0, counter.count)
+}
+
+func TestURLUpdater_UpdatePath_IsURL(t *testing.T) {
+	u := NewURLUpdater(dummyMappingURL, filepath.Join(t.TempDir(), "cache.json"), func() {})
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL, u.UpdatePath())
+}
+
+func TestURLUpdater_FailedDownload_StaysNotReady(t *testing.T) {
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, filepath.Join(t.TempDir(), "cache.json"), counter.fn)
+
+	u.onDownloadComplete(errors.New("connection refused"), 0)
+
+	assert.False(t, u.Ready())
+	assert.Equal(t, 0, counter.count)
+}
+
+func TestURLUpdater_FailedDownload_KeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.True(t, u.Ready())
+	require.Equal(t, 1, counter.count)
+
+	u.onDownloadComplete(errors.New("connection refused"), 0)
+
+	assert.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count, "onChange must not re-fire when a failed refresh keeps the same content")
+}
+
+func TestURLUpdater_SuccessfulDownload_AppliesNewContent(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.False(t, u.Ready())
+
+	// Simulate what filedownloader's atomic write already did before
+	// invoking onComplete: the new content is on disk at cachePath.
+	writeFile(t, cachePath, validMappingJSON)
+	u.onDownloadComplete(nil, 0)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+	assert.Equal(t, 1, counter.count)
+}
+
+func TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.Equal(t, 1, counter.count)
+
+	writeFile(t, cachePath, invalidMappingJSON)
+	u.onDownloadComplete(nil, 0)
+
+	assert.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count, "onChange must not fire when the refreshed content fails validation")
+}

--- a/generated/internalapi/virtualmachine/v1/vm_service.pb.go
+++ b/generated/internalapi/virtualmachine/v1/vm_service.pb.go
@@ -23,6 +23,55 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type RepoCPEMappingUpdatePath int32
+
+const (
+	RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED RepoCPEMappingUpdatePath = 0
+	RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR      RepoCPEMappingUpdatePath = 1
+	RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL         RepoCPEMappingUpdatePath = 2
+)
+
+// Enum value maps for RepoCPEMappingUpdatePath.
+var (
+	RepoCPEMappingUpdatePath_name = map[int32]string{
+		0: "REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED",
+		1: "REPO_CPE_MAPPING_UPDATE_PATH_SENSOR",
+		2: "REPO_CPE_MAPPING_UPDATE_PATH_URL",
+	}
+	RepoCPEMappingUpdatePath_value = map[string]int32{
+		"REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED": 0,
+		"REPO_CPE_MAPPING_UPDATE_PATH_SENSOR":      1,
+		"REPO_CPE_MAPPING_UPDATE_PATH_URL":         2,
+	}
+)
+
+func (x RepoCPEMappingUpdatePath) Enum() *RepoCPEMappingUpdatePath {
+	p := new(RepoCPEMappingUpdatePath)
+	*p = x
+	return p
+}
+
+func (x RepoCPEMappingUpdatePath) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RepoCPEMappingUpdatePath) Descriptor() protoreflect.EnumDescriptor {
+	return file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes[0].Descriptor()
+}
+
+func (RepoCPEMappingUpdatePath) Type() protoreflect.EnumType {
+	return &file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes[0]
+}
+
+func (x RepoCPEMappingUpdatePath) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RepoCPEMappingUpdatePath.Descriptor instead.
+func (RepoCPEMappingUpdatePath) EnumDescriptor() ([]byte, []int) {
+	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{0}
+}
+
 type ErrorCode int32
 
 const (
@@ -41,6 +90,10 @@ const (
 	ErrorCode_ERROR_CODE_REQUEST_TOO_LARGE ErrorCode = 5
 	// Agent is already serving another connection; retry after a backoff.
 	ErrorCode_ERROR_CODE_BUSY ErrorCode = 6
+	// No usable mapping yet; guest disk has not been scanned.
+	ErrorCode_ERROR_CODE_MAPPING_REQUIRED ErrorCode = 7
+	// SyncRepoCPEMapping rejected because updater is not Sensor-managed.
+	ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED ErrorCode = 8
 )
 
 // Enum value maps for ErrorCode.
@@ -53,15 +106,19 @@ var (
 		4: "ERROR_CODE_MALFORMED_REQUEST",
 		5: "ERROR_CODE_REQUEST_TOO_LARGE",
 		6: "ERROR_CODE_BUSY",
+		7: "ERROR_CODE_MAPPING_REQUIRED",
+		8: "ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED",
 	}
 	ErrorCode_value = map[string]int32{
-		"ERROR_CODE_UNSPECIFIED":       0,
-		"ERROR_CODE_UNKNOWN_METHOD":    1,
-		"ERROR_CODE_NOT_READY":         2,
-		"ERROR_CODE_INTERNAL":          3,
-		"ERROR_CODE_MALFORMED_REQUEST": 4,
-		"ERROR_CODE_REQUEST_TOO_LARGE": 5,
-		"ERROR_CODE_BUSY":              6,
+		"ERROR_CODE_UNSPECIFIED":                0,
+		"ERROR_CODE_UNKNOWN_METHOD":             1,
+		"ERROR_CODE_NOT_READY":                  2,
+		"ERROR_CODE_INTERNAL":                   3,
+		"ERROR_CODE_MALFORMED_REQUEST":          4,
+		"ERROR_CODE_REQUEST_TOO_LARGE":          5,
+		"ERROR_CODE_BUSY":                       6,
+		"ERROR_CODE_MAPPING_REQUIRED":           7,
+		"ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED": 8,
 	}
 )
 
@@ -76,11 +133,11 @@ func (x ErrorCode) String() string {
 }
 
 func (ErrorCode) Descriptor() protoreflect.EnumDescriptor {
-	return file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes[0].Descriptor()
+	return file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes[1].Descriptor()
 }
 
 func (ErrorCode) Type() protoreflect.EnumType {
-	return &file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes[0]
+	return &file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes[1]
 }
 
 func (x ErrorCode) Number() protoreflect.EnumNumber {
@@ -89,7 +146,7 @@ func (x ErrorCode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ErrorCode.Descriptor instead.
 func (ErrorCode) EnumDescriptor() ([]byte, []int) {
-	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{0}
+	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{1}
 }
 
 // VMServiceRequest is sent by Sensor to roxagent over a length-prefixed VSOCK frame.
@@ -100,6 +157,7 @@ type VMServiceRequest struct {
 	// Types that are valid to be assigned to Method:
 	//
 	//	*VMServiceRequest_GetReport
+	//	*VMServiceRequest_SyncRepoCpeMapping
 	Method        isVMServiceRequest_Method `protobuf_oneof:"method"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -158,6 +216,15 @@ func (x *VMServiceRequest) GetGetReport() *GetReportRequest {
 	return nil
 }
 
+func (x *VMServiceRequest) GetSyncRepoCpeMapping() *SyncRepoCPEMappingRequest {
+	if x != nil {
+		if x, ok := x.Method.(*VMServiceRequest_SyncRepoCpeMapping); ok {
+			return x.SyncRepoCpeMapping
+		}
+	}
+	return nil
+}
+
 type isVMServiceRequest_Method interface {
 	isVMServiceRequest_Method()
 }
@@ -166,7 +233,13 @@ type VMServiceRequest_GetReport struct {
 	GetReport *GetReportRequest `protobuf:"bytes,2,opt,name=get_report,json=getReport,proto3,oneof"`
 }
 
+type VMServiceRequest_SyncRepoCpeMapping struct {
+	SyncRepoCpeMapping *SyncRepoCPEMappingRequest `protobuf:"bytes,3,opt,name=sync_repo_cpe_mapping,json=syncRepoCpeMapping,proto3,oneof"`
+}
+
 func (*VMServiceRequest_GetReport) isVMServiceRequest_Method() {}
+
+func (*VMServiceRequest_SyncRepoCpeMapping) isVMServiceRequest_Method() {}
 
 // VMServiceResponse is returned by roxagent. Contains either a successful result
 // or an ErrorResponse, never both.
@@ -177,6 +250,7 @@ type VMServiceResponse struct {
 	//
 	//	*VMServiceResponse_GetReport
 	//	*VMServiceResponse_Error
+	//	*VMServiceResponse_SyncRepoCpeMapping
 	Result        isVMServiceResponse_Result `protobuf_oneof:"result"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -244,6 +318,15 @@ func (x *VMServiceResponse) GetError() *ErrorResponse {
 	return nil
 }
 
+func (x *VMServiceResponse) GetSyncRepoCpeMapping() *SyncRepoCPEMappingResponse {
+	if x != nil {
+		if x, ok := x.Result.(*VMServiceResponse_SyncRepoCpeMapping); ok {
+			return x.SyncRepoCpeMapping
+		}
+	}
+	return nil
+}
+
 type isVMServiceResponse_Result interface {
 	isVMServiceResponse_Result()
 }
@@ -256,9 +339,15 @@ type VMServiceResponse_Error struct {
 	Error *ErrorResponse `protobuf:"bytes,3,opt,name=error,proto3,oneof"`
 }
 
+type VMServiceResponse_SyncRepoCpeMapping struct {
+	SyncRepoCpeMapping *SyncRepoCPEMappingResponse `protobuf:"bytes,4,opt,name=sync_repo_cpe_mapping,json=syncRepoCpeMapping,proto3,oneof"`
+}
+
 func (*VMServiceResponse_GetReport) isVMServiceResponse_Result() {}
 
 func (*VMServiceResponse_Error) isVMServiceResponse_Result() {}
+
+func (*VMServiceResponse_SyncRepoCpeMapping) isVMServiceResponse_Result() {}
 
 type RequestMeta struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -346,9 +435,14 @@ type ResponseMeta struct {
 	// false-negative dedup when a restarted agent's reset generation coincides
 	// with Sensor's cached value for that VM. Zero means the agent predates this
 	// field; Sensor falls back to generation-only comparison in that case.
-	Epoch         uint32 `protobuf:"varint,6,opt,name=epoch,proto3" json:"epoch,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Epoch uint32 `protobuf:"varint,6,opt,name=epoch,proto3" json:"epoch,omitempty"`
+	// XXH64 hex of active mapping; empty string means none. optional so absence
+	// means an older agent that does not report mapping metadata.
+	RepoCpeMappingHash *string `protobuf:"bytes,7,opt,name=repo_cpe_mapping_hash,json=repoCpeMappingHash,proto3,oneof" json:"repo_cpe_mapping_hash,omitempty"`
+	// SENSOR or URL only; UNSPECIFIED means Sensor must not sync.
+	RepoCpeMappingUpdatePath *RepoCPEMappingUpdatePath `protobuf:"varint,8,opt,name=repo_cpe_mapping_update_path,json=repoCpeMappingUpdatePath,proto3,enum=virtualmachine.v1.RepoCPEMappingUpdatePath,oneof" json:"repo_cpe_mapping_update_path,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ResponseMeta) Reset() {
@@ -421,6 +515,20 @@ func (x *ResponseMeta) GetEpoch() uint32 {
 		return x.Epoch
 	}
 	return 0
+}
+
+func (x *ResponseMeta) GetRepoCpeMappingHash() string {
+	if x != nil && x.RepoCpeMappingHash != nil {
+		return *x.RepoCpeMappingHash
+	}
+	return ""
+}
+
+func (x *ResponseMeta) GetRepoCpeMappingUpdatePath() RepoCPEMappingUpdatePath {
+	if x != nil && x.RepoCpeMappingUpdatePath != nil {
+		return *x.RepoCpeMappingUpdatePath
+	}
+	return RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED
 }
 
 type GetReportRequest struct {
@@ -540,6 +648,95 @@ func (x *GetReportResponse) GetUnchanged() bool {
 	return false
 }
 
+type SyncRepoCPEMappingRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Mapping       []byte                 `protobuf:"bytes,1,opt,name=mapping,proto3" json:"mapping,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SyncRepoCPEMappingRequest) Reset() {
+	*x = SyncRepoCPEMappingRequest{}
+	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncRepoCPEMappingRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncRepoCPEMappingRequest) ProtoMessage() {}
+
+func (x *SyncRepoCPEMappingRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncRepoCPEMappingRequest.ProtoReflect.Descriptor instead.
+func (*SyncRepoCPEMappingRequest) Descriptor() ([]byte, []int) {
+	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SyncRepoCPEMappingRequest) GetMapping() []byte {
+	if x != nil {
+		return x.Mapping
+	}
+	return nil
+}
+
+type SyncRepoCPEMappingResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// True when the agent accepted new content (applied or staged).
+	Updated       bool `protobuf:"varint,1,opt,name=updated,proto3" json:"updated,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SyncRepoCPEMappingResponse) Reset() {
+	*x = SyncRepoCPEMappingResponse{}
+	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SyncRepoCPEMappingResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SyncRepoCPEMappingResponse) ProtoMessage() {}
+
+func (x *SyncRepoCPEMappingResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SyncRepoCPEMappingResponse.ProtoReflect.Descriptor instead.
+func (*SyncRepoCPEMappingResponse) Descriptor() ([]byte, []int) {
+	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *SyncRepoCPEMappingResponse) GetUpdated() bool {
+	if x != nil {
+		return x.Updated
+	}
+	return false
+}
+
 type ErrorResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Code  ErrorCode              `protobuf:"varint,1,opt,name=code,proto3,enum=virtualmachine.v1.ErrorCode" json:"code,omitempty"`
@@ -553,7 +750,7 @@ type ErrorResponse struct {
 
 func (x *ErrorResponse) Reset() {
 	*x = ErrorResponse{}
-	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[6]
+	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -565,7 +762,7 @@ func (x *ErrorResponse) String() string {
 func (*ErrorResponse) ProtoMessage() {}
 
 func (x *ErrorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[6]
+	mi := &file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -578,7 +775,7 @@ func (x *ErrorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ErrorResponse.ProtoReflect.Descriptor instead.
 func (*ErrorResponse) Descriptor() ([]byte, []int) {
-	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{6}
+	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ErrorResponse) GetCode() ErrorCode {
@@ -606,17 +803,19 @@ var File_internalapi_virtualmachine_v1_vm_service_proto protoreflect.FileDescrip
 
 const file_internalapi_virtualmachine_v1_vm_service_proto_rawDesc = "" +
 	"\n" +
-	".internalapi/virtualmachine/v1/vm_service.proto\x12\x11virtualmachine.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a)internalapi/scanner/v4/index_report.proto\"\x96\x01\n" +
+	".internalapi/virtualmachine/v1/vm_service.proto\x12\x11virtualmachine.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a)internalapi/scanner/v4/index_report.proto\"\xf9\x01\n" +
 	"\x10VMServiceRequest\x122\n" +
 	"\x04meta\x18\x01 \x01(\v2\x1e.virtualmachine.v1.RequestMetaR\x04meta\x12D\n" +
 	"\n" +
-	"get_report\x18\x02 \x01(\v2#.virtualmachine.v1.GetReportRequestH\x00R\tgetReportB\b\n" +
-	"\x06method\"\xd3\x01\n" +
+	"get_report\x18\x02 \x01(\v2#.virtualmachine.v1.GetReportRequestH\x00R\tgetReport\x12a\n" +
+	"\x15sync_repo_cpe_mapping\x18\x03 \x01(\v2,.virtualmachine.v1.SyncRepoCPEMappingRequestH\x00R\x12syncRepoCpeMappingB\b\n" +
+	"\x06method\"\xb7\x02\n" +
 	"\x11VMServiceResponse\x123\n" +
 	"\x04meta\x18\x01 \x01(\v2\x1f.virtualmachine.v1.ResponseMetaR\x04meta\x12E\n" +
 	"\n" +
 	"get_report\x18\x02 \x01(\v2$.virtualmachine.v1.GetReportResponseH\x00R\tgetReport\x128\n" +
-	"\x05error\x18\x03 \x01(\v2 .virtualmachine.v1.ErrorResponseH\x00R\x05errorB\b\n" +
+	"\x05error\x18\x03 \x01(\v2 .virtualmachine.v1.ErrorResponseH\x00R\x05error\x12b\n" +
+	"\x15sync_repo_cpe_mapping\x18\x04 \x01(\v2-.virtualmachine.v1.SyncRepoCPEMappingResponseH\x00R\x12syncRepoCpeMappingB\b\n" +
 	"\x06result\"\xcb\x01\n" +
 	"\vRequestMeta\x12\x1d\n" +
 	"\n" +
@@ -626,32 +825,44 @@ const file_internalapi_virtualmachine_v1_vm_service_proto_rawDesc = "" +
 	"\n" +
 	"FactsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xeb\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd0\x04\n" +
 	"\fResponseMeta\x12#\n" +
 	"\ragent_version\x18\x01 \x01(\tR\fagentVersion\x12J\n" +
 	"\x13report_generated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x11reportGeneratedAt\x12+\n" +
 	"\x11report_generation\x18\x03 \x01(\rR\x10reportGeneration\x12+\n" +
 	"\x11supported_methods\x18\x04 \x03(\tR\x10supportedMethods\x12@\n" +
 	"\x05facts\x18\x05 \x03(\v2*.virtualmachine.v1.ResponseMeta.FactsEntryR\x05facts\x12\x14\n" +
-	"\x05epoch\x18\x06 \x01(\rR\x05epoch\x1a8\n" +
+	"\x05epoch\x18\x06 \x01(\rR\x05epoch\x126\n" +
+	"\x15repo_cpe_mapping_hash\x18\a \x01(\tH\x00R\x12repoCpeMappingHash\x88\x01\x01\x12p\n" +
+	"\x1crepo_cpe_mapping_update_path\x18\b \x01(\x0e2+.virtualmachine.v1.RepoCPEMappingUpdatePathH\x01R\x18repoCpeMappingUpdatePath\x88\x01\x01\x1a8\n" +
 	"\n" +
 	"FactsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"g\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x18\n" +
+	"\x16_repo_cpe_mapping_hashB\x1f\n" +
+	"\x1d_repo_cpe_mapping_update_path\"g\n" +
 	"\x10GetReportRequest\x122\n" +
 	"\x15last_known_generation\x18\x01 \x01(\rR\x13lastKnownGeneration\x12\x1f\n" +
 	"\vknown_epoch\x18\x02 \x01(\rR\n" +
 	"knownEpoch\"m\n" +
 	"\x11GetReportResponse\x12:\n" +
 	"\findex_report\x18\x01 \x01(\v2\x17.scanner.v4.IndexReportR\vindexReport\x12\x1c\n" +
-	"\tunchanged\x18\x02 \x01(\bR\tunchanged\"\xe0\x01\n" +
+	"\tunchanged\x18\x02 \x01(\bR\tunchanged\"5\n" +
+	"\x19SyncRepoCPEMappingRequest\x12\x18\n" +
+	"\amapping\x18\x01 \x01(\fR\amapping\"6\n" +
+	"\x1aSyncRepoCPEMappingResponse\x12\x18\n" +
+	"\aupdated\x18\x01 \x01(\bR\aupdated\"\xe0\x01\n" +
 	"\rErrorResponse\x120\n" +
 	"\x04code\x18\x01 \x01(\x0e2\x1c.virtualmachine.v1.ErrorCodeR\x04code\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12G\n" +
 	"\adetails\x18\x03 \x03(\v2-.virtualmachine.v1.ErrorResponse.DetailsEntryR\adetails\x1a:\n" +
 	"\fDetailsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\xd2\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\x97\x01\n" +
+	"\x18RepoCPEMappingUpdatePath\x12,\n" +
+	"(REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED\x10\x00\x12'\n" +
+	"#REPO_CPE_MAPPING_UPDATE_PATH_SENSOR\x10\x01\x12$\n" +
+	" REPO_CPE_MAPPING_UPDATE_PATH_URL\x10\x02*\x9e\x02\n" +
 	"\tErrorCode\x12\x1a\n" +
 	"\x16ERROR_CODE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19ERROR_CODE_UNKNOWN_METHOD\x10\x01\x12\x18\n" +
@@ -659,7 +870,9 @@ const file_internalapi_virtualmachine_v1_vm_service_proto_rawDesc = "" +
 	"\x13ERROR_CODE_INTERNAL\x10\x03\x12 \n" +
 	"\x1cERROR_CODE_MALFORMED_REQUEST\x10\x04\x12 \n" +
 	"\x1cERROR_CODE_REQUEST_TOO_LARGE\x10\x05\x12\x13\n" +
-	"\x0fERROR_CODE_BUSY\x10\x06B$Z\"./internalapi/virtualmachine/v1;v1b\x06proto3"
+	"\x0fERROR_CODE_BUSY\x10\x06\x12\x1f\n" +
+	"\x1bERROR_CODE_MAPPING_REQUIRED\x10\a\x12)\n" +
+	"%ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED\x10\bB$Z\"./internalapi/virtualmachine/v1;v1b\x06proto3"
 
 var (
 	file_internalapi_virtualmachine_v1_vm_service_proto_rawDescOnce sync.Once
@@ -673,40 +886,46 @@ func file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP() []byte {
 	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescData
 }
 
-var file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_internalapi_virtualmachine_v1_vm_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_internalapi_virtualmachine_v1_vm_service_proto_goTypes = []any{
-	(ErrorCode)(0),                // 0: virtualmachine.v1.ErrorCode
-	(*VMServiceRequest)(nil),      // 1: virtualmachine.v1.VMServiceRequest
-	(*VMServiceResponse)(nil),     // 2: virtualmachine.v1.VMServiceResponse
-	(*RequestMeta)(nil),           // 3: virtualmachine.v1.RequestMeta
-	(*ResponseMeta)(nil),          // 4: virtualmachine.v1.ResponseMeta
-	(*GetReportRequest)(nil),      // 5: virtualmachine.v1.GetReportRequest
-	(*GetReportResponse)(nil),     // 6: virtualmachine.v1.GetReportResponse
-	(*ErrorResponse)(nil),         // 7: virtualmachine.v1.ErrorResponse
-	nil,                           // 8: virtualmachine.v1.RequestMeta.FactsEntry
-	nil,                           // 9: virtualmachine.v1.ResponseMeta.FactsEntry
-	nil,                           // 10: virtualmachine.v1.ErrorResponse.DetailsEntry
-	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
-	(*v4.IndexReport)(nil),        // 12: scanner.v4.IndexReport
+	(RepoCPEMappingUpdatePath)(0),      // 0: virtualmachine.v1.RepoCPEMappingUpdatePath
+	(ErrorCode)(0),                     // 1: virtualmachine.v1.ErrorCode
+	(*VMServiceRequest)(nil),           // 2: virtualmachine.v1.VMServiceRequest
+	(*VMServiceResponse)(nil),          // 3: virtualmachine.v1.VMServiceResponse
+	(*RequestMeta)(nil),                // 4: virtualmachine.v1.RequestMeta
+	(*ResponseMeta)(nil),               // 5: virtualmachine.v1.ResponseMeta
+	(*GetReportRequest)(nil),           // 6: virtualmachine.v1.GetReportRequest
+	(*GetReportResponse)(nil),          // 7: virtualmachine.v1.GetReportResponse
+	(*SyncRepoCPEMappingRequest)(nil),  // 8: virtualmachine.v1.SyncRepoCPEMappingRequest
+	(*SyncRepoCPEMappingResponse)(nil), // 9: virtualmachine.v1.SyncRepoCPEMappingResponse
+	(*ErrorResponse)(nil),              // 10: virtualmachine.v1.ErrorResponse
+	nil,                                // 11: virtualmachine.v1.RequestMeta.FactsEntry
+	nil,                                // 12: virtualmachine.v1.ResponseMeta.FactsEntry
+	nil,                                // 13: virtualmachine.v1.ErrorResponse.DetailsEntry
+	(*timestamppb.Timestamp)(nil),      // 14: google.protobuf.Timestamp
+	(*v4.IndexReport)(nil),             // 15: scanner.v4.IndexReport
 }
 var file_internalapi_virtualmachine_v1_vm_service_proto_depIdxs = []int32{
-	3,  // 0: virtualmachine.v1.VMServiceRequest.meta:type_name -> virtualmachine.v1.RequestMeta
-	5,  // 1: virtualmachine.v1.VMServiceRequest.get_report:type_name -> virtualmachine.v1.GetReportRequest
-	4,  // 2: virtualmachine.v1.VMServiceResponse.meta:type_name -> virtualmachine.v1.ResponseMeta
-	6,  // 3: virtualmachine.v1.VMServiceResponse.get_report:type_name -> virtualmachine.v1.GetReportResponse
-	7,  // 4: virtualmachine.v1.VMServiceResponse.error:type_name -> virtualmachine.v1.ErrorResponse
-	8,  // 5: virtualmachine.v1.RequestMeta.facts:type_name -> virtualmachine.v1.RequestMeta.FactsEntry
-	11, // 6: virtualmachine.v1.ResponseMeta.report_generated_at:type_name -> google.protobuf.Timestamp
-	9,  // 7: virtualmachine.v1.ResponseMeta.facts:type_name -> virtualmachine.v1.ResponseMeta.FactsEntry
-	12, // 8: virtualmachine.v1.GetReportResponse.index_report:type_name -> scanner.v4.IndexReport
-	0,  // 9: virtualmachine.v1.ErrorResponse.code:type_name -> virtualmachine.v1.ErrorCode
-	10, // 10: virtualmachine.v1.ErrorResponse.details:type_name -> virtualmachine.v1.ErrorResponse.DetailsEntry
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	4,  // 0: virtualmachine.v1.VMServiceRequest.meta:type_name -> virtualmachine.v1.RequestMeta
+	6,  // 1: virtualmachine.v1.VMServiceRequest.get_report:type_name -> virtualmachine.v1.GetReportRequest
+	8,  // 2: virtualmachine.v1.VMServiceRequest.sync_repo_cpe_mapping:type_name -> virtualmachine.v1.SyncRepoCPEMappingRequest
+	5,  // 3: virtualmachine.v1.VMServiceResponse.meta:type_name -> virtualmachine.v1.ResponseMeta
+	7,  // 4: virtualmachine.v1.VMServiceResponse.get_report:type_name -> virtualmachine.v1.GetReportResponse
+	10, // 5: virtualmachine.v1.VMServiceResponse.error:type_name -> virtualmachine.v1.ErrorResponse
+	9,  // 6: virtualmachine.v1.VMServiceResponse.sync_repo_cpe_mapping:type_name -> virtualmachine.v1.SyncRepoCPEMappingResponse
+	11, // 7: virtualmachine.v1.RequestMeta.facts:type_name -> virtualmachine.v1.RequestMeta.FactsEntry
+	14, // 8: virtualmachine.v1.ResponseMeta.report_generated_at:type_name -> google.protobuf.Timestamp
+	12, // 9: virtualmachine.v1.ResponseMeta.facts:type_name -> virtualmachine.v1.ResponseMeta.FactsEntry
+	0,  // 10: virtualmachine.v1.ResponseMeta.repo_cpe_mapping_update_path:type_name -> virtualmachine.v1.RepoCPEMappingUpdatePath
+	15, // 11: virtualmachine.v1.GetReportResponse.index_report:type_name -> scanner.v4.IndexReport
+	1,  // 12: virtualmachine.v1.ErrorResponse.code:type_name -> virtualmachine.v1.ErrorCode
+	13, // 13: virtualmachine.v1.ErrorResponse.details:type_name -> virtualmachine.v1.ErrorResponse.DetailsEntry
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_virtualmachine_v1_vm_service_proto_init() }
@@ -716,18 +935,21 @@ func file_internalapi_virtualmachine_v1_vm_service_proto_init() {
 	}
 	file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[0].OneofWrappers = []any{
 		(*VMServiceRequest_GetReport)(nil),
+		(*VMServiceRequest_SyncRepoCpeMapping)(nil),
 	}
 	file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[1].OneofWrappers = []any{
 		(*VMServiceResponse_GetReport)(nil),
 		(*VMServiceResponse_Error)(nil),
+		(*VMServiceResponse_SyncRepoCpeMapping)(nil),
 	}
+	file_internalapi_virtualmachine_v1_vm_service_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_virtualmachine_v1_vm_service_proto_rawDesc), len(file_internalapi_virtualmachine_v1_vm_service_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   10,
+			NumEnums:      2,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/internalapi/virtualmachine/v1/vm_service_vtproto.pb.go
+++ b/generated/internalapi/virtualmachine/v1/vm_service_vtproto.pb.go
@@ -54,6 +54,15 @@ func (m *VMServiceRequest_GetReport) CloneVT() isVMServiceRequest_Method {
 	return r
 }
 
+func (m *VMServiceRequest_SyncRepoCpeMapping) CloneVT() isVMServiceRequest_Method {
+	if m == nil {
+		return (*VMServiceRequest_SyncRepoCpeMapping)(nil)
+	}
+	r := new(VMServiceRequest_SyncRepoCpeMapping)
+	r.SyncRepoCpeMapping = m.SyncRepoCpeMapping.CloneVT()
+	return r
+}
+
 func (m *VMServiceResponse) CloneVT() *VMServiceResponse {
 	if m == nil {
 		return (*VMServiceResponse)(nil)
@@ -91,6 +100,15 @@ func (m *VMServiceResponse_Error) CloneVT() isVMServiceResponse_Result {
 	}
 	r := new(VMServiceResponse_Error)
 	r.Error = m.Error.CloneVT()
+	return r
+}
+
+func (m *VMServiceResponse_SyncRepoCpeMapping) CloneVT() isVMServiceResponse_Result {
+	if m == nil {
+		return (*VMServiceResponse_SyncRepoCpeMapping)(nil)
+	}
+	r := new(VMServiceResponse_SyncRepoCpeMapping)
+	r.SyncRepoCpeMapping = m.SyncRepoCpeMapping.CloneVT()
 	return r
 }
 
@@ -144,6 +162,14 @@ func (m *ResponseMeta) CloneVT() *ResponseMeta {
 		}
 		r.Facts = tmpContainer
 	}
+	if rhs := m.RepoCpeMappingHash; rhs != nil {
+		tmpVal := *rhs
+		r.RepoCpeMappingHash = &tmpVal
+	}
+	if rhs := m.RepoCpeMappingUpdatePath; rhs != nil {
+		tmpVal := *rhs
+		r.RepoCpeMappingUpdatePath = &tmpVal
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -194,6 +220,44 @@ func (m *GetReportResponse) CloneVT() *GetReportResponse {
 }
 
 func (m *GetReportResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *SyncRepoCPEMappingRequest) CloneVT() *SyncRepoCPEMappingRequest {
+	if m == nil {
+		return (*SyncRepoCPEMappingRequest)(nil)
+	}
+	r := new(SyncRepoCPEMappingRequest)
+	if rhs := m.Mapping; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.Mapping = tmpBytes
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *SyncRepoCPEMappingRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *SyncRepoCPEMappingResponse) CloneVT() *SyncRepoCPEMappingResponse {
+	if m == nil {
+		return (*SyncRepoCPEMappingResponse)(nil)
+	}
+	r := new(SyncRepoCPEMappingResponse)
+	r.Updated = m.Updated
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *SyncRepoCPEMappingResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -270,6 +334,31 @@ func (this *VMServiceRequest_GetReport) EqualVT(thatIface isVMServiceRequest_Met
 		}
 		if q == nil {
 			q = &GetReportRequest{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *VMServiceRequest_SyncRepoCpeMapping) EqualVT(thatIface isVMServiceRequest_Method) bool {
+	that, ok := thatIface.(*VMServiceRequest_SyncRepoCpeMapping)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.SyncRepoCpeMapping, that.SyncRepoCpeMapping; p != q {
+		if p == nil {
+			p = &SyncRepoCPEMappingRequest{}
+		}
+		if q == nil {
+			q = &SyncRepoCPEMappingRequest{}
 		}
 		if !p.EqualVT(q) {
 			return false
@@ -359,6 +448,31 @@ func (this *VMServiceResponse_Error) EqualVT(thatIface isVMServiceResponse_Resul
 	return true
 }
 
+func (this *VMServiceResponse_SyncRepoCpeMapping) EqualVT(thatIface isVMServiceResponse_Result) bool {
+	that, ok := thatIface.(*VMServiceResponse_SyncRepoCpeMapping)
+	if !ok {
+		return false
+	}
+	if this == that {
+		return true
+	}
+	if this == nil && that != nil || this != nil && that == nil {
+		return false
+	}
+	if p, q := this.SyncRepoCpeMapping, that.SyncRepoCpeMapping; p != q {
+		if p == nil {
+			p = &SyncRepoCPEMappingResponse{}
+		}
+		if q == nil {
+			q = &SyncRepoCPEMappingResponse{}
+		}
+		if !p.EqualVT(q) {
+			return false
+		}
+	}
+	return true
+}
+
 func (this *RequestMeta) EqualVT(that *RequestMeta) bool {
 	if this == that {
 		return true
@@ -438,6 +552,12 @@ func (this *ResponseMeta) EqualVT(that *ResponseMeta) bool {
 	if this.Epoch != that.Epoch {
 		return false
 	}
+	if p, q := this.RepoCpeMappingHash, that.RepoCpeMappingHash; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
+	if p, q := this.RepoCpeMappingUpdatePath, that.RepoCpeMappingUpdatePath; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -491,6 +611,44 @@ func (this *GetReportResponse) EqualVT(that *GetReportResponse) bool {
 
 func (this *GetReportResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*GetReportResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *SyncRepoCPEMappingRequest) EqualVT(that *SyncRepoCPEMappingRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if string(this.Mapping) != string(that.Mapping) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SyncRepoCPEMappingRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*SyncRepoCPEMappingRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *SyncRepoCPEMappingResponse) EqualVT(that *SyncRepoCPEMappingResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Updated != that.Updated {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SyncRepoCPEMappingResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*SyncRepoCPEMappingResponse)
 	if !ok {
 		return false
 	}
@@ -605,6 +763,29 @@ func (m *VMServiceRequest_GetReport) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	}
 	return len(dAtA) - i, nil
 }
+func (m *VMServiceRequest_SyncRepoCpeMapping) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VMServiceRequest_SyncRepoCpeMapping) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.SyncRepoCpeMapping != nil {
+		size, err := m.SyncRepoCpeMapping.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, 0)
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
 func (m *VMServiceResponse) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -700,6 +881,29 @@ func (m *VMServiceResponse_Error) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i = protohelpers.EncodeVarint(dAtA, i, 0)
 		i--
 		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *VMServiceResponse_SyncRepoCpeMapping) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VMServiceResponse_SyncRepoCpeMapping) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.SyncRepoCpeMapping != nil {
+		size, err := m.SyncRepoCpeMapping.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, 0)
+		i--
+		dAtA[i] = 0x22
 	}
 	return len(dAtA) - i, nil
 }
@@ -800,6 +1004,18 @@ func (m *ResponseMeta) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.RepoCpeMappingUpdatePath != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RepoCpeMappingUpdatePath))
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.RepoCpeMappingHash != nil {
+		i -= len(*m.RepoCpeMappingHash)
+		copy(dAtA[i:], *m.RepoCpeMappingHash)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.RepoCpeMappingHash)))
+		i--
+		dAtA[i] = 0x3a
 	}
 	if m.Epoch != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Epoch))
@@ -967,6 +1183,89 @@ func (m *GetReportResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *SyncRepoCPEMappingRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SyncRepoCPEMappingRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SyncRepoCPEMappingRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Mapping) > 0 {
+		i -= len(m.Mapping)
+		copy(dAtA[i:], m.Mapping)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Mapping)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SyncRepoCPEMappingResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SyncRepoCPEMappingResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SyncRepoCPEMappingResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Updated {
+		i--
+		if m.Updated {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ErrorResponse) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1062,6 +1361,20 @@ func (m *VMServiceRequest_GetReport) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *VMServiceRequest_SyncRepoCpeMapping) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SyncRepoCpeMapping != nil {
+		l = m.SyncRepoCpeMapping.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	} else {
+		n += 2
+	}
+	return n
+}
 func (m *VMServiceResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1101,6 +1414,20 @@ func (m *VMServiceResponse_Error) SizeVT() (n int) {
 	_ = l
 	if m.Error != nil {
 		l = m.Error.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	} else {
+		n += 2
+	}
+	return n
+}
+func (m *VMServiceResponse_SyncRepoCpeMapping) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.SyncRepoCpeMapping != nil {
+		l = m.SyncRepoCpeMapping.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	} else {
 		n += 2
@@ -1169,6 +1496,13 @@ func (m *ResponseMeta) SizeVT() (n int) {
 	if m.Epoch != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Epoch))
 	}
+	if m.RepoCpeMappingHash != nil {
+		l = len(*m.RepoCpeMappingHash)
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.RepoCpeMappingUpdatePath != nil {
+		n += 1 + protohelpers.SizeOfVarint(uint64(*m.RepoCpeMappingUpdatePath))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1206,6 +1540,33 @@ func (m *GetReportResponse) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.Unchanged {
+		n += 2
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SyncRepoCPEMappingRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Mapping)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *SyncRepoCPEMappingResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Updated {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -1341,6 +1702,47 @@ func (m *VMServiceRequest) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 				m.Method = &VMServiceRequest_GetReport{GetReport: v}
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SyncRepoCpeMapping", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Method.(*VMServiceRequest_SyncRepoCpeMapping); ok {
+				if err := oneof.SyncRepoCpeMapping.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &SyncRepoCPEMappingRequest{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Method = &VMServiceRequest_SyncRepoCpeMapping{SyncRepoCpeMapping: v}
 			}
 			iNdEx = postIndex
 		default:
@@ -1510,6 +1912,47 @@ func (m *VMServiceResponse) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 				m.Result = &VMServiceResponse_Error{Error: v}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SyncRepoCpeMapping", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Result.(*VMServiceResponse_SyncRepoCpeMapping); ok {
+				if err := oneof.SyncRepoCpeMapping.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &SyncRepoCPEMappingResponse{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Result = &VMServiceResponse_SyncRepoCpeMapping{SyncRepoCpeMapping: v}
 			}
 			iNdEx = postIndex
 		default:
@@ -2070,6 +2513,59 @@ func (m *ResponseMeta) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(dAtA[iNdEx:postIndex])
+			m.RepoCpeMappingHash = &s
+			iNdEx = postIndex
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingUpdatePath", wireType)
+			}
+			var v RepoCPEMappingUpdatePath
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= RepoCPEMappingUpdatePath(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RepoCpeMappingUpdatePath = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2274,6 +2770,162 @@ func (m *GetReportResponse) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Unchanged = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SyncRepoCPEMappingRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mapping", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Mapping = append(m.Mapping[:0], dAtA[iNdEx:postIndex]...)
+			if m.Mapping == nil {
+				m.Mapping = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SyncRepoCPEMappingResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Updated", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Updated = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2631,6 +3283,47 @@ func (m *VMServiceRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.Method = &VMServiceRequest_GetReport{GetReport: v}
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SyncRepoCpeMapping", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Method.(*VMServiceRequest_SyncRepoCpeMapping); ok {
+				if err := oneof.SyncRepoCpeMapping.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &SyncRepoCPEMappingRequest{}
+				if err := v.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Method = &VMServiceRequest_SyncRepoCpeMapping{SyncRepoCpeMapping: v}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2798,6 +3491,47 @@ func (m *VMServiceResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 					return err
 				}
 				m.Result = &VMServiceResponse_Error{Error: v}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SyncRepoCpeMapping", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Result.(*VMServiceResponse_SyncRepoCpeMapping); ok {
+				if err := oneof.SyncRepoCpeMapping.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &SyncRepoCPEMappingResponse{}
+				if err := v.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Result = &VMServiceResponse_SyncRepoCpeMapping{SyncRepoCpeMapping: v}
 			}
 			iNdEx = postIndex
 		default:
@@ -3390,6 +4124,63 @@ func (m *ResponseMeta) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			s := stringValue
+			m.RepoCpeMappingHash = &s
+			iNdEx = postIndex
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingUpdatePath", wireType)
+			}
+			var v RepoCPEMappingUpdatePath
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= RepoCPEMappingUpdatePath(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RepoCpeMappingUpdatePath = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -3594,6 +4385,159 @@ func (m *GetReportResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.Unchanged = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SyncRepoCPEMappingRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mapping", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Mapping = dAtA[iNdEx:postIndex]
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SyncRepoCPEMappingResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SyncRepoCPEMappingResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Updated", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Updated = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/filedownloader/filedownloader.go
+++ b/pkg/filedownloader/filedownloader.go
@@ -224,7 +224,7 @@ func (d *Downloader) doDownload(ctx context.Context) error {
 		return fmt.Errorf("response body exceeds maximum size of %d bytes", d.maxSize)
 	}
 
-	if err := atomicWriteFile(d.filePath, body); err != nil {
+	if err := AtomicWriteFile(d.filePath, body); err != nil {
 		return fmt.Errorf("writing file: %w", err)
 	}
 
@@ -232,7 +232,10 @@ func (d *Downloader) doDownload(ctx context.Context) error {
 	return nil
 }
 
-func atomicWriteFile(path string, data []byte) error {
+// AtomicWriteFile writes data to path via a temp file plus rename, so
+// concurrent readers never observe a partially written file. Creates
+// path's parent directory (mode 0700) if it does not already exist.
+func AtomicWriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("creating directory %q: %w", dir, err)

--- a/pkg/filedownloader/filedownloader_test.go
+++ b/pkg/filedownloader/filedownloader_test.go
@@ -268,7 +268,7 @@ func TestAtomicWriteFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "output.json")
 
-	require.NoError(t, atomicWriteFile(path, []byte("hello")))
+	require.NoError(t, AtomicWriteFile(path, []byte("hello")))
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestAtomicWriteFile_CreatesParentDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "output.json")
 
-	require.NoError(t, atomicWriteFile(path, []byte("hello")))
+	require.NoError(t, AtomicWriteFile(path, []byte("hello")))
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)

--- a/pkg/scannerv4/repositorytocpe/mapping_validate.go
+++ b/pkg/scannerv4/repositorytocpe/mapping_validate.go
@@ -2,6 +2,7 @@ package repositorytocpe
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/cespare/xxhash/v2"
@@ -20,7 +21,7 @@ func ValidateMapping(content []byte) error {
 		return fmt.Errorf("decode mapping: %w", err)
 	}
 	if m.Data == nil {
-		return fmt.Errorf("mapping missing data object")
+		return errors.New("mapping missing data object")
 	}
 	return nil
 }

--- a/pkg/scannerv4/repositorytocpe/mapping_validate.go
+++ b/pkg/scannerv4/repositorytocpe/mapping_validate.go
@@ -1,0 +1,32 @@
+package repositorytocpe
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// MaxMappingBytes is the accepted size cap for repository-to-CPE JSON (5 MiB).
+const MaxMappingBytes = 5 * 1024 * 1024
+
+// ValidateMapping rejects oversize or undecodable repository-to-CPE JSON.
+func ValidateMapping(content []byte) error {
+	if len(content) > MaxMappingBytes {
+		return fmt.Errorf("mapping size %d exceeds %d bytes", len(content), MaxMappingBytes)
+	}
+	var m MappingFile
+	if err := json.Unmarshal(content, &m); err != nil {
+		return fmt.Errorf("decode mapping: %w", err)
+	}
+	if m.Data == nil {
+		return fmt.Errorf("mapping missing data object")
+	}
+	return nil
+}
+
+// HashMapping returns XXH64 of content as 16 lowercase hex characters.
+func HashMapping(content []byte) string {
+	sum := xxhash.Sum64(content)
+	return fmt.Sprintf("%016x", sum)
+}

--- a/pkg/scannerv4/repositorytocpe/mapping_validate_test.go
+++ b/pkg/scannerv4/repositorytocpe/mapping_validate_test.go
@@ -1,0 +1,62 @@
+package repositorytocpe
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMapping(t *testing.T) {
+	tests := map[string]struct {
+		content []byte
+		wantErr bool
+	}{
+		"valid minimal JSON accepted": {
+			content: []byte(`{"data":{}}`),
+			wantErr: false,
+		},
+		"malformed JSON rejected": {
+			content: []byte(`{"data":`),
+			wantErr: true,
+		},
+		"oversize content rejected": {
+			content: bytes.Repeat([]byte("a"), MaxMappingBytes+1),
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateMapping(tt.content)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestHashMapping(t *testing.T) {
+	tests := map[string]struct {
+		content  []byte
+		wantHash string
+	}{
+		"stable hash for fixed bytes": {
+			content:  []byte(`{"data":{"repo-1":{"cpes":["cpe:/o:redhat:rhel:8"]}}}`),
+			wantHash: "e34b7b416f5e54e8",
+		},
+		"empty content hash is still 16 hex chars": {
+			content:  []byte(""),
+			wantHash: "ef46db3751d8e999",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hash := HashMapping(tt.content)
+			assert.Len(t, hash, 16)
+			assert.Equal(t, tt.wantHash, hash)
+		})
+	}
+}

--- a/proto/internalapi/virtualmachine/v1/vm_service.proto
+++ b/proto/internalapi/virtualmachine/v1/vm_service.proto
@@ -19,6 +19,7 @@ message VMServiceRequest {
   RequestMeta meta = 1;
   oneof method {
     GetReportRequest get_report = 2;
+    SyncRepoCPEMappingRequest sync_repo_cpe_mapping = 3;
   }
 }
 
@@ -29,6 +30,7 @@ message VMServiceResponse {
   oneof result {
     GetReportResponse get_report = 2;
     ErrorResponse error = 3;
+    SyncRepoCPEMappingResponse sync_repo_cpe_mapping = 4;
   }
 }
 
@@ -66,6 +68,11 @@ message ResponseMeta {
   // with Sensor's cached value for that VM. Zero means the agent predates this
   // field; Sensor falls back to generation-only comparison in that case.
   uint32 epoch = 6;
+  // XXH64 hex of active mapping; empty string means none. optional so absence
+  // means an older agent that does not report mapping metadata.
+  optional string repo_cpe_mapping_hash = 7;
+  // SENSOR or URL only; UNSPECIFIED means Sensor must not sync.
+  optional RepoCPEMappingUpdatePath repo_cpe_mapping_update_path = 8;
 }
 
 // --- Methods ---
@@ -91,6 +98,21 @@ message GetReportResponse {
   // True when agent's generation matches last_known_generation; index_report
   // is nil in this case. Sensor may still force a refresh after 4 h (ADR-0006 §2).
   bool unchanged = 2;
+}
+
+message SyncRepoCPEMappingRequest {
+  bytes mapping = 1;
+}
+
+message SyncRepoCPEMappingResponse {
+  // True when the agent accepted new content (applied or staged).
+  bool updated = 1;
+}
+
+enum RepoCPEMappingUpdatePath {
+  REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED = 0;
+  REPO_CPE_MAPPING_UPDATE_PATH_SENSOR = 1;
+  REPO_CPE_MAPPING_UPDATE_PATH_URL = 2;
 }
 
 // --- Errors ---
@@ -119,4 +141,8 @@ enum ErrorCode {
   ERROR_CODE_REQUEST_TOO_LARGE = 5;
   // Agent is already serving another connection; retry after a backoff.
   ERROR_CODE_BUSY = 6;
+  // No usable mapping yet; guest disk has not been scanned.
+  ERROR_CODE_MAPPING_REQUIRED = 7;
+  // SyncRepoCPEMapping rejected because updater is not Sensor-managed.
+  ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED = 8;
 }

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -1,16 +1,21 @@
 package scannerdefinitions
 
 import (
+	"context"
 	"crypto/x509"
 	"io"
 	"net/http"
 	"net/url"
 	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralclient"
@@ -18,6 +23,22 @@ import (
 )
 
 const scannerDefsPath = "/api/extensions/scannerdefinitions"
+
+const (
+	// repo2CPEFileParam matches sensorMappingsFile in compliance/node/index/indexer.go.
+	repo2CPEFileParam = "repo2cpe"
+
+	// repo2CPERefreshInterval is the steady-state cadence other repo2cpe consumers use.
+	repo2CPERefreshInterval = 4 * time.Hour
+	// repo2CPERetryInterval is short so a cold cache reaches its first success quickly.
+	repo2CPERetryInterval = time.Minute
+	repo2CPEFetchTimeout  = 30 * time.Second
+
+	etagHeader            = "ETag"
+	ifNoneMatchHeader     = "If-None-Match"
+	lastModifiedHeader    = "Last-Modified"
+	ifModifiedSinceHeader = "If-Modified-Since"
+)
 
 var (
 	headersToProxy = set.NewFrozenStringSet("If-Modified-Since", "Accept-Encoding")
@@ -29,6 +50,22 @@ var (
 type Handler struct {
 	centralClient    *http.Client
 	centralReachable atomic.Bool
+
+	refreshOnce sync.Once
+	cacheMu     sync.Mutex
+	cache       repo2CPECache
+}
+
+// repo2CPECache is Sensor's in-process copy of Central's repo-to-CPE mapping,
+// independent of ServeHTTP's per-request proxying, plus enough state to issue
+// a conditional GET and to tell "never fetched" apart from "stale".
+type repo2CPECache struct {
+	mapping      []byte
+	hash         string
+	etag         string
+	lastModified string
+	lastAttempt  time.Time
+	lastSuccess  time.Time
 }
 
 // NewDefinitionsHandler creates a new scanner definitions handler.
@@ -48,6 +85,7 @@ func (h *Handler) Notify(e common.SensorComponentEvent) {
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReachable.Store(true)
+		h.startRepo2CPERefresh()
 	case common.SensorComponentEventOfflineMode:
 		h.centralReachable.Store(false)
 	}
@@ -101,5 +139,153 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		httputil.WriteGRPCStyleErrorf(writer, codes.Internal, "failed write response: %v", err)
 		return
+	}
+}
+
+// FetchRepo2CPE returns Sensor's cached repo-to-CPE mapping for in-process
+// callers such as vmscraper, starting the background refresh loop on first
+// call. ok is false only if Central has never been fetched successfully; a
+// copy served while central is unreachable is still ok, just possibly stale.
+func (h *Handler) FetchRepo2CPE(_ context.Context) (mapping []byte, hash string, ok bool) {
+	h.startRepo2CPERefresh()
+
+	return concurrency.WithLock3(&h.cacheMu, func() ([]byte, string, bool) {
+		if h.cache.lastSuccess.IsZero() {
+			return nil, "", false
+		}
+		if !h.centralReachable.Load() {
+			log.Info("Serving stale repo-to-CPE mapping: central is unreachable")
+		}
+		return h.cache.mapping, h.cache.hash, true
+	})
+}
+
+// startRepo2CPERefresh launches the background refresh loop exactly once,
+// however many times Notify or FetchRepo2CPE end up triggering it.
+func (h *Handler) startRepo2CPERefresh() {
+	h.refreshOnce.Do(func() {
+		go h.refreshRepo2CPELoop()
+	})
+}
+
+// refreshRepo2CPELoop refetches after repo2CPERefreshInterval on success, or
+// after repo2CPERetryInterval on failure or while offline, so a cold cache
+// doesn't wait hours for its first successful fetch.
+func (h *Handler) refreshRepo2CPELoop() {
+	for {
+		delay := repo2CPERetryInterval
+		if h.centralReachable.Load() {
+			ctx, cancel := context.WithTimeout(context.Background(), repo2CPEFetchTimeout)
+			ok := h.attemptRepo2CPERefresh(ctx)
+			cancel()
+			if ok {
+				delay = repo2CPERefreshInterval
+			}
+		}
+		time.Sleep(delay)
+	}
+}
+
+// attemptRepo2CPERefresh issues one conditional GET for the repo-to-CPE
+// mapping and updates the cache on success or "unchanged". It reports
+// whether the attempt succeeded, so the caller can pick the next delay.
+func (h *Handler) attemptRepo2CPERefresh(ctx context.Context) bool {
+	etag, lastModified := concurrency.WithLock2(&h.cacheMu, func() (string, string) {
+		return h.cache.etag, h.cache.lastModified
+	})
+
+	req, err := h.newRepo2CPERequest(ctx, etag, lastModified)
+	if err != nil {
+		log.Warnf("Failed to build repo-to-CPE mapping request: %v", err)
+		h.recordRepo2CPEAttempt(false)
+		return false
+	}
+
+	resp, err := h.centralClient.Do(req)
+	if err != nil {
+		log.Warnf("Failed to fetch repo-to-CPE mapping from central: %v", err)
+		h.recordRepo2CPEAttempt(false)
+		return false
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		h.recordRepo2CPEUnchanged(resp)
+		return true
+	case http.StatusOK:
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Warnf("Failed to read repo-to-CPE mapping response: %v", err)
+			h.recordRepo2CPEAttempt(false)
+			return false
+		}
+		h.recordRepo2CPESuccess(body, resp)
+		return true
+	default:
+		log.Warnf("Unexpected status %d fetching repo-to-CPE mapping from central", resp.StatusCode)
+		h.recordRepo2CPEAttempt(false)
+		return false
+	}
+}
+
+func (h *Handler) newRepo2CPERequest(ctx context.Context, etag, lastModified string) (*http.Request, error) {
+	centralURL := url.URL{
+		Path:     scannerDefsPath,
+		RawQuery: "file=" + repo2CPEFileParam,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, centralURL.String(), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating request")
+	}
+	if etag != "" {
+		req.Header.Set(ifNoneMatchHeader, etag)
+	}
+	if lastModified != "" {
+		req.Header.Set(ifModifiedSinceHeader, lastModified)
+	}
+	return req, nil
+}
+
+func (h *Handler) recordRepo2CPEAttempt(success bool) {
+	concurrency.WithLock(&h.cacheMu, func() {
+		h.cache.lastAttempt = time.Now()
+		if success {
+			h.cache.lastSuccess = h.cache.lastAttempt
+		}
+	})
+}
+
+func (h *Handler) recordRepo2CPEUnchanged(resp *http.Response) {
+	concurrency.WithLock(&h.cacheMu, func() {
+		h.cache.lastAttempt = time.Now()
+		h.cache.lastSuccess = h.cache.lastAttempt
+		h.updateRepo2CPEValidatorsLocked(resp)
+	})
+}
+
+// recordRepo2CPESuccess keeps the existing cached bytes when the new content
+// hashes the same as what's cached, treating a same-hash 200 like a 304.
+func (h *Handler) recordRepo2CPESuccess(body []byte, resp *http.Response) {
+	hash := repositorytocpe.HashMapping(body)
+	concurrency.WithLock(&h.cacheMu, func() {
+		h.cache.lastAttempt = time.Now()
+		h.cache.lastSuccess = h.cache.lastAttempt
+		if hash != h.cache.hash {
+			h.cache.mapping = body
+			h.cache.hash = hash
+		}
+		h.updateRepo2CPEValidatorsLocked(resp)
+	})
+}
+
+// updateRepo2CPEValidatorsLocked refreshes the cached conditional-GET
+// validators from resp. Callers must hold h.cacheMu.
+func (h *Handler) updateRepo2CPEValidatorsLocked(resp *http.Response) {
+	if etag := resp.Header.Get(etagHeader); etag != "" {
+		h.cache.etag = etag
+	}
+	if lm := resp.Header.Get(lastModifiedHeader); lm != "" {
+		h.cache.lastModified = lm
 	}
 }

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -2,14 +2,20 @@ package scannerdefinitions
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServeHTTP_Responses(t *testing.T) {
@@ -120,4 +126,180 @@ func TestServeHTTP_Responses(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newTestCentralClient spins up a real httptest.Server and returns a client
+// whose transport rewrites relative URLs to point at it, mirroring how the
+// production Central transport fills in scheme/host for requests built with
+// only a path (see newRepo2CPERequest).
+func newTestCentralClient(t *testing.T, handler http.HandlerFunc) *http.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	base, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := server.Client()
+	client.Transport = httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		req = req.Clone(req.Context())
+		req.URL.Scheme = base.Scheme
+		req.URL.Host = base.Host
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	return client
+}
+
+func TestAttemptRepo2CPERefresh(t *testing.T) {
+	const mappingV1 = `{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`
+	const mappingV2 = `{"data":{"bar":{"cpes":["cpe:/o:bar"]}}}`
+	hashV1 := repositorytocpe.HashMapping([]byte(mappingV1))
+	hashV2 := repositorytocpe.HashMapping([]byte(mappingV2))
+
+	tests := map[string]struct {
+		seedCache     repo2CPECache
+		serverHandler http.HandlerFunc
+		networkErr    bool
+		wantOK        bool
+		wantMapping   string
+		wantHash      string
+	}{
+		"first fetch succeeds and populates an empty cache": {
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, repo2CPEFileParam, r.URL.Query().Get("file"))
+				w.Header().Set(etagHeader, `"v1"`)
+				_, _ = w.Write([]byte(mappingV1))
+			},
+			wantOK:      true,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"304 with matching validators keeps the cached mapping": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, etag: `"v1"`},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, `"v1"`, r.Header.Get(ifNoneMatchHeader))
+				w.WriteHeader(http.StatusNotModified)
+			},
+			wantOK:      true,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"200 with a same-hash body is treated as unchanged": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(mappingV1))
+			},
+			wantOK:      true,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"200 with a different hash replaces the cached mapping": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(mappingV2))
+			},
+			wantOK:      true,
+			wantMapping: mappingV2,
+			wantHash:    hashV2,
+		},
+		"an unexpected status leaves the cache untouched": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantOK:      false,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"a network error leaves the cache untouched": {
+			seedCache:   repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			networkErr:  true,
+			wantOK:      false,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := &Handler{cache: tt.seedCache}
+			if tt.networkErr {
+				h.centralClient = &http.Client{
+					Transport: httputil.RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+						return nil, errors.New("connection refused")
+					}),
+				}
+			} else {
+				h.centralClient = newTestCentralClient(t, tt.serverHandler)
+			}
+
+			ok := h.attemptRepo2CPERefresh(context.Background())
+
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantMapping, string(h.cache.mapping))
+			assert.Equal(t, tt.wantHash, h.cache.hash)
+			assert.False(t, h.cache.lastAttempt.IsZero(), "lastAttempt should be recorded regardless of outcome")
+			if tt.wantOK {
+				assert.False(t, h.cache.lastSuccess.IsZero())
+			} else {
+				assert.True(t, h.cache.lastSuccess.IsZero())
+			}
+		})
+	}
+}
+
+// TestAttemptRepo2CPERefresh_RetryRecoversWithoutLosingCache calls the
+// refresh helper directly (no timers/sleeps) to verify a failed attempt
+// keeps serving the last good mapping and a later success can recover.
+func TestAttemptRepo2CPERefresh_RetryRecoversWithoutLosingCache(t *testing.T) {
+	const mapping = `{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`
+	hash := repositorytocpe.HashMapping([]byte(mapping))
+
+	var fail atomic.Bool
+	h := &Handler{centralClient: newTestCentralClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(mapping))
+	})}
+
+	require.True(t, h.attemptRepo2CPERefresh(context.Background()))
+	assert.Equal(t, hash, h.cache.hash)
+
+	fail.Store(true)
+	require.False(t, h.attemptRepo2CPERefresh(context.Background()))
+	assert.Equal(t, hash, h.cache.hash, "a failed refresh must not drop the last good mapping")
+
+	fail.Store(false)
+	require.True(t, h.attemptRepo2CPERefresh(context.Background()))
+	assert.Equal(t, hash, h.cache.hash)
+}
+
+func TestFetchRepo2CPE(t *testing.T) {
+	mapping := []byte(`{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`)
+	hash := repositorytocpe.HashMapping(mapping)
+
+	t.Run("never fetched returns ok=false", func(t *testing.T) {
+		h := &Handler{centralClient: &http.Client{}}
+		h.centralReachable.Store(false)
+
+		gotMapping, gotHash, ok := h.FetchRepo2CPE(context.Background())
+
+		assert.False(t, ok)
+		assert.Nil(t, gotMapping)
+		assert.Empty(t, gotHash)
+	})
+
+	t.Run("offline serves the last cached mapping with ok=true", func(t *testing.T) {
+		h := &Handler{centralClient: &http.Client{}}
+		h.cache = repo2CPECache{mapping: mapping, hash: hash, lastSuccess: time.Now()}
+		h.centralReachable.Store(false)
+
+		gotMapping, gotHash, ok := h.FetchRepo2CPE(context.Background())
+
+		assert.True(t, ok)
+		assert.Equal(t, mapping, gotMapping)
+		assert.Equal(t, hash, gotHash)
+	})
 }

--- a/sensor/common/sensor/repo2cpe_inject_test.go
+++ b/sensor/common/sensor/repo2cpe_inject_test.go
@@ -1,0 +1,79 @@
+package sensor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/scannerdefinitions"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vmscraper"
+	"github.com/stretchr/testify/assert"
+)
+
+// noopComponent satisfies common.SensorComponent with no-op behavior, so
+// test cases only need to add the interface(s) they actually care about.
+type noopComponent struct{}
+
+func (noopComponent) Start() error                                               { return nil }
+func (noopComponent) Stop()                                                      {}
+func (noopComponent) Capabilities() []centralsensor.SensorCapability             { return nil }
+func (noopComponent) Name() string                                               { return "noop" }
+func (noopComponent) Notify(common.SensorComponentEvent)                         {}
+func (noopComponent) ProcessMessage(context.Context, *central.MsgToSensor) error { return nil }
+func (noopComponent) Accepts(*central.MsgToSensor) bool                          { return false }
+func (noopComponent) ResponsesC() <-chan *message.ExpiringMessage                { return nil }
+
+var _ common.SensorComponent = noopComponent{}
+
+// fakeVMScraperComponent stands in for *vmscraper.VMScraper: it satisfies
+// repo2CPEFetcherSetter without pulling in the real VMScraper's dependencies.
+type fakeVMScraperComponent struct {
+	noopComponent
+	fetcher vmscraper.Repo2CPEFetcher
+	calls   int
+}
+
+func (f *fakeVMScraperComponent) SetRepo2CPEFetcher(fetcher vmscraper.Repo2CPEFetcher) {
+	f.calls++
+	f.fetcher = fetcher
+}
+
+func TestInjectRepo2CPEFetcher(t *testing.T) {
+	t.Run("should wire the handler into a matching component exactly once", func(t *testing.T) {
+		scraper := &fakeVMScraperComponent{}
+		handler := &scannerdefinitions.Handler{}
+		s := &Sensor{
+			scannerDefsHandler: handler,
+			components:         []common.SensorComponent{noopComponent{}, scraper},
+		}
+
+		s.injectRepo2CPEFetcher()
+
+		assert.Equal(t, 1, scraper.calls)
+		assert.Same(t, handler, scraper.fetcher)
+	})
+
+	t.Run("should do nothing when no component implements the setter", func(t *testing.T) {
+		s := &Sensor{
+			scannerDefsHandler: &scannerdefinitions.Handler{},
+			components:         []common.SensorComponent{noopComponent{}},
+		}
+
+		assert.NotPanics(t, s.injectRepo2CPEFetcher)
+	})
+
+	t.Run("should do nothing when the handler was never built", func(t *testing.T) {
+		scraper := &fakeVMScraperComponent{}
+		s := &Sensor{
+			scannerDefsHandler: nil,
+			components:         []common.SensorComponent{scraper},
+		}
+
+		s.injectRepo2CPEFetcher()
+
+		assert.Zero(t, scraper.calls)
+	})
+}

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -93,6 +93,10 @@ type Sensor struct {
 	reconcile  atomic.Bool
 
 	clusterID clusterIDPeekSetter
+
+	// scannerDefsHandler is kept regardless of whether the HTTP route is
+	// registered, so VM-only clusters can inject it into vmscraper.
+	scannerDefsHandler *scannerdefinitions.Handler
 }
 
 // NewSensor initializes a Sensor, including reading configurations from the environment.
@@ -235,16 +239,23 @@ func (s *Sensor) Start() {
 		s.AddNotifiable(wrapNotifiable(koCacheSource, "Kernel object cache"))
 	}
 
-	// Enable endpoint to retrieve vulnerability definitions if local image scanning or Node Indexing is enabled.
-	// Node Indexing requires access to the repo to cpe mapping file hosted by central.
-	if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() {
-		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint, centralCertificates)
+	// Construct the scanner definitions handler if local image scanning, Node Indexing, or VM
+	// scanning is enabled: all three need access to the repo-to-CPE mapping file hosted by
+	// central, whether through the HTTP route below or, for VM scanning, via FetchRepo2CPE.
+	if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() || features.VirtualMachines.Enabled() {
+		handler, err := scannerdefinitions.NewDefinitionsHandler(s.centralEndpoint, centralCertificates)
 		if err != nil {
-			utils.Should(errors.Wrap(err, "Failed to create scanner definition route"))
-		}
-		customRoutes = append(customRoutes, *route)
+			utils.Should(errors.Wrap(err, "Failed to create scanner definitions handler"))
+		} else {
+			s.scannerDefsHandler = handler
+			s.AddNotifiable(handler)
 
-		s.AddNotifiable(scannerclient.ResetNotifiable())
+			// The HTTP route itself is only needed by Scanner/Collector/node-index callers.
+			if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() {
+				customRoutes = append(customRoutes, s.newScannerDefinitionsRoute(handler))
+				s.AddNotifiable(scannerclient.ResetNotifiable())
+			}
+		}
 	}
 
 	// Enable proxy endpoint for forwarding requests to Central on OpenShift.
@@ -318,19 +329,14 @@ func (s *Sensor) Start() {
 }
 
 // newScannerDefinitionsRoute returns a custom route that serves scanner
-// definitions retrieved from Central.
-func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string, centralCertificates []*x509.Certificate) (*routes.CustomRoute, error) {
-	handler, err := scannerdefinitions.NewDefinitionsHandler(centralEndpoint, centralCertificates)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating scanner definitions handler")
-	}
-	s.AddNotifiable(handler)
+// definitions retrieved from Central via handler.
+func (s *Sensor) newScannerDefinitionsRoute(handler *scannerdefinitions.Handler) routes.CustomRoute {
 	// We rely on central to handle content encoding negotiation.
-	return &routes.CustomRoute{
+	return routes.CustomRoute{
 		Route:         scannerDefinitionsRoute,
 		Authorizer:    or.Or(idcheck.ScannerOnly(), idcheck.ScannerV4IndexerOnly(), idcheck.CollectorOnly()),
 		ServerHandler: handler,
-	}, nil
+	}
 }
 
 func (s *Sensor) registerSoftRestartHandler() {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/scannerclient"
 	"github.com/stackrox/rox/sensor/common/scannerdefinitions"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vmscraper"
 )
 
 const (
@@ -249,6 +250,7 @@ func (s *Sensor) Start() {
 		} else {
 			s.scannerDefsHandler = handler
 			s.AddNotifiable(handler)
+			s.injectRepo2CPEFetcher()
 
 			// The HTTP route itself is only needed by Scanner/Collector/node-index callers.
 			if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() {
@@ -326,6 +328,28 @@ func (s *Sensor) Start() {
 
 	log.Info("Running Sensor with connection retry: preventing sensor restart on disconnect")
 	go s.communicationWithCentralWithRetries(&centralReachable)
+}
+
+// repo2CPEFetcherSetter is satisfied by *vmscraper.VMScraper. Asserting
+// against this small interface, rather than the concrete type, keeps the
+// match working for any future SensorComponent with the same setter.
+type repo2CPEFetcherSetter interface {
+	SetRepo2CPEFetcher(f vmscraper.Repo2CPEFetcher)
+}
+
+// injectRepo2CPEFetcher gives a VMScraper found in s.components access to
+// s.scannerDefsHandler, if both exist. A direct, one-shot call rather than
+// pub/sub: there is exactly one producer and one consumer in this process.
+func (s *Sensor) injectRepo2CPEFetcher() {
+	if s.scannerDefsHandler == nil {
+		return
+	}
+	for _, c := range s.components {
+		if setter, ok := c.(repo2CPEFetcherSetter); ok {
+			setter.SetRepo2CPEFetcher(s.scannerDefsHandler)
+			return
+		}
+	}
 }
 
 // newScannerDefinitionsRoute returns a custom route that serves scanner

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -152,6 +152,21 @@ const (
 	PullStatusNotReady      = "not_ready"
 	PullStatusUnknownMethod = "unknown_method"
 	PullStatusTimeout       = "timeout"
+	// PullStatusMappingRequired marks a GetReport error response the agent
+	// sends because it has no repo-to-CPE mapping yet.
+	PullStatusMappingRequired = "mapping_required"
+	// PullStatusSyncSuccess marks a repo-to-CPE mapping sync the agent
+	// accepted (Updated is informational only; both true and false count here).
+	PullStatusSyncSuccess = "sync_success"
+	// PullStatusSyncError marks a repo-to-CPE mapping sync that failed to
+	// dial or was rejected for a reason other than not-Sensor-managed.
+	PullStatusSyncError = "sync_error"
+	// PullStatusSyncNotManaged marks a sync rejected because the agent is
+	// URL-managed; Sensor's own gate should prevent this, so it signals a bug.
+	PullStatusSyncNotManaged = "sync_not_managed"
+	// PullStatusURLHashMismatch marks a URL-managed agent whose reported
+	// mapping hash differs from Sensor's own cache; Sensor never dials for this.
+	PullStatusURLHashMismatch = "url_hash_mismatch"
 )
 
 // PullDialDurationSeconds measures time to establish a websocket connection per VM.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
@@ -66,6 +67,13 @@ type IndexReportSender interface {
 // ProtocolClient performs the request/response protocol over a stream.
 type ProtocolClient interface {
 	GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error)
+	SyncRepoCPEMapping(ctx context.Context, stream io.ReadWriteCloser, mapping []byte) (updated bool, meta *pb.ResponseMeta, err error)
+}
+
+// Repo2CPEFetcher supplies Sensor's cached repo-to-CPE mapping so maybeSync
+// can tell whether a VM's agent needs a pushed update.
+type Repo2CPEFetcher interface {
+	FetchRepo2CPE(ctx context.Context) (mapping []byte, hash string, ok bool)
 }
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
@@ -86,6 +94,7 @@ type VMScraper struct {
 	mu        sync.Mutex
 	vmState   map[string]*vmState
 	activeVMs set.StringSet
+	fetcher   Repo2CPEFetcher
 }
 
 type vmState struct {
@@ -123,6 +132,22 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 func (s *VMScraper) IsActivelyScraped(key string) bool {
 	return concurrency.WithLock1(&s.mu, func() bool {
 		return s.activeVMs.Contains(key)
+	})
+}
+
+// SetRepo2CPEFetcher wires the source maybeSync reads to decide whether a
+// VM's agent needs a pushed repo-to-CPE mapping. Nil-safe: if never called
+// (e.g. Sensor could not build the scanner definitions handler), maybeSync
+// stays a no-op.
+func (s *VMScraper) SetRepo2CPEFetcher(f Repo2CPEFetcher) {
+	concurrency.WithLock(&s.mu, func() {
+		s.fetcher = f
+	})
+}
+
+func (s *VMScraper) repo2CPEFetcher() Repo2CPEFetcher {
+	return concurrency.WithLock1(&s.mu, func() Repo2CPEFetcher {
+		return s.fetcher
 	})
 }
 
@@ -334,10 +359,26 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	result, err := s.client.GetReport(ctx, stream, ifNewerThan, knownEpoch)
 	metrics.PullReadDurationSeconds.Observe(time.Since(readStart).Seconds())
 	if err != nil {
+		// MAPPING_REQUIRED is the only error whose Meta still needs
+		// inspecting: a VM with no mapping at all has nothing to report
+		// except this error, and it's the only way Sensor learns to push one.
+		if errors.Is(err, vsockclient.ErrMappingRequired) {
+			s.maybeSync(ctx, vm, key, port, resultMeta(result))
+		}
 		s.handleGetReportError(ctx, key, err)
 		return nil, false
 	}
+	s.maybeSync(ctx, vm, key, port, result.Meta)
 	return result, true
+}
+
+// resultMeta returns result.Meta, tolerating a nil result: ProtocolClient
+// implementations are not required to populate a result on every error.
+func resultMeta(result *vsockclient.GetReportResult) *pb.ResponseMeta {
+	if result == nil {
+		return nil
+	}
+	return result.Meta
 }
 
 func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err error) {
@@ -353,6 +394,9 @@ func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err er
 	case errors.Is(err, vsockclient.ErrNotReady):
 		log.Debugf("VMScraper: roxagent on %q has not yet generated a report", key)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusNotReady).Inc()
+	case errors.Is(err, vsockclient.ErrMappingRequired):
+		log.Debugf("VMScraper: roxagent on %q has no repo-to-CPE mapping yet", key)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusMappingRequired).Inc()
 	case errors.Is(err, vsockclient.ErrUnknownMethod):
 		log.Warnf("VMScraper: roxagent on %q does not support the GetReport method", key)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnknownMethod).Inc()
@@ -363,6 +407,65 @@ func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err er
 		log.Warnf("VMScraper: protocol error for %q (possible version mismatch): %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
 	}
+}
+
+// maybeSync inspects meta from a completed GetReport exchange (success,
+// Unchanged, or a MAPPING_REQUIRED error) and pushes a fresh mapping when
+// the agent is Sensor-managed and its reported hash is stale. A URL-managed
+// agent with a stale hash is only logged and counted, since Sensor doesn't own it.
+func (s *VMScraper) maybeSync(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, meta *pb.ResponseMeta) {
+	updatePath := meta.GetRepoCpeMappingUpdatePath()
+	if updatePath == pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED {
+		return
+	}
+	fetcher := s.repo2CPEFetcher()
+	if fetcher == nil {
+		return
+	}
+	mapping, sensorHash, ok := fetcher.FetchRepo2CPE(ctx)
+	if !ok || sensorHash == meta.GetRepoCpeMappingHash() {
+		return
+	}
+
+	switch updatePath {
+	case pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR:
+		s.syncRepoCPEMapping(ctx, vm, key, port, mapping)
+	case pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL:
+		log.Warnf("VMScraper: roxagent on %q reports a URL-managed repo-to-CPE mapping (hash=%s) that differs from Sensor's own cache (hash=%s)",
+			key, meta.GetRepoCpeMappingHash(), sensorHash)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusURLHashMismatch).Inc()
+	}
+}
+
+// syncRepoCPEMapping pushes mapping to the VM over a second, short-lived
+// VSOCK connection — GetReport's one-request-per-connection contract means
+// the push cannot ride the same connection as the report exchange.
+func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, mapping []byte) {
+	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
+	if err != nil {
+		log.Warnf("VMScraper: dialing roxagent on %q for repo-to-CPE mapping sync failed: %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSyncError).Inc()
+		return
+	}
+	defer func() { _ = stream.Close() }()
+
+	updated, _, err := s.client.SyncRepoCPEMapping(ctx, stream, mapping)
+	if err != nil {
+		// NOT_SENSOR_MANAGED should never happen here: maybeSync only takes
+		// the SENSOR path for agents it believes accept a push. Counting it
+		// (without retrying) turns a gating bug into a visible signal.
+		if errors.Is(err, vsockclient.ErrMappingNotSensorManaged) {
+			log.Warnf("VMScraper: roxagent on %q rejected repo-to-CPE mapping sync as not Sensor-managed", key)
+			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSyncNotManaged).Inc()
+			return
+		}
+		log.Warnf("VMScraper: repo-to-CPE mapping sync to %q failed: %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSyncError).Inc()
+		return
+	}
+
+	log.Infof("VMScraper: synced repo-to-CPE mapping to %q (updated=%t)", key, updated)
+	metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSyncSuccess).Inc()
 }
 
 // vmKey returns the identifier used for vmState and activeVMs lookups.

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -67,6 +67,11 @@ type mockProtocolClient struct {
 	errQueue    []error
 	calls       []protocolCall
 	callIdx     int
+
+	syncCalls   [][]byte
+	syncUpdated bool
+	syncMeta    *pb.ResponseMeta
+	syncErr     error
 }
 
 type protocolCall struct {
@@ -79,7 +84,13 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	idx := m.callIdx
 	m.callIdx++
 	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
-		return nil, m.errQueue[idx]
+		// Some errors (e.g. MAPPING_REQUIRED) still carry a queued result
+		// with Meta, mirroring the real client's error-case behavior.
+		var result *vsockclient.GetReportResult
+		if idx < len(m.resultQueue) {
+			result = m.resultQueue[idx]
+		}
+		return result, m.errQueue[idx]
 	}
 	if idx < len(m.resultQueue) {
 		return m.resultQueue[idx], nil
@@ -87,9 +98,28 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	return nil, errors.New("unexpected call: no more queued results")
 }
 
+func (m *mockProtocolClient) SyncRepoCPEMapping(_ context.Context, _ io.ReadWriteCloser, mapping []byte) (bool, *pb.ResponseMeta, error) {
+	m.syncCalls = append(m.syncCalls, mapping)
+	return m.syncUpdated, m.syncMeta, m.syncErr
+}
+
 func (m *mockProtocolClient) reset() {
 	m.calls = nil
 	m.callIdx = 0
+	m.syncCalls = nil
+}
+
+// fakeFetcher is a Repo2CPEFetcher test double.
+type fakeFetcher struct {
+	mapping []byte
+	hash    string
+	ok      bool
+	calls   int
+}
+
+func (f *fakeFetcher) FetchRepo2CPE(_ context.Context) ([]byte, string, bool) {
+	f.calls++
+	return f.mapping, f.hash, f.ok
 }
 
 type mockSender struct {
@@ -148,6 +178,15 @@ func unchangedResultWithEpoch(gen, epoch uint32) *vsockclient.GetReportResult {
 	return &vsockclient.GetReportResult{
 		Unchanged: true,
 		Meta:      &pb.ResponseMeta{ReportGeneration: gen, Epoch: epoch},
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+func metaWithMapping(hash string, path pb.RepoCPEMappingUpdatePath) *pb.ResponseMeta {
+	return &pb.ResponseMeta{
+		RepoCpeMappingHash:       strPtr(hash),
+		RepoCpeMappingUpdatePath: path.Enum(),
 	}
 }
 
@@ -536,6 +575,10 @@ func (c *safeProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	return makeReport(c.gen), nil
 }
 
+func (c *safeProtocolClient) SyncRepoCPEMapping(_ context.Context, _ io.ReadWriteCloser, _ []byte) (bool, *pb.ResponseMeta, error) {
+	return false, nil, nil
+}
+
 type safeSender struct {
 	mu   sync.Mutex
 	sent int
@@ -591,6 +634,148 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 	maxObserved := dialer.maxObserved.Load()
 	require.Greater(t, maxObserved, int32(1),
 		"expected multiple VMs to be dialed concurrently, observed max concurrency of %d", maxObserved)
+}
+
+func TestVMScraper_MaybeSync(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+
+	cases := map[string]struct {
+		meta          *pb.ResponseMeta
+		fetcher       *fakeFetcher
+		noFetcher     bool
+		syncErr       error
+		wantSyncCalls int
+		wantMetric    string
+	}{
+		"hash match on the SENSOR path should not dial a second time": {
+			meta:    metaWithMapping("same-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher: &fakeFetcher{ok: true, hash: "same-hash"},
+		},
+		"SENSOR mismatch should dial and sync": {
+			meta:          metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher:       &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")},
+			wantSyncCalls: 1,
+			wantMetric:    metrics.PullStatusSyncSuccess,
+		},
+		"URL mismatch should log and count but never dial": {
+			meta:       metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL),
+			fetcher:    &fakeFetcher{ok: true, hash: "new-hash"},
+			wantMetric: metrics.PullStatusURLHashMismatch,
+		},
+		"UNSPECIFIED update path should never sync": {
+			meta:    metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED),
+			fetcher: &fakeFetcher{ok: true, hash: "new-hash"},
+		},
+		"nil meta (agent predates this feature) should never sync": {
+			meta:    nil,
+			fetcher: &fakeFetcher{ok: true, hash: "new-hash"},
+		},
+		"fetcher not ok should never sync even on a SENSOR mismatch": {
+			meta:    metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher: &fakeFetcher{ok: false},
+		},
+		"no fetcher ever set should be a no-op": {
+			meta:      metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			noFetcher: true,
+		},
+		"NOT_SENSOR_MANAGED on the sync dial should log and count, not retry": {
+			meta:          metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher:       &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")},
+			syncErr:       vsockclient.ErrMappingNotSensorManaged,
+			wantSyncCalls: 1,
+			wantMetric:    metrics.PullStatusSyncNotManaged,
+		},
+		"a generic sync failure should log and count": {
+			meta:          metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher:       &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")},
+			syncErr:       errors.New("connection reset"),
+			wantSyncCalls: 1,
+			wantMetric:    metrics.PullStatusSyncError,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &mockProtocolClient{syncErr: tc.syncErr}
+			s := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, client)
+			if !tc.noFetcher {
+				s.SetRepo2CPEFetcher(tc.fetcher)
+			}
+
+			var before float64
+			if tc.wantMetric != "" {
+				before = testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(tc.wantMetric))
+			}
+
+			s.maybeSync(context.Background(), vm, "ns1/vm-a", 9999, tc.meta)
+
+			assert.Len(t, client.syncCalls, tc.wantSyncCalls)
+			if tc.wantMetric != "" {
+				assert.Equal(t, before+1, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(tc.wantMetric)))
+			}
+		})
+	}
+}
+
+// TestVMScraper_DialAndGetReport_SyncTriggering exercises maybeSync's
+// integration point inside dialAndGetReport: only a successful exchange or
+// MAPPING_REQUIRED carries usable Meta, so only those should ever reach the
+// fetcher/second dial.
+func TestVMScraper_DialAndGetReport_SyncTriggering(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	staleFetcher := func() *fakeFetcher {
+		return &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
+	}
+
+	cases := map[string]struct {
+		resultQueue   []*vsockclient.GetReportResult
+		errQueue      []error
+		wantOK        bool
+		wantSyncCalls int
+	}{
+		"MAPPING_REQUIRED error triggers a sync attempt": {
+			resultQueue:   []*vsockclient.GetReportResult{{Meta: metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR)}},
+			errQueue:      []error{vsockclient.ErrMappingRequired},
+			wantOK:        false,
+			wantSyncCalls: 1,
+		},
+		"NOT_READY never triggers a sync attempt": {
+			errQueue: []error{vsockclient.ErrNotReady},
+			wantOK:   false,
+		},
+		"a generic protocol error never triggers a sync attempt": {
+			errQueue: []error{errors.New("connection refused")},
+			wantOK:   false,
+		},
+		"a successful report with a stale Sensor-managed hash also triggers a sync": {
+			resultQueue: []*vsockclient.GetReportResult{{
+				IndexReport: &v4.IndexReport{State: "IndexFinished"},
+				Meta:        metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			}},
+			wantOK:        true,
+			wantSyncCalls: 1,
+		},
+		"an Unchanged report with a matching hash never triggers a sync": {
+			resultQueue: []*vsockclient.GetReportResult{{
+				Unchanged: true,
+				Meta:      metaWithMapping("new-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			}},
+			wantOK: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &mockProtocolClient{resultQueue: tc.resultQueue, errQueue: tc.errQueue}
+			s := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, client)
+			s.SetRepo2CPEFetcher(staleFetcher())
+
+			_, ok := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, 0, 0)
+
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Len(t, client.syncCalls, tc.wantSyncCalls)
+		})
+	}
 }
 
 func TestClampPollInterval(t *testing.T) {

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -27,6 +27,14 @@ var (
 	ErrUnknownMethod = errors.New("agent does not support the requested method")
 	// ErrInternal indicates the agent encountered an internal error.
 	ErrInternal = errors.New("agent internal error")
+	// ErrMappingRequired indicates the agent has no repository-to-CPE
+	// mapping yet and cannot serve a report until one is pushed or
+	// downloaded; the response's Meta still carries the hash/update-path
+	// fields callers need to decide whether to push one.
+	ErrMappingRequired = errors.New("agent has no repository-to-CPE mapping")
+	// ErrMappingNotSensorManaged indicates the agent rejected a
+	// SyncRepoCPEMapping because it is URL-managed, not Sensor-managed.
+	ErrMappingNotSensorManaged = errors.New("agent does not accept a sensor-pushed mapping")
 )
 
 // GetReportResult holds the parsed response from a GetReport call.
@@ -121,9 +129,59 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNew
 			Meta:        resp.GetMeta(),
 		}, nil
 	case *pb.VMServiceResponse_Error:
-		return nil, errorFromResponse(r.Error)
+		// Meta is still returned alongside the error: a VM with no mapping
+		// at all has nothing to report except MAPPING_REQUIRED, and that
+		// error's Meta is the only way the caller learns it needs to push one.
+		return &GetReportResult{Meta: resp.GetMeta()}, errorFromResponse(r.Error)
 	default:
 		return nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
+	}
+}
+
+// SyncRepoCPEMapping pushes mapping to the agent over stream and reports
+// whether the agent applied it. Mirrors GetReport's request/response framing
+// and error classification for the sync_repo_cpe_mapping method.
+func (c *Client) SyncRepoCPEMapping(ctx context.Context, stream io.ReadWriteCloser, mapping []byte) (updated bool, meta *pb.ResponseMeta, err error) {
+	stop := context.AfterFunc(ctx, func() {
+		_ = stream.Close()
+	})
+	defer stop()
+
+	req := &pb.VMServiceRequest{
+		Meta: &pb.RequestMeta{
+			RequestId:    uuid.NewV4().String(),
+			Capabilities: c.capabilities,
+		},
+		Method: &pb.VMServiceRequest_SyncRepoCpeMapping{
+			SyncRepoCpeMapping: &pb.SyncRepoCPEMappingRequest{Mapping: mapping},
+		},
+	}
+
+	reqData, err := proto.Marshal(req)
+	if err != nil {
+		return false, nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	if err := vsockframing.WriteFrame(stream, reqData); err != nil {
+		return false, nil, wrapStreamErr(ctx, "sending request", err)
+	}
+
+	respData, err := vsockframing.ReadFrame(stream, uint32(c.maxResponseSize))
+	if err != nil {
+		return false, nil, wrapStreamErr(ctx, "reading response", err)
+	}
+
+	var resp pb.VMServiceResponse
+	if err := proto.Unmarshal(respData, &resp); err != nil {
+		return false, nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	switch r := resp.GetResult().(type) {
+	case *pb.VMServiceResponse_SyncRepoCpeMapping:
+		return r.SyncRepoCpeMapping.GetUpdated(), resp.GetMeta(), nil
+	case *pb.VMServiceResponse_Error:
+		return false, resp.GetMeta(), errorFromResponse(r.Error)
+	default:
+		return false, nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
 	}
 }
 
@@ -142,6 +200,10 @@ func errorFromResponse(e *pb.ErrorResponse) error {
 		return fmt.Errorf("%w: %s", ErrUnknownMethod, e.GetMessage())
 	case pb.ErrorCode_ERROR_CODE_INTERNAL:
 		return fmt.Errorf("%w: %s", ErrInternal, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED:
+		return fmt.Errorf("%w: %s", ErrMappingRequired, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED:
+		return fmt.Errorf("%w: %s", ErrMappingNotSensorManaged, e.GetMessage())
 	default:
 		return fmt.Errorf("agent error (%s): %s", e.GetCode(), e.GetMessage())
 	}

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -2,6 +2,7 @@ package vsockclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -16,6 +17,23 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+// fakeMappingProvider is a minimal roxagentvsock.MappingProvider double.
+// Ready defaults to true so report-only test cases exercise NOT_READY on an
+// empty cache instead of MAPPING_REQUIRED.
+type fakeMappingProvider struct {
+	ready      bool
+	hash       string
+	updatePath pb.RepoCPEMappingUpdatePath
+}
+
+func (f *fakeMappingProvider) Ready() bool                             { return f.ready }
+func (f *fakeMappingProvider) Hash() string                            { return f.hash }
+func (f *fakeMappingProvider) UpdatePath() pb.RepoCPEMappingUpdatePath { return f.updatePath }
+func (f *fakeMappingProvider) Bytes() ([]byte, error)                  { return nil, errors.New("not implemented") }
+func (f *fakeMappingProvider) Path() (string, error)                   { return "", errors.New("not implemented") }
+
+var _ roxagentvsock.MappingProvider = (*fakeMappingProvider)(nil)
 
 // exchangeTimeout bounds a single client/handler exchange. Under synctest the
 // fake clock advances this duration instantly once every goroutine is durably
@@ -61,7 +79,7 @@ func newProtocolHarness(t *testing.T, opts protocolHarnessOptions) *protocolHarn
 	return &protocolHarness{
 		client:  NewClient(opts.capabilities, opts.maxResponseSize),
 		cache:   cache,
-		handler: roxagentvsock.NewHandler(cache, opts.agentVersion),
+		handler: roxagentvsock.NewHandler(cache, opts.agentVersion, &fakeMappingProvider{ready: true}, nil),
 	}
 }
 

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -121,6 +121,16 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			wantErr:   ErrInternal,
 			wantInMsg: "scan crashed",
 		},
+		"should wrap ErrMappingRequired for MAPPING_REQUIRED": {
+			code:    pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED,
+			message: "no mapping yet",
+			wantErr: ErrMappingRequired,
+		},
+		"should wrap ErrMappingNotSensorManaged for MAPPING_NOT_SENSOR_MANAGED": {
+			code:    pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED,
+			message: "url-managed",
+			wantErr: ErrMappingNotSensorManaged,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -141,6 +151,87 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			if tc.wantInMsg != "" {
 				assert.Contains(t, err.Error(), tc.wantInMsg)
 			}
+		})
+	}
+}
+
+// TestSendGetReport_ErrorCarriesMeta verifies that an error response's Meta
+// is still returned alongside the error, not dropped: MAPPING_REQUIRED is
+// the only way a VM with no mapping at all can tell Sensor it needs one.
+func TestSendGetReport_ErrorCarriesMeta(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer utils.IgnoreError(clientConn.Close)
+
+	go serveOnce(t, agentConn, &pb.VMServiceResponse{
+		Meta: &pb.ResponseMeta{
+			AgentVersion:             "test-agent",
+			RepoCpeMappingHash:       proto.String(""),
+			RepoCpeMappingUpdatePath: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR.Enum(),
+		},
+		Result: &pb.VMServiceResponse_Error{
+			Error: &pb.ErrorResponse{Code: pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED, Message: "no mapping yet"},
+		},
+	}, nil)
+
+	result, err := client.GetReport(context.Background(), clientConn, 0, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMappingRequired)
+	require.NotNil(t, result, "error result must still carry Meta")
+	require.NotNil(t, result.Meta)
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, result.Meta.GetRepoCpeMappingUpdatePath())
+	assert.Empty(t, result.Meta.GetRepoCpeMappingHash())
+}
+
+func TestSendSyncRepoCPEMapping(t *testing.T) {
+	cases := map[string]struct {
+		resp        *pb.VMServiceResponse
+		wantUpdated bool
+		wantErr     error
+	}{
+		"should report updated true on success": {
+			resp: &pb.VMServiceResponse{
+				Meta:   &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_SyncRepoCpeMapping{SyncRepoCpeMapping: &pb.SyncRepoCPEMappingResponse{Updated: true}},
+			},
+			wantUpdated: true,
+		},
+		"should report updated false when the mapping already matched": {
+			resp: &pb.VMServiceResponse{
+				Meta:   &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_SyncRepoCpeMapping{SyncRepoCpeMapping: &pb.SyncRepoCPEMappingResponse{Updated: false}},
+			},
+			wantUpdated: false,
+		},
+		"should wrap ErrMappingNotSensorManaged when the agent is URL-managed": {
+			resp: &pb.VMServiceResponse{
+				Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_Error{
+					Error: &pb.ErrorResponse{Code: pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED, Message: "url-managed"},
+				},
+			},
+			wantErr: ErrMappingNotSensorManaged,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := NewClient(nil, 10<<20)
+			clientConn, agentConn := net.Pipe()
+			defer utils.IgnoreError(clientConn.Close)
+
+			go serveOnce(t, agentConn, tc.resp, func(req *pb.VMServiceRequest) {
+				assert.Equal(t, []byte("mapping-bytes"), req.GetSyncRepoCpeMapping().GetMapping())
+			})
+
+			updated, meta, err := client.SyncRepoCPEMapping(context.Background(), clientConn, []byte("mapping-bytes"))
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUpdated, updated)
+			assert.Equal(t, "test-agent", meta.GetAgentVersion())
 		})
 	}
 }


### PR DESCRIPTION
## Description

`roxagent` (StackRox's pull-mode VM vulnerability-scanning agent) needs a repository-to-CPE mapping file to enrich the packages it finds with CPEs for vulnerability matching. Today it gets that mapping from a single configurable URL (`--repo-cpe-url`), which defaults to a public Red Hat URL fetched directly from inside the VM. That default doesn't work in a disconnected/air-gapped cluster, where the VM has no route to the public internet, and pointing it at a URL at all requires the customer to already run and maintain their own reachable mirror - and the failure mode when neither is available is worse than degraded scanning: the fetch is a mandatory, blocking step at process startup, so if it fails, roxagent refuses to start at all rather than running without a mapping. 
The pattern used in Node scanning - fetching that mapping from Sensor acting as a proxy for Central - is impossible, as the agent has no guarantee to reach Sensor over HTTP and it also cannot initiate a secure VSOCK connection on its own. The required mapping must be pushed from Sensor.

This PR removes that internet dependency by having Sensor deliver the mapping instead, over the VSOCK connection Sensor already maintains to every VM it scans. Sensor reuses the mapping it already fetches from Central for its other consumers (Scanner, Collector, node scanning) and pushes it to a roxagent whenever that agent reports a stale copy. roxagent no longer blocks startup on having a mapping either: it now starts immediately and stays idle until one arrives, whether pushed by Sensor or, for operators who explicitly configure `--repo-cpe-url`, downloaded from that URL as before.

Key design decisions:

- The Sensor-backed updater defers applying a pushed update while a VM disk scan is in flight, and only promotes it once that scan's report has been sent, so a report is never built against a mapping that changed mid-scan.
- Sensor and roxagent agree on freshness via a content hash rather than a version number or timestamp, so either side can detect staleness without shared state beyond what's already exchanged on `GetReport`.
- Mapping content is capped at 5 MiB and validated (JSON-decodable, has a `data` object) on every ingestion path (VSOCK receive, URL download, on-disk bootstrap), so a truncated or malformed mapping can never replace a good one.
- A roxagent with no mapping yet reports itself as not-ready (`ERROR_CODE_MAPPING_REQUIRED`) instead of erroring or scanning against nothing; Sensor's `vmscraper` treats that response the same as any other metadata-bearing response for the purpose of bootstrapping the first sync.

Known gaps intentionally left out of this PR, tracked as follow-ups rather than blocking it:

- No end-to-end test yet exercises the full Sensor-delivery path: the existing e2e harness only drives roxagent's one-shot CLI mode, not the `serve` VSOCK listener this feature relies on.
- A `--repo-cpe-url` that never successfully downloads logs at WARN rather than the intended ERROR level.
- roxagent's URL-backed and Sensor-backed updaters currently read/write the same on-disk cache file instead of separate ones (harmless today since content is validated either way and gets overwritten on the next successful fetch/sync, but worth tightening later).

Partially generated with AI assistance (subagent-driven implementation and review, human-directed).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

CI coverage is unit tests only at this point: table-driven tests across every touched package (roxagent's mapping updaters and VSOCK handler, Sensor's mapping cache, `vmscraper`'s sync logic, and the shared validation/hashing helpers), including deterministic coverage of the deferred-apply-under-busy-scan path and offline/stale-cache serving. End-to-end coverage of the full Sensor-delivery path is a follow-up: it needs a `roxagent serve`-mode test harness plus egress-blocking and sync-wait helpers that don't exist yet in the e2e suite, which today only drives roxagent's one-shot CLI mode.

### How I validated my change

No manual/cluster validation performed; validation so far is the automated unit tests described above. Suggested manual test plan for a reviewer/tester with a cluster available:

1. Deploy with the VM-scanning feature enabled, pull-mode active, and `--repo-cpe-url` left unset on the agent.
2. Confirm roxagent starts and logs that it is waiting for a mapping (`MAPPING_REQUIRED`) instead of erroring or scanning immediately.
3. Confirm Sensor logs a successful repo-to-CPE fetch from Central, then a `SyncRepoCPEMapping` push to the VM shortly after its first `GetReport`.
4. Confirm roxagent logs that it applied the pushed mapping and subsequently produces a scan report.
5. Confirm the resulting VM report in Central shows CPE-enriched packages.
6. Optional: temporarily block Sensor's connectivity to Central, and confirm Sensor keeps serving its last-known-good cached mapping to agents instead of erroring.