### PR TITLE
ROX-35925: Add e2e tests for cluster/sensor compat UI

### DIFF
--- a/ui/apps/platform/cypress/integration/clusters/clustersSensorCompatibility.test.js
+++ b/ui/apps/platform/cypress/integration/clusters/clustersSensorCompatibility.test.js
@@ -1,0 +1,135 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import { interceptAndOverrideFeatureFlags } from '../../helpers/request';
+
+import { clustersAlias, visitClusters } from './Clusters.helpers';
+
+const metadata = {
+    version: '5.0.0',
+    buildFlavor: 'development',
+    releaseBuild: false,
+    licenseStatus: 'VALID',
+    compatibleSensorVersions: ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3'],
+};
+
+function makeCluster(name, sensorVersionCompatibility, sensorVersion = '5.0.0') {
+    return {
+        id: name,
+        name,
+        type: 'KUBERNETES_CLUSTER',
+        labels: {},
+        mainImage: 'quay.io/stackrox-io/main',
+        collectorImage: '',
+        centralApiEndpoint: 'central.stackrox.svc:443',
+        runtimeSupport: false,
+        collectionMethod: 'CORE_BPF',
+        admissionController: false,
+        admissionControllerUpdates: false,
+        admissionControllerEvents: false,
+        status: {
+            sensorVersion,
+            sensorVersionCompatibility,
+            upgradeStatus: {
+                upgradability: 'UP_TO_DATE',
+                upgradabilityStatusReason: '',
+                mostRecentProcess: null,
+            },
+            certExpiryStatus: { sensorCertExpiry: '2027-01-01T00:00:00Z' },
+        },
+        dynamicConfig: {
+            admissionControllerConfig: {
+                enabled: false,
+                timeoutSeconds: 3,
+                scanInline: false,
+                disableBypass: false,
+                enforceOnUpdates: false,
+            },
+            registryOverride: '',
+            disableAuditLogs: false,
+            autoLockProcessBaselinesConfig: null,
+        },
+        tolerationsConfig: { disabled: false },
+        priority: '0',
+        healthStatus: {
+            sensorHealthStatus: 'HEALTHY',
+            collectorHealthStatus: 'HEALTHY',
+            overallHealthStatus: 'HEALTHY',
+            admissionControlHealthStatus: 'HEALTHY',
+            scannerHealthStatus: 'UNINITIALIZED',
+            lastContact: '2026-08-07T00:00:00Z',
+            healthInfoComplete: true,
+            id: name,
+        },
+        slimCollector: true,
+        helmConfig: null,
+        mostRecentSensorId: null,
+        auditLogState: {},
+        sensorCapabilities: [],
+        initBundleId: '',
+        managedBy: 'MANAGER_TYPE_MANUAL',
+        admissionControllerFailOnError: false,
+    };
+}
+
+const clustersResponse = {
+    clusters: [
+        makeCluster('matched-cluster', 'SENSOR_VERSION_COMPATIBILITY_MATCHED'),
+        makeCluster(
+            'compatible-behind-cluster',
+            'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND',
+            '4.9.0'
+        ),
+        makeCluster(
+            'compatible-ahead-cluster',
+            'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD',
+            '5.1.0'
+        ),
+        makeCluster(
+            'incompatible-behind-cluster',
+            'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND',
+            '4.6.0'
+        ),
+        makeCluster(
+            'incompatible-ahead-cluster',
+            'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD',
+            '5.4.0'
+        ),
+        makeCluster('unknown-cluster', 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN', ''),
+        makeCluster('unexpected-cluster', 'SOME_FUTURE_ENUM_VALUE', '5.0.0'),
+    ],
+    clusterIdToRetentionInfo: {},
+};
+
+describe('Clusters Sensor Compatibility Status', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_SENSOR_COMPATIBILITY_STATUS')) {
+            this.skip();
+        }
+    });
+
+    beforeEach(() => {
+        interceptAndOverrideFeatureFlags({ ROX_SENSOR_COMPATIBILITY_STATUS: true });
+        cy.intercept('GET', 'v1/metadata', { body: metadata }).as('metadata');
+    });
+
+    it('should display the sensor compatibility status column and cell values', () => {
+        visitClusters({
+            [clustersAlias]: { body: clustersResponse },
+        });
+        cy.wait('@metadata');
+
+        cy.get('th:contains("Sensor compatibility status")');
+
+        const compatCell = 'td[data-label="Sensor compatibility status"]';
+        cy.get(compatCell).eq(0).should('contain', 'Matched');
+        cy.get(compatCell).eq(1).should('contain', 'Compatible (Behind)');
+        cy.get(compatCell).eq(2).should('contain', 'Compatible (Ahead)');
+        cy.get(compatCell).eq(3).should('contain', 'Incompatible (Behind)');
+        cy.get(compatCell).eq(4).should('contain', 'Incompatible (Ahead)');
+        cy.get(compatCell).eq(5).should('contain', 'Unknown');
+        // Unexpected enum value from server should fall back to Unknown
+        cy.get(compatCell).eq(6).should('contain', 'Unknown');
+    });
+});


### PR DESCRIPTION
## Description

Tests display of sensor compatibility in the clusters table when the flag is enabled. Mocks data to cover all expected cases, and one unexpected case.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Currently disabled in CI, but a local run:
<img width="1780" height="1146" alt="image" src="https://github.com/user-attachments/assets/c4934ba1-4539-4071-af95-aa8e4ca767f3" />

