### PR TITLE
ROX-35365: sync major version bumps to release branches

### DIFF
--- a/.github/workflows/sync-major-version-bumps.yaml
+++ b/.github/workflows/sync-major-version-bumps.yaml
@@ -1,0 +1,128 @@
+name: Sync major version bumps to release branches
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - pkg/version/productstreams/major_version_bumps.yaml
+  schedule:
+    - cron: '0 8 * * 1' # Weekly Monday 8am UTC safety net
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Log what would be updated without creating PRs'
+        type: boolean
+        default: true
+      target-branch:
+        description: 'Only target this release branch (e.g. release-5.0). Leave empty for all.'
+        type: string
+        default: ''
+
+jobs:
+  discover:
+    name: Discover release branches
+    if: ${{ github.repository_owner == 'stackrox' }}
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.find.outputs.branches }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Find branches with bump file
+        id: find
+        run: |
+          set -euo pipefail
+
+          TARGET="${{ inputs.target-branch }}"
+          BUMP_FILE="pkg/version/productstreams/major_version_bumps.yaml"
+
+          if [[ -n "$TARGET" ]]; then
+            if git show "origin/$TARGET:$BUMP_FILE" &>/dev/null; then
+              BRANCHES=$(jq -nc --arg b "$TARGET" '[$b]')
+            else
+              echo "::warning::Branch $TARGET does not have $BUMP_FILE, skipping"
+              BRANCHES="[]"
+            fi
+          else
+            BRANCHES="[]"
+            for ref in $(git branch -r --list 'origin/release-*' | tr -d ' '); do
+              branch="${ref#origin/}"
+              if git show "$ref:$BUMP_FILE" &>/dev/null; then
+                BRANCHES=$(echo "$BRANCHES" | jq --arg b "$branch" '. + [$b]')
+              fi
+            done
+          fi
+
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+          echo "Branches to sync: $BRANCHES"
+
+  sync:
+    name: Sync to ${{ matrix.branch }}
+    needs: discover
+    if: ${{ needs.discover.outputs.branches != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.discover.outputs.branches) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+      - name: Copy bump file from master
+        run: |
+          git show origin/master:pkg/version/productstreams/major_version_bumps.yaml \
+            > pkg/version/productstreams/major_version_bumps.yaml
+
+      - name: Show diff
+        run: |
+          if git diff --quiet; then
+            echo "Already up to date on ${{ matrix.branch }}"
+          else
+            echo "Changes to apply on ${{ matrix.branch }}:"
+            git diff
+          fi
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        id: cpr
+        if: ${{ steps.check.outputs.changed == 'true' && inputs.dry-run != 'true' }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+          commit-message: 'chore: sync major_version_bumps.yaml from master'
+          committer: '${{ secrets.RHACS_BOT_GITHUB_USERNAME }} <${{ secrets.RHACS_BOT_GITHUB_EMAIL }}>'
+          author: '${{ secrets.RHACS_BOT_GITHUB_USERNAME }} <${{ secrets.RHACS_BOT_GITHUB_EMAIL }}>'
+          branch: lvm/rox-35365-${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          signoff: false
+          delete-branch: true
+          title: 'chore: sync major_version_bumps.yaml from master to ${{ matrix.branch }}'
+          body: |
+            Automated sync of `pkg/version/productstreams/major_version_bumps.yaml` from `master` to `${{ matrix.branch }}`.
+
+            This keeps the major version bump history up to date so that builds from this release branch compute correct version compatibility ranges.
+          labels: |
+            dependencies
+          draft: false
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # ratchet:peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/sync-major-version-bumps.yaml
+++ b/.github/workflows/sync-major-version-bumps.yaml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - pkg/version/productstreams/major_version_bumps.yaml
+  pull_request:
+    paths:
+      - .github/workflows/sync-major-version-bumps.yaml
   schedule:
     - cron: '0 8 * * 1' # Weekly Monday 8am UTC safety net
   workflow_dispatch:
@@ -99,7 +102,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        if: ${{ steps.check.outputs.changed == 'true' && inputs.dry-run != 'true' }}
+        if: ${{ steps.check.outputs.changed == 'true' && github.event_name != 'pull_request' && inputs.dry-run != 'true' }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
@@ -120,7 +123,7 @@ jobs:
           draft: false
 
       - name: Enable Pull Request Automerge
-        if: steps.cpr.outputs.pull-request-operation == 'created'
+        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' }}
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # ratchet:peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that keeps `pkg/version/productstreams/major_version_bumps.yaml` in sync across release branches.

The bump file (introduced in #21589) is embedded at compile time via `//go:embed`. When a new major bump entry is added on `master`, release branches need the update too or their builds will compute wrong version compatibility ranges.

**How it works:**
- Triggers on push to `master` (when the bump file changes), weekly cron, or manual dispatch
- Discovers `release-*` branches that already have the bump file (older branches without the `productstreams` package are skipped)
- For each branch with stale data, opens a PR with automerge via `peter-evans/create-pull-request`

**Manual dispatch inputs:**
- `dry-run` (default: true) — logs what would change without creating PRs
- `target-branch` — restrict to a single branch for testing

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No unit/e2e tests — this is a CI-only workflow. Validated via manual dispatch with dry-run.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Will use `workflow_dispatch` with `dry-run: true` on this PR branch to verify branch discovery and diff logic before merging
- Currently no release branches have the bump file, so the workflow will correctly discover zero branches to sync
