### PR TITLE
feat(devtools): add remote-cluster devloop skill

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -143,6 +143,9 @@ var (
 	// EvaluationFilter enables evaluation filtering in policy evaluation.
 	EvaluationFilter = registerFeature("Enable evaluation filtering in policy evaluation", "ROX_EVALUATION_FILTER", enabled)
 
+	// PolicyReports enables ingestion of wgpolicyk8s.io PolicyReport CRDs from external policy engines.
+	PolicyReports = registerFeature("Enables PolicyReport CRD ingestion from external policy engines", "ROX_POLICY_REPORTS")
+
 	// UISecretsPageMigration enables the secrets list page under the Risk section
 	UISecretsPageMigration = registerFeature("Display secrets list page under Risk section", "ROX_UI_SECRETS_PAGE_MIGRATION")
 )

--- a/pkg/policyreport/api.go
+++ b/pkg/policyreport/api.go
@@ -10,15 +10,11 @@ var (
 	groupVersion         = schema.GroupVersion{Group: "wgpolicyk8s.io", Version: "v1alpha2"}
 	requiredAPIResources []k8sapi.APIResource
 
+	// PolicyReport is the only resource we currently watch. ClusterPolicyReport
+	// support will be added in a follow-up when cluster-scoped reports are needed.
 	PolicyReport = registerAPIResource(v1.APIResource{
 		Name:    "policyreports",
 		Kind:    "PolicyReport",
-		Group:   groupVersion.Group,
-		Version: groupVersion.Version,
-	})
-	ClusterPolicyReport = registerAPIResource(v1.APIResource{
-		Name:    "clusterpolicyreports",
-		Kind:    "ClusterPolicyReport",
 		Group:   groupVersion.Group,
 		Version: groupVersion.Version,
 	})

--- a/pkg/policyreport/api.go
+++ b/pkg/policyreport/api.go
@@ -1,0 +1,43 @@
+package policyreport
+
+import (
+	"github.com/stackrox/rox/pkg/k8sapi"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	groupVersion         = schema.GroupVersion{Group: "wgpolicyk8s.io", Version: "v1alpha2"}
+	requiredAPIResources []k8sapi.APIResource
+
+	PolicyReport = registerAPIResource(v1.APIResource{
+		Name:    "policyreports",
+		Kind:    "PolicyReport",
+		Group:   groupVersion.Group,
+		Version: groupVersion.Version,
+	})
+	ClusterPolicyReport = registerAPIResource(v1.APIResource{
+		Name:    "clusterpolicyreports",
+		Kind:    "ClusterPolicyReport",
+		Group:   groupVersion.Group,
+		Version: groupVersion.Version,
+	})
+)
+
+// GetGroupVersion returns the group version for wgpolicyk8s.io PolicyReport CRDs.
+func GetGroupVersion() schema.GroupVersion {
+	return groupVersion
+}
+
+// GetRequiredResources returns the PolicyReport API resources required by ACS.
+func GetRequiredResources() []k8sapi.APIResource {
+	return requiredAPIResources
+}
+
+func registerAPIResource(resource v1.APIResource) k8sapi.APIResource {
+	r := k8sapi.APIResource{
+		APIResource: resource,
+	}
+	requiredAPIResources = append(requiredAPIResources, r)
+	return r
+}

--- a/pkg/policyreport/diff.go
+++ b/pkg/policyreport/diff.go
@@ -1,0 +1,90 @@
+package policyreport
+
+import "sort"
+
+// Diff reconciles a previous snapshot of SecurityEvents against a new
+// snapshot for the same report, keyed by SecurityEvent.ID, returning which
+// events to create, update, or remove. Per security-event-plan.md's "Treat
+// reports as current state" guiding decision:
+//
+//   - new minus old  -> created
+//   - shared identity, changed content -> updated
+//   - old minus new  -> removed
+//
+// Report deletion is modeled by calling Diff(previousEvents, nil) — every
+// previously-actionable event is returned in removed.
+//
+// All three return slices are sorted by ID for determinism.
+func Diff(oldEvents, newEvents []SecurityEvent) (created, updated, removed []SecurityEvent) {
+	oldByID := indexByID(oldEvents)
+	newByID := indexByID(newEvents)
+
+	for id, newEvent := range newByID {
+		oldEvent, existed := oldByID[id]
+		switch {
+		case !existed:
+			created = append(created, newEvent)
+		case !equalContent(oldEvent, newEvent):
+			updated = append(updated, newEvent)
+		}
+	}
+	for id, oldEvent := range oldByID {
+		if _, stillPresent := newByID[id]; !stillPresent {
+			removed = append(removed, oldEvent)
+		}
+	}
+
+	sortByID(created)
+	sortByID(updated)
+	sortByID(removed)
+	return created, updated, removed
+}
+
+func indexByID(events []SecurityEvent) map[string]SecurityEvent {
+	byID := make(map[string]SecurityEvent, len(events))
+	for _, e := range events {
+		byID[e.ID] = e
+	}
+	return byID
+}
+
+func sortByID(events []SecurityEvent) {
+	sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
+}
+
+// equalContent reports whether two SecurityEvents sharing the same ID
+// otherwise carry identical content. ObservedAt is derived from the report's
+// own result timestamp (not wall-clock at parse time), so re-canonicalizing
+// unchanged report content is expected to produce byte-identical events —
+// this is what makes repeated processing idempotent (see
+// kyverno_v1alpha2_test.go).
+func equalContent(a, b SecurityEvent) bool {
+	if a.Source != b.Source || a.Type != b.Type || !a.ObservedAt.Equal(b.ObservedAt) {
+		return false
+	}
+	if a.Report != b.Report || a.Subject != b.Subject || a.ResolvedEntity != b.ResolvedEntity {
+		return false
+	}
+	if a.Details.ReportedPolicy != b.Details.ReportedPolicy ||
+		a.Details.ReportedRule != b.Details.ReportedRule ||
+		a.Details.Category != b.Details.Category ||
+		a.Details.Result != b.Details.Result ||
+		a.Details.ReportedSeverity != b.Details.ReportedSeverity ||
+		a.Details.Message != b.Details.Message ||
+		a.Details.OriginalSource != b.Details.OriginalSource {
+		return false
+	}
+	return stringMapsEqual(a.Details.Properties, b.Details.Properties)
+}
+
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/policyreport/diff_test.go
+++ b/pkg/policyreport/diff_test.go
@@ -1,0 +1,99 @@
+package policyreport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestEvent(id string, message string) SecurityEvent {
+	return SecurityEvent{
+		ID:     id,
+		Source: SourceKyverno,
+		Type:   EventTypePolicyResult,
+		Report: ReportRef{UID: "report-1"},
+		Subject: Subject{
+			Kind: "Pod",
+			UID:  "pod-1",
+		},
+		Details: PolicyResult{
+			ReportedPolicy: "policy-a",
+			ReportedRule:   "rule-a",
+			Result:         PolicyResultFail,
+			Message:        message,
+		},
+	}
+}
+
+func TestDiff(t *testing.T) {
+	for name, tc := range map[string]struct {
+		old             []SecurityEvent
+		new             []SecurityEvent
+		expectedCreated []string
+		expectedUpdated []string
+		expectedRemoved []string
+	}{
+		"new report, no prior events: everything created": {
+			old:             nil,
+			new:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			expectedCreated: []string{"a", "b"},
+		},
+		"unchanged content: no created/updated/removed": {
+			old: []SecurityEvent{newTestEvent("a", "m1")},
+			new: []SecurityEvent{newTestEvent("a", "m1")},
+			// all nil
+		},
+		"changed content, same ID: updated": {
+			old:             []SecurityEvent{newTestEvent("a", "m1")},
+			new:             []SecurityEvent{newTestEvent("a", "m2")},
+			expectedUpdated: []string{"a"},
+		},
+		"result no longer present: removed": {
+			old:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			new:             []SecurityEvent{newTestEvent("a", "m1")},
+			expectedRemoved: []string{"b"},
+		},
+		"report deleted entirely: everything removed": {
+			old:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			new:             nil,
+			expectedRemoved: []string{"a", "b"},
+		},
+		"mixed create, update, remove in one diff": {
+			old:             []SecurityEvent{newTestEvent("a", "m1"), newTestEvent("b", "m2")},
+			new:             []SecurityEvent{newTestEvent("a", "m1-changed"), newTestEvent("c", "m3")},
+			expectedCreated: []string{"c"},
+			expectedUpdated: []string{"a"},
+			expectedRemoved: []string{"b"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			created, updated, removed := Diff(tc.old, tc.new)
+			assert.Equal(t, tc.expectedCreated, idsOf(created))
+			assert.Equal(t, tc.expectedUpdated, idsOf(updated))
+			assert.Equal(t, tc.expectedRemoved, idsOf(removed))
+		})
+	}
+}
+
+func idsOf(events []SecurityEvent) []string {
+	if len(events) == 0 {
+		return nil
+	}
+	ids := make([]string, len(events))
+	for i, e := range events {
+		ids[i] = e.ID
+	}
+	return ids
+}
+
+func TestDiff_IsIdempotentWhenAppliedTwiceToSameInputs(t *testing.T) {
+	old := []SecurityEvent{newTestEvent("a", "m1")}
+	new := []SecurityEvent{newTestEvent("a", "m1-changed"), newTestEvent("b", "m2")}
+
+	created1, updated1, removed1 := Diff(old, new)
+	created2, updated2, removed2 := Diff(old, new)
+
+	assert.Equal(t, created1, created2)
+	assert.Equal(t, updated1, updated2)
+	assert.Equal(t, removed1, removed2)
+}

--- a/pkg/policyreport/event.go
+++ b/pkg/policyreport/event.go
@@ -1,0 +1,140 @@
+// Package policyreport canonicalizes external PolicyReport/ClusterPolicyReport
+// results (e.g. from Kyverno) into a source-neutral SecurityEvent envelope.
+//
+// This package is deliberately free of Kubernetes client, Sensor, and Central
+// wiring: adapters here are pure functions from a raw report object to a
+// deterministic slice of SecurityEvent values. See security-event-plan.md at
+// the repo root for the full design and phased rollout this package is part of.
+package policyreport
+
+import "time"
+
+// Source identifies the normalized producer of a SecurityEvent. Kept as a
+// bounded string rather than an enum so a standards-based report producer can
+// be supported without a new release, per security-event-plan.md's "Source
+// normalization" section.
+type Source string
+
+// SourceKyverno is the canonical source value for Kyverno-produced reports.
+const SourceKyverno Source = "Kyverno"
+
+// EventType identifies which typed payload a SecurityEvent carries.
+type EventType string
+
+// EventTypePolicyResult is the only EventType implemented so far.
+const EventTypePolicyResult EventType = "PolicyResult"
+
+// PolicyResultOutcome mirrors a PolicyReport result's `result` field.
+type PolicyResultOutcome string
+
+// Outcomes a PolicyReport result can report. Only Fail, Error, and Warn are
+// actionable in the MVP scope (see ActionableOutcomes) — Pass and Skip are
+// explicitly deferred per security-event-plan.md.
+const (
+	PolicyResultPass  PolicyResultOutcome = "pass"
+	PolicyResultFail  PolicyResultOutcome = "fail"
+	PolicyResultWarn  PolicyResultOutcome = "warn"
+	PolicyResultError PolicyResultOutcome = "error"
+	PolicyResultSkip  PolicyResultOutcome = "skip"
+)
+
+// ActionableOutcomes are the PolicyResultOutcome values that produce a
+// SecurityEvent. Pass and skip results are parsed (so callers can compute
+// summaries) but never canonicalized into events.
+var ActionableOutcomes = map[PolicyResultOutcome]bool{
+	PolicyResultFail:  true,
+	PolicyResultError: true,
+	PolicyResultWarn:  true,
+}
+
+// Severity mirrors a result's optional `severity` field. Producers are not
+// required to set one.
+type Severity string
+
+// Severity values a producer may report. SeverityUnknown means the producer
+// didn't set one at all — this is common; severity is opt-in per policy.
+const (
+	SeverityUnknown  Severity = ""
+	SeverityLow      Severity = "low"
+	SeverityMedium   Severity = "medium"
+	SeverityHigh     Severity = "high"
+	SeverityCritical Severity = "critical"
+)
+
+// EntityType identifies what kind of ACS-resolvable entity a SecurityEvent's
+// ResolvedEntity refers to. Only Deployment is implemented so far; Node is
+// listed in security-event-plan.md as a later expansion.
+type EntityType string
+
+// EntityTypeUnknown means resolution hasn't happened yet (or failed). This
+// package never sets ResolvedEntity — that's Phase 3's Pod-to-Deployment
+// resolver, layered on top of this pure canonicalizer.
+const (
+	EntityTypeUnknown    EntityType = ""
+	EntityTypeDeployment EntityType = "Deployment"
+)
+
+// ReportRef identifies the producer report object a SecurityEvent was
+// extracted from (a single PolicyReport or ClusterPolicyReport object).
+type ReportRef struct {
+	APIVersion      string
+	Kind            string // "PolicyReport" or "ClusterPolicyReport"
+	UID             string
+	Name            string
+	Namespace       string // empty for ClusterPolicyReport
+	ResourceVersion string
+}
+
+// Subject identifies the original Kubernetes object the report result
+// concerns. For Kyverno this comes from the report's top-level `scope` field
+// — one report object exists per subject resource, not one report per
+// namespace with a results-array of resources (confirmed against a real
+// Kyverno v1.18.2 cluster; see pkg/policyreport/testdata/raw/README.md).
+type Subject struct {
+	APIVersion string
+	Kind       string
+	UID        string
+	Name       string
+	Namespace  string
+}
+
+// ResolvedEntity is the ACS entity a Subject was resolved to. Always the zero
+// value coming out of this package — populated by a later resolution stage.
+type ResolvedEntity struct {
+	Type EntityType
+	ID   string
+}
+
+// PolicyResult is the typed payload for EventTypePolicyResult events.
+type PolicyResult struct {
+	ReportedPolicy   string
+	ReportedRule     string
+	Category         string
+	Result           PolicyResultOutcome
+	ReportedSeverity Severity
+	Message          string
+	// OriginalSource preserves the report result's own `source` field
+	// verbatim, for diagnostics — never used for matching (see Source).
+	OriginalSource string
+	// Properties preserves unknown/producer-specific key-value pairs
+	// without promoting them to policy criteria (security-event-plan.md:
+	// "retain them for details and diagnostics").
+	Properties map[string]string
+}
+
+// SecurityEvent is the canonical, source-neutral ingestion envelope described
+// in security-event-plan.md's "Canonical domain contract".
+type SecurityEvent struct {
+	// ID is a stable identity computed by ComputeID. Two SecurityEvents
+	// with the same ID represent the same logical finding across updates.
+	ID         string
+	Source     Source
+	Type       EventType
+	ObservedAt time.Time
+
+	Report         ReportRef
+	Subject        Subject
+	ResolvedEntity ResolvedEntity
+
+	Details PolicyResult
+}

--- a/pkg/policyreport/identity.go
+++ b/pkg/policyreport/identity.go
@@ -1,0 +1,27 @@
+package policyreport
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// ComputeID derives a stable SecurityEvent identity from the tuple documented
+// in security-event-plan.md's "Stable identity" section: cluster ID + report
+// UID + normalized source + reported policy name + rule name + subject UID.
+//
+// Deliberately excludes result-array position and observation timestamp, so
+// reordered results and repeated observations of unchanged content produce
+// the same ID. If a producer is ever found to emit legitimate duplicates
+// under this tuple, add the smallest stable additional discriminator here and
+// document why in a test, since any identity change affects alert
+// continuity for every existing SecurityEvent.
+func ComputeID(clusterID, reportUID string, source Source, reportedPolicy, reportedRule, subjectUID string) string {
+	h := sha256.New()
+	for _, part := range []string{clusterID, reportUID, string(source), reportedPolicy, reportedRule, subjectUID} {
+		h.Write([]byte(part))
+		// NUL separator: none of these fields can legitimately contain a NUL
+		// byte, so this keeps e.g. ("ab","c") distinguishable from ("a","bc").
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/policyreport/identity_test.go
+++ b/pkg/policyreport/identity_test.go
@@ -1,0 +1,53 @@
+package policyreport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeID_DeterministicForSameInput(t *testing.T) {
+	id1 := ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1")
+	id2 := ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1")
+	assert.Equal(t, id1, id2)
+	assert.NotEmpty(t, id1)
+}
+
+func TestComputeID_DiffersWhenAnyComponentChanges(t *testing.T) {
+	base := func() string {
+		return ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1")
+	}
+	baseID := base()
+
+	for name, id := range map[string]string{
+		"different cluster": ComputeID("cluster-2", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-1"),
+		"different report":  ComputeID("cluster-1", "report-uid-2", SourceKyverno, "policy-a", "rule-a", "subject-uid-1"),
+		"different policy":  ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-b", "rule-a", "subject-uid-1"),
+		"different rule":    ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-b", "subject-uid-1"),
+		"different subject": ComputeID("cluster-1", "report-uid-1", SourceKyverno, "policy-a", "rule-a", "subject-uid-2"),
+		"different source":  ComputeID("cluster-1", "report-uid-1", Source("Gatekeeper"), "policy-a", "rule-a", "subject-uid-1"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NotEqual(t, baseID, id)
+		})
+	}
+}
+
+func TestComputeID_ConcatenationAmbiguityIsAvoided(t *testing.T) {
+	// Without a separator, ("cluster-1x", "report-1") and ("cluster-1", "x-report-1")
+	// could hash identically. The NUL separator in ComputeID must prevent this.
+	idA := ComputeID("cluster-1x", "report-1", SourceKyverno, "p", "r", "s")
+	idB := ComputeID("cluster-1", "x-report-1", SourceKyverno, "p", "r", "s")
+	assert.NotEqual(t, idA, idB)
+}
+
+func TestComputeID_IndependentOfResultOrdering(t *testing.T) {
+	// ComputeID takes explicit fields, not a result's position in an array —
+	// this test documents that guarantee at the identity layer directly
+	// (the adapter-level reordering-stability test lives in
+	// kyverno_v1alpha2_test.go, since ordering is a property of the results
+	// slice the adapter walks, not of ComputeID's own arguments).
+	idFirst := ComputeID("cluster-1", "report-1", SourceKyverno, "policy-a", "rule-a", "subject-1")
+	idSecond := ComputeID("cluster-1", "report-1", SourceKyverno, "policy-a", "rule-a", "subject-1")
+	assert.Equal(t, idFirst, idSecond)
+}

--- a/pkg/policyreport/kyverno_v1alpha2.go
+++ b/pkg/policyreport/kyverno_v1alpha2.go
@@ -1,0 +1,254 @@
+package policyreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// KyvernoV1Alpha2APIVersion is the only report API version this adapter
+// understands. Confirmed against a real Kyverno v1.18.2 cluster — see
+// pkg/policyreport/testdata/raw/README.md. A future openreports.io/v1alpha1
+// (or newer wgpolicyk8s.io) adapter belongs in its own file behind the same
+// signature, per security-event-plan.md's "Prefer adapters over a
+// version-specific domain model".
+const KyvernoV1Alpha2APIVersion = "wgpolicyk8s.io/v1alpha2"
+
+const (
+	kindPolicyReport        = "PolicyReport"
+	kindClusterPolicyReport = "ClusterPolicyReport"
+)
+
+// CanonicalizeKyvernoV1Alpha2 is a pure adapter from a single Kyverno
+// wgpolicyk8s.io/v1alpha2 PolicyReport or ClusterPolicyReport object to a
+// deterministic slice of canonical SecurityEvents.
+//
+// Only actionable results (fail, error, warn — see ActionableOutcomes) become
+// SecurityEvents; pass/skip results are parsed but produce no event, per the
+// plan's MVP scope. A report with no actionable results yields an empty,
+// non-nil slice and no error — that's a normal, common case, not a failure.
+//
+// A malformed individual result (missing policy/rule/result) is skipped
+// without discarding its valid siblings. Only a structurally unusable report
+// (wrong API version/kind, or a missing/unidentifiable scope) returns an
+// error, since without a subject there is nothing to attribute any result to.
+func CanonicalizeKyvernoV1Alpha2(clusterID string, report *unstructured.Unstructured) ([]SecurityEvent, error) {
+	if report == nil {
+		return nil, errors.New("policyreport: report is nil")
+	}
+
+	if apiVersion := report.GetAPIVersion(); apiVersion != KyvernoV1Alpha2APIVersion {
+		return nil, errors.Errorf("policyreport: unsupported apiVersion %q, expected %q", apiVersion, KyvernoV1Alpha2APIVersion)
+	}
+	kind := report.GetKind()
+	if kind != kindPolicyReport && kind != kindClusterPolicyReport {
+		return nil, errors.Errorf("policyreport: unsupported kind %q", kind)
+	}
+
+	subject, err := extractSubject(report)
+	if err != nil {
+		return nil, errors.Wrap(err, "policyreport: extracting subject scope")
+	}
+
+	reportRef := ReportRef{
+		APIVersion:      report.GetAPIVersion(),
+		Kind:            kind,
+		UID:             string(report.GetUID()),
+		Name:            report.GetName(),
+		Namespace:       report.GetNamespace(),
+		ResourceVersion: report.GetResourceVersion(),
+	}
+
+	rawResults, found, err := unstructured.NestedSlice(report.Object, "results")
+	if err != nil {
+		return nil, errors.Wrap(err, "policyreport: reading results")
+	}
+	if !found || len(rawResults) == 0 {
+		return []SecurityEvent{}, nil
+	}
+
+	events := make([]SecurityEvent, 0, len(rawResults))
+	for _, raw := range rawResults {
+		resultMap, ok := raw.(map[string]interface{})
+		if !ok {
+			// A single malformed entry in the results array must not
+			// discard its valid siblings.
+			continue
+		}
+
+		event, ok := canonicalizeResult(clusterID, reportRef, subject, resultMap)
+		if !ok {
+			continue
+		}
+		events = append(events, event)
+	}
+
+	sort.Slice(events, func(i, j int) bool { return events[i].ID < events[j].ID })
+	return events, nil
+}
+
+// extractSubject reads the report's top-level `scope` field. Kyverno emits
+// exactly one report object per subject resource (see testdata README), so
+// unlike the plan's original draft there is no per-result resources array to
+// walk — the whole report shares one subject.
+func extractSubject(report *unstructured.Unstructured) (Subject, error) {
+	scopeMap, found, err := unstructured.NestedMap(report.Object, "scope")
+	if err != nil {
+		return Subject{}, errors.Wrap(err, "reading scope")
+	}
+	if !found {
+		return Subject{}, errors.New("scope is missing")
+	}
+
+	uid := strings.TrimSpace(nestedStringOrEmpty(scopeMap, "uid"))
+	if uid == "" {
+		return Subject{}, errors.New("scope.uid is missing or empty")
+	}
+
+	return Subject{
+		APIVersion: sanitizeProducerString(nestedStringOrEmpty(scopeMap, "apiVersion")),
+		Kind:       sanitizeProducerString(nestedStringOrEmpty(scopeMap, "kind")),
+		UID:        uid,
+		Name:       sanitizeProducerString(nestedStringOrEmpty(scopeMap, "name")),
+		Namespace:  sanitizeProducerString(nestedStringOrEmpty(scopeMap, "namespace")),
+	}, nil
+}
+
+// canonicalizeResult converts a single `results[]` entry into a SecurityEvent.
+// Returns ok=false when the result is either malformed (missing a required
+// field) or simply non-actionable (pass/skip) — both are normal, silent
+// skips, not errors.
+func canonicalizeResult(clusterID string, reportRef ReportRef, subject Subject, resultMap map[string]interface{}) (SecurityEvent, bool) {
+	policyName := strings.TrimSpace(nestedStringOrEmpty(resultMap, "policy"))
+	ruleName := strings.TrimSpace(nestedStringOrEmpty(resultMap, "rule"))
+	rawOutcome := strings.ToLower(strings.TrimSpace(nestedStringOrEmpty(resultMap, "result")))
+	if policyName == "" || ruleName == "" || rawOutcome == "" {
+		return SecurityEvent{}, false
+	}
+
+	outcome := PolicyResultOutcome(rawOutcome)
+	if !isKnownOutcome(outcome) || !ActionableOutcomes[outcome] {
+		return SecurityEvent{}, false
+	}
+
+	reportedSource := nestedStringOrEmpty(resultMap, "source")
+	canonicalSource := normalizeSource(reportedSource)
+
+	details := PolicyResult{
+		ReportedPolicy:   sanitizeProducerString(policyName),
+		ReportedRule:     sanitizeProducerString(ruleName),
+		Category:         sanitizeProducerString(nestedStringOrEmpty(resultMap, "category")),
+		Result:           outcome,
+		ReportedSeverity: normalizeSeverity(nestedStringOrEmpty(resultMap, "severity")),
+		Message:          sanitizeProducerString(nestedStringOrEmpty(resultMap, "message")),
+		OriginalSource:   sanitizeProducerString(reportedSource),
+		Properties:       extractProperties(resultMap),
+	}
+
+	id := ComputeID(clusterID, reportRef.UID, canonicalSource, details.ReportedPolicy, details.ReportedRule, subject.UID)
+
+	return SecurityEvent{
+		ID:         id,
+		Source:     canonicalSource,
+		Type:       EventTypePolicyResult,
+		ObservedAt: parseResultTimestamp(resultMap),
+		Report:     reportRef,
+		Subject:    subject,
+		Details:    details,
+	}, true
+}
+
+func isKnownOutcome(o PolicyResultOutcome) bool {
+	switch o {
+	case PolicyResultPass, PolicyResultFail, PolicyResultWarn, PolicyResultError, PolicyResultSkip:
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizeSource maps a report result's own `source` string to a canonical
+// Source. This adapter is registered specifically for Kyverno-shaped
+// wgpolicyk8s.io/v1alpha2 reports, so its own adapter identity (Kyverno) is
+// always the fallback, per security-event-plan.md's source-normalization
+// precedence ("explicit report result source, then ... adapter identity") —
+// the original string is preserved separately in PolicyResult.OriginalSource
+// for diagnostics regardless of what this returns.
+func normalizeSource(_ string) Source {
+	return SourceKyverno
+}
+
+func normalizeSeverity(raw string) Severity {
+	switch Severity(strings.ToLower(strings.TrimSpace(raw))) {
+	case SeverityLow:
+		return SeverityLow
+	case SeverityMedium:
+		return SeverityMedium
+	case SeverityHigh:
+		return SeverityHigh
+	case SeverityCritical:
+		return SeverityCritical
+	default:
+		return SeverityUnknown
+	}
+}
+
+func extractProperties(resultMap map[string]interface{}) map[string]string {
+	rawProps, found, err := unstructured.NestedMap(resultMap, "properties")
+	if err != nil || !found || len(rawProps) == 0 {
+		return nil
+	}
+	props := make(map[string]string, len(rawProps))
+	for k, v := range rawProps {
+		props[sanitizeProducerString(k)] = sanitizeProducerString(fmt.Sprintf("%v", v))
+	}
+	return props
+}
+
+func parseResultTimestamp(resultMap map[string]interface{}) time.Time {
+	tsMap, found, err := unstructured.NestedMap(resultMap, "timestamp")
+	if err != nil || !found {
+		return time.Time{}
+	}
+	seconds, secondsOK := toInt64(tsMap["seconds"])
+	nanos, _ := toInt64(tsMap["nanos"])
+	if !secondsOK || seconds == 0 {
+		return time.Time{}
+	}
+	return time.Unix(seconds, nanos).UTC()
+}
+
+// toInt64 tolerates every numeric representation a `map[string]interface{}`
+// built from JSON/YAML can realistically contain: encoding/json.Unmarshal
+// produces float64, the k8s-flavored decoders can produce int64 or
+// json.Number depending on path. Being defensive here is what lets
+// CanonicalizeKyvernoV1Alpha2 never panic on the unstructured boundary,
+// regardless of which decoder produced the object.
+func toInt64(v interface{}) (int64, bool) {
+	switch t := v.(type) {
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	case float64:
+		return int64(t), true
+	case json.Number:
+		n, err := t.Int64()
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func nestedStringOrEmpty(m map[string]interface{}, field string) string {
+	s, found, err := unstructured.NestedString(m, field)
+	if err != nil || !found {
+		return ""
+	}
+	return s
+}

--- a/pkg/policyreport/kyverno_v1alpha2_test.go
+++ b/pkg/policyreport/kyverno_v1alpha2_test.go
@@ -1,0 +1,360 @@
+package policyreport
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+const testClusterID = "test-cluster-id"
+
+// loadFixtureList reads a captured `kubectl get policyreport -o yaml` List
+// dump (see testdata/raw/README.md for provenance) and returns each item as
+// its own *unstructured.Unstructured, matching what a real CRD informer
+// hands the adapter one object at a time.
+func loadFixtureList(t *testing.T, path string) []*unstructured.Unstructured {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var list struct {
+		Items []map[string]interface{} `json:"items"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &list))
+	require.NotEmpty(t, list.Items, "fixture %s has no items", path)
+
+	reports := make([]*unstructured.Unstructured, 0, len(list.Items))
+	for _, item := range list.Items {
+		reports = append(reports, &unstructured.Unstructured{Object: item})
+	}
+	return reports
+}
+
+func canonicalizeAll(t *testing.T, reports []*unstructured.Unstructured) []SecurityEvent {
+	t.Helper()
+	var all []SecurityEvent
+	for _, r := range reports {
+		events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		all = append(all, events...)
+	}
+	return all
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_RealFixtures exercises the adapter against
+// real `oc get policyreport -o yaml` captures (see testdata/raw/README.md for
+// exactly how/where they were produced), not hand-guessed data.
+func TestCanonicalizeKyvernoV1Alpha2_RealFixtures(t *testing.T) {
+	for name, tc := range map[string]struct {
+		fixture             string
+		expectedTotalEvents int
+	}{
+		"new failures and multi-rule failure": {
+			fixture:             "testdata/raw/01-new-failures-and-multi-rule.yaml",
+			expectedTotalEvents: 9, // 6 report objects; see file for the fail/pass breakdown per object.
+		},
+		"fail-to-pass via pod replacement": {
+			fixture:             "testdata/raw/02-fail-to-pass-via-pod-replacement.yaml",
+			expectedTotalEvents: 7,
+		},
+		"after deployment deletion": {
+			fixture:             "testdata/raw/03-after-deployment-deletion.yaml",
+			expectedTotalEvents: 1, // only the stale, scaled-to-zero ReplicaSet report still fails.
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reports := loadFixtureList(t, tc.fixture)
+			events := canonicalizeAll(t, reports)
+			assert.Len(t, events, tc.expectedTotalEvents)
+
+			// Every actionable event must carry a non-empty ID, policy, rule,
+			// and subject UID — no partially-populated events.
+			for _, e := range events {
+				assert.NotEmpty(t, e.ID)
+				assert.Equal(t, SourceKyverno, e.Source)
+				assert.Equal(t, EventTypePolicyResult, e.Type)
+				assert.NotEmpty(t, e.Details.ReportedPolicy)
+				assert.NotEmpty(t, e.Details.ReportedRule)
+				assert.NotEmpty(t, e.Subject.UID)
+				assert.True(t, ActionableOutcomes[e.Details.Result], "non-actionable outcome leaked through: %s", e.Details.Result)
+			}
+		})
+	}
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_SpotCheckKnownResult pins the exact field
+// values for one specific, known result from fixture 1, so a future
+// refactor can't silently change field mapping without a test noticing.
+func TestCanonicalizeKyvernoV1Alpha2_SpotCheckKnownResult(t *testing.T) {
+	reports := loadFixtureList(t, "testdata/raw/01-new-failures-and-multi-rule.yaml")
+
+	var found *SecurityEvent
+	for _, r := range reports {
+		if r.GetKind() != kindPolicyReport {
+			continue
+		}
+		scope, _, _ := unstructured.NestedMap(r.Object, "scope")
+		if nestedStringOrEmpty(scope, "kind") != "Pod" || nestedStringOrEmpty(scope, "name") != "fail-multi-rule-cdb6d9f8d-pdmq4" {
+			continue
+		}
+		events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		for i := range events {
+			if events[i].Details.ReportedRule == "disallow-latest-tag" {
+				found = &events[i]
+			}
+		}
+	}
+
+	require.NotNil(t, found, "expected to find the disallow-latest-tag result for fail-multi-rule's pod")
+	assert.Equal(t, "require-secure-pod-security-context", found.Details.ReportedPolicy)
+	assert.Equal(t, PolicyResultFail, found.Details.Result)
+	assert.Equal(t, SeverityHigh, found.Details.ReportedSeverity)
+	assert.Equal(t, "kyverno", found.Details.OriginalSource)
+	assert.Contains(t, found.Details.Message, "Using 'latest' image tag is not allowed")
+	assert.Equal(t, "Pod", found.Subject.Kind)
+	assert.Equal(t, "fail-multi-rule-cdb6d9f8d-pdmq4", found.Subject.Name)
+	assert.Equal(t, "security-event-test", found.Subject.Namespace)
+	assert.False(t, found.ObservedAt.IsZero())
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_RejectsWrongAPIVersionOrKind(t *testing.T) {
+	for name, obj := range map[string]map[string]interface{}{
+		"wrong apiVersion": {
+			"apiVersion": "wgpolicyk8s.io/v1beta1",
+			"kind":       kindPolicyReport,
+			"metadata":   map[string]interface{}{"uid": "u1"},
+			"scope":      map[string]interface{}{"uid": "s1", "kind": "Pod"},
+		},
+		"wrong kind": {
+			"apiVersion": KyvernoV1Alpha2APIVersion,
+			"kind":       "SomethingElse",
+			"metadata":   map[string]interface{}{"uid": "u1"},
+			"scope":      map[string]interface{}{"uid": "s1", "kind": "Pod"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: obj})
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_NilReport(t *testing.T) {
+	_, err := CanonicalizeKyvernoV1Alpha2(testClusterID, nil)
+	assert.Error(t, err)
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_MissingOrEmptyScopeIsAnError(t *testing.T) {
+	for name, scope := range map[string]interface{}{
+		"scope missing entirely": nil,
+		"scope.uid empty":        map[string]interface{}{"uid": "", "kind": "Pod"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			obj := map[string]interface{}{
+				"apiVersion": KyvernoV1Alpha2APIVersion,
+				"kind":       kindPolicyReport,
+				"metadata":   map[string]interface{}{"uid": "report-uid"},
+				"results": []interface{}{
+					map[string]interface{}{"policy": "p", "rule": "r", "result": "fail"},
+				},
+			}
+			if scope != nil {
+				obj["scope"] = scope
+			}
+			_, err := CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: obj})
+			assert.Error(t, err)
+		})
+	}
+}
+
+func minimalReport(results []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": KyvernoV1Alpha2APIVersion,
+		"kind":       kindPolicyReport,
+		"metadata": map[string]interface{}{
+			"uid":       "report-uid-1",
+			"name":      "report-name-1",
+			"namespace": "ns1",
+		},
+		"scope": map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"name":       "pod-1",
+			"namespace":  "ns1",
+			"uid":        "pod-uid-1",
+		},
+		"results": results,
+	}}
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_NoResultsFieldOrEmptyIsNotAnError(t *testing.T) {
+	for name, results := range map[string][]interface{}{
+		"nil results":   nil,
+		"empty results": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport(results))
+			require.NoError(t, err)
+			assert.Empty(t, events)
+		})
+	}
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_OnlyPassOrSkipResultsProduceNoEvents(t *testing.T) {
+	events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+		map[string]interface{}{"policy": "p1", "rule": "r1", "result": "pass"},
+		map[string]interface{}{"policy": "p2", "rule": "r2", "result": "skip"},
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_MalformedResultDoesNotDiscardValidSiblings
+// covers Phase 1's validation requirement directly: a single malformed
+// result entry must not prevent its valid siblings in the same report from
+// being canonicalized.
+func TestCanonicalizeKyvernoV1Alpha2_MalformedResultDoesNotDiscardValidSiblings(t *testing.T) {
+	events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+		map[string]interface{}{"policy": "", "rule": "r1", "result": "fail"},    // missing policy
+		map[string]interface{}{"policy": "p2", "rule": "", "result": "fail"},    // missing rule
+		map[string]interface{}{"policy": "p3", "rule": "r3", "result": ""},      // missing result
+		map[string]interface{}{"policy": "p4", "rule": "r4", "result": "bogus"}, // unknown result value
+		"not-even-a-map", // wrong type entirely
+		map[string]interface{}{"policy": "p5", "rule": "r5", "result": "fail"}, // the one valid entry
+	}))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "p5", events[0].Details.ReportedPolicy)
+	assert.Equal(t, "r5", events[0].Details.ReportedRule)
+}
+
+func TestCanonicalizeKyvernoV1Alpha2_UnknownOptionalPropertiesDoNotBreakParsing(t *testing.T) {
+	events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+		map[string]interface{}{
+			"policy":            "p1",
+			"rule":              "r1",
+			"result":            "fail",
+			"someFutureField":   "unrecognized-by-this-adapter-version",
+			"anotherNewFeature": map[string]interface{}{"nested": true},
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "p1", events[0].Details.ReportedPolicy)
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_ReorderingResultsDoesNotChangeIDs is the
+// adapter-level counterpart to identity_test.go's ComputeID guarantee:
+// shuffling the results array must produce the same set of IDs.
+func TestCanonicalizeKyvernoV1Alpha2_ReorderingResultsDoesNotChangeIDs(t *testing.T) {
+	forward := []interface{}{
+		map[string]interface{}{"policy": "p1", "rule": "r1", "result": "fail"},
+		map[string]interface{}{"policy": "p2", "rule": "r2", "result": "fail"},
+		map[string]interface{}{"policy": "p3", "rule": "r3", "result": "fail"},
+	}
+	reversed := []interface{}{forward[2], forward[1], forward[0]}
+
+	forwardEvents, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport(forward))
+	require.NoError(t, err)
+	reversedEvents, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport(reversed))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, idsOf(forwardEvents), idsOf(reversedEvents))
+	// The adapter itself still returns a deterministic (ID-sorted) order
+	// regardless of input order.
+	assert.Equal(t, forwardEvents, reversedEvents)
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_IsIdempotent covers "repeated processing is
+// idempotent": canonicalizing the same report object twice must produce
+// byte-identical output, including ObservedAt (derived from the report's own
+// timestamp field, not wall-clock time).
+func TestCanonicalizeKyvernoV1Alpha2_IsIdempotent(t *testing.T) {
+	reports := loadFixtureList(t, "testdata/raw/01-new-failures-and-multi-rule.yaml")
+	for i, r := range reports {
+		first, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		second, err := CanonicalizeKyvernoV1Alpha2(testClusterID, r)
+		require.NoError(t, err)
+		assert.Equal(t, first, second, "report index %d was not canonicalized idempotently", i)
+	}
+}
+
+// TestCanonicalizeKyvernoV1Alpha2_NormalizationIsDeterministic covers
+// "normalization is deterministic": varying case/whitespace on the
+// producer-supplied source string must always normalize to the same
+// canonical Source, while the original is preserved verbatim (trimmed) for
+// diagnostics.
+func TestCanonicalizeKyvernoV1Alpha2_NormalizationIsDeterministic(t *testing.T) {
+	for name, source := range map[string]string{
+		"lowercase":         "kyverno",
+		"uppercase":         "KYVERNO",
+		"mixed case":        "Kyverno",
+		"surrounding space": "  kyverno  ",
+		"empty":             "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			events, err := CanonicalizeKyvernoV1Alpha2(testClusterID, minimalReport([]interface{}{
+				map[string]interface{}{"policy": "p1", "rule": "r1", "result": "fail", "source": source},
+			}))
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			assert.Equal(t, SourceKyverno, events[0].Source)
+		})
+	}
+}
+
+// FuzzCanonicalizeKyvernoV1Alpha2 fuzzes the unstructured boundary: arbitrary
+// bytes, decoded as YAML/JSON into a generic map and handed to the adapter,
+// must never panic — malformed input should surface as an error (or simply
+// no events), never a crash.
+func FuzzCanonicalizeKyvernoV1Alpha2(f *testing.F) {
+	for _, path := range []string{
+		"testdata/raw/01-new-failures-and-multi-rule.yaml",
+		"testdata/raw/02-fail-to-pass-via-pod-replacement.yaml",
+		"testdata/raw/03-after-deployment-deletion.yaml",
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(data)
+	}
+	// A handful of adversarial seeds: wrong types, deeply nested garbage,
+	// truncated structures.
+	f.Add([]byte(`{"apiVersion":"wgpolicyk8s.io/v1alpha2","kind":"PolicyReport","results":"not-a-list"}`))
+	f.Add([]byte(`{"apiVersion":"wgpolicyk8s.io/v1alpha2","kind":"PolicyReport","scope":123}`))
+	f.Add([]byte(`{"results":[{"policy":1,"rule":[1,2,3],"result":{}}]}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var single map[string]interface{}
+		if err := yaml.Unmarshal(data, &single); err != nil {
+			return
+		}
+		assert.NotPanics(t, func() {
+			_, _ = CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: single})
+		})
+
+		// Also try treating the input as a List of report items, since
+		// that's the shape our real fixtures come in.
+		var list struct {
+			Items []map[string]interface{} `json:"items"`
+		}
+		if err := yaml.Unmarshal(data, &list); err != nil {
+			return
+		}
+		for _, item := range list.Items {
+			assert.NotPanics(t, func() {
+				_, _ = CanonicalizeKyvernoV1Alpha2(testClusterID, &unstructured.Unstructured{Object: item})
+			})
+		}
+	})
+}

--- a/pkg/policyreport/sanitize.go
+++ b/pkg/policyreport/sanitize.go
@@ -1,6 +1,9 @@
 package policyreport
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // maxProducerStringLength bounds any single producer-supplied string field
 // (message, category, reported source, property values, ...). Long enough
@@ -27,7 +30,11 @@ func sanitizeProducerString(raw string) string {
 	sanitized := b.String()
 
 	if len(sanitized) > maxProducerStringLength {
-		return sanitized[:maxProducerStringLength]
+		truncated := sanitized[:maxProducerStringLength]
+		for !utf8.ValidString(truncated) {
+			truncated = truncated[:len(truncated)-1]
+		}
+		return truncated
 	}
 	return sanitized
 }

--- a/pkg/policyreport/sanitize.go
+++ b/pkg/policyreport/sanitize.go
@@ -1,0 +1,33 @@
+package policyreport
+
+import "strings"
+
+// maxProducerStringLength bounds any single producer-supplied string field
+// (message, category, reported source, property values, ...). Long enough
+// for a realistic human-readable message, short enough to bound storage and
+// log volume regardless of what a misbehaving producer sends.
+const maxProducerStringLength = 4096
+
+// sanitizeProducerString trims surrounding whitespace, strips control
+// characters (a misbehaving or malicious producer must not be able to inject
+// them), and truncates to maxProducerStringLength. Used for every
+// producer-supplied string that ends up in a SecurityEvent, per
+// security-event-plan.md's "Source normalization" section ("Apply length
+// limits and reject control characters").
+func sanitizeProducerString(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+
+	var b strings.Builder
+	b.Grow(len(trimmed))
+	for _, r := range trimmed {
+		if r == '\t' || (r >= 0x20 && r != 0x7f) {
+			b.WriteRune(r)
+		}
+	}
+	sanitized := b.String()
+
+	if len(sanitized) > maxProducerStringLength {
+		return sanitized[:maxProducerStringLength]
+	}
+	return sanitized
+}

--- a/pkg/policyreport/sanitize_test.go
+++ b/pkg/policyreport/sanitize_test.go
@@ -1,0 +1,96 @@
+package policyreport
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeProducerString(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"empty string": {
+			input:    "",
+			expected: "",
+		},
+		"whitespace trimmed": {
+			input:    "  hello  ",
+			expected: "hello",
+		},
+		"control characters stripped": {
+			input:    "hello\x00world\x07end",
+			expected: "helloworldend",
+		},
+		"NUL stripped": {
+			input:    "a\x00b",
+			expected: "ab",
+		},
+		"BEL stripped": {
+			input:    "a\x07b",
+			expected: "ab",
+		},
+		"DEL stripped": {
+			input:    "a\x7fb",
+			expected: "ab",
+		},
+		"tabs preserved": {
+			input:    "a\tb",
+			expected: "a\tb",
+		},
+		"newlines stripped": {
+			input:    "a\nb\rc",
+			expected: "abc",
+		},
+		"under limit unchanged": {
+			input:    "short string",
+			expected: "short string",
+		},
+		"at limit unchanged": {
+			input:    strings.Repeat("a", maxProducerStringLength),
+			expected: strings.Repeat("a", maxProducerStringLength),
+		},
+		"over limit truncated": {
+			input:    strings.Repeat("a", maxProducerStringLength+100),
+			expected: strings.Repeat("a", maxProducerStringLength),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := sanitizeProducerString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSanitizeProducerString_UTF8Truncation(t *testing.T) {
+	// 4-byte emoji at the truncation boundary must not be split.
+	prefix := strings.Repeat("a", maxProducerStringLength-2)
+	input := prefix + "\U0001F600" // 4-byte emoji, straddles byte 4094-4097
+
+	result := sanitizeProducerString(input)
+
+	assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+	assert.LessOrEqual(t, len(result), maxProducerStringLength)
+	// The emoji doesn't fit within the byte limit, so it's excluded entirely.
+	assert.Equal(t, prefix, result)
+}
+
+func TestSanitizeProducerString_MultiByteSafe(t *testing.T) {
+	// CJK characters are 3 bytes each.
+	input := strings.Repeat("世", maxProducerStringLength) // way over limit in bytes
+	result := sanitizeProducerString(input)
+
+	assert.True(t, utf8.ValidString(result), "result must be valid UTF-8")
+	assert.LessOrEqual(t, len(result), maxProducerStringLength)
+	// Every rune in the result should be complete.
+	for i := 0; i < len(result); {
+		r, size := utf8.DecodeRuneInString(result[i:])
+		assert.NotEqual(t, utf8.RuneError, r, "no replacement characters allowed")
+		i += size
+	}
+}

--- a/pkg/policyreport/testdata/raw/01-new-failures-and-multi-rule.yaml
+++ b/pkg/policyreport/testdata/raw/01-new-failures-and-multi-rule.yaml
@@ -1,0 +1,332 @@
+apiVersion: v1
+items:
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 31c699a5-1798-49cf-85fb-62725c46779d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-tag-only
+      uid: 31c699a5-1798-49cf-85fb-62725c46779d
+    resourceVersion: "133851"
+    uid: 6c14bf46-fbf8-48f1-ae43-3ed142b631b4
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320712
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320712
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-tag-only
+    namespace: security-event-test
+    uid: 31c699a5-1798-49cf-85fb-62725c46779d
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 46632384-8a71-4bc3-8fac-1b2005113c23
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-tag-only-7f68f8847-k9pd2
+      uid: 46632384-8a71-4bc3-8fac-1b2005113c23
+    resourceVersion: "133570"
+    uid: 13781ace-dd0c-45c7-9da8-333891084753
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule disallow-latest-tag
+      failed at path /spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320717
+  - message: validation rule 'require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320717
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-tag-only-7f68f8847-k9pd2
+    namespace: security-event-test
+    uid: 46632384-8a71-4bc3-8fac-1b2005113c23
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 90c4c107-354f-467e-907a-fa72c98459f0
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-multi-rule-cdb6d9f8d-pdmq4
+      uid: 90c4c107-354f-467e-907a-fa72c98459f0
+    resourceVersion: "133628"
+    uid: fbb4098f-3d11-4ff4-95a7-bead39c19e1b
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule disallow-latest-tag
+      failed at path /spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  - message: 'validation error: Pods must carry a ''team'' label. rule require-team-label
+      failed at path /metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-multi-rule-cdb6d9f8d-pdmq4
+    namespace: security-event-test
+    uid: 90c4c107-354f-467e-907a-fa72c98459f0
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-multi-rule
+      uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    resourceVersion: "133667"
+    uid: 54517f89-e984-47ef-8a5f-3db9c6e56338
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-multi-rule
+    namespace: security-event-test
+    uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7f68f8847
+      uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    resourceVersion: "133309"
+    uid: 1f005714-5112-4713-b8af-aaeb85b397a8
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320713
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320713
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7f68f8847
+    namespace: security-event-test
+    uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-multi-rule-cdb6d9f8d
+      uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    resourceVersion: "133432"
+    uid: 0367218f-1b49-4b08-a5fd-49ea8dd57be7
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-multi-rule-cdb6d9f8d
+    namespace: security-event-test
+    uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+kind: List
+metadata:
+  resourceVersion: ""

--- a/pkg/policyreport/testdata/raw/02-fail-to-pass-via-pod-replacement.yaml
+++ b/pkg/policyreport/testdata/raw/02-fail-to-pass-via-pod-replacement.yaml
@@ -1,0 +1,383 @@
+apiVersion: v1
+items:
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:42Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7ff5d585cc
+      uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    resourceVersion: "134574"
+    uid: f070f491-4a85-4e5e-a080-980b6cb6b77f
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7ff5d585cc
+    namespace: security-event-test
+    uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 5
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 31c699a5-1798-49cf-85fb-62725c46779d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-tag-only
+      uid: 31c699a5-1798-49cf-85fb-62725c46779d
+    resourceVersion: "134571"
+    uid: 6c14bf46-fbf8-48f1-ae43-3ed142b631b4
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-tag-only
+    namespace: security-event-test
+    uid: 31c699a5-1798-49cf-85fb-62725c46779d
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:22Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-tag-only-7ff5d585cc-s2ncj
+      uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    resourceVersion: "134576"
+    uid: b0328cb0-9cc4-4629-8044-ce5865679522
+  results:
+  - message: validation rule 'disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-tag-only-7ff5d585cc-s2ncj
+    namespace: security-event-test
+    uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 90c4c107-354f-467e-907a-fa72c98459f0
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-multi-rule-cdb6d9f8d-pdmq4
+      uid: 90c4c107-354f-467e-907a-fa72c98459f0
+    resourceVersion: "133628"
+    uid: fbb4098f-3d11-4ff4-95a7-bead39c19e1b
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule disallow-latest-tag
+      failed at path /spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  - message: 'validation error: Pods must carry a ''team'' label. rule require-team-label
+      failed at path /metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320721
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-multi-rule-cdb6d9f8d-pdmq4
+    namespace: security-event-test
+    uid: 90c4c107-354f-467e-907a-fa72c98459f0
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-multi-rule
+      uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+    resourceVersion: "133667"
+    uid: 54517f89-e984-47ef-8a5f-3db9c6e56338
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320711
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-multi-rule
+    namespace: security-event-test
+    uid: bd48abf0-f733-4540-8a6a-44cb57c0489a
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7f68f8847
+      uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    resourceVersion: "134663"
+    uid: 1f005714-5112-4713-b8af-aaeb85b397a8
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7f68f8847
+    namespace: security-event-test
+    uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-multi-rule-cdb6d9f8d
+      uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+    resourceVersion: "133432"
+    uid: 0367218f-1b49-4b08-a5fd-49ea8dd57be7
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  - message: 'validation error: Pods must carry a ''team'' label. rule autogen-require-team-label
+      failed at path /spec/template/metadata/labels/team/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320715
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-multi-rule-cdb6d9f8d
+    namespace: security-event-test
+    uid: e3d501a1-9406-4415-b5d0-a5d0fc451e5d
+  summary:
+    error: 0
+    fail: 2
+    pass: 0
+    skip: 0
+    warn: 0
+kind: List
+metadata:
+  resourceVersion: ""

--- a/pkg/policyreport/testdata/raw/03-after-deployment-deletion.yaml
+++ b/pkg/policyreport/testdata/raw/03-after-deployment-deletion.yaml
@@ -1,0 +1,218 @@
+apiVersion: v1
+items:
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:42Z"
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7ff5d585cc
+      uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+    resourceVersion: "134574"
+    uid: f070f491-4a85-4e5e-a080-980b6cb6b77f
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7ff5d585cc
+    namespace: security-event-test
+    uid: 207f7b66-be7e-461b-bdac-eccb1ef2136f
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:37:51Z"
+    generation: 5
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 31c699a5-1798-49cf-85fb-62725c46779d
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: fail-tag-only
+      uid: 31c699a5-1798-49cf-85fb-62725c46779d
+    resourceVersion: "134571"
+    uid: 6c14bf46-fbf8-48f1-ae43-3ed142b631b4
+  results:
+  - message: validation rule 'autogen-disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fail-tag-only
+    namespace: security-event-test
+    uid: 31c699a5-1798-49cf-85fb-62725c46779d
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:39:22Z"
+    generation: 2
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: v1
+      kind: Pod
+      name: fail-tag-only-7ff5d585cc-s2ncj
+      uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+    resourceVersion: "134576"
+    uid: b0328cb0-9cc4-4629-8044-ce5865679522
+  results:
+  - message: validation rule 'disallow-latest-tag' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  - message: validation rule 'require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320772
+  scope:
+    apiVersion: v1
+    kind: Pod
+    name: fail-tag-only-7ff5d585cc-s2ncj
+    namespace: security-event-test
+    uid: 6574d48e-5fd5-41f1-8401-4efc03ebf0e8
+  summary:
+    error: 0
+    fail: 0
+    pass: 2
+    skip: 0
+    warn: 0
+- apiVersion: wgpolicyk8s.io/v1alpha2
+  kind: PolicyReport
+  metadata:
+    creationTimestamp: "2026-07-17T20:38:11Z"
+    generation: 3
+    labels:
+      app.kubernetes.io/managed-by: kyverno
+    name: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    namespace: security-event-test
+    ownerReferences:
+    - apiVersion: apps/v1
+      kind: ReplicaSet
+      name: fail-tag-only-7f68f8847
+      uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+    resourceVersion: "134663"
+    uid: 1f005714-5112-4713-b8af-aaeb85b397a8
+  results:
+  - message: 'validation error: Using ''latest'' image tag is not allowed. rule autogen-disallow-latest-tag
+      failed at path /spec/template/spec/containers/0/image/'
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: fail
+    rule: autogen-disallow-latest-tag
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  - message: validation rule 'autogen-require-team-label' passed.
+    policy: require-secure-pod-security-context
+    properties:
+      process: background scan
+    result: pass
+    rule: autogen-require-team-label
+    scored: true
+    severity: high
+    source: kyverno
+    timestamp:
+      nanos: 0
+      seconds: 1784320779
+  scope:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: fail-tag-only-7f68f8847
+    namespace: security-event-test
+    uid: e31df1d7-dfaa-43df-87fd-53c5ec55ffe7
+  summary:
+    error: 0
+    fail: 1
+    pass: 1
+    skip: 0
+    warn: 0
+kind: List
+metadata:
+  resourceVersion: ""

--- a/pkg/policyreport/testdata/raw/README.md
+++ b/pkg/policyreport/testdata/raw/README.md
@@ -1,0 +1,26 @@
+# Raw PolicyReport fixtures
+
+Captured live from a real cluster, not hand-authored. Provenance:
+
+- Cluster: `infractl`-provisioned OpenShift 4 (`rc-devloop-test`), Kubernetes v1.35.5, CRI-O 1.35.4 (RHAOS 4.22).
+- Kyverno: Helm chart `kyverno/kyverno` 3.8.2, app version v1.18.2, installed with default values (admission, background, cleanup, reports controllers).
+- PolicyReport API: `wgpolicyk8s.io/v1alpha2` (the only version this Kyverno version serves; confirmed via `oc get crd policyreports.wgpolicyk8s.io -o jsonpath='{.spec.versions[*].name}'`).
+- Test `ClusterPolicy` (`require-secure-pod-security-context`, `validationFailureAction: Audit`) with two rules: `disallow-latest-tag` (image tag must not be `latest`) and `require-team-label` (pod must carry a `team` label), annotated `policies.kyverno.io/severity: high`.
+
+## Real behavior these fixtures capture (not assumed from docs)
+
+- **One `PolicyReport` object per resource**, linked via `ownerReferences`, identified by a top-level `scope` field (`apiVersion`/`kind`/`name`/`namespace`/`uid`) — **not** a `results[].resources[]` array as the original plan draft speculated. Kyverno creates separate report objects for the Pod, its ReplicaSet, and its Deployment independently (via "autogen" rules for the higher-level controllers).
+- `results[]` entries carry `policy`, `rule`, `result` (`pass`/`fail`/etc.), `message`, `scored`, `source: kyverno`, a `timestamp`, and — only when set via the `policies.kyverno.io/severity` annotation on the source `ClusterPolicy` — `severity`. It's absent if the policy doesn't set it.
+- A rolling Deployment update that fixes a violation does **not** update the Pod-scoped report in place — the old Pod (and its report, via owner-reference garbage collection) is deleted and an entirely new Pod (new UID) gets a brand new report. In-place updates only happen for reports scoped to a resource whose UID doesn't change (e.g. the Deployment itself).
+- Deleting a Deployment removes its own and its ReplicaSet's reports promptly; the terminating Pod's report lags slightly behind actual pod termination.
+- A ReplicaSet that's scaled to 0 (but not deleted, e.g. kept for rollback history after a rolling update) **keeps its stale report** — report lifetime tracks resource existence, not liveness/replica count. See `03-after-deployment-deletion.yaml`, entry `e31df1d7-...` (`fail-tag-only-7f68f8847`, the pre-rollout ReplicaSet, `DESIRED: 0`).
+
+## Files
+
+1. `01-new-failures-and-multi-rule.yaml` — two Deployments just created: one failing a single rule, one failing both rules (multiple failing rules for one Pod), each with Deployment/ReplicaSet/Pod-scoped reports.
+2. `02-fail-to-pass-via-pod-replacement.yaml` — after fixing the first Deployment's image tag: new Pod, new all-passing report; old Pod/report gone.
+3. `03-after-deployment-deletion.yaml` — after deleting the second (multi-rule-failing) Deployment: its reports are gone; includes the orphaned scaled-to-zero ReplicaSet report described above.
+
+## Deferred to hand-crafted fixtures (not practical to force from a live cluster)
+
+Reordered results and malformed/unknown-property results are authored directly as Go test fixtures in `kyverno_v1alpha2_test.go`, based on the real shape captured here.

--- a/security-event-plan.md
+++ b/security-event-plan.md
@@ -1,0 +1,790 @@
+# Security event plan
+
+This document consolidates the original issue definition and its detailed
+implementation and validation plan.
+
+## Issue: External PolicyReport ingestion and vulnerability enrichment
+
+### Problem
+
+Customers use policy engines such as Kyverno, Gatekeeper, and Kubernetes
+ValidatingAdmissionPolicy alongside ACS. Their findings are reported independently,
+leaving customers without a unified, vulnerability-aware view of policy violations.
+
+ACS already has the cluster context, deployment inventory, vulnerability data, and
+multi-cluster visibility needed to make these external findings more actionable.
+
+### Desired outcome
+
+Ingest PolicyReport and ClusterPolicyReport resources through Sensor, persist them in
+Central, expose them through a scoped read API, and enrich violations with relevant
+deployment vulnerability context.
+
+### Proposed scope
+
+- Watch supported PolicyReport resources when their CRDs are available.
+- Normalize external results into a stable ACS representation.
+- Send create, update, and delete events from Sensor to Central.
+- Reconcile current state after Sensor reconnects.
+- Store violations in PostgreSQL with cluster- and namespace-aware access control.
+- Provide a read-only API supporting filters such as cluster, namespace, source, policy, and severity.
+- Correlate affected Kubernetes objects with ACS deployments.
+- Attach a vulnerability summary, including critical and fixable CVE counts.
+- Protect the integration with a feature flag during development and validation.
+
+### Non-goals
+
+- Deploying or managing external policies.
+- Replacing the ACS policy engine.
+- Performing admission control or enforcement.
+- Automatically remediating violations.
+- Building a complete UI experience in the initial milestone.
+
+### Suggested milestones
+
+1. Parse PolicyReport resources and cover normalization with unit tests.
+2. Demonstrate PolicyReport events flowing from Sensor to Central.
+3. Add reconciliation-correct storage and a scoped read API.
+4. Correlate violations with ACS deployments.
+5. Add vulnerability enrichment and validate at realistic volume.
+
+### Key design questions
+
+- What fields form a stable violation identity across updates and API versions?
+- How are deleted or stale findings removed reliably?
+- Which PolicyReport and OpenReports API versions should be supported?
+- How should Pod findings map to higher-level ACS deployment objects?
+- How should cluster-scoped findings interact with scoped access control?
+- What event-volume and memory bounds are required for large clusters?
+
+### Acceptance criteria
+
+- A supported external policy engine can produce a violation that becomes queryable through ACS.
+- Updates and deletions converge correctly, including after Sensor reconnects.
+- Users cannot read violations outside their authorized cluster and namespace scopes.
+- A violation associated with a known deployment includes a vulnerability summary.
+- Clusters without the relevant CRDs experience no errors or material resource overhead.
+- Existing ACS policy evaluation and enforcement behavior is unchanged.
+
+### Risks
+
+- PolicyReport APIs are evolving and may require multi-version compatibility.
+- Incorrect object correlation could produce misleading enrichment.
+- High-volume reports could increase Sensor or Central load.
+- Treating reports as event history instead of current state could retain stale violations.
+
+### References
+
+- `projects/policy-engine-evolution/spec.md`
+- `pkg/policyreport/`
+- `sensor/kubernetes/listener/resources/policyreport/`
+- `sensor/kubernetes/listener/watcher/policyreport/`
+- `proto/internalapi/central/external_policy_violation.proto`
+- `proto/storage/external_policy_violation.proto`
+
+---
+
+## Implementation and validation plan: Kyverno policy results as ACS violations
+
+## Objective
+
+When Kyverno reports a failing policy result for a Pod owned by a workload, ACS displays it as an ordinary alert on the owning deployment in the main Violations view.
+
+The first production path is deliberately narrow:
+
+```text
+Kyverno PolicyReport/OpenReports PolicyResult
+  -> Sensor SecurityEvent
+  -> Pod-to-deployment resolution
+  -> ACS SECURITY_EVENT policy evaluation
+  -> ordinary AlertResults
+  -> ordinary storage.Alert
+  -> main Violations view
+```
+
+Implementation and validation advance together. Each phase must leave a demonstrable, testable artifact and has a checkpoint at which scope or design can be adjusted before the next layer is added.
+
+## User-visible definition of done
+
+Given a secured cluster running Kyverno:
+
+1. A Kyverno audit policy reports a property of a Pod template, such as use of a privileged container, as noncompliant.
+2. A Deployment creates a Pod that produces a failing Kyverno report result.
+3. Sensor discovers the result and associates the Pod with its owning ACS deployment.
+4. Central receives and stores an ordinary ACS alert.
+5. The main Violations view shows the alert against that Deployment.
+6. The alert identifies Kyverno, the reported policy and rule, the original Pod, result, reported severity, and message.
+7. Existing cluster, namespace, deployment, policy, state, and severity filtering works.
+8. Applicable ACS scopes and exclusions prevent unwanted alerts.
+9. Fixing or deleting the violating workload causes the alert to resolve.
+10. Sensor reconnect and report reordering do not create duplicates or leave stale active alerts.
+
+## Guiding decisions
+
+### Reuse the standard alert path
+
+The primary user-facing object is `storage.Alert`. A separate integration-specific table or screen is not the MVP. Producer fields are retained as alert violation details.
+
+### Treat reports as current state
+
+PolicyReport resources are state aggregates, not durable event logs. Correctness is defined by idempotence and eventual convergence rather than global event ordering.
+
+### Use a source-neutral event envelope
+
+`SecurityEvent` is the canonical ingestion envelope. It contains common provenance, subject, resolved entity, and observation time plus a typed payload. The first payload is `PolicyResult`; later adapters may add `FileIntegrityResult` or `SecurityProfileDenial` without flattening their semantics into policy-result fields.
+
+The producer boundary is represented by `SecurityEvent.source`, not by calling the event external. Kyverno, FIO, SPO, Compliance Operator, Kubernetes admission, and ACS are all potential security-event sources from a customer's perspective.
+
+### Evaluate through an explicit event source
+
+Add `SECURITY_EVENT` to the policy event-source model. Security-event criteria are valid only for that source, and payload-specific criteria are valid only for compatible event types. A default catch-all ACS policy makes initial Kyverno failures visible without requiring customers to author a policy first.
+
+Validated against the current code (`pkg/booleanpolicy/validate.go`): the minimum-required-fields mechanism (`eventSourceRequirements`) is a plain `map[storage.EventSource]set.StringSet`, checked generically with no per-source logic. `DEPLOYMENT_EVENT`/`NOT_APPLICABLE` today require zero fields; `NODE_EVENT` requires exactly one (`File Path`). Adding `SECURITY_EVENT` with zero or one required field is a single map entry — no changes needed to the validation functions themselves. The new enum value does, however, need an explicit case added at several other non-exhaustive `switch policy.GetEventSource()` call sites for it to actually function end to end: `pkg/detection/compiled_policy.go` (compilation/matcher wiring, two switches), `pkg/detection/runtime/utils.go`, `central/policy/service/validator.go` (`validateEventSource` and its `isAuditLogEventSource`/`isNodeEventSource`-style helpers), and Sensor's settings-propagation managers (`sensor/common/filesystem/settings_manager.go`, `sensor/common/admissioncontroller/settings_manager_impl.go`). None of this is hard, but it's not isolated to one file — track it as a checklist when Phase 4 lands.
+
+### Ship a default, built-in policy before a customer-facing criteria language
+
+The MVP does not need customers to author their own `SECURITY_EVENT` match criteria. Split Phase 4 into two parts:
+
+1. **MVP**: one feature-flagged, built-in `storage.Policy` row (visible/clonable in the Policies UI like any other default policy, but with a single trivial required criterion, e.g. "Security Event Type equals PolicyResult") that the detector matches against unconditionally for every actionable, deployment-resolved finding. Because it's a real `Policy`, exclusions, scoping/RBAC, enable/disable, notifier dispatch, and the standard `Alert` lifecycle/UI all work for free — none of that infrastructure is specific to how rich the match criteria are.
+2. **Deferred**: the full `PolicyResult` field vocabulary (Reported Policy, Reported Rule, Policy Result, Reported Severity as independently matchable criteria) and the field-metadata/validation/matcher build-out this doc originally scoped as all of Phase 4. Build this only once there's real demand for customer-authored filtering (e.g. "only alert on HIGH severity Kyverno findings") — retrofitting it onto the default-policy plumbing later is additive, not a rewrite, since both share the same `SECURITY_EVENT` source and detector path.
+
+This was chosen over building a separate, non-policy-engine violation store (what the deleted prototype under `central/externalpolicyviolation/` attempted): a parallel system would have to reimplement exclusions/scoping/notifiers/lifecycle/UI rendering from scratch, and would fragment the user's mental model of "where do I check for problems" — something the Deferred scope section below already rules out ("a separate security-events or integration-findings UI").
+
+### Keep signal and violation semantics separate
+
+A `SecurityEvent` is reported evidence. An ACS policy decides whether that evidence creates a violation. Producer severity remains reported data; ACS policy severity controls the resulting alert unless a later product decision explicitly introduces severity inheritance.
+
+### Reuse ResourceAction for lifecycle
+
+The report result is current state. `ResourceAction` expresses observation, update, and removal during transport. Stable event identity connects those actions, and reconciliation ensures convergence. Do not duplicate lifecycle state inside `SecurityEvent` unless an existing pipeline contract requires it.
+
+### Resolve identity before evaluation
+
+Sensor performs Pod-to-deployment resolution using Kubernetes UID and owner relationships. The canonical event retains both the original subject and resolved ACS entity.
+
+### Prefer adapters over a version-specific domain model
+
+Version-specific report adapters produce one internal canonical event. Start with the report API observed in the test fixture, then add `openreports.io/v1alpha1` without changing detection or alert creation.
+
+## Scope
+
+### MVP scope
+
+- Kyverno-produced namespaced reports.
+- Results `fail`, `error`, and `warn`.
+- Report-level Pod scope.
+- Pod UID to ACS Deployment resolution.
+- `SECURITY_EVENT` with `PolicyResult` payload matching.
+- Security-event source, type, reported policy, reported rule, result, reported severity, and subject-kind criteria.
+- Default catch-all Kyverno policy-result ACS policy.
+- Standard alert creation, filtering, exclusions, notification compatibility, and resolution.
+- Feature-flagged rollout.
+
+### Deferred scope
+
+- Blocked admission attempts for resources that were never created.
+- Node, cluster, and arbitrary Kubernetes-resource entities.
+- Pass and skip results as alerts.
+- ACS context projected back into Kyverno.
+- Automatic enforcement or remediation.
+- A separate security-events or integration-findings UI.
+- Vulnerability enrichment beyond what the standard deployment alert view already provides.
+- Kyverno intermediary AdmissionReport and BackgroundScanReport CRDs.
+
+## Canonical domain contract
+
+The exact protobuf shape should follow repository conventions, but the logical contract is:
+
+```text
+SecurityEvent
+  id
+  source
+  type
+  observed_at
+
+  report
+    api_version
+    kind
+    uid
+    name
+    namespace
+    resource_version
+
+  subject
+    api_version
+    kind
+    uid
+    name
+    namespace
+
+  resolved_entity
+    type
+    id
+
+  details (oneof)
+    PolicyResult
+      reported_policy
+      reported_rule
+      category
+      result
+      reported_severity
+      message
+      properties
+
+    // Deferred until a real adapter is implemented:
+    FileIntegrityResult
+    SecurityProfileDenial
+```
+
+Use typed enums for event type, policy result, reported severity, and entity type. Represent producer source as a normalized, bounded string unless repository compatibility conventions strongly favor an enum. A string permits a standards-based report producer to integrate without requiring a new ACS protobuf release; well-known sources still receive canonical display names. Preserve unknown producer properties inside the typed payload without making arbitrary properties policy criteria by default.
+
+### Source normalization
+
+Adapters must normalize source safely and predictably:
+
+- Preserve the original producer source in details for diagnostics.
+- Generate a canonical source used for matching and display, such as `Kyverno`.
+- Apply length limits and reject control characters.
+- Never infer source solely from free-form message text.
+- Prefer an explicit report result source, then well-known management labels, then the adapter identity.
+- Record the normalization method in tests, not as customer-visible mutable state.
+
+Adding support for an unknown source must not require changes to the core detector. Adding a new event type or typed payload does require an explicit schema and policy-language decision.
+
+### Alert representation
+
+`SecurityEvent` is an ingestion and evaluation object; `storage.Alert` remains the durable customer object. During Phase 4, decide whether to:
+
+1. Add typed security-event attributes to `storage.Alert.Violation`, or
+2. Reuse its existing key/value attributes with a stable, documented key set.
+
+Prefer typed attributes if key/value reuse would make search indexing, API evolution, or UI rendering depend on string conventions. Whichever representation is chosen must preserve source, type, reported policy, reported rule, subject, result, reported severity, and message in the ordinary alert without requiring a parallel user-facing datastore.
+
+### Semantic layers
+
+Keep the terms distinct throughout APIs, metrics, logs, and UI:
+
+| Layer | Term | Kyverno example |
+|---|---|---|
+| Producer output | Report result | A failed PolicyReport entry |
+| Canonical ingestion | Security event | Source Kyverno, type Policy Result |
+| Typed evidence | Policy result | Policy, rule, result, message |
+| ACS decision | Violation | An ACS policy matched the event |
+| Stored/presented object | Alert | Deployment alert in the Violations view |
+
+### Stable identity
+
+Do not use result-array position or observation timestamp. The initial identity input should be:
+
+```text
+cluster ID
++ report UID
++ normalized source
++ reported policy name
++ rule name
++ subject UID
+```
+
+If fixtures reveal legitimate duplicate results with this tuple, add the smallest stable producer-provided discriminator. Document and test any identity change because it affects alert continuity.
+
+## Phase 0: fixtures, baseline, and seam confirmation
+
+### Implementation
+
+- Capture sanitized fixtures produced by supported Kyverno versions for:
+  - a new failing Pod result;
+  - multiple failing rules for one Pod;
+  - fail-to-pass or fail-to-absent transition;
+  - reordered results;
+  - report deletion;
+  - a report with no actionable results.
+- Capture both report API shapes intended for eventual support.
+- Trace and document the existing paths for:
+  - unstructured CRD discovery and informer registration;
+  - Sensor resource reconciliation;
+  - Pod-to-deployment ownership lookup;
+  - discrete-event policy matching;
+  - `AlertResults` delivery and alert resolution.
+- Record baseline behavior of the main Violations view using a normal deployment runtime alert.
+- Inventory naming collisions with existing Kubernetes Event, audit event, SensorEvent, AlertResults, and ACS policy event-source types.
+- Trace how `storage.Alert.Violation` attributes are serialized, indexed, exposed through APIs, and rendered by the main view.
+
+### Validation
+
+- Reproduce fixture generation in a disposable cluster with a pinned Kyverno version.
+- Verify where subject identity resides (`scope`, owner reference, or version-specific equivalent).
+- Verify whether a corrected workload removes a result, changes it to pass, or replaces the report.
+- Measure the delay from workload creation to final report update.
+
+### Checkpoint 0
+
+Proceed when the final report provides a stable Pod UID and observed transitions can be represented as create/update/remove.
+
+Adjust if:
+
+- Final reports do not reliably identify the subject: evaluate owner references or a narrowly scoped Kyverno adapter.
+- Report latency is too high for the desired UX: retain the state path but separately investigate admission signals; do not couple the MVP to intermediary CRDs.
+- Corrected resources do not converge reliably: make periodic reconciliation mandatory before continuing.
+- `SecurityEvent` is too ambiguous in an affected API/package: qualify the package or local Go type rather than changing customer-facing terminology prematurely.
+
+## Phase 1: canonicalization as a pure, versioned adapter
+
+### Implementation
+
+- Define the internal canonical event and typed result/severity mappings.
+- Define normalized source and event type independently: `source=Kyverno`, `type=PolicyResult`.
+- Implement a pure adapter from the first report API version.
+- Read subject information from report-level scope.
+- Normalize source and result values without discarding the original strings.
+- Return a deterministic collection sorted by canonical ID.
+- Diff old and new report objects:
+  - new minus old -> create;
+  - shared identity with changed content -> update;
+  - old minus new -> remove.
+- Treat report deletion as removal of every previously actionable result.
+
+### Validation
+
+- Table-driven unit tests using the captured fixtures.
+- Property-style tests for:
+  - result reordering does not change IDs;
+  - repeated processing is idempotent;
+  - unknown optional properties do not break parsing;
+  - malformed individual results do not discard valid siblings;
+  - normalization is deterministic.
+- Fuzz the unstructured-object boundary and assert no panics.
+- Test source normalization, length bounds, unknown sources, and conflicting source hints.
+
+### Checkpoint 1
+
+Review the canonical contract before adding generated APIs or wiring. Confirm that it contains only producer facts and entity references, not ACS alert-policy decisions. Confirm that adding a future typed payload does not require changing the Kyverno adapter.
+
+Adjust if:
+
+- Identity collisions occur: incorporate a stable discriminator supported by fixtures.
+- API versions differ substantially: create explicit adapters behind one interface rather than adding version conditionals throughout the dispatcher.
+- Report updates replace results too aggressively: model the entire report as a snapshot and rely on set reconciliation.
+
+## Phase 2: Sensor watch and observable dry-run flow
+
+### Implementation
+
+- Register report CRDs using the established optional-CRD availability pattern.
+- Start no informer when the feature flag is disabled.
+- Handle CRD absence and removal without degrading Sensor health.
+- Feed canonical events into a bounded internal queue or the existing resource-event pipeline.
+- Add dry-run diagnostics and metrics before producing alerts:
+  - reports observed;
+  - actionable results canonicalized;
+  - parse failures;
+  - create/update/remove operations;
+  - processing latency;
+  - queue pressure or drops.
+- Do not log full producer messages or properties at info level.
+
+### Validation
+
+- Unit tests for availability and informer registration.
+- Component test with a fake dynamic client covering add, update, delete, and CRD absence.
+- Disposable-cluster test proving that a real Kyverno result reaches the dry-run handler.
+- Load a synthetic report set large enough to expose unbounded allocation or excessive logging.
+
+### Checkpoint 2
+
+Demo one real Kyverno failure reaching Sensor with stable identity and correct lifecycle operations. Review report latency and resource cost.
+
+Adjust if:
+
+- Watch volume is excessive: filter persisted result types operationally, reduce retained object data, or evaluate the reports-server path.
+- Informer wiring duplicates existing generic CRD infrastructure: refactor only the minimum reusable seam needed by this adapter.
+- Metrics reveal frequent malformed results: preserve forward compatibility and expose producer/version diagnostics.
+
+## Phase 3: Pod-to-deployment resolution
+
+### Implementation
+
+- Resolve a report subject by Pod UID first, then namespace/name only as a guarded fallback.
+- Traverse the existing Sensor ownership model to the ACS deployment identity.
+- Retain the original Pod reference in the canonical event.
+- Classify unresolved subjects explicitly instead of silently dropping them.
+- Record resolution method and failure reason in bounded metrics.
+- Define behavior for terminated Pods whose report remains briefly visible.
+
+### Validation
+
+- Table-driven tests for:
+  - Pod -> ReplicaSet -> Deployment;
+  - Pod -> StatefulSet;
+  - Pod -> DaemonSet;
+  - Pod -> Job/CronJob if represented by the ACS deployment model;
+  - standalone Pod;
+  - missing owner;
+  - deleted Pod;
+  - namespace/name reuse with a different UID.
+- Integration test against Sensor stores with a realistic ownership chain.
+- Real-cluster test confirms the resolved ACS deployment ID matches the UI deployment.
+
+### Checkpoint 3
+
+Require a high successful-resolution rate for supported workload types in the fixture and cluster test set. Do not silently convert unresolved Pod findings into deployment alerts.
+
+Adjust if:
+
+- Deleted Pods frequently fail resolution: add a bounded UID-to-deployment tombstone cache with explicit retention.
+- Job/CronJob ownership does not map cleanly: defer those types and expose them as unresolved metrics.
+- Name fallback produces ambiguity: remove it from production behavior and require UID-based resolution.
+
+## Phase 4: security event source and PolicyResult matching
+
+### Implementation — MVP (Phase 4a)
+
+- Add `SECURITY_EVENT` to the storage policy event-source enum, plus a single minimal field (e.g. Security Event Type) as its only `eventSourceRequirements` entry — see the "Ship a default, built-in policy" guiding decision above. Update the non-exhaustive `EventSource` switch call sites listed there so the new value is actually recognized end to end.
+- Define a dedicated detector entry point that accepts the resolved deployment and `SecurityEvent`, matching unconditionally against the one built-in default policy (no field-level criteria beyond the minimal required field).
+- Produce standard alert violations containing source, reported policy, reported rule, subject, result, reported severity, and message — packed into the violation message/details even before any of these are independently matchable criteria.
+- Ensure security events have no enforcement actions in the initial release.
+- Choose and implement the alert-violation representation described in the canonical contract (needed regardless of how much of the criteria language exists).
+
+### Implementation — deferred (Phase 4b, gated on demand)
+
+- Add common field names and metadata beyond the MVP minimum: Security Event Source, Subject Kind.
+- Add `PolicyResult` field names and metadata: Reported Policy, Reported Rule, Policy Result, Reported Severity, each independently matchable.
+- Restrict common fields to `SECURITY_EVENT` and payload fields to compatible event types during validation.
+- Compile a full matcher over `SecurityEvent` with typed `PolicyResult` accessors (today's minimal detector only needs an unconditional match, not a compiled matcher).
+- Keep arbitrary `properties` out of the policy language even at this stage; retain them for details and diagnostics only.
+- Document policy field display labels independently of protobuf and Go identifiers.
+
+### Validation
+
+- Policy validation tests reject security-event fields on incompatible event sources.
+- Policy validation tests reject `PolicyResult` fields for incompatible security-event types.
+- Unknown but valid event sources can be matched without recompiling the detector.
+- Matcher tests cover exact, multi-value, negated, and multi-group criteria.
+- Detector tests prove:
+  - matching policies create an alert;
+  - nonmatching policies do not;
+  - multiple matching reported rules remain distinguishable **as separate violation entries within one alert**, not as separate alerts (see validated finding below);
+  - repeated events deduplicate;
+  - remove operations resolve the expected alert **once no actionable findings remain for that deployment** (whole-alert resolve, not per-violation — see below).
+- Backward-compatibility and generated-proto checks pass.
+
+**Validated finding (`central/detection/alertmanager/alert_manager_impl.go`, `proto/storage/alert.proto`)**: `Alert_Violation` has no independent lifecycle — no per-violation state, and `ResolveAlertRequest` only takes a whole alert ID. Alerts merge by `(PolicyID, ViolationState, Entity)`, so every concurrent Kyverno finding against the same deployment, under the one default policy, accumulates into a **single Alert** (violations list capped at 40, oldest evicted first on merge). Consequence: if a deployment fails two Kyverno rules and only one gets fixed, the alert correctly stays active — resolution is "no active findings remain," matching Definition of done #9's literal wording, but a fixed rule's violation entry can linger in the list until evicted or the whole alert resolves, rather than disappearing immediately. Accepted as correct MVP behavior; revisit only if user testing (Checkpoint 6) shows this is confusing.
+
+### Checkpoint 4
+
+Review policy semantics with UI and policy owners before creating the default policy. Confirm whether `warn` should alert by default and whether reported severity is only match data or also influences ACS severity.
+
+Initial recommendation:
+
+- ACS policy severity controls alert severity.
+- Reported severity remains visible and filterable within event criteria/details.
+- `fail` and `error` match the default policy.
+- `warn` support exists but default behavior is decided using product feedback.
+
+Also decide the alert-detail representation here. Do not proceed with an undocumented string-key contract if the fields need first-class search or API compatibility guarantees.
+
+## Phase 5: first end-to-end standard alert
+
+### Implementation
+
+- Connect the detector output to the existing Sensor `AlertResults` path.
+- Use the resolved deployment ID and the existing deployment alert path. Preserve `SecurityEvent.source` and type in violation details without misrepresenting producer provenance as an ACS detector.
+- Ensure Central constructs and stores an ordinary `storage.Alert`.
+- Preserve original event time while recording normal ACS first/last occurrence semantics.
+- Add a feature-flagged default policy named `Reported Kubernetes policy violation` or another product-reviewed name that does not use “external.”
+- Give the policy no enforcement actions.
+
+### Validation
+
+- Focused Sensor-to-Central integration test covering create and resolve.
+- Verify alert ID stability across identical report resyncs and result reordering.
+- Verify the stored alert contains the correct cluster, namespace, Deployment, policy snapshot, lifecycle stage, and violation details.
+- Verify no separate security-event datastore is required for the main user-facing path.
+- Run existing alert lifecycle and deduplication tests affected by the new source.
+
+### Checkpoint 5: first product demo
+
+Demonstrate:
+
+1. Create a violating Deployment.
+2. Observe the Kyverno report.
+3. Observe Sensor canonicalization and deployment resolution metrics.
+4. Query the standard Central alert API and find the active deployment alert.
+5. Correct the Deployment and observe the same alert resolve.
+
+At this checkpoint, decide whether to proceed directly to UI work or first repair lifecycle or identity gaps. Do not expand entity types until create/update/resolve is reliable.
+
+## Phase 6: main Violations view integration
+
+### Implementation
+
+- Render the alert through the existing deployment-violation presentation.
+- Show event provenance in violation details:
+  - source;
+  - event type;
+  - reported policy;
+  - reported rule;
+  - original subject;
+  - reported severity and result;
+  - message.
+- Reuse normal cluster, namespace, deployment, ACS policy, lifecycle, severity, and state filters.
+- Add source or reported-policy filters only if the existing search model cannot express the required workflow.
+- Add search/index fields required for the agreed workflows:
+  - Security Event Source;
+  - Security Event Type;
+  - Reported Policy;
+  - Reported Rule, if justified by expected usage.
+- Keep `Policy` as the ACS policy filter; label producer policy explicitly as `Reported Policy` to avoid ambiguity.
+- Verify sorting semantics for source and reported policy, including absent values on ACS-native alerts.
+- Ensure alert links navigate to the resolved Deployment.
+
+**Validated findings that shape this phase (`ui/apps/platform/src/Containers/Violations/`, `pkg/search/options.go`)**:
+- Sorting is entirely server-side: every sortable column's `sortField` must match a `FieldLabel` registered in `pkg/search/options.go`, which drives the actual Postgres `ORDER BY`. Since `Alert.violations` is stored as an opaque protobuf blob (`search:"-"`, no Postgres column of its own), **Reported Policy/Rule/Severity/Source must be promoted to real top-level `search:`-tagged fields on `storage.Alert`** (not left inside the violation message) before they can be sorted or used as a workflow-view filter. This is a small, targeted proto + schema + search-option change — separate from, and does not require, the Phase 4b customer-criteria language.
+- The "Platform"/"Node" split some teams call "tabs" is actually a shared `NavList` sub-nav (`filteredWorkflowView`, also reused by the Risk page), where each item maps to a hardcoded `SearchFilter` on existing fields (`Entity Type`, `Platform Component`) — not a literal `Tabs` component (that's reserved for the separate Active/Resolved/Attempted `ViolationState` tabs). A future "Security Events" nav item is a small, additive UI change (one literal in `FilteredWorkflowViewSelector/types.ts`, one route, one `NavigationItem`, one `switch` case) once it has a real backend field to filter on — decoupled from Phase 4b, can land as soon as the search-field promotion above is done.
+
+### Validation
+
+- UI unit/component tests for rendering and filtering.
+- API and PostgreSQL search tests for new alert search fields.
+- Mixed-result tests containing ACS-native and security-event-derived alerts.
+- Browser-level validation against a real or fixture-backed Central.
+- Accessibility and truncation tests for long producer messages and reported policy names.
+- Confirm the alert is visible in existing totals and does not require a separate page.
+
+### Checkpoint 6: user workflow review
+
+Have a user complete these tasks without implementation knowledge:
+
+- Find all active Kyverno-derived violations.
+- Filter them to one cluster and namespace.
+- Open the affected Deployment.
+- Identify the original Kyverno policy and rule.
+- Determine whether the violation is still active.
+- Distinguish the ACS policy from the Kyverno reported policy without documentation.
+
+Adjust labels, details, and filters based on observed confusion rather than adding a new view preemptively.
+
+## Phase 7: exclusions, scopes, notifications, and reconciliation
+
+### Implementation
+
+- Apply existing deployment policy scope and exclusion logic before alert emission.
+- Confirm namespace, deployment, image, and expiration-based exclusions that are meaningful for runtime deployment alerts.
+- Exercise existing notifier selection without adding producer-specific notification code.
+- Add Sensor reconnect reconciliation for active canonical IDs.
+- Reject or ignore stale report resource versions where the pipeline can observe them.
+- Bound any tombstone or reconciliation state.
+
+### Validation
+
+- End-to-end tests for:
+  - namespace exclusion;
+  - deployment exclusion;
+  - exclusion expiration;
+  - scoped policy inclusion;
+  - notifier invocation;
+  - Sensor disconnect during report update;
+  - reconnect with a result removed while disconnected;
+  - report deletion;
+  - duplicate delivery;
+  - out-of-order stale update.
+- Restart Sensor and Central independently and verify convergence.
+
+### Checkpoint 7: reliability gate
+
+Proceed to broader rollout only when repeated restart and reconnect testing produces no duplicate active alerts and no stale alerts beyond the documented convergence interval.
+
+If convergence cannot use the standard alert pipeline safely, introduce the minimum durable security-event index required for reconciliation; do not expose it as a second user-facing model.
+
+## Phase 8: compatibility, scale, and rollout
+
+### Implementation
+
+- Add the second report API adapter, expected to be `openreports.io/v1alpha1`.
+- Detect available APIs independently and prevent duplicate ingestion when a producer writes both formats.
+- Add component capability negotiation if required for Central/Sensor version skew.
+- Define feature-flag upgrade and downgrade behavior.
+- Add support bundle diagnostics for:
+  - discovered report APIs;
+  - watched report count;
+  - canonicalization failures;
+  - resolution rate;
+  - active event count;
+  - reconciliation status.
+
+### Validation
+
+- Compatibility matrix:
+  - supported Kyverno versions;
+  - each supported report API;
+  - reports absent;
+  - both report APIs present;
+  - Sensor older than Central;
+  - Central older than Sensor, where supported.
+- Scale tests with representative numbers of clusters, reports, results, and update bursts.
+- Measure Sensor CPU/memory, API watch traffic, Central ingest rate, alert storage growth, and UI query latency.
+- Security review untrusted strings, property sizes, RBAC, scoped access, and log handling.
+
+### Checkpoint 8: rollout decision
+
+Roll out in stages:
+
+1. Development-only feature flag.
+2. Internal or selected-cluster dogfood.
+3. Opt-in customer preview with diagnostics.
+4. Default-on ingestion with default policy behavior decided from preview data.
+5. Remove the feature flag only after upgrade, scale, and support evidence is complete.
+
+Pause or narrow rollout if:
+
+- report watch load materially affects cluster API performance;
+- deployment resolution is below the agreed threshold;
+- alert churn or duplication is visible;
+- default policy volume overwhelms the main Violations view;
+- Kyverno/report-version compatibility requires producer-specific semantics in the core detector.
+
+## Expansion checkpoints and additional adapters
+
+Expansion should be evidence-driven and performed one entity, source, or typed payload at a time. Adding an adapter must not require producer-specific conditionals in the core detector.
+
+### File Integrity Operator
+
+Use `FileIntegrityNodeStatus` as the authoritative current-state input and canonicalize relevant results as:
+
+```text
+SecurityEvent
+  source: OPENSHIFT_FILE_INTEGRITY_OPERATOR
+  type: FILE_INTEGRITY_RESULT
+  details: FileIntegrityResult
+  subject: Node
+```
+
+Map Kubernetes node identity to an ACS Node and use the standard Node alert path. Treat a clean subsequent scan as resolution. Treat scan execution errors separately from actual file-integrity changes. Kubernetes Events may supplement transition detail but must not be authoritative reconciliation state.
+
+Gate implementation on the Kyverno adapter proving that a second typed payload can reuse transport, entity resolution, policy evaluation, and alert creation without weakening type safety.
+
+### Security Profiles Operator
+
+Separate three SPO concerns:
+
+- Runtime seccomp/AppArmor/SELinux denials become `SecurityProfileDenial` events and map to Deployment when Pod/container identity is available, otherwise Node.
+- Profile installation/readiness failures are resource or platform health results and require a product decision before entering the main Violations view.
+- Profile inventory and recording outputs are posture context, not violations by default.
+
+Before implementation, capture supported structured denial output and decide whether Collector, Sensor, or another supported stream owns ingestion. Do not infer runtime denials solely from profile CRD readiness.
+
+### Node-scoped policy results
+
+Add when real reports contain reliable Node UID or Kubernetes node-name scope. Reuse the standard Node alert path and validate node-specific scopes and UI behavior.
+
+### Cluster and generic resource events
+
+First decide whether ACS needs a first-class Cluster alert entity. Do not model cluster findings as fake deployments. Generic Resource may be an interim representation only if filtering and UI semantics remain truthful.
+
+### Blocked admission attempts
+
+Treat these as event history rather than report state. Investigate the existing Kubernetes audit path or supported producer output. Kubernetes `Event` objects are best-effort and should be supplemental. Do not consume Kyverno intermediary report CRDs by default.
+
+### Vulnerability and runtime enrichment
+
+After standard deployment alerts work, verify which enrichment is already available through the normal alert and deployment views. Add only missing context that materially improves prioritization.
+
+## Validation environments
+
+Maintain three layers:
+
+### Fast local tests
+
+- Pure adapter, identity, diff, matcher, resolution, and policy-validation tests.
+- Must run without Kubernetes or PostgreSQL.
+
+### Component integration tests
+
+- Fake dynamic client and Sensor stores.
+- Sensor-to-Central alert lifecycle.
+- PostgreSQL-backed alert queries where storage behavior changes.
+
+### Disposable-cluster scenario
+
+- Pinned Kubernetes and Kyverno versions.
+- Installs ACS components required for the flow.
+- Creates, updates, and deletes a known violating Deployment.
+- Captures report, metrics, Central API result, and final resolution as artifacts.
+- Runs on demand initially; promote to periodic CI after stability is demonstrated.
+
+## Operational success measures
+
+- Percentage of actionable Pod-scoped results resolved to an ACS deployment.
+- P50/P95 time from report resource version to visible Central alert.
+- Duplicate alert rate after report updates and Sensor reconnects.
+- Stale active alert count after convergence interval.
+- Sensor CPU and memory per 1,000 watched reports.
+- Canonicalization error rate by API version and producer.
+- Number of alerts suppressed by scopes and exclusions.
+- Main Violations query latency and alert-volume change.
+
+Initial thresholds should be recorded during dogfood rather than invented before measurement. Promotion between rollout stages requires explicit agreed thresholds.
+
+## Pull request decomposition
+
+Keep changes independently reviewable and reversible:
+
+1. Fixtures and pure canonicalizer with identity/diff tests.
+2. Optional CRD discovery and dry-run metrics.
+3. Pod-to-deployment resolver and tests.
+4. Policy enum, criteria metadata, validation, and matcher.
+5. Security-event detector with `PolicyResult` matching producing standard `AlertResults`.
+6. Central standard-alert lifecycle and reconciliation integration.
+7. Default policy behind the feature flag.
+8. Main Violations rendering and workflow tests.
+9. Exclusions, notifier, restart, and reconnect validation.
+10. OpenReports adapter, compatibility diagnostics, and scale hardening.
+
+Avoid combining generated protobuf output, Sensor wiring, Central lifecycle changes, and UI changes into one initial pull request.
+
+## Immediate next actions
+
+Done (PR #1 — `pkg/policyreport/`, fixtures + pure canonicalizer):
+
+1. ~~Validate the current prototype against a real Kyverno report and correct it to use report-level scope.~~ Done against real Kyverno v1.18.2 output — corrected the schema assumption to a single top-level `scope` field per report object (see `pkg/policyreport/testdata/raw/README.md`), not the `results[].resources[]` array originally assumed here.
+2. ~~Replace result-index identity with semantic stable identity.~~ Done (`pkg/policyreport/identity.go`).
+3. ~~Add old/new snapshot diff tests before adding more wiring.~~ Done (`pkg/policyreport/diff.go` + tests).
+4. ~~Locate and document the exact existing Pod-to-deployment resolver to reuse.~~ Done — `references.ParentHierarchy.TopLevelParents(podUID)` + `DeploymentStore`, both exposed via `StoreProvider`.
+5. ~~Trace the smallest existing discrete-event detector path that produces a deployment `AlertResults` message.~~ Done — the file-access path in `sensor/common/detector/detector.go` is the template (already conditionally sets `AlertResults.Source`).
+7. ~~Produce the Phase 0 disposable-cluster fixtures and record report convergence behavior.~~ Done — 3 real fixtures captured from a live cluster (see `pkg/policyreport/testdata/raw/`).
+
+Superseded: item 6 below (draft `SecurityEvent`/`PolicyResult` protobuf) is deferred, not skipped — see "Ship a default, built-in policy" above. The MVP no longer needs the full field vocabulary drafted up front, only the minimal shape needed for Phase 4a.
+
+Next (PR #2 onward):
+
+1. Register the `wgpolicyk8s.io/v1alpha2` CRDs in Sensor behind a feature flag (Phase 2), copying the VirtualMachine/KubeVirt availability-checker + CRD-watcher pattern.
+2. Wire Pod-to-Deployment resolution using the already-identified existing mechanism (Phase 3) — no new resolver needed.
+3. Add `SECURITY_EVENT` to `storage.EventSource` with the Phase 4a minimal shape (one built-in policy, no customer criteria yet), updating the non-exhaustive `EventSource` switch call sites enumerated above.
+4. Build the Phase 5 detector path (template: file-access) and confirm the whole-alert-resolve behavior documented in Phase 4's validation section is acceptable end to end.
+5. Promote Reported Policy/Rule/Severity/Source to real `search:`-tagged `Alert` fields (Phase 6) so they're sortable/filterable — independent of, and can land before, any Phase 4b customer-criteria work.
+
+## Terminology decision record
+
+The plan intentionally uses:
+
+- `SecurityEvent` for the source-neutral canonical envelope.
+- `PolicyResult` for Kyverno/OpenReports semantics.
+- `Security Event` for the ACS policy event source.
+- `Source` for producer provenance.
+- `Reported Policy`, `Reported Rule`, and `Reported Severity` for producer-supplied values.
+- `Violation` and `Alert` only after ACS policy evaluation.
+
+It intentionally avoids `external`, `third-party`, `finding`, and `cluster security event`. Revisit this terminology only if implementation reveals a concrete collision or user research shows misunderstanding.
+
+## Related files
+
+- `issues/issue_external_policy_report_ingestion.md`
+- `projects/policy-engine-evolution/spec.md`
+- `pkg/policyreport/`
+- `sensor/kubernetes/listener/resources/policyreport/`
+- `sensor/kubernetes/listener/watcher/policyreport/`
+- `central/externalpolicyviolation/` (prototype to be renamed or replaced)
+- `proto/internalapi/central/external_policy_violation.proto` (prototype to be replaced by the agreed domain contract)
+- `proto/storage/external_policy_violation.proto` (prototype; a separate user-facing store is not the MVP)
+- `proto/storage/policy.proto`
+- `proto/storage/alert.proto`
+- `pkg/booleanpolicy/`

--- a/sensor/kubernetes/listener/informer_sync_tracker.go
+++ b/sensor/kubernetes/listener/informer_sync_tracker.go
@@ -36,6 +36,7 @@ const (
 	informerNetworkPolicies               = "NetworkPolicies"
 	informerNodes                         = "Nodes"
 	informerPodCache                      = "PodCache"
+	informerPolicyReports                 = "PolicyReports"
 	informerPods                          = "Pods"
 	informerReplicaSets                   = "ReplicaSets"
 	informerReplicationControllers        = "ReplicationControllers"

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	kubernetesPkg "github.com/stackrox/rox/pkg/kubernetes"
+	"github.com/stackrox/rox/pkg/policyreport"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/virtualmachine"
@@ -27,6 +28,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher"
 	complianceOperatorAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/complianceoperator"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher/crd"
+	policyReportAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/policyreport"
 	virtualMachineAvailabilityChecker "github.com/stackrox/rox/sensor/kubernetes/listener/watcher/virtualmachine"
 	sensorUtils "github.com/stackrox/rox/sensor/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -263,6 +265,40 @@ func (k *listenerImpl) handleAllEvents() {
 		}
 	}
 
+	// PolicyReport Watcher and Informers
+	shouldTrackPolicyReports := features.PolicyReports.Enabled()
+	var policyReportInformer cache.SharedIndexInformer
+
+	if features.PolicyReports.Enabled() {
+		prWatcher := crd.NewCRDWatcher(&k.stopSig, dynamicSif)
+		prAvailabilityChecker := policyReportAvailabilityChecker.NewAvailabilityChecker()
+		if err := prAvailabilityChecker.AppendToCRDWatcher(prWatcher); err != nil {
+			log.Errorf("Unable to add the Resource to the PolicyReport CRD Watcher: %v", err)
+		}
+
+		prCrdHandlerFn := crdWatcherCallbackWrapper(k.context,
+			allResourcesAvailable(),
+			k.pubSub,
+			"PolicyReport resources have been updated. Connection will restart to force reconciliation with Central")
+
+		shouldTrackPolicyReports, err = prAvailabilityChecker.Available(k.client)
+		if err != nil {
+			log.Errorf("Failed to check the availability of PolicyReport resources: %v", err)
+		}
+
+		if shouldTrackPolicyReports {
+			log.Info("Initializing PolicyReport informers")
+			policyReportInformer = crdSharedInformerFactory.ForResource(policyreport.PolicyReport.GroupVersionResource()).Informer()
+			prCrdHandlerFn = crdWatcherCallbackWrapper(k.context,
+				resourcesUnavailable(),
+				k.pubSub,
+				"PolicyReport resources have been removed. Connection will restart to force reconciliation with Central")
+		}
+		if err := prWatcher.Watch(prCrdHandlerFn); err != nil {
+			log.Errorf("Failed to start watching the PolicyReport CRDs: %v", err)
+		}
+	}
+
 	// This call to clusterID.Get might block if a cluster ID is initially unavailable, which is okay.
 	clusterID := k.clusterID.Get()
 
@@ -370,6 +406,11 @@ func (k *listenerImpl) handleAllEvents() {
 		// send duplicate update events during sync
 		log.Info("Syncing virtual machine instances")
 		handle(k.context, informerVirtualMachineInstances, virtualMachineInstanceInformer, dispatchers.ForVirtualMachineInstances(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
+	}
+
+	if shouldTrackPolicyReports {
+		log.Info("Syncing policy reports")
+		handle(k.context, informerPolicyReports, policyReportInformer, dispatchers.ForPolicyReports(), k.pubSubDispatcher, k.outputQueue, &syncingResources, noDependencyWaitGroup, stopSignal, &eventLock, informerTracker)
 	}
 
 	if !startAndWait(stopSignal, noDependencyWaitGroup, sif, osConfigFactory, osOperatorFactory, crdSharedInformerFactory) {

--- a/sensor/kubernetes/listener/resources/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/dispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/kubernetes/complianceoperator/dispatchers"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	policyReportDispatcher "github.com/stackrox/rox/sensor/kubernetes/listener/resources/policyreport"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/rbac"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/virtualmachine/dispatcher"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -49,6 +50,8 @@ type DispatcherRegistry interface {
 
 	ForVirtualMachines() Dispatcher
 	ForVirtualMachineInstances() Dispatcher
+
+	ForPolicyReports() Dispatcher
 
 	ForComplianceOperatorResults() Dispatcher
 	ForComplianceOperatorProfiles() Dispatcher
@@ -112,6 +115,8 @@ func NewDispatcherRegistry(
 
 		virtualMachineDispatcher:         dispatcher.NewVirtualMachineDispatcher(clusterID, storeProvider.VirtualMachines()),
 		virtualMachineInstanceDispatcher: dispatcher.NewVirtualMachineInstanceDispatcher(clusterID, storeProvider.VirtualMachines()),
+
+		policyReportDispatcher: policyReportDispatcher.NewDispatcher(clusterID),
 	}
 }
 
@@ -142,6 +147,8 @@ type registryImpl struct {
 
 	virtualMachineDispatcher         *dispatcher.VirtualMachineDispatcher
 	virtualMachineInstanceDispatcher *dispatcher.VirtualMachineInstanceDispatcher
+
+	policyReportDispatcher *policyReportDispatcher.Dispatcher
 }
 
 func wrapWithDumpingDispatcher(d Dispatcher, w io.Writer) Dispatcher {
@@ -346,4 +353,8 @@ func (d *registryImpl) ForVirtualMachines() Dispatcher {
 
 func (d *registryImpl) ForVirtualMachineInstances() Dispatcher {
 	return wrapDispatcher(d.virtualMachineInstanceDispatcher, d.traceWriter)
+}
+
+func (d *registryImpl) ForPolicyReports() Dispatcher {
+	return wrapDispatcher(d.policyReportDispatcher, d.traceWriter)
 }

--- a/sensor/kubernetes/listener/resources/mocks/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/mocks/dispatcher.go
@@ -277,6 +277,20 @@ func (mr *MockDispatcherRegistryMockRecorder) ForNetworkPolicies() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForNetworkPolicies", reflect.TypeOf((*MockDispatcherRegistry)(nil).ForNetworkPolicies))
 }
 
+// ForPolicyReports mocks base method.
+func (m *MockDispatcherRegistry) ForPolicyReports() resources.Dispatcher {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForPolicyReports")
+	ret0, _ := ret[0].(resources.Dispatcher)
+	return ret0
+}
+
+// ForPolicyReports indicates an expected call of ForPolicyReports.
+func (mr *MockDispatcherRegistryMockRecorder) ForPolicyReports() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForPolicyReports", reflect.TypeOf((*MockDispatcherRegistry)(nil).ForPolicyReports))
+}
+
 // ForNodes mocks base method.
 func (m *MockDispatcherRegistry) ForNodes() resources.Dispatcher {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/listener/resources/policyreport/dispatcher.go
+++ b/sensor/kubernetes/listener/resources/policyreport/dispatcher.go
@@ -1,0 +1,92 @@
+package policyreport
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var log = logging.LoggerForModule()
+
+// Dispatcher processes PolicyReport CRD events, canonicalizes them into
+// SecurityEvents, and records dry-run metrics. It does not forward events
+// to Central — that wiring comes in a later PR once the protobuf contract
+// and detector path exist.
+type Dispatcher struct {
+	clusterID string
+}
+
+// NewDispatcher creates a PolicyReport dispatcher.
+func NewDispatcher(clusterID string) *Dispatcher {
+	return &Dispatcher{clusterID: clusterID}
+}
+
+// ProcessEvent implements resources.Dispatcher.
+func (d *Dispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *component.ResourceEvent {
+	if !features.PolicyReports.Enabled() {
+		return nil
+	}
+
+	u, ok := toUnstructured(obj)
+	if !ok {
+		reportsProcessed.WithLabelValues("error").Inc()
+		return nil
+	}
+
+	if action == central.ResourceAction_REMOVE_RESOURCE {
+		reportsProcessed.WithLabelValues("removed").Inc()
+		log.Debugf("PolicyReport %s/%s removed", u.GetNamespace(), u.GetName())
+		return nil
+	}
+
+	events, err := policyreport.CanonicalizeKyvernoV1Alpha2(d.clusterID, u)
+	if err != nil {
+		reportsProcessed.WithLabelValues("error").Inc()
+		log.Warnf("Failed to canonicalize PolicyReport %s/%s: %v", u.GetNamespace(), u.GetName(), err)
+		return nil
+	}
+
+	reportsProcessed.WithLabelValues("ok").Inc()
+	eventsCanonicalizedTotal.Add(float64(len(events)))
+
+	if len(events) > 0 {
+		log.Debugf("Canonicalized %d actionable SecurityEvents from PolicyReport %s/%s",
+			len(events), u.GetNamespace(), u.GetName())
+	}
+
+	// No forwarding to Central yet — dry-run metrics only.
+	return nil
+}
+
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if ok {
+		return u, true
+	}
+	log.Errorf("PolicyReport dispatcher received non-Unstructured object: %T", obj)
+	return nil, false
+}
+
+var (
+	reportsProcessed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "policyreport_reports_processed_total",
+		Help:      "Total PolicyReport objects processed by the canonicalizer, by outcome (ok, error, removed).",
+	}, []string{"outcome"})
+
+	eventsCanonicalizedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "rox",
+		Subsystem: "sensor",
+		Name:      "policyreport_events_canonicalized_total",
+		Help:      "Total actionable SecurityEvents produced from PolicyReport canonicalization.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(reportsProcessed, eventsCanonicalizedTotal)
+}

--- a/sensor/kubernetes/listener/resources/policyreport/dispatcher_test.go
+++ b/sensor/kubernetes/listener/resources/policyreport/dispatcher_test.go
@@ -1,0 +1,91 @@
+package policyreport
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestProcessEvent_FeatureDisabled(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "false")
+	d := NewDispatcher("test-cluster")
+	result := d.ProcessEvent(&unstructured.Unstructured{}, nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result)
+}
+
+func TestProcessEvent_NonUnstructuredObject(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+	result := d.ProcessEvent("not-an-unstructured", nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result)
+}
+
+func TestProcessEvent_RemoveAction(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+
+	u := &unstructured.Unstructured{}
+	u.SetName("test-report")
+	u.SetNamespace("default")
+
+	result := d.ProcessEvent(u, nil, central.ResourceAction_REMOVE_RESOURCE)
+	assert.Nil(t, result)
+}
+
+func TestProcessEvent_ValidReport(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "wgpolicyk8s.io/v1alpha2",
+			"kind":       "PolicyReport",
+			"metadata": map[string]interface{}{
+				"name":            "test-report",
+				"namespace":       "default",
+				"uid":             "report-uid-1",
+				"resourceVersion": "123",
+			},
+			"scope": map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"name":       "my-pod",
+				"namespace":  "default",
+				"uid":        "pod-uid-1",
+			},
+			"results": []interface{}{
+				map[string]interface{}{
+					"policy": "require-labels",
+					"rule":   "check-team-label",
+					"result": "fail",
+					"source": "kyverno",
+				},
+			},
+		},
+	}
+
+	// Dry-run: should return nil (no Central forwarding), but not error.
+	result := d.ProcessEvent(u, nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result, "dry-run dispatcher should not forward events to Central")
+}
+
+func TestProcessEvent_InvalidReport(t *testing.T) {
+	t.Setenv(features.PolicyReports.EnvVar(), "true")
+	d := NewDispatcher("test-cluster")
+
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "wrong/v1",
+			"kind":       "PolicyReport",
+			"metadata": map[string]interface{}{
+				"name": "bad-report",
+			},
+		},
+	}
+
+	result := d.ProcessEvent(u, nil, central.ResourceAction_CREATE_RESOURCE)
+	assert.Nil(t, result)
+}

--- a/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker.go
+++ b/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker.go
@@ -1,0 +1,12 @@
+package policyreport
+
+import (
+	"github.com/stackrox/rox/pkg/policyreport"
+	"github.com/stackrox/rox/sensor/kubernetes/listener/watcher/availability"
+)
+
+// NewAvailabilityChecker creates an availability checker for PolicyReport CRDs.
+func NewAvailabilityChecker() availability.Checker {
+	resources := policyreport.GetRequiredResources()
+	return availability.NewChecker(policyreport.GetGroupVersion(), resources)
+}

--- a/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker_test.go
+++ b/sensor/kubernetes/listener/watcher/policyreport/availabilitychecker_test.go
@@ -1,0 +1,73 @@
+package policyreport
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllPolicyReportResourcesAreAddedToTheAvailabilityChecker(t *testing.T) {
+	ac := NewAvailabilityChecker()
+	pwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path.Join(pwd, "../../../../../pkg/policyreport/api.go"), nil, 0)
+	require.NoError(t, err)
+
+	allowList := []string{
+		"groupVersion",
+		"requiredAPIResources",
+	}
+
+	resFinder := &resourcesFinder{}
+	ast.Walk(resFinder, file)
+	require.NotEmpty(t, resFinder.resources)
+
+	var notFound []string
+finderLoop:
+	for _, resource := range resFinder.resources {
+		for _, acResource := range ac.GetResources() {
+			if acResource.Kind == resource {
+				continue finderLoop
+			}
+		}
+		for _, allowed := range allowList {
+			if allowed == resource {
+				continue finderLoop
+			}
+		}
+		notFound = append(notFound, resource)
+	}
+
+	assert.Empty(t, notFound, "Please add the missing types to the availability checker or to the allowList in this test")
+}
+
+type resourcesFinder struct {
+	resources []string
+}
+
+func (f *resourcesFinder) Visit(n ast.Node) ast.Visitor {
+	switch n := n.(type) {
+	case *ast.Package:
+		return f
+	case *ast.File:
+		return f
+	case *ast.GenDecl:
+		if n.Tok == token.VAR {
+			return f
+		}
+	case *ast.ValueSpec:
+		if len(n.Names) < 1 {
+			return nil
+		}
+		f.resources = append(f.resources, n.Names[0].Name)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

Adds a Claude Code skill for the build → push → deploy → validate devloop on remote clusters (e.g. infractl OpenShift). Covers environment setup, `make image`, registry push, roxie deploy, and validation — delegates build details to Makefiles and roxie details to `deploy/AGENTS.md` rather than embedding workarounds.

Single file: `.claude/skills/remote-cluster-devloop/SKILL.md` (93 lines).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No tests — this is a markdown skill file for Claude Code, not runtime code.

### How I validated my change

Used this skill across multiple devloop iterations on an infractl OpenShift cluster while building the security-event ingestion POC. The simplified version removes build workarounds that belong in Makefiles.