### PR TITLE
ROX-35685: push Sensor's repo-to-CPE mapping to roxagent

### DIFF
--- a/compliance/virtualmachines/roxagent/cmd/serve_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve_test.go
@@ -48,6 +48,16 @@ func withMappingCachePath(t *testing.T) string {
 	return path
 }
 
+// registerSensorPersistDrain waits for SensorUpdater's fire-and-forget cache
+// writes before t.TempDir() cleanup, so AtomicWriteFile's sibling .tmp files
+// cannot race directory removal.
+func registerSensorPersistDrain(t *testing.T, updater vsockserver.MappingUpdater) {
+	t.Helper()
+	u, ok := updater.(*vsockserver.SensorUpdater)
+	require.True(t, ok, "registerSensorPersistDrain requires a *SensorUpdater")
+	t.Cleanup(u.WaitPersist)
+}
+
 func TestNewRescannerAndProvider_URLSelection(t *testing.T) {
 	withMappingCachePath(t)
 
@@ -130,6 +140,7 @@ func TestNewRescannerAndProvider_SyncKicksFirstScan(t *testing.T) {
 	vmRescanner, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{rescanInterval: time.Hour})
 	require.False(t, provider.Ready())
 	require.NotNil(t, updater, "Sensor path must produce a non-nil updater")
+	registerSensorPersistDrain(t, updater)
 
 	var mu sync.Mutex
 	var calls int
@@ -312,6 +323,7 @@ func TestNewRescannerAndProvider_SensorSync_DefersUnderScanThenApplies(t *testin
 	_, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
 	require.True(t, provider.Ready(), "a pre-seeded Sensor cache must bootstrap the provider Ready")
 	require.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), provider.Hash())
+	registerSensorPersistDrain(t, updater)
 
 	gate, ok := updater.(vsockserver.ScanBusyGate)
 	require.True(t, ok, "the Sensor updater must implement ScanBusyGate")
