### PR TITLE
ROX-35770: Ensure image upsert when duplicates removed

### DIFF
--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -421,10 +421,17 @@ func (s *storeImpl) isUpdated(oldImage, image *storage.Image) (bool, bool, error
 
 type hashWrapper struct {
 	Components []*storage.EmbeddedImageScanComponent `hash:"set"`
+	Count      int
+	VulnCount  int
 }
 
 func populateImageScanHash(scan *storage.ImageScan) error {
-	hash, err := hashstructure.Hash(hashWrapper{scan.GetComponents()}, &hashstructure.HashOptions{ZeroNil: true})
+	components := scan.GetComponents()
+	vulnCount := 0
+	for _, c := range components {
+		vulnCount += len(c.GetVulns())
+	}
+	hash, err := hashstructure.Hash(hashWrapper{Components: components, Count: len(components), VulnCount: vulnCount}, &hashstructure.HashOptions{ZeroNil: true})
 	if err != nil {
 		return errors.Wrap(err, "calculating hash for image scan")
 	}

--- a/central/image/datastore/store/v2/postgres/store_hash_test.go
+++ b/central/image/datastore/store/v2/postgres/store_hash_test.go
@@ -1,0 +1,108 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPopulateImageScanHash_DuplicateComponentsChangeHash(t *testing.T) {
+	component := &storage.EmbeddedImageScanComponent{
+		Name:    "ubi10/ubi-micro",
+		Version: "1784668691",
+	}
+
+	scanWith1 := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{component},
+	}
+	scanWith3 := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{component, component, component},
+	}
+
+	require.NoError(t, populateImageScanHash(scanWith1))
+	require.NoError(t, populateImageScanHash(scanWith3))
+
+	assert.NotEqual(t, scanWith1.GetHash(), scanWith3.GetHash(),
+		"removing duplicate components must produce a different hash")
+}
+
+func TestPopulateImageScanHash_DuplicateVulnsChangeHash(t *testing.T) {
+	vuln := &storage.EmbeddedVulnerability{
+		Cve:      "CVE-2025-1234",
+		Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+	}
+
+	scanWith1Vuln := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{vuln}},
+		},
+	}
+	scanWith3Vulns := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{vuln, vuln, vuln}},
+		},
+	}
+
+	require.NoError(t, populateImageScanHash(scanWith1Vuln))
+	require.NoError(t, populateImageScanHash(scanWith3Vulns))
+
+	assert.NotEqual(t, scanWith1Vuln.GetHash(), scanWith3Vulns.GetHash(),
+		"removing duplicate vulns must produce a different hash")
+}
+
+func TestPopulateImageScanHash_DistinctChangesDetected(t *testing.T) {
+	scanA := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{
+				{Cve: "CVE-2025-1111"},
+			}},
+		},
+	}
+	scanB := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{
+				{Cve: "CVE-2025-2222"},
+			}},
+		},
+	}
+
+	require.NoError(t, populateImageScanHash(scanA))
+	require.NoError(t, populateImageScanHash(scanB))
+
+	assert.NotEqual(t, scanA.GetHash(), scanB.GetHash(),
+		"different CVEs must produce a different hash")
+}
+
+func TestPopulateImageScanHash_IdenticalScansMatch(t *testing.T) {
+	scan1 := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg-a", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{
+				{Cve: "CVE-2025-1111"},
+			}},
+			{Name: "pkg-b", Version: "2.0"},
+		},
+	}
+	scan2 := scan1.CloneVT()
+
+	require.NoError(t, populateImageScanHash(scan1))
+	require.NoError(t, populateImageScanHash(scan2))
+
+	assert.Equal(t, scan1.GetHash(), scan2.GetHash(),
+		"identical scans must produce the same hash")
+}
+
+func TestPopulateImageScanHash_OrderIndependent(t *testing.T) {
+	compA := &storage.EmbeddedImageScanComponent{Name: "aaa", Version: "1.0"}
+	compB := &storage.EmbeddedImageScanComponent{Name: "bbb", Version: "2.0"}
+
+	scanAB := &storage.ImageScan{Components: []*storage.EmbeddedImageScanComponent{compA, compB}}
+	scanBA := &storage.ImageScan{Components: []*storage.EmbeddedImageScanComponent{compB, compA}}
+
+	require.NoError(t, populateImageScanHash(scanAB))
+	require.NoError(t, populateImageScanHash(scanBA))
+
+	assert.Equal(t, scanAB.GetHash(), scanBA.GetHash(),
+		"component order must not affect the hash")
+}

