### PR TITLE
ROX-36075: Fix lost busy signal on roxagent connection race

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/server.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server.go
@@ -170,8 +170,9 @@ func (s *Server) rejectConn(ctx context.Context, conn net.Conn) {
 
 	_ = conn.SetReadDeadline(time.Now().Add(rejectAbsorbTimeout))
 	// Outcome never affects control flow: timeout/EOF means the peer never
-	// wrote (or wrote late).
-	if _, err := vsockframing.ReadFrame(conn, maxRequestSize); err != nil {
+	// wrote (or wrote late). DiscardFrame avoids allocating a payload buffer
+	// for a request we only need to drain.
+	if err := vsockframing.DiscardFrame(conn, maxRequestSize); err != nil {
 		log.Debugf("No request absorbed from rejected peer %s before closing: %v", conn.RemoteAddr(), err)
 	}
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/server.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server.go
@@ -8,39 +8,48 @@ import (
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/vsockframing"
 	"golang.org/x/sync/semaphore"
 )
 
-// maxConcurrentConns is the number of connections handled simultaneously.
-// intentional simplification: set to 1 because the agent serves a single
-// Sensor poller; raising this would require a request queue instead of
-// the current reject-and-retry approach.
-const maxConcurrentConns = 1
-
-// Backoff bounds for retrying transient (non-context) Accept() errors.
 const (
+	// maxConcurrentConns is the number of connections handled simultaneously.
+	// intentional simplification: set to 1 because the agent serves a single
+	// Sensor poller; raising this would require a request queue instead of
+	// the current reject-and-retry approach.
+	maxConcurrentConns = 1
+
+	// minAcceptRetryDelay and maxAcceptRetryDelay bound backoff for retrying
+	// transient (non-context) Accept() errors.
 	minAcceptRetryDelay = 5 * time.Millisecond
 	maxAcceptRetryDelay = 1 * time.Second
-)
 
-// DefaultConnDeadline bounds the entire lifetime of one accepted connection -
-// TLS handshake plus request/response - so a stalled or malicious peer
-// can hold at most one goroutine and one semaphore slot for this long,
-// never more, and never blocks Serve's accept loop itself (see below).
-// Overridable via WithConnDeadline; see that option's doc for the
-// availability/DoS trade-off involved in changing it.
-const DefaultConnDeadline = 30 * time.Second
+	// DefaultConnDeadline bounds the entire lifetime of one accepted connection -
+	// TLS handshake plus request/response - so a stalled or malicious peer
+	// can hold at most one goroutine and one semaphore slot for this long,
+	// never more, and never blocks Serve's accept loop itself (see below).
+	// Overridable via WithConnDeadline; see that option's doc for the
+	// availability/DoS trade-off involved in changing it.
+	DefaultConnDeadline = 30 * time.Second
+
+	// DefaultRejectAbsorbTimeout bounds how long rejectConn waits to absorb a
+	// racing peer's request before closing, independent of the much longer
+	// connDeadline. This applies when the client sends a request immediately
+	// after opening the connection without waiting for the potential busy response.
+	DefaultRejectAbsorbTimeout = 2 * time.Second
+)
 
 // Server listens on a VSOCK port and dispatches connections to the Handler.
 // tlsCfg must be non-nil in production: sensor always dials TLS, so a
 // plaintext listener is unreachable. The nil path is retained only for
 // testing convenience.
 type Server struct {
-	handler      *Handler
-	tlsCfg       *tls.Config
-	sem          *semaphore.Weighted // enforces at most one concurrent HandleConn
-	wg           sync.WaitGroup
-	connDeadline time.Duration
+	handler             *Handler
+	tlsCfg              *tls.Config
+	sem                 *semaphore.Weighted // enforces at most one concurrent HandleConn
+	wg                  sync.WaitGroup
+	connDeadline        time.Duration
+	rejectAbsorbTimeout time.Duration
 }
 
 // ServerOption configures optional Server parameters.
@@ -57,13 +66,20 @@ func WithConnDeadline(d time.Duration) ServerOption {
 	return func(s *Server) { s.connDeadline = d }
 }
 
+// WithRejectAbsorbTimeout overrides how long rejectConn waits to absorb a
+// racing peer's request before closing (default 2s).
+func WithRejectAbsorbTimeout(d time.Duration) ServerOption {
+	return func(s *Server) { s.rejectAbsorbTimeout = d }
+}
+
 // NewServer creates a VSOCK server. tlsCfg should be non-nil in production.
 func NewServer(handler *Handler, tlsCfg *tls.Config, opts ...ServerOption) *Server {
 	s := &Server{
-		handler:      handler,
-		tlsCfg:       tlsCfg,
-		sem:          semaphore.NewWeighted(maxConcurrentConns),
-		connDeadline: DefaultConnDeadline,
+		handler:             handler,
+		tlsCfg:              tlsCfg,
+		sem:                 semaphore.NewWeighted(maxConcurrentConns),
+		connDeadline:        DefaultConnDeadline,
+		rejectAbsorbTimeout: DefaultRejectAbsorbTimeout,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -119,7 +135,8 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) {
 		// may ever block on, or a single stalled/malicious peer could
 		// prevent every subsequent connection (including the legitimate
 		// one) from ever being accepted.
-		_ = conn.SetDeadline(time.Now().Add(s.connDeadline))
+		connDeadline := time.Now().Add(s.connDeadline)
+		_ = conn.SetDeadline(connDeadline)
 
 		// TryAcquire is non-blocking, so deciding here - synchronously, in
 		// accept order - keeps "first accepted wins the slot" deterministic,
@@ -132,7 +149,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) {
 				s.serveConn(ctx, conn)
 			})
 		} else {
-			s.wg.Go(func() { s.rejectConn(ctx, conn) })
+			s.wg.Go(func() { s.rejectConn(ctx, conn, connDeadline) })
 		}
 	}
 }