@@ -344,6 +356,7 @@ func TestNewRescannerAndProvider_SensorSync_DefersUnderScanThenApplies(t *testin
 func TestNewRescannerAndProvider_SensorUpdate_InvalidContentKeepsLastGood(t *testing.T) {
 	cachePath := withMappingCachePath(t)
 	_, provider, updater, _ := newRescannerAndProvider(&vsockserver.ReportCache{}, serveConfig{})
+	registerSensorPersistDrain(t, updater)
 
 	updated, err := updater.Update([]byte(validMappingJSON))
 	require.NoError(t, err)

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -203,10 +203,10 @@ func (u *SensorUpdater) persistAndNotify() {
 	}
 }
 
-// waitPersist blocks until every persistAndNotify goroutine has finished
+// WaitPersist blocks until every persistAndNotify goroutine has finished
 // writing cachePath. Tests register it with t.Cleanup so TempDir removal
 // cannot race AtomicWriteFile's sibling .tmp files.
-func (u *SensorUpdater) waitPersist() {
+func (u *SensorUpdater) WaitPersist() {
 	u.persistWG.Wait()
 }
 

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -31,7 +31,7 @@ func writeFile(t *testing.T, path, content string) {
 func newSensorUpdater(t *testing.T, cachePath, bundledPath string, onChange func()) *SensorUpdater {
 	t.Helper()
 	u := NewSensorUpdater(cachePath, bundledPath, onChange)
-	t.Cleanup(u.waitPersist)
+	t.Cleanup(u.WaitPersist)
 	return u
 }
 
@@ -39,7 +39,7 @@ func newSensorUpdater(t *testing.T, cachePath, bundledPath string, onChange func
 // checks cachePath, so the assertion cannot race AtomicWriteFile.
 func waitForCacheContent(t *testing.T, u *SensorUpdater, cachePath, want string) {
 	t.Helper()
-	u.waitPersist()
+	u.WaitPersist()
 	b, err := os.ReadFile(cachePath)
 	require.NoError(t, err)
 	assert.Equal(t, want, string(b), "expected %q to be persisted to %s", want, cachePath)

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -70,8 +70,8 @@ var (
 	// min(poll interval, 30m).
 	VirtualMachinesScraperInitialBackoff = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_INITIAL_BACKOFF", 10*time.Second)
 
-	// VirtualMachinesScraperPerVMTimeout defines the per-VM deadline for dialing
-	// and pulling a report in a single scrape cycle.
+	// VirtualMachinesScraperPerVMTimeout is the deadline for one Sensor-to-agent
+	// call (GetReport or a mapping sync). Doing both can take twice as long.
 	VirtualMachinesScraperPerVMTimeout = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_PER_VM_TIMEOUT", 30*time.Second)
 
 	// VirtualMachinesScraperMandatoryRefreshInterval defines the maximum age of a VM's last forwarded

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -105,10 +105,10 @@ var IndexReportAcksReceived = prometheus.NewCounterVec(
 	[]string{"action"}, // "ACK" or "NACK"
 )
 
-// Pull-mode outcome labels are split across three counters so transport,
-// GetReport protocol, and scrape-pipeline results stay distinct as more
-// VSOCK RPC methods are added later. Each per-VM pull attempt increments
-// exactly one of these counters (mutually exclusive partition).
+// Pull-mode GetReport outcomes are split across three counters so transport,
+// GetReport protocol, and scrape-pipeline results stay distinct. Each
+// GetReport attempt increments exactly one of those. PullSyncTotal counts
+// the optional second VSOCK RPC that pushes a repo-to-CPE mapping.
 
 // Transport-layer status values for PullTransportTotal.
 const (
@@ -137,6 +137,20 @@ const (
 	PullScrapeSuccess       = "success"
 	PullScrapeInvalidReport = "invalid_report"
 	PullScrapeSendError     = "send_error"
+)
+
+// Sync-RPC status values for PullSyncTotal.
+const (
+	// PullSyncSuccess counts an accepted push; Updated true/false both count.
+	PullSyncSuccess = "success"
+	// PullSyncError is a sync dial failure or a rejection other than not-Sensor-managed.
+	PullSyncError = "error"
+	// PullSyncNotManaged is a rejection Sensor's own gate should have prevented.
+	PullSyncNotManaged = "not_managed"
+	// PullSyncURLHashMismatch is a URL-managed agent whose hash differs from Sensor's cache; Sensor never dials.
+	PullSyncURLHashMismatch = "url_hash_mismatch"
+	// PullSyncTimeout is a skipped sync because GetReport already consumed the per-VM deadline.
+	PullSyncTimeout = "timeout"
 )
 
 // PullDialDurationSeconds measures time to establish a websocket connection per VM.
@@ -249,6 +263,19 @@ var PullScrapeTotal = prometheus.NewCounterVec(
 	[]string{"status"},
 )
 
+// PullSyncTotal counts the optional second VSOCK RPC that pushes a
+// repo-to-CPE mapping after GetReport. It is not part of the GetReport
+// transport/protocol/scrape partition.
+var PullSyncTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_sync_total",
+		Help:      "Per-VM repo-to-CPE mapping sync outcomes (second VSOCK RPC after GetReport)",
+	},
+	[]string{"status"},
+)
+
 // PullTicksTotal counts scraper ticks executed.
 var PullTicksTotal = prometheus.NewCounter(
 	prometheus.CounterOpts{
@@ -341,6 +368,7 @@ func init() {
 		PullTransportTotal,
 		PullGetReportTotal,
 		PullScrapeTotal,
+		PullSyncTotal,
 		PullTicksTotal,
 		PullTrackedVMs,
 		PullDueVMs,

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -451,9 +451,6 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	}
 	log.Infof("VMScraper: scraping %q (reason=%s backoff=%s)", key, reason, snap.backoff)
 
-	vmCtx, cancel := context.WithTimeout(ctx, s.perVMTimeout)
-	defer cancel()
-
 	totalStart := s.now()
 	port := getVsockPort()
 
@@ -467,7 +464,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	}
 
 	log.Debugf("VMScraper: dialing roxagent on %q with TLS", key)
-	result, outcome := s.dialAndGetReport(vmCtx, vm, key, port, lastKnownToken)
+	result, outcome := s.dialAndGetReport(ctx, vm, key, port, lastKnownToken)
 	if outcome != scrapeOK {
 		next := s.scheduleAfterAttempt(key, vm.ID, outcome)
 		kind := "retryable"
@@ -502,7 +499,8 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 	logAndRecordDiscoveredFacts(key, result.Meta.GetFacts())
 
-	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
+	// Mapping sync has its own deadline, so Send uses the scrape parent.
+	if err := s.sender.Send(ctx, vm, result.IndexReport); err != nil {
 		metrics.PullScrapeTotal.WithLabelValues(metrics.PullScrapeSendError).Inc()
 		outcome := scrapeRetryable
 		if errors.Is(err, errox.NotImplemented) {
@@ -587,17 +585,20 @@ func (s *VMScraper) scheduleAfterAttempt(key string, vmID virtualmachine.VMID, o
 	})
 }
 
-// dialAndGetReport dials the VM and issues a single GetReport request,
-// recording dial/read latency metrics and classifying failures.
+// dialAndGetReport uses a separate perVMTimeout for GetReport and for the
+// mapping push so a slow report cannot abort the push.
 func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, lastKnownToken string) (*vsockclient.GetReportResult, scrapeOutcome) {
+	reportCtx, cancel := context.WithTimeout(ctx, s.perVMTimeout)
+	defer cancel()
+
 	dialStart := s.now()
-	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
+	stream, err := s.dialer.Dial(reportCtx, vm.Namespace, vm.Name, port, true)
 	metrics.PullDialDurationSeconds.Observe(s.now().Sub(dialStart).Seconds())
 	if err != nil {
-		if ctx.Err() != nil {
+		if reportCtx.Err() != nil {
 			log.Warnf("VMScraper: dialing roxagent on %q timed out: %v", key, err)
 			metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout).Inc()
-			if errors.Is(ctx.Err(), context.Canceled) {
+			if errors.Is(reportCtx.Err(), context.Canceled) {
 				// Parent cancel (Sensor stop): do not keep retrying on the short tick.
 				return nil, scrapeNonRetryable
 			}
@@ -610,9 +611,12 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	defer func() { _ = stream.Close() }()
 
 	readStart := s.now()
-	result, err := s.client.GetReport(ctx, stream, lastKnownToken)
+	result, err := s.client.GetReport(reportCtx, stream, lastKnownToken)
 	metrics.PullReadDurationSeconds.Observe(s.now().Sub(readStart).Seconds())
 	if err != nil {
+		// Classify before cancel(): cancel() looks like Sensor stop to
+		// handleGetReportError.
+		outcome := s.handleGetReportError(reportCtx, key, err)
 		// MAPPING_REQUIRED is the only error whose Meta still needs
 		// inspecting: a VM with no mapping at all has nothing to report
 		// except this error, and it's the only way Sensor learns to push one.
@@ -621,11 +625,13 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 			// enforces at most one connection at a time: this one must be
 			// closed first, not left to the deferred close on return.
 			_ = stream.Close()
+			cancel()
 			s.maybeSyncRepoCPEMapping(ctx, vm, key, port, resultMeta(result))
 		}
-		return nil, s.handleGetReportError(ctx, key, err)
+		return nil, outcome
 	}
 	_ = stream.Close()
+	cancel()
 	s.maybeSyncRepoCPEMapping(ctx, vm, key, port, result.Meta)
 	return result, scrapeOK
 }
@@ -749,19 +755,17 @@ func (s *VMScraper) maybeSyncRepoCPEMapping(ctx context.Context, vm *virtualmach
 	}
 }
 
-// syncRepoCPEMapping pushes mapping to the VM over a second, short-lived
-// VSOCK connection — GetReport's one-request-per-connection contract means
-// the push cannot ride the same connection as the report exchange.
+// syncRepoCPEMapping pushes mapping on a new connection (one request per
+// connection). The deadline is independent of GetReport's.
 func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, mapping []byte) {
-	if ctx.Err() != nil {
-		// ctx is the per-VM timeout GetReport already consumed; dialing
-		// with it already expired is an exhausted deadline, not a sync
-		// failure (dialAndGetReport/handleGetReportError apply the same rule).
-		log.Debugf("VMScraper: skipping repo-to-CPE mapping sync for %q: %v", key, ctx.Err())
+	syncCtx, cancel := context.WithTimeout(ctx, s.perVMTimeout)
+	defer cancel()
+	if syncCtx.Err() != nil {
+		log.Debugf("VMScraper: skipping repo-to-CPE mapping sync for %q: %v", key, syncCtx.Err())
 		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout).Inc()
 		return
 	}
-	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
+	stream, err := s.dialer.Dial(syncCtx, vm.Namespace, vm.Name, port, true)
 	if err != nil {
 		log.Warnf("VMScraper: dialing roxagent on %q for repo-to-CPE mapping sync failed: %v", key, err)
 		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError).Inc()
@@ -769,7 +773,7 @@ func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.I
 	}
 	defer func() { _ = stream.Close() }()
 
-	updated, _, err := s.client.SyncRepoCPEMapping(ctx, stream, mapping)
+	updated, _, err := s.client.SyncRepoCPEMapping(syncCtx, stream, mapping)
 	if err != nil {
 		// NOT_SENSOR_MANAGED should never happen here: maybeSyncRepoCPEMapping only takes
 		// the SENSOR path for agents it believes accept a push. Counting it

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -78,7 +78,7 @@ type ProtocolClient interface {
 	SyncRepoCPEMapping(ctx context.Context, stream io.ReadWriteCloser, mapping []byte) (updated bool, meta *pb.ResponseMeta, err error)
 }
 
-// Repo2CPEFetcher supplies Sensor's cached repo-to-CPE mapping so maybeSync
+// Repo2CPEFetcher supplies Sensor's cached repo-to-CPE mapping so maybeSyncRepoCPEMapping
 // can tell whether a VM's agent needs a pushed update.
 type Repo2CPEFetcher interface {
 	FetchRepo2CPE(ctx context.Context) (mapping []byte, hash string, ok bool)
@@ -98,7 +98,7 @@ type VMScraper struct {
 	sender                IndexReportSender
 	dialer                VMDialer
 	client                ProtocolClient
-	fetcher               Repo2CPEFetcher
+	repo2CPEFetcher       Repo2CPEFetcher
 	interval              time.Duration
 	tickInterval          time.Duration
 	initialBackoff        time.Duration
@@ -136,16 +136,16 @@ type vmState struct {
 
 var _ common.SensorComponent = (*VMScraper)(nil)
 
-// New creates a VMScraper with production defaults. A nil fetcher leaves
-// maybeSync a no-op, so pull still works if the repo-to-CPE cache was not built.
-func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient, fetcher Repo2CPEFetcher) *VMScraper {
+// New creates a VMScraper with production defaults. A nil repo2CPEFetcher leaves
+// maybeSyncRepoCPEMapping a no-op, so pull still works if the repo-to-CPE cache was not built.
+func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient, repo2CPEFetcher Repo2CPEFetcher) *VMScraper {
 	interval := clampPollInterval(env.VirtualMachinesScraperPollInterval.DurationSetting())
 	return &VMScraper{
 		store:                 store,
 		sender:                sender,
 		dialer:                dialer,
 		client:                client,
-		fetcher:               fetcher,
+		repo2CPEFetcher:       repo2CPEFetcher,
 		interval:              interval,
 		tickInterval:          env.VirtualMachinesScraperTickInterval.DurationSetting(),
 		initialBackoff:        env.VirtualMachinesScraperInitialBackoff.DurationSetting(),
@@ -617,16 +617,16 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 		// inspecting: a VM with no mapping at all has nothing to report
 		// except this error, and it's the only way Sensor learns to push one.
 		if errors.Is(err, vsockclient.ErrMappingRequired) {
-			// maybeSync dials a second connection to the same agent, which
+			// maybeSyncRepoCPEMapping dials a second connection to the same agent, which
 			// enforces at most one connection at a time: this one must be
 			// closed first, not left to the deferred close on return.
 			_ = stream.Close()
-			s.maybeSync(ctx, vm, key, port, resultMeta(result))
+			s.maybeSyncRepoCPEMapping(ctx, vm, key, port, resultMeta(result))
 		}
 		return nil, s.handleGetReportError(ctx, key, err)
 	}
 	_ = stream.Close()
-	s.maybeSync(ctx, vm, key, port, result.Meta)
+	s.maybeSyncRepoCPEMapping(ctx, vm, key, port, result.Meta)
 	return result, scrapeOK
 }
 
@@ -719,19 +719,18 @@ func isAbnormalClose(err error, target *closeCoder) bool {
 	return code != 0 && code != closeCodeNormalClosure
 }
 
-// maybeSync inspects meta from a completed GetReport exchange (success,
-// Unchanged, or a MAPPING_REQUIRED error) and pushes a fresh mapping when
-// the agent is Sensor-managed and its reported hash is stale. A URL-managed
-// agent with a stale hash is only logged and counted, since Sensor doesn't own it.
-func (s *VMScraper) maybeSync(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, meta *pb.ResponseMeta) {
+// maybeSyncRepoCPEMapping pushes a fresh mapping when the agent is
+// Sensor-managed and its reported hash is stale. A URL-managed agent with
+// a stale hash is only logged and counted, since Sensor doesn't own it.
+func (s *VMScraper) maybeSyncRepoCPEMapping(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, meta *pb.ResponseMeta) {
 	updatePath := meta.GetRepoCpeMappingUpdatePath()
 	if updatePath == pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED {
 		return
 	}
-	if s.fetcher == nil {
+	if s.repo2CPEFetcher == nil {
 		return
 	}
-	mapping, sensorHash, ok := s.fetcher.FetchRepo2CPE(ctx)
+	mapping, sensorHash, ok := s.repo2CPEFetcher.FetchRepo2CPE(ctx)
 	if !ok {
 		return
 	}
@@ -772,7 +771,7 @@ func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.I
 
 	updated, _, err := s.client.SyncRepoCPEMapping(ctx, stream, mapping)
 	if err != nil {
-		// NOT_SENSOR_MANAGED should never happen here: maybeSync only takes
+		// NOT_SENSOR_MANAGED should never happen here: maybeSyncRepoCPEMapping only takes
 		// the SENSOR path for agents it believes accept a push. Counting it
 		// (without retrying) turns a gating bug into a visible signal.
 		if errors.Is(err, vsockclient.ErrMappingNotSensorManaged) {

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -767,6 +767,11 @@ func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.I
 	}
 	stream, err := s.dialer.Dial(syncCtx, vm.Namespace, vm.Name, port, true)
 	if err != nil {
+		if syncCtx.Err() != nil {
+			log.Warnf("VMScraper: dialing roxagent on %q for repo-to-CPE mapping sync timed out: %v", key, err)
+			metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout).Inc()
+			return
+		}
 		log.Warnf("VMScraper: dialing roxagent on %q for repo-to-CPE mapping sync failed: %v", key, err)
 		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError).Inc()
 		return
@@ -781,6 +786,11 @@ func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.I
 		if errors.Is(err, vsockclient.ErrMappingNotSensorManaged) {
 			log.Warnf("VMScraper: roxagent on %q rejected repo-to-CPE mapping sync as not Sensor-managed", key)
 			metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncNotManaged).Inc()
+			return
+		}
+		if syncCtx.Err() != nil {
+			log.Warnf("VMScraper: repo-to-CPE mapping sync to %q timed out: %v", key, err)
+			metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout).Inc()
 			return
 		}
 		log.Warnf("VMScraper: repo-to-CPE mapping sync to %q failed: %v", key, err)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -732,7 +732,11 @@ func (s *VMScraper) maybeSync(ctx context.Context, vm *virtualmachine.Info, key 
 		return
 	}
 	mapping, sensorHash, ok := s.fetcher.FetchRepo2CPE(ctx)
-	if !ok || sensorHash == meta.GetRepoCpeMappingHash() {
+	if !ok {
+		return
+	}
+	if sensorHash == meta.GetRepoCpeMappingHash() {
+		log.Debugf("VMScraper: repo-to-CPE mapping on %q is up to date (hash=%s)", key, sensorHash)
 		return
 	}
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -631,10 +631,15 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 		// inspecting: a VM with no mapping at all has nothing to report
 		// except this error, and it's the only way Sensor learns to push one.
 		if errors.Is(err, vsockclient.ErrMappingRequired) {
+			// maybeSync dials a second connection to the same agent, which
+			// enforces at most one connection at a time: this one must be
+			// closed first, not left to the deferred close on return.
+			_ = stream.Close()
 			s.maybeSync(ctx, vm, key, port, resultMeta(result))
 		}
 		return nil, s.handleGetReportError(ctx, key, err)
 	}
+	_ = stream.Close()
 	s.maybeSync(ctx, vm, key, port, result.Meta)
 	return result, scrapeOK
 }
@@ -760,6 +765,14 @@ func (s *VMScraper) maybeSync(ctx context.Context, vm *virtualmachine.Info, key 
 // VSOCK connection — GetReport's one-request-per-connection contract means
 // the push cannot ride the same connection as the report exchange.
 func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, mapping []byte) {
+	if ctx.Err() != nil {
+		// ctx is the per-VM timeout GetReport already consumed; dialing
+		// with it already expired is an exhausted deadline, not a sync
+		// failure (dialAndGetReport/handleGetReportError apply the same rule).
+		log.Debugf("VMScraper: skipping repo-to-CPE mapping sync for %q: %v", key, ctx.Err())
+		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout).Inc()
+		return
+	}
 	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
 	if err != nil {
 		log.Warnf("VMScraper: dialing roxagent on %q for repo-to-CPE mapping sync failed: %v", key, err)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
@@ -74,6 +75,13 @@ type IndexReportSender interface {
 // ProtocolClient performs the request/response protocol over a stream.
 type ProtocolClient interface {
 	GetReport(ctx context.Context, stream io.ReadWriteCloser, lastKnownToken string) (*vsockclient.GetReportResult, error)
+	SyncRepoCPEMapping(ctx context.Context, stream io.ReadWriteCloser, mapping []byte) (updated bool, meta *pb.ResponseMeta, err error)
+}
+
+// Repo2CPEFetcher supplies Sensor's cached repo-to-CPE mapping so maybeSync
+// can tell whether a VM's agent needs a pushed update.
+type Repo2CPEFetcher interface {
+	FetchRepo2CPE(ctx context.Context) (mapping []byte, hash string, ok bool)
 }
 
 // closeCoder is satisfied by transport errors carrying a structured close
@@ -114,6 +122,7 @@ type VMScraper struct {
 	lastReconcile   time.Time
 	inFlight        set.StringSet
 	lastForwardTime time.Time // Sensor-level; for forward interarrival metric
+	fetcher         Repo2CPEFetcher
 }
 
 type vmState struct {
@@ -152,6 +161,22 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		now:          time.Now,
 		randFloat64:  rand.Float64,
 	}
+}
+
+// SetRepo2CPEFetcher wires the source maybeSync reads to decide whether a
+// VM's agent needs a pushed repo-to-CPE mapping. Nil-safe: if never called
+// (e.g. Sensor could not build the scanner definitions handler), maybeSync
+// stays a no-op.
+func (s *VMScraper) SetRepo2CPEFetcher(f Repo2CPEFetcher) {
+	concurrency.WithLock(&s.mu, func() {
+		s.fetcher = f
+	})
+}
+
+func (s *VMScraper) repo2CPEFetcher() Repo2CPEFetcher {
+	return concurrency.WithLock1(&s.mu, func() Repo2CPEFetcher {
+		return s.fetcher
+	})
 }
 
 func (s *VMScraper) Name() string { return "virtualmachine.vmscraper" }
@@ -602,9 +627,25 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	result, err := s.client.GetReport(ctx, stream, lastKnownToken)
 	metrics.PullReadDurationSeconds.Observe(s.now().Sub(readStart).Seconds())
 	if err != nil {
+		// MAPPING_REQUIRED is the only error whose Meta still needs
+		// inspecting: a VM with no mapping at all has nothing to report
+		// except this error, and it's the only way Sensor learns to push one.
+		if errors.Is(err, vsockclient.ErrMappingRequired) {
+			s.maybeSync(ctx, vm, key, port, resultMeta(result))
+		}
 		return nil, s.handleGetReportError(ctx, key, err)
 	}
+	s.maybeSync(ctx, vm, key, port, result.Meta)
 	return result, scrapeOK
+}
+
+// resultMeta returns result.Meta, tolerating a nil result: ProtocolClient
+// implementations are not required to populate a result on every error.
+func resultMeta(result *vsockclient.GetReportResult) *pb.ResponseMeta {
+	if result == nil {
+		return nil
+	}
+	return result.Meta
 }
 
 func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err error) scrapeOutcome {
@@ -685,6 +726,65 @@ func isAbnormalClose(err error, target *closeCoder) bool {
 	}
 	code, _ := (*target).CloseCode()
 	return code != 0 && code != closeCodeNormalClosure
+}
+
+// maybeSync inspects meta from a completed GetReport exchange (success,
+// Unchanged, or a MAPPING_REQUIRED error) and pushes a fresh mapping when
+// the agent is Sensor-managed and its reported hash is stale. A URL-managed
+// agent with a stale hash is only logged and counted, since Sensor doesn't own it.
+func (s *VMScraper) maybeSync(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, meta *pb.ResponseMeta) {
+	updatePath := meta.GetRepoCpeMappingUpdatePath()
+	if updatePath == pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED {
+		return
+	}
+	fetcher := s.repo2CPEFetcher()
+	if fetcher == nil {
+		return
+	}
+	mapping, sensorHash, ok := fetcher.FetchRepo2CPE(ctx)
+	if !ok || sensorHash == meta.GetRepoCpeMappingHash() {
+		return
+	}
+
+	switch updatePath {
+	case pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR:
+		s.syncRepoCPEMapping(ctx, vm, key, port, mapping)
+	case pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL:
+		log.Warnf("VMScraper: roxagent on %q reports a URL-managed repo-to-CPE mapping (hash=%s) that differs from Sensor's own cache (hash=%s)",
+			key, meta.GetRepoCpeMappingHash(), sensorHash)
+		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncURLHashMismatch).Inc()
+	}
+}
+
+// syncRepoCPEMapping pushes mapping to the VM over a second, short-lived
+// VSOCK connection — GetReport's one-request-per-connection contract means
+// the push cannot ride the same connection as the report exchange.
+func (s *VMScraper) syncRepoCPEMapping(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, mapping []byte) {
+	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
+	if err != nil {
+		log.Warnf("VMScraper: dialing roxagent on %q for repo-to-CPE mapping sync failed: %v", key, err)
+		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError).Inc()
+		return
+	}
+	defer func() { _ = stream.Close() }()
+
+	updated, _, err := s.client.SyncRepoCPEMapping(ctx, stream, mapping)
+	if err != nil {
+		// NOT_SENSOR_MANAGED should never happen here: maybeSync only takes
+		// the SENSOR path for agents it believes accept a push. Counting it
+		// (without retrying) turns a gating bug into a visible signal.
+		if errors.Is(err, vsockclient.ErrMappingNotSensorManaged) {
+			log.Warnf("VMScraper: roxagent on %q rejected repo-to-CPE mapping sync as not Sensor-managed", key)
+			metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncNotManaged).Inc()
+			return
+		}
+		log.Warnf("VMScraper: repo-to-CPE mapping sync to %q failed: %v", key, err)
+		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError).Inc()
+		return
+	}
+
+	log.Infof("VMScraper: synced repo-to-CPE mapping to %q (updated=%t)", key, updated)
+	metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncSuccess).Inc()
 }
 
 type vmStateSnapshot struct {

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -98,6 +98,7 @@ type VMScraper struct {
 	sender                IndexReportSender
 	dialer                VMDialer
 	client                ProtocolClient
+	fetcher               Repo2CPEFetcher
 	interval              time.Duration
 	tickInterval          time.Duration
 	initialBackoff        time.Duration
@@ -122,7 +123,6 @@ type VMScraper struct {
 	lastReconcile   time.Time
 	inFlight        set.StringSet
 	lastForwardTime time.Time // Sensor-level; for forward interarrival metric
-	fetcher         Repo2CPEFetcher
 }
 
 type vmState struct {
@@ -136,14 +136,16 @@ type vmState struct {
 
 var _ common.SensorComponent = (*VMScraper)(nil)
 
-// New creates a VMScraper with production defaults.
-func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) *VMScraper {
+// New creates a VMScraper with production defaults. A nil fetcher leaves
+// maybeSync a no-op, so pull still works if the repo-to-CPE cache was not built.
+func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient, fetcher Repo2CPEFetcher) *VMScraper {
 	interval := clampPollInterval(env.VirtualMachinesScraperPollInterval.DurationSetting())
 	return &VMScraper{
 		store:                 store,
 		sender:                sender,
 		dialer:                dialer,
 		client:                client,
+		fetcher:               fetcher,
 		interval:              interval,
 		tickInterval:          env.VirtualMachinesScraperTickInterval.DurationSetting(),
 		initialBackoff:        env.VirtualMachinesScraperInitialBackoff.DurationSetting(),
@@ -161,22 +163,6 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		now:          time.Now,
 		randFloat64:  rand.Float64,
 	}
-}
-
-// SetRepo2CPEFetcher wires the source maybeSync reads to decide whether a
-// VM's agent needs a pushed repo-to-CPE mapping. Nil-safe: if never called
-// (e.g. Sensor could not build the scanner definitions handler), maybeSync
-// stays a no-op.
-func (s *VMScraper) SetRepo2CPEFetcher(f Repo2CPEFetcher) {
-	concurrency.WithLock(&s.mu, func() {
-		s.fetcher = f
-	})
-}
-
-func (s *VMScraper) repo2CPEFetcher() Repo2CPEFetcher {
-	return concurrency.WithLock1(&s.mu, func() Repo2CPEFetcher {
-		return s.fetcher
-	})
 }
 
 func (s *VMScraper) Name() string { return "virtualmachine.vmscraper" }
@@ -742,11 +728,10 @@ func (s *VMScraper) maybeSync(ctx context.Context, vm *virtualmachine.Info, key 
 	if updatePath == pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED {
 		return
 	}
-	fetcher := s.repo2CPEFetcher()
-	if fetcher == nil {
+	if s.fetcher == nil {
 		return
 	}
-	mapping, sensorHash, ok := fetcher.FetchRepo2CPE(ctx)
+	mapping, sensorHash, ok := s.fetcher.FetchRepo2CPE(ctx)
 	if !ok || sensorHash == meta.GetRepoCpeMappingHash() {
 		return
 	}

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -139,12 +139,13 @@ type mockProtocolClient struct {
 	calls       []protocolCall
 	callIdx     int
 
-	getReportDelay time.Duration
-	syncDelay      time.Duration
-	syncCalls      [][]byte
-	syncUpdated    bool
-	syncMeta       *pb.ResponseMeta
-	syncErr        error
+	getReportDelay  time.Duration
+	syncDelay       time.Duration
+	syncBlocksOnCtx bool
+	syncCalls       [][]byte
+	syncUpdated     bool
+	syncMeta        *pb.ResponseMeta
+	syncErr         error
 }
 
 type protocolCall struct {
@@ -175,7 +176,12 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	return nil, errors.New("unexpected call: no more queued results")
 }
 
-func (m *mockProtocolClient) SyncRepoCPEMapping(_ context.Context, _ io.ReadWriteCloser, mapping []byte) (bool, *pb.ResponseMeta, error) {
+func (m *mockProtocolClient) SyncRepoCPEMapping(ctx context.Context, _ io.ReadWriteCloser, mapping []byte) (bool, *pb.ResponseMeta, error) {
+	if m.syncBlocksOnCtx {
+		m.syncCalls = append(m.syncCalls, mapping)
+		<-ctx.Done()
+		return false, nil, ctx.Err()
+	}
 	if m.syncDelay > 0 {
 		time.Sleep(m.syncDelay)
 	}
@@ -1600,6 +1606,44 @@ func TestVMScraper_SyncRepoCPEMapping_CanceledParent_ClassifiedAsTimeout(t *test
 	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout)))
 	assert.Equal(t, syncErrBefore, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError)),
 		"a canceled parent must not be counted as a sync error")
+}
+
+// TestVMScraper_SyncRepoCPEMapping_DialTimeout_ClassifiedAsTimeout covers
+// perVMTimeout expiring during Dial counting as PullSyncTimeout, not
+// PullSyncError (same rule as dialAndGetReport).
+func TestVMScraper_SyncRepoCPEMapping_DialTimeout_ClassifiedAsTimeout(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, blockingDialer{}, &mockProtocolClient{})
+	s.perVMTimeout = 20 * time.Millisecond
+
+	timeoutBefore := testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout))
+	syncErrBefore := testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError))
+
+	s.syncRepoCPEMapping(context.Background(), vm, "ns1/vm-a", 1, []byte("payload"))
+
+	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout)))
+	assert.Equal(t, syncErrBefore, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError)),
+		"a dial timeout must not be counted as a sync error")
+}
+
+// TestVMScraper_SyncRepoCPEMapping_SyncTimeout_ClassifiedAsTimeout covers
+// perVMTimeout expiring during SyncRepoCPEMapping counting as
+// PullSyncTimeout, not PullSyncError (same rule as handleGetReportError).
+func TestVMScraper_SyncRepoCPEMapping_SyncTimeout_ClassifiedAsTimeout(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	client := &mockProtocolClient{syncBlocksOnCtx: true}
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
+	s.perVMTimeout = 20 * time.Millisecond
+
+	timeoutBefore := testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout))
+	syncErrBefore := testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError))
+
+	s.syncRepoCPEMapping(context.Background(), vm, "ns1/vm-a", 1, []byte("payload"))
+
+	require.Len(t, client.syncCalls, 1)
+	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout)))
+	assert.Equal(t, syncErrBefore, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError)),
+		"a sync timeout must not be counted as a sync error")
 }
 
 // TestVMScraper_SendSucceedsAfterSyncOverrunsGetReportDeadline covers Send

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -269,9 +269,6 @@ func unchangedResult() *vsockclient.GetReportResult {
 	}
 }
 
