### PR TITLE
ROX-28590: [POC] (03) Sensor CRD watcher for PolicyReport

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -143,6 +143,9 @@ var (
 	// EvaluationFilter enables evaluation filtering in policy evaluation.
 	EvaluationFilter = registerFeature("Enable evaluation filtering in policy evaluation", "ROX_EVALUATION_FILTER", enabled)
 
+	// PolicyReports enables ingestion of wgpolicyk8s.io PolicyReport CRDs from external policy engines.
+	PolicyReports = registerFeature("Enables PolicyReport CRD ingestion from external policy engines", "ROX_POLICY_REPORTS")
+
 	// UISecretsPageMigration enables the secrets list page under the Risk section
 	UISecretsPageMigration = registerFeature("Display secrets list page under Risk section", "ROX_UI_SECRETS_PAGE_MIGRATION")
 )

--- a/pkg/policyreport/api.go
+++ b/pkg/policyreport/api.go
@@ -10,15 +10,11 @@ var (
 	groupVersion         = schema.GroupVersion{Group: "wgpolicyk8s.io", Version: "v1alpha2"}
 	requiredAPIResources []k8sapi.APIResource
 
+	// PolicyReport is the only resource we currently watch. ClusterPolicyReport
+	// support will be added in a follow-up when cluster-scoped reports are needed.
 	PolicyReport = registerAPIResource(v1.APIResource{
 		Name:    "policyreports",
 		Kind:    "PolicyReport",
-		Group:   groupVersion.Group,
-		Version: groupVersion.Version,
-	})
-	ClusterPolicyReport = registerAPIResource(v1.APIResource{
-		Name:    "clusterpolicyreports",
-		Kind:    "ClusterPolicyReport",
 		Group:   groupVersion.Group,
 		Version: groupVersion.Version,
 	})

--- a/pkg/policyreport/api.go
+++ b/pkg/policyreport/api.go
@@ -1,0 +1,43 @@
+package policyreport
+
+import (
+	"github.com/stackrox/rox/pkg/k8sapi"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	groupVersion         = schema.GroupVersion{Group: "wgpolicyk8s.io", Version: "v1alpha2"}
+	requiredAPIResources []k8sapi.APIResource
+
+	PolicyReport = registerAPIResource(v1.APIResource{
+		Name:    "policyreports",
+		Kind:    "PolicyReport",
+		Group:   groupVersion.Group,
+		Version: groupVersion.Version,
+	})
+	ClusterPolicyReport = registerAPIResource(v1.APIResource{
+		Name:    "clusterpolicyreports",
+		Kind:    "ClusterPolicyReport",
+		Group:   groupVersion.Group,
+		Version: groupVersion.Version,
+	})
+)
+
+// GetGroupVersion returns the group version for wgpolicyk8s.io PolicyReport CRDs.
+func GetGroupVersion() schema.GroupVersion {
+	return groupVersion
+}
+
+// GetRequiredResources returns the PolicyReport API resources required by ACS.
+func GetRequiredResources() []k8sapi.APIResource {
+	return requiredAPIResources
+}
+
+func registerAPIResource(resource v1.APIResource) k8sapi.APIResource {
+	r := k8sapi.APIResource{
+		APIResource: resource,
+	}
+	requiredAPIResources = append(requiredAPIResources, r)
+	return r
+}

--- a/sensor/kubernetes/listener/informer_sync_tracker.go
+++ b/sensor/kubernetes/listener/informer_sync_tracker.go
@@ -36,6 +36,7 @@ const (
 	informerNetworkPolicies               = "NetworkPolicies"
 	informerNodes                         = "Nodes"
 	informerPodCache                      = "PodCache"
+	informerPolicyReports                 = "PolicyReports"
 	informerPods                          = "Pods"
 	informerReplicaSets                   = "ReplicaSets"
 	informerReplicationControllers        = "ReplicationControllers"

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	kubernetesPkg "github.com/stackrox/rox/pkg/kubernetes"
+	"github.com/stackrox/rox/pkg/policyreport"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/virtualmachine"
@@ -27,6 +28,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher"
 	complianceOperatorAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/complianceoperator"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher/crd"
+	policyReportAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/policyreport"
 	virtualMachineAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/virtualmachine"
 	sensorUtils "github.com/stackrox/rox/sensor/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -263,6 +265,40 @@ func (k *listenerImpl) handleAllEvents() {
 		}
 	}
 
