### PR TITLE
fix(ci): use mixed GKE node pools to protect DBs from spot preemption

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -19,19 +19,20 @@ function inject_db_node_placement {
             echo "  Skipping ${manifest} (not found)"
             continue
         fi
+        if ! grep -q 'kind: Deployment' "${manifest}"; then
+            echo "  Skipping ${manifest} (not a Deployment)"
+            continue
+        fi
         echo "  Patching ${manifest}"
-        python3 -c "
-import yaml, sys
-key, value = sys.argv[1], sys.argv[2]
-with open(sys.argv[3]) as f:
-    doc = yaml.safe_load(f)
-spec = doc['spec']['template']['spec']
-spec.setdefault('nodeSelector', {})[key] = value
-tol = {'key': key, 'operator': 'Equal', 'value': value, 'effect': 'NoSchedule'}
-spec.setdefault('tolerations', []).append(tol)
-with open(sys.argv[3], 'w') as f:
-    yaml.dump(doc, f, default_flow_style=False)
-" "${key}" "${value}" "${manifest}"
+        sed -i "/^    spec:/{a\\
+\\      nodeSelector:\\
+\\        ${key}: ${value}\\
+\\      tolerations:\\
+\\      - key: ${key}\\
+\\        operator: Equal\\
+\\        value: ${value}\\
+\\        effect: NoSchedule
+}" "${manifest}"
     done
 }
 

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -5,6 +5,36 @@ function realpath {
 	python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
 }
 
