### PR TITLE
ROX-29390: Paginate listening endpoints within a deployment in UI

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 function realpath {
 	[[ -n "$1" ]] || return 0

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 
 function realpath {
 	[[ -n "$1" ]] || return 0

--- a/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsPagination.test.js
+++ b/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsPagination.test.js
@@ -114,9 +114,9 @@ describe('Listening endpoints pagination within a deployment', () => {
         cy.get(`${processTableA} > tbody > tr`).should('have.length', 20);
 
         // Verify deployment A page 1 starts with port 8000
-        cy.get(
-            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`
-        ).should('exist');
+        cy.get(`${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`).should(
+            'exist'
+        );
 
         // Navigate deployment A to page 2
         cy.get(expandedContentA).find('[data-action="next"]').click();
@@ -124,12 +124,12 @@ describe('Listening endpoints pagination within a deployment', () => {
         cy.get(`${processTableA} > tbody > tr`).should('have.length', 20);
 
         // Deployment A page 2 should start with port 8020, not 8000
-        cy.get(
-            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8020')}`
-        ).should('exist');
-        cy.get(
-            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`
-        ).should('not.exist');
+        cy.get(`${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8020')}`).should(
+            'exist'
+        );
+        cy.get(`${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`).should(
+            'not.exist'
+        );
 
         // Now expand deployment B — it should start on page 1 independently
         cy.get(`${rowSelectorB} ${selectors.expandableRowToggle}`).click();
@@ -138,17 +138,17 @@ describe('Listening endpoints pagination within a deployment', () => {
 
         // Deployment B should show page 1 starting with port 9000
         cy.get(`${processTableB} > tbody > tr`).should('have.length', 20);
-        cy.get(
-            `${processTableB} ${selectors.tableRowWithValueForColumn('Port', '9000')}`
-        ).should('exist');
+        cy.get(`${processTableB} ${selectors.tableRowWithValueForColumn('Port', '9000')}`).should(
+            'exist'
+        );
 
         // Deployment A should still be on page 2 (port 8020 present, port 8000 absent)
-        cy.get(
-            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8020')}`
-        ).should('exist');
-        cy.get(
-            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`
-        ).should('not.exist');
+        cy.get(`${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8020')}`).should(
+            'exist'
+        );
+        cy.get(`${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`).should(
+            'not.exist'
+        );
     });
 
     it('should navigate to the last page and disable the next button', () => {

--- a/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsPagination.test.js
+++ b/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsPagination.test.js
@@ -1,0 +1,188 @@
+import withAuth from '../../helpers/basicAuth';
+import { visitListeningEndpointsFromLeftNav } from './ListeningEndpoints.helpers';
+import selectors from './ListeningEndpoints.selectors';
+
+function makeEndpoint(deploymentId, port) {
+    return {
+        endpoint: { port, protocol: 'L4_PROTOCOL_TCP' },
+        clusterId: 'test-cluster-id',
+        namespace: 'default',
+        deploymentId,
+        imageId: 'test-image-id',
+        containerName: 'listeners',
+        podId: `pod-${deploymentId}`,
+        podUid: `uid-${deploymentId}`,
+        signal: {
+            id: `signal-${deploymentId}-${port}`,
+            containerId: `container-${deploymentId}`,
+            time: '2026-08-06T00:00:00Z',
+            pid: 1000 + port,
+            uid: 0,
+            gid: 0,
+            lineage: [],
+            scraped: false,
+            lineageInfo: [],
+            execFilePath: '/usr/bin/python3',
+        },
+        containerStartTime: '2026-08-06T00:00:00Z',
+    };
+}
+
+const endpointsByDeployment = {
+    'deployment-a-id': Array.from({ length: 50 }, (_, i) =>
+        makeEndpoint('deployment-a-id', 8000 + i)
+    ),
+    'deployment-b-id': Array.from({ length: 50 }, (_, i) =>
+        makeEndpoint('deployment-b-id', 9000 + i)
+    ),
+};
+
+const deploymentResponse = {
+    deployments: [
+        {
+            id: 'deployment-a-id',
+            name: 'listeners-alpha',
+            namespace: 'default',
+            cluster: 'test-cluster',
+            clusterId: 'test-cluster-id',
+        },
+        {
+            id: 'deployment-b-id',
+            name: 'listeners-beta',
+            namespace: 'default',
+            cluster: 'test-cluster',
+            clusterId: 'test-cluster-id',
+        },
+    ],
+};
+
+function interceptListeningEndpointsAPI() {
+    cy.intercept('GET', '/v1/listening_endpoints/deployment/*', (req) => {
+        const url = new URL(req.url, window.location.origin);
+        const deploymentId = url.pathname.split('/').pop();
+        const offset = parseInt(url.searchParams.get('pagination.offset') || '0', 10);
+        const limit = parseInt(url.searchParams.get('pagination.limit') || '0', 10);
+
+        const allEndpoints = endpointsByDeployment[deploymentId] || [];
+        const page = limit > 0 ? allEndpoints.slice(offset, offset + limit) : allEndpoints;
+        req.reply({
+            body: {
+                listeningEndpoints: page,
+                totalListeningEndpoints: allEndpoints.length,
+            },
+        });
+    }).as('listeningEndpoints');
+}
+
+describe('Listening endpoints pagination within a deployment', () => {
+    withAuth();
+
+    beforeEach(() => {
+        cy.intercept('GET', '/v1/deployments?*', {
+            body: deploymentResponse,
+        }).as('deployments');
+
+        cy.intercept('GET', '/v1/deploymentscount?*', {
+            body: { count: 2 },
+        }).as('deploymentsCount');
+
+        interceptListeningEndpointsAPI();
+    });
+
+    it('should paginate listening endpoints independently for each deployment', () => {
+        visitListeningEndpointsFromLeftNav();
+
+        cy.wait(['@deployments', '@deploymentsCount']);
+
+        // Assert that two deployment rows are displayed
+        cy.get(`${selectors.deploymentTable} > tbody`).should('have.length', 2);
+
+        // Both deployments should show a count of 50
+        const rowSelectorA = `${selectors.deploymentTable} > tbody:has(${selectors.tableRowWithValueForColumn('Deployment', 'listeners-alpha')})`;
+        const rowSelectorB = `${selectors.deploymentTable} > tbody:has(${selectors.tableRowWithValueForColumn('Deployment', 'listeners-beta')})`;
+
+        cy.get(`${rowSelectorA} ${selectors.tableRowWithValueForColumn('Count', '50')}`);
+        cy.get(`${rowSelectorB} ${selectors.tableRowWithValueForColumn('Count', '50')}`);
+
+        // Expand deployment A
+        cy.get(`${rowSelectorA} ${selectors.expandableRowToggle}`).click();
+
+        const processTableA = `${rowSelectorA} ${selectors.processTable}`;
+        const expandedContentA = `${rowSelectorA} .pf-v6-c-card`;
+
+        // Assert that the first page shows 20 rows
+        cy.get(`${processTableA} > tbody > tr`).should('have.length', 20);
+
+        // Verify deployment A page 1 starts with port 8000
+        cy.get(
+            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`
+        ).should('exist');
+
+        // Navigate deployment A to page 2
+        cy.get(expandedContentA).find('[data-action="next"]').click();
+        cy.wait('@listeningEndpoints');
+        cy.get(`${processTableA} > tbody > tr`).should('have.length', 20);
+
+        // Deployment A page 2 should start with port 8020, not 8000
+        cy.get(
+            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8020')}`
+        ).should('exist');
+        cy.get(
+            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`
+        ).should('not.exist');
+
+        // Now expand deployment B — it should start on page 1 independently
+        cy.get(`${rowSelectorB} ${selectors.expandableRowToggle}`).click();
+
+        const processTableB = `${rowSelectorB} ${selectors.processTable}`;
+
+        // Deployment B should show page 1 starting with port 9000
+        cy.get(`${processTableB} > tbody > tr`).should('have.length', 20);
+        cy.get(
+            `${processTableB} ${selectors.tableRowWithValueForColumn('Port', '9000')}`
+        ).should('exist');
+
+        // Deployment A should still be on page 2 (port 8020 present, port 8000 absent)
+        cy.get(
+            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8020')}`
+        ).should('exist');
+        cy.get(
+            `${processTableA} ${selectors.tableRowWithValueForColumn('Port', '8000')}`
+        ).should('not.exist');
+    });
+
+    it('should navigate to the last page and disable the next button', () => {
+        visitListeningEndpointsFromLeftNav();
+
+        cy.wait(['@deployments', '@deploymentsCount']);
+
+        const rowSelector = `${selectors.deploymentTable} > tbody:has(${selectors.tableRowWithValueForColumn('Deployment', 'listeners-alpha')})`;
+
+        // Expand deployment A
+        cy.get(`${rowSelector} ${selectors.expandableRowToggle}`).click();
+
+        const processTable = `${rowSelector} ${selectors.processTable}`;
+        const expandedContent = `${rowSelector} .pf-v6-c-card`;
+
+        // Page 1: 20 rows
+        cy.get(`${processTable} > tbody > tr`).should('have.length', 20);
+
+        // Page 2: 20 rows
+        cy.get(expandedContent).find('[data-action="next"]').click();
+        cy.wait('@listeningEndpoints');
+        cy.get(`${processTable} > tbody > tr`).should('have.length', 20);
+
+        // Page 3 (last): 10 rows
+        cy.get(expandedContent).find('[data-action="next"]').click();
+        cy.wait('@listeningEndpoints');
+        cy.get(`${processTable} > tbody > tr`).should('have.length', 10);
+
+        // Next button should be disabled
+        cy.get(expandedContent).find('[data-action="next"]').should('be.disabled');
+
+        // Navigate back to page 2
+        cy.get(expandedContent).find('[data-action="previous"]').click();
+        cy.wait('@listeningEndpoints');
+        cy.get(`${processTable} > tbody > tr`).should('have.length', 20);
+    });
+});

--- a/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsPagination.test.js
+++ b/ui/apps/platform/cypress/integration/listeningEndpoints/listeningEndpointsPagination.test.js
@@ -1,6 +1,13 @@
 import withAuth from '../../helpers/basicAuth';
-import { visitListeningEndpointsFromLeftNav } from './ListeningEndpoints.helpers';
+import { visit } from '../../helpers/visit';
 import selectors from './ListeningEndpoints.selectors';
+
+const listeningEndpointsPath = '/main/listening-endpoints';
+
+const deploymentsRouteMatcherMap = {
+    deployments: { method: 'GET', url: '/v1/deployments?*' },
+    deploymentsCount: { method: 'GET', url: '/v1/deploymentscount?*' },
+};
 
 function makeEndpoint(deploymentId, port) {
     return {
@@ -78,21 +85,16 @@ describe('Listening endpoints pagination within a deployment', () => {
     withAuth();
 
     beforeEach(() => {
-        cy.intercept('GET', '/v1/deployments?*', {
-            body: deploymentResponse,
-        }).as('deployments');
-
-        cy.intercept('GET', '/v1/deploymentscount?*', {
-            body: { count: 2 },
-        }).as('deploymentsCount');
-
         interceptListeningEndpointsAPI();
     });
 
     it('should paginate listening endpoints independently for each deployment', () => {
-        visitListeningEndpointsFromLeftNav();
+        visit(listeningEndpointsPath, deploymentsRouteMatcherMap, {
+            deployments: { body: deploymentResponse },
+            deploymentsCount: { body: { count: 2 } },
+        });
 
-        cy.wait(['@deployments', '@deploymentsCount']);
+        cy.get('h1:contains("Listening endpoints")');
 
         // Assert that two deployment rows are displayed
         cy.get(`${selectors.deploymentTable} > tbody`).should('have.length', 2);
@@ -152,9 +154,12 @@ describe('Listening endpoints pagination within a deployment', () => {
     });
 
     it('should navigate to the last page and disable the next button', () => {
-        visitListeningEndpointsFromLeftNav();
+        visit(listeningEndpointsPath, deploymentsRouteMatcherMap, {
+            deployments: { body: deploymentResponse },
+            deploymentsCount: { body: { count: 2 } },
+        });
 
-        cy.wait(['@deployments', '@deploymentsCount']);
+        cy.get('h1:contains("Listening endpoints")');
 
         const rowSelector = `${selectors.deploymentTable} > tbody:has(${selectors.tableRowWithValueForColumn('Deployment', 'listeners-alpha')})`;
 

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -5,10 +5,8 @@ import { Bullseye, Card, Content, Pagination, Spinner } from '@patternfly/react-
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { riskWorkloadsBasePath } from 'routePaths';
-import {
-    getListeningEndpointsForDeployment,
-    type ProcessListeningOnPort,
-} from 'services/ProcessListeningOnPortsService';
+import { getListeningEndpointsForDeployment } from 'services/ProcessListeningOnPortsService';
+import type { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import type { ListDeployment } from 'types/deployment.proto';
 import useSet from 'hooks/useSet';

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -1,52 +1,113 @@
+import { useCallback, useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { Card, Content } from '@patternfly/react-core';
+import { Bullseye, Card, Content, Pagination, Spinner } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { riskWorkloadsBasePath } from 'routePaths';
-import type { ProcessListeningOnPort } from 'services/ProcessListeningOnPortsService';
+import {
+    getListeningEndpointsForDeployment,
+    type ProcessListeningOnPort,
+} from 'services/ProcessListeningOnPortsService';
 import { l4ProtocolLabels } from 'constants/networkFlow';
 import type { ListDeployment } from 'types/deployment.proto';
 import useSet from 'hooks/useSet';
+import useRestQuery from 'hooks/useRestQuery';
 import type { GetSortParams } from 'hooks/useURLSort';
+import { DEFAULT_ENDPOINTS_PER_PAGE } from './hooks/useDeploymentListeningEndpoints';
 
 function EmbeddedTable({
     deploymentId,
-    listeningEndpoints,
+    preloadedEndpoints,
+    totalEndpoints,
 }: {
     deploymentId: string;
-    listeningEndpoints: ProcessListeningOnPort[];
+    preloadedEndpoints: ProcessListeningOnPort[];
+    totalEndpoints: number;
 }) {
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(DEFAULT_ENDPOINTS_PER_PAGE);
+
+    const queryFn = useCallback(() => {
+        if (page === 1 && perPage === DEFAULT_ENDPOINTS_PER_PAGE) {
+            return Promise.resolve(preloadedEndpoints);
+        }
+        const { request } = getListeningEndpointsForDeployment(deploymentId, {
+            offset: (page - 1) * perPage,
+            limit: perPage,
+        });
+        return request.then((r) => r.listeningEndpoints);
+    }, [deploymentId, page, perPage, preloadedEndpoints]);
+
+    const { data: endpoints, isLoading, error } = useRestQuery(queryFn);
+
+    if (error) {
+        return (
+            <Content component="p" className="pf-v6-u-p-md">
+                Error loading listening endpoints
+            </Content>
+        );
+    }
+
+    if (isLoading || !endpoints) {
+        return (
+            <Bullseye>
+                <Spinner size="md" aria-label="Loading listening endpoints" />
+            </Bullseye>
+        );
+    }
+
     return (
-        <Table isNested aria-label="Listening endpoints for deployment">
-            <Thead noWrap>
-                <Tr>
-                    <Th width={30}>Exec file path</Th>
-                    <Th>PID</Th>
-                    <Th>Port</Th>
-                    <Th>Protocol</Th>
-                    <Th width={30}>Pod ID</Th>
-                    <Th width={20}>Container name</Th>
-                </Tr>
-            </Thead>
-            <Tbody>
-                {listeningEndpoints.map(({ podId, endpoint, signal, containerName }) => (
-                    <Tr key={`${deploymentId}/${podId}/${endpoint.port}`}>
-                        <Td dataLabel="Exec file path">{signal.execFilePath}</Td>
-                        <Td dataLabel="PID">{signal.pid}</Td>
-                        <Td dataLabel="Port">{endpoint.port}</Td>
-                        <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>
-                        <Td dataLabel="Pod ID">{podId}</Td>
-                        <Td dataLabel="Container name">{containerName}</Td>
+        <>
+            <Table isNested aria-label="Listening endpoints for deployment">
+                <Thead noWrap>
+                    <Tr>
+                        <Th width={30}>Exec file path</Th>
+                        <Th>PID</Th>
+                        <Th>Port</Th>
+                        <Th>Protocol</Th>
+                        <Th width={30}>Pod ID</Th>
+                        <Th width={20}>Container name</Th>
                     </Tr>
-                ))}
-            </Tbody>
-        </Table>
+                </Thead>
+                <Tbody>
+                    {endpoints.map(({ podId, endpoint, signal, containerName }) => (
+                        <Tr key={`${deploymentId}/${podId}/${endpoint.port}`}>
+                            <Td dataLabel="Exec file path">{signal.execFilePath}</Td>
+                            <Td dataLabel="PID">{signal.pid}</Td>
+                            <Td dataLabel="Port">{endpoint.port}</Td>
+                            <Td dataLabel="Protocol">{l4ProtocolLabels[endpoint.protocol]}</Td>
+                            <Td dataLabel="Pod ID">{podId}</Td>
+                            <Td dataLabel="Container name">{containerName}</Td>
+                        </Tr>
+                    ))}
+                </Tbody>
+            </Table>
+            {totalEndpoints > DEFAULT_ENDPOINTS_PER_PAGE && (
+                <Pagination
+                    itemCount={totalEndpoints}
+                    page={page}
+                    perPage={perPage}
+                    onSetPage={(_, newPage) => setPage(newPage)}
+                    onPerPageSelect={(_, newPerPage) => {
+                        setPerPage(newPerPage);
+                        setPage(1);
+                    }}
+                    variant="bottom"
+                    isCompact
+                />
+            )}
+        </>
     );
 }
 
+type DeploymentWithEndpoints = ListDeployment & {
+    listeningEndpoints: ProcessListeningOnPort[];
+    totalListeningEndpoints: number;
+};
+
 export type ListeningEndpointsTableProps = {
-    deployments: (ListDeployment & { listeningEndpoints: ProcessListeningOnPort[] })[];
+    deployments: DeploymentWithEndpoints[];
     getSortParams: GetSortParams;
     areAllRowsExpanded: boolean;
     setAllRowsExpanded: Dispatch<SetStateAction<boolean>>;
@@ -91,51 +152,56 @@ function ListeningEndpointsTable({
                     <Th>Count</Th>
                 </Tr>
             </Thead>
-            {deployments.map(({ id, name, namespace, cluster, listeningEndpoints }, rowIndex) => {
-                // A row is expanded if
-                //   - the "are all rows expanded" toggle is on and the row is not in the toggled set
-                //   - the "are all rows expanded" toggle is off and the row is in the toggled set
-                const isExpanded = areAllRowsExpanded
-                    ? !invertedExpansionRowSet.has(id)
-                    : invertedExpansionRowSet.has(id);
-                const count = listeningEndpoints.length;
-                return (
-                    <Tbody key={id} isExpanded={isExpanded}>
-                        <Tr>
-                            <Td
-                                expand={{
-                                    rowIndex,
-                                    isExpanded,
-                                    onToggle: () => invertedExpansionRowSet.toggle(id),
-                                }}
-                            />
-                            <Td dataLabel="Deployment">
-                                <Link to={`${riskWorkloadsBasePath}/${id}`}>{name}</Link>
-                            </Td>
-                            <Td dataLabel="Cluster">{cluster}</Td>
-                            <Td dataLabel="Namespace">{namespace}</Td>
-                            <Td dataLabel="Count">{count}</Td>
-                        </Tr>
-                        <Tr isExpanded={isExpanded}>
-                            <Td colSpan={5}>
-                                <Card className="pf-v6-u-m-md">
-                                    {count > 0 ? (
-                                        <EmbeddedTable
-                                            deploymentId={id}
-                                            listeningEndpoints={listeningEndpoints}
-                                        />
-                                    ) : (
-                                        <Content component="p" className="pf-v6-u-p-md">
-                                            This deployment does not have any reported listening
-                                            endpoints
-                                        </Content>
-                                    )}
-                                </Card>
-                            </Td>
-                        </Tr>
-                    </Tbody>
-                );
-            })}
+            {deployments.map(
+                (
+                    { id, name, namespace, cluster, listeningEndpoints, totalListeningEndpoints },
+                    rowIndex
+                ) => {
+                    // A row is expanded if
+                    //   - the "are all rows expanded" toggle is on and the row is not in the toggled set
+                    //   - the "are all rows expanded" toggle is off and the row is in the toggled set
+                    const isExpanded = areAllRowsExpanded
+                        ? !invertedExpansionRowSet.has(id)
+                        : invertedExpansionRowSet.has(id);
+                    return (
+                        <Tbody key={id} isExpanded={isExpanded}>
+                            <Tr>
+                                <Td
+                                    expand={{
+                                        rowIndex,
+                                        isExpanded,
+                                        onToggle: () => invertedExpansionRowSet.toggle(id),
+                                    }}
+                                />
+                                <Td dataLabel="Deployment">
+                                    <Link to={`${riskWorkloadsBasePath}/${id}`}>{name}</Link>
+                                </Td>
+                                <Td dataLabel="Cluster">{cluster}</Td>
+                                <Td dataLabel="Namespace">{namespace}</Td>
+                                <Td dataLabel="Count">{totalListeningEndpoints}</Td>
+                            </Tr>
+                            <Tr isExpanded={isExpanded}>
+                                <Td colSpan={5}>
+                                    <Card className="pf-v6-u-m-md">
+                                        {totalListeningEndpoints > 0 ? (
+                                            <EmbeddedTable
+                                                deploymentId={id}
+                                                preloadedEndpoints={listeningEndpoints}
+                                                totalEndpoints={totalListeningEndpoints}
+                                            />
+                                        ) : (
+                                            <Content component="p" className="pf-v6-u-p-md">
+                                                This deployment does not have any reported listening
+                                                endpoints
+                                            </Content>
+                                        )}
+                                    </Card>
+                                </Td>
+                            </Tr>
+                        </Tbody>
+                    );
+                }
+            )}
         </Table>
     );
 }

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -32,11 +32,14 @@ function EmbeddedTable({
         if (page === 1 && perPage === DEFAULT_ENDPOINTS_PER_PAGE) {
             return Promise.resolve(preloadedEndpoints);
         }
-        const { request } = getListeningEndpointsForDeployment(deploymentId, {
+        const { request, cancel } = getListeningEndpointsForDeployment(deploymentId, {
             offset: (page - 1) * perPage,
             limit: perPage,
         });
-        return request.then((r) => r.listeningEndpoints);
+        return {
+            request: request.then((r) => r.listeningEndpoints),
+            cancel,
+        };
     }, [deploymentId, page, perPage, preloadedEndpoints]);
 
     const { data: endpoints, isLoading, error } = useRestQuery(queryFn);

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/hooks/useDeploymentListeningEndpoints.tsx
@@ -4,8 +4,10 @@ import { getListeningEndpointsForDeployment } from 'services/ProcessListeningOnP
 import useRestQuery from 'hooks/useRestQuery';
 import type { ApiSortOption, SearchFilter } from 'types/search';
 
+export const DEFAULT_ENDPOINTS_PER_PAGE = 20;
+
 /**
- * Returns a paginated list of deployments with their listening endpoints.
+ * Returns a paginated list of deployments with the first page of their listening endpoints.
  */
 export function useDeploymentListeningEndpoints(
     searchFilter: SearchFilter,
@@ -17,10 +19,14 @@ export function useDeploymentListeningEndpoints(
         return listDeployments(searchFilter, sortOption, page, perPage).then((res) => {
             return Promise.all(
                 res.map((deployment) => {
-                    const { request } = getListeningEndpointsForDeployment(deployment.id);
-                    return request.then((listeningEndpoints) => ({
+                    const { request } = getListeningEndpointsForDeployment(deployment.id, {
+                        offset: 0,
+                        limit: DEFAULT_ENDPOINTS_PER_PAGE,
+                    });
+                    return request.then((response) => ({
                         ...deployment,
-                        listeningEndpoints,
+                        listeningEndpoints: response.listeningEndpoints,
+                        totalListeningEndpoints: response.totalListeningEndpoints,
                     }));
                 })
             );

--- a/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
+++ b/ui/apps/platform/src/services/ProcessListeningOnPortsService.ts
@@ -46,17 +46,32 @@ export type ProcessListeningOnPort = {
     containerStartTime: string | null;
 };
 
+type ListeningEndpointsResponse = {
+    listeningEndpoints: ProcessListeningOnPort[];
+    totalListeningEndpoints: number;
+};
+
 /**
- * Get all listening endpoints for a deployment
+ * Get paginated listening endpoints for a deployment.
  */
 export function getListeningEndpointsForDeployment(
-    deploymentId: string
-): CancellableRequest<ProcessListeningOnPort[]> {
+    deploymentId: string,
+    pagination?: { offset: number; limit: number }
+): CancellableRequest<ListeningEndpointsResponse> {
     return makeCancellableAxiosRequest((signal) =>
         axios
-            .get<{
-                listeningEndpoints: ProcessListeningOnPort[];
-            }>(`${listeningEndpointsBaseUrl}/deployment/${deploymentId}`, { signal })
-            .then((response) => response.data.listeningEndpoints)
+            .get<ListeningEndpointsResponse>(
+                `${listeningEndpointsBaseUrl}/deployment/${deploymentId}`,
+                {
+                    signal,
+                    params: pagination
+                        ? {
+                              'pagination.offset': pagination.offset,
+                              'pagination.limit': pagination.limit,
+                          }
+                        : undefined,
+                }
+            )
+            .then((response) => response.data)
     );
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When there are a large number of listening endpoints, the listening endpoints UI can become unresponsive, and can overwhelm the user with repetitive information. The UI currently displays 10 deployments at a time and there is pagination for the deployments. When a deployment is clicked on it displays all of the listening endpoints for that deployment, even if the number of listening endpoints is in the thousands. The listening endpoints API has pagination, but the UI does not make use of it. This PR makes it so that there is pagination for listening endpoints within deployments. 

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

ACS was deployed. Two deployments were also created with the following yaml file. The second deployment just had a different name.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: many-listening-endpoints
  namespace: default
  labels:
    app: many-listening-endpoints
spec:
  replicas: 1
  selector:
    matchLabels:
      app: many-listening-endpoints
  template:
    metadata:
      labels:
        app: many-listening-endpoints
    spec:
      containers:
        - name: listeners
          image: python:3.12-slim
          command:
            - python3
            - -c
            - |
              import socket, time
              sockets = []
              for port in range(8000, 8050):
                  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                  s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                  s.bind(('0.0.0.0', port))
                  s.listen(1)
                  sockets.append(s)
                  print(f'Listening on port {port}')
              print(f'{len(sockets)} listeners started')
              while True:
                  time.sleep(3600)
```

The UI was checked and the pages were navigated for both deployments.

<img width="1915" height="907" alt="Screenshot From 2026-08-07 11-50-22" src="https://github.com/user-attachments/assets/6387d403-4875-41f4-8892-d43796cabe02" />

<img width="1915" height="907" alt="Screenshot From 2026-08-07 11-50-31" src="https://github.com/user-attachments/assets/9a9e6afe-501c-4230-a67f-84b06d01cbba" />

<img width="1915" height="907" alt="Screenshot From 2026-08-07 11-50-38" src="https://github.com/user-attachments/assets/17432768-8dc2-4fe9-8422-2e6f8ba56aca" />


