### PR TITLE
ROX-35508: Suppress OSV.dev records when Red Hat VEX data exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-35546: File access policies now detect extended attribute (xattr) changes.
 - ROX-32461: Red Hat OpenShift Data Foundation is now officially supported as an S3-compatible backup target.
 - ROX-35962: On OCP, central API is exposed via a new `central-ocp` service, signed and rotated by OCP.
+- ROX-35508: Scanner V4 now suppresses duplicate OSV.dev vulnerability records when Red Hat VEX data covers the same CVE for a Red Hat product image, showing Red Hat's own severity/CVSS/remediation data instead of a conflicting OSV.dev one. Enabled by default; disable via `ROX_SCANNER_V4_SUPPRESS_OSV_WITH_RED_HAT_VEX=false` if needed.
 
 ### Removed Features
 

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -206,4 +206,7 @@ var (
 
 	// ScannerV4Dedupe de-duplicates packages and vulnerabilities from appearing in scan results.
 	ScannerV4Dedupe = registerFeature("Deduplicate packages and vulnerabilities found in Scanner V4 results.", "ROX_SCANNER_V4_DEDUPE", enabled)
+
+	// ScannerV4SuppressOSVWithRedHatVEX suppresses OSV.dev vulnerabilities when a corresponding Red Hat VEX assertion exists.
+	ScannerV4SuppressOSVWithRedHatVEX = registerFeature("Scanner V4 will suppress OSV.dev vulnerabilities when a corresponding Red Hat VEX assertion exists", "ROX_SCANNER_V4_SUPPRESS_OSV_WITH_RED_HAT_VEX", enabled)
 )

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -34,6 +34,9 @@ func imageScan(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport, 
 	if features.ScannerV4RedHatVEXNotAffected.Enabled() {
 		filterNotAffectedVulnerabilities(report, layerSHAToIndex)
 	}
+	if features.ScannerV4SuppressOSVWithRedHatVEX.Enabled() {
+		filterOSVSupersededByRedHatVEX(report, layerSHAToIndex)
+	}
 
 	scan := &storage.ImageScan{
 		ScannerVersion:  scannerVersion,
@@ -548,6 +551,15 @@ func getPackageLayerSHA(report *v4.VulnerabilityReport, pkgID string) (string, b
 	return env.GetIntroducedIn(), true
 }
 
+func getPackageLayerIndex(report *v4.VulnerabilityReport, layerSHAToIndex map[string]int32, pkgID string) (int32, bool) {
+	layerSHA, ok := getPackageLayerSHA(report, pkgID)
+	if !ok {
+		return 0, false
+	}
+	layerIdx, ok := layerSHAToIndex[layerSHA]
+	return layerIdx, ok
+}
+
 // filterNotAffectedVulnerabilities removes vulnerabilities from PackageVulnerabilities
 // when they are covered by VEX not-affected assertions via AncestryPackage entries.
 // A package is covered if it was introduced at or below the AncestryPackage's layer
@@ -557,58 +569,42 @@ func filterNotAffectedVulnerabilities(report *v4.VulnerabilityReport, layerSHATo
 		return
 	}
 
-	// Find AncestryPackage entries and collect their boundaries with aliases.
-	type boundary struct {
-		layerIndex      int32
-		notAffectedKeys set.StringSet
-	}
-	var boundaries []boundary
-
+	// Find AncestryPackage entries. A package at or below that layer is
+	// covered by any lower layer index too, so only the highest is kept.
+	aliasKeyToLayerIndex := make(map[string]int32)
 	for pkgID, vulnIDs := range report.GetPackageNotVulnerable() {
 		pkg := report.GetContents().GetPackages()[pkgID]
 		if pkg == nil || pkg.GetKind() != "ancestry" {
 			continue
 		}
 
-		layerSHA, ok := getPackageLayerSHA(report, pkgID)
-		if !ok {
-			continue
-		}
-		layerIdx, ok := layerSHAToIndex[layerSHA]
+		layerIdx, ok := getPackageLayerIndex(report, layerSHAToIndex, pkgID)
 		if !ok {
 			continue
 		}
 
-		aliasKeys := set.NewStringSet()
 		for _, vulnID := range vulnIDs.GetValues() {
 			vuln := report.GetVulnerabilities()[vulnID]
 			if vuln == nil {
 				continue
 			}
 			for _, alias := range vuln.GetAliases() {
-				aliasKeys.Add(aliasKey(alias))
+				key := aliasKey(alias)
+				if cur, ok := aliasKeyToLayerIndex[key]; !ok || layerIdx > cur {
+					aliasKeyToLayerIndex[key] = layerIdx
+				}
 			}
-		}
-
-		if aliasKeys.Cardinality() > 0 {
-			boundaries = append(boundaries, boundary{
-				layerIndex:      layerIdx,
-				notAffectedKeys: aliasKeys,
-			})
 		}
 	}
 
-	if len(boundaries) == 0 {
+	if len(aliasKeyToLayerIndex) == 0 {
 		return
 	}
 
-	// Filter PackageVulnerabilities based on boundaries.
+	// Remove PackageVulnerabilities entries covered by a same-or-lower-layer
+	// not-affected assertion.
 	for pkgID, vulnIDs := range report.GetPackageVulnerabilities() {
-		pkgLayerSHA, ok := getPackageLayerSHA(report, pkgID)
-		if !ok {
-			continue
-		}
-		pkgLayerIdx, ok := layerSHAToIndex[pkgLayerSHA]
+		pkgLayerIdx, ok := getPackageLayerIndex(report, layerSHAToIndex, pkgID)
 		if !ok {
 			continue
 		}
@@ -621,24 +617,95 @@ func filterNotAffectedVulnerabilities(report *v4.VulnerabilityReport, layerSHATo
 				continue
 			}
 
-			suppressed := false
-			for _, b := range boundaries {
-				if pkgLayerIdx > b.layerIndex {
-					continue
-				}
-				for _, alias := range vuln.GetAliases() {
-					if b.notAffectedKeys.Contains(aliasKey(alias)) {
-						suppressed = true
-						break
-					}
-				}
-				if suppressed {
+			removed := false
+			for _, alias := range vuln.GetAliases() {
+				if layerIdx, ok := aliasKeyToLayerIndex[aliasKey(alias)]; ok && pkgLayerIdx <= layerIdx {
+					removed = true
 					break
 				}
 			}
 
-			if suppressed {
+			if removed {
 				log.Debugf("Suppressing vuln %q for package %q due to VEX not-affected assertion", vuln.GetName(), pkgID)
+			} else {
+				filtered = append(filtered, vulnID)
+			}
+		}
+
+		if len(filtered) == 0 {
+			delete(report.PackageVulnerabilities, pkgID) //nolint:protogetter // mutation requires direct field access
+		} else {
+			report.PackageVulnerabilities[pkgID] = &v4.StringList{Values: filtered}
+		}
+	}
+}
+
+// filterOSVSupersededByRedHatVEX removes osv/*-sourced vulnerabilities from
+// PackageVulnerabilities when a rhel-vex updater vulnerability shares a
+// CVE alias at or above the OSV package's layer.
+func filterOSVSupersededByRedHatVEX(report *v4.VulnerabilityReport, layerSHAToIndex map[string]int32) {
+	const (
+		osvUpdaterPrefix     = "osv/"
+		redHatVEXUpdaterName = "rhel-vex"
+	)
+
+	if len(report.GetPackageVulnerabilities()) == 0 {
+		return
+	}
+
+	// Find packages with an affirmative rhel-vex vulnerability. An OSV
+	// package at or below that layer is covered by any lower layer index
+	// too, so only the highest is kept.
+	aliasKeyToLayerIndex := make(map[string]int32)
+	for pkgID, vulnIDs := range report.GetPackageVulnerabilities() {
+		layerIdx, ok := getPackageLayerIndex(report, layerSHAToIndex, pkgID)
+		if !ok {
+			continue
+		}
+
+		for _, vulnID := range vulnIDs.GetValues() {
+			vuln := report.GetVulnerabilities()[vulnID]
+			if vuln.GetUpdater() != redHatVEXUpdaterName {
+				continue
+			}
+			for _, alias := range vuln.GetAliases() {
+				key := aliasKey(alias)
+				if cur, ok := aliasKeyToLayerIndex[key]; !ok || layerIdx > cur {
+					aliasKeyToLayerIndex[key] = layerIdx
+				}
+			}
+		}
+	}
+
+	if len(aliasKeyToLayerIndex) == 0 {
+		return
+	}
+
+	// Remove osv/* vulnerabilities covered by a same-or-lower-layer rhel-vex vulnerability.
+	for pkgID, vulnIDs := range report.GetPackageVulnerabilities() {
+		pkgLayerIdx, ok := getPackageLayerIndex(report, layerSHAToIndex, pkgID)
+		if !ok {
+			continue
+		}
+
+		var filtered []string
+		for _, vulnID := range vulnIDs.GetValues() {
+			vuln := report.GetVulnerabilities()[vulnID]
+			if vuln == nil || !strings.HasPrefix(vuln.GetUpdater(), osvUpdaterPrefix) {
+				filtered = append(filtered, vulnID)
+				continue
+			}
+
+			removed := false
+			for _, alias := range vuln.GetAliases() {
+				if layerIdx, ok := aliasKeyToLayerIndex[aliasKey(alias)]; ok && pkgLayerIdx <= layerIdx {
+					removed = true
+					break
+				}
+			}
+
+			if removed {
+				log.Debugf("Suppressing OSV vuln %q for package %q in favor of Red Hat VEX", vuln.GetName(), pkgID)
 			} else {
 				filtered = append(filtered, vulnID)
 			}

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -658,6 +658,12 @@ func filterOSVSupersededByRedHatVEX(report *v4.VulnerabilityReport, layerSHAToIn
 	// too, so only the highest is kept.
 	aliasKeyToLayerIndex := make(map[string]int32)
 	for pkgID, vulnIDs := range report.GetPackageVulnerabilities() {
+		// Only consider OCI (RHCC) packages.
+		pkg := report.GetContents().GetPackages()[pkgID]
+		if pkg == nil || pkg.GetNormalizedVersion().GetKind() != "rhctag" {
+			continue
+		}
+
 		layerIdx, ok := getPackageLayerIndex(report, layerSHAToIndex, pkgID)
 		if !ok {
 			continue

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -585,8 +585,8 @@ func filterNotAffectedVulnerabilities(report *v4.VulnerabilityReport, layerSHATo
 		return
 	}
 
-	// Find AncestryPackage entries. A package at or below that layer is
-	// covered by any lower layer index too, so only the highest is kept.
+	// Find AncestryPackage entries. A package introduced at or before that
+	// layer is also not affected, so keep the highest layer index per alias.
 	aliasKeyToLayerIndex := make(map[string]int32)
 	for pkgID, vulnIDs := range report.GetPackageNotVulnerable() {
 		pkg := report.GetContents().GetPackages()[pkgID]
@@ -673,9 +673,8 @@ func filterOSVSupersededByRedHatVEX(report *v4.VulnerabilityReport, layerSHAToIn
 		return
 	}
 
-	// Find packages with an affirmative rhel-vex vulnerability. An OSV
-	// package at or below that layer is covered by any lower layer index
-	// too, so only the highest is kept.
+	// Find packages with a rhel-vex vulnerability. An OSV package introduced
+	// at or before that layer is superseded too, so keep the highest layer per alias.
 	aliasKeyToLayerIndex := make(map[string]int32)
 	for pkgID, vulnIDs := range report.GetPackageVulnerabilities() {
 		// Only consider OCI (RHCC) packages.
@@ -690,7 +689,7 @@ func filterOSVSupersededByRedHatVEX(report *v4.VulnerabilityReport, layerSHAToIn
 
 		for _, vulnID := range vulnIDs.GetValues() {
 			vuln := report.GetVulnerabilities()[vulnID]
-			if vuln.GetUpdater() != redHatVEXUpdaterName {
+			if vuln == nil || vuln.GetUpdater() != redHatVEXUpdaterName {
 				continue
 			}
 			for _, alias := range vuln.GetAliases() {

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -149,18 +149,20 @@ func envOS(env *v4.Environment, report *v4.VulnerabilityReport) string {
 	return dist.GetDid() + ":" + dist.GetVersionId()
 }
 
-func environment(report *v4.VulnerabilityReport, id string) *v4.Environment {
+// environmentList returns the *v4.Environment_List associated with the given
+// package ID, falling back to the deprecated environments map if the
+// current one is unset.
+func environmentList(report *v4.VulnerabilityReport, id string) *v4.Environment_List {
 	environments := report.GetContents().GetEnvironments()
 	if environments == nil {
 		// Fallback to deprecated environments.
 		environments = report.GetContents().GetEnvironmentsDEPRECATED()
 	}
-	envList, ok := environments[id]
-	if !ok {
-		return nil
-	}
+	return environments[id]
+}
 
-	envs := envList.GetEnvironments()
+func environment(report *v4.VulnerabilityReport, id string) *v4.Environment {
+	envs := environmentList(report, id).GetEnvironments()
 	if len(envs) > 0 {
 		// Just use the first environment.
 		// It is possible there are multiple environments associated with this package;
@@ -171,6 +173,20 @@ func environment(report *v4.VulnerabilityReport, id string) *v4.Environment {
 	}
 
 	return nil
+}
+
+// packageHasRepositoryKey reports whether pkgID is associated, via any of
+// its Environment entries, with a Repository whose Key matches key.
+func packageHasRepositoryKey(report *v4.VulnerabilityReport, pkgID, key string) bool {
+	repos := report.GetContents().GetRepositories()
+	for _, env := range environmentList(report, pkgID).GetEnvironments() {
+		for _, repoID := range env.GetRepositoryIds() {
+			if repos[repoID].GetKey() == key {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ParsePackageDB parses the given packageDB into its source type + filepath.
@@ -647,6 +663,10 @@ func filterOSVSupersededByRedHatVEX(report *v4.VulnerabilityReport, layerSHAToIn
 	const (
 		osvUpdaterPrefix     = "osv/"
 		redHatVEXUpdaterName = "rhel-vex"
+		// redHatContainerRepositoryKey matches
+		// github.com/quay/claircore/rhel/rhcc.RepositoryKey: it is set on
+		// every Repository indexed by claircore's RHCC (container) ecosystem.
+		redHatContainerRepositoryKey = "rhcc-container-repository"
 	)
 
 	if len(report.GetPackageVulnerabilities()) == 0 {
@@ -659,8 +679,7 @@ func filterOSVSupersededByRedHatVEX(report *v4.VulnerabilityReport, layerSHAToIn
 	aliasKeyToLayerIndex := make(map[string]int32)
 	for pkgID, vulnIDs := range report.GetPackageVulnerabilities() {
 		// Only consider OCI (RHCC) packages.
-		pkg := report.GetContents().GetPackages()[pkgID]
-		if pkg == nil || pkg.GetNormalizedVersion().GetKind() != "rhctag" {
+		if !packageHasRepositoryKey(report, pkgID, redHatContainerRepositoryKey) {
 			continue
 		}
 

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -2314,18 +2314,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -2361,18 +2357,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer2"}}},
 					},
 				},
@@ -2409,18 +2401,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -2457,18 +2445,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -2505,18 +2489,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -2553,28 +2533,17 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
-						"bin-2": {
-							Id:   "bin-2",
-							Kind: "binary",
-							Name: "rhel8-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "pkg1"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer1"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
+						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer1", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer1"}}},
 					},
@@ -2630,18 +2599,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -2694,28 +2659,17 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
-						"bin-2": {
-							Id:   "bin-2",
-							Kind: "binary",
-							Name: "rhel8-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-						"bin-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
+						"bin-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						// go-pkg-1 intentionally has no Environments entry.
 						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:unknown-layer"}}},
 					},
@@ -2773,28 +2727,17 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
-						"bin-2": {
-							Id:   "bin-2",
-							Kind: "binary",
-							Name: "rhel8-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
+						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
@@ -2843,38 +2786,20 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
-						"bin-2": {
-							Id:   "bin-2",
-							Kind: "binary",
-							Name: "rhel8-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
-						"bin-3": {
-							Id:   "bin-3",
-							Kind: "binary",
-							Name: "other-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"bin-3":    {Id: "bin-3", Kind: "binary", Name: "other-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "pkg1"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 						"go-pkg-3": {Id: "go-pkg-3", Kind: "binary", Name: "pkg3"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
 						// bin-1 intentionally has no Environments entry.
-						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:unknown-layer"}}},
-						"bin-3":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:unknown-layer", RepositoryIds: []string{"rhcc-repo"}}}},
+						"bin-3":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 						"go-pkg-3": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
@@ -2952,19 +2877,15 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "github.com/other/vendored-copy"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
@@ -3010,18 +2931,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -3065,18 +2982,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1": {
-							Id:   "bin-1",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -3111,27 +3024,17 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"rhcc-pkg": {
-							Id:   "rhcc-pkg",
-							Kind: "binary",
-							Name: "ubi9-container",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "rhctag",
-							},
-						},
-						"rpm-pkg": {Id: "rpm-pkg", Kind: "binary", Name: "some-rpm-package"},
-						"go-pkg": {
-							Id:   "go-pkg",
-							Kind: "binary",
-							Name: "google.golang.org/protobuf",
-							NormalizedVersion: &v4.NormalizedVersion{
-								Kind: "pep440",
-							},
-						},
+						"rhcc-pkg": {Id: "rhcc-pkg", Kind: "binary", Name: "ubi9-container"},
+						"rpm-pkg":  {Id: "rpm-pkg", Kind: "binary", Name: "some-rpm-package"},
+						"go-pkg":   {Id: "go-pkg", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Repositories: map[string]*v4.Repository{
+						"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+						"rhel-repo": {Id: "rhel-repo", Key: "rhel-cpe-repository"},
 					},
 					Environments: map[string]*v4.Environment_List{
-						"rhcc-pkg": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-						"rpm-pkg":  {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"rhcc-pkg": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
+						"rpm-pkg":  {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhel-repo"}}}},
 						"go-pkg":   {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
@@ -3201,18 +3104,14 @@ func TestFilterOSVSupersededByRedHatVEX_FeatureFlag(t *testing.T) {
 		return &v4.VulnerabilityReport{
 			Contents: &v4.Contents{
 				Packages: map[string]*v4.Package{
-					"bin-1": {
-						Id:   "bin-1",
-						Kind: "binary",
-						Name: "ubi9-container",
-						NormalizedVersion: &v4.NormalizedVersion{
-							Kind: "rhctag",
-						},
-					},
+					"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
 					"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 				},
+				Repositories: map[string]*v4.Repository{
+					"rhcc-repo": {Id: "rhcc-repo", Key: "rhcc-container-repository"},
+				},
 				Environments: map[string]*v4.Environment_List{
-					"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0", RepositoryIds: []string{"rhcc-repo"}}}},
 					"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 				},
 			},

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -2251,6 +2251,903 @@ func TestFilterNotAffectedVulnerabilities(t *testing.T) {
 	}
 }
 
+func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
+	layerSHAToIndex := map[string]int32{
+		"sha256:layer0": 0,
+		"sha256:layer1": 1,
+		"sha256:layer2": 2,
+	}
+
+	testcases := []struct {
+		name             string
+		report           *v4.VulnerabilityReport
+		expectedPkgVulns map[string][]string
+	}{
+		{
+			name: "nil/empty PackageVulnerabilities - no-op",
+			report: &v4.VulnerabilityReport{
+				PackageVulnerabilities: nil,
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-1111",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+				},
+			},
+			expectedPkgVulns: map[string][]string{},
+		},
+		{
+			name: "no rhel-vex vuln in the report - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer1"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"go-pkg-1": {"osv-vuln"},
+			},
+		},
+		{
+			name: "two packages, same layer, share a CVE alias - OSV suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1": {"vex-vuln"},
+			},
+		},
+		{
+			name: "two packages share a CVE alias, OSV package on a later layer - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer2"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln"},
+				"go-pkg-1": {"osv-vuln"},
+			},
+		},
+		{
+			name: "two packages, same layer, different vuln names, share a CVE alias - OSV suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "GHSA-8r3f-844c-mc37",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "ghsa", Name: "GHSA-8r3f-844c-mc37"},
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1": {"vex-vuln"},
+			},
+		},
+		{
+			name: "no shared alias between an OSV vuln and a rhel-vex vuln - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-2222",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-1111",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln"},
+				"go-pkg-1": {"osv-vuln"},
+			},
+		},
+		{
+			name: "non-osv vuln sharing an alias with a rhel-vex vuln, same layer - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"nvd-vuln": {
+						Id:      "nvd-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "nvd",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"nvd-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln"},
+				"go-pkg-1": {"nvd-vuln"},
+			},
+		},
+		{
+			name: "two pairs of packages, each pair sharing its own CVE alias - both OSV vulns suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "pkg1"},
+						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer1"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer1"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln-1": {
+						Id:      "vex-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"vex-vuln-2": {
+						Id:      "vex-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+					"osv-vuln-1": {
+						Id:      "osv-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"osv-vuln-2": {
+						Id:      "osv-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln-1"}},
+					"bin-2":    {Values: []string{"vex-vuln-2"}},
+					"go-pkg-1": {Values: []string{"osv-vuln-1"}},
+					"go-pkg-2": {Values: []string{"osv-vuln-2"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1": {"vex-vuln-1"},
+				"bin-2": {"vex-vuln-2"},
+			},
+		},
+		{
+			name: "partial suppression - only the matching OSV id is removed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-match": {
+						Id:      "osv-match",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-other": {
+						Id:      "osv-other",
+						Name:    "CVE-2024-3333",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-3333"},
+						},
+					},
+					"nvd-other": {
+						Id:      "nvd-other",
+						Name:    "CVE-2024-24786",
+						Updater: "nvd",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-match", "osv-other", "nvd-other"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln"},
+				"go-pkg-1": {"osv-other", "nvd-other"},
+			},
+		},
+		{
+			name: "OSV package has no resolvable layer - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						// go-pkg-1 intentionally has no Environments entry.
+						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:unknown-layer"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln-1": {
+						Id:      "vex-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"vex-vuln-2": {
+						Id:      "vex-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+					"osv-vuln-1": {
+						Id:      "osv-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"osv-vuln-2": {
+						Id:      "osv-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln-1"}},
+					"bin-2":    {Values: []string{"vex-vuln-2"}},
+					"go-pkg-1": {Values: []string{"osv-vuln-1"}},
+					"go-pkg-2": {Values: []string{"osv-vuln-2"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln-1"},
+				"bin-2":    {"vex-vuln-2"},
+				"go-pkg-1": {"osv-vuln-1"},
+				"go-pkg-2": {"osv-vuln-2"},
+			},
+		},
+		{
+			name: "vuln ID missing from report.Vulnerabilities - kept, no panic",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln-1": {
+						Id:      "vex-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"vex-vuln-2": {
+						Id:      "vex-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+					"osv-vuln-2": {
+						Id:      "osv-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln-1"}},
+					"bin-2":    {Values: []string{"vex-vuln-2"}},
+					"go-pkg-1": {Values: []string{"missing-vuln-id"}},
+					"go-pkg-2": {Values: []string{"osv-vuln-2"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln-1"},
+				"bin-2":    {"vex-vuln-2"},
+				"go-pkg-1": {"missing-vuln-id"},
+			},
+		},
+		{
+			name: "rhel-vex package has no resolvable layer - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"bin-3":    {Id: "bin-3", Kind: "binary", Name: "other-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "pkg1"},
+						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
+						"go-pkg-3": {Id: "go-pkg-3", Kind: "binary", Name: "pkg3"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						// bin-1 intentionally has no Environments entry.
+						"bin-2":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:unknown-layer"}}},
+						"bin-3":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-3": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln-1": {
+						Id:      "vex-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"vex-vuln-2": {
+						Id:      "vex-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+					"vex-vuln-3": {
+						Id:      "vex-vuln-3",
+						Name:    "CVE-2024-3333",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-3333"},
+						},
+					},
+					"osv-vuln-1": {
+						Id:      "osv-vuln-1",
+						Name:    "CVE-2024-1111",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-1111"},
+						},
+					},
+					"osv-vuln-2": {
+						Id:      "osv-vuln-2",
+						Name:    "CVE-2024-2222",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-2222"},
+						},
+					},
+					"osv-vuln-3": {
+						Id:      "osv-vuln-3",
+						Name:    "CVE-2024-3333",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-3333"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln-1"}},
+					"bin-2":    {Values: []string{"vex-vuln-2"}},
+					"bin-3":    {Values: []string{"vex-vuln-3"}},
+					"go-pkg-1": {Values: []string{"osv-vuln-1"}},
+					"go-pkg-2": {Values: []string{"osv-vuln-2"}},
+					"go-pkg-3": {Values: []string{"osv-vuln-3"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln-1"},
+				"bin-2":    {"vex-vuln-2"},
+				"bin-3":    {"vex-vuln-3"},
+				"go-pkg-1": {"osv-vuln-1"},
+				"go-pkg-2": {"osv-vuln-2"},
+			},
+		},
+		{
+			name: "one rhel-vex vuln suppresses OSV vulns on two different packages",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "github.com/other/vendored-copy"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-2": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-vuln-1": {
+						Id:      "osv-vuln-1",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-vuln-2": {
+						Id:      "osv-vuln-2",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln-1"}},
+					"go-pkg-2": {Values: []string{"osv-vuln-2"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1": {"vex-vuln"},
+			},
+		},
+		{
+			name: "rhel-vex package also has a different-updater vuln alongside it",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"other-vuln": {
+						Id:      "other-vuln",
+						Name:    "CVE-2024-9999",
+						Updater: "nvd",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-9999"},
+						},
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln", "other-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1": {"vex-vuln", "other-vuln"},
+			},
+		},
+		{
+			name: "rhel-vex vuln with an empty alias list - not suppressed",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						// Intentionally no aliases.
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1":    {"vex-vuln"},
+				"go-pkg-1": {"osv-vuln"},
+			},
+		},
+		{
+			name: "package with a pre-existing empty vuln list is deleted",
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					"bin-1":    {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{}},
+				},
+			},
+			expectedPkgVulns: map[string][]string{
+				"bin-1": {"vex-vuln"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			filterOSVSupersededByRedHatVEX(tc.report, layerSHAToIndex)
+
+			got := make(map[string][]string)
+			for pkgID, vulns := range tc.report.GetPackageVulnerabilities() {
+				got[pkgID] = vulns.GetValues()
+			}
+			assert.Equal(t, tc.expectedPkgVulns, got)
+		})
+	}
+
+	// filterOSVSupersededByRedHatVEX never reads Package.Kind, so a rhel-vex
+	// vulnerability suppresses OSV regardless of which Kind carries it.
+	for _, kind := range []string{"binary", "source", "ancestry"} {
+		t.Run("rhel-vex package has kind "+kind, func(t *testing.T) {
+			const pkgID = "vex-pkg"
+			report := &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						pkgID:      {Id: pkgID, Kind: kind, Name: "ubi9-container"},
+						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+					},
+					Environments: map[string]*v4.Environment_List{
+						pkgID:      {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					},
+				},
+				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+					"vex-vuln": {
+						Id:      "vex-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+					"osv-vuln": {
+						Id:      "osv-vuln",
+						Name:    "CVE-2024-24786",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-24786"},
+						},
+					},
+				},
+				PackageVulnerabilities: map[string]*v4.StringList{
+					pkgID:      {Values: []string{"vex-vuln"}},
+					"go-pkg-1": {Values: []string{"osv-vuln"}},
+				},
+			}
+
+			filterOSVSupersededByRedHatVEX(report, layerSHAToIndex)
+
+			got := make(map[string][]string)
+			for id, vulns := range report.GetPackageVulnerabilities() {
+				got[id] = vulns.GetValues()
+			}
+			assert.Equal(t, map[string][]string{pkgID: {"vex-vuln"}}, got)
+		})
+	}
+}
+
+func TestFilterOSVSupersededByRedHatVEX_FeatureFlag(t *testing.T) {
+	newReport := func() *v4.VulnerabilityReport {
+		return &v4.VulnerabilityReport{
+			Contents: &v4.Contents{
+				Packages: map[string]*v4.Package{
+					"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+					"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+				},
+				Environments: map[string]*v4.Environment_List{
+					"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+					"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+				},
+			},
+			Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"vex-vuln": {
+					Id:      "vex-vuln",
+					Name:    "CVE-2024-24786",
+					Updater: "rhel-vex",
+					Aliases: []*v4.VulnerabilityReport_Alias{
+						{Space: "cve", Name: "CVE-2024-24786"},
+					},
+				},
+				"osv-vuln": {
+					Id:      "osv-vuln",
+					Name:    "GHSA-osv-flag-test",
+					Updater: "osv/go",
+					Aliases: []*v4.VulnerabilityReport_Alias{
+						{Space: "ghsa", Name: "GHSA-osv-flag-test"},
+						{Space: "cve", Name: "CVE-2024-24786"},
+					},
+				},
+			},
+			PackageVulnerabilities: map[string]*v4.StringList{
+				"bin-1":    {Values: []string{"vex-vuln"}},
+				"go-pkg-1": {Values: []string{"osv-vuln"}},
+			},
+		}
+	}
+	metadata := &storage.ImageMetadata{
+		V2:        &storage.V2Metadata{},
+		V1:        &storage.V1Metadata{Layers: []*storage.ImageLayer{{Empty: false}}},
+		LayerShas: []string{"sha256:layer0"},
+	}
+	const osvCVE = "GHSA-osv-flag-test"
+
+	t.Run("flag off - OSV vuln survives", func(t *testing.T) {
+		t.Setenv(features.ScannerV4SuppressOSVWithRedHatVEX.EnvVar(), "false")
+		scan := imageScan(metadata, newReport(), scannerVersion)
+		assert.True(t, hasCVE(scan, osvCVE), "expected %s to survive with the flag disabled", osvCVE)
+	})
+
+	t.Run("flag on - OSV vuln suppressed", func(t *testing.T) {
+		t.Setenv(features.ScannerV4SuppressOSVWithRedHatVEX.EnvVar(), "true")
+		scan := imageScan(metadata, newReport(), scannerVersion)
+		assert.False(t, hasCVE(scan, osvCVE), "expected %s to be suppressed with the flag enabled", osvCVE)
+	})
+}
+
+// hasCVE reports whether any component in scan carries a vulnerability whose
+// Cve field matches cve.
+func hasCVE(scan *storage.ImageScan, cve string) bool {
+	for _, c := range scan.GetComponents() {
+		for _, v := range c.GetVulns() {
+			if v.GetCve() == cve {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // TestVulnDataSource
 //
 // If this test fails due to a datasource format change

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -2314,7 +2314,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2354,7 +2361,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2395,7 +2409,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2436,7 +2457,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2477,7 +2505,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2518,8 +2553,22 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
-						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
+						"bin-2": {
+							Id:   "bin-2",
+							Kind: "binary",
+							Name: "rhel8-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "pkg1"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 					},
@@ -2581,7 +2630,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2638,8 +2694,22 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
-						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
+						"bin-2": {
+							Id:   "bin-2",
+							Kind: "binary",
+							Name: "rhel8-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 					},
@@ -2703,8 +2773,22 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
-						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
+						"bin-2": {
+							Id:   "bin-2",
+							Kind: "binary",
+							Name: "rhel8-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 					},
@@ -2759,9 +2843,30 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
-						"bin-2":    {Id: "bin-2", Kind: "binary", Name: "rhel8-container"},
-						"bin-3":    {Id: "bin-3", Kind: "binary", Name: "other-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
+						"bin-2": {
+							Id:   "bin-2",
+							Kind: "binary",
+							Name: "rhel8-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
+						"bin-3": {
+							Id:   "bin-3",
+							Kind: "binary",
+							Name: "other-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "pkg1"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "pkg2"},
 						"go-pkg-3": {Id: "go-pkg-3", Kind: "binary", Name: "pkg3"},
@@ -2847,7 +2952,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 						"go-pkg-2": {Id: "go-pkg-2", Kind: "binary", Name: "github.com/other/vendored-copy"},
 					},
@@ -2898,7 +3010,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2946,7 +3065,14 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+						"bin-1": {
+							Id:   "bin-1",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
 						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 					},
 					Environments: map[string]*v4.Environment_List{
@@ -2981,35 +3107,78 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			},
 		},
 		{
-			name: "package with a pre-existing empty vuln list is deleted",
+			name: "Mixed RHCC (OCI) and RPM packages: only RHCC suppresses OSV",
 			report: &v4.VulnerabilityReport{
 				Contents: &v4.Contents{
 					Packages: map[string]*v4.Package{
-						"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
-						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
+						"rhcc-pkg": {
+							Id:   "rhcc-pkg",
+							Kind: "binary",
+							Name: "ubi9-container",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "rhctag",
+							},
+						},
+						"rpm-pkg": {Id: "rpm-pkg", Kind: "binary", Name: "some-rpm-package"},
+						"go-pkg": {
+							Id:   "go-pkg",
+							Kind: "binary",
+							Name: "google.golang.org/protobuf",
+							NormalizedVersion: &v4.NormalizedVersion{
+								Kind: "pep440",
+							},
+						},
 					},
 					Environments: map[string]*v4.Environment_List{
-						"bin-1":    {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"rhcc-pkg": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"rpm-pkg":  {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
+						"go-pkg":   {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
 					},
 				},
 				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
-					"vex-vuln": {
-						Id:      "vex-vuln",
-						Name:    "CVE-2024-24786",
+					"rhcc-vex-vuln": {
+						Id:      "rhcc-vex-vuln",
+						Name:    "CVE-2024-11111",
 						Updater: "rhel-vex",
 						Aliases: []*v4.VulnerabilityReport_Alias{
-							{Space: "cve", Name: "CVE-2024-24786"},
+							{Space: "cve", Name: "CVE-2024-11111"},
+						},
+					},
+					"rpm-vex-vuln": {
+						Id:      "rpm-vex-vuln",
+						Name:    "CVE-2024-22222",
+						Updater: "rhel-vex",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-22222"},
+						},
+					},
+					"osv-vuln-1": {
+						Id:      "osv-vuln-1",
+						Name:    "CVE-2024-11111",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-11111"},
+						},
+					},
+					"osv-vuln-2": {
+						Id:      "osv-vuln-2",
+						Name:    "CVE-2024-22222",
+						Updater: "osv/go",
+						Aliases: []*v4.VulnerabilityReport_Alias{
+							{Space: "cve", Name: "CVE-2024-22222"},
 						},
 					},
 				},
 				PackageVulnerabilities: map[string]*v4.StringList{
-					"bin-1":    {Values: []string{"vex-vuln"}},
-					"go-pkg-1": {Values: []string{}},
+					"rhcc-pkg": {Values: []string{"rhcc-vex-vuln"}},
+					"rpm-pkg":  {Values: []string{"rpm-vex-vuln"}},
+					"go-pkg":   {Values: []string{"osv-vuln-1", "osv-vuln-2"}},
 				},
 			},
 			expectedPkgVulns: map[string][]string{
-				"bin-1": {"vex-vuln"},
+				"rhcc-pkg": {"rhcc-vex-vuln"},
+				"rpm-pkg":  {"rpm-vex-vuln"},
+				"go-pkg":   {"osv-vuln-2"},
 			},
 		},
 	}
@@ -3025,56 +3194,6 @@ func TestFilterOSVSupersededByRedHatVEX(t *testing.T) {
 			assert.Equal(t, tc.expectedPkgVulns, got)
 		})
 	}
-
-	// filterOSVSupersededByRedHatVEX never reads Package.Kind, so a rhel-vex
-	// vulnerability suppresses OSV regardless of which Kind carries it.
-	for _, kind := range []string{"binary", "source", "ancestry"} {
-		t.Run("rhel-vex package has kind "+kind, func(t *testing.T) {
-			const pkgID = "vex-pkg"
-			report := &v4.VulnerabilityReport{
-				Contents: &v4.Contents{
-					Packages: map[string]*v4.Package{
-						pkgID:      {Id: pkgID, Kind: kind, Name: "ubi9-container"},
-						"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
-					},
-					Environments: map[string]*v4.Environment_List{
-						pkgID:      {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-						"go-pkg-1": {Environments: []*v4.Environment{{IntroducedIn: "sha256:layer0"}}},
-					},
-				},
-				Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
-					"vex-vuln": {
-						Id:      "vex-vuln",
-						Name:    "CVE-2024-24786",
-						Updater: "rhel-vex",
-						Aliases: []*v4.VulnerabilityReport_Alias{
-							{Space: "cve", Name: "CVE-2024-24786"},
-						},
-					},
-					"osv-vuln": {
-						Id:      "osv-vuln",
-						Name:    "CVE-2024-24786",
-						Updater: "osv/go",
-						Aliases: []*v4.VulnerabilityReport_Alias{
-							{Space: "cve", Name: "CVE-2024-24786"},
-						},
-					},
-				},
-				PackageVulnerabilities: map[string]*v4.StringList{
-					pkgID:      {Values: []string{"vex-vuln"}},
-					"go-pkg-1": {Values: []string{"osv-vuln"}},
-				},
-			}
-
-			filterOSVSupersededByRedHatVEX(report, layerSHAToIndex)
-
-			got := make(map[string][]string)
-			for id, vulns := range report.GetPackageVulnerabilities() {
-				got[id] = vulns.GetValues()
-			}
-			assert.Equal(t, map[string][]string{pkgID: {"vex-vuln"}}, got)
-		})
-	}
 }
 
 func TestFilterOSVSupersededByRedHatVEX_FeatureFlag(t *testing.T) {
@@ -3082,7 +3201,14 @@ func TestFilterOSVSupersededByRedHatVEX_FeatureFlag(t *testing.T) {
 		return &v4.VulnerabilityReport{
 			Contents: &v4.Contents{
 				Packages: map[string]*v4.Package{
-					"bin-1":    {Id: "bin-1", Kind: "binary", Name: "ubi9-container"},
+					"bin-1": {
+						Id:   "bin-1",
+						Kind: "binary",
+						Name: "ubi9-container",
+						NormalizedVersion: &v4.NormalizedVersion{
+							Kind: "rhctag",
+						},
+					},
 					"go-pkg-1": {Id: "go-pkg-1", Kind: "binary", Name: "google.golang.org/protobuf"},
 				},
 				Environments: map[string]*v4.Environment_List{


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

ROX-35508: when a vulnerability is covered by Red Hat VEX security data (`known_affected`) for a Red Hat product image, suppress the corresponding OSV.dev-sourced record for the same CVE and let Red Hat's own
severity/CVSS/remediation data be the only one shown, instead of reporting both (often with conflicting severity).

Changes:

- [major] Added `ROX_SCANNER_V4_SUPPRESS_OSV_WITH_RED_HAT_VEX` feature flag
- [major] Added `filterOSVSupersededByRedHatVEX` function to supress OSV records when red hat vex is present. 
- [minor] Refactored repetitive codes into `getPackageLayerIndex` and `environmentList` functions. 
- [minor] Optmize `filterNotAffectedVulnerabilities` to simplify the filtering logic

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

**Unit tests**

- same-package and cross-package boundaries
- alias-only matching (GHSA↔CVE)
- later-layer non-suppression, NVD/non-`osv/*` sources left untouched, 
- partial suppression, 
- missing-layer/missing-vuln safety, 
- multiple independent boundaries, 
- feature-flag kill switch. 

**Live cluster verification** (deployed a debug build to a real GKE cluster,
A/B toggled the flag, re-scanned real images):

<details>
<summary><b>Real-image before/after evidence</b></summary>

#### Case 1: `registry.redhat.io/openshift-gitops-1/kam-delivery-rhel8` — `CVE-2024-45337`

| | Flag off (before) | Flag on (default) |
|---|---|---|
| Findings | 2 vulnerabilities: `golang.org/x/crypto` (OSV) *AND* `openshift-gitops-1/kam-delivery-rhel8` (Red Hat VEX, RHSA-2025:3069) | 1 vulnerability:  Red Hat VEX only |

#### Case 2: `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel9:4.11.1` — `CVE-2026-53492`

| | Flag off (before) | Flag on (default) |
|---|---|---|
| Findings | 2 vulnerabilities: `github.com/containerd/containerd` (OSV) *AND* `rhacs-main-rhel9` (Red Hat VEX) | 1 vulnerability: Red Hat VEX only |
| Displayed severity/CVSS | Critical / 9.6 (OSV) | **Important / 8.2 (Red Hat's own)** |

Both cases: same image, forced re-scan, flag toggled via `kubectl set env deploy/central ROX_SCANNER_V4_SUPPRESS_OSV_WITH_RED_HAT_VEX=<bool>`, confirmed via the same GraphQL query the UI's Vulnerabilities tab uses.

</details>

**UI Check**

Before fix:
<img width="1354" height="591" alt="before_ROX-35508" src="https://github.com/user-attachments/assets/0cadfd18-f155-4ba7-a7cd-ec6b81a1d80d" />

After fix
<img width="1346" height="370" alt="after_ROX-35508" src="https://github.com/user-attachments/assets/d4852a0a-eb71-443a-9b89-5f326a124e97" />

