### PR TITLE
ROX-28590: [POC] (02) PolicyReport canonicalizer

### DIFF
--- a/pkg/policyreport/diff.go
+++ b/pkg/policyreport/diff.go
@@ -1,0 +1,90 @@
+package policyreport
+
+import "sort"
+
+// Diff reconciles a previous snapshot of SecurityEvents against a new
+// snapshot for the same report, keyed by SecurityEvent.ID, returning which
+// events to create, update, or remove. Per security-event-plan.md's "Treat
+// reports as current state" guiding decision:
+//
+//   - new minus old  -> created
+//   - shared identity, changed content -> updated
+//   - old minus new  -> removed
+//
+// Report deletion is modeled by calling Diff(previousEvents, nil) — every
+// previously-actionable event is returned in removed.
+//
+// All three return slices are sorted by ID for determinism.
+func Diff(oldEvents, newEvents []SecurityEvent) (created, updated, removed []SecurityEvent) {
+	oldByID := indexByID(oldEvents)
+	newByID := indexByID(newEvents)
+
+	for id, newEvent := range newByID {
+		oldEvent, existed := oldByID[id]
+		switch {
+		case !existed:
+			created = append(created, newEvent)
+		case !equalContent(oldEvent, newEvent):
+			updated = append(updated, newEvent)
+		}
+	}
+	for id, oldEvent := range oldByID {
+		if _, stillPresent := newByID[id]; !stillPresent {
+			removed = append(removed, oldEvent)
+		}
+	}
+
+	sortByID(created)
+	sortByID(updated)
+	sortByID(removed)
+	return created, updated, removed
+}
+
+func indexByID(events []SecurityEvent) map[string]SecurityEvent {
+	byID := make(map[string]SecurityEvent, len(events))
+	for _, e := range events {
+		byID[e.ID] = e
+	}
+	return byID
+}
+
+func sortByID(events []SecurityEvent) {
+	sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
+}
+
+// equalContent reports whether two SecurityEvents sharing the same ID
+// otherwise carry identical content. ObservedAt is derived from the report's
+// own result timestamp (not wall-clock at parse time), so re-canonicalizing
+// unchanged report content is expected to produce byte-identical events —
+// this is what makes repeated processing idempotent (see
+// kyverno_v1alpha2_test.go).
+func equalContent(a, b SecurityEvent) bool {
+	if a.Source != b.Source || a.Type != b.Type || !a.ObservedAt.Equal(b.ObservedAt) {
+		return false
+	}
+	if a.Report != b.Report || a.Subject != b.Subject || a.ResolvedEntity != b.ResolvedEntity {
+		return false
+	}
+	if a.Details.ReportedPolicy != b.Details.ReportedPolicy ||
+		a.Details.ReportedRule != b.Details.ReportedRule ||
+		a.Details.Category != b.Details.Category ||
+		a.Details.Result != b.Details.Result ||
+		a.Details.ReportedSeverity != b.Details.ReportedSeverity ||
+		a.Details.Message != b.Details.Message ||
+		a.Details.OriginalSource != b.Details.OriginalSource {
+		return false
+	}
+	return stringMapsEqual(a.Details.Properties, b.Details.Properties)
+}
+
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/policyreport/diff_test.go
+++ b/pkg/policyreport/diff_test.go
@@ -1,0 +1,99 @@
+package policyreport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestEvent(id string, message string) SecurityEvent {
+	return SecurityEvent{
+		ID:     id,
+		Source: SourceKyverno,
+		Type:   EventTypePolicyResult,
+		Report: ReportRef{UID: "report-1"},
+		Subject: Subject{
+			Kind: "Pod",
+			UID:  "pod-1",
+		},
+		Details: PolicyResult{
+			ReportedPolicy: "policy-a",
+			ReportedRule:   "rule-a",
+			Result:         PolicyResultFail,
+			Message:        message,
+		},
+	}
+}
+
+func TestDiff(t *testing.T) {
+	for name, tc := range map[string]struct {
+		old             []SecurityEvent
+		new             []SecurityEvent
+		expectedCreated []string
+		expectedUpdated []string
+		expectedRemoved []string
+	}{
+		"new report, no prior events: everything created": {
+			old:             nil,
+			new:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			expectedCreated: []string{"a", "b"},
+		},
+		"unchanged content: no created/updated/removed": {
+			old: []SecurityEvent{newTestEvent("a", "m1")},
+			new: []SecurityEvent{newTestEvent("a", "m1")},
+			// all nil
+		},
+		"changed content, same ID: updated": {
+			old:             []SecurityEvent{newTestEvent("a", "m1")},
+			new:             []SecurityEvent{newTestEvent("a", "m2")},
+			expectedUpdated: []string{"a"},
+		},
+		"result no longer present: removed": {
+			old:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			new:             []SecurityEvent{newTestEvent("a", "m1")},
+			expectedRemoved: []string{"b"},
+		},
+		"report deleted entirely: everything removed": {
+			old:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			new:             nil,
+			expectedRemoved: []string{"a", "b"},
+		},
+		"mixed create, update, remove in one diff": {
+			old:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			new:             []SecurityEvent{newTestEvent("a", "m1-changed"), newTestEvent("c", "m3")},
+			expectedCreated: []string{"c"},
+			expectedUpdated: []string{"a"},
+			expectedRemoved: []string{"b"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			created, updated, removed := Diff(tc.old, tc.new)
+			assert.Equal(t, tc.expectedCreated, idsOf(created))
+			assert.Equal(t, tc.expectedUpdated, idsOf(updated))
+			assert.Equal(t, tc.expectedRemoved, idsOf(removed))
+		})
+	}
+}
+
+func idsOf(events []SecurityEvent) []string {
+	if len(events) == 0 {
+		return nil
+	}
+	ids := make([]string, len(events))
+	for i, e := range events {
+		ids[i] = e.ID
+	}
+	return ids
+}
+
+func TestDiff_IsIdempotentWhenAppliedTwiceToSameInputs(t *testing.T) {
+	old := []SecurityEvent{newTestEvent("a", "m1")}
+	new := []SecurityEvent{newTestEvent("a", "m1-changed"), newTestEvent("b", "m2")}
+
+	created1, updated1, removed1 := Diff(old, new)
+	created2, updated2, removed2 := Diff(old, new)
+
+	assert.Equal(t, created1, created2)
+	assert.Equal(t, updated1, updated2)
+	assert.Equal(t, removed1, removed2)
+}

