### PR TITLE
ROX-36110,ROX-36112,ROX-35963: block all GKE maintenance in tests

### DIFF
--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -240,7 +240,7 @@ add_a_maintenance_exclusion() {
         --add-maintenance-exclusion-name leave-these-clusters-alone \
         --add-maintenance-exclusion-start "${from_now}" \
         --add-maintenance-exclusion-end "${plus_five}" \
-        --add-maintenance-exclusion-scope no_upgrades
+        --add-maintenance-exclusion-scope no_minor_or_node_upgrades
 }
 
 wait_for_cluster() {


### PR DESCRIPTION
## Description

The maintenance exclusion scope `no_upgrades` only prevents version upgrades but allows GKE-initiated node repairs and host maintenance events. These events disrupt nodes mid-test, causing pod rescheduling and transient service unavailability that fails tests.

`no_minor_or_node_upgrades` blocks all GKE-initiated maintenance during the 5-hour test window. Zero cost impact since these clusters are ephemeral and deleted after the test.

> You can disable node auto-upgrades for all node pools in a cluster by using a [cluster maintenance exclusion](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#scope_of_maintenance_to_exclude) with the scope of "No minor or node upgrades".
https://docs.cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades#check-state-exclusions


Partially generated by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI