### PR TITLE
feat(ui): Replace sensor upgrade card on cluster page

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
@@ -3,10 +3,13 @@ import { Alert, Content, Flex, FlexItem, Title } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useMetadata from 'hooks/useMetadata';
 import type { Cluster, ClusterManagerType, CompleteClusterConfig } from 'types/cluster.proto';
 import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 import ClusterStatusGrid from './ClusterStatusGrid';
 import ClusterSummaryGrid from './ClusterSummaryGrid';
+import SensorCompatibilityPanel from './Components/SensorCompatibilityPanel';
 import DynamicConfigurationForm from './DynamicConfigurationForm';
 import StaticConfigurationForm from './StaticConfigurationForm';
 // Delete whenever deprecated properties are deleted.
@@ -38,6 +41,11 @@ function ClusterLabelsConfigurationStatusSummary({
     handleChange,
     handleChangeAdmissionControllerEnforcementBehavior,
 }: ClusterLabelsConfigurationStatusSummaryProps): ReactElement {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isSensorCompatStatusEnabled = isFeatureFlagEnabled('ROX_SENSOR_COMPATIBILITY_STATUS');
+    const metadata = useMetadata();
+    const compatibleVersions = metadata?.compatibleSensorVersions ?? [];
+
     const isManagerTypeNonConfigurable =
         managerType === 'MANAGER_TYPE_KUBERNETES_OPERATOR' ||
         managerType === 'MANAGER_TYPE_HELM_CHART';
@@ -162,6 +170,17 @@ function ClusterLabelsConfigurationStatusSummary({
                             clusterRetentionInfo={clusterRetentionInfo}
                         />
                     </Flex>
+                </Flex>
+            )}
+            {selectedCluster.id && selectedCluster.status && isSensorCompatStatusEnabled && (
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                    <Title headingLevel="h2">Compatibility status</Title>
+                    <SensorCompatibilityPanel
+                        compatibility={selectedCluster.status.sensorVersionCompatibility}
+                        compatibleVersions={compatibleVersions}
+                        sensorVersion={selectedCluster.status.sensorVersion}
+                        centralVersion={centralVersion}
+                    />
                 </Flex>
             )}
         </Flex>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
@@ -1,5 +1,6 @@
 import { Grid, GridItem } from '@patternfly/react-core';
 
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import type { Cluster } from 'types/cluster.proto';
 import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
 
@@ -21,6 +22,9 @@ export function ClusterSummaryGrid({
     clusterRetentionInfo,
     clusterInfo,
 }: ClusterSummaryGridProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isSensorCompatStatusEnabled = isFeatureFlagEnabled('ROX_SENSOR_COMPATIBILITY_STATUS');
+
     return (
         <Grid hasGutter>
             {clusterInfo.status && (
@@ -30,7 +34,7 @@ export function ClusterSummaryGrid({
                     </ClusterHealthPanel>
                 </GridItem>
             )}
-            {clusterInfo.status && (
+            {clusterInfo.status && !isSensorCompatStatusEnabled && (
                 <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
                     <SensorUpgradePanel
                         centralVersion={centralVersion}


### PR DESCRIPTION
## Description

Removes the "sensor upgrade" card when the SENSOR_COMPATIBILITY_UI flag is on, and adds a new section titled "Compatibility Status" below "Cluster Status". This new section displays the same three cards that are displayed in the expanded table row.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
<img width="1613" height="888" alt="image" src="https://github.com/user-attachments/assets/d7f98c68-ea4a-49c1-afb5-21c7ad1c9355" />