### PR TITLE
fix(CI): Bump workflow reference to latest commit (#22038)

### DIFF
--- a/.github/workflows/create-clusters.yml
+++ b/.github/workflows/create-clusters.yml
@@ -64,7 +64,7 @@ jobs:
   clusters:
     name: Setup demo clusters
     needs: trim-cluster-names
-    uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
+    uses: stackrox/actions/.github/workflows/create-demo-clusters.yml@43bb707aa4f32ead5bfb8d5ab11fb409f971ffc8 # ratchet:stackrox/actions/.github/workflows/create-demo-clusters.yml@v1
     secrets: inherit
     with:
       version: ${{github.event.inputs.version}}


### PR DESCRIPTION
Manual backport of https://github.com/stackrox/stackrox/pull/22038.