--- a/pkg/policyreport/event.go
+++ b/pkg/policyreport/event.go
@@ -1,0 +1,140 @@
+// Package policyreport canonicalizes external PolicyReport/ClusterPolicyReport
+// results (e.g. from Kyverno) into a source-neutral SecurityEvent envelope.
+//
+// This package is deliberately free of Kubernetes client, Sensor, and Central
+// wiring: adapters here are pure functions from a raw report object to a
+// deterministic slice of SecurityEvent values. See security-event-plan.md at
+// the repo root for the full design and phased rollout this package is part of.
+package policyreport
+
+import "time"
+
+// Source identifies the normalized producer of a SecurityEvent. Kept as a
+// bounded string rather than an enum so a standards-based report producer can
+// be supported without a new release, per security-event-plan.md's "Source
+// normalization" section.
+type Source string
+
+// SourceKyverno is the canonical source value for Kyverno-produced reports.
+const SourceKyverno Source = "Kyverno"
+
+// EventType identifies which typed payload a SecurityEvent carries.
+type EventType string
+
+// EventTypePolicyResult is the only EventType implemented so far.
+const EventTypePolicyResult EventType = "PolicyResult"
+
+// PolicyResultOutcome mirrors a PolicyReport result's `result` field.
+type PolicyResultOutcome string
+
+// Outcomes a PolicyReport result can report. Only Fail, Error, and Warn are
+// actionable in the MVP scope (see ActionableOutcomes) — Pass and Skip are
+// explicitly deferred per security-event-plan.md.
+const (
+	PolicyResultPass  PolicyResultOutcome = "pass"
+	PolicyResultFail  PolicyResultOutcome = "fail"
+	PolicyResultWarn  PolicyResultOutcome = "warn"
+	PolicyResultError PolicyResultOutcome = "error"
+	PolicyResultSkip  PolicyResultOutcome = "skip"
+)
+
+// ActionableOutcomes are the PolicyResultOutcome values that produce a
+// SecurityEvent. Pass and skip results are parsed (so callers can compute
+// summaries) but never canonicalized into events.
+var ActionableOutcomes = map[PolicyResultOutcome]bool{
+	PolicyResultFail:  true,
+	PolicyResultError: true,
+	PolicyResultWarn:  true,
+}
+
+// Severity mirrors a result's optional `severity` field. Producers are not
+// required to set one.
+type Severity string
+
+// Severity values a producer may report. SeverityUnknown means the producer
+// didn't set one at all — this is common; severity is opt-in per policy.
+const (
+	SeverityUnknown  Severity = ""
+	SeverityLow      Severity = "low"
+	SeverityMedium   Severity = "medium"
+	SeverityHigh     Severity = "high"
+	SeverityCritical Severity = "critical"
+)
+
+// EntityType identifies what kind of ACS-resolvable entity a SecurityEvent's
+// ResolvedEntity refers to. Only Deployment is implemented so far; Node is
+// listed in security-event-plan.md as a later expansion.
+type EntityType string
+
+// EntityTypeUnknown means resolution hasn't happened yet (or failed). This
+// package never sets ResolvedEntity — that's Phase 3's Pod-to-Deployment
+// resolver, layered on top of this pure canonicalizer.
+const (
+	EntityTypeUnknown    EntityType = ""
+	EntityTypeDeployment EntityType = "Deployment"
+)
+
+// ReportRef identifies the producer report object a SecurityEvent was
+// extracted from (a single PolicyReport or ClusterPolicyReport object).
+type ReportRef struct {
+	APIVersion      string
+	Kind            string // "PolicyReport" or "ClusterPolicyReport"
+	UID             string
+	Name            string
+	Namespace       string // empty for ClusterPolicyReport
+	ResourceVersion string
+}
+
+// Subject identifies the original Kubernetes object the report result
+// concerns. For Kyverno this comes from the report's top-level `scope` field
+// — one report object exists per subject resource, not one report per
+// namespace with a results-array of resources (confirmed against a real
+// Kyverno v1.18.2 cluster; see pkg/policyreport/testdata/raw/README.md).
+type Subject struct {
+	APIVersion string
+	Kind       string
+	UID        string
+	Name       string
+	Namespace  string
+}
+
+// ResolvedEntity is the ACS entity a Subject was resolved to. Always the zero
+// value coming out of this package — populated by a later resolution stage.
+type ResolvedEntity struct {
+	Type EntityType
+	ID   string
+}
+
+// PolicyResult is the typed payload for EventTypePolicyResult events.
+type PolicyResult struct {
+	ReportedPolicy   string
+	ReportedRule     string
+	Category         string
+	Result           PolicyResultOutcome
+	ReportedSeverity Severity
+	Message          string
+	// OriginalSource preserves the report result's own `source` field
+	// verbatim, for diagnostics — never used for matching (see Source).
+	OriginalSource string
+	// Properties preserves unknown/producer-specific key-value pairs
+	// without promoting them to policy criteria (security-event-plan.md:
+	// "retain them for details and diagnostics").
+	Properties map[string]string
+}
+
+// SecurityEvent is the canonical, source-neutral ingestion envelope described
+// in security-event-plan.md's "Canonical domain contract".
+type SecurityEvent struct {
+	// ID is a stable identity computed by ComputeID. Two SecurityEvents
+	// with the same ID represent the same logical finding across updates.
+	ID         string
+	Source     Source
+	Type       EventType
+	ObservedAt time.Time
+
+	Report         ReportRef
+	Subject        Subject
+	ResolvedEntity ResolvedEntity
+
+	Details PolicyResult
+}

