### PR TITLE
fix(ci): skip prefetcher metrics on IPv6-primary clusters

### DIFF
--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -12,8 +12,9 @@ from common import enable_sfa_for_ocp
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["KUBERNETES_PROVIDER"] = "ocp"
-# Workload identities are only set up for `openshift-4` infra clusters.
-if 'openshift-4' in os.environ.get('CLUSTER_FLAVOR_VARIANT', ''):
+# Workload identities are only set up for GCP `openshift-4` infra clusters.
+if 'openshift-4' in os.environ.get('CLUSTER_FLAVOR_VARIANT', '') \
+        and os.environ.get('CLOUD_PROVIDER', 'gcp') != 'aws':
     os.environ["SETUP_WORKLOAD_IDENTITIES"] = "true"
 
 enable_sfa_for_ocp()

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -730,12 +730,17 @@ image_prefetcher_start_set() {
     esac
 
     # daemonset, etc
+    local collect_metrics="--collect-metrics"
+    if [[ "${NETWORK_STACK:-}" =~ ipv6 ]]; then
+        collect_metrics=""
+        info "Skipping prefetcher metrics collection (LoadBalancer not supported on IPv6-primary)"
+    fi
     ${image_prefetcher_deploy_bin} \
         --use-kubelet-image-credential-integration="${kubelet_image_creds}" \
         --version="${image_prefetcher_version}" \
         --k8s-flavor="$flavor" \
         --secret=stackrox \
-        --collect-metrics \
+        ${collect_metrics} \
         --namespace="$ns" \
         "$name" > "$manifest"
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -898,6 +898,11 @@ EOM
         fi
         rm -f "${query}"
     fi
+    # Skip metrics retrieval on IPv6 clusters where CLB-backed metrics services can't be created
+    if [[ "${NETWORK_STACK:-}" =~ ipv6 ]] || kubectl get network.config.openshift.io cluster -o jsonpath='{.spec.serviceNetwork[0]}' 2>/dev/null | grep -q ':'; then
+        info "Skipping prefetcher metrics retrieval (CLB not supported on IPv6 clusters)"
+        return
+    fi
     info "Now retrieving prefetcher metrics..."
     local attempt=0
     local service="service/${name}-metrics"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -731,9 +731,11 @@ image_prefetcher_start_set() {
 
     # daemonset, etc
     local collect_metrics="--collect-metrics"
-    if [[ "${NETWORK_STACK:-}" =~ ipv6 ]]; then
+    # AWS CLBs don't support IPv6. Skip metrics (which creates a LoadBalancer service)
+    # on IPv6-primary clusters. Check env var first, then detect from cluster config.
+    if [[ "${NETWORK_STACK:-}" =~ ipv6 ]] || kubectl get network.config.openshift.io cluster -o jsonpath='{.spec.serviceNetwork[0]}' 2>/dev/null | grep -q ':'; then
         collect_metrics=""
-        info "Skipping prefetcher metrics collection (LoadBalancer not supported on IPv6-primary)"
+        info "Skipping prefetcher metrics collection (CLB not supported on IPv6 clusters)"
     fi
     ${image_prefetcher_deploy_bin} \
         --use-kubelet-image-credential-integration="${kubelet_image_creds}" \

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -355,7 +355,12 @@ export_test_environment() {
     ci_export COLLECTION_METHOD "${COLLECTION_METHOD:-core_bpf}"
     ci_export DEPLOY_STACKROX_VIA_OPERATOR "${DEPLOY_STACKROX_VIA_OPERATOR:-false}"
     ci_export INSTALL_COMPLIANCE_OPERATOR "${INSTALL_COMPLIANCE_OPERATOR:-false}"
-    ci_export LOAD_BALANCER "${LOAD_BALANCER:-lb}"
+    local _lb_default="lb"
+    # AWS CLBs don't support IPv6; use route on IPv6-primary clusters
+    if [[ "${NETWORK_STACK:-}" =~ ipv6 ]] || kubectl get network.config.openshift.io cluster -o jsonpath='{.spec.serviceNetwork[0]}' 2>/dev/null | grep -q ':'; then
+        _lb_default="route"
+    fi
+    ci_export LOAD_BALANCER "${LOAD_BALANCER:-${_lb_default}}"
     ci_export LOCAL_PORT "${LOCAL_PORT:-443}"
     ci_export MONITORING_SUPPORT "${MONITORING_SUPPORT:-false}"
     ci_export SCANNER_SUPPORT "${SCANNER_SUPPORT:-true}"


### PR DESCRIPTION
AWS Classic Load Balancers do not support IPv6. On dual-stack IPv6-primary OCP clusters, the image prefetcher's metrics service (type: LoadBalancer) fails with:

```
Error syncing load balancer: failed to ensure load balancer:
classic load balancer for service stackrox-images-metrics does not support IPv6
```

This causes the e2e test to timeout waiting for the metrics endpoint, which cascades into the ACS deployment test also failing.

Fix: skip `--collect-metrics` when `NETWORK_STACK` contains "ipv6". The prefetcher still runs and pre-fetches images — only the LoadBalancer-based metrics collection is skipped.

Observed in rehearsals on PR openshift/release#83132 and #83114.

ROX-10856