-//go:fix inline
-func strPtr(s string) *string { return new(s) }
-
 func metaWithMapping(hash string, path pb.RepoCPEMappingUpdatePath) *pb.ResponseMeta {
 	return &pb.ResponseMeta{
 		RepoCpeMappingHash:       new(hash),

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -1388,7 +1388,7 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 	}
 }
 
-func TestVMScraper_MaybeSync(t *testing.T) {
+func TestVMScraper_MaybeSyncRepoCPEMapping(t *testing.T) {
 	vm := makeVM("ns1", "vm-a", 100)
 
 	cases := map[string]struct {
@@ -1451,7 +1451,7 @@ func TestVMScraper_MaybeSync(t *testing.T) {
 			client := &mockProtocolClient{syncErr: tc.syncErr}
 			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
 			if !tc.noFetcher {
-				s.fetcher = tc.fetcher
+				s.repo2CPEFetcher = tc.fetcher
 			}
 
 			var before float64
@@ -1459,7 +1459,7 @@ func TestVMScraper_MaybeSync(t *testing.T) {
 				before = testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(tc.wantMetric))
 			}
 
-			s.maybeSync(context.Background(), vm, "ns1/vm-a", 9999, tc.meta)
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, "ns1/vm-a", 9999, tc.meta)
 
 			assert.Len(t, client.syncCalls, tc.wantSyncCalls)
 			if tc.wantMetric != "" {
@@ -1510,7 +1510,7 @@ func cachedNextAttemptAt(t *testing.T, s *VMScraper, key string) time.Time {
 	})
 }
 
-// TestVMScraper_DialAndGetReport_SyncTriggering exercises maybeSync's
+// TestVMScraper_DialAndGetReport_SyncTriggering exercises maybeSyncRepoCPEMapping's
 // integration point inside dialAndGetReport: only a successful exchange or
 // MAPPING_REQUIRED carries usable Meta, so only those should ever reach the
 // fetcher/second dial.
@@ -1561,7 +1561,7 @@ func TestVMScraper_DialAndGetReport_SyncTriggering(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			client := &mockProtocolClient{resultQueue: tc.resultQueue, errQueue: tc.errQueue}
 			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
-			s.fetcher = staleFetcher()
+			s.repo2CPEFetcher = staleFetcher()
 
 			_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
@@ -1594,9 +1594,9 @@ func TestVMScraper_SyncRepoCPEMapping_ExpiredContext_ClassifiedAsTimeout(t *test
 }
 
 // TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync guards against
-// maybeSync's second dial racing the first GetReport connection: roxagent
+// maybeSyncRepoCPEMapping's second dial racing the first GetReport connection: roxagent
 // allows only one connection at a time, so dialAndGetReport must close its
-// stream before calling maybeSync, not rely solely on its deferred close.
+// stream before calling maybeSyncRepoCPEMapping, not rely solely on its deferred close.
 func TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync(t *testing.T) {
 	vm := makeVM("ns1", "vm-a", 100)
 	dialer := &singleConnDialer{}
@@ -1605,12 +1605,12 @@ func TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync(t *testing.T) {
 		Meta:        metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
 	}}}
 	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, client)