@@ -151,13 +168,30 @@ func (s *Server) serveConn(ctx context.Context, conn net.Conn) {
 // in-flight-connection slot. Handshaking here (rather than closing the raw
 // socket outright) costs a little CPU but lets Sensor tell "agent is busy,
 // retry me" apart from an unexplained connection drop.
-func (s *Server) rejectConn(ctx context.Context, conn net.Conn) {
+//
+// deadline is the connection's overall deadline from Serve. rejectConn
+// absorbs one framed request after writing the busy response and before
+// closing, so a racing peer's write never sees a reset instead of it.
+func (s *Server) rejectConn(ctx context.Context, conn net.Conn, deadline time.Time) {
 	log.Warnf("Rejecting connection from %s: another request is in flight", conn.RemoteAddr())
 	if !completeHandshake(ctx, conn) {
 		return
 	}
 	defer func() { _ = conn.Close() }()
 	s.handler.writeError(conn, pb.ErrorCode_ERROR_CODE_BUSY, "agent is already serving another request; retry after a backoff")
+
+	absorbDeadline := time.Now().Add(s.rejectAbsorbTimeout)
+	if absorbDeadline.After(deadline) {
+		absorbDeadline = deadline
+	}
+	_ = conn.SetReadDeadline(absorbDeadline)
+	// The outcome never affects control flow - a timeout/EOF here just
+	// means the peer never wrote (or wrote late).
+	if _, err := vsockframing.ReadFrame(conn, maxRequestSize); err != nil {
+		log.Infof("No request absorbed from rejected peer %s before closing: %v", conn.RemoteAddr(), err)
+	} else {
+		log.Infof("Absorbed request from rejected peer %s before closing", conn.RemoteAddr())
+	}
 }
 
 // completeHandshake finishes the TLS handshake on conn, if it is a TLS

--- a/compliance/virtualmachines/roxagent/vsockserver/server.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server.go
@@ -32,11 +32,9 @@ const (
 	// availability/DoS trade-off involved in changing it.
 	DefaultConnDeadline = 30 * time.Second
 
-	// DefaultRejectAbsorbTimeout bounds how long rejectConn waits to absorb a
-	// racing peer's request before closing, independent of the much longer
-	// connDeadline. This applies when the client sends a request immediately
-	// after opening the connection without waiting for the potential busy response.
-	DefaultRejectAbsorbTimeout = 2 * time.Second
+	// rejectAbsorbTimeout bounds how long rejectConn waits to absorb a racing
+	// peer's request before closing.
+	rejectAbsorbTimeout = 2 * time.Second
 )
 
 // Server listens on a VSOCK port and dispatches connections to the Handler.
@@ -44,12 +42,11 @@ const (
 // plaintext listener is unreachable. The nil path is retained only for
 // testing convenience.
 type Server struct {
-	handler             *Handler
-	tlsCfg              *tls.Config
-	sem                 *semaphore.Weighted // enforces at most one concurrent HandleConn
-	wg                  sync.WaitGroup
-	connDeadline        time.Duration
-	rejectAbsorbTimeout time.Duration
+	handler      *Handler
+	tlsCfg       *tls.Config
+	sem          *semaphore.Weighted // enforces at most one concurrent HandleConn
+	wg           sync.WaitGroup
+	connDeadline time.Duration
 }
 
 // ServerOption configures optional Server parameters.
@@ -66,20 +63,13 @@ func WithConnDeadline(d time.Duration) ServerOption {
 	return func(s *Server) { s.connDeadline = d }
 }
 
-// WithRejectAbsorbTimeout overrides how long rejectConn waits to absorb a
-// racing peer's request before closing (default 2s).
-func WithRejectAbsorbTimeout(d time.Duration) ServerOption {
-	return func(s *Server) { s.rejectAbsorbTimeout = d }
-}
-
 // NewServer creates a VSOCK server. tlsCfg should be non-nil in production.
 func NewServer(handler *Handler, tlsCfg *tls.Config, opts ...ServerOption) *Server {
 	s := &Server{
-		handler:             handler,
-		tlsCfg:              tlsCfg,
-		sem:                 semaphore.NewWeighted(maxConcurrentConns),
-		connDeadline:        DefaultConnDeadline,
-		rejectAbsorbTimeout: DefaultRejectAbsorbTimeout,
+		handler:      handler,
+		tlsCfg:       tlsCfg,
+		sem:          semaphore.NewWeighted(maxConcurrentConns),
+		connDeadline: DefaultConnDeadline,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -135,8 +125,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) {
 		// may ever block on, or a single stalled/malicious peer could
 		// prevent every subsequent connection (including the legitimate
 		// one) from ever being accepted.
-		connDeadline := time.Now().Add(s.connDeadline)
-		_ = conn.SetDeadline(connDeadline)
+		_ = conn.SetDeadline(time.Now().Add(s.connDeadline))
 
 		// TryAcquire is non-blocking, so deciding here - synchronously, in
 		// accept order - keeps "first accepted wins the slot" deterministic,
@@ -149,7 +138,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) {
 				s.serveConn(ctx, conn)
 			})
 		} else {
-			s.wg.Go(func() { s.rejectConn(ctx, conn, connDeadline) })
+			s.wg.Go(func() { s.rejectConn(ctx, conn) })
 		}
 	}
 }