+	// PolicyReport Watcher and Informers
+	shouldTrackPolicyReports := features.PolicyReports.Enabled()
+	var policyReportInformer cache.SharedIndexInformer
+
+	if features.PolicyReports.Enabled() {
+		prWatcher := crd.NewCRDWatcher(&k.stopSig, dynamicSif)
+		prAvailabilityChecker := policyReportAvailabilityChecker.NewAvailabilityChecker()
+		if err := prAvailabilityChecker.AppendToCRDWatcher(prWatcher); err != nil {
+			log.Errorf("Unable to add the Resource to the PolicyReport CRD Watcher: %v", err)
+		}
+
+		prCrdHandlerFn := crdWatcherCallbackWrapper(k.context,
+			allResourcesAvailable(),
+			k.pubSub,
+			"PolicyReport resources have been updated. Connection will restart to force reconciliation with Central")
+
+		shouldTrackPolicyReports, err = prAvailabilityChecker.Available(k.client)
+		if err != nil {
+			log.Errorf("Failed to check the availability of PolicyReport resources: %v", err)
+		}
+
+		if shouldTrackPolicyReports {
+			log.Info("Initializing PolicyReport informers")
+			policyReportInformer = crdSharedInformerFactory.ForResource(policyreport.PolicyReport.GroupVersionResource()).Informer()
+			prCrdHandlerFn = crdWatcherCallbackWrapper(k.context,
+				resourcesUnavailable(),
+				k.pubSub,
+				"PolicyReport resources have been removed. Connection will restart to force reconciliation with Central")
+		}
+		if err := prWatcher.Watch(prCrdHandlerFn); err != nil {
+			log.Errorf("Failed to start watching the PolicyReport CRDs: %v", err)
+		}
+	}
+
 	// This call to clusterID.Get might block if a cluster ID is initially unavailable, which is okay.
 	clusterID := k.clusterID.Get()
 
