### PR TITLE
ROX-36100: Node reports page scaffolding

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -52,6 +52,7 @@ import {
     vulnerabilitiesUserWorkloadsPath,
     vulnerabilitiesVirtualMachineCvesPath,
     vulnerabilitiesWorkloadCvesPath,
+    vulnerabilityNodeReportsPath,
     vulnerabilityReportsPath,
 } from 'routePaths';
 import type { RouteKey } from 'routePaths';
@@ -290,6 +291,13 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
     'vulnerabilities/images-without-cves': {
         component: makeVulnMgmtUserWorkloadView('images-without-cves'),
         path: vulnerabilitiesImagesWithoutCvesPath,
+    },
+    'vulnerabilities/node-reports': {
+        component: asyncComponent(
+            () =>
+                import('Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingPage')
+        ),
+        path: vulnerabilityNodeReportsPath,
     },
     'vulnerabilities/reports': {
         component: asyncComponent(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingLayout.tsx
@@ -2,6 +2,7 @@ import { PageSection, Tab, TabContent, Tabs, Title } from '@patternfly/react-cor
 import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
+import usePermissions from 'hooks/usePermissions';
 import {
     vulnerabilityNodeConfigurationReportsPath,
     vulnerabilityNodeViewBasedReportsPath,
@@ -10,6 +11,9 @@ import {
 function NodeVulnerabilityReportingLayout() {
     const location = useLocation();
     const navigate = useNavigate();
+
+    const { hasReadAccess } = usePermissions();
+    const hasAccessForConfiguration = hasReadAccess('WorkflowAdministration');
 
     const activeKey = location.pathname.startsWith(vulnerabilityNodeConfigurationReportsPath)
         ? 'configuration'
@@ -33,11 +37,13 @@ function NodeVulnerabilityReportingLayout() {
                     }}
                     usePageInsets
                 >
-                    <Tab
-                        eventKey="configuration"
-                        title="Report configurations"
-                        tabContentId="report-configuration-tab-content"
-                    />
+                    {hasAccessForConfiguration && (
+                        <Tab
+                            eventKey="configuration"
+                            title="Report configurations"
+                            tabContentId="report-configuration-tab-content"
+                        />
+                    )}
                     <Tab
                         eventKey="view-based"
                         title="View-based reports"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingLayout.tsx
@@ -1,0 +1,53 @@
+import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
+
+import PageTitle from 'Components/PageTitle';
+import {
+    vulnerabilityNodeConfigurationReportsPath,
+    vulnerabilityNodeViewBasedReportsPath,
+} from 'routePaths';
+
+function NodeVulnerabilityReportingLayout() {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const activeKey = location.pathname.startsWith(vulnerabilityNodeConfigurationReportsPath)
+        ? 'configuration'
+        : 'view-based';
+
+    return (
+        <>
+            <PageTitle title="Node vulnerability reports" />
+            <PageSection>
+                <Title headingLevel="h1">Node vulnerability reports</Title>
+            </PageSection>
+            <PageSection type="tabs">
+                <Tabs
+                    activeKey={activeKey}
+                    onSelect={(_event, tabKey) => {
+                        navigate(
+                            tabKey === 'configuration'
+                                ? vulnerabilityNodeConfigurationReportsPath
+                                : vulnerabilityNodeViewBasedReportsPath
+                        );
+                    }}
+                    usePageInsets
+                >
+                    <Tab
+                        eventKey="configuration"
+                        title="Report configurations"
+                        tabContentId="report-configuration-tab-content"
+                    />
+                    <Tab
+                        eventKey="view-based"
+                        title="View-based reports"
+                        tabContentId="view-based-reports-tab-content"
+                    />
+                </Tabs>
+            </PageSection>
+            <Outlet />
+        </>
+    );
+}
+
+export default NodeVulnerabilityReportingLayout;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingLayout.tsx
@@ -1,4 +1,4 @@
-import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
+import { PageSection, Tab, TabContent, Tabs, Title } from '@patternfly/react-core';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
@@ -45,7 +45,15 @@ function NodeVulnerabilityReportingLayout() {
                     />
                 </Tabs>
             </PageSection>
-            <Outlet />
+            <TabContent
+                id={
+                    activeKey === 'configuration'
+                        ? 'report-configuration-tab-content'
+                        : 'view-based-reports-tab-content'
+                }
+            >
+                <Outlet />
+            </TabContent>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingPage.tsx
@@ -1,13 +1,27 @@
 import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
+import usePermissions from 'hooks/usePermissions';
+
 import NodeVulnerabilityReportingLayout from './NodeVulnerabilityReportingLayout';
 
 function NodeVulnerabilityReportingPage() {
+    const { hasReadAccess } = usePermissions();
+    const hasAccessForConfiguration = hasReadAccess('WorkflowAdministration');
+
     return (
         <Routes>
             <Route element={<NodeVulnerabilityReportingLayout />}>
                 <Route index element={<Navigate to="configuration" replace />} />
-                <Route path="configuration" element={<div>List view</div>} />
+                <Route
+                    path="configuration"
+                    element={
+                        hasAccessForConfiguration ? (
+                            <div>List view</div>
+                        ) : (
+                            <Navigate to="../view-based" replace />
+                        )
+                    }
+                />
                 <Route path="view-based" element={<div>View-based reports</div>} />
             </Route>
         </Routes>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/NodeVulnerabilityReportingPage.tsx
@@ -1,0 +1,17 @@
+import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
+
+import NodeVulnerabilityReportingLayout from './NodeVulnerabilityReportingLayout';
+
+function NodeVulnerabilityReportingPage() {
+    return (
+        <Routes>
+            <Route element={<NodeVulnerabilityReportingLayout />}>
+                <Route index element={<Navigate to="configuration" replace />} />
+                <Route path="configuration" element={<div>List view</div>} />
+                <Route path="view-based" element={<div>View-based reports</div>} />
+            </Route>
+        </Routes>
+    );
+}
+
+export default NodeVulnerabilityReportingPage;

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -102,6 +102,10 @@ export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 export const vulnerabilityConfigurationReportsPath = `${vulnerabilityReportsPath}/configuration`;
 export const vulnerabilityViewBasedReportsPath = `${vulnerabilityReportsPath}/view-based`;
 
+export const vulnerabilityNodeReportsPath = `${vulnerabilityReportsPath}/node`;
+export const vulnerabilityNodeConfigurationReportsPath = `${vulnerabilityNodeReportsPath}/configuration`;
+export const vulnerabilityNodeViewBasedReportsPath = `${vulnerabilityNodeReportsPath}/view-based`;
+
 // Vulnerability Management 1.0 path for links from Dashboard:
 
 export const vulnManagementImagesPath = `${vulnManagementPath}/images`;
@@ -193,6 +197,7 @@ export type RouteKey =
     | 'violations'
     | 'vulnerabilities/exception-management'
     | 'vulnerabilities/node-cves'
+    | 'vulnerabilities/node-reports'
     | 'vulnerabilities/reports'
     | 'vulnerabilities/user-workloads'
     | 'vulnerabilities/platform'
@@ -368,6 +373,10 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'vulnerabilities/platform-cves': {
         featureFlagRequirements: allEnabled(['ROX_LEGACY_SCANNER']),
         resourceAccessRequirements: everyResource(['Cluster']),
+    },
+    'vulnerabilities/node-reports': {
+        featureFlagRequirements: allEnabled(['ROX_NODE_VULNERABILITY_REPORTS']),
+        resourceAccessRequirements: everyResource(['Node', 'WorkflowAdministration']),
     },
     'vulnerabilities/reports': {
         resourceAccessRequirements: everyResource(['WorkflowAdministration']),

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -370,13 +370,13 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'vulnerabilities/node-cves': {
         resourceAccessRequirements: everyResource(['Cluster', 'Node']),
     },
+    'vulnerabilities/node-reports': {
+        featureFlagRequirements: allEnabled(['ROX_NODE_VULNERABILITY_REPORTS']),
+        resourceAccessRequirements: everyResource(['Node']),
+    },
     'vulnerabilities/platform-cves': {
         featureFlagRequirements: allEnabled(['ROX_LEGACY_SCANNER']),
         resourceAccessRequirements: everyResource(['Cluster']),
-    },
-    'vulnerabilities/node-reports': {
-        featureFlagRequirements: allEnabled(['ROX_NODE_VULNERABILITY_REPORTS']),
-        resourceAccessRequirements: everyResource(['Node', 'WorkflowAdministration']),
     },
     'vulnerabilities/reports': {
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),


### PR DESCRIPTION
## Description

Scaffolds the Node vulnerability reports page behind the `ROX_NODE_VULNERABILITY_REPORTS` feature flag

Notes:
- Permission requirements (`Node` + `WorkflowAdministration`)
- The layout uses react routers `<Outlet />` to render tab content since each tab is its own route
- Currently have to manually visit the route to view content. An overview page will be added later to link to image or node reports

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Confirmed page renders at `/main/vulnerabilities/reports/node` with title and two tabs

<img width="1432" height="839" alt="Screenshot 2026-08-07 at 1 25 21 PM" src="https://github.com/user-attachments/assets/37baefae-3f44-4bb5-be69-304b2bcb51d2" />