@@ -169,10 +158,9 @@ func (s *Server) serveConn(ctx context.Context, conn net.Conn) {
 // socket outright) costs a little CPU but lets Sensor tell "agent is busy,
 // retry me" apart from an unexplained connection drop.
 //
-// deadline is the connection's overall deadline from Serve. rejectConn
-// absorbs one framed request after writing the busy response and before
-// closing, so a racing peer's write never sees a reset instead of it.
-func (s *Server) rejectConn(ctx context.Context, conn net.Conn, deadline time.Time) {
+// After writing BUSY, rejectConn absorbs one framed request before closing
+// so a racing peer's write never sees a reset instead of the busy reply.
+func (s *Server) rejectConn(ctx context.Context, conn net.Conn) {
 	log.Warnf("Rejecting connection from %s: another request is in flight", conn.RemoteAddr())
 	if !completeHandshake(ctx, conn) {
 		return
@@ -180,17 +168,11 @@ func (s *Server) rejectConn(ctx context.Context, conn net.Conn, deadline time.Ti
 	defer func() { _ = conn.Close() }()
 	s.handler.writeError(conn, pb.ErrorCode_ERROR_CODE_BUSY, "agent is already serving another request; retry after a backoff")
 
-	absorbDeadline := time.Now().Add(s.rejectAbsorbTimeout)
-	if absorbDeadline.After(deadline) {
-		absorbDeadline = deadline
-	}
-	_ = conn.SetReadDeadline(absorbDeadline)
-	// The outcome never affects control flow - a timeout/EOF here just
-	// means the peer never wrote (or wrote late).
+	_ = conn.SetReadDeadline(time.Now().Add(rejectAbsorbTimeout))
+	// Outcome never affects control flow: timeout/EOF means the peer never
+	// wrote (or wrote late).
 	if _, err := vsockframing.ReadFrame(conn, maxRequestSize); err != nil {
-		log.Infof("No request absorbed from rejected peer %s before closing: %v", conn.RemoteAddr(), err)
-	} else {
-		log.Infof("Absorbed request from rejected peer %s before closing", conn.RemoteAddr())
+		log.Debugf("No request absorbed from rejected peer %s before closing: %v", conn.RemoteAddr(), err)
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -58,6 +59,68 @@ func TestServeAcceptLoop(t *testing.T) {
 	<-serveDone
 }
 
+func TestRejectConn(t *testing.T) {
+	cases := map[string]struct {
+		writeRequest  bool
+		absorbTimeout time.Duration
+	}{
+		"client sends a request before rejectConn closes should still let the client read the busy reply": {
+			writeRequest: true,
+		},
+		"client never sends a request should let rejectConn close promptly": {
+			writeRequest:  false,
+			absorbTimeout: 50 * time.Millisecond,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				handler := NewHandler(&ReportCache{}, "test")
+				var opts []ServerOption
+				if tc.absorbTimeout > 0 {
+					opts = append(opts, WithRejectAbsorbTimeout(tc.absorbTimeout))
+				}
+				srv := NewServer(handler, nil, opts...)
+
+				serverConn, clientConn := net.Pipe()
+				defer func() { _ = clientConn.Close() }()
+
+				serverDone := make(chan struct{})
+				go func() {
+					defer close(serverDone)
+					srv.rejectConn(context.Background(), serverConn, time.Now().Add(30*time.Second))
+				}()
+
+				// The write runs on its own goroutine, independent of the read below,
+				// the same way a real full-duplex connection's two directions would.
+				writeErrCh := make(chan error, 1)
+				if tc.writeRequest {
+					go func() {
+						req, err := proto.Marshal(&pb.VMServiceRequest{Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}}})
+						if err != nil {
+							writeErrCh <- err
+							return
+						}
+						writeErrCh <- vsockframing.WriteFrame(clientConn, req)
+					}()
+				}
+
+				respData, err := vsockframing.ReadFrame(clientConn, 1<<20)
+				require.NoError(t, err)
+				var resp pb.VMServiceResponse
+				require.NoError(t, proto.Unmarshal(respData, &resp))
+				assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
+
+				synctest.Wait()
+				<-serverDone
+				if tc.writeRequest {
+					require.NoError(t, <-writeErrCh)
+				}
+			})
+		})
+	}
+}
+
 // TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections is a
 // regression test for a bug where the TLS handshake ran inline in Serve's
 // accept loop: a peer that connects and never completes (or never starts)
@@ -71,8 +134,6 @@ func TestServeAcceptLoop(t *testing.T) {
 // the second peer always takes the rejectConn path and receives
 // ERROR_CODE_BUSY. That is enough to prove Accept() kept running: a blocked
 // accept loop would never handshake the second peer or write BUSY.
-// The client must only ReadFrame here - writing a request races rejectConn's
-// close-after-BUSY and flakes with broken pipe on Linux.
 func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing.T) {
 	handler := NewHandler(&ReportCache{}, "test")
 	srv := NewServer(handler, &tls.Config{Certificates: []tls.Certificate{testServerCert(t)}})

--- a/compliance/virtualmachines/roxagent/vsockserver/server_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/server_test.go
@@ -36,13 +36,15 @@ func TestServeAcceptLoop(t *testing.T) {
 	// Second connection: should be rejected (semaphore full) with a BUSY response.
 	conn2, err := net.Dial("tcp", ln.Addr().String())
 	require.NoError(t, err)
-	defer func() { _ = conn2.Close() }()
 	busyData, err := vsockframing.ReadFrame(conn2, 1<<20)
 	require.NoError(t, err, "rejected connection should still receive a framed response before closing")
 	var busyResp pb.VMServiceResponse
 	require.NoError(t, proto.Unmarshal(busyData, &busyResp))
 	require.NotNil(t, busyResp.GetError())
 	assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, busyResp.GetError().GetCode())
+	// Close after reading BUSY so rejectConn's absorb-read gets EOF instead of
+	// waiting out rejectAbsorbTimeout before Serve can drain.
+	_ = conn2.Close()
 
 	// Complete first connection: send a request and read NOT_READY response.
 	req, _ := proto.Marshal(&pb.VMServiceRequest{Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{}}})
@@ -61,26 +63,22 @@ func TestServeAcceptLoop(t *testing.T) {
 
 func TestRejectConn(t *testing.T) {
 	cases := map[string]struct {
-		writeRequest  bool
-		absorbTimeout time.Duration
+		writeRequest bool
 	}{
 		"client sends a request before rejectConn closes should still let the client read the busy reply": {
 			writeRequest: true,
 		},
-		"client never sends a request should let rejectConn close promptly": {
-			writeRequest:  false,
-			absorbTimeout: 50 * time.Millisecond,
+		// synctest advances fake time through rejectAbsorbTimeout when the
+		// peer stays quiet, so this does not burn wall-clock seconds.
+		"client never sends a request should let rejectConn close after absorb timeout": {
+			writeRequest: false,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				handler := NewHandler(&ReportCache{}, "test")
-				var opts []ServerOption
-				if tc.absorbTimeout > 0 {
-					opts = append(opts, WithRejectAbsorbTimeout(tc.absorbTimeout))
-				}
-				srv := NewServer(handler, nil, opts...)
+				srv := NewServer(handler, nil)
 
 				serverConn, clientConn := net.Pipe()
 				defer func() { _ = clientConn.Close() }()
@@ -88,7 +86,7 @@ func TestRejectConn(t *testing.T) {
 				serverDone := make(chan struct{})
 				go func() {
 					defer close(serverDone)
-					srv.rejectConn(context.Background(), serverConn, time.Now().Add(30*time.Second))
+					srv.rejectConn(context.Background(), serverConn)
 				}()
 
 				// The write runs on its own goroutine, independent of the read below,
@@ -167,7 +165,6 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	}
 	clientConn, err := dialer.DialContext(ctx, "tcp", ln.Addr().String())
 	require.NoError(t, err, "second peer should be accepted promptly; accept loop may be blocked")
-	defer func() { _ = clientConn.Close() }()
 
 	require.NoError(t, clientConn.SetDeadline(time.Now().Add(5*time.Second)))
 	respData, err := vsockframing.ReadFrame(clientConn, 1<<20)
@@ -176,4 +173,7 @@ func TestServeAcceptLoop_StalledHandshakeDoesNotBlockOtherConnections(t *testing
 	require.NoError(t, proto.Unmarshal(respData, &resp))
 	require.NotNil(t, resp.GetError())
 	assert.Equal(t, pb.ErrorCode_ERROR_CODE_BUSY, resp.GetError().GetCode())
+	// Close after reading BUSY so rejectConn's absorb-read gets EOF instead of
+	// waiting out rejectAbsorbTimeout before Serve can drain.
+	_ = clientConn.Close()
 }

--- a/pkg/vsockframing/framing.go
+++ b/pkg/vsockframing/framing.go
@@ -8,8 +8,8 @@ import (
 	"math"
 )
 
-// ErrFrameTooLarge is returned by ReadFrame when the incoming frame's declared
-// length exceeds the caller-supplied maxSize.
+// ErrFrameTooLarge is returned by ReadFrame and DiscardFrame when the incoming
+// frame's declared length exceeds the caller-supplied maxSize.
 var ErrFrameTooLarge = errors.New("frame size exceeds limit")
 
 // WriteFrame writes a length-prefixed frame: [4-byte big-endian uint32 length][payload].
@@ -41,4 +41,26 @@ func ReadFrame(r io.Reader, maxSize uint32) ([]byte, error) {
 		return nil, fmt.Errorf("reading frame payload: %w", err)
 	}
 	return payload, nil
+}
+
+// DiscardFrame drains one length-prefixed frame without allocating a payload
+// buffer, for callers that only need to consume the frame (e.g. absorb on reject).
+func DiscardFrame(r io.Reader, maxSize uint32) error {
+	var length uint32
+	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+		return fmt.Errorf("reading frame length: %w", err)
+	}
+	if length > maxSize {
+		return fmt.Errorf("%w: %d exceeds limit %d", ErrFrameTooLarge, length, maxSize)
+	}
+	n, err := io.CopyN(io.Discard, r, int64(length))
+	if err != nil {
+		// CopyN returns EOF on a short read; ReadFrame uses ReadFull, which
+		// returns ErrUnexpectedEOF — match that so callers can treat both alike.
+		if errors.Is(err, io.EOF) && n < int64(length) {
+			err = io.ErrUnexpectedEOF
+		}
+		return fmt.Errorf("discarding frame payload: %w", err)
+	}
+	return nil
 }

--- a/pkg/vsockframing/framing_test.go
+++ b/pkg/vsockframing/framing_test.go
@@ -84,6 +84,34 @@ func TestFraming(t *testing.T) {
 				_ = r.Close()
 			},
 		},
+		"should discard a framed payload without error": {
+			run: func(t *testing.T) {
+				payload := []byte("hello world")
+				var buf bytes.Buffer
+				require.NoError(t, WriteFrame(&buf, payload))
+				require.NoError(t, DiscardFrame(&buf, 1024))
+				assert.Zero(t, buf.Len())
+			},
+		},
+		"should reject discarded frame exceeding size limit": {
+			run: func(t *testing.T) {
+				payload := bytes.Repeat([]byte("x"), 100)
+				var buf bytes.Buffer
+				require.NoError(t, WriteFrame(&buf, payload))
+				err := DiscardFrame(&buf, 50)
+				assert.ErrorIs(t, err, ErrFrameTooLarge)
+			},
+		},
+		"should error when discarded payload is truncated": {
+			run: func(t *testing.T) {
+				var buf bytes.Buffer
+				_ = binary.Write(&buf, binary.BigEndian, uint32(100))
+				buf.Write(make([]byte, 50))
+				err := DiscardFrame(&buf, 1024)
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, tc.run)

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -152,6 +152,7 @@ const (
 	PullStatusNotReady      = "not_ready"
 	PullStatusUnknownMethod = "unknown_method"
 	PullStatusTimeout       = "timeout"
+	PullStatusBusy          = "busy"
 )
 
 // PullDialDurationSeconds measures time to establish a websocket connection per VM.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -423,6 +423,9 @@ func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err er
 	case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
 		log.Debugf("VMScraper: roxagent on %q connection closed (agent may be down or restarting): %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
+	case errors.Is(err, vsockclient.ErrBusy):
+		log.Infof("VMScraper: roxagent on %q is busy with another request: %v", key, err)
+		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy).Inc()
 	default:
 		log.Warnf("VMScraper: protocol error for %q (possible version mismatch): %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -637,6 +637,26 @@ func TestVMScraper_GetReportTimeoutClassified(t *testing.T) {
 		"timed-out read must not be counted as a protocol/read error")
 }
 
+// TestVMScraper_GetReportBusyClassified verifies busy is counted separately
+// from generic read/protocol errors.
+func TestVMScraper_GetReportBusyClassified(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	client := &mockProtocolClient{
+		errQueue: []error{vsockclient.ErrBusy},
+	}
+	s := newTestScraper(&mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
+
+	busyBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy))
+	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
+
+	_, ok := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, 0, 0)
+
+	assert.False(t, ok)
+	assert.Equal(t, busyBefore+1, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy)))
+	assert.Equal(t, readErrBefore, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError)),
+		"a busy response must not be counted as a generic protocol/read error")
+}
+
 func TestVMScraper_PrunesStaleState(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -27,6 +27,8 @@ var (
 	ErrUnknownMethod = errors.New("agent does not support the requested method")
 	// ErrInternal indicates the agent encountered an internal error.
 	ErrInternal = errors.New("agent internal error")
+	// ErrBusy indicates the agent's single connection slot is held by another request.
+	ErrBusy = errors.New("agent is busy with another request")
 )
 
 // GetReportResult holds the parsed response from a GetReport call.
@@ -97,6 +99,11 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNew
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 	if err := vsockframing.WriteFrame(stream, reqData); err != nil {
+		// The agent may have already sent a response and closed before
+		// this write landed; salvage it instead of discarding it.
+		if salvaged := salvageAfterWriteFailure(stream, c.maxResponseSize); salvaged != nil {
+			return nil, salvaged
+		}
 		return nil, wrapStreamErr(ctx, "sending request", err)
 	}
 
@@ -127,6 +134,24 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNew
 	}
 }
 
