### PR TITLE
chore(tests): disable JaVers Pro promotional banner

### DIFF
--- a/qa-tests-backend/gradle/libs.versions.toml
+++ b/qa-tests-backend/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ javax-mail = { module = "com.sun.mail:javax.mail", version = "1.6.2" }
 slack-api-client = { module = "com.slack.api:slack-api-client", version = "1.49.0" }
 jaxb-api = { module = "javax.xml.bind:jaxb-api", version = "2.3.1" }
 jaxb-runtime = { module = "org.glassfish.jaxb:jaxb-runtime", version = "4.0.9" }
-javers-core = { module = "org.javers:javers-core", version = "7.11.4" }
+javers-core = { module = "org.javers:javers-core", version = "7.11.7" }
 picocontainer = { module = "org.picocontainer:picocontainer", version = "2.15.2" }
 commons-codec = { module = "commons-codec:commons-codec", version = "1.22.0" }
 uuid-creator = { module = "com.github.f4b6a3:uuid-creator", version = "6.1.1" }

--- a/qa-tests-backend/src/main/groovy/sampleScripts/compareDeploymentCounts.groovy
+++ b/qa-tests-backend/src/main/groovy/sampleScripts/compareDeploymentCounts.groovy
@@ -73,6 +73,7 @@ log.info "Stackrox count: ${stackroxDeploymentCounts}, " +
 List<String> stackroxDeploymentNames = DeploymentService.listDeployments()*.name
 Javers javers = JaversBuilder.javers()
         .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
