### PR TITLE
ROX-33160: Use pvc for nongroovy GKE tests

### DIFF
--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -37,6 +37,8 @@ jobs:
       ARTIFACT_DIR: ./junit-reports
       LOAD_BALANCER: lb
       ROX_SCANNER_V4: "false"
+      STORAGE: pvc
+      STORAGE_CLASS: faster
       PYTHONUNBUFFERED: "1"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -44,6 +44,8 @@ jobs:
       ROX_DEPLOY_SENSOR_WITH_CRS: "true"
       SENSOR_HELM_MANAGED: "true"
       SCANNER_V4_DB_STORAGE_CLASS: faster
+      STORAGE: pvc
+      STORAGE_CLASS: faster
       ROX_SCANNER_V4: "false"
       PYTHONUNBUFFERED: "1"
     timeout-minutes: 120


### PR DESCRIPTION
## Description

We have situation where nongroovy e2e tests are failing because DB get cleaned up.

An example: https://github.com/stackrox/stackrox/actions/runs/30682039142/job/91322035268

1. The reason is that `central-db` got restarted.
2. Since we are using `emptyDir` for `central-db` - after restart we lose ACS database and we are not sure at what point in time that will happen.
3. Such cases can be more frequent for spot instances that we use in our tests.

**Note**
- OCP tests are using `pvc`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified test setup

### How I validated my change

- [x] run tests in CI and check that created `central-db` pod uses `pvc`