+// salvageAfterWriteFailure attempts one bounded read after a failed write,
+// returning the mapped error for a usable error response, or nil if
+// nothing could be salvaged.
+func salvageAfterWriteFailure(stream io.Reader, maxResponseSize int) error {
+	respData, err := vsockframing.ReadFrame(stream, uint32(maxResponseSize))
+	if err != nil {
+		return nil
+	}
+	var resp pb.VMServiceResponse
+	if err := proto.Unmarshal(respData, &resp); err != nil {
+		return nil
+	}
+	if e, ok := resp.GetResult().(*pb.VMServiceResponse_Error); ok {
+		return errorFromResponse(e.Error)
+	}
+	return nil
+}
+
 func wrapStreamErr(ctx context.Context, op string, err error) error {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return fmt.Errorf("%s: %w", op, ctxErr)
@@ -142,6 +167,8 @@ func errorFromResponse(e *pb.ErrorResponse) error {
 		return fmt.Errorf("%w: %s", ErrUnknownMethod, e.GetMessage())
 	case pb.ErrorCode_ERROR_CODE_INTERNAL:
 		return fmt.Errorf("%w: %s", ErrInternal, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_BUSY:
+		return fmt.Errorf("%w: %s", ErrBusy, e.GetMessage())
 	default:
 		return fmt.Errorf("agent error (%s): %s", e.GetCode(), e.GetMessage())
 	}

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -99,11 +99,6 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNew
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}
 	if err := vsockframing.WriteFrame(stream, reqData); err != nil {
-		// The agent may have already sent a response and closed before
-		// this write landed; salvage it instead of discarding it.
-		if salvaged := salvageAfterWriteFailure(stream, c.maxResponseSize); salvaged != nil {
-			return nil, salvaged
-		}
 		return nil, wrapStreamErr(ctx, "sending request", err)
 	}
 
@@ -132,24 +127,6 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNew
 	default:
 		return nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
 	}
