### PR TITLE
ROX-28590: [POC] (09) multi-source support (FIO, Gatekeeper)

### DIFF
--- a/central/sensor/service/pipeline/alerts/pipeline.go
+++ b/central/sensor/service/pipeline/alerts/pipeline.go
@@ -112,7 +112,18 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		return nil
 	}
 
-	// SECURITY_EVENT alerts are deployment-scoped and handled the same as deployment events.
+	if alertResults.GetSource() == central.AlertResults_SECURITY_EVENT {
+		if alertResults.GetDeploymentId() != "" {
+			if err := s.lifecycleManager.HandleDeploymentAlerts(alertResults.GetDeploymentId(), alertResults.GetAlerts(), alertResults.GetStage()); err != nil {
+				return errors.Wrap(err, "error handling security event deployment alerts")
+			}
+			return nil
+		}
+		if err := s.lifecycleManager.HandleNodeAlerts(clusterID, alertResults.GetAlerts(), alertResults.GetStage()); err != nil {
+			return errors.Wrap(err, "error handling security event node alerts")
+		}
+		return nil
+	}
 
 	// Treat all other alerts, even if they don't have a listed deployment as a "non-resource" alert for backwards compatibility
 	if err := s.lifecycleManager.HandleDeploymentAlerts(alertResults.GetDeploymentId(), alertResults.GetAlerts(), alertResults.GetStage()); err != nil {

--- a/pkg/policyreport/event.go
+++ b/pkg/policyreport/event.go
@@ -18,6 +18,9 @@ type Source string
 // SourceKyverno is the canonical source value for Kyverno-produced reports.
 const SourceKyverno Source = "Kyverno"
 
+// SourceFIO is the canonical source value for File Integrity Operator findings.
+const SourceFIO Source = "File Integrity Operator"
+
 // EventType identifies which typed payload a SecurityEvent carries.
 type EventType string
 
@@ -72,6 +75,7 @@ type EntityType string
 const (
 	EntityTypeUnknown    EntityType = ""
 	EntityTypeDeployment EntityType = "Deployment"
+	EntityTypeNode       EntityType = "Node"
 )
 
 // ReportRef identifies the producer report object a SecurityEvent was

--- a/pkg/policyreport/event.go
+++ b/pkg/policyreport/event.go
@@ -18,6 +18,9 @@ type Source string
 // SourceKyverno is the canonical source value for Kyverno-produced reports.
 const SourceKyverno Source = "Kyverno"
 
+// SourceGatekeeper is the canonical source value for Gatekeeper-produced reports.
+const SourceGatekeeper Source = "Gatekeeper"
+
 // SourceFIO is the canonical source value for File Integrity Operator findings.
 const SourceFIO Source = "File Integrity Operator"
 

--- a/pkg/policyreport/fio.go
+++ b/pkg/policyreport/fio.go
@@ -1,0 +1,102 @@
+package policyreport
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// CanonicalizeFIO converts a FileIntegrityNodeStatus resource into SecurityEvents.
+// Only "Failed" results produce events; "Succeeded" and "Errored" are ignored
+// for the MVP (Errored is an operational issue, not a security finding).
+func CanonicalizeFIO(clusterID string, u *unstructured.Unstructured) ([]SecurityEvent, error) {
+	nodeName, _, _ := unstructured.NestedString(u.Object, "nodeName")
+	if nodeName == "" {
+		return nil, fmt.Errorf("FileIntegrityNodeStatus missing nodeName")
+	}
+
+	ownerName := u.GetLabels()["file-integrity.openshift.io/owner"]
+	if ownerName == "" {
+		ownerName = "unknown"
+	}
+
+	results, found, err := unstructured.NestedSlice(u.Object, "results")
+	if err != nil {
+		return nil, fmt.Errorf("FileIntegrityNodeStatus results field error: %w", err)
+	}
+	if !found {
+		return nil, fmt.Errorf("FileIntegrityNodeStatus missing results field")
+	}
+
+	var events []SecurityEvent
+	for _, r := range results {
+		result, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		condition, _, _ := unstructured.NestedString(result, "condition")
+		if condition != "Failed" {
+			continue
+		}
+
+		filesAdded, _, _ := unstructured.NestedInt64(result, "filesAdded")
+		filesChanged, _, _ := unstructured.NestedInt64(result, "filesChanged")
+		filesRemoved, _, _ := unstructured.NestedInt64(result, "filesRemoved")
+
+		probeTime := parseFIOTimestamp(result)
+
+		message := fmt.Sprintf("File integrity check failed on node %s: %d files changed, %d added, %d removed",
+			nodeName, filesChanged, filesAdded, filesRemoved)
+
+		id := ComputeID(clusterID, string(u.GetUID()), SourceFIO, ownerName, "aide-check", nodeName)
+
+		events = append(events, SecurityEvent{
+			ID:         id,
+			Source:     SourceFIO,
+			Type:       EventTypePolicyResult,
+			ObservedAt: probeTime,
+			Report: ReportRef{
+				APIVersion:      "fileintegrity.openshift.io/v1alpha1",
+				Kind:            "FileIntegrityNodeStatus",
+				UID:             string(u.GetUID()),
+				Name:            u.GetName(),
+				Namespace:       u.GetNamespace(),
+				ResourceVersion: u.GetResourceVersion(),
+			},
+			Subject: Subject{
+				APIVersion: "v1",
+				Kind:       "Node",
+				Name:       nodeName,
+			},
+			ResolvedEntity: ResolvedEntity{
+				Type: EntityTypeNode,
+				ID:   nodeName,
+			},
+			Details: PolicyResult{
+				ReportedPolicy:   ownerName,
+				ReportedRule:     "aide-check",
+				Category:         "File Integrity",
+				Result:           PolicyResultFail,
+				ReportedSeverity: SeverityHigh,
+				Message:          message,
+				OriginalSource:   "file-integrity-operator",
+			},
+		})
+	}
+
+	return events, nil
+}
+
+func parseFIOTimestamp(result map[string]interface{}) time.Time {
+	ts, ok := result["lastProbeTime"].(string)
+	if !ok || ts == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/pkg/policyreport/fio_api.go
+++ b/pkg/policyreport/fio_api.go
@@ -1,0 +1,38 @@
+package policyreport
+
+import (
+	"github.com/stackrox/rox/pkg/k8sapi"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	fioGroupVersion         = schema.GroupVersion{Group: "fileintegrity.openshift.io", Version: "v1alpha1"}
+	fioRequiredAPIResources []k8sapi.APIResource
+
+	// FileIntegrityNodeStatus is the FIO resource that reports per-node scan results.
+	FileIntegrityNodeStatus = registerFIOAPIResource(v1.APIResource{
+		Name:    "fileintegritynodestatuses",
+		Kind:    "FileIntegrityNodeStatus",
+		Group:   fioGroupVersion.Group,
+		Version: fioGroupVersion.Version,
+	})
+)
+
+// GetFIOGroupVersion returns the group version for FileIntegrity CRDs.
+func GetFIOGroupVersion() schema.GroupVersion {
+	return fioGroupVersion
+}
+
+// GetFIORequiredResources returns the FIO API resources required by ACS.
+func GetFIORequiredResources() []k8sapi.APIResource {
+	return fioRequiredAPIResources
+}
+
+func registerFIOAPIResource(resource v1.APIResource) k8sapi.APIResource {
+	r := k8sapi.APIResource{
+		APIResource: resource,
+	}
+	fioRequiredAPIResources = append(fioRequiredAPIResources, r)
+	return r
+}

--- a/pkg/policyreport/kyverno_v1alpha2.go
+++ b/pkg/policyreport/kyverno_v1alpha2.go
@@ -172,15 +172,13 @@ func isKnownOutcome(o PolicyResultOutcome) bool {
 	}
 }
 
-// normalizeSource maps a report result's own `source` string to a canonical
-// Source. This adapter is registered specifically for Kyverno-shaped
-// wgpolicyk8s.io/v1alpha2 reports, so its own adapter identity (Kyverno) is
-// always the fallback, per security-event-plan.md's source-normalization
-// precedence ("explicit report result source, then ... adapter identity") —
-// the original string is preserved separately in PolicyResult.OriginalSource
-// for diagnostics regardless of what this returns.
-func normalizeSource(_ string) Source {
-	return SourceKyverno
+func normalizeSource(raw string) Source {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "gatekeeper":
+		return SourceGatekeeper
+	default:
+		return SourceKyverno
+	}
 }
 
 func normalizeSeverity(raw string) Severity {

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -650,32 +650,61 @@ func (d *detectorImpl) detectAndAlertForSecurityEvent(event *policyreport.Securi
 		return
 	}
 
-	deploymentID := event.ResolvedEntity.ID
-	if deploymentID == "" {
-		log.Debugf("Security event from source %q has no resolved deployment, skipping alert", event.Source)
+	entityID := event.ResolvedEntity.ID
+	if entityID == "" {
+		log.Debugf("Security event from source %q has no resolved entity, skipping alert", event.Source)
 		return
 	}
 
-	deployment := d.deploymentStore.GetSnapshot(deploymentID)
 	for _, alert := range alerts {
-		if deployment != nil {
-			alert.Entity = alertconvert.ToAlertDeployment(deployment)
-		}
 		enrichSecurityEventViolations(alert, event)
+	}
+
+	var alertResults *central.AlertResults
+	switch event.ResolvedEntity.Type {
+	case policyreport.EntityTypeNode:
+		node := d.nodeStore.GetNode(entityID)
+		if node == nil {
+			log.Warnf("Node %q not found in store for security event from source %q, skipping alert", entityID, event.Source)
+			return
+		}
+		for _, alert := range alerts {
+			alert.Entity = &storage.Alert_Node_{
+				Node: &storage.Alert_Node{
+					Id:          node.GetId(),
+					Name:        node.GetName(),
+					ClusterId:   node.GetClusterId(),
+					ClusterName: node.GetClusterName(),
+				},
+			}
+		}
+		alertResults = &central.AlertResults{
+			Alerts: alerts,
+			Stage:  storage.LifecycleStage_RUNTIME,
+			Source: central.AlertResults_SECURITY_EVENT,
+		}
+	default:
+		deployment := d.deploymentStore.GetSnapshot(entityID)
+		for _, alert := range alerts {
+			if deployment != nil {
+				alert.Entity = alertconvert.ToAlertDeployment(deployment)
+			}
+		}
+		alertResults = &central.AlertResults{
+			DeploymentId: entityID,
+			Alerts:       alerts,
+			Stage:        storage.LifecycleStage_RUNTIME,
+			Source:       central.AlertResults_SECURITY_EVENT,
+		}
 	}
 
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
 			Event: &central.SensorEvent{
-				Id:     deploymentID,
+				Id:     entityID,
 				Action: central.ResourceAction_CREATE_RESOURCE,
 				Resource: &central.SensorEvent_AlertResults{
-					AlertResults: &central.AlertResults{
-						DeploymentId: deploymentID,
-						Alerts:       alerts,
-						Stage:        storage.LifecycleStage_RUNTIME,
-						Source:       central.AlertResults_SECURITY_EVENT,
-					},
+					AlertResults: alertResults,
 				},
 			},
 		},

--- a/sensor/kubernetes/listener/informer_sync_tracker.go
+++ b/sensor/kubernetes/listener/informer_sync_tracker.go
@@ -36,6 +36,7 @@ const (
 	informerNetworkPolicies               = "NetworkPolicies"
 	informerNodes                         = "Nodes"
 	informerPodCache                      = "PodCache"
+	informerFileIntegrityNodeStatuses     = "FileIntegrityNodeStatuses"
 	informerPolicyReports                 = "PolicyReports"
 	informerPods                          = "Pods"
 	informerReplicaSets                   = "ReplicaSets"

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -445,15 +445,7 @@ func (k *listenerImpl) handleAllEvents() {
 		handle(k.context, informerVirtualMachineInstances, virtualMachineInstanceInformer, dispatchers.ForVirtualMachineInstances(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
 	}
 
-	if shouldTrackPolicyReports {
-		log.Info("Syncing policy reports")
-		handle(k.context, informerPolicyReports, policyReportInformer, dispatchers.ForPolicyReports(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
-	}
-
-	if shouldTrackFIO {
-		log.Info("Syncing file integrity node statuses")
-		handle(k.context, informerFileIntegrityNodeStatuses, fioInformer, dispatchers.ForFileIntegrityNodeStatuses(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
-	}
+	// PolicyReports are deferred to after pods sync — see below.
 
 	if !startAndWait(stopSignal, noDependencyWaitGroup, sif, osConfigFactory, osOperatorFactory, crdSharedInformerFactory) {
 		return
@@ -529,6 +521,8 @@ func (k *listenerImpl) handleAllEvents() {
 
 	log.Info("Successfully synced network policies, nodes, services, jobs, replica sets, and replication controllers")
 
+	// FIO is deferred to after pods sync — see below.
+
 	wg := &concurrency.WaitGroup{}
 
 	// Deployment types.
@@ -568,6 +562,25 @@ func (k *listenerImpl) handleAllEvents() {
 	}
 
 	log.Info("Successfully synced pods")
+
+	// SecurityEvent informers (PolicyReport, FIO) are deferred to after pods
+	// sync so that the parent hierarchy and node store are fully populated
+	// when initial-sync events are processed by the detector.
+	seWaitGroup := &concurrency.WaitGroup{}
+	if shouldTrackPolicyReports {
+		log.Info("Syncing policy reports")
+		handle(k.context, informerPolicyReports, policyReportInformer, dispatchers.ForPolicyReports(), k.pubSubDispatcher, k.outputQueue, &syncingResources, seWaitGroup, stopSignal, &eventLock, informerTracker)
+	}
+	if shouldTrackFIO {
+		log.Info("Syncing file integrity node statuses")
+		handle(k.context, informerFileIntegrityNodeStatuses, fioInformer, dispatchers.ForFileIntegrityNodeStatuses(), k.pubSubDispatcher, k.outputQueue, &syncingResources, seWaitGroup, stopSignal, &eventLock, informerTracker)
+	}
+	if shouldTrackPolicyReports || shouldTrackFIO {
+		if !startAndWait(stopSignal, seWaitGroup, sif, crdSharedInformerFactory) {
+			return
+		}
+		log.Info("Successfully synced security event informers")
+	}
 
 	// Set the flag that all objects present at start up have been consumed.
 	syncingResources.Set(false)

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher"
 	complianceOperatorAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/complianceoperator"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher/crd"
+	fioAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/fio"
 	policyReportAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/policyreport"
 	virtualMachineAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/virtualmachine"
 	sensorUtils "github.com/stackrox/rox/sensor/utils"
@@ -299,6 +300,40 @@ func (k *listenerImpl) handleAllEvents() {
 		}
 	}
 
+	// File Integrity Operator Watcher and Informers
+	shouldTrackFIO := features.PolicyReports.Enabled()
+	var fioInformer cache.SharedIndexInformer
+
+	if features.PolicyReports.Enabled() {
+		fioWatcher := crd.NewCRDWatcher(&k.stopSig, dynamicSif)
+		fioChecker := fioAvailabilityChecker.NewAvailabilityChecker()
+		if err := fioChecker.AppendToCRDWatcher(fioWatcher); err != nil {
+			log.Errorf("Unable to add the Resource to the FIO CRD Watcher: %v", err)
+		}
+
+		fioCrdHandlerFn := crdWatcherCallbackWrapper(k.context,
+			allResourcesAvailable(),
+			k.pubSub,
+			"FileIntegrity resources have been updated. Connection will restart to force reconciliation with Central")
+
+		shouldTrackFIO, err = fioChecker.Available(k.client)
+		if err != nil {
+			log.Errorf("Failed to check the availability of FileIntegrity resources: %v", err)
+		}
+
+		if shouldTrackFIO {
+			log.Info("Initializing FileIntegrityNodeStatus informers")
+			fioInformer = crdSharedInformerFactory.ForResource(policyreport.FileIntegrityNodeStatus.GroupVersionResource()).Informer()
+			fioCrdHandlerFn = crdWatcherCallbackWrapper(k.context,
+				resourcesUnavailable(),
+				k.pubSub,
+				"FileIntegrity resources have been removed. Connection will restart to force reconciliation with Central")
+		}
+		if err := fioWatcher.Watch(fioCrdHandlerFn); err != nil {
+			log.Errorf("Failed to start watching the FileIntegrity CRDs: %v", err)
+		}
+	}
+
 	// This call to clusterID.Get might block if a cluster ID is initially unavailable, which is okay.
 	clusterID := k.clusterID.Get()
 
@@ -313,6 +348,7 @@ func (k *listenerImpl) handleAllEvents() {
 		k.traceWriter,
 		k.storeProvider,
 		k.client.Kubernetes(),
+		k.policyReportDetectFunc,
 		k.policyReportDetectFunc,
 	)
 
@@ -412,6 +448,11 @@ func (k *listenerImpl) handleAllEvents() {
 	if shouldTrackPolicyReports {
 		log.Info("Syncing policy reports")
 		handle(k.context, informerPolicyReports, policyReportInformer, dispatchers.ForPolicyReports(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
+	}
+
+	if shouldTrackFIO {
+		log.Info("Syncing file integrity node statuses")
+		handle(k.context, informerFileIntegrityNodeStatuses, fioInformer, dispatchers.ForFileIntegrityNodeStatuses(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
 	}
 
 	if !startAndWait(stopSignal, noDependencyWaitGroup, sif, osConfigFactory, osOperatorFactory, crdSharedInformerFactory) {

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/kubernetes/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	fioDispatcher "github.com/stackrox/rox/sensor/kubernetes/listener/resources/fio"
 	policyReportDispatcher "github.com/stackrox/rox/sensor/kubernetes/listener/resources/policyreport"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
@@ -53,6 +54,7 @@ type DispatcherRegistry interface {
 	ForVirtualMachineInstances() Dispatcher
 
 	ForPolicyReports() Dispatcher
+	ForFileIntegrityNodeStatuses() Dispatcher
 
 	ForComplianceOperatorResults() Dispatcher
 	ForComplianceOperatorProfiles() Dispatcher
@@ -76,6 +78,7 @@ func NewDispatcherRegistry(
 	storeProvider *StoreProvider,
 	k8sAPI kubernetes.Interface,
 	policyReportDetectFunc policyReportDispatcher.DetectFunc,
+	fioDetectFunc fioDispatcher.DetectFunc,
 ) DispatcherRegistry {
 	serviceStore := storeProvider.serviceStore
 	rbacUpdater := storeProvider.rbacStore
@@ -120,6 +123,7 @@ func NewDispatcherRegistry(
 		virtualMachineInstanceDispatcher: dispatcher.NewVirtualMachineInstanceDispatcher(clusterID, storeProvider.VirtualMachines()),
 
 		policyReportDispatcher: policyReportDispatcher.NewDispatcher(clusterID, hierarchy, storeProvider.Deployments(), policyReportDetectFunc),
+		fioDispatcher:          fioDispatcher.NewDispatcher(clusterID, fioDetectFunc),
 	}
 }
 
@@ -152,6 +156,7 @@ type registryImpl struct {
 	virtualMachineInstanceDispatcher *dispatcher.VirtualMachineInstanceDispatcher
 
 	policyReportDispatcher *policyReportDispatcher.Dispatcher
+	fioDispatcher          *fioDispatcher.Dispatcher
 }
 
 func wrapWithDumpingDispatcher(d Dispatcher, w io.Writer) Dispatcher {
@@ -360,4 +365,8 @@ func (d *registryImpl) ForVirtualMachineInstances() Dispatcher {
 
 func (d *registryImpl) ForPolicyReports() Dispatcher {
 	return wrapDispatcher(d.policyReportDispatcher, d.traceWriter)
+}
+
+func (d *registryImpl) ForFileIntegrityNodeStatuses() Dispatcher {
+	return wrapDispatcher(d.fioDispatcher, d.traceWriter)
 }

--- a/sensor/kubernetes/listener/resources/fio/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/fio/dispatcher.go
@@ -1,0 +1,101 @@
+package fio
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var log = logging.LoggerForModule()
+
+// DetectFunc is a callback for security event detection. Type alias so callers
+// can pass the same function used for PolicyReport detection.
+type DetectFunc = func(event *policyreport.SecurityEvent)
+
+// Dispatcher processes FileIntegrityNodeStatus CRD events.
+type Dispatcher struct {
+	clusterID  string
+	detectFunc DetectFunc
+}
+
+// NewDispatcher creates a FileIntegrityNodeStatus dispatcher.
+func NewDispatcher(clusterID string, detectFunc DetectFunc) *Dispatcher {
+	return &Dispatcher{
+		clusterID:  clusterID,
+		detectFunc: detectFunc,
+	}
+}
+
+// ProcessEvent implements resources.Dispatcher.
+func (d *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *component.ResourceEvent {
+	if !features.PolicyReports.Enabled() {
+		return nil
+	}
+
+	u, ok := toUnstructured(obj)
+	if !ok {
+		reportsProcessed.WithLabelValues("error").Inc()
+		return nil
+	}
+
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		reportsProcessed.WithLabelValues("removed").Inc()
+		return nil
+	}
+
+	events, err := policyreport.CanonicalizeFIO(d.clusterID, u)
+	if err != nil {
+		reportsProcessed.WithLabelValues("error").Inc()
+		log.Warnf("Failed to canonicalize FileIntegrityNodeStatus %s/%s: %v", u.GetNamespace(), u.GetName(), err)
+		return nil
+	}
+
+	reportsProcessed.WithLabelValues("ok").Inc()
+	eventsCanonicalizedTotal.Add(float64(len(events)))
+
+	if len(events) > 0 {
+		log.Debugf("Canonicalized %d SecurityEvents from FileIntegrityNodeStatus %s/%s",
+			len(events), u.GetNamespace(), u.GetName())
+	}
+
+	if d.detectFunc != nil {
+		for i := range events {
+			d.detectFunc(&events[i])
+		}
+	}
+
+	return nil
+}
+
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if ok {
+		return u, true
+	}
+	log.Errorf("FIO dispatcher received non-Unstructured object: %T", obj)
+	return nil, false
+}
+
+var (
+	reportsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "fio_reports_processed_total",
+		Help:      "Total FileIntegrityNodeStatus objects processed, by outcome.",
+	}, []string{"outcome"})
+
+	eventsCanonicalizedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "fio_events_canonicalized_total",
+		Help:      "Total SecurityEvents produced from FileIntegrityNodeStatus canonicalization.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(reportsProcessed, eventsCanonicalizedTotal)
+}

--- a/sensor/kubernetes/listener/resources/mocks/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/mocks/dispatcher.go
@@ -291,6 +291,20 @@ func (mr *MockDispatcherRegistryMockRecorder) ForPolicyReports() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForPolicyReports", reflect.TypeOf((*MockDispatcherRegistry)(nil).ForPolicyReports))
 }
 
+// ForFileIntegrityNodeStatuses mocks base method.
+func (m *MockDispatcherRegistry) ForFileIntegrityNodeStatuses() resources.Dispatcher {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForFileIntegrityNodeStatuses")
+	ret0, _ := ret[0].(resources.Dispatcher)
+	return ret0
+}
+
+// ForFileIntegrityNodeStatuses indicates an expected call of ForFileIntegrityNodeStatuses.
+func (mr *MockDispatcherRegistryMockRecorder) ForFileIntegrityNodeStatuses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForFileIntegrityNodeStatuses", reflect.TypeOf((*MockDispatcherRegistry)(nil).ForFileIntegrityNodeStatuses))
+}
+
 // ForNodes mocks base method.
 func (m *MockDispatcherRegistry) ForNodes() resources.Dispatcher {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/listener/watcher/fio/availabilitychecker.go
+++ b/sensor/kubernetes/listener/watcher/fio/availabilitychecker.go
@@ -1,0 +1,12 @@
+package fio
+
+import (
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher/availability"
+)
+
+// NewAvailabilityChecker creates an availability checker for FileIntegrity CRDs.
+func NewAvailabilityChecker() availability.Checker {
+	resources := policyreport.GetFIORequiredResources()
+	return availability.NewChecker(policyreport.GetFIOGroupVersion(), resources)
+}


### PR DESCRIPTION
## Description

POC branch 9/9. Adds FIO (File Integrity Operator) and Gatekeeper as additional security event sources alongside Kyverno. FIO canonicalizer for FileIntegrityNodeStatus CRDs producing node-scoped alerts. Source normalization to distinguish Gatekeeper from Kyverno in shared PolicyReport CRDs. Central alert pipeline routing by entity type. SecurityEvent informer sync ordering to ensure resolution succeeds.

AI-assisted development.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Full 3-source E2E on infractl cluster:
- Kyverno PolicyReport -> deployment-scoped alert
- Gatekeeper PolicyReport -> deployment-scoped alert with distinct source labels
- FIO FileIntegrityNodeStatus -> node-scoped alert on control plane node
- Metrics: 3 resolved PolicyReport events, 1 FIO event, 4 alerts generated, 0 errors


<img width="1340" height="993" alt="Screenshot 2026-08-05 at 12 22 30 PM" src="https://github.com/user-attachments/assets/27c4831b-2cb5-459e-bf46-bb3216ec4b43" />
<img width="1331" height="976" alt="Screenshot 2026-08-05 at 12 22 04 PM" src="https://github.com/user-attachments/assets/3f571238-1837-41f0-8136-79258620746f" />


