### PR TITLE
ROX-28590: [POC] (08) SecurityEvent violation card

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/Details/RuntimeMessages.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/RuntimeMessages.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import type { ProcessViolation, Violation } from 'types/alert.proto';
 import NetworkFlowCard from './NetworkFlowCard';
 import K8sCard from './K8sCard';
+import SecurityEventCard from './SecurityEventCard';
 import TimestampedEventCard from './TimestampedEventCard';
 import ProcessCardContent from './ProcessCardContent';
 import FileAccessCard from './FileAccessCard';
@@ -47,6 +48,15 @@ function RuntimeMessages({ processViolation, violations }: RuntimeMessagesProps)
                     key={`${fileAccess.timestamp}-${fileAccess.operation}-${fileAccess.file.actualPath}`}
                     fileAccess={fileAccess}
                     message={message}
+                />
+            );
+        } else if (violation.type === 'SECURITY_EVENT') {
+            const { keyValueAttrs } = violation;
+            plainViolations.push(
+                <SecurityEventCard
+                    key={`${time}-${message}`}
+                    message={message}
+                    keyValueAttrs={keyValueAttrs}
                 />
             );
         }

--- a/ui/apps/platform/src/Containers/Violations/Details/SecurityEventCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/SecurityEventCard.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import {
+    Card,
+    CardBody,
+    CardExpandableContent,
+    CardHeader,
+    CardTitle,
+    DescriptionList,
+    Label,
+} from '@patternfly/react-core';
+
+import DescriptionListItem from 'Components/DescriptionListItem';
+
+type SecurityEventCardProps = {
+    keyValueAttrs: {
+        attrs: {
+            key: string;
+            value: string;
+        }[];
+    };
+    message: string;
+};
+
+const severityColorMap: Record<string, 'red' | 'orange' | 'blue' | 'grey'> = {
+    critical: 'red',
+    high: 'red',
+    medium: 'orange',
+    low: 'blue',
+};
+
+function SecurityEventCard({ message, keyValueAttrs }: SecurityEventCardProps): ReactElement {
+    const [isExpanded, setIsExpanded] = useState(true);
+
+    function onExpand() {
+        setIsExpanded((prev) => !prev);
+    }
+
+    const attrMap = new Map(keyValueAttrs.attrs.map(({ key, value }) => [key, value]));
+
+    const source = attrMap.get('Source') ?? 'Unknown';
+    const reportedPolicy = attrMap.get('Reported Policy') ?? '';
+    const reportedRule = attrMap.get('Reported Rule') ?? '';
+    const severity = attrMap.get('Severity') ?? '';
+    const result = attrMap.get('Result') ?? '';
+
+    const severityColor = severityColorMap[severity.toLowerCase()] ?? 'grey';
+
+    return (
+        <div className="pf-v6-u-pb-md">
+            <Card isExpanded={isExpanded}>
+                <CardHeader
+                    onExpand={onExpand}
+                    toggleButtonProps={{ 'aria-expanded': isExpanded, 'aria-label': 'Details' }}
+                    actions={{
+                        actions: (
+                            <>
+                                <Label color={severityColor} isCompact>
+                                    {severity || 'unknown'}
+                                </Label>
+                                <Label color="purple" isCompact className="pf-v6-u-ml-sm">
+                                    {source}
+                                </Label>
+                            </>
+                        ),
+                        hasNoOffset: true,
+                    }}
+                >
+                    <CardTitle>{message}</CardTitle>
+                </CardHeader>
+                <CardExpandableContent>
+                    <CardBody className="pf-v6-u-mt-lg">
+                        <DescriptionList isHorizontal>
+                            <DescriptionListItem term="Source" desc={source} />
+                            <DescriptionListItem term="Reported policy" desc={reportedPolicy} />
+                            {reportedRule && (
+                                <DescriptionListItem term="Reported rule" desc={reportedRule} />
+                            )}
+                            <DescriptionListItem term="Result" desc={result} />
+                            <DescriptionListItem term="Severity" desc={severity} />
+                        </DescriptionList>
+                    </CardBody>
+                </CardExpandableContent>
+            </Card>
+        </div>
+    );
+}
+
+export default SecurityEventCard;

--- a/ui/apps/platform/src/types/alert.proto.ts
+++ b/ui/apps/platform/src/types/alert.proto.ts
@@ -103,7 +103,8 @@ export type Violation =
     | GenericViolation
     | K8sEventViolation
     | NetworkFlowViolation
-    | FileAccessViolation;
+    | FileAccessViolation
+    | SecurityEventViolation;
 
 export type GenericViolation = {
     type: 'GENERIC';
@@ -143,6 +144,16 @@ export type FileAccessViolation = {
     fileAccess: FileAccess;
 } & BaseViolation;
 
+export type SecurityEventViolation = {
+    type: 'SECURITY_EVENT';
+    keyValueAttrs: {
+        attrs: {
+            key: string;
+            value: string;
+        }[];
+    };
+} & BaseViolation;
+
 type BaseViolation = {
     type: ViolationType;
     message: string;
@@ -157,7 +168,8 @@ export type ViolationType =
     | 'K8S_EVENT'
     | 'NETWORK_FLOW'
     | 'NETWORK_POLICY'
-    | 'FILE_ACCESS';
+    | 'FILE_ACCESS'
+    | 'SECURITY_EVENT';
 
 export type ProcessViolation = {
     message: string;


### PR DESCRIPTION
## Description

POC branch 8/9. Adds `SecurityEventCard.tsx` to render SecurityEvent violations in the violation detail view. Expandable card with source badge, severity label, and structured description list for reported policy, rule, result, and message.

AI-assisted development.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Browser-validated: navigated to violation detail page for a SecurityEvent alert, confirmed card renders with source, severity, and details.