### PR TITLE
ROX-35685: add roxagent repo-to-CPE mapping updaters

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/mapping.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/mapping.go
@@ -1,0 +1,29 @@
+package vsockserver
+
+import (
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+)
+
+// MappingProvider supplies the current repository-to-CPE mapping regardless
+// of which updater (Sensor-backed or URL-backed) owns it in this process.
+type MappingProvider interface {
+	Ready() bool
+	Hash() string
+	UpdatePath() pb.RepoCPEMappingUpdatePath
+	Bytes() ([]byte, error)
+	Path() (string, error)
+}
+
+// MappingUpdater accepts new mapping content pushed in over VSOCK. Only the
+// Sensor-backed updater implements this; a URL-backed agent's Handler keeps
+// its updater reference nil and rejects SyncRepoCPEMapping instead.
+type MappingUpdater interface {
+	Update(content []byte) (updated bool, err error)
+}
+
+// ScanBusyGate is implemented by the Sensor updater so rescanner/Handler
+// can defer active applies across an in-flight scan + GetReport send.
+type ScanBusyGate interface {
+	MarkScanBusy()
+	MarkScanIdleAndApplyPending()
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/mapping.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/mapping.go
@@ -11,6 +11,8 @@ type MappingProvider interface {
 	Hash() string
 	UpdatePath() pb.RepoCPEMappingUpdatePath
 	Bytes() ([]byte, error)
+	// Path returns a file matching Bytes(). It may write that file if a
+	// background persist has not landed yet.
 	Path() (string, error)
 }
 

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -1,0 +1,193 @@
+package vsockserver
+
+import (
+	"bytes"
+	"errors"
+	"os"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/filedownloader"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	_ MappingProvider = (*SensorUpdater)(nil)
+	_ MappingUpdater  = (*SensorUpdater)(nil)
+	_ ScanBusyGate    = (*SensorUpdater)(nil)
+)
+
+var errSensorMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
+
+// SensorUpdater is the MappingProvider/MappingUpdater/ScanBusyGate for an
+// agent whose mapping is pushed in over VSOCK via SyncRepoCPEMapping. It
+// defers applying a new mapping into active while busy is set, so an
+// in-flight VM-disk scan (and the GetReport response for it) never
+// observes the active mapping change mid-flight.
+type SensorUpdater struct {
+	active     []byte
+	activeHash string
+	cachePath  string
+	pending    []byte
+	busy       bool
+	onChange   func()
+	mu         sync.Mutex
+}
+
+// NewSensorUpdater seeds active from cachePath if it holds a validated
+// mapping, else from bundledPath if non-empty and validated, else stays
+// empty until the first Update. onChange must already be non-nil by the
+// time any bootstrap content is found, so construct dependents (e.g. the
+// rescanner) before calling this.
+func NewSensorUpdater(cachePath, bundledPath string, onChange func()) *SensorUpdater {
+	u := &SensorUpdater{cachePath: cachePath, onChange: onChange}
+	if u.bootstrapFrom(cachePath) || u.bootstrapFrom(bundledPath) {
+		if onChange != nil {
+			onChange()
+		}
+	}
+	return u
+}
+
+// bootstrapFrom seeds active/activeHash from path if it decodes as a valid
+// mapping. A no-op for an empty path, so the optional bundled seed can be
+// skipped by passing "". Reports whether it seeded active.
+func (u *SensorUpdater) bootstrapFrom(path string) bool {
+	if path == "" {
+		return false
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		log.Warnf("Ignoring invalid repo-to-CPE mapping at %q: %v", path, err)
+		return false
+	}
+	u.active = content
+	u.activeHash = repositorytocpe.HashMapping(content)
+	return true
+}
+
+// Ready reports whether a validated mapping is currently active.
+func (u *SensorUpdater) Ready() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.active) > 0
+}
+
+// Hash returns the active mapping's content hash, or "" if not Ready.
+func (u *SensorUpdater) Hash() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.activeHash
+}
+
+// UpdatePath reports this updater's mapping source for ResponseMeta.
+func (u *SensorUpdater) UpdatePath() pb.RepoCPEMappingUpdatePath {
+	return pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR
+}
+
+// Bytes returns a copy of the active mapping content.
+func (u *SensorUpdater) Bytes() ([]byte, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if len(u.active) == 0 {
+		return nil, errSensorMappingNotReady
+	}
+	out := make([]byte, len(u.active))
+	copy(out, u.active)
+	return out, nil
+}
+
+// Path returns cachePath after (re-)writing it with the active mapping, so
+// callers always get a file whose content matches Bytes() even if the
+// fire-and-forget persistence from the last apply has not landed yet.
+func (u *SensorUpdater) Path() (string, error) {
+	u.mu.Lock()
+	active := u.active
+	cachePath := u.cachePath
+	u.mu.Unlock()
+	if len(active) == 0 {
+		return "", errSensorMappingNotReady
+	}
+	if err := filedownloader.AtomicWriteFile(cachePath, active); err != nil {
+		return "", err
+	}
+	return cachePath, nil
+}
+
+// Update validates content and either applies it to active immediately or,
+// if a scan is in flight (busy), stages it as pending for
+// MarkScanIdleAndApplyPending to promote later. updated is false only when
+// content is invalid or already equal to the current active/pending
+// content; a validation error never touches state.
+func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		return false, err
+	}
+	hash := repositorytocpe.HashMapping(content)
+
+	u.mu.Lock()
+	if hash == u.activeHash || bytes.Equal(content, u.pending) {
+		u.mu.Unlock()
+		return false, nil
+	}
+	if u.busy {
+		u.pending = content
+		u.mu.Unlock()
+		log.Infof("SyncRepoCPEMapping: deferring apply of mapping (hash=%s) until the in-flight scan finishes", hash)
+		return true, nil
+	}
+	u.applyLocked(content, hash)
+	u.mu.Unlock()
+	u.persistAndNotify(content)
+	return true, nil
+}
+
+// MarkScanBusy marks a VM-disk scan in progress, so a concurrent Update
+// stages new content as pending instead of mutating active underneath it.
+func (u *SensorUpdater) MarkScanBusy() {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.busy = true
+}
+
+// MarkScanIdleAndApplyPending clears busy and, if Update staged content
+// while busy, promotes it to active now that the scan (and its GetReport
+// response) has finished.
+func (u *SensorUpdater) MarkScanIdleAndApplyPending() {
+	u.mu.Lock()
+	u.busy = false
+	pending := u.pending
+	if pending == nil {
+		u.mu.Unlock()
+		return
+	}
+	u.pending = nil
+	u.applyLocked(pending, repositorytocpe.HashMapping(pending))
+	u.mu.Unlock()
+	u.persistAndNotify(pending)
+}
+
+// applyLocked sets active/activeHash to content/hash. Caller must hold mu.
+func (u *SensorUpdater) applyLocked(content []byte, hash string) {
+	u.active = content
+	u.activeHash = hash
+}
+
+// persistAndNotify writes content to cachePath in the background - a scan
+// or another Update must never block on disk I/O - then synchronously
+// fires onChange so the caller's later reads already see the new active
+// mapping.
+func (u *SensorUpdater) persistAndNotify(content []byte) {
+	cachePath := u.cachePath
+	go func() {
+		if err := filedownloader.AtomicWriteFile(cachePath, content); err != nil {
+			log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", cachePath, err)
+		}
+	}()
+	if u.onChange != nil {
+		u.onChange()
+	}
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -123,7 +123,13 @@ func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 	hash := repositorytocpe.HashMapping(content)
 
 	updated, deferred := concurrency.WithLock2(&u.mu, func() (bool, bool) {
-		if hash == u.activeHash || bytes.Equal(content, u.pending) {
+		if hash == u.activeHash {
+			// The newest push matches active, so it supersedes whatever
+			// an earlier, now-stale push staged as pending.
+			u.pending = nil
+			return false, false
+		}
+		if bytes.Equal(content, u.pending) {
 			return false, false
 		}
 		if u.busy {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/filedownloader"
 	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
@@ -100,10 +101,9 @@ func (u *SensorUpdater) Bytes() ([]byte, error) {
 // callers always get a file whose content matches Bytes() even if the
 // fire-and-forget persistence from the last apply has not landed yet.
 func (u *SensorUpdater) Path() (string, error) {
-	u.mu.Lock()
-	active := u.active
-	cachePath := u.cachePath
-	u.mu.Unlock()
+	active, cachePath := concurrency.WithLock2(&u.mu, func() ([]byte, string) {
+		return u.active, u.cachePath
+	})
 	if len(active) == 0 {
 		return "", errSensorMappingNotReady
 	}
@@ -122,19 +122,24 @@ func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 	}
 	hash := repositorytocpe.HashMapping(content)
 
-	u.mu.Lock()
-	if hash == u.activeHash || bytes.Equal(content, u.pending) {
-		u.mu.Unlock()
+	updated, deferred := concurrency.WithLock2(&u.mu, func() (bool, bool) {
+		if hash == u.activeHash || bytes.Equal(content, u.pending) {
+			return false, false
+		}
+		if u.busy {
+			u.pending = content
+			return true, true
+		}
+		u.applyLocked(content, hash)
+		return true, false
+	})
+	if !updated {
 		return false, nil
 	}
-	if u.busy {
-		u.pending = content
-		u.mu.Unlock()
+	if deferred {
 		log.Infof("SyncRepoCPEMapping: deferring apply of mapping (hash=%s) until the in-flight scan finishes", hash)
 		return true, nil
 	}
-	u.applyLocked(content, hash)
-	u.mu.Unlock()
 	u.persistAndNotify(content)
 	return true, nil
 }
@@ -151,17 +156,19 @@ func (u *SensorUpdater) MarkScanBusy() {
 // while busy, promotes it to active now that the scan (and its GetReport
 // response) has finished.
 func (u *SensorUpdater) MarkScanIdleAndApplyPending() {
-	u.mu.Lock()
-	u.busy = false
-	pending := u.pending
-	if pending == nil {
-		u.mu.Unlock()
-		return
+	pending := concurrency.WithLock1(&u.mu, func() []byte {
+		u.busy = false
+		pending := u.pending
+		if pending == nil {
+			return nil
+		}
+		u.pending = nil
+		u.applyLocked(pending, repositorytocpe.HashMapping(pending))
+		return pending
+	})
+	if pending != nil {
+		u.persistAndNotify(pending)
 	}
-	u.pending = nil
-	u.applyLocked(pending, repositorytocpe.HashMapping(pending))
-	u.mu.Unlock()
-	u.persistAndNotify(pending)
 }
 
 // applyLocked sets active/activeHash to content/hash. Caller must hold mu.

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -58,6 +58,10 @@ func (u *SensorUpdater) bootstrapFrom(path string) bool {
 	}
 	content, err := os.ReadFile(path)
 	if err != nil {
+		// First boot always misses cache; do not treat that as an error.
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Warnf("Reading repo-to-CPE mapping at %q: %v", path, err)
+		}
 		return false
 	}
 	if err := cpemapping.ValidateMapping(content); err != nil {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -181,8 +181,9 @@ func (u *SensorUpdater) applyLocked(content []byte, hash string) {
 	u.activeHash = hash
 }
 
-// persistAndNotify persists the active mapping in the background, then
-// fires onChange so later reads already see it.
+// persistAndNotify fires onChange now and persists cachePath in the
+// background. Path is the write barrier if the file is needed before
+// that goroutine finishes.
 func (u *SensorUpdater) persistAndNotify() {
 	go func() {
 		if _, err := u.persistActive(); err != nil {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -120,6 +120,10 @@ func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 	if err := cpemapping.ValidateMapping(content); err != nil {
 		return false, err
 	}
+	// MappingUpdater retains content in active/pending and in the async
+	// cache write; clone so a caller reusing the buffer cannot desync
+	// those from activeHash.
+	content = bytes.Clone(content)
 	hash := cpemapping.HashMapping(content)
 
 	updated, deferred := concurrency.WithLock2(&u.mu, func() (bool, bool) {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -8,8 +8,8 @@ import (
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/filedownloader"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 )
 
 var (
@@ -57,12 +57,12 @@ func (u *SensorUpdater) bootstrapFrom(path string) bool {
 	if err != nil {
 		return false
 	}
-	if err := repositorytocpe.ValidateMapping(content); err != nil {
+	if err := cpemapping.ValidateMapping(content); err != nil {
 		log.Warnf("Ignoring invalid repo-to-CPE mapping at %q: %v", path, err)
 		return false
 	}
 	u.active = content
-	u.activeHash = repositorytocpe.HashMapping(content)
+	u.activeHash = cpemapping.HashMapping(content)
 	return true
 }
 
@@ -117,10 +117,10 @@ func (u *SensorUpdater) Path() (string, error) {
 // for MarkScanIdleAndApplyPending to promote later if a scan is in
 // flight (busy), so it never mutates active out from under that scan.
 func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
-	if err := repositorytocpe.ValidateMapping(content); err != nil {
+	if err := cpemapping.ValidateMapping(content); err != nil {
 		return false, err
 	}
-	hash := repositorytocpe.HashMapping(content)
+	hash := cpemapping.HashMapping(content)
 
 	updated, deferred := concurrency.WithLock2(&u.mu, func() (bool, bool) {
 		if hash == u.activeHash {
@@ -169,7 +169,7 @@ func (u *SensorUpdater) MarkScanIdleAndApplyPending() {
 			return nil
 		}
 		u.pending = nil
-		u.applyLocked(pending, repositorytocpe.HashMapping(pending))
+		u.applyLocked(pending, cpemapping.HashMapping(pending))
 		return pending
 	})
 	if pending != nil {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -31,6 +31,9 @@ type SensorUpdater struct {
 	busy       bool
 	onChange   func()
 	mu         sync.Mutex
+	// persistMu serializes cachePath writes. persistActive is the only
+	// acquirer; it takes persistMu, then mu, never the reverse.
+	persistMu sync.Mutex
 }
 
 // NewSensorUpdater seeds active from cachePath, else bundledPath, else
@@ -101,16 +104,7 @@ func (u *SensorUpdater) Bytes() ([]byte, error) {
 // callers always get a file whose content matches Bytes() even if the
 // fire-and-forget persistence from the last apply has not landed yet.
 func (u *SensorUpdater) Path() (string, error) {
-	active, cachePath := concurrency.WithLock2(&u.mu, func() ([]byte, string) {
-		return u.active, u.cachePath
-	})
-	if len(active) == 0 {
-		return "", errSensorMappingNotReady
-	}
-	if err := filedownloader.AtomicWriteFile(cachePath, active); err != nil {
-		return "", err
-	}
-	return cachePath, nil
+	return u.persistActive()
 }
 
 // Update applies content to active immediately, or stages it as pending
@@ -150,7 +144,7 @@ func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 		log.Infof("SyncRepoCPEMapping: deferring apply of mapping (hash=%s) until the in-flight scan finishes", hash)
 		return true, nil
 	}
-	u.persistAndNotify(content)
+	u.persistAndNotify()
 	return true, nil
 }
 
@@ -177,7 +171,7 @@ func (u *SensorUpdater) MarkScanIdleAndApplyPending() {
 		return pending
 	})
 	if pending != nil {
-		u.persistAndNotify(pending)
+		u.persistAndNotify()
 	}
 }
 
@@ -187,17 +181,36 @@ func (u *SensorUpdater) applyLocked(content []byte, hash string) {
 	u.activeHash = hash
 }
 
-// persistAndNotify writes content to cachePath in the background, then
-// synchronously fires onChange so the caller's later reads already see
-// the new active mapping.
-func (u *SensorUpdater) persistAndNotify(content []byte) {
-	cachePath := u.cachePath
+// persistAndNotify persists the active mapping in the background, then
+// fires onChange so later reads already see it.
+func (u *SensorUpdater) persistAndNotify() {
 	go func() {
-		if err := filedownloader.AtomicWriteFile(cachePath, content); err != nil {
-			log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", cachePath, err)
+		if _, err := u.persistActive(); err != nil {
+			log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", u.cachePath, err)
 		}
 	}()
 	if u.onChange != nil {
 		u.onChange()
 	}
+}
+
+// persistActive writes a copy of the current active mapping to cachePath.
+// It takes persistMu, then mu, so a late persist cannot overwrite the
+// file with a superseded mapping.
+func (u *SensorUpdater) persistActive() (string, error) {
+	return concurrency.WithLock2(&u.persistMu, func() (string, error) {
+		active, cachePath := concurrency.WithLock2(&u.mu, func() ([]byte, string) {
+			if len(u.active) == 0 {
+				return nil, u.cachePath
+			}
+			return bytes.Clone(u.active), u.cachePath
+		})
+		if len(active) == 0 {
+			return "", errSensorMappingNotReady
+		}
+		if err := filedownloader.AtomicWriteFile(cachePath, active); err != nil {
+			return "", err
+		}
+		return cachePath, nil
+	})
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -19,11 +19,9 @@ var (
 
 var errSensorMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
 
-// SensorUpdater is the MappingProvider/MappingUpdater/ScanBusyGate for an
-// agent whose mapping is pushed in over VSOCK via SyncRepoCPEMapping. It
-// defers applying a new mapping into active while busy is set, so an
-// in-flight VM-disk scan (and the GetReport response for it) never
-// observes the active mapping change mid-flight.
+// SensorUpdater applies repo-to-CPE mappings pushed in over VSOCK via
+// SyncRepoCPEMapping, deferring the apply while busy is set so an
+// in-flight scan's GetReport response never sees a mid-flight change.
 type SensorUpdater struct {
 	active     []byte
 	activeHash string
@@ -34,11 +32,9 @@ type SensorUpdater struct {
 	mu         sync.Mutex
 }
 
-// NewSensorUpdater seeds active from cachePath if it holds a validated
-// mapping, else from bundledPath if non-empty and validated, else stays
-// empty until the first Update. onChange must already be non-nil by the
-// time any bootstrap content is found, so construct dependents (e.g. the
-// rescanner) before calling this.
+// NewSensorUpdater seeds active from cachePath, else bundledPath, else
+// stays empty until the first Update. Construct onChange's dependents
+// (e.g. the rescanner) first, since it may fire during this call.
 func NewSensorUpdater(cachePath, bundledPath string, onChange func()) *SensorUpdater {
 	u := &SensorUpdater{cachePath: cachePath, onChange: onChange}
 	if u.bootstrapFrom(cachePath) || u.bootstrapFrom(bundledPath) {
@@ -117,11 +113,9 @@ func (u *SensorUpdater) Path() (string, error) {
 	return cachePath, nil
 }
 
-// Update validates content and either applies it to active immediately or,
-// if a scan is in flight (busy), stages it as pending for
-// MarkScanIdleAndApplyPending to promote later. updated is false only when
-// content is invalid or already equal to the current active/pending
-// content; a validation error never touches state.
+// Update applies content to active immediately, or stages it as pending
+// for MarkScanIdleAndApplyPending to promote later if a scan is in
+// flight (busy), so it never mutates active out from under that scan.
 func (u *SensorUpdater) Update(content []byte) (updated bool, err error) {
 	if err := repositorytocpe.ValidateMapping(content); err != nil {
 		return false, err
@@ -176,10 +170,9 @@ func (u *SensorUpdater) applyLocked(content []byte, hash string) {
 	u.activeHash = hash
 }
 
-// persistAndNotify writes content to cachePath in the background - a scan
-// or another Update must never block on disk I/O - then synchronously
-// fires onChange so the caller's later reads already see the new active
-// mapping.
+// persistAndNotify writes content to cachePath in the background, then
+// synchronously fires onChange so the caller's later reads already see
+// the new active mapping.
 func (u *SensorUpdater) persistAndNotify(content []byte) {
 	cachePath := u.cachePath
 	go func() {

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -149,6 +149,23 @@ func TestSensorUpdater_Update_OwnsContent(t *testing.T) {
 	waitForCacheContent(t, cachePath, validMappingJSON)
 }
 
+func TestSensorUpdater_Path_WritesCurrentActive(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	u := NewSensorUpdater(cachePath, "", func() {})
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	_, err = u.Update([]byte(otherValidMappingJSON))
+	require.NoError(t, err)
+
+	path, err := u.Path()
+	require.NoError(t, err)
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, otherValidMappingJSON, string(onDisk),
+		"Path must persist the current active mapping, not an in-flight older write")
+	waitForCacheContent(t, cachePath, otherValidMappingJSON)
+}
+
 func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "cache.json")

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -133,6 +133,22 @@ func TestNewSensorUpdater_InvalidCacheNoBundled_NotReady(t *testing.T) {
 	assert.Equal(t, 0, counter.count)
 }
 
+func TestSensorUpdater_Update_OwnsContent(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	u := NewSensorUpdater(cachePath, "", func() {})
+	content := []byte(validMappingJSON)
+
+	updated, err := u.Update(content)
+	require.NoError(t, err)
+	require.True(t, updated)
+	content[0] ^= 0xff
+
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b), "mutating the caller's buffer must not change the active mapping")
+	waitForCacheContent(t, cachePath, validMappingJSON)
+}
+
 func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "cache.json")

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -233,6 +233,30 @@ func TestSensorUpdater_UpdateWhileBusy_SameAsPending_NoOp(t *testing.T) {
 	assert.False(t, updated, "re-staging identical pending content must be a no-op")
 }
 
+// TestSensorUpdater_UpdateWhileBusy_RevertToActive_ClearsStalePending covers
+// a revert push landing after a newer one was already staged: Sensor pushes
+// are ordered, so the newest push (matching active) must win, not the
+// earlier, now-stale pending content.
+func TestSensorUpdater_UpdateWhileBusy_RevertToActive_ClearsStalePending(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	u.MarkScanBusy()
+
+	updated, err := u.Update([]byte(otherValidMappingJSON))
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	updated, err = u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.False(t, updated, "reverting to the already-active content is not itself an update")
+
+	u.MarkScanIdleAndApplyPending()
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash(),
+		"the newest push (matching active) must win over the stale pending mapping")
+}
+
 func TestSensorUpdater_MarkScanIdleAndApplyPending_NoPending_NoOp(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
 	counter := &onChangeCounter{}

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -1,0 +1,255 @@
+package vsockserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validMappingJSON = `{"data":{"rhel-8-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:8"]}}}`
+const otherValidMappingJSON = `{"data":{"rhel-9-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:9"]}}}`
+const invalidMappingJSON = `{not json`
+
+// waitTimeout/waitTick bound assert.Eventually polling for the
+// fire-and-forget cache-persistence goroutine shared by both updaters' tests.
+const (
+	waitTimeout = 2 * time.Second
+	waitTick    = 10 * time.Millisecond
+)
+
+// onChangeCounter is a test double for a MappingProvider's onChange
+// callback that records how many times it fired.
+type onChangeCounter struct {
+	count int
+}
+
+func (c *onChangeCounter) fn() { c.count++ }
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+}
+
+// waitForCacheContent polls cachePath for the persist goroutine an applied
+// Update starts in the background, so tests can drain it deterministically
+// instead of letting it race the tempdir's end-of-test cleanup.
+func waitForCacheContent(t *testing.T, cachePath, want string) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		b, err := os.ReadFile(cachePath)
+		return err == nil && string(b) == want
+	}, waitTimeout, waitTick, "expected %q to be persisted to %s", want, cachePath)
+}
+
+func TestNewSensorUpdater_EmptyStart_NotReady(t *testing.T) {
+	dir := t.TempDir()
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), "", counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Empty(t, u.Hash())
+	assert.Equal(t, 0, counter.count)
+
+	_, err := u.Bytes()
+	assert.Error(t, err)
+	_, err = u.Path()
+	assert.Error(t, err)
+}
+
+func TestNewSensorUpdater_BootstrapFromCache(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+	assert.Equal(t, 1, counter.count, "onChange should fire once for a valid bootstrap")
+}
+
+func TestNewSensorUpdater_BootstrapFromBundled_WhenNoCache(t *testing.T) {
+	dir := t.TempDir()
+	bundledPath := filepath.Join(dir, "bundled.json")
+	writeFile(t, bundledPath, validMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), bundledPath, counter.fn)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count)
+}
+
+func TestNewSensorUpdater_CacheTakesPrecedenceOverBundled(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	bundledPath := filepath.Join(dir, "bundled.json")
+	writeFile(t, cachePath, validMappingJSON)
+	writeFile(t, bundledPath, otherValidMappingJSON)
+
+	u := NewSensorUpdater(cachePath, bundledPath, func() {})
+
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b), "a valid cache must win over a valid bundled file")
+}
+
+func TestNewSensorUpdater_InvalidCacheFallsBackToBundled(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	bundledPath := filepath.Join(dir, "bundled.json")
+	writeFile(t, cachePath, invalidMappingJSON)
+	writeFile(t, bundledPath, validMappingJSON)
+
+	u := NewSensorUpdater(cachePath, bundledPath, func() {})
+
+	require.True(t, u.Ready())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+}
+
+func TestNewSensorUpdater_InvalidCacheNoBundled_NotReady(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, invalidMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Equal(t, 0, counter.count)
+}
+
+func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+
+	updated, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.True(t, updated)
+	assert.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count)
+	waitForCacheContent(t, cachePath, validMappingJSON)
+}
+
+func TestSensorUpdater_Update_NoOpWhenUnchanged(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	u := NewSensorUpdater(cachePath, "", func() {})
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	waitForCacheContent(t, cachePath, validMappingJSON)
+
+	updated, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.False(t, updated, "re-applying identical content must be a no-op")
+}
+
+func TestSensorUpdater_Update_RejectsInvalidKeepsLastGood(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	u := NewSensorUpdater(cachePath, "", func() {})
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	wantHash := u.Hash()
+	waitForCacheContent(t, cachePath, validMappingJSON)
+
+	updated, err := u.Update([]byte(invalidMappingJSON))
+	assert.Error(t, err)
+	assert.False(t, updated)
+	assert.Equal(t, wantHash, u.Hash(), "invalid content must not replace the last-good mapping")
+}
+
+func TestSensorUpdater_Update_OversizeRejected(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	oversized := make([]byte, repositorytocpe.MaxMappingBytes+1)
+
+	updated, err := u.Update(oversized)
+	assert.Error(t, err)
+	assert.False(t, updated)
+	assert.False(t, u.Ready())
+}
+
+func TestSensorUpdater_UpdateWhileBusy_DefersUntilIdle(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.count)
+	idleHash := u.Hash()
+	idleBytes, err := u.Bytes()
+	require.NoError(t, err)
+
+	u.MarkScanBusy()
+
+	updated, err := u.Update([]byte(otherValidMappingJSON))
+	require.NoError(t, err)
+	assert.True(t, updated, "a genuinely new candidate is reported as updated even while deferred")
+
+	// While busy, active content (and therefore Hash/Bytes) must not change:
+	// an in-flight scan may still be reading these values.
+	assert.Equal(t, idleHash, u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, idleBytes, b)
+	assert.Equal(t, 1, counter.count, "onChange must not fire for a deferred apply")
+
+	u.MarkScanIdleAndApplyPending()
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(otherValidMappingJSON)), u.Hash())
+	b, err = u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, otherValidMappingJSON, string(b))
+	assert.Equal(t, 2, counter.count, "onChange must fire once the pending mapping is promoted")
+	waitForCacheContent(t, cachePath, otherValidMappingJSON)
+}
+
+func TestSensorUpdater_UpdateWhileBusy_SameAsPending_NoOp(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	u.MarkScanBusy()
+
+	updated, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.True(t, updated)
+
+	updated, err = u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	assert.False(t, updated, "re-staging identical pending content must be a no-op")
+}
+
+func TestSensorUpdater_MarkScanIdleAndApplyPending_NoPending_NoOp(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	counter := &onChangeCounter{}
+	u := NewSensorUpdater(cachePath, "", counter.fn)
+	_, err := u.Update([]byte(validMappingJSON))
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.count)
+	waitForCacheContent(t, cachePath, validMappingJSON)
+
+	u.MarkScanBusy()
+	u.MarkScanIdleAndApplyPending()
+
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count, "onChange must not fire when there is nothing pending to apply")
+}
+
+func TestSensorUpdater_UpdatePath_IsSensor(t *testing.T) {
+	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, u.UpdatePath())
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,7 +72,7 @@ func TestNewSensorUpdater_BootstrapFromCache(t *testing.T) {
 	u := NewSensorUpdater(cachePath, "", counter.fn)
 
 	require.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	b, err := u.Bytes()
 	require.NoError(t, err)
 	assert.Equal(t, validMappingJSON, string(b))
@@ -88,7 +88,7 @@ func TestNewSensorUpdater_BootstrapFromBundled_WhenNoCache(t *testing.T) {
 	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), bundledPath, counter.fn)
 
 	require.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count)
 }
 
@@ -143,7 +143,7 @@ func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, updated)
 	assert.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count)
 	waitForCacheContent(t, cachePath, validMappingJSON)
 }
@@ -176,7 +176,7 @@ func TestSensorUpdater_Update_RejectsInvalidKeepsLastGood(t *testing.T) {
 
 func TestSensorUpdater_Update_OversizeRejected(t *testing.T) {
 	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
-	oversized := make([]byte, repositorytocpe.MaxMappingBytes+1)
+	oversized := make([]byte, cpemapping.MaxMappingBytes+1)
 
 	updated, err := u.Update(oversized)
 	assert.Error(t, err)
@@ -212,7 +212,7 @@ func TestSensorUpdater_UpdateWhileBusy_DefersUntilIdle(t *testing.T) {
 
 	u.MarkScanIdleAndApplyPending()
 
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(otherValidMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(otherValidMappingJSON)), u.Hash())
 	b, err = u.Bytes()
 	require.NoError(t, err)
 	assert.Equal(t, otherValidMappingJSON, string(b))
@@ -253,7 +253,7 @@ func TestSensorUpdater_UpdateWhileBusy_RevertToActive_ClearsStalePending(t *test
 
 	u.MarkScanIdleAndApplyPending()
 
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash(),
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash(),
 		"the newest push (matching active) must win over the stale pending mapping")
 }
 
@@ -269,7 +269,7 @@ func TestSensorUpdater_MarkScanIdleAndApplyPending_NoPending_NoOp(t *testing.T) 
 	u.MarkScanBusy()
 	u.MarkScanIdleAndApplyPending()
 
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count, "onChange must not fire when there is nothing pending to apply")
 }
 

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -1,0 +1,160 @@
+package vsockserver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/filedownloader"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// Retry/refresh policy for the periodic mapping download, mirroring
+// cmd.newMappingDownloader: WaitMin=5s with the default WaitMax=30s covers
+// four HTTP attempts (5+10+20=35s) within urlMappingClientTimeout.
+const (
+	urlMappingFetchRetryMax     = 3
+	urlMappingFetchRetryWaitMin = 5 * time.Second
+	urlMappingClientTimeout     = 2 * time.Minute
+	urlMappingRefreshInterval   = time.Hour
+)
+
+var _ MappingProvider = (*URLUpdater)(nil)
+
+var errURLMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
+
+// URLUpdater is the MappingProvider for an agent configured with a
+// mapping URL. It only implements MappingProvider: Handler keeps its
+// updater reference nil for URL-backed agents, since this mapping source
+// never accepts a Sensor-pushed Update.
+type URLUpdater struct {
+	downloader *filedownloader.Downloader
+	cachePath  string
+	active     []byte
+	activeHash string
+	onChange   func()
+	mu         sync.Mutex
+}
+
+// NewURLUpdater seeds active from cachePath if it holds a validated
+// mapping (e.g. left by a prior process's successful download), else
+// stays empty until the first successful fetch. There is no bundled-file
+// fallback: a URL-backed agent has exactly one mapping source.
+func NewURLUpdater(url, cachePath string, onChange func()) *URLUpdater {
+	u := &URLUpdater{cachePath: cachePath, onChange: onChange}
+	if u.bootstrap() && onChange != nil {
+		onChange()
+	}
+	u.downloader = filedownloader.New(url, cachePath, urlMappingRefreshInterval,
+		filedownloader.WithRequestTimeout(urlMappingClientTimeout),
+		filedownloader.WithRetryMax(urlMappingFetchRetryMax),
+		filedownloader.WithRetryWaitMin(urlMappingFetchRetryWaitMin),
+		filedownloader.WithOnComplete(u.onDownloadComplete),
+	)
+	return u
+}
+
+// bootstrap seeds active/activeHash from cachePath if it decodes as a
+// valid mapping. Reports whether it seeded active.
+func (u *URLUpdater) bootstrap() bool {
+	content, err := os.ReadFile(u.cachePath)
+	if err != nil {
+		return false
+	}
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		log.Warnf("Ignoring invalid repo-to-CPE mapping cache at %q: %v", u.cachePath, err)
+		return false
+	}
+	u.active = content
+	u.activeHash = repositorytocpe.HashMapping(content)
+	return true
+}
+
+// Start begins the periodic download loop in the background; agent
+// startup never blocks on a successful fetch.
+func (u *URLUpdater) Start(ctx context.Context) error {
+	return u.downloader.Start(ctx, false)
+}
+
+// Stop signals the download loop to stop and blocks until it exits.
+func (u *URLUpdater) Stop() {
+	u.downloader.Stop()
+}
+
+// Ready reports whether a validated mapping is currently active.
+func (u *URLUpdater) Ready() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.active) > 0
+}
+
+// Hash returns the active mapping's content hash, or "" if not Ready.
+func (u *URLUpdater) Hash() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.activeHash
+}
+
+// UpdatePath reports this updater's mapping source for ResponseMeta.
+func (u *URLUpdater) UpdatePath() pb.RepoCPEMappingUpdatePath {
+	return pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL
+}
+
+// Bytes returns a copy of the active mapping content.
+func (u *URLUpdater) Bytes() ([]byte, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if len(u.active) == 0 {
+		return nil, errURLMappingNotReady
+	}
+	out := make([]byte, len(u.active))
+	copy(out, u.active)
+	return out, nil
+}
+
+// Path returns cachePath, which the downloader already keeps in sync with
+// the active mapping via its own atomic writes.
+func (u *URLUpdater) Path() (string, error) {
+	u.mu.Lock()
+	ready := len(u.active) > 0
+	u.mu.Unlock()
+	if !ready {
+		return "", errURLMappingNotReady
+	}
+	return u.cachePath, nil
+}
+
+// onDownloadComplete is filedownloader's OnComplete callback. On a failed
+// fetch it only logs, keeping the last-good active mapping (if any). On a
+// successful fetch it re-reads cachePath (the callback carries no bytes)
+// and validates before promoting it to active, so a since-corrupted file
+// can never replace a good in-memory mapping.
+func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
+	if err != nil {
+		log.Warnf("Downloading repo-to-CPE mapping: %v", err)
+		return
+	}
+	content, err := os.ReadFile(u.cachePath)
+	if err != nil {
+		log.Warnf("Reading downloaded repo-to-CPE mapping at %q: %v", u.cachePath, err)
+		return
+	}
+	if err := repositorytocpe.ValidateMapping(content); err != nil {
+		log.Warnf("Downloaded repo-to-CPE mapping failed validation, keeping last-good: %v", err)
+		return
+	}
+	hash := repositorytocpe.HashMapping(content)
+
+	u.mu.Lock()
+	unchanged := hash == u.activeHash
+	u.active = content
+	u.activeHash = hash
+	u.mu.Unlock()
+
+	if !unchanged && u.onChange != nil {
+		u.onChange()
+	}
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/filedownloader"
 	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
