### PR TITLE
ROX-35907: fix export policy bulk action flake

### DIFF
--- a/ui/apps/platform/cypress/integration/policies/exportPolicy.test.js
+++ b/ui/apps/platform/cypress/integration/policies/exportPolicy.test.js
@@ -87,7 +87,7 @@ describe('Export policy', () => {
             cy.get(selectors.table.bulkActionsDropdownButton).should('be.disabled');
 
             cy.get(`thead ${selectors.table.selectCheckbox}`).should('not.be.checked').click();
-            cy.get(selectors.table.bulkActionsDropdownButton).click();
+            cy.get(selectors.table.bulkActionsDropdownButton).should('not.be.disabled').click();
             cy.get(`${pf6.dropdownItem}:contains("Export policies")`).click();
 
             cy.wait('@exportPolicy').then(({ request, response }) => {


### PR DESCRIPTION
Restore the `.should('not.be.disabled')` guard before clicking the bulk actions dropdown button in the export policy Cypress test.  The guard was originally present (PR #9743, Feb 2024) but was removed during the PatternFly 6 migration (PR #17809, Mar 2026). Without it,  Cypress clicks the button before React state propagation enables it after checkbox selection, causing intermittent `cy.click() failed because this element is disabled` failures.

This is the third occurrence of this flake: ROX-22920 (2024, different variant), ROX-34767 (2026-05, closed without fix), ROX-35907  (2026-07).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked
above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are
[inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

The fix restores a guard that existed before and was accidentally removed. The Cypress assertion `.should('not.be.disabled')` will retry until the button transitions from disabled to enabled, preventing the race condition.