### PR TITLE
ROX-36214: add resource requests to Splunk test deployment

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
@@ -56,6 +56,7 @@ class Deployment {
     Boolean automountServiceAccountToken = true
     Boolean livenessProbeDefined = false
     Boolean readinessProbeDefined = false
+    Integer readinessProbeTcpPort = null
     String serviceName
     String serviceAccountName
     List<Map<String, Object>> initContainers = []
@@ -325,6 +326,11 @@ class Deployment {
 
     Deployment setReadinessProbeDefined(Boolean probeDefined) {
         this.readinessProbeDefined = probeDefined
+        return this
+    }
+
+    Deployment setReadinessProbeTcpPort(Integer port) {
+        this.readinessProbeTcpPort = port
         return this
     }
 

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -47,6 +47,7 @@ import io.fabric8.kubernetes.api.model.PodSpec
 import io.fabric8.kubernetes.api.model.PodTemplateSpec
 import io.fabric8.kubernetes.api.model.PreferredSchedulingTerm
 import io.fabric8.kubernetes.api.model.Probe
+import io.fabric8.kubernetes.api.model.TCPSocketAction
 import io.fabric8.kubernetes.api.model.Quantity
 import io.fabric8.kubernetes.api.model.ResourceFieldSelectorBuilder
 import io.fabric8.kubernetes.api.model.ResourceRequirements
@@ -2411,7 +2412,14 @@ class Kubernetes {
             )
             container.setLivenessProbe(livenessProbe)
         }
-        if (deployment.readinessProbeDefined) {
+        if (deployment.readinessProbeTcpPort != null) {
+            Probe readinessProbe = new Probe(
+                    tcpSocket: new TCPSocketAction(port: new IntOrString(deployment.readinessProbeTcpPort)),
+                    initialDelaySeconds: 30,
+                    periodSeconds: 10,
+            )
+            container.setReadinessProbe(readinessProbe)
+        } else if (deployment.readinessProbeDefined) {
             Probe readinessProbe = new Probe(
                     exec: new ExecAction(command: ["touch", "/tmp/ready"]),
                     periodSeconds: 5,

--- a/qa-tests-backend/src/main/groovy/util/SplunkUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SplunkUtil.groovy
@@ -202,6 +202,9 @@ class SplunkUtil {
                             .addPort(514)
                             .setEnv(ENV_VARIABLES)
                             .addLabel("app", deploymentName)
+                            .addRequest("cpu", "500m")
+                            .addLimits("memory", "3Gi")
+                            .setReadinessProbeTcpPort(8089)
             orchestrator.createDeployment(deployment)
 
             collectorSvc = new Service("splunk-collector-" + uid, namespace)


### PR DESCRIPTION
  ## Description

  Splunk test deployment had no resource requests or limits (BestEffort QoS),  causing scheduling deprioritization and boot timeouts on spot VMs.

  Local profiling of `quay.io/rhacs-eng/qa:splunk-ta-test-latest` shows:
  - Boot peak: ~1.2GiB RAM, 124% CPU
  - Steady state: ~2.5GiB RAM, ~5% CPU
  - Time to healthy: ~3 minutes

  Changes:
  - Add TCP socket readiness probe support to the test `Deployment` class
  - Set memory limit=3Gi, cpu request=500m (no cpu limit per project policy)
  - Add TCP readiness probe on port 8089 (matches the image's built-in Docker HEALTHCHECK)

  No CPU limits per "Stop advising for setting CPU limits" proposal: CIS Docker  benchmark only requires memory limit, removing CPU limits avoids throttling  during boot spikes.

- https://docs.google.com/document/d/1B97y8RMAGrJx4wte2yGmuk1VKM9CHrZp2p8UPifMqWo/edit?tab=t.0

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked
  above **OR** is not needed

  ## Testing and quality

  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
  functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [ ] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [ ] modified existing tests

  ### How I validated my change

  - Ran `quay.io/rhacs-eng/qa:splunk-ta-test-latest` locally with `docker run`
  - Sampled `docker stats` every 15s during boot (~20 samples over 5 min)
  - Observed memory stabilize at ~2.5GiB, CPU peak at 124% during boot settling to ~5%
  - Confirmed Docker HEALTHCHECK (`/sbin/checkstate.sh`) reports `healthy` via `curl https://localhost:8089/`
  - TCP probe on port 8089 matches this existing healthcheck