### PR TITLE
ROX-36117: filter image-prefetcher labels from node comparison

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1274,7 +1274,11 @@ class Kubernetes {
                 new Node(
                         uid: it.metadata.uid,
                         name: it.metadata.name,
-                        labels: it.metadata.labels,
+                        // The CI image-prefetcher DaemonSet adds labels to nodes
+                        // asynchronously, after Sensor has already reported them.
+                        labels: it.metadata.labels.findAll { k, v ->
+                            !k.startsWith("image-prefetcher.stackrox.io/")
+                        },
                         annotations: it.metadata.annotations,
                         internalIps: it.status.addresses.findAll { it.type == "InternalIP" }*.address,
                         externalIps: it.status.addresses.findAll { it.type == "ExternalIP" }*.address,

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -1274,11 +1274,7 @@ class Kubernetes {
                 new Node(
                         uid: it.metadata.uid,
                         name: it.metadata.name,
-                        // The CI image-prefetcher DaemonSet adds labels to nodes
-                        // asynchronously, after Sensor has already reported them.
-                        labels: it.metadata.labels.findAll { k, v ->
-                            !k.startsWith("image-prefetcher.stackrox.io/")
-                        },
+                        labels: it.metadata.labels,
                         annotations: it.metadata.annotations,
                         internalIps: it.status.addresses.findAll { it.type == "InternalIP" }*.address,
                         externalIps: it.status.addresses.findAll { it.type == "ExternalIP" }*.address,

--- a/qa-tests-backend/src/test/groovy/NodeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeTest.groovy
@@ -9,6 +9,10 @@ import spock.lang.Tag
 @Tag("PZ")
 class NodeTest extends BaseSpecification {
 
+    private static Map<String, String> filterVolatileLabels(Map<String, String> labels) {
+        return labels.findAll { k, v -> !k.startsWith("image-prefetcher.stackrox.io/") }
+    }
+
     @Tag("BAT")
     def "Verify node details"() {
         given:
@@ -23,14 +27,16 @@ class NodeTest extends BaseSpecification {
             objects.Node orchestratorNode = orchestratorNodes.find { it.uid == stackroxNode.id }
             assert stackroxNode.clusterId == ClusterService.getClusterId()
             assert stackroxNode.name == orchestratorNode.name
-            if (stackroxNode.labelsMap != orchestratorNode.labels) {
+            def stableStackroxLabels = filterVolatileLabels(stackroxNode.labelsMap)
+            def stableOrchestratorLabels = filterVolatileLabels(orchestratorNode.labels)
+            if (stableStackroxLabels != stableOrchestratorLabels) {
                 log.info "There is a node label difference"
                 // Javers helps provide an useful error in the test log
-                def diff = JAVERS.compare(stackroxNode.labelsMap, orchestratorNode.labels)
+                def diff = JAVERS.compare(stableStackroxLabels, stableOrchestratorLabels)
                 assert diff.changes.size() == 0
                 assert diff.changes.size() != 0 // should not get here
             }
-            assert stackroxNode.labelsMap == orchestratorNode.labels
+            assert stableStackroxLabels == stableOrchestratorLabels
             // compareAnnotations() - asserts on difference
             Helpers.compareAnnotations(orchestratorNode.annotations, stackroxNode.getAnnotationsMap())
             assert stackroxNode.internalIpAddressesList == orchestratorNode.internalIps


### PR DESCRIPTION
## Description

Filter `image-prefetcher.stackrox.io/*` labels from node label comparison in `getNodeDetails()`.  The CI image-prefetcher DaemonSet adds labels to nodes asynchronously, after Sensor has already reported them to Central. This creates a  mismatch when NodeTest compares fresh k8s labels against StackRox's cached view.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are
[inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

The filter excludes CI-only labels that are not part of the product under test. The existing annotation filtering pattern in `Helpers.groovy` validates this approach.