-}
-
-// salvageAfterWriteFailure attempts one bounded read after a failed write,
-// returning the mapped error for a usable error response, or nil if
-// nothing could be salvaged.
-func salvageAfterWriteFailure(stream io.Reader, maxResponseSize int) error {
-	respData, err := vsockframing.ReadFrame(stream, uint32(maxResponseSize))
-	if err != nil {
-		return nil
-	}
-	var resp pb.VMServiceResponse
-	if err := proto.Unmarshal(respData, &resp); err != nil {
-		return nil
-	}
-	if e, ok := resp.GetResult().(*pb.VMServiceResponse_Error); ok {
-		return errorFromResponse(e.Error)
-	}
-	return nil
 }
 
 func wrapStreamErr(ctx context.Context, op string, err error) error {

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -1,9 +1,13 @@
 package vsockclient
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"net"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -14,6 +18,40 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+// fakeStream is an io.ReadWriteCloser with scripted Write/Read behavior,
+// for testing GetReport's write-failure salvage path.
+type fakeStream struct {
+	writeErr error
+	reader   io.Reader
+}
+
+func (f *fakeStream) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return len(p), nil
+}
+
+func (f *fakeStream) Read(p []byte) (int, error) {
+	if f.reader == nil {
+		return 0, io.EOF
+	}
+	return f.reader.Read(p)
+}
+
+func (f *fakeStream) Close() error { return nil }
+
+// framedResponse marshals and frames resp exactly as the agent would write
+// it, for use as a fakeStream's readable backing.
+func framedResponse(t *testing.T, resp *pb.VMServiceResponse) *bytes.Buffer {
+	t.Helper()
+	data, err := proto.Marshal(resp)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, vsockframing.WriteFrame(&buf, data))
+	return &buf
+}
 
 // serveOnce plays the agent side of a request/response exchange over
 // agentConn. Run in its own goroutine, since GetReport blocks on the
