### PR TITLE
ROX-36233: Increase retries for admctrl configmap test

### DIFF
--- a/tests/admctrl_configmap_test.go
+++ b/tests/admctrl_configmap_test.go
@@ -90,7 +90,7 @@ func TestAdmissionControllerConfigMapWithPostgres(t *testing.T) {
 	}()
 	require.NoError(t, err, "failed to create new policy")
 
-	testutils.Retry(t, 10, 3*time.Second, func(t testutils.T) {
+	testutils.Retry(t, 30, 3*time.Second, func(t testutils.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 


### PR DESCRIPTION
## Description

The e2e test `TestAdmissionControllerConfigMapWithPostgres` is flaky because its 30-second
retry window (10 x 3s) can be exceeded by the async Central → Sensor → ConfigMap propagation
chain, especially under CI load or when the test runs first in the suite before the system
has fully settled. The `PostPolicy` call succeeds but the policy never reaches the ConfigMap
within the window.

Increase retry attempts from 10 to 30 (90s total) to accommodate transient propagation delays.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Test-only change that increases the retry window for an existing e2e test. The fix addresses
the flaky failure observed in [ROX-36233](https://redhat.atlassian.net/browse/ROX-36233)
(build [31179874810](https://github.com/stackrox/stackrox/actions/runs/31179874810)) where
the admission-control ConfigMap was never updated within the 30s window after creating a
deploy-time policy. CI will validate the fix.

Made with [Cursor](https://cursor.com)

[ROX-36233]: https://redhat.atlassian.net/browse/ROX-36233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