### PR TITLE
ROX-35964: add compatibility to telemetry

### DIFF
--- a/central/cluster/datastore/telemetry.go
+++ b/central/cluster/datastore/telemetry.go
@@ -180,6 +180,8 @@ func UpdateSecuredClusterIdentity(ctx context.Context, clusterID string, metrics
 	}
 	props["Orchestrator Version"] = omd.GetVersion()
 
+	props["Sensor Version Compatibility"] = cluster.GetStatus().GetSensorVersionCompatibility().String()
+
 	if vmTraits := buildVMTraits(hasVMTelemetryCap, metrics.GetVirtualMachineMetrics()); vmTraits != nil {
 		maps.Copy(props, vmTraits)
 	}


### PR DESCRIPTION
## Description

Add sensor version compatibility status to the phone-home secured cluster identity properties. The `"Sensor Version Compatibility"` field is included in the `"Updated Secured Cluster Identity"` track event, reporting the classification (MATCHED, COMPATIBLE_BEHIND, COMPATIBLE_AHEAD, etc.) for each secured cluster.

The value is already computed at read time by `populateSensorVersionCompatibility` when `GetCluster` is called within `UpdateSecuredClusterIdentity`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added — the change is a single property addition to an existing
telemetry call with no existing test coverage for this function.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Deployed Central with the new image and pointed `ROX_TELEMETRY_ENDPOINT` at a local request-logging pod. Confirmed the `"Sensor Version Compatibility"` property appears in the `"Updated Secured Cluster Identity"` track event for the secured clusters:

```json
"traits": {
  ...
  "Sensor Version Compatibility": "SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND",
  ...
}
```

Clusters reported `COMPATIBLE_BEHIND` as expected — Central runs the dev build
(4.12.x) while sensors are on older release images within the supported skew window.

This is the telemetry deployment I used for testing:
```
  kubectl -n stackrox run telemetry-sink \
    --image=python:3-alpine \
    --port=8888 \
    --expose \
    -- python3 -c "
  from http.server import HTTPServer, BaseHTTPRequestHandler
  import json, sys

  class H(BaseHTTPRequestHandler):
      def do_POST(self):
          body = self.rfile.read(int(self.headers['Content-Length']))
          print(json.dumps(json.loads(body), indent=2), flush=True)
          self.send_response(200)
          self.end_headers()

  HTTPServer(('', 8888), H).serve_forever()
  "
```
Central env variables:
```
  kubectl -n stackrox set env deploy/central \
    ROX_TELEMETRY_STORAGE_KEY_V1=test \
    ROX_TELEMETRY_ENDPOINT=http://telemetry-sink:8888 \
    ROX_TELEMETRY_CONFIG_URL="" \
    ROX_TELEMETRY_FREQUENCY=5s
```
Checking telemetry logs:
```
kubectl -n stackrox logs -f telemetry-sink
```