@@ -121,6 +159,11 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			wantErr:   ErrInternal,
 			wantInMsg: "scan crashed",
 		},
+		"should wrap ErrBusy for BUSY": {
+			code:    pb.ErrorCode_ERROR_CODE_BUSY,
+			message: "agent is already serving another request",
+			wantErr: ErrBusy,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -183,5 +226,37 @@ func TestSendGetReport_ContextCancelUnblocks(t *testing.T) {
 		assert.ErrorIs(t, err, context.Canceled)
 	case <-time.After(2 * time.Second):
 		t.Fatal("GetReport did not unblock on context cancel")
+	}
+}
+
+func TestSendGetReport_WriteFailure(t *testing.T) {
+	writeErr := errors.New("write: broken pipe")
+	cases := map[string]struct {
+		reader  io.Reader
+		wantErr error
+	}{
+		"busy reply behind the failed write should be salvaged": {
+			reader: framedResponse(t, &pb.VMServiceResponse{
+				Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_Error{
+					Error: &pb.ErrorResponse{Code: pb.ErrorCode_ERROR_CODE_BUSY, Message: "agent is busy"},
+				},
+			}),
+			wantErr: ErrBusy,
+		},
+		"nothing salvageable behind the failed write should surface the write error unchanged": {
+			reader:  iotest.ErrReader(errors.New("read: connection reset")),
+			wantErr: writeErr,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := NewClient(nil, 10<<20)
+			stream := &fakeStream{writeErr: writeErr, reader: tc.reader}
+
+			_, err := client.GetReport(context.Background(), stream, 0, 0)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tc.wantErr)
+		})
 	}
 }

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -1,13 +1,9 @@
 package vsockclient
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"io"
 	"net"
 	"testing"
