### PR TITLE
ROX-36213: always upload e2e artifacts regardless of test outcome

### DIFF
--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -150,7 +150,7 @@ jobs:
       run: tests/byodb/run.sh /tmp/byodb-test-logs
 
     - name: Persist env vars for post-test
-      if: failure() || github.event_name == 'push'
+      if: always()
       run: |
         source tests/e2e/lib.sh
         wait_for_api
@@ -158,7 +158,7 @@ jobs:
         echo "ROX_ADMIN_PASSWORD=$(cat deploy/k8s/central-deploy/password)" >> "$GITHUB_ENV"
 
     - name: Run post-test
-      if: failure() || github.event_name == 'push'
+      if: always()
       shell: python
       env:
         ROX_USERNAME: admin

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -116,7 +116,7 @@ jobs:
         db_backup_and_restore_test /tmp/db-backup-restore-test
 
     - name: Run post-test
-      if: failure() || github.event_name == 'push'
+      if: always()
       shell: python
       run: |
         import sys

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -153,7 +153,7 @@ jobs:
       run: tests/e2e/run.sh /tmp/e2e-test-logs
 
     - name: Persist env vars for post-test
-      if: failure() || github.event_name == 'push'
+      if: always()
       run: |
         source tests/e2e/lib.sh
         wait_for_api
@@ -161,7 +161,7 @@ jobs:
         echo "ROX_ADMIN_PASSWORD=$(cat deploy/k8s/central-deploy/password)" >> "$GITHUB_ENV"
 
     - name: Run post-test
-      if: failure() || github.event_name == 'push'
+      if: always()
       shell: python
       env:
         ROX_USERNAME: admin


### PR DESCRIPTION
## Description

Post-test and env-persist steps were gated on `failure() || push`, skipping artifact upload on successful PR runs. The upgrade tests workflow already uses `if: always()` — align the three other e2e workflows to match.

Partially generated by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