--- a/central/imagev2/datastore/store/postgres/store.go
+++ b/central/imagev2/datastore/store/postgres/store.go
@@ -416,10 +416,17 @@ func (s *storeImpl) isUpdated(oldImage, image *storage.ImageV2) (bool, bool, err
 
 type hashWrapper struct {
 	Components []*storage.EmbeddedImageScanComponent `hash:"set"`
+	Count      int
+	VulnCount  int
 }
 
 func populateImageScanHash(scan *storage.ImageScan) error {
-	hash, err := hashstructure.Hash(hashWrapper{scan.GetComponents()}, &hashstructure.HashOptions{ZeroNil: true})
+	components := scan.GetComponents()
+	vulnCount := 0
+	for _, c := range components {
+		vulnCount += len(c.GetVulns())
+	}
+	hash, err := hashstructure.Hash(hashWrapper{Components: components, Count: len(components), VulnCount: vulnCount}, &hashstructure.HashOptions{ZeroNil: true})
 	if err != nil {
 		return errors.Wrap(err, "calculating hash for image scan")
 	}

--- a/central/imagev2/datastore/store/postgres/store_hash_test.go
+++ b/central/imagev2/datastore/store/postgres/store_hash_test.go
@@ -1,0 +1,108 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPopulateImageScanHash_DuplicateComponentsChangeHash(t *testing.T) {
+	component := &storage.EmbeddedImageScanComponent{
+		Name:    "ubi10/ubi-micro",
+		Version: "1784668691",
+	}
+
+	scanWith1 := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{component},
+	}
+	scanWith3 := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{component, component, component},
+	}
+
+	require.NoError(t, populateImageScanHash(scanWith1))
+	require.NoError(t, populateImageScanHash(scanWith3))
+
+	assert.NotEqual(t, scanWith1.GetHash(), scanWith3.GetHash(),
+		"removing duplicate components must produce a different hash")
+}
+
+func TestPopulateImageScanHash_DuplicateVulnsChangeHash(t *testing.T) {
+	vuln := &storage.EmbeddedVulnerability{
+		Cve:      "CVE-2025-1234",
+		Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+	}
+
+	scanWith1Vuln := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{vuln}},
+		},
+	}
+	scanWith3Vulns := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{vuln, vuln, vuln}},
+		},
+	}
+
+	require.NoError(t, populateImageScanHash(scanWith1Vuln))
+	require.NoError(t, populateImageScanHash(scanWith3Vulns))
+
+	assert.NotEqual(t, scanWith1Vuln.GetHash(), scanWith3Vulns.GetHash(),
+		"removing duplicate vulns must produce a different hash")
+}
+
+func TestPopulateImageScanHash_DistinctChangesDetected(t *testing.T) {
+	scanA := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{
+				{Cve: "CVE-2025-1111"},
+			}},
+		},
+	}
+	scanB := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{
+				{Cve: "CVE-2025-2222"},
+			}},
+		},
+	}
+
+	require.NoError(t, populateImageScanHash(scanA))
+	require.NoError(t, populateImageScanHash(scanB))
+
+	assert.NotEqual(t, scanA.GetHash(), scanB.GetHash(),
+		"different CVEs must produce a different hash")
+}
+
+func TestPopulateImageScanHash_IdenticalScansMatch(t *testing.T) {
+	scan1 := &storage.ImageScan{
+		Components: []*storage.EmbeddedImageScanComponent{
+			{Name: "pkg-a", Version: "1.0", Vulns: []*storage.EmbeddedVulnerability{
+				{Cve: "CVE-2025-1111"},
+			}},
+			{Name: "pkg-b", Version: "2.0"},
+		},
+	}
+	scan2 := scan1.CloneVT()
+
+	require.NoError(t, populateImageScanHash(scan1))
+	require.NoError(t, populateImageScanHash(scan2))
+
+	assert.Equal(t, scan1.GetHash(), scan2.GetHash(),
+		"identical scans must produce the same hash")
+}
+
+func TestPopulateImageScanHash_OrderIndependent(t *testing.T) {
+	compA := &storage.EmbeddedImageScanComponent{Name: "aaa", Version: "1.0"}
+	compB := &storage.EmbeddedImageScanComponent{Name: "bbb", Version: "2.0"}
+
+	scanAB := &storage.ImageScan{Components: []*storage.EmbeddedImageScanComponent{compA, compB}}
+	scanBA := &storage.ImageScan{Components: []*storage.EmbeddedImageScanComponent{compB, compA}}
+
+	require.NoError(t, populateImageScanHash(scanAB))
+	require.NoError(t, populateImageScanHash(scanBA))
+
+	assert.Equal(t, scanAB.GetHash(), scanBA.GetHash(),
+		"component order must not affect the hash")
+}


### PR DESCRIPTION
## Description

Addresses an edge case where an image scan is not updated in Central when the new scan is exactly the same except for identical components or vulnerabilities removed.

Counts of components and vulnerabilities are now added to the hash calculation used to determine if the old vs. new scans differ. 

This was noticed immediately after enabling deduping and comparing scan results (until next vuln load + reprocess). In majority of cases duplicate CVEs have some detail that differs (ie: by severity, cvss, description, etc.) which would yield a different hash and successful upsert, however this is not 100%.

This affects `roxctl image scan --force` as well. 

**Alternative Considered**
Re-using the already calculated stats from `storage.Image[V2]`. The component count could be re-used, however the CVE count cannot because it counts unique CVEs vs. total CVEs and would be affected by the same bug.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests


### How I validated my change

Unit tests and manually as described below.

**WIP, initial testing had a reproducible deploy, 4.11.2 does not**

Installed ACS 4.11.2 on OCP with feature flag off, and using a custom utility for detecting dupes recording findings from all images::

```
Summary
  Images scanned:          95
  Images with findings:    86
  Total components:        26168
  Total CVE entries:       8817
  Duplicate CVEs:          1584
  Identical components:    337 groups, 674 extra entries
  Apparent duplicates:     3 packages, 28 shared CVEs
  Arch duplicates:         0 packages, 0 shared CVEs

  If duplicates removed:
    CVEs:        8817 -> 7233  (18.0% reduction)
    Components:  26168 -> 25494  (2.6% reduction)
```
