### PR TITLE
ROX-28590: [POC] (04) Pod-to-Deployment resolution

### DIFF
--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -100,6 +100,7 @@ func newDeploymentHandler(
 	namespaces *orchestratornamespaces.OrchestratorNamespaces,
 	registryStore *registry.Store,
 	credentialsManager awscredentials.RegistryCredentialsManager,
+	hierarchy references.ParentHierarchy,
 ) *deploymentHandler {
 	return &deploymentHandler{
 		podLister:              podLister,
@@ -110,7 +111,7 @@ func newDeploymentHandler(
 		namespaceStore:         namespaceStore,
 		processFilter:          processFilter,
 		config:                 config,
-		hierarchy:              references.NewParentHierarchy(),
+		hierarchy:              hierarchy,
 		rbac:                   rbac,
 		orchestratorNamespaces: namespaces,
 		registryStore:          registryStore,

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	policyReportDispatcher "github.com/stackrox/rox/sensor/kubernetes/listener/resources/policyreport"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/virtualmachine/dispatcher"
 	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/client-go/kubernetes"
@@ -86,10 +87,11 @@ func NewDispatcherRegistry(
 	portExposureReconciler := newPortExposureReconciler(deploymentStore, storeProvider.Services())
 	registryStore := storeProvider.registryStore
 	registryMirrorStore := storeProvider.registryMirrorStore
+	hierarchy := references.NewParentHierarchy()
 
 	return &registryImpl{
 		deploymentHandler: newDeploymentHandler(clusterID, storeProvider.Services(), deploymentStore, podStore, endpointManager, nsStore,
-			rbacUpdater, podLister, processFilter, configHandler, storeProvider.orchestratorNamespaces, registryStore, credentialsManager),
+			rbacUpdater, podLister, processFilter, configHandler, storeProvider.orchestratorNamespaces, registryStore, credentialsManager, hierarchy),
 
 		rbacDispatcher:             rbac.NewDispatcher(rbacUpdater, k8sAPI),
 		namespaceDispatcher:        newNamespaceDispatcher(nsStore, serviceStore, deploymentStore, podStore, netPolicyStore, storeProvider.VirtualMachines()),
@@ -116,7 +118,7 @@ func NewDispatcherRegistry(
 		virtualMachineDispatcher:         dispatcher.NewVirtualMachineDispatcher(clusterID, storeProvider.VirtualMachines()),
 		virtualMachineInstanceDispatcher: dispatcher.NewVirtualMachineInstanceDispatcher(clusterID, storeProvider.VirtualMachines()),
 
-		policyReportDispatcher: policyReportDispatcher.NewDispatcher(clusterID),
+		policyReportDispatcher: policyReportDispatcher.NewDispatcher(clusterID, hierarchy, storeProvider.Deployments()),
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/policyreport/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/policyreport/dispatcher.go
@@ -6,23 +6,31 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var log = logging.LoggerForModule()
 
 // Dispatcher processes PolicyReport CRD events, canonicalizes them into
-// SecurityEvents, and records dry-run metrics. It does not forward events
-// to Central — that wiring comes in a later PR once the protobuf contract
-// and detector path exist.
+// SecurityEvents, resolves Pod subjects to ACS deployments, and records
+// dry-run metrics. It does not forward events to Central — that wiring
+// comes in a later PR once the protobuf contract and detector path exist.
 type Dispatcher struct {
-	clusterID string
+	clusterID       string
+	hierarchy       references.ParentHierarchy
+	deploymentStore store.DeploymentStore
 }
 
 // NewDispatcher creates a PolicyReport dispatcher.
-func NewDispatcher(clusterID string) *Dispatcher {
-	return &Dispatcher{clusterID: clusterID}
+func NewDispatcher(clusterID string, hierarchy references.ParentHierarchy, deploymentStore store.DeploymentStore) *Dispatcher {
+	return &Dispatcher{
+		clusterID:       clusterID,
+		hierarchy:       hierarchy,
+		deploymentStore: deploymentStore,
+	}
 }
 
 // ProcessEvent implements resources.Dispatcher.
@@ -53,6 +61,10 @@ func (d *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAct
 	reportsProcessed.WithLabelValues("ok").Inc()
 	eventsCanonicalizedTotal.Add(float64(len(events)))
 
+	for i := range events {
+		d.resolveSubject(&events[i])
+	}
+
 	if len(events) > 0 {
 		log.Debugf("Canonicalized %d actionable SecurityEvents from PolicyReport %s/%s",
 			len(events), u.GetNamespace(), u.GetName())
@@ -60,6 +72,48 @@ func (d *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAct
 
 	// No forwarding to Central yet — dry-run metrics only.
 	return nil
+}
+
+// resolveSubject attempts to resolve a SecurityEvent's Pod subject to an ACS
+// Deployment using the parent ownership hierarchy. This mirrors the resolution
+// logic in deployments.go's processWithType.
+func (d *Dispatcher) resolveSubject(event *policyreport.SecurityEvent) {
+	if event.Subject.Kind != "Pod" || event.Subject.UID == "" {
+		resolutionTotal.WithLabelValues("unresolved").Inc()
+		return
+	}
+
+	ownerIDs := d.hierarchy.TopLevelParents(event.Subject.UID)
+	// TopLevelParents returns the child itself when unknown, so this is
+	// effectively unreachable. Kept for defensive parity with deployments.go.
+	if ownerIDs.Cardinality() == 0 {
+		resolutionTotal.WithLabelValues("unresolved").Inc()
+		log.Debugf("No owning deployment found for Pod %s/%s (UID %s)",
+			event.Subject.Namespace, event.Subject.Name, event.Subject.UID)
+		return
+	}
+
+	if ownerIDs.Cardinality() > 1 {
+		resolutionTotal.WithLabelValues("error").Inc()
+		log.Warnf("Multiple owning deployments for Pod %s/%s (UID %s), skipping resolution",
+			event.Subject.Namespace, event.Subject.Name, event.Subject.UID)
+		return
+	}
+
+	ownerID := ownerIDs.GetArbitraryElem()
+	deployment := d.deploymentStore.Get(ownerID)
+	if deployment == nil {
+		resolutionTotal.WithLabelValues("unresolved").Inc()
+		log.Debugf("Owning deployment %s not in store for Pod %s/%s",
+			ownerID, event.Subject.Namespace, event.Subject.Name)
+		return
+	}
+
+	event.ResolvedEntity = policyreport.ResolvedEntity{
+		Type: policyreport.EntityTypeDeployment,
+		ID:   deployment.GetId(),
+	}
+	resolutionTotal.WithLabelValues("resolved").Inc()
 }
 
 func toUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
@@ -85,8 +139,15 @@ var (
 		Name:      "policyreport_events_canonicalized_total",
 		Help:      "Total actionable SecurityEvents produced from PolicyReport canonicalization.",
 	})
+
+	resolutionTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "policyreport_resolution_total",
+		Help:      "Total Pod-to-Deployment resolution attempts, by outcome (resolved, unresolved, error).",
+	}, []string{"outcome"})
 )
 
 func init() {
-	prometheus.MustRegister(reportsProcessed, eventsCanonicalizedTotal)
+	prometheus.MustRegister(reportsProcessed, eventsCanonicalizedTotal, resolutionTotal)
 }

--- a/sensor/kubernetes/listener/resources/policyreport/dispatcher_test.go
+++ b/sensor/kubernetes/listener/resources/policyreport/dispatcher_test.go
@@ -4,28 +4,94 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/common/selector"
+	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+type fakeHierarchy struct {
+	parents map[string]set.StringSet
+}
+
+func (f *fakeHierarchy) Add(_ metav1.Object)                         {}
+func (f *fakeHierarchy) AddManually(_, _ string)                     {}
+func (f *fakeHierarchy) Remove(_ string)                             {}
+func (f *fakeHierarchy) IsValidChild(_ string, _ metav1.Object) bool { return false }
+func (f *fakeHierarchy) TopLevelParents(child string) set.StringSet {
+	result := set.NewStringSet()
+	f.topLevelRecursive(child, result)
+	return result
+}
+
+func (f *fakeHierarchy) topLevelRecursive(child string, result set.StringSet) {
+	parents, ok := f.parents[child]
+	if !ok || parents.Cardinality() == 0 {
+		result.Add(child)
+		return
+	}
+	for parent := range parents {
+		f.topLevelRecursive(parent, result)
+	}
+}
+
+type fakeDeploymentStore struct {
+	deployments map[string]*storage.Deployment
+}
+
+func (f *fakeDeploymentStore) Get(id string) *storage.Deployment {
+	return f.deployments[id]
+}
+
+func (f *fakeDeploymentStore) GetAll() []*storage.Deployment            { return nil }
+func (f *fakeDeploymentStore) GetSnapshot(_ string) *storage.Deployment { return nil }
+func (f *fakeDeploymentStore) GetBuiltDeployment(_ string) (*storage.Deployment, bool) {
+	return nil, false
+}
+func (f *fakeDeploymentStore) FindDeploymentIDsWithServiceAccount(_, _ string) []string { return nil }
+func (f *fakeDeploymentStore) FindDeploymentIDsByLabels(_ string, _ selector.Selector) []string {
+	return nil
+}
+func (f *fakeDeploymentStore) FindDeploymentIDsByImages(_ []*storage.Image) []string { return nil }
+func (f *fakeDeploymentStore) BuildDeploymentWithDependencies(_ string, _ store.Dependencies) (*storage.Deployment, bool, error) {
+	return nil, false, nil
+}
+func (f *fakeDeploymentStore) CountDeploymentsForNamespace(_ string) int { return 0 }
+func (f *fakeDeploymentStore) EnhanceDeploymentReadOnly(_ *storage.Deployment, _ store.Dependencies) {
+}
+
+func newTestDispatcher(hierarchy *fakeHierarchy, deployStore *fakeDeploymentStore) *Dispatcher {
+	if hierarchy == nil {
+		hierarchy = &fakeHierarchy{parents: map[string]set.StringSet{}}
+	}
+	if deployStore == nil {
+		deployStore = &fakeDeploymentStore{deployments: map[string]*storage.Deployment{}}
+	}
+	return NewDispatcher("test-cluster", hierarchy, deployStore)
+}
+
 func TestProcessEvent_FeatureDisabled(t *testing.T) {
 	t.Setenv(features.PolicyReports.EnvVar(), "false")
-	d := NewDispatcher("test-cluster")
+	d := newTestDispatcher(nil, nil)
 	result := d.ProcessEvent(&unstructured.Unstructured{}, nil, central.ResourceAction_CREATE_RESOURCE)
 	assert.Nil(t, result)
 }
 
 func TestProcessEvent_NonUnstructuredObject(t *testing.T) {
 	t.Setenv(features.PolicyReports.EnvVar(), "true")
-	d := NewDispatcher("test-cluster")
+	d := newTestDispatcher(nil, nil)
 	result := d.ProcessEvent("not-an-unstructured", nil, central.ResourceAction_CREATE_RESOURCE)
 	assert.Nil(t, result)
 }
 
 func TestProcessEvent_RemoveAction(t *testing.T) {
 	t.Setenv(features.PolicyReports.EnvVar(), "true")
-	d := NewDispatcher("test-cluster")
+	d := newTestDispatcher(nil, nil)
 
 	u := &unstructured.Unstructured{}
 	u.SetName("test-report")
@@ -37,7 +103,7 @@ func TestProcessEvent_RemoveAction(t *testing.T) {
 
 func TestProcessEvent_ValidReport(t *testing.T) {
 	t.Setenv(features.PolicyReports.EnvVar(), "true")
-	d := NewDispatcher("test-cluster")
+	d := newTestDispatcher(nil, nil)
 
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -74,7 +140,7 @@ func TestProcessEvent_ValidReport(t *testing.T) {
 
 func TestProcessEvent_InvalidReport(t *testing.T) {
 	t.Setenv(features.PolicyReports.EnvVar(), "true")
-	d := NewDispatcher("test-cluster")
+	d := newTestDispatcher(nil, nil)
 
 	u := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -88,4 +154,137 @@ func TestProcessEvent_InvalidReport(t *testing.T) {
 
 	result := d.ProcessEvent(u, nil, central.ResourceAction_CREATE_RESOURCE)
 	assert.Nil(t, result)
+}
+
+func TestResolveSubject_PodResolved(t *testing.T) {
+	hierarchy := &fakeHierarchy{
+		parents: map[string]set.StringSet{
+			"pod-uid-1": set.NewStringSet("deployment-uid-1"),
+		},
+	}
+	deployStore := &fakeDeploymentStore{
+		deployments: map[string]*storage.Deployment{
+			"deployment-uid-1": {
+				Id:   "deployment-uid-1",
+				Name: "my-deployment",
+			},
+		},
+	}
+	d := newTestDispatcher(hierarchy, deployStore)
+
+	event := &policyreport.SecurityEvent{
+		Subject: policyreport.Subject{
+			Kind: "Pod",
+			UID:  "pod-uid-1",
+			Name: "my-pod",
+		},
+	}
+	d.resolveSubject(event)
+
+	assert.Equal(t, policyreport.EntityTypeDeployment, event.ResolvedEntity.Type)
+	assert.Equal(t, "deployment-uid-1", event.ResolvedEntity.ID)
+}
+
+func TestResolveSubject_PodUnresolved(t *testing.T) {
+	d := newTestDispatcher(nil, nil)
+
+	event := &policyreport.SecurityEvent{
+		Subject: policyreport.Subject{
+			Kind: "Pod",
+			UID:  "unknown-pod",
+			Name: "orphan-pod",
+		},
+	}
+	d.resolveSubject(event)
+
+	assert.Equal(t, policyreport.EntityTypeUnknown, event.ResolvedEntity.Type)
+	assert.Empty(t, event.ResolvedEntity.ID)
+}
+
+func TestResolveSubject_NonPodSubject(t *testing.T) {
+	d := newTestDispatcher(nil, nil)
+
+	event := &policyreport.SecurityEvent{
+		Subject: policyreport.Subject{
+			Kind: "Node",
+			UID:  "node-uid-1",
+			Name: "my-node",
+		},
+	}
+	d.resolveSubject(event)
+
+	assert.Equal(t, policyreport.EntityTypeUnknown, event.ResolvedEntity.Type)
+}
+
+func TestResolveSubject_MultipleOwners(t *testing.T) {
+	hierarchy := &fakeHierarchy{
+		parents: map[string]set.StringSet{
+			"pod-uid-1": set.NewStringSet("deploy-1", "deploy-2"),
+		},
+	}
+	d := newTestDispatcher(hierarchy, nil)
+
+	event := &policyreport.SecurityEvent{
+		Subject: policyreport.Subject{
+			Kind: "Pod",
+			UID:  "pod-uid-1",
+			Name: "confused-pod",
+		},
+	}
+	d.resolveSubject(event)
+
+	assert.Equal(t, policyreport.EntityTypeUnknown, event.ResolvedEntity.Type)
+}
+
+func TestResolveSubject_OwnerNotInStore(t *testing.T) {
+	hierarchy := &fakeHierarchy{
+		parents: map[string]set.StringSet{
+			"pod-uid-1": set.NewStringSet("missing-deploy"),
+		},
+	}
+	deployStore := &fakeDeploymentStore{
+		deployments: map[string]*storage.Deployment{},
+	}
+	d := newTestDispatcher(hierarchy, deployStore)
+
+	event := &policyreport.SecurityEvent{
+		Subject: policyreport.Subject{
+			Kind: "Pod",
+			UID:  "pod-uid-1",
+			Name: "my-pod",
+		},
+	}
+	d.resolveSubject(event)
+
+	assert.Equal(t, policyreport.EntityTypeUnknown, event.ResolvedEntity.Type)
+}
+
+func TestResolveSubject_TransitiveOwnership(t *testing.T) {
+	hierarchy := &fakeHierarchy{
+		parents: map[string]set.StringSet{
+			"pod-uid-1": set.NewStringSet("rs-uid-1"),
+			"rs-uid-1":  set.NewStringSet("deploy-uid-1"),
+		},
+	}
+	deployStore := &fakeDeploymentStore{
+		deployments: map[string]*storage.Deployment{
+			"deploy-uid-1": {
+				Id:   "deploy-uid-1",
+				Name: "my-deployment",
+			},
+		},
+	}
+	d := newTestDispatcher(hierarchy, deployStore)
+
+	event := &policyreport.SecurityEvent{
+		Subject: policyreport.Subject{
+			Kind: "Pod",
+			UID:  "pod-uid-1",
+			Name: "my-pod",
+		},
+	}
+	d.resolveSubject(event)
+
+	assert.Equal(t, policyreport.EntityTypeDeployment, event.ResolvedEntity.Type)
+	assert.Equal(t, "deploy-uid-1", event.ResolvedEntity.ID)
 }


### PR DESCRIPTION
## Description

POC branch 4/9. Resolves PolicyReport Pod subjects to ACS Deployments via `ParentHierarchy.TopLevelParents()` and `DeploymentStore`. Adds resolution outcome metrics (`resolved`, `unresolved`, `error`).

AI-assisted development.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Cluster-validated: deployed, created PolicyReport, confirmed resolution metrics show resolved outcomes.