+        .withPrintProBanner(false)
         .build()
 log.info javers.compare(stackroxDeploymentNames, orchestratorResourceNames).prettyPrint()
 

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -251,7 +251,7 @@ class Helpers {
 
         log.info "There is an annotation difference"
         // Javers helps provide an useful error in the test log
-        Javers javers = JaversBuilder.javers().build()
+        Javers javers = JaversBuilder.javers().withPrintProBanner(false).build()
         def diff = javers.compare(stackroxTruncated, orchestratorTruncated)
         assert diff.changes.size() == 0
         assert diff.changes.size() != 0 // should not get here

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -43,6 +43,11 @@ import spock.lang.Specification
 @OnFailure(handler = { Helpers.collectDebugForFailure(delegate as Throwable) })
 class BaseSpecification extends Specification {
 
+    static final Javers JAVERS = JaversBuilder.javers()
+            .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
+            .withPrintProBanner(false)
+            .build()
+
     static final Logger LOG = LoggerFactory.getLogger("test." + BaseSpecification.getSimpleName())
 
     static final String TEST_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3@$TEST_IMAGE_SHA"
@@ -339,12 +344,8 @@ class BaseSpecification extends Specification {
     }
 
     private static void compareResourcesAtRunEnd(Kubernetes orchestrator) {
-        Javers javers = JaversBuilder.javers()
-                .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
-                .build()
-
         List<String> namespaces = orchestrator.getNamespaces()
-        Diff diff = javers.compare(resourceRecord["namespaces"], namespaces)
+        Diff diff = JAVERS.compare(resourceRecord["namespaces"], namespaces)
         if (diff.hasChanges()) {
             LOG.info "There is a difference in namespaces between the start and end of this test run:"
             LOG.info diff.prettyPrint()
@@ -354,7 +355,7 @@ class BaseSpecification extends Specification {
 
         List<String> deployments = orchestrator.getDeployments("default") +
                 orchestrator.getDeployments(Constants.ORCHESTRATOR_NAMESPACE)
-        diff = javers.compare(resourceRecord["deployments"], deployments)
+        diff = JAVERS.compare(resourceRecord["deployments"], deployments)
         if (diff.hasChanges()) {
             LOG.info "There is a difference in deployments between the start and end of this test run"
             LOG.info diff.prettyPrint()

--- a/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
+++ b/qa-tests-backend/src/test/groovy/K8sRbacTest.groovy
@@ -2,10 +2,7 @@ import static util.Helpers.withRetry
 
 import com.google.common.base.CaseFormat
 import io.fabric8.openshift.api.model.PolicyRule
-import org.javers.core.Javers
-import org.javers.core.JaversBuilder
 import org.javers.core.diff.Diff
-import org.javers.core.diff.ListCompareAlgorithm
 
 import io.stackrox.proto.api.v1.RbacServiceOuterClass
 import io.stackrox.proto.api.v1.ServiceAccountServiceOuterClass
@@ -249,10 +246,6 @@ class K8sRbacTest extends BaseSpecification {
 
     @Tag("BAT")
     def "Verify scraped bindings"() {
-        given:
-        Javers javers = JaversBuilder.javers()
-                .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
-                .build()
         expect:
         "SR should have the same bindings"
         withRetry(5, 30) {
@@ -262,7 +255,7 @@ class K8sRbacTest extends BaseSpecification {
             def stackroxBindingsSet = stackroxBindings.collect { "${it.namespace}/${it.name}" }
             def orchestratorBindingsSet = orchestratorBindings.collect { "${it.namespace}/${it.name}" }
 
-            Diff diff = javers.compareCollections(stackroxBindingsSet, orchestratorBindingsSet, String)
+            Diff diff = JAVERS.compareCollections(stackroxBindingsSet, orchestratorBindingsSet, String)
             assert diff.changes.empty, diff.prettyPrint()
 
             stackroxBindings.each { Rbac.K8sRoleBinding b ->

--- a/qa-tests-backend/src/test/groovy/NamespaceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NamespaceTest.groovy
@@ -1,9 +1,5 @@
 import static util.Helpers.withRetry
 
-import org.javers.core.Javers
-import org.javers.core.JaversBuilder
-import org.javers.core.diff.ListCompareAlgorithm
-
 import io.stackrox.proto.api.v1.SearchServiceOuterClass
 
 import services.ClusterService
@@ -39,10 +35,7 @@ class NamespaceTest extends BaseSpecification {
                         "the orchestrator has ${orchestratorNamespaces.size()}"
                 log.info "In this diff, 'removed' means 'missing in orchestrator but given in ACS', " +
                         "whereas 'added' - the other way round"
-                Javers javers = JaversBuilder.javers()
-                        .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
-                        .build()
-                log.info javers.compare(stackroxNamespaces.keySet().sort(), orchestratorNamespaces.sort())
+                log.info JAVERS.compare(stackroxNamespaces.keySet().sort(), orchestratorNamespaces.sort())
                         .prettyPrint()
             }
             assert stackroxNamespaces.keySet().sort() == orchestratorNamespaces.sort()
@@ -68,10 +61,7 @@ class NamespaceTest extends BaseSpecification {
                             SearchServiceOuterClass.RawQuery.newBuilder().setQuery(
                                     "Namespace:${ stackroxNamespaceDetails.metadata.name }").build()
                     )*.name
-                    Javers javers = JaversBuilder.javers()
-                            .withListCompareAlgorithm(ListCompareAlgorithm.AS_SET)
-                            .build()
-                    log.info javers.compare(stackroxDeploymentNames, orchestratorNamespaceDetails.deployments)
+                    log.info JAVERS.compare(stackroxDeploymentNames, orchestratorNamespaceDetails.deployments)
                             .prettyPrint()
                 }
                 verifyAll(stackroxNamespaceDetails) {

--- a/qa-tests-backend/src/test/groovy/NodeTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NodeTest.groovy
@@ -1,6 +1,3 @@
-import org.javers.core.Javers
-import org.javers.core.JaversBuilder
-
 import io.stackrox.proto.storage.NodeOuterClass
 
 import services.ClusterService
@@ -29,8 +26,7 @@ class NodeTest extends BaseSpecification {
             if (stackroxNode.labelsMap != orchestratorNode.labels) {
                 log.info "There is a node label difference"
                 // Javers helps provide an useful error in the test log
-                Javers javers = JaversBuilder.javers().build()
-                def diff = javers.compare(stackroxNode.labelsMap, orchestratorNode.labels)
+                def diff = JAVERS.compare(stackroxNode.labelsMap, orchestratorNode.labels)
                 assert diff.changes.size() == 0
                 assert diff.changes.size() != 0 // should not get here
             }


### PR DESCRIPTION

## Description

JaVers prints a promotional "JaVers Pro" ASCII banner to stdout on first use, polluting CI test output and artifacts. Disable it via `withPrintProBanner(false)` 

- https://github.com/javers/javers/issues/1488

Also deduplicate the repeated `JaversBuilder` construction across test specs by extracting a shared `JAVERS` constant in `BaseSpecification`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked
above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are
[inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Test-only change — no new behavior, only suppresses a banner. CI will validate compilation.