-	s.fetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
+	s.repo2CPEFetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
 
 	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
 	require.Equal(t, scrapeOK, outcome)
-	require.Len(t, client.syncCalls, 1, "maybeSync's dial must succeed, not be rejected as busy by a still-open first connection")
+	require.Len(t, client.syncCalls, 1, "maybeSyncRepoCPEMapping's dial must succeed, not be rejected as busy by a still-open first connection")
 }
 
 // TestVMScraper_DialAndGetReport_MappingRequired_ClosesConnectionBeforeSync
@@ -1624,12 +1624,12 @@ func TestVMScraper_DialAndGetReport_MappingRequired_ClosesConnectionBeforeSync(t
 		errQueue:    []error{vsockclient.ErrMappingRequired},
 	}
 	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, client)
-	s.fetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
+	s.repo2CPEFetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
 
 	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
 	require.Equal(t, scrapeRetryable, outcome)
-	require.Len(t, client.syncCalls, 1, "maybeSync's dial must succeed, not be rejected as busy by a still-open first connection")
+	require.Len(t, client.syncCalls, 1, "maybeSyncRepoCPEMapping's dial must succeed, not be rejected as busy by a still-open first connection")
 }
 
 func TestClampPollInterval(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -108,6 +108,11 @@ type mockProtocolClient struct {
 	errQueue    []error
 	calls       []protocolCall
 	callIdx     int
+
+	syncCalls   [][]byte
+	syncUpdated bool
+	syncMeta    *pb.ResponseMeta
+	syncErr     error
 }
 
 type protocolCall struct {
@@ -121,7 +126,13 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	idx := m.callIdx
 	m.callIdx++
 	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
-		return nil, m.errQueue[idx]
+		// Some errors (e.g. MAPPING_REQUIRED) still carry a queued result
+		// with Meta, mirroring the real client's error-case behavior.
+		var result *vsockclient.GetReportResult
+		if idx < len(m.resultQueue) {
+			result = m.resultQueue[idx]
+		}
+		return result, m.errQueue[idx]
 	}
 	if idx < len(m.resultQueue) {
 		return m.resultQueue[idx], nil
@@ -129,11 +140,30 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	return nil, errors.New("unexpected call: no more queued results")
 }
 
+func (m *mockProtocolClient) SyncRepoCPEMapping(_ context.Context, _ io.ReadWriteCloser, mapping []byte) (bool, *pb.ResponseMeta, error) {
+	m.syncCalls = append(m.syncCalls, mapping)
+	return m.syncUpdated, m.syncMeta, m.syncErr
+}
+
 func (m *mockProtocolClient) reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls = nil
 	m.callIdx = 0
+	m.syncCalls = nil
+}
+
+// fakeFetcher is a Repo2CPEFetcher test double.
+type fakeFetcher struct {
+	mapping []byte
+	hash    string
+	ok      bool
+	calls   int
+}
+
+func (f *fakeFetcher) FetchRepo2CPE(_ context.Context) ([]byte, string, bool) {
+	f.calls++
+	return f.mapping, f.hash, f.ok
 }
 
 type mockSender struct {
@@ -206,6 +236,16 @@ func unchangedResult() *vsockclient.GetReportResult {
 	return &vsockclient.GetReportResult{
 		Unchanged: true,
 		Meta:      &pb.ResponseMeta{ReportToken: "1"},
+	}
+}
+
+//go:fix inline
+func strPtr(s string) *string { return new(s) }
+
+func metaWithMapping(hash string, path pb.RepoCPEMappingUpdatePath) *pb.ResponseMeta {
+	return &pb.ResponseMeta{
+		RepoCpeMappingHash:       new(hash),
+		RepoCpeMappingUpdatePath: path.Enum(),
 	}
 }
 
@@ -1137,6 +1177,10 @@ func (c *safeProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 	return makeReport(c.token), nil
 }
 
+func (c *safeProtocolClient) SyncRepoCPEMapping(_ context.Context, _ io.ReadWriteCloser, _ []byte) (bool, *pb.ResponseMeta, error) {
+	return false, nil, nil
+}
+
 type safeSender struct {
 	mu   sync.Mutex
 	sent int
@@ -1317,6 +1361,87 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 	}
 }
 