+function inject_db_node_placement {
+    local dir="$1"
+    local key="${ROX_DB_NODE_SELECTOR_KEY}"
+    local value="${ROX_DB_NODE_SELECTOR_VALUE}"
+    echo "Injecting nodeSelector ${key}=${value} and toleration into DB deployment manifests"
+    local db_manifests=(
+        "${dir}/central/01-central-12-central-db.yaml"
+        "${dir}/scanner-v4/02-scanner-v4-07-db-deployment.yaml"
+    )
+    for manifest in "${db_manifests[@]}"; do
+        if [[ ! -f "${manifest}" ]]; then
+            echo "  Skipping ${manifest} (not found)"
+            continue
+        fi
+        echo "  Patching ${manifest}"
+        python3 -c "
+import yaml, sys
+key, value = sys.argv[1], sys.argv[2]
+with open(sys.argv[3]) as f:
+    doc = yaml.safe_load(f)
+spec = doc['spec']['template']['spec']
+spec.setdefault('nodeSelector', {})[key] = value
+tol = {'key': key, 'operator': 'Equal', 'value': value, 'effect': 'NoSchedule'}
+spec.setdefault('tolerations', []).append(tol)
+with open(sys.argv[3], 'w') as f:
+    yaml.dump(doc, f, default_flow_style=False)
+" "${key}" "${value}" "${manifest}"
+    done
+}
+
 function launch_service {
     local dir="$1"
     local service="$2"
@@ -500,6 +530,9 @@ function launch_central {
         ROX_NAMESPACE="${central_namespace}" "${unzip_dir}/central/scripts/setup.sh"
       fi
       central_scripts_dir="$unzip_dir/central/scripts"
+      if [[ -n "${ROX_DB_NODE_SELECTOR_KEY:-}" ]]; then
+        inject_db_node_placement "${unzip_dir}"
+      fi
       launch_service "${unzip_dir}" central
       echo
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -260,8 +260,9 @@ add_spot_node_pool() {
     local image_type="$4"
 
     local spot_nodes=$((num_nodes - 1))
-    if (( spot_nodes < 1 )); then
-        spot_nodes=1
+    if (( spot_nodes == 0 )); then
+        info "Skipping spot node pool because no workload nodes were requested"
+        return
     fi
 
     info "Adding spot node pool with ${spot_nodes} nodes"

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -279,6 +279,9 @@ add_spot_node_pool() {
 }
 
 export_db_node_selector_values() {
+    ci_export ROX_DB_NODE_SELECTOR_KEY "stackrox-node-role"
+    ci_export ROX_DB_NODE_SELECTOR_VALUE "db"
+
     local values_file="/tmp/spot-db-node-selector-values.yaml"
     cat > "${values_file}" <<'EOF'
 central:
@@ -301,7 +304,7 @@ scannerV4:
         effect: NoSchedule
 EOF
     ci_export ROX_CENTRAL_EXTRA_HELM_VALUES_FILE "${values_file}"
-    info "Exported DB nodeSelector/tolerations values to ${values_file}"
+    info "Exported DB node placement config (nodeSelector: stackrox-node-role=db)"
 }
 
 add_a_maintenance_exclusion() {

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -157,10 +157,10 @@ create_cluster() {
     if [[ "${POD_SECURITY_POLICIES}" == "true" ]]; then
         PSP_ARG="--enable-pod-security-policy"
     fi
-    SPOT_ARG=
+    local use_spot="false"
     if [[ "${GKE_SPOT:-false}" == "true" ]]; then
-        SPOT_ARG="--spot"
-        echo "Using spot (preemptible) VMs for cost savings"
+        use_spot="true"
+        echo "Using mixed node pools: 1 non-spot node for databases, $((NUM_NODES - 1)) spot nodes for workloads"
     fi
     zones=$(gcloud compute zones list --format="value(name,region.basename(),status)" | awk "/${REGION}\tUP\$/{print \$1}" | shuf)
     success=0
@@ -169,24 +169,41 @@ create_cluster() {
         ci_export ZONE "$zone"
         gcloud config set compute/zone "${zone}"
         status=0
+
+        local cluster_create_args=(
+            --machine-type "${MACHINE_TYPE}"
+            --disk-type=pd-ssd
+            --disk-size="${DISK_SIZE_GB}GB"
+            --create-subnetwork range=/28
+            --cluster-ipv4-cidr=/20
+            --services-ipv4-cidr=/24
+            --enable-ip-alias
+            --enable-network-policy
+            --no-enable-autorepair
+            "${VERSION_ARGS[@]}"
+            --image-type "${GCP_IMAGE_TYPE}"
+            --tags="${tags}"
+            --labels="${labels}"
+        )
+        if [[ -n "${PSP_ARG}" ]]; then
+            cluster_create_args+=("${PSP_ARG}")
+        fi
+
+        if [[ "${use_spot}" == "true" ]]; then
+            # Default pool: 1 non-spot node for database pods.
+            # Tainted so only pods with a matching toleration are scheduled here.
+            cluster_create_args+=(
+                --num-nodes 1
+                --node-labels=stackrox-node-role=db
+                --node-taints=stackrox-node-role=db:NoSchedule
+            )
+        else
+            cluster_create_args+=(--num-nodes "${NUM_NODES}")
+        fi
+
         # shellcheck disable=SC2153
         timeout 830 gcloud beta container clusters create \
-            --machine-type "${MACHINE_TYPE}" \
-            --num-nodes "${NUM_NODES}" \
-            --disk-type=pd-ssd \
-            --disk-size="${DISK_SIZE_GB}GB" \
-            --create-subnetwork range=/28 \
-            --cluster-ipv4-cidr=/20 \
-            --services-ipv4-cidr=/24 \
-            --enable-ip-alias \
-            --enable-network-policy \
-            --no-enable-autorepair \
-            "${VERSION_ARGS[@]}" \
-            --image-type "${GCP_IMAGE_TYPE}" \
-            --tags="${tags}" \
-            --labels="${labels}" \
-            ${PSP_ARG} \
-            ${SPOT_ARG} \
+            "${cluster_create_args[@]}" \
             "${CLUSTER_NAME}" || status="$?"
         if [[ "${status}" == 0 ]]; then
             success=1
@@ -228,7 +245,62 @@ create_cluster() {
         return 1
     fi
 
+    if [[ "${use_spot}" == "true" ]]; then
+        add_spot_node_pool "${NUM_NODES}" "${MACHINE_TYPE}" "${DISK_SIZE_GB}" "${GCP_IMAGE_TYPE}"
+        export_db_node_selector_values
+    fi
+
     add_a_maintenance_exclusion
+}
+
+add_spot_node_pool() {
+    local num_nodes="$1"
+    local machine_type="$2"
+    local disk_size_gb="$3"
+    local image_type="$4"
+
+    local spot_nodes=$((num_nodes - 1))
+    if (( spot_nodes < 1 )); then
+        spot_nodes=1
+    fi
+
+    info "Adding spot node pool with ${spot_nodes} nodes"
+    gcloud beta container node-pools create spot-pool \
+        --cluster "${CLUSTER_NAME}" \
+        --machine-type "${machine_type}" \
+        --num-nodes "${spot_nodes}" \
+        --spot \
+        --disk-type=pd-ssd \
+        --disk-size="${disk_size_gb}GB" \
+        --image-type "${image_type}" \
+        --no-enable-autorepair \
+        --no-enable-autoupgrade
+}
+
+export_db_node_selector_values() {
+    local values_file="/tmp/spot-db-node-selector-values.yaml"
+    cat > "${values_file}" <<'EOF'
+central:
+  db:
+    nodeSelector:
+      stackrox-node-role: db
+    tolerations:
+      - key: stackrox-node-role
+        operator: Equal
+        value: db
+        effect: NoSchedule
+scannerV4:
+  db:
+    nodeSelector:
+      stackrox-node-role: db
+    tolerations:
+      - key: stackrox-node-role
+        operator: Equal
+        value: db
+        effect: NoSchedule
+EOF
+    ci_export ROX_CENTRAL_EXTRA_HELM_VALUES_FILE "${values_file}"
+    info "Exported DB nodeSelector/tolerations values to ${values_file}"
 }
 
 add_a_maintenance_exclusion() {

--- a/tests/byodb/lib.sh
+++ b/tests/byodb/lib.sh
@@ -19,12 +19,12 @@ deploy_external_postgres() {
     kubectl create namespace database
     envsubst < ./tests/byodb/simple-postgres.yaml | kubectl apply -f -
 
-    if [[ "${GKE_SPOT:-false}" == "true" ]]; then
-        info "Pinning external postgres to non-spot node (stackrox-node-role=db)"
+    if [[ -n "${ROX_DB_NODE_SELECTOR_KEY:-}" ]]; then
+        info "Pinning external postgres to non-spot node (${ROX_DB_NODE_SELECTOR_KEY}=${ROX_DB_NODE_SELECTOR_VALUE})"
         kubectl -n database patch statefulset postgres --type=strategic -p '{
           "spec": {"template": {"spec": {
-            "nodeSelector": {"stackrox-node-role": "db"},
-            "tolerations": [{"key": "stackrox-node-role", "operator": "Equal", "value": "db", "effect": "NoSchedule"}]
+            "nodeSelector": {"'"${ROX_DB_NODE_SELECTOR_KEY}"'": "'"${ROX_DB_NODE_SELECTOR_VALUE}"'"},
+            "tolerations": [{"key": "'"${ROX_DB_NODE_SELECTOR_KEY}"'", "operator": "Equal", "value": "'"${ROX_DB_NODE_SELECTOR_VALUE}"'", "effect": "NoSchedule"}]
           }}}
         }'
     fi

--- a/tests/byodb/lib.sh
+++ b/tests/byodb/lib.sh
@@ -19,6 +19,16 @@ deploy_external_postgres() {
     kubectl create namespace database
     envsubst < ./tests/byodb/simple-postgres.yaml | kubectl apply -f -
 
+    if [[ "${GKE_SPOT:-false}" == "true" ]]; then
+        info "Pinning external postgres to non-spot node (stackrox-node-role=db)"
+        kubectl -n database patch statefulset postgres --type=strategic -p '{
+          "spec": {"template": {"spec": {
+            "nodeSelector": {"stackrox-node-role": "db"},
+            "tolerations": [{"key": "stackrox-node-role", "operator": "Equal", "value": "db", "effect": "NoSchedule"}]
+          }}}
+        }'
+    fi
+
     kubectl wait --for=condition=Ready pod -l app=postgres -n database --timeout=180s
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -59,6 +59,15 @@ retrying_kubectl() {
 export -f retrying_kubectl
 
 # shellcheck disable=SC2120
+log_db_pod_placement() {
+    local ns="${1:-stackrox}"
+    info "=== DB pod node placement ==="
+    kubectl get nodes -o wide --show-labels | grep -E 'NAME|stackrox-node-role' || kubectl get nodes -o wide
+    info "--- Pod-to-node mapping (stackrox namespace) ---"
+    kubectl -n "${ns}" get pods -o wide | grep -E 'NAME|central-db|scanner.*db'
+    info "=== end DB pod placement ==="
+}
+
 deploy_stackrox() {
     local tls_client_certs=${1:-}
     local central_namespace=${2:-stackrox}
@@ -90,6 +99,10 @@ deploy_stackrox() {
 
     if retrying_kubectl </dev/null -n "${central_namespace}" get deployment scanner-v4-indexer >/dev/null 2>&1; then
         wait_for_scanner_V4 "${central_namespace}"
+    fi
+
+    if [[ -n "${ROX_DB_NODE_SELECTOR_KEY:-}" ]]; then
+        log_db_pod_placement "${central_namespace}"
     fi
 
     touch "${STATE_DEPLOYED}"

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -96,7 +96,13 @@ deploy_earlier_postgres_central() {
     ROX_ADMIN_PASSWORD="$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c12 || true)"
     PATH="bin/$TEST_HOST_PLATFORM:$PATH" roxctl helm output central-services --image-defaults opensource --output-dir /tmp/early-stackrox-central-services-chart --remove
 
+    local extra_values_args=()
+    if [[ -n "${ROX_CENTRAL_EXTRA_HELM_VALUES_FILE:-}" ]]; then
+        extra_values_args+=(-f "${ROX_CENTRAL_EXTRA_HELM_VALUES_FILE}")
+    fi
+
     helm install -n stackrox --create-namespace stackrox-central-services /tmp/early-stackrox-central-services-chart \
+         "${extra_values_args[@]}" \
          --set central.adminPassword.value="${ROX_ADMIN_PASSWORD}" \
          --set central.db.enabled=true \
          --set central.db.persistence.persistentVolumeClaim.size="${PVC_SIZE:-100Gi}" \


### PR DESCRIPTION
## Description

GKE e2e tests use spot VMs (`GKE_SPOT: "true"`) for cost savings, but spot preemptions cause cascading test failures when database pods lose their nodes. With EmptyDir storage the database is destroyed entirely; with PVCs there is still a ~2 minute service disruption during rescheduling that causes test timeouts.

This PR splits the single GKE node pool into two:

- **Default pool**: 1 non-spot node with taint `stackrox-node-role=db:NoSchedule`, reserved exclusively for database pods (central-db, scanner-v4-db)
- **Spot pool**: remaining N-1 nodes for all other workloads (central, sensor, scanner, collector, admission-controller)

Database pods get `nodeSelector` + `toleration` via `ROX_CENTRAL_EXTRA_HELM_VALUES_FILE` so they are guaranteed to land on the non-spot node. The taint prevents other pods from consuming the non-spot node's capacity, which answers the question "what if other pods fill the non-spot node before the DBs schedule?" — they can't.

Also handles two edge cases:
- **BYODB external postgres**: patched via `kubectl patch` after creation when `GKE_SPOT=true`
- **Upgrade tests**: their direct `helm install` now picks up `ROX_CENTRAL_EXTRA_HELM_VALUES_FILE`

Total node count stays the same (e.g. 3 = 1 non-spot + 2 spot), so cost savings from spot are mostly preserved. The 1 non-spot node costs more but protects the most preemption-sensitive pods.

Addresses: ROX-36110, ROX-36099, ROX-36196, ROX-36178, ROX-36116, ROX-36115, ROX-35988, ROX-35943, ROX-35904

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI-only change — validated by reviewing GKE `gcloud` API docs for `--node-taints`, `--node-labels`, and `node-pools create --spot`. The Helm values paths (`central.db.nodeSelector`, `central.db.tolerations`, `scannerV4.db.nodeSelector`, `scannerV4.db.tolerations`) are confirmed present in the chart templates. The `ROX_CENTRAL_EXTRA_HELM_VALUES_FILE` mechanism is already used in production CI deploys. Needs CI run to fully validate — requesting `/test` after PR creation.