### PR TITLE
fix(style): use new(x) instead of github.String

### DIFF
--- a/tools/retest/github_test.go
+++ b/tools/retest/github_test.go
@@ -69,7 +69,7 @@ func Test_jobStateMapping(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			if tt.fromCheck {
-				check := &github.CheckRun{Conclusion: github.String(tt.raw)}
+				check := &github.CheckRun{Conclusion: new(tt.raw)}
 				assert.Equal(t, tt.wantState, checkToState(check))
 				return
 			}


### PR DESCRIPTION
## Description

`golangci-lint`'s `modernize` check (`newexpr`) flags `github.String(x)` on Go 1.26: the same `*string` can be written as `new(x)`.

This updates the one call site in `tools/retest/github_test.go` so style CI passes. Behavior is unchanged.
Not sure how the original PR passed through the style checks...

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI