### PR TITLE
fix: use new instead of removed prt.To

### DIFF
--- a/operator/internal/central/defaults/static.go
+++ b/operator/internal/central/defaults/static.go
@@ -89,7 +89,7 @@ var staticDefaults = platform.CentralSpec{
 		Policies: new(platform.NetworkPoliciesEnabled),
 	},
 	CentralWorker: &platform.CentralWorkerSpec{
-		Enabled: ptr.To(false),
+		Enabled: new(false),
 	},
 	ConfigAsCode: &platform.ConfigAsCodeSpec{
 		ComponentPolicy: new(platform.ConfigAsCodeComponentEnabled),


### PR DESCRIPTION
Fixes semantic conflict between:
- https://github.com/stackrox/stackrox/pull/21189
- https://github.com/stackrox/stackrox/pull/21569