### PR TITLE
ROX-36234: roxctl whoami warns on incompatible Central

### DIFF
--- a/roxctl/central/whoami/whoami.go
+++ b/roxctl/central/whoami/whoami.go
@@ -2,7 +2,9 @@ package whoami
 
 import (
 	"context"
+	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -10,10 +12,14 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version"
+	"github.com/stackrox/rox/pkg/version/productstreams"
+	"github.com/stackrox/rox/pkg/version/versioncompatibility"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/util"
+	"google.golang.org/grpc"
 )
 
 type centralWhoAmICommand struct {
@@ -92,7 +98,72 @@ User name:
 		cmd.env.Logger().PrintfLn("\t%s %s", accessString(access), resource)
 	}
 
+	cmd.checkVersionCompatibility(ctx, conn)
+
 	return nil
+}
+
+func (cmd *centralWhoAmICommand) checkVersionCompatibility(ctx context.Context, conn *grpc.ClientConn) {
+	metadata, err := v1.NewMetadataServiceClient(conn).GetMetadata(ctx, &v1.Empty{})
+	if err != nil {
+		cmd.env.Logger().WarnfLn("getting metadata: %v", err)
+		return
+	}
+
+	roxctlVersion := version.GetMainVersion()
+
+	centralVersion := metadata.GetVersion()
+	if centralVersion == "" {
+		cmd.env.Logger().WarnfLn("Central did not report its version; skipping compatibility check")
+		return
+	}
+
+	centralXY, err := productstreams.ParseXYFromVersionString(centralVersion)
+	if err != nil {
+		cmd.env.Logger().WarnfLn("parsing Central version %q: %v", centralVersion, err)
+		return
+	}
+
+	compat, err := versioncompatibility.ClassifyVersion(centralXY)
+	if err != nil {
+		cmd.env.Logger().WarnfLn("classifying Central version %q: %v", centralVersion, err)
+		return
+	}
+	if compat != versioncompatibility.IncompatibleAhead && compat != versioncompatibility.IncompatibleBehind {
+		return
+	}
+	versionRange, err := versioncompatibility.CompatibleVersions()
+	if err != nil {
+		cmd.env.Logger().WarnfLn("generating compatible versions %q: %v", roxctlVersion, err)
+		return
+	}
+	compatRange := formatVersionRange(versionRange)
+	w := cmd.env.InputOutput().ErrOut()
+
+	switch compat {
+	case versioncompatibility.IncompatibleAhead:
+		fmt.Fprintf(w, "Warning: Your roxctl %s is too old for this Central %s. "+
+			"Correct functioning is not guaranteed. "+
+			"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
+			roxctlVersion, centralVersion)
+		fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
+			roxctlVersion, centralVersion, compatRange)
+	case versioncompatibility.IncompatibleBehind:
+		fmt.Fprintf(w, "Warning: Your roxctl %s is too new for this Central %s. "+
+			"Correct functioning is not guaranteed. "+
+			"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
+			roxctlVersion, centralVersion)
+		fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
+			roxctlVersion, centralVersion, compatRange)
+	}
+}
+
+func formatVersionRange(versions []productstreams.XYVersion) string {
+	strs := make([]string, len(versions))
+	for i, v := range versions {
+		strs[i] = v.String()
+	}
+	return strings.Join(strs, ", ")
 }
 
 func accessString(access storage.Access) string {

--- a/roxctl/central/whoami/whoami_test.go
+++ b/roxctl/central/whoami/whoami_test.go
@@ -12,6 +12,8 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version/productstreams"
+	versiontestutils "github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stackrox/rox/roxctl/common/environment/mocks"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -31,9 +33,11 @@ type centralWhoAmITestSuite struct {
 type mockAuthServiceServer struct {
 	v1.UnimplementedAuthServiceServer
 	v1.UnimplementedRoleServiceServer
+	v1.UnimplementedMetadataServiceServer
 
 	userInfo         *storage.UserInfo
 	resourceToAccess map[string]storage.Access
+	centralVersion   string
 }
 
 func (m *mockAuthServiceServer) GetAuthStatus(_ context.Context, _ *v1.Empty) (*v1.AuthStatus, error) {
@@ -49,6 +53,10 @@ func (m *mockAuthServiceServer) GetMyPermissions(_ context.Context, _ *v1.Empty)
 	return &v1.GetPermissionsResponse{ResourceToAccess: m.resourceToAccess}, nil
 }
 
+func (m *mockAuthServiceServer) GetMetadata(_ context.Context, _ *v1.Empty) (*v1.Metadata, error) {
+	return &v1.Metadata{Version: m.centralVersion}, nil
+}
+
 func (c *centralWhoAmITestSuite) createGRPCMockServices(mockServer *mockAuthServiceServer) (*grpc.ClientConn, func()) {
 	buffer := 1024 * 1024
 	listener := bufconn.Listen(buffer)
@@ -57,6 +65,7 @@ func (c *centralWhoAmITestSuite) createGRPCMockServices(mockServer *mockAuthServ
 
 	v1.RegisterAuthServiceServer(server, mockServer)
 	v1.RegisterRoleServiceServer(server, mockServer)
+	v1.RegisterMetadataServiceServer(server, mockServer)
 
 	go func() {
 		utils.IgnoreError(func() error { return server.Serve(listener) })
@@ -139,4 +148,78 @@ Access:
 	-- Valhalla
 `,
 		stdout.String())
+}
+
+func (c *centralWhoAmITestSuite) setupVersionTest(centralVersion string) (*cobra.Command, func(), *bytes.Buffer, *bytes.Buffer) {
+	const testBumpsYAML = `bumps:
+  - from: "3.74"
+    to: "4.0"
+  - from: "4.11"
+    to: "5.0"
+`
+	versiontestutils.SetMainVersion(c.T(), "5.0.0")
+	productstreams.OverrideBumpsForTesting(c.T(), testBumpsYAML)
+
+	mockServer := &mockAuthServiceServer{
+		userInfo:       &storage.UserInfo{Username: "user", FriendlyName: "user"},
+		centralVersion: centralVersion,
+	}
+	return c.setupCommand(mockServer)
+}
+
+func (c *centralWhoAmITestSuite) TestVersionCompatibilityMatched() {
+	cbr, closeFunction, _, stderr := c.setupVersionTest("5.0.2")
+	defer closeFunction()
+
+	cbr.SetArgs([]string{"--timeout", "5s"})
+	c.Require().NoError(cbr.Execute())
+	c.Assert().Empty(stderr.String())
+}
+
+func (c *centralWhoAmITestSuite) TestVersionCompatibilityCompatibleAhead() {
+	cbr, closeFunction, _, stderr := c.setupVersionTest("5.3.1")
+	defer closeFunction()
+
+	cbr.SetArgs([]string{"--timeout", "5s"})
+	c.Require().NoError(cbr.Execute())
+	c.Assert().Empty(stderr.String())
+}
+
+func (c *centralWhoAmITestSuite) TestVersionCompatibilityCompatibleBehind() {
+	cbr, closeFunction, _, stderr := c.setupVersionTest("4.10.1")
+	defer closeFunction()
+
+	cbr.SetArgs([]string{"--timeout", "5s"})
+	c.Require().NoError(cbr.Execute())
+	c.Assert().Empty(stderr.String())
+}
+
+func (c *centralWhoAmITestSuite) TestVersionCompatibilityIncompatibleAhead() {
+	cbr, closeFunction, _, stderr := c.setupVersionTest("5.6.0")
+	defer closeFunction()
+
+	cbr.SetArgs([]string{"--timeout", "5s"})
+	c.Require().NoError(cbr.Execute())
+	c.Assert().Contains(stderr.String(), "Warning: Your roxctl 5.0.0 is too old for this Central 5.6.0.")
+	c.Assert().Contains(stderr.String(), "roxctl: 5.0.0 | Central: 5.6.0 | Compatible Centrals: 4.9, 4.10, 4.11, 5.0, 5.1, 5.2, 5.3")
+}
+
+func (c *centralWhoAmITestSuite) TestVersionCompatibilityIncompatibleBehind() {
+	cbr, closeFunction, _, stderr := c.setupVersionTest("4.5.2")
+	defer closeFunction()
+
+	cbr.SetArgs([]string{"--timeout", "5s"})
+	c.Require().NoError(cbr.Execute())
+	c.Assert().Contains(stderr.String(), "Warning: Your roxctl 5.0.0 is too new for this Central 4.5.2.")
+	c.Assert().Contains(stderr.String(), "roxctl: 5.0.0 | Central: 4.5.2 | Compatible Centrals: 4.9, 4.10, 4.11, 5.0, 5.1, 5.2, 5.3")
+}
+
+func (c *centralWhoAmITestSuite) TestVersionCompatibilityUnknownCentralVersion() {
+	cbr, closeFunction, _, stderr := c.setupVersionTest("")
+	defer closeFunction()
+
+	cbr.SetArgs([]string{"--timeout", "5s"})
+	c.Require().NoError(cbr.Execute())
+	c.Assert().Contains(stderr.String(), "WARN:")
+	c.Assert().Contains(stderr.String(), "Central did not report its version")
 }


### PR DESCRIPTION
## Description

After `roxctl central whoami` prints the user's auth info, it now fetches Central's version
via `MetadataService.GetMetadata` and checks compatibility using the `versioncompatibility` package.

- **Incompatible states** emit a `Warning:` to stderr with version details and the compatible range.
- **Matched and Compatible states** are silent — no extra output.
- **Failures** (GetMetadata RPC error, unparseable version, empty Central version) log at warn level
  and return silently — the compatibility check is best-effort and never blocks the command.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests cover all six compatibility states: matched (silent), compatible ahead (silent),
  compatible behind (silent), incompatible ahead (warning emitted), incompatible behind
  (warning emitted), unknown/empty Central version (warn log, no user message).
- Tests use a mock gRPC server with `MetadataService`, `testutils.SetMainVersion`, and
  `productstreams.OverrideBumpsForTesting` for deterministic version data.