+func TestVMScraper_MaybeSync(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+
+	cases := map[string]struct {
+		meta          *pb.ResponseMeta
+		fetcher       *fakeFetcher
+		noFetcher     bool
+		syncErr       error
+		wantSyncCalls int
+		wantMetric    string
+	}{
+		"hash match on the SENSOR path should not dial a second time": {
+			meta:    metaWithMapping("same-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher: &fakeFetcher{ok: true, hash: "same-hash"},
+		},
+		"SENSOR mismatch should dial and sync": {
+			meta:          metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher:       &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")},
+			wantSyncCalls: 1,
+			wantMetric:    metrics.PullSyncSuccess,
+		},
+		"URL mismatch should log and count but never dial": {
+			meta:       metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL),
+			fetcher:    &fakeFetcher{ok: true, hash: "new-hash"},
+			wantMetric: metrics.PullSyncURLHashMismatch,
+		},
+		"UNSPECIFIED update path should never sync": {
+			meta:    metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED),
+			fetcher: &fakeFetcher{ok: true, hash: "new-hash"},
+		},
+		"nil meta (agent predates this feature) should never sync": {
+			meta:    nil,
+			fetcher: &fakeFetcher{ok: true, hash: "new-hash"},
+		},
+		"fetcher not ok should never sync even on a SENSOR mismatch": {
+			meta:    metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher: &fakeFetcher{ok: false},
+		},
+		"no fetcher ever set should be a no-op": {
+			meta:      metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			noFetcher: true,
+		},
+		"NOT_SENSOR_MANAGED on the sync dial should log and count, not retry": {
+			meta:          metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher:       &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")},
+			syncErr:       vsockclient.ErrMappingNotSensorManaged,
+			wantSyncCalls: 1,
+			wantMetric:    metrics.PullSyncNotManaged,
+		},
+		"a generic sync failure should log and count": {
+			meta:          metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			fetcher:       &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")},
+			syncErr:       errors.New("connection reset"),
+			wantSyncCalls: 1,
+			wantMetric:    metrics.PullSyncError,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &mockProtocolClient{syncErr: tc.syncErr}
+			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
+			if !tc.noFetcher {
+				s.SetRepo2CPEFetcher(tc.fetcher)
+			}
+
+			var before float64
+			if tc.wantMetric != "" {
+				before = testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(tc.wantMetric))
+			}
+
+			s.maybeSync(context.Background(), vm, "ns1/vm-a", 9999, tc.meta)
+
+			assert.Len(t, client.syncCalls, tc.wantSyncCalls)
+			if tc.wantMetric != "" {
+				assert.Equal(t, before+1, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(tc.wantMetric)))
+			}
+		})
+	}
+}
+
 // TestVMScraper_NonForcedTickSkipsReconcileWhenNotDue verifies that the
 // production ticker's non-forced tick only reconciles (calling ListRunning)
 // once lastReconcile is at least reconcileEvery old, keeping ListRunning off
@@ -1356,6 +1481,67 @@ func cachedNextAttemptAt(t *testing.T, s *VMScraper, key string) time.Time {
 		require.True(t, ok, "no cached state for %q", key)
 		return st.nextAttemptAt
 	})
+}
+
+// TestVMScraper_DialAndGetReport_SyncTriggering exercises maybeSync's
+// integration point inside dialAndGetReport: only a successful exchange or
+// MAPPING_REQUIRED carries usable Meta, so only those should ever reach the
+// fetcher/second dial.
+func TestVMScraper_DialAndGetReport_SyncTriggering(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	staleFetcher := func() *fakeFetcher {
+		return &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
+	}
+
+	cases := map[string]struct {
+		resultQueue   []*vsockclient.GetReportResult
+		errQueue      []error
+		wantOutcome   scrapeOutcome
+		wantSyncCalls int
+	}{
+		"MAPPING_REQUIRED error triggers a sync attempt": {
+			resultQueue:   []*vsockclient.GetReportResult{{Meta: metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR)}},
+			errQueue:      []error{vsockclient.ErrMappingRequired},
+			wantOutcome:   scrapeRetryable,
+			wantSyncCalls: 1,
+		},
+		"NOT_READY never triggers a sync attempt": {
+			errQueue:    []error{vsockclient.ErrNotReady},
+			wantOutcome: scrapeRetryable,
+		},
+		"a generic protocol error never triggers a sync attempt": {
+			errQueue:    []error{errors.New("connection refused")},
+			wantOutcome: scrapeRetryable,
+		},
+		"a successful report with a stale Sensor-managed hash also triggers a sync": {
+			resultQueue: []*vsockclient.GetReportResult{{
+				IndexReport: &v4.IndexReport{State: "IndexFinished"},
+				Meta:        metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			}},
+			wantOutcome:   scrapeOK,
+			wantSyncCalls: 1,
+		},
+		"an Unchanged report with a matching hash never triggers a sync": {
+			resultQueue: []*vsockclient.GetReportResult{{
+				Unchanged: true,
+				Meta:      metaWithMapping("new-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			}},
+			wantOutcome: scrapeOK,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := &mockProtocolClient{resultQueue: tc.resultQueue, errQueue: tc.errQueue}
+			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
+			s.SetRepo2CPEFetcher(staleFetcher())
+
+			_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
+
+			assert.Equal(t, tc.wantOutcome, outcome)
+			assert.Len(t, client.syncCalls, tc.wantSyncCalls)
+		})
+	}
 }
 
 func TestClampPollInterval(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -139,10 +139,12 @@ type mockProtocolClient struct {
 	calls       []protocolCall
 	callIdx     int
 
-	syncCalls   [][]byte
-	syncUpdated bool
-	syncMeta    *pb.ResponseMeta
-	syncErr     error
+	getReportDelay time.Duration
+	syncDelay      time.Duration
+	syncCalls      [][]byte
+	syncUpdated    bool
+	syncMeta       *pb.ResponseMeta
+	syncErr        error
 }
 
 type protocolCall struct {
@@ -150,6 +152,9 @@ type protocolCall struct {
 }
 
 func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, lastKnownToken string) (*vsockclient.GetReportResult, error) {
+	if m.getReportDelay > 0 {
+		time.Sleep(m.getReportDelay)
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls = append(m.calls, protocolCall{lastKnownToken: lastKnownToken})
@@ -171,6 +176,9 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 }
 
 func (m *mockProtocolClient) SyncRepoCPEMapping(_ context.Context, _ io.ReadWriteCloser, mapping []byte) (bool, *pb.ResponseMeta, error) {
+	if m.syncDelay > 0 {
+		time.Sleep(m.syncDelay)
+	}
 	m.syncCalls = append(m.syncCalls, mapping)
 	return m.syncUpdated, m.syncMeta, m.syncErr
 }
@@ -202,9 +210,12 @@ type mockSender struct {
 	err  error
 }
 
-func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+func (m *mockSender) Send(ctx context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if m.err != nil {
 		return m.err
 	}
@@ -1571,11 +1582,9 @@ func TestVMScraper_DialAndGetReport_SyncTriggering(t *testing.T) {
 	}
 }
 
-// TestVMScraper_SyncRepoCPEMapping_ExpiredContext_ClassifiedAsTimeout covers
-// syncRepoCPEMapping's own ctx check: an already-expired context (GetReport
-// already consumed its deadline) must count as a timeout, not a sync
-// failure, matching dialAndGetReport's own ctx.Err() handling.
-func TestVMScraper_SyncRepoCPEMapping_ExpiredContext_ClassifiedAsTimeout(t *testing.T) {
+// TestVMScraper_SyncRepoCPEMapping_CanceledParent_ClassifiedAsTimeout covers
+// Sensor stop counting as PullSyncTimeout, not PullSyncError.
+func TestVMScraper_SyncRepoCPEMapping_CanceledParent_ClassifiedAsTimeout(t *testing.T) {
 	vm := makeVM("ns1", "vm-a", 100)
 	dialer := &mockDialer{err: errors.New("dial must not be attempted")}
 	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, &mockProtocolClient{})
@@ -1587,10 +1596,64 @@ func TestVMScraper_SyncRepoCPEMapping_ExpiredContext_ClassifiedAsTimeout(t *test
 	cancel()
 	s.syncRepoCPEMapping(ctx, vm, "ns1/vm-a", 1, []byte("payload"))
 
-	assert.Zero(t, dialer.callIdx.Load(), "an already-expired context must not be dialed at all")
+	assert.Zero(t, dialer.callIdx.Load(), "a canceled parent must not be dialed at all")
 	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout)))
 	assert.Equal(t, syncErrBefore, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError)),
-		"an expired context must not be counted as a sync error")
+		"a canceled parent must not be counted as a sync error")
+}
+
+// TestVMScraper_SendSucceedsAfterSyncOverrunsGetReportDeadline covers Send
+// succeeding after GetReport and mapping sync each consume a full timeout.
+func TestVMScraper_SendSucceedsAfterSyncOverrunsGetReportDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		vm := makeVM("ns1", "vm-a", 100)
+		rep := makeReport("1")
+		rep.Meta.RepoCpeMappingHash = new("old-hash")
+		rep.Meta.RepoCpeMappingUpdatePath = pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR.Enum()
+		sender := &mockSender{}
+		client := &mockProtocolClient{
+			resultQueue:    []*vsockclient.GetReportResult{rep},
+			getReportDelay: 15 * time.Millisecond,
+			syncDelay:      15 * time.Millisecond,
+		}
+		s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, sender, &mockDialer{}, client)
+		s.perVMTimeout = 20 * time.Millisecond
+		s.repo2CPEFetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
+
+		s.pollOnce(t.Context())
+
+		require.Len(t, sender.sent, 1, "GetReport's deadline must not fail Send after a mapping sync")
+		require.Len(t, client.syncCalls, 1)
+	})
+}
+
+// TestVMScraper_MappingRequiredClassifiedDespiteSlowSync covers MAPPING_REQUIRED
+// staying mapping_required when mapping sync overruns GetReport's deadline.
+func TestVMScraper_MappingRequiredClassifiedDespiteSlowSync(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		vm := makeVM("ns1", "vm-a", 100)
+		client := &mockProtocolClient{
+			resultQueue: []*vsockclient.GetReportResult{{
+				Meta: metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+			}},
+			errQueue:       []error{vsockclient.ErrMappingRequired},
+			getReportDelay: 15 * time.Millisecond,
+			syncDelay:      15 * time.Millisecond,
+		}
+		s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
+		s.perVMTimeout = 20 * time.Millisecond
+		s.repo2CPEFetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
+
+		mappingBefore := testutil.ToFloat64(metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportMappingRequired))
+		timeoutBefore := testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout))
+
+		s.pollOnce(t.Context())
+
+		require.Len(t, client.syncCalls, 1)
+		assert.Equal(t, mappingBefore+1, testutil.ToFloat64(metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportMappingRequired)))
+		assert.Equal(t, timeoutBefore, testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout)),
+			"a slow mapping sync must not rewrite MAPPING_REQUIRED as a transport timeout")
+	})
 }
 
 // TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync guards against

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -102,6 +102,36 @@ type fakeCloseCoder struct {
 func (e *fakeCloseCoder) Error() string            { return "connection closed" }
 func (e *fakeCloseCoder) CloseCode() (int, string) { return e.code, e.reason }
 
+// singleConnDialer rejects a Dial while a previously dialed stream is still
+// open, mirroring roxagent's real maxConcurrentConns=1 semaphore, so a
+// caller that dials again before closing its current connection sees the
+// same failure it would against the real agent.
+type singleConnDialer struct {
+	mu   sync.Mutex
+	open bool
+}
+
+func (d *singleConnDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	return concurrency.WithLock2(&d.mu, func() (io.ReadWriteCloser, error) {
+		if d.open {
+			return nil, errors.New("agent is already serving another request; retry after a backoff")
+		}
+		d.open = true
+		return &trackedStream{dialer: d}, nil
+	})
+}
+
+type trackedStream struct {
+	dialer *singleConnDialer
+}
+
+func (t *trackedStream) Read([]byte) (int, error)  { return 0, io.EOF }
+func (t *trackedStream) Write([]byte) (int, error) { return 0, nil }
+func (t *trackedStream) Close() error {
+	concurrency.WithLock(&t.dialer.mu, func() { t.dialer.open = false })
+	return nil
+}
+
 type mockProtocolClient struct {
 	mu          sync.Mutex
 	resultQueue []*vsockclient.GetReportResult
@@ -1542,6 +1572,67 @@ func TestVMScraper_DialAndGetReport_SyncTriggering(t *testing.T) {
 			assert.Len(t, client.syncCalls, tc.wantSyncCalls)
 		})
 	}
