### PR TITLE
ROX-35959: Add version skew API and roxctl central version

### DIFF
--- a/roxctl/central/central.go
+++ b/roxctl/central/central.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stackrox/rox/roxctl/central/m2m"
 	"github.com/stackrox/rox/roxctl/central/migratetooperator"
 	"github.com/stackrox/rox/roxctl/central/userpki"
+	centralversion "github.com/stackrox/rox/roxctl/central/version"
 	"github.com/stackrox/rox/roxctl/central/whoami"
 	"github.com/stackrox/rox/roxctl/common/environment"
 )
@@ -32,6 +33,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		backup.Command(cliEnvironment, new(true)),
 		debug.Command(cliEnvironment),
 		userpki.Command(cliEnvironment),
+		centralversion.Command(cliEnvironment),
 		whoami.Command(cliEnvironment),
 		initbundles.Command(cliEnvironment),
 		login.Command(cliEnvironment),

--- a/roxctl/central/version/version.go
+++ b/roxctl/central/version/version.go
@@ -1,0 +1,210 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version"
+	"github.com/stackrox/rox/pkg/version/productstreams"
+	"github.com/stackrox/rox/pkg/version/versioncompatibility"
+	"github.com/stackrox/rox/roxctl/common"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/common/util"
+)
+
+type centralVersionCommand struct {
+	env          environment.Environment
+	timeout      time.Duration
+	retryTimeout time.Duration
+}
+
+type versionResult struct {
+	RoxctlVersion             string   `json:"RoxctlVersion"`
+	CentralVersion            string   `json:"CentralVersion"`
+	CompatibleCentralVersions []string `json:"CompatibleCentralVersions"`
+	Compatibility             string   `json:"Compatibility"`
+	Guidance                  string   `json:"Guidance"`
+
+	compatibility versioncompatibility.Compatibility
+}
+
+// Command defines the central version command.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	cbr := &cobra.Command{
+		Use:           "version",
+		Short:         "Display Central's version and check compatibility with this roxctl",
+		SilenceErrors: true,
+		RunE: util.RunENoArgs(func(c *cobra.Command) error {
+			cmd := makeCentralVersionCommand(cliEnvironment, c)
+			useJSON, _ := c.Flags().GetBool("json")
+			return cmd.run(useJSON)
+		}),
+	}
+
+	flags.AddTimeout(cbr)
+	flags.AddRetryTimeout(cbr)
+	cbr.PersistentFlags().Bool("json", false, "Display version and compatibility information as JSON.")
+	return cbr
+}
+
+func makeCentralVersionCommand(cliEnvironment environment.Environment, cbr *cobra.Command) *centralVersionCommand {
+	return &centralVersionCommand{
+		env:          cliEnvironment,
+		timeout:      flags.Timeout(cbr),
+		retryTimeout: flags.RetryTimeout(cbr),
+	}
+}
+
+func (cmd *centralVersionCommand) run(useJSON bool) error {
+	result, err := cmd.fetchAndClassify()
+	if err != nil {
+		cmd.env.Logger().ErrfLn("%v", err)
+		return err
+	}
+
+	if useJSON {
+		if err := cmd.printJSON(result); err != nil {
+			cmd.env.Logger().ErrfLn("%v", err)
+			return err
+		}
+	} else {
+		cmd.printText(result)
+	}
+	return nil
+}
+
+func (cmd *centralVersionCommand) fetchAndClassify() (*versionResult, error) {
+	roxctlVersion := version.GetMainVersion()
+
+	conn, err := cmd.env.GRPCConnection(common.WithRetryTimeout(cmd.retryTimeout))
+	if err != nil {
+		return nil, errors.Wrap(err, "establishing gRPC connection to Central")
+	}
+	defer utils.IgnoreError(conn.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), cmd.timeout)
+	defer cancel()
+
+	metadata, err := v1.NewMetadataServiceClient(conn).GetMetadata(ctx, &v1.Empty{})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting Central metadata")
+	}
+
+	centralVersion := metadata.GetVersion()
+	if centralVersion == "" {
+		return nil, errors.New(
+			"Central did not return its version. " +
+				"This typically means roxctl is not authenticated. " +
+				"Run \"roxctl central login\" first")
+	}
+
+	centralXY, err := productstreams.ParseXYFromVersionString(centralVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing Central version %q", centralVersion)
+	}
+
+	compat, err := versioncompatibility.ClassifyVersion(centralXY)
+	if err != nil {
+		return nil, errors.Wrap(err, "classifying Central version")
+	}
+
+	compatVersions, err := versioncompatibility.CompatibleVersions()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting compatible versions")
+	}
+	compatStrs := make([]string, 0, len(compatVersions))
+	for _, v := range compatVersions {
+		compatStrs = append(compatStrs, v.String())
+	}
+
+	return &versionResult{
+		RoxctlVersion:             roxctlVersion,
+		CentralVersion:            centralVersion,
+		CompatibleCentralVersions: compatStrs,
+		Compatibility:             compatibilityToString(compat),
+		Guidance:                  guidance(compat),
+		compatibility:             compat,
+	}, nil
+}
+
+func (cmd *centralVersionCommand) printText(r *versionResult) {
+	const labelFmt = "%-29s%s"
+	cmd.env.Logger().PrintfLn(labelFmt, "Central version:", r.CentralVersion)
+	cmd.env.Logger().PrintfLn(labelFmt, "roxctl version:", r.RoxctlVersion)
+	cmd.env.Logger().PrintfLn("  Compatible Central versions: %s", strings.Join(r.CompatibleCentralVersions, ", "))
+	cmd.env.Logger().PrintfLn(labelFmt, "Compatibility:", displayName(r.compatibility))
+	for line := range strings.SplitSeq(r.Guidance, "\n") {
+		cmd.env.Logger().PrintfLn("  %s", line)
+	}
+}
+
+func (cmd *centralVersionCommand) printJSON(r *versionResult) error {
+	enc := json.NewEncoder(cmd.env.InputOutput().Out())
+	enc.SetIndent("", "  ")
+	return errors.Wrap(enc.Encode(r), "encoding version information as JSON")
+}
+
+func displayName(c versioncompatibility.Compatibility) string {
+	switch c {
+	case versioncompatibility.Matched:
+		return "Matched"
+	case versioncompatibility.CompatibleBehind:
+		return "Compatible (Behind)"
+	case versioncompatibility.CompatibleAhead:
+		return "Compatible (Ahead)"
+	case versioncompatibility.IncompatibleBehind:
+		return "Incompatible (Behind)"
+	case versioncompatibility.IncompatibleAhead:
+		return "Incompatible (Ahead)"
+	default:
+		return "Unknown"
+	}
+}
+
+func compatibilityToString(c versioncompatibility.Compatibility) string {
+	switch c {
+	case versioncompatibility.Unknown:
+		return "UNKNOWN"
+	case versioncompatibility.Matched:
+		return "MATCHED"
+	case versioncompatibility.CompatibleBehind:
+		return "COMPATIBLE_BEHIND"
+	case versioncompatibility.CompatibleAhead:
+		return "COMPATIBLE_AHEAD"
+	case versioncompatibility.IncompatibleBehind:
+		return "INCOMPATIBLE_BEHIND"
+	case versioncompatibility.IncompatibleAhead:
+		return "INCOMPATIBLE_AHEAD"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func guidance(c versioncompatibility.Compatibility) string {
+	switch c {
+	case versioncompatibility.Matched:
+		return "roxctl version is matched with Central."
+	case versioncompatibility.CompatibleAhead:
+		return "Central version is compatible with roxctl but is ahead of roxctl.\n" +
+			"No immediate action is required. Upgrade roxctl to match Central for optimal functionality."
+	case versioncompatibility.CompatibleBehind:
+		return "Central version is compatible with roxctl but is behind roxctl.\n" +
+			"No immediate action is required. It is recommended to plan a Central upgrade. " +
+			"If you prefer not to upgrade Central, suggest downgrading roxctl to match Central as the alternative option."
+	case versioncompatibility.IncompatibleAhead:
+		return "Central version is outside the compatible version range and is ahead roxctl.\n" +
+			"Upgrade roxctl to match Central, or at minimum to within the compatible version range."
+	case versioncompatibility.IncompatibleBehind:
+		return "Central version is outside the compatible version range and is behind roxctl.\n" +
+			"Plan a Central upgrade or downgrade roxctl to be within the compatible version range."
+	default:
+		return ""
+	}
+}

--- a/roxctl/central/version/version_test.go
+++ b/roxctl/central/version/version_test.go
@@ -1,0 +1,257 @@
+package version
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/version/productstreams"
+	"github.com/stackrox/rox/pkg/version/testutils"
+	"github.com/stackrox/rox/pkg/version/versioncompatibility"
+	"github.com/stackrox/rox/roxctl/common/environment/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const testBumpsYAML = `bumps:
+  - from: "3.74"
+    to: "4.0"
+  - from: "4.11"
+    to: "5.0"
+`
+
+func TestCentralVersionCommand(t *testing.T) {
+	suite.Run(t, new(centralVersionTestSuite))
+}
+
+type centralVersionTestSuite struct {
+	suite.Suite
+}
+
+type mockMetadataServer struct {
+	v1.UnimplementedMetadataServiceServer
+	version string
+}
+
+func (m *mockMetadataServer) GetMetadata(_ context.Context, _ *v1.Empty) (*v1.Metadata, error) {
+	return &v1.Metadata{Version: m.version}, nil
+}
+
+func (c *centralVersionTestSuite) createGRPCMockService(server *mockMetadataServer) (*grpc.ClientConn, func()) {
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+
+	srv := grpc.NewServer()
+	v1.RegisterMetadataServiceServer(srv, server)
+
+	go func() {
+		utils.IgnoreError(func() error { return srv.Serve(listener) })
+	}()
+
+	conn, err := grpc.DialContext(context.Background(), "",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	c.Require().NoError(err)
+
+	return conn, func() {
+		utils.IgnoreError(listener.Close)
+		srv.Stop()
+	}
+}
+
+func (c *centralVersionTestSuite) setupCommand(server *mockMetadataServer) (cmd *centralVersionCommand, stdout, stderr *bytes.Buffer, cleanup func()) {
+	testutils.SetMainVersion(c.T(), "5.0.0-testing")
+	conn, closeFunc := c.createGRPCMockService(server)
+	env, out, errOut := mocks.NewEnvWithConn(conn, c.T())
+	cmd = &centralVersionCommand{
+		env:          env,
+		timeout:      5 * time.Second,
+		retryTimeout: 5 * time.Second,
+	}
+	return cmd, out, errOut, closeFunc
+}
+
+func (c *centralVersionTestSuite) TestCompatibilityStates() {
+	productstreams.OverrideBumpsForTesting(c.T(), testBumpsYAML)
+
+	tests := map[string]struct {
+		centralVersion string
+		wantCompat     versioncompatibility.Compatibility
+		wantDisplay    string
+	}{
+		"matched": {
+			centralVersion: "5.0.2",
+			wantCompat:     versioncompatibility.Matched,
+			wantDisplay:    "Matched",
+		},
+		"compatible ahead": {
+			centralVersion: "5.3.1",
+			wantCompat:     versioncompatibility.CompatibleAhead,
+			wantDisplay:    "Compatible (Ahead)",
+		},
+		"compatible behind": {
+			centralVersion: "4.10.1",
+			wantCompat:     versioncompatibility.CompatibleBehind,
+			wantDisplay:    "Compatible (Behind)",
+		},
+		"incompatible ahead": {
+			centralVersion: "5.6.0",
+			wantCompat:     versioncompatibility.IncompatibleAhead,
+			wantDisplay:    "Incompatible (Ahead)",
+		},
+		"incompatible behind": {
+			centralVersion: "4.5.2",
+			wantCompat:     versioncompatibility.IncompatibleBehind,
+			wantDisplay:    "Incompatible (Behind)",
+		},
+	}
+
+	for name, tt := range tests {
+		c.Run(name, func() {
+			cmd, stdout, _, cleanup := c.setupCommand(&mockMetadataServer{version: tt.centralVersion})
+			defer cleanup()
+
+			err := cmd.run(false)
+
+			c.Assert().NoError(err)
+
+			output := stdout.String()
+			c.Assert().Contains(output, "Central version:")
+			c.Assert().Contains(output, tt.centralVersion)
+			c.Assert().Contains(output, "roxctl version:")
+			c.Assert().Contains(output, "5.0.0")
+			c.Assert().Contains(output, "Compatible Central versions:")
+			c.Assert().Contains(output, "Compatibility:")
+			c.Assert().Contains(output, tt.wantDisplay)
+			for line := range strings.SplitSeq(guidance(tt.wantCompat), "\n") {
+				c.Assert().Contains(output, "  "+line)
+			}
+		})
+	}
+}
+
+func (c *centralVersionTestSuite) TestEmptyVersionReturnsAuthError() {
+	productstreams.OverrideBumpsForTesting(c.T(), testBumpsYAML)
+
+	cmd, stdout, _, cleanup := c.setupCommand(&mockMetadataServer{version: ""})
+	defer cleanup()
+
+	err := cmd.run(false)
+
+	c.Require().Error(err)
+	c.Assert().Contains(err.Error(), "not authenticated")
+	c.Assert().Empty(stdout.String())
+}
+
+func (c *centralVersionTestSuite) TestJSONOutput() {
+	productstreams.OverrideBumpsForTesting(c.T(), testBumpsYAML)
+
+	cmd, stdout, _, cleanup := c.setupCommand(&mockMetadataServer{version: "5.0.2"})
+	defer cleanup()
+
+	err := cmd.run(true)
+	c.Require().NoError(err)
+
+	var result versionResult
+	c.Require().NoError(json.Unmarshal(stdout.Bytes(), &result))
+
+	c.Assert().Equal("5.0.0-testing", result.RoxctlVersion)
+	c.Assert().Equal("5.0.2", result.CentralVersion)
+	c.Assert().Equal("MATCHED", result.Compatibility)
+	c.Assert().NotEmpty(result.CompatibleCentralVersions)
+	c.Assert().NotEmpty(result.Guidance)
+}
+
+func (c *centralVersionTestSuite) TestJSONOutputIncompatible() {
+	productstreams.OverrideBumpsForTesting(c.T(), testBumpsYAML)
+
+	cmd, stdout, _, cleanup := c.setupCommand(&mockMetadataServer{version: "5.6.0"})
+	defer cleanup()
+
+	err := cmd.run(true)
+
+	c.Assert().NoError(err)
+
+	var result versionResult
+	c.Require().NoError(json.Unmarshal(stdout.Bytes(), &result))
+
+	c.Assert().Equal("INCOMPATIBLE_AHEAD", result.Compatibility)
+	c.Assert().Equal("5.6.0", result.CentralVersion)
+}
+
+func (c *centralVersionTestSuite) TestTextOutputFormat() {
+	productstreams.OverrideBumpsForTesting(c.T(), testBumpsYAML)
+
+	cmd, stdout, _, cleanup := c.setupCommand(&mockMetadataServer{version: "5.0.2"})
+	defer cleanup()
+
+	err := cmd.run(false)
+	c.Require().NoError(err)
+
+	output := stdout.String()
+	c.Assert().Contains(output, "Central version:             5.0.2")
+	c.Assert().Contains(output, "roxctl version:              5.0.0")
+	c.Assert().Contains(output, "Compatibility:               Matched")
+	c.Assert().Contains(output, "  Compatible Central versions:")
+	c.Assert().Contains(output, "  roxctl version is matched with Central.")
+}
+
+func TestDisplayName(t *testing.T) {
+	tests := map[string]struct {
+		c    versioncompatibility.Compatibility
+		want string
+	}{
+		"matched":             {versioncompatibility.Matched, "Matched"},
+		"compatible behind":   {versioncompatibility.CompatibleBehind, "Compatible (Behind)"},
+		"compatible ahead":    {versioncompatibility.CompatibleAhead, "Compatible (Ahead)"},
+		"incompatible behind": {versioncompatibility.IncompatibleBehind, "Incompatible (Behind)"},
+		"incompatible ahead":  {versioncompatibility.IncompatibleAhead, "Incompatible (Ahead)"},
+		"unknown":             {versioncompatibility.Unknown, "Unknown"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, displayName(tt.c))
+		})
+	}
+}
+
+func TestGuidance(t *testing.T) {
+	tests := map[string]struct {
+		c         versioncompatibility.Compatibility
+		wantEmpty bool
+		contains  string
+	}{
+		"matched":             {versioncompatibility.Matched, false, "matched with Central"},
+		"compatible ahead":    {versioncompatibility.CompatibleAhead, false, "ahead of roxctl"},
+		"compatible behind":   {versioncompatibility.CompatibleBehind, false, "behind roxctl"},
+		"incompatible ahead":  {versioncompatibility.IncompatibleAhead, false, "outside the compatible version range"},
+		"incompatible behind": {versioncompatibility.IncompatibleBehind, false, "outside the compatible version range"},
+		"unknown":             {versioncompatibility.Unknown, true, ""},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := guidance(tt.c)
+			if tt.wantEmpty {
+				assert.Empty(t, g)
+			} else {
+				require.NotEmpty(t, g)
+				assert.Contains(t, g, tt.contains)
+			}
+		})
+	}
+}

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -1085,6 +1085,25 @@ central:
         - server-name
         - token-file
         - use-current-k8s-context
+  version:
+    PERSISTENT_FLAGS:
+      - json
+      - retry-timeout
+      - timeout
+    INHERITED_FLAGS:
+      - ca
+      - direct-grpc
+      - endpoint
+      - force-http1
+      - help
+      - insecure
+      - insecure-skip-tls-verify
+      - no-color
+      - password
+      - plaintext
+      - server-name
+      - token-file
+      - use-current-k8s-context
   whoami:
     PERSISTENT_FLAGS:
       - retry-timeout

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -1065,6 +1065,25 @@ central:
         - server-name
         - token-file
         - use-current-k8s-context
+  version:
+    PERSISTENT_FLAGS:
+      - json
+      - retry-timeout
+      - timeout
+    INHERITED_FLAGS:
+      - ca
+      - direct-grpc
+      - endpoint
+      - force-http1
+      - help
+      - insecure
+      - insecure-skip-tls-verify
+      - no-color
+      - password
+      - plaintext
+      - server-name
+      - token-file
+      - use-current-k8s-context
   whoami:
     PERSISTENT_FLAGS:
       - retry-timeout


### PR DESCRIPTION
## Description

Implement version skew detection between roxctl and Central.  **`roxctl central version` command**: Contacts Central via gRPC, retrieves its version, classifies compatibility, and prints a structured report (text or `--json`). Empty Central version (unauthenticated) is treated as an auth error.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests for `roxctl central version` cover all 5 compatibility states (text + JSON output), auth error on empty version, display names, and guidance messages.