### PR TITLE
ROX-35787: Add a deprecation banner to config mgmt

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/ConfigManagementRoutes.jsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
+import { Alert } from '@patternfly/react-core';
 import PageNotFound from 'Components/PageNotFound';
 import searchContext from 'Containers/searchContext';
 import { searchParams } from 'constants/searchParams';
@@ -14,6 +15,15 @@ const entityPath = `:pageEntityId?/:entityType1?/:entityId1?/:entityType2?/:enti
 
 const ConfigManagementRoutes = () => (
     <searchContext.Provider value={searchParams.page}>
+        <Alert
+            title="Configuration Management is deprecated and will be removed in a future release"
+            component="p"
+            variant="info"
+            isInline
+        >
+            Security configuration data will integrate directly into risk and policy management
+            workflows to enhance visibility without relying on a standalone dashboard.
+        </Alert>
         <Routes>
             <Route index element={<ConfigManagementDashboardPage />} />
             <Route path={`namespace/${entityPath}`} element={<EntityPage />} />


### PR DESCRIPTION
## Description

As titled.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1623" height="947" alt="image" src="https://github.com/user-attachments/assets/9fb399c0-e128-4619-81b3-52e8f7128c67" />

<img width="1623" height="947" alt="image" src="https://github.com/user-attachments/assets/c871ba86-aabd-443e-b76e-2a005a0f98e0" />