+}
+
+// TestVMScraper_SyncRepoCPEMapping_ExpiredContext_ClassifiedAsTimeout covers
+// syncRepoCPEMapping's own ctx check: an already-expired context (GetReport
+// already consumed its deadline) must count as a timeout, not a sync
+// failure, matching dialAndGetReport's own ctx.Err() handling.
+func TestVMScraper_SyncRepoCPEMapping_ExpiredContext_ClassifiedAsTimeout(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	dialer := &mockDialer{err: errors.New("dial must not be attempted")}
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, &mockProtocolClient{})
+
+	timeoutBefore := testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout))
+	syncErrBefore := testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s.syncRepoCPEMapping(ctx, vm, "ns1/vm-a", 1, []byte("payload"))
+
+	assert.Zero(t, dialer.callIdx.Load(), "an already-expired context must not be dialed at all")
+	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncTimeout)))
+	assert.Equal(t, syncErrBefore, testutil.ToFloat64(metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncError)),
+		"an expired context must not be counted as a sync error")
+}
+
+// TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync guards against
+// maybeSync's second dial racing the first GetReport connection: roxagent
+// allows only one connection at a time, so dialAndGetReport must close its
+// stream before calling maybeSync, not rely solely on its deferred close.
+func TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	dialer := &singleConnDialer{}
+	client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{{
+		IndexReport: &v4.IndexReport{State: "IndexFinished"},
+		Meta:        metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
+	}}}
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, client)
+	s.SetRepo2CPEFetcher(&fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")})
+
+	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
+
+	require.Equal(t, scrapeOK, outcome)
+	require.Len(t, client.syncCalls, 1, "maybeSync's dial must succeed, not be rejected as busy by a still-open first connection")
+}
+
+// TestVMScraper_DialAndGetReport_MappingRequired_ClosesConnectionBeforeSync
+// is the MAPPING_REQUIRED-error counterpart: that path closes and syncs
+// from a different branch than the success path above.
+func TestVMScraper_DialAndGetReport_MappingRequired_ClosesConnectionBeforeSync(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	dialer := &singleConnDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{{Meta: metaWithMapping("", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR)}},
+		errQueue:    []error{vsockclient.ErrMappingRequired},
+	}
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, client)
+	s.SetRepo2CPEFetcher(&fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")})
+
+	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
+
+	require.Equal(t, scrapeRetryable, outcome)
+	require.Len(t, client.syncCalls, 1, "maybeSync's dial must succeed, not be rejected as busy by a still-open first connection")
 }
 
 func TestClampPollInterval(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -1454,7 +1454,7 @@ func TestVMScraper_MaybeSync(t *testing.T) {
 			client := &mockProtocolClient{syncErr: tc.syncErr}
 			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
 			if !tc.noFetcher {
-				s.SetRepo2CPEFetcher(tc.fetcher)
+				s.fetcher = tc.fetcher
 			}
 
 			var before float64
@@ -1564,7 +1564,7 @@ func TestVMScraper_DialAndGetReport_SyncTriggering(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			client := &mockProtocolClient{resultQueue: tc.resultQueue, errQueue: tc.errQueue}
 			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, client)
-			s.SetRepo2CPEFetcher(staleFetcher())
+			s.fetcher = staleFetcher()
 
 			_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
@@ -1608,7 +1608,7 @@ func TestVMScraper_DialAndGetReport_ClosesConnectionBeforeSync(t *testing.T) {
 		Meta:        metaWithMapping("old-hash", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR),
 	}}}
 	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, client)
-	s.SetRepo2CPEFetcher(&fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")})
+	s.fetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
 
 	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
@@ -1627,7 +1627,7 @@ func TestVMScraper_DialAndGetReport_MappingRequired_ClosesConnectionBeforeSync(t
 		errQueue:    []error{vsockclient.ErrMappingRequired},
 	}
 	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, dialer, client)
-	s.SetRepo2CPEFetcher(&fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")})
+	s.fetcher = &fakeFetcher{ok: true, hash: "new-hash", mapping: []byte("payload")}
 
 	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -38,6 +38,9 @@ var (
 	ErrUnknownAgentError = errors.New("unrecognized agent error code")
 	// ErrMappingRequired indicates the agent has no repository-to-CPE mapping yet.
 	ErrMappingRequired = errors.New("agent has no repository-to-CPE mapping yet")
+	// ErrMappingNotSensorManaged indicates the agent rejected a
+	// SyncRepoCPEMapping because it is URL-managed, not Sensor-managed.
+	ErrMappingNotSensorManaged = errors.New("agent does not accept a sensor-pushed mapping")
 )
 
 // GetReportResult holds the parsed response from a GetReport call.
@@ -129,9 +132,59 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, lastK
 			Meta:        resp.GetMeta(),
 		}, nil
 	case *pb.VMServiceResponse_Error:
-		return nil, errorFromResponse(r.Error)
+		// Meta is still returned alongside the error: a VM with no mapping
+		// at all has nothing to report except MAPPING_REQUIRED, and that
+		// error's Meta is the only way the caller learns it needs to push one.
+		return &GetReportResult{Meta: resp.GetMeta()}, errorFromResponse(r.Error)
 	default:
 		return nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
+	}
+}
+
+// SyncRepoCPEMapping pushes mapping to the agent over stream and reports
+// whether the agent applied it. Mirrors GetReport's request/response framing
+// and error classification for the sync_repo_cpe_mapping method.
+func (c *Client) SyncRepoCPEMapping(ctx context.Context, stream io.ReadWriteCloser, mapping []byte) (updated bool, meta *pb.ResponseMeta, err error) {
+	stop := context.AfterFunc(ctx, func() {
+		_ = stream.Close()
+	})
+	defer stop()
+
+	req := &pb.VMServiceRequest{
+		Meta: &pb.RequestMeta{
+			RequestId:    uuid.NewV4().String(),
+			Capabilities: c.capabilities,
+		},
+		Method: &pb.VMServiceRequest_SyncRepoCpeMapping{
+			SyncRepoCpeMapping: &pb.SyncRepoCPEMappingRequest{Mapping: mapping},
+		},
+	}
+
+	reqData, err := proto.Marshal(req)
+	if err != nil {
+		return false, nil, fmt.Errorf("marshaling request: %w", err)
+	}
+	if err := vsockframing.WriteFrame(stream, reqData); err != nil {
+		return false, nil, wrapStreamErr(ctx, "sending request", err)
+	}
+
+	respData, err := vsockframing.ReadFrame(stream, uint32(c.maxResponseSize))
+	if err != nil {
+		return false, nil, wrapStreamErr(ctx, "reading response", err)
+	}
+
+	var resp pb.VMServiceResponse
+	if err := proto.Unmarshal(respData, &resp); err != nil {
+		return false, nil, fmt.Errorf("unmarshaling response: %w", err)
+	}
+
+	switch r := resp.GetResult().(type) {
+	case *pb.VMServiceResponse_SyncRepoCpeMapping:
+		return r.SyncRepoCpeMapping.GetUpdated(), resp.GetMeta(), nil
+	case *pb.VMServiceResponse_Error:
+		return false, resp.GetMeta(), errorFromResponse(r.Error)
+	default:
+		return false, nil, fmt.Errorf("unexpected response type: %T", resp.GetResult())
 	}
 }
 