@@ -116,9 +117,9 @@ func (u *URLUpdater) Bytes() ([]byte, error) {
 // Path returns cachePath, which the downloader already keeps in sync with
 // the active mapping via its own atomic writes.
 func (u *URLUpdater) Path() (string, error) {
-	u.mu.Lock()
-	ready := len(u.active) > 0
-	u.mu.Unlock()
+	ready := concurrency.WithLock1(&u.mu, func() bool {
+		return len(u.active) > 0
+	})
 	if !ready {
 		return "", errURLMappingNotReady
 	}
@@ -144,11 +145,12 @@ func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	}
 	hash := repositorytocpe.HashMapping(content)
 
-	u.mu.Lock()
-	unchanged := hash == u.activeHash
-	u.active = content
-	u.activeHash = hash
-	u.mu.Unlock()
+	unchanged := concurrency.WithLock1(&u.mu, func() bool {
+		unchanged := hash == u.activeHash
+		u.active = content
+		u.activeHash = hash
+		return unchanged
+	})
 
 	if !unchanged && u.onChange != nil {
 		u.onChange()

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -120,8 +120,8 @@ func (u *URLUpdater) Bytes() ([]byte, error) {
 	return out, nil
 }
 
-// Path returns cachePath, which onDownloadComplete keeps in sync with the
-// active mapping by only promoting validated downloads into it.
+// Path returns cachePath. onDownloadComplete only sets active after a
+// validated download has been persisted there, so the file matches Bytes().
 func (u *URLUpdater) Path() (string, error) {
 	ready := concurrency.WithLock1(&u.mu, func() bool {
 		return len(u.active) > 0
@@ -132,10 +132,9 @@ func (u *URLUpdater) Path() (string, error) {
 	return u.cachePath, nil
 }
 
-// onDownloadComplete is filedownloader's OnComplete callback: it logs and
-// keeps the last-good mapping on failure, and validates the download
-// staged at stagingPath before promoting it to cachePath on success, so
-// an invalid fetch can never replace the persisted last-good mapping.
+// onDownloadComplete applies a staged download only after it validates
+// and persists to cachePath, so Bytes() and Path() stay aligned and a
+// failed persist is retried on the next identical fetch.
 func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	if err != nil {
 		log.Warnf("Downloading repo-to-CPE mapping: %v", err)
@@ -152,18 +151,20 @@ func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	}
 	hash := cpemapping.HashMapping(content)
 
-	unchanged := concurrency.WithLock1(&u.mu, func() bool {
-		unchanged := hash == u.activeHash
-		u.active = content
-		u.activeHash = hash
-		return unchanged
+	alreadyActive := concurrency.WithLock1(&u.mu, func() bool {
+		return hash == u.activeHash
 	})
-	if unchanged {
+	if alreadyActive {
 		return
 	}
 	if err := filedownloader.AtomicWriteFile(u.cachePath, content); err != nil {
 		log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", u.cachePath, err)
+		return
 	}
+	concurrency.WithLock(&u.mu, func() {
+		u.active = content
+		u.activeHash = hash
+	})
 	if u.onChange != nil {
 		u.onChange()
 	}

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -27,9 +27,7 @@ var _ MappingProvider = (*URLUpdater)(nil)
 var errURLMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
 
 // URLUpdater is the MappingProvider for an agent configured with a
-// mapping URL. It only implements MappingProvider: Handler keeps its
-// updater reference nil for URL-backed agents, since this mapping source
-// never accepts a Sensor-pushed Update.
+// mapping URL; this mapping source never accepts a Sensor-pushed Update.
 type URLUpdater struct {
 	downloader *filedownloader.Downloader
 	cachePath  string
@@ -127,11 +125,9 @@ func (u *URLUpdater) Path() (string, error) {
 	return u.cachePath, nil
 }
 
-// onDownloadComplete is filedownloader's OnComplete callback. On a failed
-// fetch it only logs, keeping the last-good active mapping (if any). On a
-// successful fetch it re-reads cachePath (the callback carries no bytes)
-// and validates before promoting it to active, so a since-corrupted file
-// can never replace a good in-memory mapping.
+// onDownloadComplete is filedownloader's OnComplete callback: it logs and
+// keeps the last-good mapping on failure, or re-validates before promoting
+// on success, so a corrupted file can never replace a good mapping.
 func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	if err != nil {
 		log.Warnf("Downloading repo-to-CPE mapping: %v", err)

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -21,6 +21,11 @@ const (
 	urlMappingFetchRetryWaitMin = 5 * time.Second
 	urlMappingClientTimeout     = 2 * time.Minute
 	urlMappingRefreshInterval   = time.Hour
+	// urlMappingStagingSuffix names the path the downloader writes to.
+	// onDownloadComplete only promotes a staged download to cachePath
+	// once it passes validation, so a bad fetch can never corrupt the
+	// persisted last-good mapping.
+	urlMappingStagingSuffix = ".download"
 )
 
 var _ MappingProvider = (*URLUpdater)(nil)
@@ -30,12 +35,13 @@ var errURLMappingNotReady = errors.New("no repo-to-CPE mapping available yet")
 // URLUpdater is the MappingProvider for an agent configured with a
 // mapping URL; this mapping source never accepts a Sensor-pushed Update.
 type URLUpdater struct {
-	downloader *filedownloader.Downloader
-	cachePath  string
-	active     []byte
-	activeHash string
-	onChange   func()
-	mu         sync.Mutex
+	downloader  *filedownloader.Downloader
+	cachePath   string
+	stagingPath string
+	active      []byte
+	activeHash  string
+	onChange    func()
+	mu          sync.Mutex
 }
 
 // NewURLUpdater seeds active from cachePath if it holds a validated
@@ -43,11 +49,11 @@ type URLUpdater struct {
 // stays empty until the first successful fetch. There is no bundled-file
 // fallback: a URL-backed agent has exactly one mapping source.
 func NewURLUpdater(url, cachePath string, onChange func()) *URLUpdater {
-	u := &URLUpdater{cachePath: cachePath, onChange: onChange}
+	u := &URLUpdater{cachePath: cachePath, stagingPath: cachePath + urlMappingStagingSuffix, onChange: onChange}
 	if u.bootstrap() && onChange != nil {
 		onChange()
 	}
-	u.downloader = filedownloader.New(url, cachePath, urlMappingRefreshInterval,
+	u.downloader = filedownloader.New(url, u.stagingPath, urlMappingRefreshInterval,
 		filedownloader.WithRequestTimeout(urlMappingClientTimeout),
 		filedownloader.WithRetryMax(urlMappingFetchRetryMax),
 		filedownloader.WithRetryWaitMin(urlMappingFetchRetryWaitMin),
@@ -114,8 +120,8 @@ func (u *URLUpdater) Bytes() ([]byte, error) {
 	return out, nil
 }
 
-// Path returns cachePath, which the downloader already keeps in sync with
-// the active mapping via its own atomic writes.
+// Path returns cachePath, which onDownloadComplete keeps in sync with the
+// active mapping by only promoting validated downloads into it.
 func (u *URLUpdater) Path() (string, error) {
 	ready := concurrency.WithLock1(&u.mu, func() bool {
 		return len(u.active) > 0
@@ -127,16 +133,17 @@ func (u *URLUpdater) Path() (string, error) {
 }
 
 // onDownloadComplete is filedownloader's OnComplete callback: it logs and
-// keeps the last-good mapping on failure, or re-validates before promoting
-// on success, so a corrupted file can never replace a good mapping.
+// keeps the last-good mapping on failure, and validates the download
+// staged at stagingPath before promoting it to cachePath on success, so
+// an invalid fetch can never replace the persisted last-good mapping.
 func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	if err != nil {
 		log.Warnf("Downloading repo-to-CPE mapping: %v", err)
 		return
 	}
-	content, err := os.ReadFile(u.cachePath)
+	content, err := os.ReadFile(u.stagingPath)
 	if err != nil {
-		log.Warnf("Reading downloaded repo-to-CPE mapping at %q: %v", u.cachePath, err)
+		log.Warnf("Reading downloaded repo-to-CPE mapping at %q: %v", u.stagingPath, err)
 		return
 	}
 	if err := repositorytocpe.ValidateMapping(content); err != nil {
@@ -151,8 +158,13 @@ func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 		u.activeHash = hash
 		return unchanged
 	})
-
-	if !unchanged && u.onChange != nil {
+	if unchanged {
+		return
+	}
+	if err := filedownloader.AtomicWriteFile(u.cachePath, content); err != nil {
+		log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", u.cachePath, err)
+	}
+	if u.onChange != nil {
 		u.onChange()
 	}
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -9,8 +9,8 @@ import (
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/filedownloader"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 )
 
 // Retry/refresh policy for the periodic mapping download, mirroring
@@ -69,12 +69,12 @@ func (u *URLUpdater) bootstrap() bool {
 	if err != nil {
 		return false
 	}
-	if err := repositorytocpe.ValidateMapping(content); err != nil {
+	if err := cpemapping.ValidateMapping(content); err != nil {
 		log.Warnf("Ignoring invalid repo-to-CPE mapping cache at %q: %v", u.cachePath, err)
 		return false
 	}
 	u.active = content
-	u.activeHash = repositorytocpe.HashMapping(content)
+	u.activeHash = cpemapping.HashMapping(content)
 	return true
 }
 
@@ -146,11 +146,11 @@ func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 		log.Warnf("Reading downloaded repo-to-CPE mapping at %q: %v", u.stagingPath, err)
 		return
 	}
-	if err := repositorytocpe.ValidateMapping(content); err != nil {
+	if err := cpemapping.ValidateMapping(content); err != nil {
 		log.Warnf("Downloaded repo-to-CPE mapping failed validation, keeping last-good: %v", err)
 		return
 	}
-	hash := repositorytocpe.HashMapping(content)
+	hash := cpemapping.HashMapping(content)
 
 	unchanged := concurrency.WithLock1(&u.mu, func() bool {
 		unchanged := hash == u.activeHash

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater.go
@@ -44,10 +44,9 @@ type URLUpdater struct {
 	mu          sync.Mutex
 }
 
-// NewURLUpdater seeds active from cachePath if it holds a validated
-// mapping (e.g. left by a prior process's successful download), else
-// stays empty until the first successful fetch. There is no bundled-file
-// fallback: a URL-backed agent has exactly one mapping source.
+// NewURLUpdater seeds active from cachePath (last-good from a prior
+// successful download), else stays empty until the first fetch. Bundled
+// image content is not used: a never-working URL would look configured.
 func NewURLUpdater(url, cachePath string, onChange func()) *URLUpdater {
 	u := &URLUpdater{cachePath: cachePath, stagingPath: cachePath + urlMappingStagingSuffix, onChange: onChange}
 	if u.bootstrap() && onChange != nil {
@@ -67,6 +66,10 @@ func NewURLUpdater(url, cachePath string, onChange func()) *URLUpdater {
 func (u *URLUpdater) bootstrap() bool {
 	content, err := os.ReadFile(u.cachePath)
 	if err != nil {
+		// First boot always misses cache; do not treat that as an error.
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Warnf("Reading repo-to-CPE mapping cache at %q: %v", u.cachePath, err)
+		}
 		return false
 	}
 	if err := cpemapping.ValidateMapping(content); err != nil {
@@ -137,7 +140,7 @@ func (u *URLUpdater) Path() (string, error) {
 // failed persist is retried on the next identical fetch.
 func (u *URLUpdater) onDownloadComplete(err error, _ time.Duration) {
 	if err != nil {
-		log.Warnf("Downloading repo-to-CPE mapping: %v", err)
+		log.Warnf("Error downloading repo-to-CPE mapping: %v", err)
 		return
 	}
 	content, err := os.ReadFile(u.stagingPath)

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
@@ -1,0 +1,133 @@
+package vsockserver
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dummyMappingURL is never dialed in these tests: NewURLUpdater's
+// constructor only builds the filedownloader.Downloader, and the actual
+// fetch is exercised indirectly via onDownloadComplete.
+const dummyMappingURL = "http://127.0.0.1:0/mapping.json"
+
+func TestNewURLUpdater_BootstrapFromCache(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+	path, err := u.Path()
+	require.NoError(t, err)
+	assert.Equal(t, cachePath, path)
+	assert.Equal(t, 1, counter.count, "onChange should fire once for a valid bootstrap")
+}
+
+func TestNewURLUpdater_NotReadyWithoutCache(t *testing.T) {
+	dir := t.TempDir()
+	counter := &onChangeCounter{}
+
+	u := NewURLUpdater(dummyMappingURL, filepath.Join(dir, "cache.json"), counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Empty(t, u.Hash())
+	assert.Equal(t, 0, counter.count)
+	_, err := u.Bytes()
+	assert.Error(t, err)
+	_, err = u.Path()
+	assert.Error(t, err)
+}
+
+func TestNewURLUpdater_InvalidCacheStaysNotReady_NoBundledFallback(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, invalidMappingJSON)
+	counter := &onChangeCounter{}
+
+	// The URL updater has no bundled-file parameter and no secondary
+	// source at all: an invalid cachePath must leave it not Ready, not
+	// fall back to anything else.
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+
+	assert.False(t, u.Ready())
+	assert.Equal(t, 0, counter.count)
+}
+
+func TestURLUpdater_UpdatePath_IsURL(t *testing.T) {
+	u := NewURLUpdater(dummyMappingURL, filepath.Join(t.TempDir(), "cache.json"), func() {})
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL, u.UpdatePath())
+}
+
+func TestURLUpdater_FailedDownload_StaysNotReady(t *testing.T) {
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, filepath.Join(t.TempDir(), "cache.json"), counter.fn)
+
+	u.onDownloadComplete(errors.New("connection refused"), 0)
+
+	assert.False(t, u.Ready())
+	assert.Equal(t, 0, counter.count)
+}
+
+func TestURLUpdater_FailedDownload_KeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.True(t, u.Ready())
+	require.Equal(t, 1, counter.count)
+
+	u.onDownloadComplete(errors.New("connection refused"), 0)
+
+	assert.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count, "onChange must not re-fire when a failed refresh keeps the same content")
+}
+
+func TestURLUpdater_SuccessfulDownload_AppliesNewContent(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.False(t, u.Ready())
+
+	// Simulate what filedownloader's atomic write already did before
+	// invoking onComplete: the new content is on disk at cachePath.
+	writeFile(t, cachePath, validMappingJSON)
+	u.onDownloadComplete(nil, 0)
+
+	require.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	b, err := u.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(b))
+	assert.Equal(t, 1, counter.count)
+}
+
+func TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.Equal(t, 1, counter.count)
+
+	writeFile(t, cachePath, invalidMappingJSON)
+	u.onDownloadComplete(nil, 0)
+
+	assert.True(t, u.Ready())
+	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, 1, counter.count, "onChange must not fire when the refreshed content fails validation")
+}

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +26,7 @@ func TestNewURLUpdater_BootstrapFromCache(t *testing.T) {
 	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
 
 	require.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	b, err := u.Bytes()
 	require.NoError(t, err)
 	assert.Equal(t, validMappingJSON, string(b))
@@ -93,7 +93,7 @@ func TestURLUpdater_FailedDownload_KeepsLastGood(t *testing.T) {
 	u.onDownloadComplete(errors.New("connection refused"), 0)
 
 	assert.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count, "onChange must not re-fire when a failed refresh keeps the same content")
 }
 
@@ -110,7 +110,7 @@ func TestURLUpdater_SuccessfulDownload_AppliesNewContent(t *testing.T) {
 	u.onDownloadComplete(nil, 0)
 
 	require.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	b, err := u.Bytes()
 	require.NoError(t, err)
 	assert.Equal(t, validMappingJSON, string(b))
@@ -133,7 +133,7 @@ func TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood(t *testing.T)
 	u.onDownloadComplete(nil, 0)
 
 	assert.True(t, u.Ready())
-	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count, "onChange must not fire when the refreshed content fails validation")
 }
 

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
@@ -2,6 +2,7 @@ package vsockserver
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -104,8 +105,8 @@ func TestURLUpdater_SuccessfulDownload_AppliesNewContent(t *testing.T) {
 	require.False(t, u.Ready())
 
 	// Simulate what filedownloader's atomic write already did before
-	// invoking onComplete: the new content is on disk at cachePath.
-	writeFile(t, cachePath, validMappingJSON)
+	// invoking onComplete: the new content is on disk at stagingPath.
+	writeFile(t, u.stagingPath, validMappingJSON)
 	u.onDownloadComplete(nil, 0)
 
 	require.True(t, u.Ready())
@@ -114,6 +115,10 @@ func TestURLUpdater_SuccessfulDownload_AppliesNewContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, validMappingJSON, string(b))
 	assert.Equal(t, 1, counter.count)
+
+	onDisk, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(onDisk), "a validated download must be promoted to cachePath")
 }
 
 func TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood(t *testing.T) {
@@ -124,10 +129,31 @@ func TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood(t *testing.T)
 	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
 	require.Equal(t, 1, counter.count)
 
-	writeFile(t, cachePath, invalidMappingJSON)
+	writeFile(t, u.stagingPath, invalidMappingJSON)
 	u.onDownloadComplete(nil, 0)
 
 	assert.True(t, u.Ready())
 	assert.Equal(t, repositorytocpe.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count, "onChange must not fire when the refreshed content fails validation")
+}
+
+// TestURLUpdater_SuccessfulDownload_InvalidContentDoesNotCorruptCache covers
+// what TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood only
+// checks in memory: an invalid refresh must leave the persisted cachePath
+// itself untouched, since a restart bootstraps from that file, not memory.
+func TestURLUpdater_SuccessfulDownload_InvalidContentDoesNotCorruptCache(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	u := NewURLUpdater(dummyMappingURL, cachePath, func() {})
+
+	writeFile(t, u.stagingPath, invalidMappingJSON)
+	u.onDownloadComplete(nil, 0)
+
+	onDisk, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(onDisk), "an invalid refresh must not overwrite the persisted last-good cache")
+
+	restarted := NewURLUpdater(dummyMappingURL, cachePath, func() {})
+	assert.True(t, restarted.Ready(), "a restart must still bootstrap from the untouched cache")
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
@@ -121,6 +121,71 @@ func TestURLUpdater_SuccessfulDownload_AppliesNewContent(t *testing.T) {
 	assert.Equal(t, validMappingJSON, string(onDisk), "a validated download must be promoted to cachePath")
 }
 
+// TestURLUpdater_PersistFailure_DoesNotActivate covers a validated
+// download whose cache promotion fails: active stays unchanged so Path()
+// still matches Bytes(), and a later identical fetch retries the persist.
+func TestURLUpdater_PersistFailure_DoesNotActivate(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	require.NoError(t, os.Mkdir(cacheDir, 0700))
+	cachePath := filepath.Join(cacheDir, "cache.json")
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	writeFile(t, u.stagingPath, validMappingJSON)
+
+	require.NoError(t, os.Chmod(cacheDir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(cacheDir, 0700) })
+
+	u.onDownloadComplete(nil, 0)
+
+	assert.False(t, u.Ready(), "a failed persist must not expose the new mapping as active")
+	assert.Equal(t, 0, counter.count)
+	_, err := os.Stat(cachePath)
+	assert.Error(t, err, "cachePath must not exist after a failed persist")
+
+	require.NoError(t, os.Chmod(cacheDir, 0700))
+	u.onDownloadComplete(nil, 0)
+
+	require.True(t, u.Ready(), "the next identical fetch must retry persist and then activate")
+	assert.Equal(t, 1, counter.count)
+	onDisk, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(onDisk))
+}
+
+func TestURLUpdater_PersistFailure_KeepsLastGoodThenRetries(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	require.NoError(t, os.Mkdir(cacheDir, 0700))
+	cachePath := filepath.Join(cacheDir, "cache.json")
+	writeFile(t, cachePath, validMappingJSON)
+	counter := &onChangeCounter{}
+	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
+	require.Equal(t, 1, counter.count)
+	writeFile(t, u.stagingPath, otherValidMappingJSON)
+
+	require.NoError(t, os.Chmod(cacheDir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(cacheDir, 0700) })
+
+	u.onDownloadComplete(nil, 0)
+
+	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash(),
+		"a failed persist must keep serving the last-good mapping")
+	assert.Equal(t, 1, counter.count)
+	onDisk, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, validMappingJSON, string(onDisk))
+
+	require.NoError(t, os.Chmod(cacheDir, 0700))
+	u.onDownloadComplete(nil, 0)
+
+	assert.Equal(t, cpemapping.HashMapping([]byte(otherValidMappingJSON)), u.Hash())
+	assert.Equal(t, 2, counter.count)
+	onDisk, err = os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, otherValidMappingJSON, string(onDisk))
+}
+
 func TestURLUpdater_SuccessfulDownload_InvalidContentKeepsLastGood(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "cache.json")

--- a/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/url_updater_test.go
@@ -57,9 +57,8 @@ func TestNewURLUpdater_InvalidCacheStaysNotReady_NoBundledFallback(t *testing.T)
 	writeFile(t, cachePath, invalidMappingJSON)
 	counter := &onChangeCounter{}
 
-	// The URL updater has no bundled-file parameter and no secondary
-	// source at all: an invalid cachePath must leave it not Ready, not
-	// fall back to anything else.
+	// Cache is last-good from a successful URL fetch. An invalid cache
+	// must leave the updater not Ready, not seed from anything else.
 	u := NewURLUpdater(dummyMappingURL, cachePath, counter.fn)
 
 	assert.False(t, u.Ready())

--- a/pkg/filedownloader/filedownloader.go
+++ b/pkg/filedownloader/filedownloader.go
@@ -224,7 +224,7 @@ func (d *Downloader) doDownload(ctx context.Context) error {
 		return fmt.Errorf("response body exceeds maximum size of %d bytes", d.maxSize)
 	}
 
-	if err := atomicWriteFile(d.filePath, body); err != nil {
+	if err := AtomicWriteFile(d.filePath, body); err != nil {
 		return fmt.Errorf("writing file: %w", err)
 	}
 
@@ -232,7 +232,10 @@ func (d *Downloader) doDownload(ctx context.Context) error {
 	return nil
 }
 
-func atomicWriteFile(path string, data []byte) error {
+// AtomicWriteFile writes data to path via a temp file plus rename, so
+// concurrent readers never observe a partially written file. Creates
+// path's parent directory (mode 0700) if it does not already exist.
+func AtomicWriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("creating directory %q: %w", dir, err)

--- a/pkg/filedownloader/filedownloader_test.go
+++ b/pkg/filedownloader/filedownloader_test.go
@@ -268,7 +268,7 @@ func TestAtomicWriteFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "output.json")
 
-	require.NoError(t, atomicWriteFile(path, []byte("hello")))
+	require.NoError(t, AtomicWriteFile(path, []byte("hello")))
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestAtomicWriteFile_CreatesParentDirectory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "nested", "output.json")
 
-	require.NoError(t, atomicWriteFile(path, []byte("hello")))
+	require.NoError(t, AtomicWriteFile(path, []byte("hello")))
 
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Part 2 of 5 in the ROX-35685 stack (delivering repository-to-CPE mapping to `roxagent` via Sensor over VSOCK, for disconnected environments where the agent cannot reach the public mapping URL directly). See [ROX-35685](https://redhat.atlassian.net/browse/ROX-35685) for the full problem statement and the last PR in this stack for the end-to-end behavior and manual test plan. Stacked on top of the proto/shared-helpers PR earlier in this series.

This PR adds roxagent's two interchangeable mapping updaters, not yet wired into `roxagent serve` (that's the next PR): `MappingProvider`/`MappingUpdater`/`ScanBusyGate` interfaces, `SensorUpdater` (applies mappings pushed in over VSOCK, deferring the apply while a disk scan is in flight so a report is never built against a mapping that changes mid-scan), and `URLUpdater` (wraps the existing `filedownloader`-based logic that already backs `--repo-cpe-url` today). It also exports `filedownloader.AtomicWriteFile` (previously package-private), which both updaters need for their on-disk cache persistence.

Key design decision: Sensor and roxagent agree on freshness via a content hash rather than a version number or timestamp, so either side can detect staleness without shared state beyond what's already exchanged on `GetReport`.

Known gap: `URLUpdater` logs at WARN, not the intended ERROR level, for a `--repo-cpe-url` that has never successfully downloaded a mapping - a customer-side URL/connectivity misconfiguration should be loud, not just a routine retry warning. Left as a follow-up rather than fixed here since it needs a small state addition (tracking "has ever succeeded") that's a real production behavior change.

Partially generated with AI assistance (subagent-driven implementation and review, human-directed).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

Table-driven unit tests cover both updaters: bootstrap from an on-disk cache (and, for `SensorUpdater`, a bundled seed file), rejecting invalid content while keeping the last-known-good mapping, and - the one genuinely tricky path - `SensorUpdater`'s deferred-apply behavior across a busy/idle scan transition, exercised deterministically via `ScanBusyGate` rather than real timing.

### How I validated my change

Unit tests only; these updaters aren't wired into anything yet. See the last PR in this stack for the full manual test plan once the feature is fully wired end-to-end.


[ROX-35685]: https://redhat.atlassian.net/browse/ROX-35685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