### PR TITLE
ROX-36126: pin v3 stream to release-4.11 with source filtering

### DIFF
--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -6,4 +6,5 @@
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v2 heads/release-4.9.x/scanner-updater-v2
-v3 heads/e83e6e51034c51a851513daa2584700fae46834a
+# release-4.11 at 2026-08-06, after 4.11.3-rc.0.
+v3 heads/2e8d7a35b1200eb29d5a75cad2a443719cf265e1


### PR DESCRIPTION
## Description

Pin the v3 vulnerability bundle stream from a pre-source-filtering SHA (`e83e6e51`) to the current `release-4.11` tip (`2e8d7a35`), which includes source filtering (PR #21791). This is required for the per-updater scheduling workflow to correctly filter sources when building v3 updaters.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Verified that SHA `2e8d7a35` resolves to `v3` in `scanner/VULNERABILITY_VERSION` and that `scanner/updater/export.go` at that SHA includes the `filterSources` function.