@@ -370,6 +406,11 @@ func (k *listenerImpl) handleAllEvents() {
 		// send duplicate update events during sync
 		log.Info("Syncing virtual machine instances")
 		handle(k.context, informerVirtualMachineInstances, virtualMachineInstanceInformer, dispatchers.ForVirtualMachineInstances(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
+	}
+
+	if shouldTrackPolicyReports {
+		log.Info("Syncing policy reports")
+		handle(k.context, informerPolicyReports, policyReportInformer, dispatchers.ForPolicyReports(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
 	}
 
 	if !startAndWait(stopSignal, noDependencyWaitGroup, sif, osConfigFactory, osOperatorFactory, crdSharedInformerFactory) {

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/kubernetes/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	policyReportDispatcher "github.com/stackrox/rox/sensor/kubernetes/listener/resources/policyreport"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/virtualmachine/dispatcher"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -49,6 +50,8 @@ type DispatcherRegistry interface {
 
 	ForVirtualMachines() Dispatcher
 	ForVirtualMachineInstances() Dispatcher
+
+	ForPolicyReports() Dispatcher
 
 	ForComplianceOperatorResults() Dispatcher
 	ForComplianceOperatorProfiles() Dispatcher
@@ -112,6 +115,8 @@ func NewDispatcherRegistry(
 
 		virtualMachineDispatcher:         dispatcher.NewVirtualMachineDispatcher(clusterID, storeProvider.VirtualMachines()),
 		virtualMachineInstanceDispatcher: dispatcher.NewVirtualMachineInstanceDispatcher(clusterID, storeProvider.VirtualMachines()),
+
+		policyReportDispatcher: policyReportDispatcher.NewDispatcher(clusterID),
 	}
 }
 
@@ -142,6 +147,8 @@ type registryImpl struct {
 
 	virtualMachineDispatcher         *dispatcher.VirtualMachineDispatcher
 	virtualMachineInstanceDispatcher *dispatcher.VirtualMachineInstanceDispatcher
+
+	policyReportDispatcher *policyReportDispatcher.Dispatcher
 }
 
 func wrapWithDumpingDispatcher(d Dispatcher, w io.Writer) Dispatcher {
@@ -346,4 +353,8 @@ func (d *registryImpl) ForVirtualMachines() Dispatcher {
 
 func (d *registryImpl) ForVirtualMachineInstances() Dispatcher {
 	return wrapDispatcher(d.virtualMachineInstanceDispatcher, d.traceWriter)
+}
+
+func (d *registryImpl) ForPolicyReports() Dispatcher {
+	return wrapDispatcher(d.policyReportDispatcher, d.traceWriter)
 }

--- a/sensor/kubernetes/listener/resources/mocks/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/mocks/dispatcher.go
@@ -277,6 +277,20 @@ func (mr *MockDispatcherRegistryMockRecorder) ForNetworkPolicies() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForNetworkPolicies", reflect.TypeOf((*MockDispatcherRegistry)(nil).ForNetworkPolicies))
 }
 
+// ForPolicyReports mocks base method.
+func (m *MockDispatcherRegistry) ForPolicyReports() resources.Dispatcher {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForPolicyReports")
+	ret0, _ := ret[0].(resources.Dispatcher)
+	return ret0
+}
+
+// ForPolicyReports indicates an expected call of ForPolicyReports.
+func (mr *MockDispatcherRegistryMockRecorder) ForPolicyReports() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForPolicyReports", reflect.TypeOf((*MockDispatcherRegistry)(nil).ForPolicyReports))
+}
+
 // ForNodes mocks base method.
 func (m *MockDispatcherRegistry) ForNodes() resources.Dispatcher {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/listener/resources/policyreport/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/policyreport/dispatcher.go
@@ -1,0 +1,92 @@
+package policyreport
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var log = logging.LoggerForModule()
+
+// Dispatcher processes PolicyReport CRD events, canonicalizes them into
+// SecurityEvents, and records dry-run metrics. It does not forward events
+// to Central — that wiring comes in a later PR once the protobuf contract
+// and detector path exist.
+type Dispatcher struct {
+	clusterID string
+}
+
+// NewDispatcher creates a PolicyReport dispatcher.
+func NewDispatcher(clusterID string) *Dispatcher {
+	return &Dispatcher{clusterID: clusterID}
+}
+
+// ProcessEvent implements resources.Dispatcher.
+func (d *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *component.ResourceEvent {
+	if !features.PolicyReports.Enabled() {
+		return nil
+	}
+
+	u, ok := toUnstructured(obj)
+	if !ok {
+		reportsProcessed.WithLabelValues("error").Inc()
+		return nil
+	}
+
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		reportsProcessed.WithLabelValues("removed").Inc()
+		log.Debugf("PolicyReport %s/%s removed", u.GetNamespace(), u.GetName())
+		return nil
+	}
+
+	events, err := policyreport.CanonicalizeKyvernoV1Alpha2(d.clusterID, u)
+	if err != nil {
+		reportsProcessed.WithLabelValues("error").Inc()
+		log.Warnf("Failed to canonicalize PolicyReport %s/%s: %v", u.GetNamespace(), u.GetName(), err)
+		return nil
+	}
+
+	reportsProcessed.WithLabelValues("ok").Inc()
+	eventsCanonicalizedTotal.Add(float64(len(events)))
+
+	if len(events) > 0 {
+		log.Debugf("Canonicalized %d actionable SecurityEvents from PolicyReport %s/%s",
+			len(events), u.GetNamespace(), u.GetName())
+	}
+
+	// No forwarding to Central yet — dry-run metrics only.
+	return nil
+}
+
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if ok {
+		return u, true
+	}
+	log.Errorf("PolicyReport dispatcher received non-Unstructured object: %T", obj)
+	return nil, false
+}
+
+var (
+	reportsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "policyreport_reports_processed_total",
+		Help:      "Total PolicyReport objects processed by the canonicalizer, by outcome (ok, error, removed).",
+	}, []string{"outcome"})
+
+	eventsCanonicalizedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "policyreport_events_canonicalized_total",
+		Help:      "Total actionable SecurityEvents produced from PolicyReport canonicalization.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(reportsProcessed, eventsCanonicalizedTotal)
+}

--- a/sensor/kubernetes/listener/resources/policyreport/dispatcher_test.go
+++ b/sensor/kubernetes/listener/resources/policyreport/dispatcher_test.go
@@ -1,0 +1,91 @@
+package policyreport
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestProcessEvent_FeatureDisabled(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "false")
+	d := NewDispatcher("test-cluster")
+	result := d.ProcessEvent(&unstructured.Unstructured{}, nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result)
+}
+
+func TestProcessEvent_NonUnstructuredObject(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+	result := d.ProcessEvent("not-an-unstructured", nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result)
+}
+
+func TestProcessEvent_RemoveAction(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+
+	u := &unstructured.Unstructured{}
+	u.SetName("test-report")
+	u.SetNamespace("default")
+
+	result := d.ProcessEvent(u, nil, central.ResourceAction_REMOVE_RESOURCE)
+	assert.Nil(t, result)
+}
+
+func TestProcessEvent_ValidReport(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "wgpolicyk8s.io/v1alpha2",
+			"kind":       "PolicyReport",
+			"metadata": map[string]interface{}{
+				"name":            "test-report",
+				"namespace":       "default",
+				"uid":             "report-uid-1",
+				"resourceVersion": "123",
+			},
+			"scope": map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"name":       "my-pod",
+				"namespace":  "default",
+				"uid":        "pod-uid-1",
+			},
+			"results": []interface{}{
+				map[string]interface{}{
+					"policy": "require-labels",
+					"rule":   "check-team-label",
+					"result": "fail",
+					"source": "kyverno",
+				},
+			},
+		},
+	}
+
+	// Dry-run: should return nil (no Central forwarding), but not error.
+	result := d.ProcessEvent(u, nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result, "dry-run dispatcher should not forward events to Central")
+}
+
+func TestProcessEvent_InvalidReport(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "wrong/v1",
+			"kind":       "PolicyReport",
+			"metadata": map[string]interface{}{
+				"name": "bad-report",
+			},
+		},
+	}
+
+	result := d.ProcessEvent(u, nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result)
+}

