### PR TITLE
ROX-35981: Migrate audit log manager audit event msgs to PubSub

### DIFF
--- a/sensor/common/compliance/auditlog_manager.go
+++ b/sensor/common/compliance/auditlog_manager.go
@@ -46,7 +46,7 @@ type clusterIDWaiter interface {
 }
 
 // NewAuditLogCollectionManager creates a new instance of AuditLogCollectionManager, which provides an API to manage the lifecycle of audit log collection within the cluster
-func NewAuditLogCollectionManager(clusterID clusterIDWaiter) AuditLogCollectionManager {
+func NewAuditLogCollectionManager(clusterID clusterIDWaiter, pubSubDispatcher common.PubSubDispatcher) AuditLogCollectionManager {
 	return &auditLogCollectionManagerImpl{
 		// Need to use a getter instead of directly calling clusterid.Get because it may block if the communication with central is not yet finished
 		// Putting it as a getter so it can be overridden in tests
@@ -59,5 +59,6 @@ func NewAuditLogCollectionManager(clusterID clusterIDWaiter) AuditLogCollectionM
 		forceUpdateSig:          concurrency.NewSignal(),
 		centralReady:            concurrency.NewSignal(),
 		updaterTicker:           time.NewTicker(defaultInterval),
+		pubSubDispatcher:        pubSubDispatcher,
 	}
 }

--- a/sensor/common/compliance/auditlog_manager_event.go
+++ b/sensor/common/compliance/auditlog_manager_event.go
@@ -1,0 +1,21 @@
+package compliance
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// AuditLogManagerEvent carries an audit log message from a compliance node, routed to the
+// AuditLogCollectionManager to update its per-node file state tracking.
+type AuditLogManagerEvent struct {
+	Node        string
+	AuditEvents *sensor.AuditEvents
+}
+
+func (e *AuditLogManagerEvent) Topic() pubsub.Topic {
+	return pubsub.AuditLogManagerTopic
+}
+
+func (e *AuditLogManagerEvent) Lane() pubsub.LaneID {
+	return pubsub.AuditLogManagerLane
+}

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -4,15 +4,18 @@ import (
 	"maps"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 )
 
@@ -44,6 +47,8 @@ type auditLogCollectionManagerImpl struct {
 
 	fileStateLock  sync.RWMutex
 	connectionLock sync.RWMutex
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 func (a *auditLogCollectionManagerImpl) Name() string {
@@ -51,7 +56,18 @@ func (a *auditLogCollectionManagerImpl) Name() string {
 }
 
 func (a *auditLogCollectionManagerImpl) Start() error {
-	go a.runStateSaver()
+	if features.SensorInternalPubSub.Enabled() && a.pubSubDispatcher != nil {
+		if err := a.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.AuditLogManagerAuditEventsConsumer,
+			pubsub.AuditLogManagerTopic,
+			pubsub.AuditLogManagerLane,
+			a.handleAuditLogManagerEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register audit log manager consumer")
+		}
+	} else {
+		go a.runStateSaver()
+	}
 	go a.runUpdater(a.updaterTicker.C)
 	return nil
 }
@@ -96,21 +112,35 @@ func (a *auditLogCollectionManagerImpl) runStateSaver() {
 		case <-a.stopper.Flow().StopRequested():
 			return
 		case msg := <-a.auditEventMsgs:
-			node := msg.GetNode()
-			if events := msg.GetAuditEvents(); len(events.GetEvents()) > 0 {
-				// Given how audit logs are always in chronological order, and given how compliance is parsing it in said order,
-				// we can make an assumption that the earliest event in this message is still later than the state before
-				// But we won't check it, in case there is a corner case where the time is out of order.
-				latestEvent := events.GetEvents()[0]
-				for _, e := range events.GetEvents()[1:] {
-					if protoutils.After(e.GetTimestamp(), latestEvent.GetTimestamp()) {
-						latestEvent = e
-					}
-				}
-				a.updateFileState(node, latestEvent)
-			}
+			a.handleAuditEvents(msg.GetNode(), msg.GetAuditEvents())
 		}
 	}
+}
+
+// handleAuditLogManagerEvent adapts a PubSub AuditLogManagerEvent to handleAuditEvents.
+func (a *auditLogCollectionManagerImpl) handleAuditLogManagerEvent(event pubsub.Event) error {
+	auditLogManagerEvent, ok := event.(*AuditLogManagerEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	a.handleAuditEvents(auditLogManagerEvent.Node, auditLogManagerEvent.AuditEvents)
+	return nil
+}
+
+func (a *auditLogCollectionManagerImpl) handleAuditEvents(node string, events *sensor.AuditEvents) {
+	if len(events.GetEvents()) == 0 {
+		return
+	}
+	// Given how audit logs are always in chronological order, and given how compliance is parsing it in said order,
+	// we can make an assumption that the earliest event in this message is still later than the state before
+	// But we won't check it, in case there is a corner case where the time is out of order.
+	latestEvent := events.GetEvents()[0]
+	for _, e := range events.GetEvents()[1:] {
+		if protoutils.After(e.GetTimestamp(), latestEvent.GetTimestamp()) {
+			latestEvent = e
+		}
+	}
+	a.updateFileState(node, latestEvent)
 }
 
 func (a *auditLogCollectionManagerImpl) updateFileState(node string, latestEvent *storage.KubernetesEvent) {

--- a/sensor/common/compliance/auditlog_manager_pubsub_test.go
+++ b/sensor/common/compliance/auditlog_manager_pubsub_test.go
@@ -1,0 +1,107 @@
+package compliance
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAuditLogManagerDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.AuditLogManagerLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+// TestPubSubAuditLogManagerEventUpdatesFileState verifies that publishing an
+// AuditLogManagerEvent updates file state the same way the legacy AuditMessagesChan() path does.
+func (s *AuditLogCollectionManagerTestSuite) TestPubSubAuditLogManagerEventUpdatesFileState() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestAuditLogManagerDispatcher(t)
+	defer dispatcher.Stop()
+
+	manager := s.getManager(make(map[string]sensor.ComplianceService_CommunicateServer), nil)
+	manager.pubSubDispatcher = dispatcher
+	manager.enabled.Set(true)
+
+	s.Require().NoError(manager.Start())
+	defer manager.Stop()
+
+	expectedFileStates := make(map[string]*storage.AuditLogFileState)
+	startTime := time.Now()
+	for node := range 2 {
+		nodeName := fmt.Sprintf("node-%d", node)
+		msg := s.getMsgFromCompliance(nodeName, startTime)
+		expectedFileStates[nodeName] = s.getAuditLogFileState(startTime, msg.GetAuditEvents().GetEvents()[0].GetId())
+
+		require.NoError(t, dispatcher.Publish(&AuditLogManagerEvent{Node: msg.GetNode(), AuditEvents: msg.GetAuditEvents()}))
+	}
+
+	s.Eventually(func() bool {
+		return len(manager.getLatestFileStates()) == len(expectedFileStates)
+	}, updateTimeout, 10*time.Millisecond)
+
+	protoassert.MapEqual(t, expectedFileStates, manager.getLatestFileStates())
+
+	// The legacy channel must stay untouched while PubSub is enabled.
+	select {
+	case <-manager.auditEventMsgs:
+		s.Fail("unexpected message on legacy auditEventMsgs channel while PubSub is enabled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func (s *AuditLogCollectionManagerTestSuite) TestHandleAuditLogManagerEventWrongType() {
+	manager := s.getManager(make(map[string]sensor.ComplianceService_CommunicateServer), nil)
+	s.Error(manager.handleAuditLogManagerEvent(&wrongAuditLogManagerEvent{}))
+}
+
+// TestPubSubDisabledFallsBackToAuditMessagesChan verifies that with PubSub disabled, the
+// manager behaves exactly as before: only the legacy AuditMessagesChan() path is used, even
+// with a live dispatcher present.
+func (s *AuditLogCollectionManagerTestSuite) TestPubSubDisabledFallsBackToAuditMessagesChan() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "false")
+
+	dispatcher := newTestAuditLogManagerDispatcher(t)
+	defer dispatcher.Stop()
+
+	manager := s.getManager(make(map[string]sensor.ComplianceService_CommunicateServer), nil)
+	manager.pubSubDispatcher = dispatcher
+
+	s.Require().NoError(manager.Start())
+	defer manager.Stop()
+
+	startTime := time.Now()
+	msg := s.getMsgFromCompliance("node-legacy", startTime)
+	expected := s.getAuditLogFileState(startTime, msg.GetAuditEvents().GetEvents()[0].GetId())
+
+	manager.AuditMessagesChan() <- msg
+
+	s.Eventually(func() bool {
+		return len(manager.getLatestFileStates()) == 1
+	}, updateTimeout, 10*time.Millisecond)
+
+	protoassert.MapEqual(t, map[string]*storage.AuditLogFileState{"node-legacy": expected}, manager.getLatestFileStates())
+}
+
+type wrongAuditLogManagerEvent struct{}
+
+func (*wrongAuditLogManagerEvent) Topic() pubsub.Topic { return pubsub.DefaultTopic }
+func (*wrongAuditLogManagerEvent) Lane() pubsub.LaneID { return pubsub.DefaultLane }

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -258,7 +258,13 @@ func (s *serviceImpl) Communicate(server sensor.ComplianceService_CommunicateSer
 			} else {
 				s.auditEvents <- t.AuditEvents
 			}
-			s.auditLogCollectionManager.AuditMessagesChan() <- msg
+			if features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil {
+				if err := s.pubSubDispatcher.Publish(&AuditLogManagerEvent{Node: msg.GetNode(), AuditEvents: t.AuditEvents}); err != nil {
+					logging.GetRateLimitedLogger().ErrorL("audit-log-manager-publish", "Failed to publish audit log manager event: %v", err)
+				}
+			} else {
+				s.auditLogCollectionManager.AuditMessagesChan() <- msg
+			}
 		case *sensor.MsgFromCompliance_NodeInventory:
 			s.nodeInventories <- t.NodeInventory
 		case *sensor.MsgFromCompliance_IndexReport:

--- a/sensor/common/compliance/service_impl_pubsub_test.go
+++ b/sensor/common/compliance/service_impl_pubsub_test.go
@@ -1,0 +1,75 @@
+package compliance
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServiceDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.DetectorAuditLogLane),
+			lane.NewBlockingLane(pubsub.AuditLogManagerLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+// TestPubSubAuditEventsRoutedToAuditLogManager verifies that Communicate()'s AuditEvents case
+// publishes an AuditLogManagerEvent instead of writing to the legacy AuditMessagesChan() when
+// PubSub is enabled.
+func (s *complianceServiceSuite) TestPubSubAuditEventsRoutedToAuditLogManager() {
+	t := s.T()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestServiceDispatcher(t)
+	defer dispatcher.Stop()
+	s.srv.pubSubDispatcher = dispatcher
+
+	received := make(chan *AuditLogManagerEvent, 1)
+	require.NoError(t, dispatcher.RegisterConsumerToLane(
+		pubsub.AuditLogManagerAuditEventsConsumer,
+		pubsub.AuditLogManagerTopic,
+		pubsub.AuditLogManagerLane,
+		func(event pubsub.Event) error {
+			auditLogManagerEvent, ok := event.(*AuditLogManagerEvent)
+			require.True(t, ok)
+			received <- auditLogManagerEvent
+			return nil
+		},
+	))
+
+	s.online()
+	s.Require().NoError(s.stream.Send(&sensor.MsgFromCompliance{
+		Msg: &sensor.MsgFromCompliance_AuditEvents{
+			AuditEvents: &sensor.AuditEvents{
+				Events: []*storage.KubernetesEvent{{Id: "1"}},
+			},
+		},
+	}))
+
+	select {
+	case event := <-received:
+		s.NotNil(event.AuditEvents)
+	case <-time.After(2 * time.Second):
+		s.Fail("timed out waiting for audit log manager event via pubsub")
+	}
+
+	// The legacy audit log manager channel must stay untouched while PubSub is enabled.
+	select {
+	case <-s.mockAuditLogC:
+		s.Fail("unexpected message on legacy audit log manager channel while PubSub is enabled")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,7 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	AuditLogManagerAuditEventsConsumer
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		AuditLogManagerAuditEventsConsumer:     "AuditLogManagerAuditEvents",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	AuditLogManagerLane
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		AuditLogManagerLane:            "AuditLogManager",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	AuditLogManagerTopic
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		AuditLogManagerTopic:            "AuditLogManager",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,7 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.AuditLogManagerLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -130,7 +130,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	auditLogEventsInput := make(chan *sensorInternal.AuditEvents)
-	auditLogCollectionManager := compliance.NewAuditLogCollectionManager(clusterID)
+	auditLogCollectionManager := compliance.NewAuditLogCollectionManager(clusterID, internalMessageDispatcher)
 
 	o := orchestrator.New(cfg.k8sClient.Kubernetes())
 	complianceMultiplexer := compliance.NewMultiplexer()


### PR DESCRIPTION
## Description

  Migrates the compliance service's routing of audit event messages to the
  `AuditLogCollectionManager`, gated by `features.SensorInternalPubSub`
  (`ROX_SENSOR_PUBSUB`, default-enabled):

  - **Producer** (`serviceImpl.Communicate()`): the `*sensor.MsgFromCompliance_AuditEvents`
    case now publishes an `AuditLogManagerEvent{Node, AuditEvents}` via the PubSub dispatcher
    instead of the unconditional `auditLogCollectionManager.AuditMessagesChan() <- msg` send.
  - **Consumer** (`auditLogCollectionManagerImpl`): registers a PubSub consumer in `Start()`
    when the flag is enabled, instead of spawning `runStateSaver()`'s legacy channel-select
    goroutine. The per-message logic (finding the latest `KubernetesEvent`, updating file
    state) is extracted into a shared `handleAuditEvents()` helper used by both paths.
  - When the flag is disabled, the existing `AuditMessagesChan()`/`runStateSaver()` path is
    untouched.

  **Design decision — dedicated topic/lane, not reusing the detector's.** The same
  `t.AuditEvents` payload is already published as `detectorEvents.AuditLogEvent` on
  `DetectorAuditLogTopic`/`DetectorAuditLogLane` from the same call site. I considered
  extending that event with a `Node` field and adding a second consumer on the same
  topic/lane, but rejected it:
  - `DetectorAuditLogLane` is a `BlockingLane`, which invokes every registered consumer for a
    topic **sequentially**, blocking on each (`lane/blocking.go`: "This will block if we have
    a slow consumer"). The detector's own handler can itself block on an unbuffered channel
    send when alerts fire — piggybacking the audit log manager onto that lane would couple
    its backpressure to the detector's.
    No topic in the codebase today has more than one independent consumer; every event type
    maps 1:1 to a single purpose-built consumer carrying only the fields that consumer needs.
  - Went with a new dedicated `AuditLogManagerTopic`/`AuditLogManagerLane` (also a
    `BlockingLane`, to preserve today's blocking-send semantics) and a new
    `AuditLogManagerEvent` carrying just `Node` + `AuditEvents` — consistent with the
    existing one-event-per-consumer idiom and isolated backpressure.

  `NewAuditLogCollectionManager` gains a `pubSubDispatcher common.PubSubDispatcher` parameter
  (mirrors `NewService`'s existing pattern); the one production call site
  (`sensor/kubernetes/sensor/sensor.go`) is updated accordingly.

  🤖 This change was partially generated with the assistance of AI.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**
  is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is
  gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - Added `auditlog_manager_pubsub_test.go`: publishing `AuditLogManagerEvent` updates file
    state the same way the legacy path does; wrong-event-type handling; disabled-flag
    fallback still uses `AuditMessagesChan()` with a live dispatcher present.
  - Added `service_impl_pubsub_test.go`: `Communicate()`'s `AuditEvents` case publishes
    `AuditLogManagerEvent` instead of writing to the legacy channel when the flag is enabled.
  - `go test -race` across `sensor/common/compliance`, `sensor/common/pubsub/...`, and
    `sensor/kubernetes/sensor` — all existing and new tests pass, no goroutine leaks
    (`goleak.AssertNoGoroutineLeaks` in both suites' `TearDownTest`).
  - Existing `auditlog_manager_test.go` tests are unaffected: they build the manager via a
    struct literal (not the constructor), so the new `pubSubDispatcher` field defaults to
    nil and every pre-existing test stays on the legacy path unchanged.