-	"testing/iotest"
 	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -18,40 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
-
-// fakeStream is an io.ReadWriteCloser with scripted Write/Read behavior,
-// for testing GetReport's write-failure salvage path.
-type fakeStream struct {
-	writeErr error
-	reader   io.Reader
-}
-
-func (f *fakeStream) Write(p []byte) (int, error) {
-	if f.writeErr != nil {
-		return 0, f.writeErr
-	}
-	return len(p), nil
-}
-
-func (f *fakeStream) Read(p []byte) (int, error) {
-	if f.reader == nil {
-		return 0, io.EOF
-	}
-	return f.reader.Read(p)
-}
-
-func (f *fakeStream) Close() error { return nil }
-
-// framedResponse marshals and frames resp exactly as the agent would write
-// it, for use as a fakeStream's readable backing.
-func framedResponse(t *testing.T, resp *pb.VMServiceResponse) *bytes.Buffer {
-	t.Helper()
-	data, err := proto.Marshal(resp)
-	require.NoError(t, err)
-	var buf bytes.Buffer
-	require.NoError(t, vsockframing.WriteFrame(&buf, data))
-	return &buf
-}
 
 // serveOnce plays the agent side of a request/response exchange over
 // agentConn. Run in its own goroutine, since GetReport blocks on the