@@ -158,6 +211,8 @@ func errorFromResponse(e *pb.ErrorResponse) error {
 		return fmt.Errorf("%w: %s", ErrBusy, e.GetMessage())
 	case pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED:
 		return fmt.Errorf("%w: %s", ErrMappingRequired, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED:
+		return fmt.Errorf("%w: %s", ErrMappingNotSensorManaged, e.GetMessage())
 	default:
 		return fmt.Errorf("%w: agent error (%s): %s", ErrUnknownAgentError, e.GetCode(), e.GetMessage())
 	}

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -282,7 +282,7 @@ func TestSyncRepoCPEMappingIntegration_FullRoundTrip(t *testing.T) {
 	wantHash := cpemapping.HashMapping(mapping)
 	assert.Equal(t, wantHash, syncMeta.GetRepoCpeMappingHash())
 
-	cache.SetReport(&v4.IndexReport{HashId: "sync-integration-hash"}, nil, "")
+	cache.SetReport(&v4.IndexReport{HashId: "sync-integration-hash"}, nil, wantHash)
 
 	second, err := exchangeOnce(t, client, "", handler.HandleConn)
 	require.NoError(t, err)

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -270,7 +270,7 @@ func TestSyncRepoCPEMappingIntegration_FullRoundTrip(t *testing.T) {
 	handler := roxagentvsock.NewHandler(cache, "test-agent", updater, updater)
 	client := NewClient([]string{CapabilityReportV1}, 10<<20)
 
-	first, err := exchangeOnce(t, client, 0, 0, handler.HandleConn)
+	first, err := exchangeOnce(t, client, "", handler.HandleConn)
 	require.ErrorIs(t, err, ErrMappingRequired, "no bootstrapped mapping must surface as MAPPING_REQUIRED")
 	require.NotNil(t, first.Meta)
 	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, first.Meta.GetRepoCpeMappingUpdatePath())
@@ -282,9 +282,9 @@ func TestSyncRepoCPEMappingIntegration_FullRoundTrip(t *testing.T) {
 	wantHash := cpemapping.HashMapping(mapping)
 	assert.Equal(t, wantHash, syncMeta.GetRepoCpeMappingHash())
 
-	cache.SetReport(&v4.IndexReport{HashId: "sync-integration-hash"}, nil)
+	cache.SetReport(&v4.IndexReport{HashId: "sync-integration-hash"}, nil, "")
 
-	second, err := exchangeOnce(t, client, 0, 0, handler.HandleConn)
+	second, err := exchangeOnce(t, client, "", handler.HandleConn)
 	require.NoError(t, err)
 	require.NotNil(t, second.IndexReport)
 	assert.Equal(t, "sync-integration-hash", second.IndexReport.GetHashId())

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -13,7 +13,7 @@ import (
 	roxagentvsock "github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -279,7 +279,7 @@ func TestSyncRepoCPEMappingIntegration_FullRoundTrip(t *testing.T) {
 	updated, syncMeta, err := syncOnce(t, client, mapping, handler.HandleConn)
 	require.NoError(t, err)
 	assert.True(t, updated)
-	wantHash := repositorytocpe.HashMapping(mapping)
+	wantHash := cpemapping.HashMapping(mapping)
 	assert.Equal(t, wantHash, syncMeta.GetRepoCpeMappingHash())
 
 	cache.SetReport(&v4.IndexReport{HashId: "sync-integration-hash"}, nil)

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -18,19 +18,22 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// readyMappingProvider is Ready so GetReport reaches the cache path these
-// tests cover (empty cache → NOT_READY, seeded cache → report).
-type readyMappingProvider struct{}
-
-func (readyMappingProvider) Ready() bool  { return true }
-func (readyMappingProvider) Hash() string { return "" }
-func (readyMappingProvider) UpdatePath() pb.RepoCPEMappingUpdatePath {
-	return pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR
+// fakeMappingProvider is a MappingProvider test double whose Ready/Hash/
+// UpdatePath are directly settable; Bytes/Path are unused by the Handler
+// and always error.
+type fakeMappingProvider struct {
+	ready      bool
+	hash       string
+	updatePath pb.RepoCPEMappingUpdatePath
 }
-func (readyMappingProvider) Bytes() ([]byte, error) { return nil, errors.New("not implemented") }
-func (readyMappingProvider) Path() (string, error)  { return "", errors.New("not implemented") }
 
-var _ roxagentvsock.MappingProvider = readyMappingProvider{}
+func (f *fakeMappingProvider) Ready() bool                             { return f.ready }
+func (f *fakeMappingProvider) Hash() string                            { return f.hash }
+func (f *fakeMappingProvider) UpdatePath() pb.RepoCPEMappingUpdatePath { return f.updatePath }
+func (f *fakeMappingProvider) Bytes() ([]byte, error)                  { return nil, errors.New("not implemented") }
+func (f *fakeMappingProvider) Path() (string, error)                   { return "", errors.New("not implemented") }
+
+var _ roxagentvsock.MappingProvider = (*fakeMappingProvider)(nil)
 
 // exchangeTimeout bounds a single client/handler exchange. Under synctest the
 // fake clock advances this duration instantly once every goroutine is durably
@@ -76,7 +79,7 @@ func newProtocolHarness(t *testing.T, opts protocolHarnessOptions) *protocolHarn
 	return &protocolHarness{
 		client:  NewClient(opts.capabilities, opts.maxResponseSize),
 		cache:   cache,
-		handler: roxagentvsock.NewHandler(cache, opts.agentVersion, readyMappingProvider{}, nil),
+		handler: roxagentvsock.NewHandler(cache, opts.agentVersion, &fakeMappingProvider{ready: true}, nil),
 	}
 }
 

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"path/filepath"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -12,6 +13,7 @@ import (
 	roxagentvsock "github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsockserver"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -224,6 +226,69 @@ func TestGetReportIntegration_TokenRoundTrip(t *testing.T) {
 		assert.Equal(t, "token-test-hash", result.IndexReport.GetHashId())
 		assert.Equal(t, token, result.Meta.GetReportToken())
 	})
+}
+
+// syncOnce mirrors exchangeOnce for a single SyncRepoCPEMapping exchange.
+func syncOnce(t *testing.T, client *Client, mapping []byte, responder func(net.Conn)) (bool, *pb.ResponseMeta, error) {
+	t.Helper()
+
+	var updated bool
+	var meta *pb.ResponseMeta
+	var err error
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), exchangeTimeout)
+		defer cancel()
+
+		clientConn, agentConn := net.Pipe()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			responder(agentConn)
+		}()
+
+		updated, meta, err = client.SyncRepoCPEMapping(ctx, clientConn, mapping)
+		_ = clientConn.Close()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			if err == nil {
+				err = fmt.Errorf("waiting for responder: %w", ctx.Err())
+			}
+		}
+	})
+	return updated, meta, err
+}
+
+// TestSyncRepoCPEMappingIntegration_FullRoundTrip drives a real Client and
+// Handler through GetReport (MAPPING_REQUIRED) -> SyncRepoCPEMapping ->
+// GetReport again; every seam here is otherwise only unit-tested against fakes.
+func TestSyncRepoCPEMappingIntegration_FullRoundTrip(t *testing.T) {
+	mapping := []byte(`{"data":{"rhel-9-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:9"]}}}`)
+	updater := roxagentvsock.NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", nil)
+	cache := &roxagentvsock.ReportCache{}
+	handler := roxagentvsock.NewHandler(cache, "test-agent", updater, updater)
+	client := NewClient([]string{CapabilityReportV1}, 10<<20)
+
+	first, err := exchangeOnce(t, client, 0, 0, handler.HandleConn)
+	require.ErrorIs(t, err, ErrMappingRequired, "no bootstrapped mapping must surface as MAPPING_REQUIRED")
+	require.NotNil(t, first.Meta)
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, first.Meta.GetRepoCpeMappingUpdatePath())
+	assert.Empty(t, first.Meta.GetRepoCpeMappingHash())
+
+	updated, syncMeta, err := syncOnce(t, client, mapping, handler.HandleConn)
+	require.NoError(t, err)
+	assert.True(t, updated)
+	wantHash := repositorytocpe.HashMapping(mapping)
+	assert.Equal(t, wantHash, syncMeta.GetRepoCpeMappingHash())
+
+	cache.SetReport(&v4.IndexReport{HashId: "sync-integration-hash"}, nil)
+
+	second, err := exchangeOnce(t, client, 0, 0, handler.HandleConn)
+	require.NoError(t, err)
+	require.NotNil(t, second.IndexReport)
+	assert.Equal(t, "sync-integration-hash", second.IndexReport.GetHashId())
+	assert.Equal(t, wantHash, second.Meta.GetRepoCpeMappingHash(), "the follow-up GetReport must reflect the mapping pushed via Sync")
 }
 
 // --- Compatibility persona helpers ---

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -148,6 +148,11 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			message: "repository-to-CPE mapping not yet available",
 			wantErr: ErrMappingRequired,
 		},
+		"should wrap ErrMappingNotSensorManaged for MAPPING_NOT_SENSOR_MANAGED": {
+			code:    pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED,
+			message: "url-managed",
+			wantErr: ErrMappingNotSensorManaged,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -168,6 +173,87 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			if tc.wantInMsg != "" {
 				assert.Contains(t, err.Error(), tc.wantInMsg)
 			}
+		})
+	}
+}
+
+// TestSendGetReport_ErrorCarriesMeta verifies that an error response's Meta
+// is still returned alongside the error, not dropped: MAPPING_REQUIRED is
+// the only way a VM with no mapping at all can tell Sensor it needs one.
+func TestSendGetReport_ErrorCarriesMeta(t *testing.T) {
+	client := NewClient(nil, 10<<20)
+	clientConn, agentConn := net.Pipe()
+	defer utils.IgnoreError(clientConn.Close)
+
+	go serveOnce(t, agentConn, &pb.VMServiceResponse{
+		Meta: &pb.ResponseMeta{
+			AgentVersion:             "test-agent",
+			RepoCpeMappingHash:       new(""),
+			RepoCpeMappingUpdatePath: pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR.Enum(),
+		},
+		Result: &pb.VMServiceResponse_Error{
+			Error: &pb.ErrorResponse{Code: pb.ErrorCode_ERROR_CODE_MAPPING_REQUIRED, Message: "no mapping yet"},
+		},
+	}, nil)
+
+	result, err := client.GetReport(context.Background(), clientConn, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMappingRequired)
+	require.NotNil(t, result, "error result must still carry Meta")
+	require.NotNil(t, result.Meta)
+	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, result.Meta.GetRepoCpeMappingUpdatePath())
+	assert.Empty(t, result.Meta.GetRepoCpeMappingHash())
+}
+
+func TestSendSyncRepoCPEMapping(t *testing.T) {
+	cases := map[string]struct {
+		resp        *pb.VMServiceResponse
+		wantUpdated bool
+		wantErr     error
+	}{
+		"should report updated true on success": {
+			resp: &pb.VMServiceResponse{
+				Meta:   &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_SyncRepoCpeMapping{SyncRepoCpeMapping: &pb.SyncRepoCPEMappingResponse{Updated: true}},
+			},
+			wantUpdated: true,
+		},
+		"should report updated false when the mapping already matched": {
+			resp: &pb.VMServiceResponse{
+				Meta:   &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_SyncRepoCpeMapping{SyncRepoCpeMapping: &pb.SyncRepoCPEMappingResponse{Updated: false}},
+			},
+			wantUpdated: false,
+		},
+		"should wrap ErrMappingNotSensorManaged when the agent is URL-managed": {
+			resp: &pb.VMServiceResponse{
+				Meta: &pb.ResponseMeta{AgentVersion: "test-agent"},
+				Result: &pb.VMServiceResponse_Error{
+					Error: &pb.ErrorResponse{Code: pb.ErrorCode_ERROR_CODE_MAPPING_NOT_SENSOR_MANAGED, Message: "url-managed"},
+				},
+			},
+			wantErr: ErrMappingNotSensorManaged,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := NewClient(nil, 10<<20)
+			clientConn, agentConn := net.Pipe()
+			defer utils.IgnoreError(clientConn.Close)
+
+			go serveOnce(t, agentConn, tc.resp, func(req *pb.VMServiceRequest) {
+				assert.Equal(t, []byte("mapping-bytes"), req.GetSyncRepoCpeMapping().GetMapping())
+			})
+
+			updated, meta, err := client.SyncRepoCPEMapping(context.Background(), clientConn, []byte("mapping-bytes"))
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUpdated, updated)
+			assert.Equal(t, "test-agent", meta.GetAgentVersion())
 		})
 	}
 }

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -197,7 +197,8 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 			if err != nil {
 				log.Errorf("Failed to create repo-to-CPE refresher: %v", err)
 			}
-			// repo2CPEFetcher must be a typed-nil to avoid panics from maybeSync.
+			// A typed-nil *Repo2CPE is a non-nil Repo2CPEFetcher, so
+			// maybeSyncRepoCPEMapping would call FetchRepo2CPE on a nil receiver.
 			var repo2CPEFetcher vmscraper.Repo2CPEFetcher
 			if repo2CPE != nil {
 				repo2CPEFetcher = repo2CPE

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -44,6 +44,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/processsignal"
 	"github.com/stackrox/rox/sensor/common/reprocessor"
 	"github.com/stackrox/rox/sensor/common/scan"
+	"github.com/stackrox/rox/sensor/common/scannerdefinitions"
 	"github.com/stackrox/rox/sensor/common/sensor"
 	signalService "github.com/stackrox/rox/sensor/common/signal"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -182,6 +183,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	var virtualMachineHandler vmIndex.Handler
 	var vmScraper *vmscraper.VMScraper
 	var vmStats clustermetrics.VMStatsSource
+	var repo2CPE *scannerdefinitions.Repo2CPE
 	if features.VirtualMachines.Enabled() {
 		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines())
 
@@ -191,7 +193,11 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 			log.Errorf("VSOCK pull mode disabled: failed to construct dialer: %v", err)
 		} else {
 			vmProtoClient := vsockclient.NewClient([]string{vsockclient.CapabilityReportV1}, int(pullMaxBytes))
-			vmScraper = vmscraper.New(storeProvider.VirtualMachines(), virtualMachineHandler, vmDial, vmProtoClient)
+			repo2CPE, err = scannerdefinitions.NewRepo2CPE(env.CentralEndpoint.Setting(), cfg.certLoader())
+			if err != nil {
+				log.Errorf("Failed to create repo-to-CPE refresher: %v", err)
+			}
+			vmScraper = vmscraper.New(storeProvider.VirtualMachines(), virtualMachineHandler, vmDial, vmProtoClient, repo2CPE)
 			vmStats = vmScraper
 		}
 	}