--- a/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker.go
+++ b/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker.go
@@ -1,0 +1,12 @@
+package policyreport
+
+import (
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher/availability"
+)
+
+// NewAvailabilityChecker creates an availability checker for PolicyReport CRDs.
+func NewAvailabilityChecker() availability.Checker {
+	resources := policyreport.GetRequiredResources()
+	return availability.NewChecker(policyreport.GetGroupVersion(), resources)
+}

--- a/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker_test.go
+++ b/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker_test.go
@@ -1,0 +1,73 @@
+package policyreport
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllPolicyReportResourcesAreAddedToTheAvailabilityChecker(t *testing.T) {
+	ac := NewAvailabilityChecker()
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path.Join(pwd, "../../../../../pkg/policyreport/api.go"), nil, 0)
+	require.NoError(t, err)
+
+	allowList := []string{
+		"groupVersion",
+		"requiredAPIResources",
+	}
+
+	resFinder := &resourcesFinder{}
+	ast.Walk(resFinder, file)
+	require.NotEmpty(t, resFinder.resources)
+
+	var notFound []string
+finderLoop:
+	for _, resource := range resFinder.resources {
+		for _, acResource := range ac.GetResources() {
+			if acResource.Kind == resource {
+				continue finderLoop
+			}
+		}
+		for _, allowed := range allowList {
+			if allowed == resource {
+				continue finderLoop
+			}
+		}
+		notFound = append(notFound, resource)
+	}
+
+	assert.Empty(t, notFound, "Please add the missing types to the availability checker or to the allowList in this test")
+}
+
+type resourcesFinder struct {
+	resources []string
+}
+
+func (f *resourcesFinder) Visit(n ast.Node) ast.Visitor {
+	switch n := n.(type) {
+	case *ast.Package:
+		return f
+	case *ast.File:
+		return f
+	case *ast.GenDecl:
+		if n.Tok == token.VAR {
+			return f
+		}
+	case *ast.ValueSpec:
+		if len(n.Names) < 1 {
+			return nil
+		}
+		f.resources = append(f.resources, n.Names[0].Name)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

POC branch 3/9. Registers `wgpolicyk8s.io/v1alpha2` PolicyReport CRD in Sensor behind `ROX_POLICY_REPORTS` feature flag. CRD availability checker, informer registration, and dispatcher skeleton following the existing CRD watcher pattern (used 11 times in Sensor).

AI-assisted development.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Cluster-validated: deployed to infractl cluster, confirmed informer registration and CRD event observation via metrics.