### PR TITLE
ci: [ROX-36225] Change MintMaker window from 3-7 to 0-8

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
-    // that. Another reason for this schedule is to include at least one 4 hour inteval from the moment of scheduled
+    // that. Another reason for this schedule is to include at least one 4 hour interval from the moment of scheduled
     // MintMaker execution
     "* 0-8 * * *",
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,15 +30,16 @@
     // Allowed syntax: https://docs.renovatebot.com/configuration-options/#schedule
     // The time was selected (with the help of https://time.fyi/timezones) so that Renovate isn't active during business
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
-    // that.
-    "after 3am and before 7am",
+    // that. Another reason for this schedule is to include at least one 4 hour inteval from the moment of scheduled
+    // MintMaker execution
+    "* 0-8 * * *",
   ],
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
   "tekton": {
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
-      "after 3am and before 7am",
+      "* 0-8 * * *",
     ],
     "packageRules": [
       // Note: the packageRules from the Konflux config (find URL in comments above) get merged with these.
@@ -60,14 +61,14 @@
     ],
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
-      "after 3am and before 7am",
+      "* 0-8 * * *",
     ],
   },
   "rpm-lockfile": {
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
       // Note that MintMaker will create security updates outside of schedule.
-      "after 3am and before 7am",
+      "* 0-8 * * *",
     ],
   },
   "enabledManagers": [


### PR DESCRIPTION
## Description

MintMaker has a specified schedule, and can take more than 3 hours to finish. Increase the window so that it will include at least one 4 hours run.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### How I validated my change

CI is sufficient.