@@ -218,6 +224,9 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 	if virtualMachineHandler != nil {
 		components = append(components, virtualMachineHandler)
+	}
+	if repo2CPE != nil {
+		components = append(components, repo2CPE)
 	}
 	if vmScraper != nil {
 		components = append(components, vmScraper)

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -197,7 +197,12 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 			if err != nil {
 				log.Errorf("Failed to create repo-to-CPE refresher: %v", err)
 			}
-			vmScraper = vmscraper.New(storeProvider.VirtualMachines(), virtualMachineHandler, vmDial, vmProtoClient, repo2CPE)
+			// repo2CPEFetcher must be a typed-nil to avoid panics from maybeSync.
+			var repo2CPEFetcher vmscraper.Repo2CPEFetcher
+			if repo2CPE != nil {
+				repo2CPEFetcher = repo2CPE
+			}
+			vmScraper = vmscraper.New(storeProvider.VirtualMachines(), virtualMachineHandler, vmDial, vmProtoClient, repo2CPEFetcher)
 			vmStats = vmScraper
 		}
 	}

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -75,6 +75,7 @@ scanner/e2etests/testdata/image_tests.orig.json
 scanner/enricher/csaf/testdata/*
 scanner/enricher/nvd/testdata/feed.json
 scripts/ci/lib.sh
+sensor/common/virtualmachine/vmscraper/scraper_test.go
 sensor/tests/data/policies.json
 sensor/upgrader/preflight/testdata/k8s-1.22.json.gz
 tests/common.go


### PR DESCRIPTION
## Description

Part 5 of 5 in the ROX-35685 stack (delivering repository-to-CPE mapping to `roxagent` via Sensor over VSOCK, for disconnected environments where the agent cannot reach the public mapping URL directly). See [ROX-35685](https://redhat.atlassian.net/browse/ROX-35685) for the full problem. Stacked on top of the Sensor cache PR earlier in this series; this is the last PR in the stack and the one that makes the feature end-to-end.

`roxagent` (StackRox's pull-mode VM vulnerability-scanning agent) needs a repository-to-CPE mapping file to enrich the packages it finds with CPEs for vulnerability matching. Today it gets that mapping from a single configurable URL (`--repo-cpe-url`), which defaults to a public Red Hat URL fetched directly from inside the VM - that default doesn't work in a disconnected/air-gapped cluster, where the VM has no route to the public internet, and pointing it at a URL at all requires the customer to already run and maintain their own reachable mirror. The failure mode when neither is available is worse than degraded scanning: the fetch was a mandatory, blocking step at process startup, so if it failed, roxagent refused to start at all.

This stack removes that internet dependency by having Sensor deliver the mapping instead, over the VSOCK connection Sensor already maintains to every VM it scans. This PR is the piece that actually drives the push: after each `GetReport` exchange, `vmscraper` compares the agent's reported mapping hash against Sensor's own cache (from the previous PR) and, when the agent is Sensor-managed and stale, dials the VM again and pushes a fresh mapping via `SyncRepoCPEMapping`. A URL-managed agent with a stale hash is only logged and counted, never dialed - Sensor never overrides an operator's explicit `--repo-cpe-url` choice. `vsockclient.Client.GetReport`'s error case now also surfaces `ResponseMeta`, since a VM with no mapping at all has nothing to report except `MAPPING_REQUIRED`, and that error's metadata is the only way Sensor learns it needs to push one.

`CreateSensor` constructs `Repo2CPE` and passes it into `vmscraper.New`. A nil fetcher leaves `maybeSync` a no-op, so pull still works if the cache was not built.

Also adds the integration test this stack's design review flagged as deferred: the seams here were previously only unit-tested against fakes, with nothing driving the full `GetReport` (`MAPPING_REQUIRED`) → `SyncRepoCPEMapping` → `GetReport` again round trip through real proto framing. That was blocked on the `net.Pipe()`/`synctest` harness added by [ROX-35502 / #21647](https://github.com/stackrox/stackrox/pull/21647); now that it's merged, this PR adds that round-trip test on top of it.

The qa e2e harness still only drives roxagent's one-shot CLI, not `serve` plus a Sensor-initiated sync. Manual cluster validation of that path is below.

Partially generated with AI assistance (subagent-driven implementation and review, human-directed).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

Table-driven unit tests cover `maybeSync`'s full decision table (hash match, `SENSOR`/`URL`/`UNSPECIFIED` update paths, the `MAPPING_REQUIRED` bootstrap case, and the `NOT_SENSOR_MANAGED` refusal) and the new client-side error metadata behavior. On top of that, a real-framing integration test drives an actual `Client` against an actual `Handler`/`SensorUpdater` through the full bootstrap → push → re-fetch sequence.

### How I validated my change

<details>
<summary><b>Manual verification: PASS</b> - Sensor-pushed mapping, then forwarded report; URL updater not used</summary>

**Setup:** `ROX_VIRTUAL_MACHINES=true`, OpenShift/CNV, two RHEL 10 VMs, native `roxagent-serve` with `--repo-cpe-url` unset. First scrape of a newly tracked VM can wait up to 20 minutes (`U(0, min(20m, poll/3))`).

1. Sensor fetched Central's mapping, then pushed it to both VMs (`updated=true`; hashes match):
   ```
   kubectl -n stackrox logs deploy/sensor | grep -E 'Fetched repo-to-CPE|Failed to fetch repo-to-CPE|synced repo-to-CPE'
   ```
   ```
   Fetched repo-to-CPE mapping from central, hash=c85b94ffcd6a6680
   VMScraper: synced repo-to-CPE mapping to "openshift-cnv/rhel10-2" (updated=true)
   VMScraper: synced repo-to-CPE mapping to "openshift-cnv/rhel10-1" (updated=true)
   ```

2. Agent applied that mapping, then served a report (rhel10-1; rhel10-2 the same apply line):
   ```
   sudo journalctl -u roxagent-serve.service --no-pager | grep -E 'GetReport:|SyncRepoCPEMapping:'
   ```
   ```
   GetReport: no repo-to-CPE mapping available yet
   SyncRepoCPEMapping: applied mapping (hash=c85b94ffcd6a6680)
   GetReport: serving report (token=6ab83ad64317d806, packages=529)
   ```

3. Sensor forwarded the report after the bootstrap `MAPPING_REQUIRED` retry:
   ```
   kubectl -n stackrox logs deploy/sensor | grep 'scrape "openshift-cnv/rhel10-1"'
   ```
   ```
   VMScraper: scrape "openshift-cnv/rhel10-1" failed retryable next=10s
   VMScraper: scrape "openshift-cnv/rhel10-1" ok outcome=forwarded next=5h59m34.38884253s
   ```
   The first line is the `MAPPING_REQUIRED` GetReport that triggered the push. The VM page in Central showed the index report.

4. Agents are Sensor-managed, not URL-managed. `ExecStart` is `roxagent serve --port 818 --host-path /tmp/roxroot` (no `--repo-cpe-url`). Journals have `sensor_updater.go` `applied mapping` and no `url_updater.go` download lines. Sensor would have logged `url_hash_mismatch` and skipped the push if the agent had advertised the URL path.

Not exercised: Sensor offline serving last-known-good cache after Central is unreachable.

</details>

#### Restart of roxagent preserves mapping file

Agent logs:
```
12:10:25.002150 sensor_updater.go:155: Info: SyncRepoCPEMapping: applied mapping (hash=c85b94ffcd6a6680)

# restart of agent

12:57:08.513587 rescanner.go:131: Info: Starting rescan (mapping hash=c85b94ffcd6a6680)
```

#### Restart of Sensor

```
$  logs-sensor | grep -E 'repo-to-CPE|scrap'

common/scannerdefinitions: 2026/09/01 13:03:21.047822 repo2cpe.go:262: Debug: Fetched repo-to-CPE mapping from central, hash=c85b94ffcd6a6680

common/virtualmachine/vmscraper: 2026/09/01 13:04:10.833930 scraper.go:316: Debug: VMScraper: tick: 1 due VMs [openshift-cnv/rhel10-2] (concurrency=20, reconcile=false)
common/virtualmachine/vmscraper: 2026/09/01 13:04:10.834080 scraper.go:448: Info: VMScraper: scraping "openshift-cnv/rhel10-2" (reason=poll backoff=0s)
common/virtualmachine/vmscraper: 2026/09/01 13:04:10.834126 scraper.go:465: Debug: VMScraper: dialing roxagent on "openshift-cnv/rhel10-2" with TLS
common/virtualmachine/vmscraper: 2026/09/01 13:04:10.920060 facts.go:21: Debug: VMScraper: VM discovered data for "openshift-cnv/rhel10-2": detected_os=RHEL, os_version="10.2", activation_status=INACTIVE, dnf_metadata_status=UNAVAILABLE
common/virtualmachine/vmscraper: 2026/09/01 13:04:10.920170 scraper.go:527: Info: VMScraper: scrape "openshift-cnv/rhel10-2" ok outcome=forwarded next=5h44m56.71891202s
common/virtualmachine/vmscraper: 2026/09/01 13:04:10.920186 scraper.go:529: Debug: VMScraper: successfully pulled report for "openshift-cnv/rhel10-2": token=11c9f1d6234dfee0, packages=529, size=470415 bytes, total=86ms
(...)
common/virtualmachine/vmscraper: 2026/09/01 13:04:39.421173 scraper.go:205: Debug: VMScraper: received acknowledgement for resource_id="96f062f4-1845-4d83-b011-032fb45fea89:3778032906"
```

Note missing "synced repo-to-CPE mapping" in the logs.

I have re-verified on 6b7ccc2192 (quay.io/stackrox-io/main:5.0.x-174-g6b7ccc2192); same path on both VMs with mapping hash b457037787783e89 (Central’s mapping content changed; the old c85b94ffcd6a6680 is not wrong, just from Sep 1).


[ROX-35685]: https://redhat.atlassian.net/browse/ROX-35685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
