### PR TITLE
ROX-35922: Add sensor compatibility filter

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -14,12 +14,12 @@ export type InputType =
     | 'select-exclusive-double'
     | 'select-exclusive-single';
 
-export type SelectSearchFilterOption = {
+export type SelectSearchFilterOption<T extends string = string> = {
     label: string;
-    value: string;
+    value: T;
 };
-export type SelectSearchFilterOptions = {
-    options: SelectSearchFilterOption[];
+export type SelectSearchFilterOptions<T extends string = string> = {
+    options: SelectSearchFilterOption<T>[];
 };
 
 export type SelectSearchFilterGroupedOption = {

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -18,8 +18,12 @@ import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import CloseButton from 'Components/CloseButton';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
-import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
+import {
+    getSearchFilterConfigWithFeatureFlagDependency,
+    updateSearchFilter,
+} from 'Components/CompoundSearchFilter/utils/utils';
 import Dialog from 'Components/Dialog';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useAnalytics, {
     LEGACY_SECURE_A_CLUSTER_LINK_CLICKED,
     SECURE_A_CLUSTER_LINK_CLICKED,
@@ -69,6 +73,7 @@ export type ClustersTablePanelProps = {
 function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
     const { analyticsTrack } = useAnalytics();
     const navigate = useNavigate();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasReadAccessForAdministration = hasReadAccess('Administration');
@@ -94,6 +99,16 @@ function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
     const metadata = useMetadata();
 
     const { searchFilter, setSearchFilter } = useURLSearch();
+
+    const filteredSearchFilterConfig = useMemo(
+        () =>
+            getSearchFilterConfigWithFeatureFlagDependency(
+                isFeatureFlagEnabled,
+                searchFilterConfig
+            ),
+
+        [isFeatureFlagEnabled]
+    );
 
     const [checkedClusterIds, setCheckedClusterIds] = useState<string[]>([]);
     const [upgradableClusters, setUpgradableClusters] = useState<Cluster[]>([]);
@@ -378,7 +393,7 @@ function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
                 <Toolbar>
                     <ToolbarContent>
                         <CompoundSearchFilter
-                            config={searchFilterConfig}
+                            config={filteredSearchFilterConfig}
                             defaultEntity="Cluster"
                             searchFilter={searchFilter}
                             onSearch={(payload) =>
@@ -421,7 +436,7 @@ function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
                         <ToolbarGroup className="pf-v6-u-w-100">
                             <CompoundSearchFilterLabels
                                 attributesSeparateFromConfig={[]}
-                                config={searchFilterConfig}
+                                config={filteredSearchFilterConfig}
                                 onFilterChange={setSearchFilter}
                                 searchFilter={searchFilter}
                             />

--- a/ui/apps/platform/src/Containers/Clusters/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Clusters/searchFilterConfig.ts
@@ -11,6 +11,7 @@ import type {
     CompoundSearchFilterEntity,
     SelectSearchFilterOptions,
 } from 'Components/CompoundSearchFilter/types';
+import type { SensorVersionCompatibility } from 'types/cluster.proto';
 
 export const statusSelectOptions: SelectSearchFilterOptions['options'] = [
     { label: 'Healthy', value: 'HEALTHY' },
@@ -57,6 +58,28 @@ const sensorStatusAttribute: CompoundSearchFilterAttribute = {
     searchTerm: 'Sensor Status',
     inputType: 'select',
     inputProps: { options: statusSelectOptions },
+};
+
+const sensorCompatibilityStatusOptions: SelectSearchFilterOptions<SensorVersionCompatibility>['options'] =
+    [
+        {
+            label: 'Incompatible (Behind)',
+            value: 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND',
+        },
+        { label: 'Compatible (Behind)', value: 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND' },
+        { label: 'Matched', value: 'SENSOR_VERSION_COMPATIBILITY_MATCHED' },
+        { label: 'Compatible (Ahead)', value: 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD' },
+        { label: 'Incompatible (Ahead)', value: 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD' },
+        { label: 'Unknown', value: 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN' },
+    ];
+
+const sensorCompatibilityStatusAttribute: CompoundSearchFilterAttribute = {
+    displayName: 'Compatibility status',
+    filterChipLabel: 'Sensor compatibility status',
+    searchTerm: 'Sensor Version Compatibility',
+    inputType: 'select',
+    inputProps: { options: sensorCompatibilityStatusOptions },
+    featureFlagDependency: ['ROX_SENSOR_COMPATIBILITY_STATUS'],
 };
 
 const lastContactAttributes: CompoundSearchFilterAttribute = {
@@ -107,7 +130,7 @@ const scannerSearchFilterConfig: CompoundSearchFilterEntity = {
 const sensorSearchFilterConfig: CompoundSearchFilterEntity = {
     displayName: 'Sensor',
     searchCategory: 'CLUSTERS',
-    attributes: [sensorStatusAttribute],
+    attributes: [sensorStatusAttribute, sensorCompatibilityStatusAttribute],
 };
 
 export const searchFilterConfig = [

--- a/ui/apps/platform/src/types/searchOptions.ts
+++ b/ui/apps/platform/src/types/searchOptions.ts
@@ -16,6 +16,7 @@ export const searchFieldLabels = [
     'Collector Status',
     'Admission Control Status',
     'Scanner Status',
+    'Sensor Version Compatibility',
     'Last Contact',
     //
     'Policy ID',


### PR DESCRIPTION
## Description

Adds the ability to filter clusters by sensor compatibility status.

Note: not implemented on backend yet
Note: do not merge until final naming of search field is agreed upon

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1330" height="660" alt="image" src="https://github.com/user-attachments/assets/33637d25-8af1-48b4-b51f-7ffb283f708d" />
<img width="1330" height="1010" alt="image" src="https://github.com/user-attachments/assets/2d92f443-8703-4858-a2fe-9550ef1866ad" />