@@ -226,37 +188,5 @@ func TestSendGetReport_ContextCancelUnblocks(t *testing.T) {
 		assert.ErrorIs(t, err, context.Canceled)
 	case <-time.After(2 * time.Second):
 		t.Fatal("GetReport did not unblock on context cancel")
-	}
-}
-
-func TestSendGetReport_WriteFailure(t *testing.T) {
-	writeErr := errors.New("write: broken pipe")
-	cases := map[string]struct {
-		reader  io.Reader
-		wantErr error
-	}{
-		"busy reply behind the failed write should be salvaged": {
-			reader: framedResponse(t, &pb.VMServiceResponse{
-				Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
-				Result: &pb.VMServiceResponse_Error{
-					Error: &pb.ErrorResponse{Code: pb.ErrorCode_ERROR_CODE_BUSY, Message: "agent is busy"},
-				},
-			}),
-			wantErr: ErrBusy,
-		},
-		"nothing salvageable behind the failed write should surface the write error unchanged": {
-			reader:  iotest.ErrReader(errors.New("read: connection reset")),
-			wantErr: writeErr,
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			client := NewClient(nil, 10<<20)
-			stream := &fakeStream{writeErr: writeErr, reader: tc.reader}
-
-			_, err := client.GetReport(context.Background(), stream, 0, 0)
-			require.Error(t, err)
-			assert.ErrorIs(t, err, tc.wantErr)
-		})
 	}
 }


### PR DESCRIPTION
## Description

roxagent accepts at most one in-flight connection (`maxConcurrentConns = 1`). When a second peer dials while the slot is held, `rejectConn` writes a framed `ERROR_CODE_BUSY` and closes the socket immediately, without waiting for the peer to send anything. Sensor's client (`vsockclient.Client.GetReport`) always writes its request before reading a response, so on the reject path its write can race the agent's close and fail with `broken pipe`/`connection reset` before it ever reads the busy reply. Sensor never learns the agent was busy, only that the transport failed. Even when the busy response is read successfully, Sensor had no typed handling for it and misclassified it as a generic "protocol error / possible version mismatch", indistinguishable from a real bug.

The fix is two complementary changes:

- **Agent absorbs the racing request (`rejectConn`):** before closing, the agent now reads and discards one framed request from the peer, bounded by a short fixed timeout (`rejectAbsorbTimeout`, 2s). This drains Sensor's write before the socket closes, removing the race deterministically.
- **Typed busy classification:** a new `ErrBusy` sentinel, an `ERROR_CODE_BUSY` case in `errorFromResponse`, and a dedicated `PullStatusBusy` metric label/log line in `vmscraper` make a busy agent visible and distinguishable from a real protocol error, instead of falling into the generic error bucket.

We deliberately omitted client-side write-failure salvage (reading after a failed `WriteFrame` in hope of finding a buffered BUSY reply). That path only helps during a Sensor-first rolling upgrade against an old agent without the absorb-read, is probabilistic rather than deterministic, and roughly doubles the client/test surface. With absorb-read on the agent, steady-state delivery is already deterministic; residual upgrade-window races are left to the next poll cycle.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI
- No Manual testing: The connection race this PR fixes is purely timing-dependent, so a live reproduction wouldn't prove much either way. The added/updated unit tests use Go's `testing/synctest` package so the race and its fix are exercised deterministically, not by timing luck.

**Proposed manual smoke test** (not required to confirm the fix):

1. Deploy Central + Sensor + a VM running roxagent from this branch.
2. Trigger overlapping `GetReport` calls against the agent (e.g. lower the VM scrape interval, or script two concurrent VSOCK dials) so a second connection reliably arrives while the first is still in flight.
3. Confirm Sensor logs show `VMScraper: roxagent on "<ns>/<vm>" is busy with another request` at Info level, not the old generic "protocol error / possible version mismatch" Warn.
4. Confirm the `stackrox_sensor_vm_pull_requests_total{status="busy"}` metric on Sensor increments for the rejected request, and `status="read_error"` does not.
5. Confirm the VM's index report still updates normally on the next poll (no stuck or permanently-failed VM).