### PR TITLE
ROX-36524: Add CISA KEV UI display and policy criteria

### DIFF
--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -456,6 +456,16 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden,
 		imageEnrichmentRequired)
 
+	f.registerFieldMetadataRegex(fieldnames.CisaKev,
+		querybuilders.ForCisaKev(),
+		violationmessages.VulnContextFields,
+		func(*validateConfiguration) *regexp.Regexp {
+			return booleanValueRegex
+		},
+		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden,
+		imageEnrichmentRequired)
+
 	f.registerFieldMetadataRegex(fieldnames.FixedBy,
 		querybuilders.ForFixedBy(),
 		violationmessages.VulnContextFields,

--- a/pkg/booleanpolicy/fieldnames/list.go
+++ b/pkg/booleanpolicy/fieldnames/list.go
@@ -13,6 +13,7 @@ var (
 	AutomountServiceAccountToken   = newFieldName("Automount Service Account Token")
 	CVE                            = newFieldName("CVE")
 	CVSS                           = newFieldName("CVSS")
+	CisaKev                        = newFieldName("CISA KEV")
 	ContainerCPULimit              = newFieldName("Container CPU Limit")
 	ContainerCPURequest            = newFieldName("Container CPU Request")
 	ContainerMemLimit              = newFieldName("Container Memory Limit")

--- a/pkg/booleanpolicy/querybuilders/special_cases.go
+++ b/pkg/booleanpolicy/querybuilders/special_cases.go
@@ -196,6 +196,17 @@ func mapFixedByValue(s string) string {
 	return valueToStringRegex(s)
 }
 
+// ForCisaKev returns a query builder for whether a CVE is in the CISA KEV catalog.
+func ForCisaKev() QueryBuilder {
+	return wrapForVulnMgmt(func(group *storage.PolicyGroup) []*query.FieldQuery {
+		return []*query.FieldQuery{
+			fieldQueryFromGroup(group, search.CisaKev, func(s string) string {
+				return s
+			}),
+		}
+	})
+}
+
 // ForImageSignatureVerificationStatus returns a query builder for Image
 // Signature Verification Status.
 func ForImageSignatureVerificationStatus() QueryBuilder {

--- a/pkg/booleanpolicy/violationmessages/printer.go
+++ b/pkg/booleanpolicy/violationmessages/printer.go
@@ -41,6 +41,7 @@ var (
 		fieldnames.EnvironmentVariable:            {{required: set.NewStringSet(augmentedobjs.EnvironmentVarCustomTag), printerFuncKey: printer.EnvKey}},
 		fieldnames.ExposedNodePort:                {{required: set.NewStringSet(search.ExposedNodePort.String()), printerFuncKey: printer.NodePortKey}},
 		fieldnames.ExposedPort:                    {{required: set.NewStringSet(search.Port.String()), printerFuncKey: printer.PortKey}},
+		fieldnames.CisaKev:                        {{required: set.NewStringSet(search.CVE.String()), printerFuncKey: printer.CveKey}},
 		fieldnames.Fixable:                        {{required: set.NewStringSet(search.CVE.String()), printerFuncKey: printer.CveKey}},
 		fieldnames.FixedBy:                        {{required: set.NewStringSet(search.CVE.String()), printerFuncKey: printer.CveKey}},
 		fieldnames.HostIPC:                        {{required: set.NewStringSet(search.HostIPC.String()), printerFuncKey: printer.HostIPCKey}},

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -858,11 +858,11 @@ func TestExploit(t *testing.T) {
 	}{
 		"full exploit data": {
 			input: &v4.VulnerabilityReport_Vulnerability_CISAExploit{
-				CatalogVersion: "2025.07.10",
-				DateAdded:      "2023-01-10",
-				ShortDescription: "Apache Log4j2 Remote Code Execution Vulnerability",
-				RequiredAction:   "Apply updates per vendor instructions.",
-				DueDate:          "2023-02-01",
+				CatalogVersion:             "2025.07.10",
+				DateAdded:                  "2023-01-10",
+				ShortDescription:           "Apache Log4j2 Remote Code Execution Vulnerability",
+				RequiredAction:             "Apply updates per vendor instructions.",
+				DueDate:                    "2023-02-01",
 				KnownRansomwareCampaignUse: "Known",
 			},
 			expected: &storage.Exploit{
@@ -875,11 +875,11 @@ func TestExploit(t *testing.T) {
 		},
 		"known ransomware": {
 			input: &v4.VulnerabilityReport_Vulnerability_CISAExploit{
-				CatalogVersion: "2025.07.09",
-				DateAdded:      "2024-05-15",
-				ShortDescription: "Microsoft Exchange Server Privilege Escalation",
-				RequiredAction:   "Apply mitigations per vendor advisory.",
-				DueDate:          "2024-06-05",
+				CatalogVersion:             "2025.07.09",
+				DateAdded:                  "2024-05-15",
+				ShortDescription:           "Microsoft Exchange Server Privilege Escalation",
+				RequiredAction:             "Apply mitigations per vendor advisory.",
+				DueDate:                    "2024-06-05",
 				KnownRansomwareCampaignUse: "Unknown",
 			},
 			expected: &storage.Exploit{

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -858,11 +858,11 @@ func TestExploit(t *testing.T) {
 	}{
 		"full exploit data": {
 			input: &v4.VulnerabilityReport_Vulnerability_CISAExploit{
-				CatalogVersion:             "2025.07.10",
-				DateAdded:                  "2023-01-10",
-				ShortDescription:           "Apache Log4j2 Remote Code Execution Vulnerability",
-				RequiredAction:             "Apply updates per vendor instructions.",
-				DueDate:                    "2023-02-01",
+				CatalogVersion: "2025.07.10",
+				DateAdded:      "2023-01-10",
+				ShortDescription: "Apache Log4j2 Remote Code Execution Vulnerability",
+				RequiredAction:   "Apply updates per vendor instructions.",
+				DueDate:          "2023-02-01",
 				KnownRansomwareCampaignUse: "Known",
 			},
 			expected: &storage.Exploit{
@@ -875,11 +875,11 @@ func TestExploit(t *testing.T) {
 		},
 		"known ransomware": {
 			input: &v4.VulnerabilityReport_Vulnerability_CISAExploit{
-				CatalogVersion:             "2025.07.09",
-				DateAdded:                  "2024-05-15",
-				ShortDescription:           "Microsoft Exchange Server Privilege Escalation",
-				RequiredAction:             "Apply mitigations per vendor advisory.",
-				DueDate:                    "2024-06-05",
+				CatalogVersion: "2025.07.09",
+				DateAdded:      "2024-05-15",
+				ShortDescription: "Microsoft Exchange Server Privilege Escalation",
+				RequiredAction:   "Apply mitigations per vendor advisory.",
+				DueDate:          "2024-06-05",
 				KnownRansomwareCampaignUse: "Unknown",
 			},
 			expected: &storage.Exploit{

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.test.ts
@@ -15,12 +15,14 @@ import {
 // Items that are allowed independent of context.
 const allowListForItems = [
     'API',
+    'CISA',
     'CPU',
     'CVE',
     'CVSS',
     'Dockerfile',
     'IP',
     'IPC',
+    'KEV',
     'Kubernetes',
     'MUST',
     'NOT',
@@ -33,6 +35,7 @@ const allowListForItems = [
 
 // Items that are allowed only in the content of an entire string.
 const allowListForNames = [
+    'CISA Known Exploited Vulnerabilities catalog',
     'Common Vulnerability Scoring System (CVSS) score',
     'Common Vulnerability Scoring System (CVSS) score from National Vulnerability Database (NVD)',
     'Volume type (e.g. secret, configMap, hostPath) is',

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -684,6 +684,28 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
+        label: 'CISA KEV',
+        name: 'CISA KEV',
+        shortName: 'CISA KEV',
+        longName: 'CISA Known Exploited Vulnerabilities catalog',
+        category: policyCriteriaCategories.IMAGE_SCANNING,
+        type: 'radioGroup',
+        radioButtons: [
+            {
+                text: 'CVE is in CISA KEV catalog (known exploited)',
+                value: true,
+            },
+            {
+                text: 'CVE is not in CISA KEV catalog',
+                value: false,
+            },
+        ],
+        defaultValue: true,
+        canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
+        featureFlagDependency: ['ROX_CISA_KEV'],
+    },
+    {
         label: 'Fixed by',
         name: 'Fixed By',
         shortName: 'Fixed by',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -87,6 +87,9 @@ export const imageCveMetadataQuery = gql`
                     epss {
                         epssProbability
                     }
+                    exploit {
+                        knownRansomwareCampaignUse
+                    }
                 }
             }
         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -87,6 +87,9 @@ export const deploymentWithVulnerabilitiesFragment = gql`
                 epss {
                     epssProbability
                 }
+                exploit {
+                    knownRansomwareCampaignUse
+                }
             }
             operatingSystem
             publishedOn
@@ -189,10 +192,6 @@ function DeploymentVulnerabilitiesTable({
                             isFeatureFlagEnabled('ROX_CISA_KEV') &&
                             hasKnownExploit(cveBaseInfo?.exploit)
                         ) {
-                            // Add in deploymentWithVulnerabilitiesFragment following epss:
-                            // exploit {
-                            //     knownRansomwareCampaignUse
-                            // }
                             labels.push(<KnownExploitLabel key="exploit" isCompact />);
                             if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
                                 labels.push(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -131,6 +131,9 @@ export const imageVulnerabilitiesFragment = gql`
             epss {
                 epssProbability
             }
+            exploit {
+                knownRansomwareCampaignUse
+            }
         }
         discoveredAtImage
         publishedOn
@@ -279,10 +282,6 @@ function ImageVulnerabilitiesTable({
                             isFeatureFlagEnabled('ROX_CISA_KEV') &&
                             hasKnownExploit(cveBaseInfo?.exploit)
                         ) {
-                            // Add in imageVulnerabilitiesFragment following epss:
-                            // exploit {
-                            //     knownRansomwareCampaignUse
-                            // }
                             labels.push(<KnownExploitLabel key="exploit" isCompact />);
                             if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
                                 labels.push(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -152,6 +152,9 @@ export const cveListQuery = gql`
                     epss {
                         epssProbability
                     }
+                    exploit {
+                        knownRansomwareCampaignUse
+                    }
                 }
             }
             pendingExceptionCount: exceptionCount(requestStatus: $statusesForExceptionCount)
@@ -351,10 +354,6 @@ function WorkloadCVEOverviewTable({
                                 isFeatureFlagEnabled('ROX_CISA_KEV') &&
                                 hasKnownExploit(cveBaseInfo?.exploit)
                             ) {
-                                // Add in cveListQuery following epss:
-                                // exploit {
-                                //     knownRansomwareCampaignUse
-                                // }
                                 labels.push(<KnownExploitLabel key="exploit" isCompact />);
                                 if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
                                     labels.push(


### PR DESCRIPTION
## Description

Wire CISA KEV data through the UI and add policy criteria support. PR 4/4 in a stack.

- Wire `exploit { knownRansomwareCampaignUse }` into all WorkloadCves GraphQL fragments so the existing `KnownExploitLabel` and `KnownRansomwareCampaignLabel` components (merged in #17901) receive data
- Add Go-side boolean policy field (`CISA KEV`) following the Fixable pattern: field name, query builder, field metadata, violation message printer
- Add UI policy criteria descriptor (`radioGroup` type) under Image Scanning, gated behind `ROX_CISA_KEV`

**Stack:** [Proto changes] → [Converter wiring] → [Reporting] → 4/4 — UI + Policy

**Depends on:** #21752

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Go policy tests pass: `go test ./pkg/booleanpolicy/... -count=1`
- GraphQL fragments only add fields to existing template literals — no TypeScript logic changed
- Policy criteria descriptor follows the established Fixable radioGroup pattern