--- a/pkg/policyreport/identity.go
+++ b/pkg/policyreport/identity.go
@@ -1,0 +1,27 @@
+package policyreport
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// ComputeID derives a stable SecurityEvent identity from the tuple documented
+// in security-event-plan.md's "Stable identity" section: cluster ID + report
+// UID + normalized source + reported policy name + rule name + subject UID.
+//
+// Deliberately excludes result-array position and observation timestamp, so
+// reordered results and repeated observations of unchanged content produce
+// the same ID. If a producer is ever found to emit legitimate duplicates
+// under this tuple, add the smallest stable additional discriminator here and
+// document why in a test, since any identity change affects alert
+// continuity for every existing SecurityEvent.
+func ComputeID(clusterID, reportUID string, source Source, reportedPolicy, reportedRule, subjectUID string) string {
+	h := sha256.New()
+	for _, part := range []string{clusterID, reportUID, string(source), reportedPolicy, reportedRule, subjectUID} {
+		h.Write([]byte(part))
+		// NUL separator: none of these fields can legitimately contain a NUL
+		// byte, so this keeps e.g. ("ab","c") distinguishable from ("a","bc").
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/policyreport/identity_test.go
+++ b/pkg/policyreport/identity_test.go
@@ -1,0 +1,53 @@
+package policyreport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeID_DeterministicForSameInput(t *testing.T) {
+	id1 := ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1")
+	id2 := ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1")
+	assert.Equal(t, id1, id2)
+	assert.NotEmpty(t, id1)
+}
+
+func TestComputeID_DiffersWhenAnyComponentChanges(t *testing.T) {
+	base := func() string {
+		return ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1")
+	}
+	baseID := base()
+
+	for name, id := range map[string]string{
+		"different cluster": ComputeID("cluster-2", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1"),
+		"different report":  ComputeID("cluster-1", "report-uid-2", SourceKyverno, "policy-a", "rule-a", "subject-uid-1"),
+		"different policy":  ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-b", "rule-a", "subject-uid-1"),
+		"different rule":    ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-b", "subject-uid-1"),
+		"different subject": ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-2"),
+		"different source":  ComputeID("cluster-1", "report-uid-1", Source("Gatekeeper"), "policy-a", "rule-a", "subject-uid-1"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NotEqual(t, baseID, id)
+		})
+	}
+}
+
+func TestComputeID_ConcatenationAmbiguityIsAvoided(t *testing.T) {
+	// Without a separator, ("cluster-1x", "report-1") and ("cluster-1", "x-report-1")
+	// could hash identically. The NUL separator in ComputeID must prevent this.
+	idA := ComputeID("cluster-1x", "report-1", SourceKyverno, "p", "r", "s")
+	idB := ComputeID("cluster-1", "x-report-1", SourceKyverno, "p", "r", "s")
+	assert.NotEqual(t, idA, idB)
+}
+
+func TestComputeID_IndependentOfResultOrdering(t *testing.T) {
+	// ComputeID takes explicit fields, not a result's position in an array —
+	// this test documents that guarantee at the identity layer directly
+	// (the adapter-level reordering-stability test lives in
+	// kyverno_v1alpha2_test.go, since ordering is a property of the results
+	// slice the adapter walks, not of ComputeID's own arguments).
+	idFirst := ComputeID("cluster-1", "report-1", SourceKyverno, "policy-a", "rule-a", "subject-1")
+	idSecond := ComputeID("cluster-1", "report-1", SourceKyverno, "policy-a", "rule-a", "subject-1")
+	assert.Equal(t, idFirst, idSecond)
+}

--- a/pkg/policyreport/kyverno_v1alpha2.go
+++ b/pkg/policyreport/kyverno_v1alpha2.go
@@ -1,0 +1,254 @@
+package policyreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// KyvernoV1Alpha2APIVersion is the only report API version this adapter
+// understands. Confirmed against a real Kyverno v1.18.2 cluster — see
+// pkg/policyreport/testdata/raw/README.md. A future openreports.io/v1alpha1
+// (or newer wgpolicyk8s.io) adapter belongs in its own file behind the same
+// signature, per security-event-plan.md's "Prefer adapters over a
+// version-specific domain model".
+const KyvernoV1Alpha2APIVersion = "wgpolicyk8s.io/v1alpha2"
+
+const (
+	kindPolicyReport        = "PolicyReport"
+	kindClusterPolicyReport = "ClusterPolicyReport"
+)
+
+// CanonicalizeKyvernoV1Alpha2 is a pure adapter from a single Kyverno
+// wgpolicyk8s.io/v1alpha2 PolicyReport or ClusterPolicyReport object to a
+// deterministic slice of canonical SecurityEvents.
+//
+// Only actionable results (fail, error, warn — see ActionableOutcomes) become
+// SecurityEvents; pass/skip results are parsed but produce no event, per the
+// plan's MVP scope. A report with no actionable results yields an empty,
+// non-nil slice and no error — that's a normal, common case, not a failure.
+//
+// A malformed individual result (missing policy/rule/result) is skipped
+// without discarding its valid siblings. Only a structurally unusable report
+// (wrong API version/kind, or a missing/unidentifiable scope) returns an
+// error, since without a subject there is nothing to attribute any result to.
+func CanonicalizeKyvernoV1Alpha2(clusterID string, report *unstructured.Unstructured) ([]SecurityEvent, error) {
+	if report == nil {
+		return nil, errors.New("policyreport: report is nil")
+	}
+
+	if apiVersion := report.GetAPIVersion(); apiVersion != KyvernoV1Alpha2APIVersion {
+		return nil, errors.Errorf("policyreport: unsupported apiVersion %q, expected %q", apiVersion, KyvernoV1Alpha2APIVersion)
+	}
+	kind := report.GetKind()
+	if kind != kindPolicyReport && kind != kindClusterPolicyReport {
+		return nil, errors.Errorf("policyreport: unsupported kind %q", kind)
+	}
+
+	subject, err := extractSubject(report)
+	if err != nil {
+		return nil, errors.Wrap(err, "policyreport: extracting subject scope")
+	}
+
+	reportRef := ReportRef{
+		APIVersion:      report.GetAPIVersion(),
+		Kind:            kind,
+		UID:             string(report.GetUID()),
+		Name:            report.GetName(),
+		Namespace:       report.GetNamespace(),
+		ResourceVersion: report.GetResourceVersion(),
+	}
+
+	rawResults, found, err := unstructured.NestedSlice(report.Object, "results")
+	if err != nil {
+		return nil, errors.Wrap(err, "policyreport: reading results")
+	}
+	if !found || len(rawResults) == 0 {
+		return []SecurityEvent{}, nil
+	}
+
+	events := make([]SecurityEvent, 0, len(rawResults))
+	for _, raw := range rawResults {
+		resultMap, ok := raw.(map[string]interface{})
+		if !ok {
+			// A single malformed entry in the results array must not
+			// discard its valid siblings.
+			continue
+		}
+
+		event, ok := canonicalizeResult(clusterID, reportRef, subject, resultMap)
+		if !ok {
+			continue
+		}
+		events = append(events, event)
+	}
+
+	sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
+	return events, nil
+}
+
+// extractSubject reads the report's top-level `scope` field. Kyverno emits
+// exactly one report object per subject resource (see testdata README), so
+// unlike the plan's original draft there is no per-result resources array to
+// walk — the whole report shares one subject.
+func extractSubject(report *unstructured.Unstructured) (Subject, error) {
+	scopeMap, found, err := unstructured.NestedMap(report.Object, "scope")
+	if err != nil {
+		return Subject{}, errors.Wrap(err, "reading scope")
+	}
+	if !found {
+		return Subject{}, errors.New("scope is missing")
+	}
+
+	uid := strings.TrimSpace(nestedStringOrEmpty(scopeMap, "uid"))
+	if uid == "" {
+		return Subject{}, errors.New("scope.uid is missing or empty")
+	}
+
+	return Subject{
+		APIVersion: sanitizeProducerString(nestedStringOrEmpty(scopeMap, "apiVersion")),
+		Kind:       sanitizeProducerString(nestedStringOrEmpty(scopeMap, "kind")),
+		UID:        uid,
+		Name:       sanitizeProducerString(nestedStringOrEmpty(scopeMap, "name")),
+		Namespace:  sanitizeProducerString(nestedStringOrEmpty(scopeMap, "namespace")),
+	}, nil
+}
+
+// canonicalizeResult converts a single `results[]` entry into a SecurityEvent.
+// Returns ok=false when the result is either malformed (missing a required
+// field) or simply non-actionable (pass/skip) — both are normal, silent
+// skips, not errors.
+func canonicalizeResult(clusterID string, reportRef ReportRef, subject Subject, resultMap map[string]interface{}) (SecurityEvent, bool) {
+	policyName := strings.TrimSpace(nestedStringOrEmpty(resultMap, "policy"))
+	ruleName := strings.TrimSpace(nestedStringOrEmpty(resultMap, "rule"))
+	rawOutcome := strings.ToLower(strings.TrimSpace(nestedStringOrEmpty(resultMap, "result")))
+	if policyName == "" || ruleName == "" || rawOutcome == "" {
+		return SecurityEvent{}, false
+	}
+
+	outcome := PolicyResultOutcome(rawOutcome)
+	if !isKnownOutcome(outcome) || !ActionableOutcomes[outcome] {
+		return SecurityEvent{}, false
+	}
+
+	reportedSource := nestedStringOrEmpty(resultMap, "source")
+	canonicalSource := normalizeSource(reportedSource)
+
+	details := PolicyResult{
+		ReportedPolicy:   sanitizeProducerString(policyName),
+		ReportedRule:     sanitizeProducerString(ruleName),
+		Category:         sanitizeProducerString(nestedStringOrEmpty(resultMap, "category")),
+		Result:           outcome,
+		ReportedSeverity: normalizeSeverity(nestedStringOrEmpty(resultMap, "severity")),
+		Message:          sanitizeProducerString(nestedStringOrEmpty(resultMap, "message")),
+		OriginalSource:   sanitizeProducerString(reportedSource),
+		Properties:       extractProperties(resultMap),
+	}
+
+	id := ComputeID(clusterID, reportRef.UID, canonicalSource, details.ReportedPolicy, details.ReportedRule, subject.UID)
+
+	return SecurityEvent{
+		ID:         id,
+		Source:     canonicalSource,
+		Type:       EventTypePolicyResult,
+		ObservedAt: parseResultTimestamp(resultMap),
+		Report:     reportRef,
+		Subject:    subject,
+		Details:    details,
+	}, true
+}
+
+func isKnownOutcome(o PolicyResultOutcome) bool {
+	switch o {
+	case PolicyResultPass, PolicyResultFail, PolicyResultWarn, PolicyResultError, PolicyResultSkip:
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizeSource maps a report result's own `source` string to a canonical
+// Source. This adapter is registered specifically for Kyverno-shaped
+// wgpolicyk8s.io/v1alpha2 reports, so its own adapter identity (Kyverno) is
+// always the fallback, per security-event-plan.md's source-normalization
+// precedence ("explicit report result source, then ... adapter identity") —
+// the original string is preserved separately in PolicyResult.OriginalSource
+// for diagnostics regardless of what this returns.
+func normalizeSource(_ string) Source {
+	return SourceKyverno
+}
+
+func normalizeSeverity(raw string) Severity {
+	switch Severity(strings.ToLower(strings.TrimSpace(raw))) {
+	case SeverityLow:
+		return SeverityLow
+	case SeverityMedium:
+		return SeverityMedium
+	case SeverityHigh:
+		return SeverityHigh
+	case SeverityCritical:
+		return SeverityCritical
+	default:
+		return SeverityUnknown
+	}
+}
+
+func extractProperties(resultMap map[string]interface{}) map[string]string {
+	rawProps, found, err := unstructured.NestedMap(resultMap, "properties")
+	if err != nil || !found || len(rawProps) == 0 {
+		return nil
+	}
+	props := make(map[string]string, len(rawProps))
+	for k, v := range rawProps {
+		props[sanitizeProducerString(k)] = sanitizeProducerString(fmt.Sprintf("%v", v))
+	}
+	return props
+}
+
+func parseResultTimestamp(resultMap map[string]interface{}) time.Time {
+	tsMap, found, err := unstructured.NestedMap(resultMap, "timestamp")
+	if err != nil || !found {
+		return time.Time{}
+	}
+	seconds, secondsOK := toInt64(tsMap["seconds"])
+	nanos, _ := toInt64(tsMap["nanos"])
+	if !secondsOK || seconds == 0 {
+		return time.Time{}
+	}
+	return time.Unix(seconds, nanos).UTC()
+}
+
+// toInt64 tolerates every numeric representation a `map[string]interface{}`
+// built from JSON/YAML can realistically contain: encoding/json.Unmarshal
+// produces float64, the k8s-flavored decoders can produce int64 or
+// json.Number depending on path. Being defensive here is what lets
+// CanonicalizeKyvernoV1Alpha2 never panic on the unstructured boundary,
+// regardless of which decoder produced the object.
+func toInt64(v interface{}) (int64, bool) {
+	switch t := v.(type) {
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	case float64:
+		return int64(t), true
+	case json.Number:
+		n, err := t.Int64()
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func nestedStringOrEmpty(m map[string]interface{}, field string) string {
+	s, found, err := unstructured.NestedString(m, field)
+	if err != nil || !found {
+		return ""
+	}
+	return s
+}

--- a/pkg/policyreport/kyverno_v1alpha2_test.go
+++ b/pkg/policyreport/kyverno_v1alpha2_test.go
@@ -1,0 +1,360 @@
+package policyreport
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+const testClusterID = "test-cluster-id"
+
+// loadFixtureList reads a captured `kubectl get policyreport -o yaml` List
+// dump (see testdata/raw/README.md for provenance) and returns each item as
+// its own *unstructured.Unstructured, matching what a real CRD informer
+// hands the adapter one object at a time.
+func loadFixtureList(t *testing.T, path string) []*unstructured.Unstructured {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var list struct {
+		Items []map[string]interface{} `json:"items"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &list))
+	require.NotEmpty(t, list.Items, "fixture %s has no items", path)
+
+	reports := make([]*unstructured.Unstructured, 0, len(list.Items))
+	for _, item := range list.Items {
+		reports = append(reports, &unstructured.Unstructured{Object: item})
+	}
+	return reports
+}
+
+func canonicalizeAll(t *testing.T, reports []*unstructured.Unstructured) []SecurityEvent {
+	t.Helper()
+	var all []SecurityEvent
+	for _, r := range reports {
+		events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		all = append(all, events...)
+	}
+	return all
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_RealFixtures exercises the adapter against
+// real `oc get policyreport -o yaml` captures (see testdata/raw/README.md for
+// exactly how/where they were produced), not hand-guessed data.
+func TestCanonicalizeKyvernoV1Alpha2_RealFixtures(t *testing.T) {
+	for name, tc := range map[string]struct {
+		fixture             string
+		expectedTotalEvents int
+	}{
+		"new failures and multi-rule failure": {
+			fixture:             "testdata/raw/01-new-failures-and-multi-rule.yaml",
+			expectedTotalEvents: 9, // 6 report objects; see file for the fail/pass breakdown per object.
+		},
+		"fail-to-pass via pod replacement": {
+			fixture:             "testdata/raw/02-fail-to-pass-via-pod-replacement.yaml",
+			expectedTotalEvents: 7,
+		},
+		"after deployment deletion": {
+			fixture:             "testdata/raw/03-after-deployment-deletion.yaml",
+			expectedTotalEvents: 1, // only the stale, scaled-to-zero ReplicaSet report still fails.
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reports := loadFixtureList(t, tc.fixture)
+			events := canonicalizeAll(t, reports)
+			assert.Len(t, events, tc.expectedTotalEvents)
+
+			// Every actionable event must carry a non-empty ID, policy, rule,
+			// and subject UID — no partially-populated events.
+			for _, e := range events {
+				assert.NotEmpty(t, e.ID)
+				assert.Equal(t, SourceKyverno, e.Source)
+				assert.Equal(t, EventTypePolicyResult, e.Type)
+				assert.NotEmpty(t, e.Details.ReportedPolicy)
+				assert.NotEmpty(t, e.Details.ReportedRule)
+				assert.NotEmpty(t, e.Subject.UID)
+				assert.True(t, ActionableOutcomes[e.Details.Result], "non-actionable outcome leaked through: %s", e.Details.Result)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_SpotCheckKnownResult pins the exact field
+// values for one specific, known result from fixture 1, so a future
+// refactor can't silently change field mapping without a test noticing.
+func TestCanonicalizeKyvernoV1Alpha2_SpotCheckKnownResult(t *testing.T) {
+	reports := loadFixtureList(t, "testdata/raw/01-new-failures-and-multi-rule.yaml")
+
+	var found *SecurityEvent
+	for _, r := range reports {
+		if r.GetKind() != kindPolicyReport {
+			continue
+		}
+		scope, _, _ := unstructured.NestedMap(r.Object, "scope")
+		if nestedStringOrEmpty(scope, "kind") != "Pod" || nestedStringOrEmpty(scope, "name") != "fail-multi-rule-cdb6d9f8d-pdmq4" {
+			continue
+		}
+		events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		for i := range events {
+			if events[i].Details.ReportedRule == "disallow-latest-tag" {
+				found = &events[i]
+			}
+		}
+	}
+
+	require.NotNil(t, found, "expected to find the disallow-latest-tag result for fail-multi-rule's pod")
+	assert.Equal(t, "require-secure-pod-security-context", found.Details.ReportedPolicy)
+	assert.Equal(t, PolicyResultFail, found.Details.Result)
+	assert.Equal(t, SeverityHigh, found.Details.ReportedSeverity)
+	assert.Equal(t, "kyverno", found.Details.OriginalSource)
+	assert.Contains(t, found.Details.Message, "Using 'latest' image tag is not allowed")
+	assert.Equal(t, "Pod", found.Subject.Kind)
+	assert.Equal(t, "fail-multi-rule-cdb6d9f8d-pdmq4", found.Subject.Name)
+	assert.Equal(t, "security-event-test", found.Subject.Namespace)
+	assert.False(t, found.ObservedAt.IsZero())
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_RejectsWrongAPIVersionOrKind(t *testing.T) {
+	for name, obj := range map[string]map[string]interface{}{
+		"wrong apiVersion": {
+			"apiVersion": "wgpolicyk8s.io/v1beta1",
+			"kind":       kindPolicyReport,
+			"metadata":   map[string]interface{}{"uid": "u1"},
+			"scope":      map[string]interface{}{"uid": "s1", "kind": "Pod"},
+		},
+		"wrong kind": {
+			"apiVersion": KyvernoV1Alpha2APIVersion,
+			"kind":       "SomethingElse",
+			"metadata":   map[string]interface{}{"uid": "u1"},
+			"scope":      map[string]interface{}{"uid": "s1", "kind": "Pod"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: obj})
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_NilReport(t *testing.T) {
+	_, err := CanonicalizeKyvernoV1Alpha2(testClusterID, nil)
+	assert.Error(t, err)
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_MissingOrEmptyScopeIsAnError(t *testing.T) {
+	for name, scope := range map[string]interface{}{
+		"scope missing entirely": nil,
+		"scope.uid empty":        map[string]interface{}{"uid": "", "kind": "Pod"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			obj := map[string]interface{}{
+				"apiVersion": KyvernoV1Alpha2APIVersion,
+				"kind":       kindPolicyReport,
+				"metadata":   map[string]interface{}{"uid": "report-uid"},
+				"results": []interface{}{
+					map[string]interface{}{"policy": "p", "rule": "r", "result": "fail"},
+				},
+			}
+			if scope != nil {
+				obj["scope"] = scope
+			}
+			_, err := CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: obj})
+			assert.Error(t, err)
+		})
+	}
+}
+
+func minimalReport(results []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": KyvernoV1Alpha2APIVersion,
+		"kind":       kindPolicyReport,
+		"metadata": map[string]interface{}{
+			"uid":       "report-uid-1",
+			"name":      "report-name-1",
+			"namespace": "ns1",
+		},
+		"scope": map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"name":       "pod-1",
+			"namespace":  "ns1",
+			"uid":        "pod-uid-1",
+		},
+		"results": results,
+	}}
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_NoResultsFieldOrEmptyIsNotAnError(t *testing.T) {
+	for name, results := range map[string][]interface{}{
+		"nil results":   nil,
+		"empty results": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport(results))
+			require.NoError(t, err)
+			assert.Empty(t, events)
+		})
+	}
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_OnlyPassOrSkipResultsProduceNoEvents(t *testing.T) {
+	events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+		map[string]interface{}{"policy": "p1", "rule": "r1", "result": "pass"},
+		map[string]interface{}{"policy": "p2", "rule": "r2", "result": "skip"},
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_MalformedResultDoesNotDiscardValidSiblings
+// covers Phase 1's validation requirement directly: a single malformed
+// result entry must not prevent its valid siblings in the same report from
+// being canonicalized.
+func TestCanonicalizeKyvernoV1Alpha2_MalformedResultDoesNotDiscardValidSiblings(t *testing.T) {
+	events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+		map[string]interface{}{"policy": "", "rule": "r1", "result": "fail"},    // missing policy
+		map[string]interface{}{"policy": "p2", "rule": "", "result": "fail"},    // missing rule
+		map[string]interface{}{"policy": "p3", "rule": "r3", "result": ""},      // missing result
+		map[string]interface{}{"policy": "p4", "rule": "r4", "result": "bogus"}, // unknown result value
+		"not-even-a-map", // wrong type entirely
+		map[string]interface{}{"policy": "p5", "rule": "r5", "result": "fail"}, // the one valid entry
+	}))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "p5", events[0].Details.ReportedPolicy)
+	assert.Equal(t, "r5", events[0].Details.ReportedRule)
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_UnknownOptionalPropertiesDoNotBreakParsing(t *testing.T) {
+	events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+		map[string]interface{}{
+			"policy":            "p1",
+			"rule":              "r1",
+			"result":            "fail",
+			"someFutureField":   "unrecognized-by-this-adapter-version",
+			"anotherNewFeature": map[string]interface{}{"nested": true},
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "p1", events[0].Details.ReportedPolicy)
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_ReorderingResultsDoesNotChangeIDs is the
+// adapter-level counterpart to identity_test.go's ComputeID guarantee:
+// shuffling the results array must produce the same set of IDs.
+func TestCanonicalizeKyvernoV1Alpha2_ReorderingResultsDoesNotChangeIDs(t *testing.T) {
+	forward := []interface{}{
+		map[string]interface{}{"policy": "p1", "rule": "r1", "result": "fail"},
+		map[string]interface{}{"policy": "p2", "rule": "r2", "result": "fail"},
+		map[string]interface{}{"policy": "p3", "rule": "r3", "result": "fail"},
+	}
+	reversed := []interface{}{forward[2], forward[1], forward[0]}
+
+	forwardEvents, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport(forward))
+	require.NoError(t, err)
+	reversedEvents, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport(reversed))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, idsOf(forwardEvents), idsOf(reversedEvents))
+	// The adapter itself still returns a deterministic (ID-sorted) order
+	// regardless of input order.
+	assert.Equal(t, forwardEvents, reversedEvents)
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_IsIdempotent covers "repeated processing is
+// idempotent": canonicalizing the same report object twice must produce
+// byte-identical output, including ObservedAt (derived from the report's own
+// timestamp field, not wall-clock time).
+func TestCanonicalizeKyvernoV1Alpha2_IsIdempotent(t *testing.T) {
+	reports := loadFixtureList(t, "testdata/raw/01-new-failures-and-multi-rule.yaml")
+	for i, r := range reports {
+		first, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		second, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		assert.Equal(t, first, second, "report index %d was not canonicalized idempotently", i)
+	}
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_NormalizationIsDeterministic covers
+// "normalization is deterministic": varying case/whitespace on the
+// producer-supplied source string must always normalize to the same
+// canonical Source, while the original is preserved verbatim (trimmed) for
+// diagnostics.
+func TestCanonicalizeKyvernoV1Alpha2_NormalizationIsDeterministic(t *testing.T) {
+	for name, source := range map[string]string{
+		"lowercase":         "kyverno",
+		"uppercase":         "KYVERNO",
+		"mixed case":        "Kyverno",
+		"surrounding space": "  kyverno  ",
+		"empty":             "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+				map[string]interface{}{"policy": "p1", "rule": "r1", "result": "fail", "source": source},
+			}))
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			assert.Equal(t, SourceKyverno, events[0].Source)
+		})
+	}
+}
+
+// FuzzCanonicalizeKyvernoV1Alpha2 fuzzes the unstructured boundary: arbitrary
+// bytes, decoded as YAML/JSON into a generic map and handed to the adapter,
+// must never panic — malformed input should surface as an error (or simply
+// no events), never a crash.
+func FuzzCanonicalizeKyvernoV1Alpha2(f *testing.F) {
+	for _, path := range []string{
+		"testdata/raw/01-new-failures-and-multi-rule.yaml",
+		"testdata/raw/02-fail-to-pass-via-pod-replacement.yaml",
+		"testdata/raw/03-after-deployment-deletion.yaml",
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(data)
+	}
+	// A handful of adversarial seeds: wrong types, deeply nested garbage,
+	// truncated structures.
+	f.Add([]byte(`{"apiVersion":"wgpolicyk8s.io/v1alpha2","kind":"PolicyReport","results":"not-a-list"}`))
+	f.Add([]byte(`{"apiVersion":"wgpolicyk8s.io/v1alpha2","kind":"PolicyReport","scope":123}`))
+	f.Add([]byte(`{"results":[{"policy":1,"rule":[1,2,3],"result":{}}]}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var single map[string]interface{}
+		if err := yaml.Unmarshal(data, &single); err != nil {
+			return
+		}
+		assert.NotPanics(t, func() {
+			_, _ = CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: single})
+		})
+
+		// Also try treating the input as a List of report items, since
+		// that's the shape our real fixtures come in.
+		var list struct {
+			Items []map[string]interface{} `json:"items"`
+		}
+		if err := yaml.Unmarshal(data, &list); err != nil {
+			return
+		}
+		for _, item := range list.Items {
+			assert.NotPanics(t, func() {
+				_, _ = CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: item})
+			})
+		}
+	})
+}

--- a/pkg/policyreport/sanitize.go
+++ b/pkg/policyreport/sanitize.go
@@ -1,6 +1,9 @@
 package policyreport
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // maxProducerStringLength bounds any single producer-supplied string field
 // (message, category, reported source, property values, ...). Long enough
@@ -27,7 +30,11 @@ func sanitizeProducerString(raw string) string {
 	sanitized := b.String()
 
 	if len(sanitized) > maxProducerStringLength {
-		return sanitized[:maxProducerStringLength]
+		truncated := sanitized[:maxProducerStringLength]
+		for !utf8.ValidString(truncated) {
+			truncated = truncated[:len(truncated)-1]
+		}
+		return truncated
 	}
 	return sanitized
 }

--- a/pkg/policyreport/sanitize.go
+++ b/pkg/policyreport/sanitize.go
@@ -1,0 +1,33 @@
+package policyreport
+
+import "strings"
+
+// maxProducerStringLength bounds any single producer-supplied string field
+// (message, category, reported source, property values, ...). Long enough
+// for a realistic human-readable message, short enough to bound storage and
+// log volume regardless of what a misbehaving producer sends.
+const maxProducerStringLength = 4096
+
+// sanitizeProducerString trims surrounding whitespace, strips control
+// characters (a misbehaving or malicious producer must not be able to inject
+// them), and truncates to maxProducerStringLength. Used for every
+// producer-supplied string that ends up in a SecurityEvent, per
+// security-event-plan.md's "Source normalization" section ("Apply length
+// limits and reject control characters").
+func sanitizeProducerString(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+
+	var b strings.Builder
+	b.Grow(len(trimmed))
+	for _, r := range trimmed {
+		if r == '\t' || (r >= 0x20 && r != 0x7f) {
+			b.WriteRune(r)
+		}
+	}
+	sanitized := b.String()
+
+	if len(sanitized) > maxProducerStringLength {
+		return sanitized[:maxProducerStringLength]
+	}
+	return sanitized
+}

--- a/pkg/policyreport/sanitize_test.go
+++ b/pkg/policyreport/sanitize_test.go
@@ -1,0 +1,96 @@
+package policyreport
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeProducerString(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty string": {
+			input:    "",
+			expected: "",
+		},
+		"whitespace trimmed": {
+			input:    "  hello  ",
+			expected: "hello",
+		},
+		"control characters stripped": {
+			input:    "hello\x00world\x07end",
+			expected: "helloworldend",
+		},
+		"NUL stripped": {
+			input:    "a\x00b",
+			expected: "ab",
+		},
+		"BEL stripped": {
+			input:    "a\x07b",
+			expected: "ab",
+		},
+		"DEL stripped": {
+			input:    "a\x7fb",
+			expected: "ab",
+		},
+		"tabs preserved": {
+			input:    "a\tb",
+			expected: "a\tb",
+		},
+		"newlines stripped": {
+			input:    "a\nb\rc",
+			expected: "abc",
+		},
+		"under limit unchanged": {
+			input:    "short string",
+			expected: "short string",
+		},
+		"at limit unchanged": {
+			input:    strings.Repeat("a", maxProducerStringLength),
+			expected: strings.Repeat("a", maxProducerStringLength),
+		},
+		"over limit truncated": {
+			input:    strings.Repeat("a", maxProducerStringLength+100),
+			expected: strings.Repeat("a", maxProducerStringLength),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := sanitizeProducerString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeProducerString_UTF8Truncation(t *testing.T) {
+	// 4-byte emoji at the truncation boundary must not be split.
+	prefix := strings.Repeat("a", maxProducerStringLength-2)
+	input := prefix + "\U0001F600" // 4-byte emoji, straddles byte 4094-4097
+
+	result := sanitizeProducerString(input)
+
+	assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+	assert.LessOrEqual(t, len(result), maxProducerStringLength)
+	// The emoji doesn't fit within the byte limit, so it's excluded entirely.
+	assert.Equal(t, prefix, result)
+}
+
+func TestSanitizeProducerString_MultiByteSafe(t *testing.T) {
+	// CJK characters are 3 bytes each.
+	input := strings.Repeat("世", maxProducerStringLength) // way over limit in bytes
+	result := sanitizeProducerString(input)
+
+	assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+	assert.LessOrEqual(t, len(result), maxProducerStringLength)
+	// Every rune in the result should be complete.
+	for i := 0; i < len(result); {
+		r, size := utf8.DecodeRuneInString(result[i:])
+		assert.NotEqual(t, utf8.RuneError, r, "no replacement characters allowed")
+		i += size
+	}
+}

--- a/pkg/policyreport/testdata/raw/01-new-failures-and-multi-rule.yaml
+++ b/pkg/policyreport/testdata/raw/01-new-failures-and-multi-rule.yaml
@@ -1,0 +1,332 @@
+apiVersion: v1
+items:
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 31c699a5-1798-49cf-85fb-62725c46779d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-tag-only
+      uid: 31c699a5-1798-49cf-85fb-62725c46779d
+    resourceVersion: "133851"
+    uid: 6c14bf46-fbf8-48f1-ae43-3ed142b631b4
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320712
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320712
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-tag-only
+    namespace: security-event-test
+    uid: 31c699a5-1798-49cf-85fb-62725c46779d
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 46632384-8a71-4bc3-8fac-1b2005113c23
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-tag-only-7f68f8847-k9pd2
+      uid: 46632384-8a71-4bc3-8fac-1b2005113c23
+    resourceVersion: "133570"
+    uid: 13781ace-dd0c-45c7-9da8-333891084753
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule disallow-latest-tag
+      failed at path /spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320717
+  - message: validation rule 'require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320717
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-tag-only-7f68f8847-k9pd2
+    namespace: security-event-test
+    uid: 46632384-8a71-4bc3-8fac-1b2005113c23
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 90c4c107-354f-467e-907a-fa72c98459f0
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-multi-rule-cdb6d9f8d-pdmq4
+      uid: 90c4c107-354f-467e-907a-fa72c98459f0
+    resourceVersion: "133628"
+    uid: fbb4098f-3d11-4ff4-95a7-bead39c19e1b
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule disallow-latest-tag
+      failed at path /spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  - message: 'validation error: Pods must carry a ''team'' label. rule require-team-label
+      failed at path /metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-multi-rule-cdb6d9f8d-pdmq4
+    namespace: security-event-test
+    uid: 90c4c107-354f-467e-907a-fa72c98459f0
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-multi-rule
+      uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    resourceVersion: "133667"
+    uid: 54517f89-e984-47ef-8a5f-3db9c6e56338
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-multi-rule
+    namespace: security-event-test
+    uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7f68f8847
+      uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    resourceVersion: "133309"
+    uid: 1f005714-5112-4713-b8af-aaeb85b397a8
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320713
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320713
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7f68f8847
+    namespace: security-event-test
+    uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-multi-rule-cdb6d9f8d
+      uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    resourceVersion: "133432"
+    uid: 0367218f-1b49-4b08-a5fd-49ea8dd57be7
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-multi-rule-cdb6d9f8d
+    namespace: security-event-test
+    uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+kind: List
+metadata:
+  resourceVersion: ""

--- a/pkg/policyreport/testdata/raw/02-fail-to-pass-via-pod-replacement.yaml
+++ b/pkg/policyreport/testdata/raw/02-fail-to-pass-via-pod-replacement.yaml
@@ -1,0 +1,383 @@
+apiVersion: v1
+items:
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:42Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7ff5d585cc
+      uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    resourceVersion: "134574"
+    uid: f070f491-4a85-4e5e-a080-980b6cb6b77f
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7ff5d585cc
+    namespace: security-event-test
+    uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 5
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 31c699a5-1798-49cf-85fb-62725c46779d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-tag-only
+      uid: 31c699a5-1798-49cf-85fb-62725c46779d
+    resourceVersion: "134571"
+    uid: 6c14bf46-fbf8-48f1-ae43-3ed142b631b4
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-tag-only
+    namespace: security-event-test
+    uid: 31c699a5-1798-49cf-85fb-62725c46779d
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:22Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-tag-only-7ff5d585cc-s2ncj
+      uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    resourceVersion: "134576"
+    uid: b0328cb0-9cc4-4629-8044-ce5865679522
+  results:
+  - message: validation rule 'disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-tag-only-7ff5d585cc-s2ncj
+    namespace: security-event-test
+    uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 90c4c107-354f-467e-907a-fa72c98459f0
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-multi-rule-cdb6d9f8d-pdmq4
+      uid: 90c4c107-354f-467e-907a-fa72c98459f0
+    resourceVersion: "133628"
+    uid: fbb4098f-3d11-4ff4-95a7-bead39c19e1b
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule disallow-latest-tag
+      failed at path /spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  - message: 'validation error: Pods must carry a ''team'' label. rule require-team-label
+      failed at path /metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-multi-rule-cdb6d9f8d-pdmq4
+    namespace: security-event-test
+    uid: 90c4c107-354f-467e-907a-fa72c98459f0
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-multi-rule
+      uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    resourceVersion: "133667"
+    uid: 54517f89-e984-47ef-8a5f-3db9c6e56338
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-multi-rule
+    namespace: security-event-test
+    uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7f68f8847
+      uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    resourceVersion: "134663"
+    uid: 1f005714-5112-4713-b8af-aaeb85b397a8
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7f68f8847
+    namespace: security-event-test
+    uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-multi-rule-cdb6d9f8d
+      uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    resourceVersion: "133432"
+    uid: 0367218f-1b49-4b08-a5fd-49ea8dd57be7
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-multi-rule-cdb6d9f8d
+    namespace: security-event-test
+    uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+kind: List
+metadata:
+  resourceVersion: ""

--- a/pkg/policyreport/testdata/raw/03-after-deployment-deletion.yaml
+++ b/pkg/policyreport/testdata/raw/03-after-deployment-deletion.yaml
@@ -1,0 +1,218 @@
+apiVersion: v1
+items:
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:42Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7ff5d585cc
+      uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    resourceVersion: "134574"
+    uid: f070f491-4a85-4e5e-a080-980b6cb6b77f
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7ff5d585cc
+    namespace: security-event-test
+    uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 5
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 31c699a5-1798-49cf-85fb-62725c46779d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-tag-only
+      uid: 31c699a5-1798-49cf-85fb-62725c46779d
+    resourceVersion: "134571"
+    uid: 6c14bf46-fbf8-48f1-ae43-3ed142b631b4
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-tag-only
+    namespace: security-event-test
+    uid: 31c699a5-1798-49cf-85fb-62725c46779d
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:22Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-tag-only-7ff5d585cc-s2ncj
+      uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    resourceVersion: "134576"
+    uid: b0328cb0-9cc4-4629-8044-ce5865679522
+  results:
+  - message: validation rule 'disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-tag-only-7ff5d585cc-s2ncj
+    namespace: security-event-test
+    uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7f68f8847
+      uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    resourceVersion: "134663"
+    uid: 1f005714-5112-4713-b8af-aaeb85b397a8
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7f68f8847
+    namespace: security-event-test
+    uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+kind: List
+metadata:
+  resourceVersion: ""

--- a/pkg/policyreport/testdata/raw/README.md
+++ b/pkg/policyreport/testdata/raw/README.md
@@ -1,0 +1,26 @@
+# Raw PolicyReport fixtures
+
+Captured live from a real cluster, not hand-authored. Provenance:
+
+- Cluster: `infractl`-provisioned OpenShift 4 (`rc-devloop-test`), Kubernetes v1.35.5, CRI-O 1.35.4 (RHAOS 4.22).
+- Kyverno: Helm chart `kyverno/kyverno` 3.8.2, app version v1.18.2, installed with default values (admission, background, cleanup, reports controllers).
+- PolicyReport API: `wgpolicyk8s.io/v1alpha2` (the only version this Kyverno version serves; confirmed via `oc get crd policyreports.wgpolicyk8s.io -o jsonpath='{.spec.versions[*].name}'`).
+- Test `ClusterPolicy` (`require-secure-pod-security-context`, `validationFailureAction: Audit`) with two rules: `disallow-latest-tag` (image tag must not be `latest`) and `require-team-label` (pod must carry a `team` label), annotated `policies.kyverno.io/severity: high`.
+
+## Real behavior these fixtures capture (not assumed from docs)
+
+- **One `PolicyReport` object per resource**, linked via `ownerReferences`, identified by a top-level `scope` field (`apiVersion`/`kind`/`name`/`namespace`/`uid`) — **not** a `results[].resources[]` array as the original plan draft speculated. Kyverno creates separate report objects for the Pod, its ReplicaSet, and its Deployment independently (via "autogen" rules for the higher-level controllers).
+- `results[]` entries carry `policy`, `rule`, `result` (`pass`/`fail`/etc.), `message`, `scored`, `source: kyverno`, a `timestamp`, and — only when set via the `policies.kyverno.io/severity` annotation on the source `ClusterPolicy` — `severity`. It's absent if the policy doesn't set it.
+- A rolling Deployment update that fixes a violation does **not** update the Pod-scoped report in place — the old Pod (and its report, via owner-reference garbage collection) is deleted and an entirely new Pod (new UID) gets a brand new report. In-place updates only happen for reports scoped to a resource whose UID doesn't change (e.g. the Deployment itself).
+- Deleting a Deployment removes its own and its ReplicaSet's reports promptly; the terminating Pod's report lags slightly behind actual pod termination.
+- A ReplicaSet that's scaled to 0 (but not deleted, e.g. kept for rollback history after a rolling update) **keeps its stale report** — report lifetime tracks resource existence, not liveness/replica count. See `03-after-deployment-deletion.yaml`, entry `e31df1d7-...` (`fail-tag-only-7f68f8847`, the pre-rollout ReplicaSet, `DESIRED: 0`).
+
+## Files
+
+1. `01-new-failures-and-multi-rule.yaml` — two Deployments just created: one failing a single rule, one failing both rules (multiple failing rules for one Pod), each with Deployment/ReplicaSet/Pod-scoped reports.
+2. `02-fail-to-pass-via-pod-replacement.yaml` — after fixing the first Deployment's image tag: new Pod, new all-passing report; old Pod/report gone.
+3. `03-after-deployment-deletion.yaml` — after deleting the second (multi-rule-failing) Deployment: its reports are gone; includes the orphaned scaled-to-zero ReplicaSet report described above.
+
+## Deferred to hand-crafted fixtures (not practical to force from a live cluster)
+
+Reordered results and malformed/unknown-property results are authored directly as Go test fixtures in `kyverno_v1alpha2_test.go`, based on the real shape captured here.


### PR DESCRIPTION
## Description

POC branch 2/9. Pure Go canonicalizer in `pkg/policyreport/` that converts `wgpolicyk8s.io/v1alpha2` PolicyReport CRDs into source-neutral `SecurityEvent` values. Includes stable identity computation, snapshot diffing, input sanitization, and unit tests.

AI-assisted development.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests for canonicalization, identity, diff, and sanitization. Tested against real Kyverno v1.18.2 fixtures.