### PR TITLE
ROX-35978: Migrate node inventory handler multiplexer fanin to pub sub

### DIFF
--- a/sensor/common/compliance/compliance_ack_event.go
+++ b/sensor/common/compliance/compliance_ack_event.go
@@ -1,0 +1,19 @@
+package compliance
+
+import (
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// ComplianceAckEvent carries a ComplianceACK/NACK message destined for a compliance gRPC node.
+type ComplianceAckEvent struct {
+	Msg common.MessageToComplianceWithAddress
+}
+
+func (e *ComplianceAckEvent) Topic() pubsub.Topic {
+	return pubsub.ComplianceAckTopic
+}
+
+func (e *ComplianceAckEvent) Lane() pubsub.LaneID {
+	return pubsub.ComplianceAckLane
+}

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -5,9 +5,11 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/channelmultiplexer"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 )
 
@@ -18,9 +20,14 @@ var _ common.ComplianceComponent = (*Multiplexer)(nil)
 type Multiplexer struct {
 	unimplemented.Receiver
 
-	mp         channelmultiplexer.ChannelMultiplexer[common.MessageToComplianceWithAddress]
-	components []common.ComplianceComponent
-	stopper    concurrency.Stopper
+	mp               channelmultiplexer.ChannelMultiplexer[common.MessageToComplianceWithAddress]
+	components       []common.ComplianceComponent
+	stopper          concurrency.Stopper
+	pubSubDispatcher common.PubSubDispatcher
+	// pubSubIn receives ComplianceAckEvents published by producers migrated to PubSub (eg. the
+	// Node Inventory Handler); it is folded into the same fan-in mix as any legacy ComplianceC()
+	// channel, so producers still on raw channels (eg. the VM Handler) keep working unchanged.
+	pubSubIn chan common.MessageToComplianceWithAddress
 }
 
 func (c *Multiplexer) Name() string {
@@ -33,11 +40,13 @@ func (c *Multiplexer) Stopped() concurrency.ReadOnlyErrorSignal {
 }
 
 // NewMultiplexer creates a Multiplexer of type T, wrapped up as a sensor component
-func NewMultiplexer() *Multiplexer {
+func NewMultiplexer(pubSubDispatcher common.PubSubDispatcher) *Multiplexer {
 	multiplexer := Multiplexer{
-		mp:         *channelmultiplexer.NewMultiplexer[common.MessageToComplianceWithAddress](),
-		components: []common.ComplianceComponent{},
-		stopper:    concurrency.NewStopper(),
+		mp:               *channelmultiplexer.NewMultiplexer[common.MessageToComplianceWithAddress](),
+		components:       []common.ComplianceComponent{},
+		stopper:          concurrency.NewStopper(),
+		pubSubDispatcher: pubSubDispatcher,
+		pubSubIn:         make(chan common.MessageToComplianceWithAddress),
 	}
 	return &multiplexer
 }
@@ -57,7 +66,33 @@ func (c *Multiplexer) run() error {
 	for _, comp := range c.components {
 		c.addChannel(comp.ComplianceC())
 	}
+	if features.SensorInternalPubSub.Enabled() && c.pubSubDispatcher != nil {
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceMultiplexerAckConsumer,
+			pubsub.ComplianceAckTopic,
+			pubsub.ComplianceAckLane,
+			c.handleComplianceAckEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance multiplexer ack consumer")
+		}
+		c.addChannel(c.pubSubIn)
+	}
 	c.mp.Run()
+	return nil
+}
+
+// handleComplianceAckEvent bridges a PubSub-published ComplianceAckEvent into the legacy
+// channel-based fan-in, so producers still on raw channels and producers already migrated to
+// PubSub feed the same ComplianceC() output stream.
+func (c *Multiplexer) handleComplianceAckEvent(event pubsub.Event) error {
+	ackEvent, ok := event.(*ComplianceAckEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	select {
+	case <-c.stopper.Client().Stopped().Done():
+	case c.pubSubIn <- ackEvent.Msg:
+	}
 	return nil
 }
 

--- a/sensor/common/compliance/multiplexer.go
+++ b/sensor/common/compliance/multiplexer.go
@@ -1,6 +1,8 @@
 package compliance
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/channelmultiplexer"
@@ -28,6 +30,9 @@ type Multiplexer struct {
 	// Node Inventory Handler); it is folded into the same fan-in mix as any legacy ComplianceC()
 	// channel, so producers still on raw channels (eg. the VM Handler) keep working unchanged.
 	pubSubIn chan common.MessageToComplianceWithAddress
+	// cancel stops the underlying channelmultiplexer's fan-in goroutines; without it Stop() would
+	// leave them running forever.
+	cancel context.CancelFunc
 }
 
 func (c *Multiplexer) Name() string {
@@ -41,12 +46,14 @@ func (c *Multiplexer) Stopped() concurrency.ReadOnlyErrorSignal {
 
 // NewMultiplexer creates a Multiplexer of type T, wrapped up as a sensor component
 func NewMultiplexer(pubSubDispatcher common.PubSubDispatcher) *Multiplexer {
+	ctx, cancel := context.WithCancel(context.Background())
 	multiplexer := Multiplexer{
-		mp:               *channelmultiplexer.NewMultiplexer[common.MessageToComplianceWithAddress](),
+		mp:               *channelmultiplexer.NewMultiplexer[common.MessageToComplianceWithAddress](channelmultiplexer.WithContext[common.MessageToComplianceWithAddress](ctx)),
 		components:       []common.ComplianceComponent{},
 		stopper:          concurrency.NewStopper(),
 		pubSubDispatcher: pubSubDispatcher,
 		pubSubIn:         make(chan common.MessageToComplianceWithAddress),
+		cancel:           cancel,
 	}
 	return &multiplexer
 }
@@ -99,6 +106,7 @@ func (c *Multiplexer) handleComplianceAckEvent(event pubsub.Event) error {
 // Stop stops the component
 func (c *Multiplexer) Stop() {
 	c.stopper.Client().Stop()
+	c.cancel()
 }
 
 // Capabilities is unimplemented, part of the component interface

--- a/sensor/common/compliance/multiplexer_pubsub_test.go
+++ b/sensor/common/compliance/multiplexer_pubsub_test.go
@@ -1,12 +1,10 @@
 package compliance
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/stackrox/rox/pkg/centralsensor"
-	"github.com/stackrox/rox/pkg/channelmultiplexer"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/testutils/goleak"
@@ -30,22 +28,6 @@ type MultiplexerTestSuite struct {
 
 func (s *MultiplexerTestSuite) TearDownTest() {
 	goleak.AssertNoGoroutineLeaks(s.T())
-}
-
-// newTestMultiplexer builds a Multiplexer whose underlying channelmultiplexer.ChannelMultiplexer
-// is bound to a cancellable context, so the test can fully unwind FanIn's goroutines on cleanup --
-// production code has no such lifecycle hook today (Multiplexer.Stop() does not tear down the
-// underlying fan-in), so without this the legacy channels/pubSubIn would leak goroutines forever.
-func newTestMultiplexer(dispatcher common.PubSubDispatcher) (*Multiplexer, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-	mp := &Multiplexer{
-		mp:               *channelmultiplexer.NewMultiplexer[common.MessageToComplianceWithAddress](channelmultiplexer.WithContext[common.MessageToComplianceWithAddress](ctx)),
-		components:       []common.ComplianceComponent{},
-		stopper:          concurrency.NewStopper(),
-		pubSubDispatcher: dispatcher,
-		pubSubIn:         make(chan common.MessageToComplianceWithAddress),
-	}
-	return mp, cancel
 }
 
 // legacyComplianceComponent simulates a producer still on the raw ComplianceC() channel,
@@ -100,11 +82,10 @@ func (s *MultiplexerTestSuite) TestPubSubAndLegacyProducersBothFeedComplianceC()
 	defer dispatcher.Stop()
 
 	legacy := newLegacyComplianceComponent()
-	mp, cancel := newTestMultiplexer(dispatcher)
-	defer cancel()
+	mp := NewMultiplexer(dispatcher)
+	defer mp.Stop()
 	mp.AddComponentWithComplianceC(legacy)
 	s.Require().NoError(mp.Start())
-	defer mp.Stop()
 
 	require.NoError(t, dispatcher.Publish(&ComplianceAckEvent{Msg: common.MessageToComplianceWithAddress{Hostname: "node-pubsub"}}))
 	go func() {
@@ -125,14 +106,20 @@ func (s *MultiplexerTestSuite) TestPubSubAndLegacyProducersBothFeedComplianceC()
 }
 
 // TestPubSubDisabledFallsBackToLegacyOnly verifies that with PubSub disabled, the Multiplexer
-// behaves exactly as before: only legacy ComplianceC() channels are fanned in.
+// behaves exactly as before: only legacy ComplianceC() channels are fanned in, even with a live
+// dispatcher present.
 func (s *MultiplexerTestSuite) TestPubSubDisabledFallsBackToLegacyOnly() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "false")
+
+	dispatcher := newTestMultiplexerDispatcher(t)
+	defer dispatcher.Stop()
+
 	legacy := newLegacyComplianceComponent()
-	mp, cancel := newTestMultiplexer(nil)
-	defer cancel()
+	mp := NewMultiplexer(dispatcher)
+	defer mp.Stop()
 	mp.AddComponentWithComplianceC(legacy)
 	s.Require().NoError(mp.Start())
-	defer mp.Stop()
 
 	go func() {
 		legacy.toCompliance <- common.MessageToComplianceWithAddress{Hostname: "node-legacy"}

--- a/sensor/common/compliance/multiplexer_pubsub_test.go
+++ b/sensor/common/compliance/multiplexer_pubsub_test.go
@@ -1,0 +1,147 @@
+package compliance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/channelmultiplexer"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stackrox/rox/sensor/common/unimplemented"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestMultiplexer(t *testing.T) {
+	suite.Run(t, new(MultiplexerTestSuite))
+}
+
+type MultiplexerTestSuite struct {
+	suite.Suite
+}
+
+func (s *MultiplexerTestSuite) TearDownTest() {
+	goleak.AssertNoGoroutineLeaks(s.T())
+}
+
+// newTestMultiplexer builds a Multiplexer whose underlying channelmultiplexer.ChannelMultiplexer
+// is bound to a cancellable context, so the test can fully unwind FanIn's goroutines on cleanup --
+// production code has no such lifecycle hook today (Multiplexer.Stop() does not tear down the
+// underlying fan-in), so without this the legacy channels/pubSubIn would leak goroutines forever.
+func newTestMultiplexer(dispatcher common.PubSubDispatcher) (*Multiplexer, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mp := &Multiplexer{
+		mp:               *channelmultiplexer.NewMultiplexer[common.MessageToComplianceWithAddress](channelmultiplexer.WithContext[common.MessageToComplianceWithAddress](ctx)),
+		components:       []common.ComplianceComponent{},
+		stopper:          concurrency.NewStopper(),
+		pubSubDispatcher: dispatcher,
+		pubSubIn:         make(chan common.MessageToComplianceWithAddress),
+	}
+	return mp, cancel
+}
+
+// legacyComplianceComponent simulates a producer still on the raw ComplianceC() channel,
+// eg. the VM Handler, which stays on that path until ROX-36011 migrates it.
+type legacyComplianceComponent struct {
+	unimplemented.Receiver
+	toCompliance chan common.MessageToComplianceWithAddress
+	stopper      concurrency.Stopper
+}
+
+func newLegacyComplianceComponent() *legacyComplianceComponent {
+	return &legacyComplianceComponent{
+		toCompliance: make(chan common.MessageToComplianceWithAddress),
+		stopper:      concurrency.NewStopper(),
+	}
+}
+
+func (c *legacyComplianceComponent) Name() string                                   { return "legacyComplianceComponent" }
+func (c *legacyComplianceComponent) Start() error                                   { return nil }
+func (c *legacyComplianceComponent) Stop()                                          {}
+func (c *legacyComplianceComponent) Capabilities() []centralsensor.SensorCapability { return nil }
+func (c *legacyComplianceComponent) ResponsesC() <-chan *message.ExpiringMessage    { return nil }
+func (c *legacyComplianceComponent) Notify(_ common.SensorComponentEvent)           {}
+func (c *legacyComplianceComponent) Stopped() concurrency.ReadOnlyErrorSignal {
+	return c.stopper.Client().Stopped()
+}
+func (c *legacyComplianceComponent) ComplianceC() <-chan common.MessageToComplianceWithAddress {
+	return c.toCompliance
+}
+
+func newTestMultiplexerDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ComplianceAckLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+// TestPubSubAndLegacyProducersBothFeedComplianceC verifies the Multiplexer accepts a
+// PubSub-published ComplianceAckEvent (eg. from the Node Inventory Handler) and a legacy
+// ComplianceC() channel (eg. from the still-unmigrated VM Handler) at the same time, folding
+// both into one output stream -- the dual-consumer bridge state ROX-35978 introduces ahead of
+// ROX-36011 migrating the VM Handler leg.
+func (s *MultiplexerTestSuite) TestPubSubAndLegacyProducersBothFeedComplianceC() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestMultiplexerDispatcher(t)
+	defer dispatcher.Stop()
+
+	legacy := newLegacyComplianceComponent()
+	mp, cancel := newTestMultiplexer(dispatcher)
+	defer cancel()
+	mp.AddComponentWithComplianceC(legacy)
+	s.Require().NoError(mp.Start())
+	defer mp.Stop()
+
+	require.NoError(t, dispatcher.Publish(&ComplianceAckEvent{Msg: common.MessageToComplianceWithAddress{Hostname: "node-pubsub"}}))
+	go func() {
+		legacy.toCompliance <- common.MessageToComplianceWithAddress{Hostname: "node-legacy"}
+	}()
+
+	seen := map[string]bool{}
+	for range 2 {
+		select {
+		case msg := <-mp.ComplianceC():
+			seen[msg.Hostname] = true
+		case <-time.After(2 * time.Second):
+			s.FailNow("timed out waiting for messages on ComplianceC()")
+		}
+	}
+	s.True(seen["node-pubsub"], "expected the PubSub-sourced message to appear on ComplianceC()")
+	s.True(seen["node-legacy"], "expected the legacy channel-sourced message to appear on ComplianceC()")
+}
+
+// TestPubSubDisabledFallsBackToLegacyOnly verifies that with PubSub disabled, the Multiplexer
+// behaves exactly as before: only legacy ComplianceC() channels are fanned in.
+func (s *MultiplexerTestSuite) TestPubSubDisabledFallsBackToLegacyOnly() {
+	legacy := newLegacyComplianceComponent()
+	mp, cancel := newTestMultiplexer(nil)
+	defer cancel()
+	mp.AddComponentWithComplianceC(legacy)
+	s.Require().NoError(mp.Start())
+	defer mp.Stop()
+
+	go func() {
+		legacy.toCompliance <- common.MessageToComplianceWithAddress{Hostname: "node-legacy"}
+	}()
+
+	select {
+	case msg := <-mp.ComplianceC():
+		s.Equal("node-legacy", msg.Hostname)
+	case <-time.After(2 * time.Second):
+		s.FailNow("timed out waiting for legacy message on ComplianceC()")
+	}
+}

--- a/sensor/common/compliance/node_inventory_events.go
+++ b/sensor/common/compliance/node_inventory_events.go
@@ -1,0 +1,39 @@
+package compliance
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/sensor/common/compliance/index"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// NodeInventoryEvent carries a NodeInventory relayed from a compliance gRPC node.
+type NodeInventoryEvent struct {
+	Inventory *storage.NodeInventory
+}
+
+func (e *NodeInventoryEvent) Topic() pubsub.Topic {
+	return pubsub.NodeInventoryTopic
+}
+
+// Lane returns NodeInventoryIntakeLane, shared with IndexReportWrapEvent so that both
+// event types are delivered serially, preserving the single-goroutine safety guarantee
+// the legacy select loop provided.
+func (e *NodeInventoryEvent) Lane() pubsub.LaneID {
+	return pubsub.NodeInventoryIntakeLane
+}
+
+// IndexReportWrapEvent carries an IndexReportWrap relayed from a compliance gRPC node.
+type IndexReportWrapEvent struct {
+	Wrap *index.IndexReportWrap
+}
+
+func (e *IndexReportWrapEvent) Topic() pubsub.Topic {
+	return pubsub.IndexReportWrapTopic
+}
+
+// Lane returns NodeInventoryIntakeLane, shared with NodeInventoryEvent so that both
+// event types are delivered serially, preserving the single-goroutine safety guarantee
+// the legacy select loop provided.
+func (e *IndexReportWrapEvent) Lane() pubsub.LaneID {
+	return pubsub.NodeInventoryIntakeLane
+}

--- a/sensor/common/compliance/node_inventory_handler.go
+++ b/sensor/common/compliance/node_inventory_handler.go
@@ -11,17 +11,17 @@ import (
 var _ common.ComplianceComponent = (*nodeInventoryHandlerImpl)(nil)
 
 // NewNodeInventoryHandler returns a new instance of a NodeInventoryHandler
-func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, iw <-chan *index.IndexReportWrap, nodeIDMatcher NodeIDMatcher, nodeRHCOSmatcher NodeRHCOSMatcher) *nodeInventoryHandlerImpl {
+func NewNodeInventoryHandler(ch <-chan *storage.NodeInventory, iw <-chan *index.IndexReportWrap, nodeIDMatcher NodeIDMatcher, nodeRHCOSmatcher NodeRHCOSMatcher, pubSubDispatcher common.PubSubDispatcher) *nodeInventoryHandlerImpl {
 	return &nodeInventoryHandlerImpl{
 		inventories:      ch,
 		reportWraps:      iw,
 		toCentral:        nil,
 		centralReady:     concurrency.NewSignal(),
 		toCompliance:     nil,
-		acksFromCentral:  nil,
 		lock:             &sync.Mutex{},
 		stopper:          concurrency.NewStopper(),
 		nodeMatcher:      nodeIDMatcher,
 		nodeRHCOSMatcher: nodeRHCOSmatcher,
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -33,7 +33,9 @@ type nodeInventoryHandlerImpl struct {
 	toCentral    <-chan *message.ExpiringMessage
 	centralReady concurrency.Signal
 	// ch2Central is the same channel exposed read-only as toCentral; kept as a field so both
-	// the legacy select loop (run()) and the PubSub event handlers can write to it.
+	// the legacy select loop (run()) and the PubSub event handlers can write to it. It is never
+	// closed: PubSub callbacks can still be invoked after Stop() (the dispatcher has no
+	// per-consumer unregistration), and writing to it must stay safe for the process lifetime.
 	ch2Central       chan *message.ExpiringMessage
 	toCompliance     chan common.MessageToComplianceWithAddress
 	nodeMatcher      NodeIDMatcher
@@ -240,14 +242,12 @@ func (c *nodeInventoryHandlerImpl) processNodeInventoryACK(ackMsg *central.NodeI
 	return nil
 }
 
-// run handles the messages from Compliance and forwards them to Central
-// This is the only goroutine that writes into the toCentral channel, thus it is responsible for creating and closing that chan
+// run handles the messages from Compliance and forwards them to Central. It is one of possibly
+// several writers into the toCentral channel (PubSub event handlers are the others); it never
+// closes that channel since it cannot guarantee no PubSub handler will write after it returns.
 func (c *nodeInventoryHandlerImpl) run() (toCentral <-chan *message.ExpiringMessage) {
 	go func() {
-		defer func() {
-			c.stopper.Flow().ReportStopped()
-			close(c.ch2Central)
-		}()
+		defer c.stopper.Flow().ReportStopped()
 		log.Debugf("NodeInventory/NodeIndex handler is running")
 		for {
 			select {
@@ -448,36 +448,34 @@ func (c *nodeInventoryHandlerImpl) sendNodeIndex(toC chan<- *message.ExpiringMes
 		return
 	}
 
+	if hasRHCOSPackage(indexWrap.IndexReport) {
+		log.Debugf("Node=%q has rhcos package from compliance", indexWrap.NodeName)
+	} else {
+		isRHCOS, ver, err := c.nodeRHCOSMatcher.GetRHCOSVersion(indexWrap.NodeName)
+		if err != nil {
+			log.Debugf("Unable to determine RHCOS version for node %q: %v", indexWrap.NodeName, err)
+		} else if isRHCOS {
+			log.Warnf("Node %q appears to be RHCOS (osImage version=%s) but compliance did not add rhcos package - RHCOS-level vulnerabilities will not be reported", indexWrap.NodeName, ver)
+		}
+	}
+
 	select {
 	case <-c.stopper.Flow().StopRequested():
-	default:
-		defer func() {
-			log.Debugf("Sent IndexReport to Central")
-			metrics.ObserveNodeScan(indexWrap.NodeName, metrics.NodeScanTypeNodeIndex, metrics.NodeScanOperationSendToCentral)
-		}()
-		if hasRHCOSPackage(indexWrap.IndexReport) {
-			log.Debugf("Node=%q has rhcos package from compliance", indexWrap.NodeName)
-		} else {
-			isRHCOS, ver, err := c.nodeRHCOSMatcher.GetRHCOSVersion(indexWrap.NodeName)
-			if err != nil {
-				log.Debugf("Unable to determine RHCOS version for node %q: %v", indexWrap.NodeName, err)
-			} else if isRHCOS {
-				log.Warnf("Node %q appears to be RHCOS (osImage version=%s) but compliance did not add rhcos package - RHCOS-level vulnerabilities will not be reported", indexWrap.NodeName, ver)
-			}
-		}
-		toC <- message.New(&central.MsgFromSensor{
-			Msg: &central.MsgFromSensor_Event{
-				Event: &central.SensorEvent{
-					Id: indexWrap.NodeID,
-					// ResourceAction_UNSET_ACTION_RESOURCE is the only one supported by Central 4.6 and older.
-					// This can be changed to CREATE or UPDATE for Sensor 4.8 or when Central 4.6 is out of support.
-					Action: central.ResourceAction_UNSET_ACTION_RESOURCE,
-					Resource: &central.SensorEvent_IndexReport{
-						IndexReport: indexWrap.IndexReport,
-					},
+	case toC <- message.New(&central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id: indexWrap.NodeID,
+				// ResourceAction_UNSET_ACTION_RESOURCE is the only one supported by Central 4.6 and older.
+				// This can be changed to CREATE or UPDATE for Sensor 4.8 or when Central 4.6 is out of support.
+				Action: central.ResourceAction_UNSET_ACTION_RESOURCE,
+				Resource: &central.SensorEvent_IndexReport{
+					IndexReport: indexWrap.IndexReport,
 				},
 			},
-		})
+		},
+	}):
+		log.Debugf("Sent IndexReport to Central")
+		metrics.ObserveNodeScan(indexWrap.NodeName, metrics.NodeScanTypeNodeIndex, metrics.NodeScanOperationSendToCentral)
 	}
 }
 

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -10,12 +10,15 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/compliance/index"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
 var (
@@ -29,14 +32,16 @@ type nodeInventoryHandlerImpl struct {
 	reportWraps  <-chan *index.IndexReportWrap
 	toCentral    <-chan *message.ExpiringMessage
 	centralReady concurrency.Signal
-	// acksFromCentral is for connecting the replies from Central with the toCompliance chan
-	acksFromCentral  chan common.MessageToComplianceWithAddress
+	// ch2Central is the same channel exposed read-only as toCentral; kept as a field so both
+	// the legacy select loop (run()) and the PubSub event handlers can write to it.
+	ch2Central       chan *message.ExpiringMessage
 	toCompliance     chan common.MessageToComplianceWithAddress
 	nodeMatcher      NodeIDMatcher
 	nodeRHCOSMatcher NodeRHCOSMatcher
 	// lock prevents the race condition between Start() [writer] and ResponsesC() [reader]
-	lock    *sync.Mutex
-	stopper concurrency.Stopper
+	lock             *sync.Mutex
+	stopper          concurrency.Stopper
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (c *nodeInventoryHandlerImpl) Name() string {
@@ -71,6 +76,27 @@ func (c *nodeInventoryHandlerImpl) Start() error {
 	defer c.lock.Unlock()
 	if c.toCentral != nil || c.toCompliance != nil {
 		return errStartMoreThanOnce
+	}
+	// Created here (before consumer registration) so handleNodeInventoryEvent/handleNodeIndexEvent
+	// never observe a nil channel if a PubSub event is delivered before run() would otherwise create it.
+	c.ch2Central = make(chan *message.ExpiringMessage)
+	if features.SensorInternalPubSub.Enabled() && c.pubSubDispatcher != nil {
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.NodeInventoryHandlerNodeInventoryConsumer,
+			pubsub.NodeInventoryTopic,
+			pubsub.NodeInventoryIntakeLane,
+			c.handleNodeInventoryEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register node inventory consumer")
+		}
+		if err := c.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.NodeInventoryHandlerIndexReportConsumer,
+			pubsub.IndexReportWrapTopic,
+			pubsub.NodeInventoryIntakeLane,
+			c.handleNodeIndexEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register index report consumer")
+		}
 	}
 	c.toCompliance = make(chan common.MessageToComplianceWithAddress)
 	c.toCentral = c.run()
@@ -217,11 +243,10 @@ func (c *nodeInventoryHandlerImpl) processNodeInventoryACK(ackMsg *central.NodeI
 // run handles the messages from Compliance and forwards them to Central
 // This is the only goroutine that writes into the toCentral channel, thus it is responsible for creating and closing that chan
 func (c *nodeInventoryHandlerImpl) run() (toCentral <-chan *message.ExpiringMessage) {
-	ch2Central := make(chan *message.ExpiringMessage)
 	go func() {
 		defer func() {
 			c.stopper.Flow().ReportStopped()
-			close(ch2Central)
+			close(c.ch2Central)
 		}()
 		log.Debugf("NodeInventory/NodeIndex handler is running")
 		for {
@@ -233,17 +258,37 @@ func (c *nodeInventoryHandlerImpl) run() (toCentral <-chan *message.ExpiringMess
 					c.stopper.Flow().StopWithError(errInventoryInputChanClosed)
 					return
 				}
-				c.handleNodeInventory(inventory, ch2Central)
+				c.handleNodeInventory(inventory, c.ch2Central)
 			case wrap, ok := <-c.reportWraps:
 				if !ok {
 					c.stopper.Flow().StopWithError(errIndexInputChanClosed)
 					return
 				}
-				c.handleNodeIndex(wrap, ch2Central)
+				c.handleNodeIndex(wrap, c.ch2Central)
 			}
 		}
 	}()
-	return ch2Central
+	return c.ch2Central
+}
+
+// handleNodeInventoryEvent adapts a PubSub NodeInventoryEvent to handleNodeInventory.
+func (c *nodeInventoryHandlerImpl) handleNodeInventoryEvent(event pubsub.Event) error {
+	inventoryEvent, ok := event.(*NodeInventoryEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	c.handleNodeInventory(inventoryEvent.Inventory, c.ch2Central)
+	return nil
+}
+
+// handleNodeIndexEvent adapts a PubSub IndexReportWrapEvent to handleNodeIndex.
+func (c *nodeInventoryHandlerImpl) handleNodeIndexEvent(event pubsub.Event) error {
+	wrapEvent, ok := event.(*IndexReportWrapEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	c.handleNodeIndex(wrapEvent.Wrap, c.ch2Central)
+	return nil
 }
 
 func (c *nodeInventoryHandlerImpl) handleNodeInventory(
@@ -332,11 +377,7 @@ func (c *nodeInventoryHandlerImpl) sendComplianceAck(
 	reason string,
 	metricReason metrics.AckReason,
 ) {
-	select {
-	case <-c.stopper.Flow().StopRequested():
-		log.Debugf("Skipped sending ComplianceACK (stop requested): type=%s, action=%s, resource_id=%s, reason=%s",
-			messageType, action, resourceID, reason)
-	case c.toCompliance <- common.MessageToComplianceWithAddress{
+	msg := common.MessageToComplianceWithAddress{
 		Msg: &sensor.MsgToCompliance{
 			Msg: &sensor.MsgToCompliance_ComplianceAck{
 				ComplianceAck: &sensor.MsgToCompliance_ComplianceACK{
@@ -349,18 +390,33 @@ func (c *nodeInventoryHandlerImpl) sendComplianceAck(
 		},
 		Hostname:  resourceID, // For node-based messages, resourceID is the node name
 		Broadcast: resourceID == "",
-	}:
-		log.Debugf("Sent ComplianceACK to Compliance: type=%s, action=%s, resource_id=%s, reason=%s",
-			messageType, action, resourceID, reason)
-
-		// Record old metric for compatibility.
-		metrics.ObserveNodeScanningAck(resourceID,
-			action.String(),
-			messageType.String(),
-			metrics.AckOperationSend,
-			metricReason,
-			metrics.AckOriginSensor)
 	}
+
+	if features.SensorInternalPubSub.Enabled() && c.pubSubDispatcher != nil {
+		if err := c.pubSubDispatcher.Publish(&ComplianceAckEvent{Msg: msg}); err != nil {
+			logging.GetRateLimitedLogger().ErrorL("compliance-ack-publish", "Failed to publish compliance ack event: %v", err)
+			return
+		}
+	} else {
+		select {
+		case <-c.stopper.Flow().StopRequested():
+			log.Debugf("Skipped sending ComplianceACK (stop requested): type=%s, action=%s, resource_id=%s, reason=%s",
+				messageType, action, resourceID, reason)
+			return
+		case c.toCompliance <- msg:
+		}
+	}
+
+	log.Debugf("Sent ComplianceACK to Compliance: type=%s, action=%s, resource_id=%s, reason=%s",
+		messageType, action, resourceID, reason)
+
+	// Record old metric for compatibility.
+	metrics.ObserveNodeScanningAck(resourceID,
+		action.String(),
+		messageType.String(),
+		metrics.AckOperationSend,
+		metricReason,
+		metrics.AckOriginSensor)
 }
 
 func (c *nodeInventoryHandlerImpl) sendNodeInventory(toC chan<- *message.ExpiringMessage, inventory *storage.NodeInventory) {

--- a/sensor/common/compliance/node_inventory_handler_pubsub_test.go
+++ b/sensor/common/compliance/node_inventory_handler_pubsub_test.go
@@ -1,0 +1,195 @@
+package compliance
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/compliance/index"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+)
+
+type wrongNodeInventoryEvent struct{}
+
+func (*wrongNodeInventoryEvent) Topic() pubsub.Topic { return pubsub.DefaultTopic }
+func (*wrongNodeInventoryEvent) Lane() pubsub.LaneID { return pubsub.DefaultLane }
+
+func newTestNodeInventoryHandlerDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.NodeInventoryIntakeLane),
+			lane.NewBlockingLane(pubsub.ComplianceAckLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+func (s *NodeInventoryHandlerTestSuite) TestPubSubNodeInventoryAndIndexReportDelivered() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestNodeInventoryHandlerDispatcher(t)
+	defer dispatcher.Stop()
+
+	ch := make(chan *storage.NodeInventory)
+	defer close(ch)
+	reports := make(chan *index.IndexReportWrap)
+	defer close(reports)
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, dispatcher)
+	s.Require().NoError(handler.Start())
+	handler.Notify(common.SensorComponentEventCentralReachable)
+	defer func() {
+		handler.Stop()
+		s.NoError(handler.Stopped().Wait())
+	}()
+
+	consumer := consumeAndCount(handler.ResponsesC(), 2)
+
+	require.NoError(t, dispatcher.Publish(&NodeInventoryEvent{Inventory: fakeNodeInventory("node1")}))
+	require.NoError(t, dispatcher.Publish(&IndexReportWrapEvent{Wrap: &index.IndexReportWrap{
+		NodeName:    "node1",
+		IndexReport: fakeNodeIndex("x86_64"),
+	}}))
+
+	s.NoError(consumer.Stopped().Wait())
+
+	// The legacy raw channels must stay untouched while PubSub is enabled.
+	select {
+	case <-ch:
+		s.Fail("unexpected message on legacy inventories channel while PubSub is enabled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func (s *NodeInventoryHandlerTestSuite) TestHandleNodeInventoryEventWrongType() {
+	ch := make(chan *storage.NodeInventory)
+	defer close(ch)
+	reports := make(chan *index.IndexReportWrap)
+	defer close(reports)
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
+	s.Require().NoError(handler.Start())
+	defer func() {
+		handler.Stop()
+		s.NoError(handler.Stopped().Wait())
+	}()
+
+	s.Error(handler.handleNodeInventoryEvent(&wrongNodeInventoryEvent{}))
+}
+
+func (s *NodeInventoryHandlerTestSuite) TestHandleNodeIndexEventWrongType() {
+	ch := make(chan *storage.NodeInventory)
+	defer close(ch)
+	reports := make(chan *index.IndexReportWrap)
+	defer close(reports)
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
+	s.Require().NoError(handler.Start())
+	defer func() {
+		handler.Stop()
+		s.NoError(handler.Stopped().Wait())
+	}()
+
+	s.Error(handler.handleNodeIndexEvent(&wrongNodeInventoryEvent{}))
+}
+
+// TestPubSubComplianceAckPublished verifies sendComplianceAck() publishes a ComplianceAckEvent
+// instead of writing to the legacy toCompliance channel when PubSub is enabled.
+func (s *NodeInventoryHandlerTestSuite) TestPubSubComplianceAckPublished() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestNodeInventoryHandlerDispatcher(t)
+	defer dispatcher.Stop()
+
+	ch := make(chan *storage.NodeInventory)
+	defer close(ch)
+	reports := make(chan *index.IndexReportWrap)
+	defer close(reports)
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, dispatcher)
+	s.Require().NoError(handler.Start())
+	defer func() {
+		handler.Stop()
+		s.NoError(handler.Stopped().Wait())
+	}()
+
+	received := make(chan common.MessageToComplianceWithAddress, 1)
+	require.NoError(t, dispatcher.RegisterConsumerToLane(
+		pubsub.ComplianceMultiplexerAckConsumer,
+		pubsub.ComplianceAckTopic,
+		pubsub.ComplianceAckLane,
+		func(event pubsub.Event) error {
+			ackEvent, ok := event.(*ComplianceAckEvent)
+			s.Require().True(ok)
+			received <- ackEvent.Msg
+			return nil
+		},
+	))
+
+	handler.sendComplianceAck("node1", 0, 0, "", "")
+
+	select {
+	case msg := <-received:
+		s.Equal("node1", msg.Hostname)
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for compliance ack via pubsub")
+	}
+
+	// The legacy toCompliance channel must stay untouched while PubSub is enabled.
+	select {
+	case <-handler.ComplianceC():
+		s.Fail("unexpected message on legacy toCompliance channel while PubSub is enabled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestConcurrentPubSubDeliverySerializedThroughLane publishes interleaved NodeInventoryEvent and
+// IndexReportWrapEvent for many different nodes concurrently. Both topics share
+// NodeInventoryIntakeLane (a blocking lane), which serializes their delivery through one
+// goroutine -- the same guarantee the legacy single-goroutine select loop provided.
+// Run with -race to catch a regression if that guarantee is ever broken.
+func (s *NodeInventoryHandlerTestSuite) TestConcurrentPubSubDeliverySerializedThroughLane() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestNodeInventoryHandlerDispatcher(t)
+	defer dispatcher.Stop()
+
+	ch := make(chan *storage.NodeInventory)
+	defer close(ch)
+	reports := make(chan *index.IndexReportWrap)
+	defer close(reports)
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, dispatcher)
+	s.Require().NoError(handler.Start())
+	handler.Notify(common.SensorComponentEventCentralReachable)
+	defer func() {
+		handler.Stop()
+		s.NoError(handler.Stopped().Wait())
+	}()
+
+	const numNodes = 50
+	consumer := consumeAndCount(handler.ResponsesC(), numNodes)
+
+	var wg sync.WaitGroup
+	for i := range numNodes {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			nodeName := fmt.Sprintf("node-%d", i)
+			require.NoError(t, dispatcher.Publish(&IndexReportWrapEvent{Wrap: &index.IndexReportWrap{
+				NodeName:    nodeName,
+				IndexReport: fakeNodeIndex("x86_64"),
+			}}))
+		}(i)
+	}
+	wg.Wait()
+
+	s.NoError(consumer.Stopped().Wait())
+}

--- a/sensor/common/compliance/node_inventory_handler_pubsub_test.go
+++ b/sensor/common/compliance/node_inventory_handler_pubsub_test.go
@@ -70,6 +70,45 @@ func (s *NodeInventoryHandlerTestSuite) TestPubSubNodeInventoryAndIndexReportDel
 	}
 }
 
+// TestPubSubDeliveryAfterStopDoesNotPanic guards against a regression where PubSub events
+// delivered after Stop() write to a channel run() already closed. The dispatcher has no
+// per-consumer unregistration, so callbacks can still fire post-Stop(); this must be tolerated
+// rather than panicking or hanging. Run with -race.
+func (s *NodeInventoryHandlerTestSuite) TestPubSubDeliveryAfterStopDoesNotPanic() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestNodeInventoryHandlerDispatcher(t)
+	defer dispatcher.Stop()
+
+	ch := make(chan *storage.NodeInventory)
+	defer close(ch)
+	reports := make(chan *index.IndexReportWrap)
+	defer close(reports)
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, dispatcher)
+	s.Require().NoError(handler.Start())
+	handler.Notify(common.SensorComponentEventCentralReachable)
+
+	handler.Stop()
+	s.NoError(handler.Stopped().Wait())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.NoError(t, dispatcher.Publish(&NodeInventoryEvent{Inventory: fakeNodeInventory("node1")}))
+		require.NoError(t, dispatcher.Publish(&IndexReportWrapEvent{Wrap: &index.IndexReportWrap{
+			NodeName:    "node1",
+			IndexReport: fakeNodeIndex("x86_64"),
+		}}))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		s.FailNow("timed out publishing events after Stop(); a callback is likely blocked sending on ch2Central")
+	}
+}
+
 func (s *NodeInventoryHandlerTestSuite) TestHandleNodeInventoryEventWrongType() {
 	ch := make(chan *storage.NodeInventory)
 	defer close(ch)

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -125,7 +125,7 @@ func (s *NodeInventoryHandlerTestSuite) TestCapabilities() {
 	defer close(inventories)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	caps := h.Capabilities()
 	s.Require().Len(caps, 1)
 	s.Equal(centralsensor.SensorACKSupport, caps[0])
@@ -136,7 +136,7 @@ func (s *NodeInventoryHandlerTestSuite) TestResponsesCShouldPanicWhenNotStarted(
 	defer close(inventories)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.Panics(func() {
 		h.ResponsesC()
 	})
@@ -152,7 +152,7 @@ func (s *NodeInventoryHandlerTestSuite) TestStopHandler() {
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
 	producer := concurrency.NewStopper()
-	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.NoError(h.Start())
 	h.Notify(common.SensorComponentEventCentralReachable)
 	consumer := consumeAndCount(h.ResponsesC(), 1)
@@ -183,7 +183,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerRegularRoutine() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -200,7 +200,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerStopIgnoresError() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -252,7 +252,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerCentralACKsToCompliance() {
 			defer close(ch)
 			reports := make(chan *index.IndexReportWrap)
 			defer close(reports)
-			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 			s.NoError(handler.Start())
 			handler.Notify(common.SensorComponentEventCentralReachable)
 
@@ -374,7 +374,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerSensorACKsToCompliance() {
 			defer close(ch)
 			reports := make(chan *index.IndexReportWrap)
 			defer close(reports)
-			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+			handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 			s.NoError(handler.Start())
 			handler.Notify(common.SensorComponentEventCentralReachable)
 
@@ -447,7 +447,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerAcceptsBothAckTypes() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	handler := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 
 	// Test legacy NodeInventoryACK
 	legacyMsg := &central.MsgToSensor{
@@ -494,7 +494,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerOfflineACKNACK() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.NoError(h.Start())
 
 	states := []testState{
@@ -643,7 +643,7 @@ func (s *NodeInventoryHandlerTestSuite) TestMultipleStartHandler() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
@@ -669,7 +669,7 @@ func (s *NodeInventoryHandlerTestSuite) TestDoubleStopHandler() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -687,7 +687,7 @@ func (s *NodeInventoryHandlerTestSuite) TestInputChannelClosed() {
 	ch, producer := s.generateTestInputNoClose(10)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -722,7 +722,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerNilInput() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateNilTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -739,7 +739,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerNodeUnknown() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockNeverHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockNeverHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	// Notify is called before Start to avoid race between generateTestInputNoClose and the NodeInventoryHandler
 	h.Notify(common.SensorComponentEventCentralReachable)
 	s.NoError(h.Start())
@@ -760,7 +760,7 @@ func (s *NodeInventoryHandlerTestSuite) TestHandlerCentralNotReady() {
 	defer close(ch)
 	reports := make(chan *index.IndexReportWrap)
 	defer close(reports)
-	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{})
+	h := NewNodeInventoryHandler(ch, reports, &mockAlwaysHitNodeIDMatcher{}, &mockRHCOSNodeMatcher{}, nil)
 	s.NoError(h.Start())
 	// expect centralConsumer to get 0 messages - sensor should NACK to compliance when the connection with central is not ready
 	centralConsumer := consumeAndCount(h.ResponsesC(), 0)

--- a/sensor/common/compliance/node_inventory_handler_test.go
+++ b/sensor/common/compliance/node_inventory_handler_test.go
@@ -809,7 +809,7 @@ func (s *NodeInventoryHandlerTestSuite) TestSendNodeIndex_RHCOSDetection() {
 			reports := make(chan *index.IndexReportWrap)
 			defer close(reports)
 
-			h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, tc.rhcosMatcher)
+			h := NewNodeInventoryHandler(inventories, reports, &mockAlwaysHitNodeIDMatcher{}, tc.rhcosMatcher, nil)
 			s.NoError(h.Start())
 			h.Notify(common.SensorComponentEventCentralReachable)
 

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -260,16 +260,29 @@ func (s *serviceImpl) Communicate(server sensor.ComplianceService_CommunicateSer
 			}
 			s.auditLogCollectionManager.AuditMessagesChan() <- msg
 		case *sensor.MsgFromCompliance_NodeInventory:
-			s.nodeInventories <- t.NodeInventory
+			if features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil {
+				if err := s.pubSubDispatcher.Publish(&NodeInventoryEvent{Inventory: t.NodeInventory}); err != nil {
+					logging.GetRateLimitedLogger().ErrorL("node-inventory-publish", "Failed to publish node inventory event: %v", err)
+				}
+			} else {
+				s.nodeInventories <- t.NodeInventory
+			}
 		case *sensor.MsgFromCompliance_IndexReport:
 			log.Infof("Received index report from %q with %d packages (%d deprecated)",
 				msg.GetNode(),
 				len(msg.GetIndexReport().GetContents().GetPackages()),
 				len(msg.GetIndexReport().GetContents().GetPackagesDEPRECATED()),
 			)
-			s.indexReportWraps <- &index.IndexReportWrap{
+			indexReportWrap := &index.IndexReportWrap{
 				NodeName:    msg.GetNode(),
 				IndexReport: t.IndexReport,
+			}
+			if features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil {
+				if err := s.pubSubDispatcher.Publish(&IndexReportWrapEvent{Wrap: indexReportWrap}); err != nil {
+					logging.GetRateLimitedLogger().ErrorL("index-report-publish", "Failed to publish index report event: %v", err)
+				}
+			} else {
+				s.indexReportWraps <- indexReportWrap
 			}
 		}
 	}

--- a/sensor/common/compliance/service_impl_pubsub_test.go
+++ b/sensor/common/compliance/service_impl_pubsub_test.go
@@ -1,0 +1,130 @@
+package compliance
+
+import (
+	"testing"
+	"time"
+
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/compliance/index"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestNodeInventoryIntakeDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.NodeInventoryIntakeLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+func (s *complianceServiceSuite) TestPubSubNodeInventoryDelivered() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestNodeInventoryIntakeDispatcher(t)
+	defer dispatcher.Stop()
+	s.srv.pubSubDispatcher = dispatcher
+
+	received := make(chan *storage.NodeInventory, 1)
+	require.NoError(t, dispatcher.RegisterConsumerToLane(
+		pubsub.NodeInventoryHandlerNodeInventoryConsumer,
+		pubsub.NodeInventoryTopic,
+		pubsub.NodeInventoryIntakeLane,
+		func(event pubsub.Event) error {
+			invEvent, ok := event.(*NodeInventoryEvent)
+			s.Require().True(ok)
+			received <- invEvent.Inventory
+			return nil
+		},
+	))
+
+	s.Require().NoError(s.stream.Send(&sensor.MsgFromCompliance{
+		Msg: &sensor.MsgFromCompliance_NodeInventory{
+			NodeInventory: &storage.NodeInventory{NodeName: "node1"},
+		},
+	}))
+
+	select {
+	case inv := <-received:
+		s.Require().Equal("node1", inv.GetNodeName())
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for node inventory via pubsub")
+	}
+
+	select {
+	case <-s.srv.nodeInventories:
+		s.Fail("unexpected message on legacy nodeInventories channel while PubSub is enabled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func (s *complianceServiceSuite) TestPubSubIndexReportDelivered() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestNodeInventoryIntakeDispatcher(t)
+	defer dispatcher.Stop()
+	s.srv.pubSubDispatcher = dispatcher
+	s.srv.indexReportWraps = make(chan *index.IndexReportWrap)
+
+	received := make(chan *index.IndexReportWrap, 1)
+	require.NoError(t, dispatcher.RegisterConsumerToLane(
+		pubsub.NodeInventoryHandlerIndexReportConsumer,
+		pubsub.IndexReportWrapTopic,
+		pubsub.NodeInventoryIntakeLane,
+		func(event pubsub.Event) error {
+			wrapEvent, ok := event.(*IndexReportWrapEvent)
+			s.Require().True(ok)
+			received <- wrapEvent.Wrap
+			return nil
+		},
+	))
+
+	s.Require().NoError(s.stream.Send(&sensor.MsgFromCompliance{
+		Msg: &sensor.MsgFromCompliance_IndexReport{
+			IndexReport: &v4.IndexReport{},
+		},
+	}))
+
+	select {
+	case wrap := <-received:
+		s.Require().NotNil(wrap.IndexReport)
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for index report via pubsub")
+	}
+
+	select {
+	case <-s.srv.indexReportWraps:
+		s.Fail("unexpected message on legacy indexReportWraps channel while PubSub is enabled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func (s *complianceServiceSuite) TestNodeInventoryFallsBackToRawChannelWhenPubSubDisabled() {
+	s.srv.pubSubDispatcher = nil
+
+	go func() {
+		s.Require().NoError(s.stream.Send(&sensor.MsgFromCompliance{
+			Msg: &sensor.MsgFromCompliance_NodeInventory{
+				NodeInventory: &storage.NodeInventory{NodeName: "node1"},
+			},
+		}))
+	}()
+
+	select {
+	case inv := <-s.srv.nodeInventories:
+		s.Require().Equal("node1", inv.GetNodeName())
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for node inventory on legacy channel")
+	}
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,26 +19,32 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	NodeInventoryHandlerNodeInventoryConsumer
+	NodeInventoryHandlerIndexReportConsumer
+	ComplianceMultiplexerAckConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:                            "NoConsumers",
-		DefaultConsumer:                        "Default",
-		ResolverConsumer:                       "Resolver",
-		EnrichedProcessConsumer:                "EnrichedProcess",
-		FileActivityEnrichedProcessConsumer:    "FileActivityEnrichedProcess",
-		UnenrichedProcessConsumer:              "UnenrichedProcess",
-		DetectorProcessIndicatorConsumer:       "DetectorProcessIndicator",
-		DetectorNetworkFlowConsumer:            "DetectorNetworkFlow",
-		DetectorFileAccessConsumer:             "DetectorFileAccess",
-		DetectorAuditLogConsumer:               "DetectorAuditLog",
-		DetectorDeploymentConsumer:             "DetectorDeployment",
-		DetectorScanResultConsumer:             "DetectorScanResult",
-		DetectorDeployAlertOutputConsumer:      "DetectorDeployAlertOutput",
-		OutputQueueConsumer:                    "OutputQueue",
-		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
-		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		NoConsumers:                               "NoConsumers",
+		DefaultConsumer:                           "Default",
+		ResolverConsumer:                          "Resolver",
+		EnrichedProcessConsumer:                   "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer:       "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:                 "UnenrichedProcess",
+		DetectorProcessIndicatorConsumer:          "DetectorProcessIndicator",
+		DetectorNetworkFlowConsumer:               "DetectorNetworkFlow",
+		DetectorFileAccessConsumer:                "DetectorFileAccess",
+		DetectorAuditLogConsumer:                  "DetectorAuditLog",
+		DetectorDeploymentConsumer:                "DetectorDeployment",
+		DetectorScanResultConsumer:                "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:         "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                       "OutputQueue",
+		NetworkFlowManagerResourceSyncConsumer:    "NetworkFlowManagerResourceSync",
+		SensorSoftRestartConsumer:                 "SensorSoftRestart",
+		NodeInventoryHandlerNodeInventoryConsumer: "NodeInventoryHandlerNodeInventory",
+		NodeInventoryHandlerIndexReportConsumer:   "NodeInventoryHandlerIndexReport",
+		ComplianceMultiplexerAckConsumer:          "ComplianceMultiplexerAck",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,8 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	NodeInventoryIntakeLane
+	ComplianceAckLane
 )
 
 var (
@@ -37,6 +39,8 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		NodeInventoryIntakeLane:        "NodeInventoryIntake",
+		ComplianceAckLane:              "ComplianceAck",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,9 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	NodeInventoryTopic
+	IndexReportWrapTopic
+	ComplianceAckTopic
 )
 
 var (
@@ -37,6 +40,9 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		NodeInventoryTopic:              "NodeInventory",
+		IndexReportWrapTopic:            "IndexReportWrap",
+		ComplianceAckTopic:              "ComplianceAck",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,8 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.NodeInventoryIntakeLane),
+			lane.NewBlockingLane(pubsub.ComplianceAckLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -129,7 +129,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	auditLogCollectionManager := compliance.NewAuditLogCollectionManager(clusterID)
 
 	o := orchestrator.New(cfg.k8sClient.Kubernetes())
-	complianceMultiplexer := compliance.NewMultiplexer()
+	complianceMultiplexer := compliance.NewMultiplexer(internalMessageDispatcher)
 	// TODO(ROX-16931): Turn auditLogEventsInput and auditLogCollectionManager into ComplianceComponents if possible
 	complianceService := compliance.NewService(o, auditLogEventsInput, auditLogCollectionManager, complianceMultiplexer.ComplianceC(), internalMessageDispatcher)
 
@@ -216,8 +216,12 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	matcher := compliance.NewNodeIDMatcher(storeProvider.Nodes())
-	nodeInventoryHandler := compliance.NewNodeInventoryHandler(complianceService.NodeInventories(), complianceService.IndexReportWraps(), matcher, matcher)
-	complianceMultiplexer.AddComponentWithComplianceC(nodeInventoryHandler)
+	nodeInventoryHandler := compliance.NewNodeInventoryHandler(complianceService.NodeInventories(), complianceService.IndexReportWraps(), matcher, matcher, internalMessageDispatcher)
+	if !(features.SensorInternalPubSub.Enabled() && internalMessageDispatcher != nil) {
+		// When PubSub is active, nodeInventoryHandler's ACKs reach complianceMultiplexer via its
+		// PubSub subscription instead of this legacy ComplianceC() channel.
+		complianceMultiplexer.AddComponentWithComplianceC(nodeInventoryHandler)
+	}
 	// complianceMultiplexer must start after all components that implement common.ComplianceComponent
 	// i.e., after nodeInventoryHandler
 	components = append(components, nodeInventoryHandler, complianceMultiplexer)


### PR DESCRIPTION
## Description

  Migrates the compliance Node Inventory Handler's channel boundary to the internal PubSub system, gated by `features.SensorInternalPubSub`
  (`ROX_SENSOR_PUBSUB`, default-enabled):

  - **Inbound intake** (`serviceImpl.Communicate()` → `nodeInventoryHandlerImpl`): `NodeInventory`/`IndexReportWrap` messages are published as
  `NodeInventoryEvent`/`IndexReportWrapEvent` instead of being written to the unbuffered `s.nodeInventories`/`s.indexReportWraps` channels.
  `nodeInventoryHandlerImpl.run()`'s single `select` over both channels becomes two `RegisterConsumerToLane` callbacks.
  - **Outbound ACK routing** (`sendComplianceAck()` → `compliance.Multiplexer`): ACK/NACK messages are published as a `ComplianceAckEvent` instead of
  being written to the unbuffered `toCompliance` channel. `compliance.Multiplexer` gains a PubSub-to-channel bridge that folds these events into the same
  fan-in stream as any legacy `ComplianceC()` channel.
  - When the feature flag is disabled, all existing raw-channel paths are untouched.

  **Concurrency hazard addressed:** `nodeInventoryHandlerImpl.archCache` (a plain `map[string]string`) is only race-free today because a single goroutine
  drains both intake channels serially. Both new PubSub consumers are registered onto the *same* blocking lane (`NodeInventoryIntakeLane`) to preserve
  that serialization instead of introducing a mutex.

  **Scope note — VM Handler is intentionally out of scope.** `compliance.Multiplexer` also fans in the VM Index Handler's `toCompliance` channel. That
  producer leg is tracked separately as ROX-36011 (blocked on this PR merging first, so both legs land on the same `ComplianceAckEvent` shape). This PR
  makes `Multiplexer` accept **both** the new PubSub subscription (Node Inventory Handler) and VM Handler's still-legacy channel simultaneously, which is
  the interim dual-consumer state ROX-36011 builds on. Once both producers are migrated, `pkg/channelmultiplexer` and `compliance.Multiplexer` can be
  deleted entirely (tracked as a follow-up cleanup ticket).

  Drive-by cleanup: removed the `acksFromCentral` field, which was declared and nil-initialized but never read or written anywhere in the codebase.

  🤖 This change was partially generated with the assistance of AI.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**
  is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is
  gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests
  
  ### How I validated my change

  - Added `service_impl_pubsub_test.go`: NodeInventory/IndexReportWrap are published via PubSub when the flag is enabled, and fall back to the raw
  channels when disabled.
  - Added `node_inventory_handler_pubsub_test.go`: both intake consumers register on the same lane; wrong-event-type handling for both adapters;
  `sendComplianceAck()` publishes a `ComplianceAckEvent` when enabled; a concurrency test publishing interleaved
  `NodeInventoryEvent`/`IndexReportWrapEvent` for 50 different nodes to exercise `archCache` under `-race`.
  - Added `multiplexer_pubsub_test.go`: a PubSub-published `ComplianceAckEvent` and a legacy `ComplianceC()` channel both feed
  `Multiplexer.ComplianceC()` concurrently; falls back to legacy-only behavior when the flag is disabled.
  - Updated ~16 existing `NewNodeInventoryHandler(...)` call sites for the new constructor param; all pre-existing tests still pass unmodified in
  behavior.