### PR TITLE
ROX-36012: Migrate compliance operator handler ComplianceRequest routing to PubSub

### DIFF
--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,7 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	ComplianceOperatorRequestConsumer
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		ComplianceOperatorRequestConsumer:      "ComplianceOperatorRequest",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	ComplianceOperatorRequestLane
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		ComplianceOperatorRequestLane:  "ComplianceOperatorRequest",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	ComplianceOperatorRequestTopic
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		ComplianceOperatorRequestTopic:  "ComplianceOperatorRequest",
 	}
 )
 

--- a/sensor/kubernetes/complianceoperator/handler_impl.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl.go
@@ -16,12 +16,14 @@ import (
 	"github.com/stackrox/rox/pkg/complianceoperator"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errorhelpers"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/k8sapi"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	kubeAPIErr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,6 +53,7 @@ type handlerImpl struct {
 	handlerMaxRetries     int
 	handlerAPICallTimeout time.Duration
 	handlerRetryTimeout   time.Duration
+	pubSubDispatcher      common.PubSubDispatcher
 }
 
 func (m *handlerImpl) Name() string {
@@ -66,7 +69,7 @@ type scanScheduleConfiguration struct {
 }
 
 // NewRequestHandler returns instance of common.SensorComponent interface which can handle compliance requests from Central.
-func NewRequestHandler(client dynamic.Interface, complianceOperatorInfo StatusInfo, coIsReady *concurrency.Signal) common.SensorComponent {
+func NewRequestHandler(client dynamic.Interface, complianceOperatorInfo StatusInfo, coIsReady *concurrency.Signal, pubSubDispatcher common.PubSubDispatcher) common.SensorComponent {
 	return &handlerImpl{
 		client:                 client,
 		complianceOperatorInfo: complianceOperatorInfo,
@@ -81,12 +84,23 @@ func NewRequestHandler(client dynamic.Interface, complianceOperatorInfo StatusIn
 		handlerMaxRetries:     defaultMaxRetries,
 		handlerAPICallTimeout: defaultAPICallTimeout,
 		handlerRetryTimeout:   defaultRetryTimeout,
+		pubSubDispatcher:      pubSubDispatcher,
 	}
 }
 
 func (m *handlerImpl) Start() error {
 	defer m.started.Store(true)
 	// TODO: create default scan setting for ad-hoc scan
+	if features.SensorInternalPubSub.Enabled() && m.pubSubDispatcher != nil {
+		if err := m.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.ComplianceOperatorRequestConsumer,
+			pubsub.ComplianceOperatorRequestTopic,
+			pubsub.ComplianceOperatorRequestLane,
+			m.handleComplianceRequestEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register compliance operator request consumer")
+		}
+	}
 	go m.run()
 	return nil
 }
@@ -123,6 +137,20 @@ func (m *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSens
 		return errors.Errorf("the compliance operator handler was not started ignoring message %v to avoid blocking", msg.GetComplianceRequest())
 	}
 
+	if features.SensorInternalPubSub.Enabled() && m.pubSubDispatcher != nil {
+		select {
+		case <-ctx.Done():
+			return errors.Wrapf(ctx.Err(), "message processing in component %s", m.Name())
+		case <-m.stopSignal.Done():
+			return errors.Errorf("Could not process compliance request: %s", protoutils.NewWrapper(msg))
+		default:
+		}
+		if err := m.pubSubDispatcher.Publish(&ComplianceOperatorRequestEvent{Request: req}); err != nil {
+			return errors.Wrap(err, "publishing compliance operator request event")
+		}
+		return nil
+	}
+
 	select {
 	case <-ctx.Done():
 		// TODO(ROX-30333): Pass this context together with `req` to `m.request`
@@ -142,30 +170,46 @@ func (m *handlerImpl) run() {
 	for !m.stopSignal.IsDone() {
 		select {
 		case req := <-m.request:
-			var requestProcessed bool
-			operationName := fmt.Sprintf("%T", req.GetRequest())
-			switch r := req.GetRequest().(type) {
-			case *central.ComplianceRequest_EnableCompliance:
-				requestProcessed = m.enableCompliance(r.EnableCompliance)
-			case *central.ComplianceRequest_DisableCompliance:
-				requestProcessed = m.disableCompliance(r.DisableCompliance)
-			case *central.ComplianceRequest_ApplyScanConfig:
-				requestProcessed = m.processApplyScanCfgRequest(r.ApplyScanConfig)
-			case *central.ComplianceRequest_DeleteScanConfig:
-				requestProcessed = m.processDeleteScanCfgRequest(r.DeleteScanConfig)
-			}
-			commandsFromCentral.With(prometheus.Labels{
-				"operation": operationName,
-				"processed": strconv.FormatBool(requestProcessed)},
-			).Inc()
-
-			if !requestProcessed {
-				log.Errorf("Could not send response for compliance request: %s", protoutils.NewWrapper(req))
-			}
+			m.handleRequest(req)
 		case <-m.stopSignal.Done():
 			return
 		}
 	}
+}
+
+// handleRequest dispatches a ComplianceRequest to its handler and records the outcome. It is
+// called from run()'s legacy select loop and, in PubSub mode, from handleComplianceRequestEvent.
+func (m *handlerImpl) handleRequest(req *central.ComplianceRequest) {
+	var requestProcessed bool
+	operationName := fmt.Sprintf("%T", req.GetRequest())
+	switch r := req.GetRequest().(type) {
+	case *central.ComplianceRequest_EnableCompliance:
+		requestProcessed = m.enableCompliance(r.EnableCompliance)
+	case *central.ComplianceRequest_DisableCompliance:
+		requestProcessed = m.disableCompliance(r.DisableCompliance)
+	case *central.ComplianceRequest_ApplyScanConfig:
+		requestProcessed = m.processApplyScanCfgRequest(r.ApplyScanConfig)
+	case *central.ComplianceRequest_DeleteScanConfig:
+		requestProcessed = m.processDeleteScanCfgRequest(r.DeleteScanConfig)
+	}
+	commandsFromCentral.With(prometheus.Labels{
+		"operation": operationName,
+		"processed": strconv.FormatBool(requestProcessed)},
+	).Inc()
+
+	if !requestProcessed {
+		log.Errorf("Could not send response for compliance request: %s", protoutils.NewWrapper(req))
+	}
+}
+
+// handleComplianceRequestEvent adapts a PubSub ComplianceOperatorRequestEvent to handleRequest.
+func (m *handlerImpl) handleComplianceRequestEvent(event pubsub.Event) error {
+	requestEvent, ok := event.(*ComplianceOperatorRequestEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	m.handleRequest(requestEvent.Request)
+	return nil
 }
 
 func (m *handlerImpl) enableCompliance(request *central.EnableComplianceRequest) bool {

--- a/sensor/kubernetes/complianceoperator/handler_impl_pubsub_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_pubsub_test.go
@@ -1,0 +1,83 @@
+package complianceoperator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func newTestComplianceOperatorDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ComplianceOperatorRequestLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+// TestPubSubComplianceRequestRouted verifies ProcessMessage() publishes a
+// ComplianceOperatorRequestEvent instead of writing to the legacy request channel when PubSub is
+// enabled, and that the response still comes out the other end via ResponsesC().
+func TestPubSubComplianceRequestRouted(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestComplianceOperatorDispatcher(t)
+	defer dispatcher.Stop()
+
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	readySignal := concurrency.NewSignal()
+	handler := NewRequestHandler(client, nil, &readySignal, dispatcher)
+	require.NoError(t, handler.Start())
+	defer handler.Stop()
+
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_ComplianceRequest{
+			ComplianceRequest: &central.ComplianceRequest{
+				Request: &central.ComplianceRequest_DisableCompliance{
+					DisableCompliance: &central.DisableComplianceRequest{
+						Id: uuid.NewV4().String(),
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, handler.ProcessMessage(t.Context(), msg))
+
+	select {
+	case response := <-handler.ResponsesC():
+		disableResponse := response.Msg.(*central.MsgFromSensor_ComplianceResponse).ComplianceResponse.GetDisableComplianceResponse()
+		require.NotNil(t, disableResponse)
+		require.Equal(t, msg.GetComplianceRequest().GetDisableCompliance().GetId(), disableResponse.GetId())
+		require.Empty(t, disableResponse.GetError())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for compliance response via pubsub")
+	}
+}
+
+// TestPubSubComplianceRequest_WrongEventType verifies handleComplianceRequestEvent rejects
+// events of an unexpected type instead of silently ignoring or panicking.
+func TestPubSubComplianceRequest_WrongEventType(t *testing.T) {
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	readySignal := concurrency.NewSignal()
+	handler := NewRequestHandler(client, nil, &readySignal, nil).(*handlerImpl)
+
+	require.Error(t, handler.handleComplianceRequestEvent(&wrongComplianceOperatorEvent{}))
+}
+
+type wrongComplianceOperatorEvent struct{}
+
+func (*wrongComplianceOperatorEvent) Topic() pubsub.Topic { return pubsub.DefaultTopic }
+func (*wrongComplianceOperatorEvent) Lane() pubsub.LaneID { return pubsub.DefaultLane }

--- a/sensor/kubernetes/complianceoperator/handler_impl_test.go
+++ b/sensor/kubernetes/complianceoperator/handler_impl_test.go
@@ -50,7 +50,7 @@ func (s *HandlerTestSuite) SetupTest() {
 	s.client = fake.NewSimpleDynamicClient(runtime.NewScheme(), &v1alpha1.ScanSettingBinding{TypeMeta: v1.TypeMeta{Kind: "ScanSetting", APIVersion: complianceoperator.GetGroupVersion().String()}})
 	s.statusInfo = mocks.NewMockStatusInfo(gomock.NewController(s.T()))
 	readySignal := concurrency.NewSignal()
-	s.requestHandler = NewRequestHandler(s.client, s.statusInfo, &readySignal)
+	s.requestHandler = NewRequestHandler(s.client, s.statusInfo, &readySignal, nil)
 	handler, ok := s.requestHandler.(*handlerImpl)
 	s.Require().True(ok)
 	handler.handlerAPICallTimeout = 500 * time.Millisecond

--- a/sensor/kubernetes/complianceoperator/request_event.go
+++ b/sensor/kubernetes/complianceoperator/request_event.go
@@ -1,0 +1,20 @@
+package complianceoperator
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// ComplianceOperatorRequestEvent carries a ComplianceRequest handed off from Central to the
+// handler's own processing loop.
+type ComplianceOperatorRequestEvent struct {
+	Request *central.ComplianceRequest
+}
+
+func (e *ComplianceOperatorRequestEvent) Topic() pubsub.Topic {
+	return pubsub.ComplianceOperatorRequestTopic
+}
+
+func (e *ComplianceOperatorRequestEvent) Lane() pubsub.LaneID {
+	return pubsub.ComplianceOperatorRequestLane
+}

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,7 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.ComplianceOperatorRequestLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -234,7 +234,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	coReadySignal := concurrency.NewSignal()
 	coInfoUpdater := complianceoperator.NewInfoUpdater(cfg.k8sClient.Kubernetes(), 0, &coReadySignal)
-	components = append(components, coInfoUpdater, complianceoperator.NewRequestHandler(cfg.k8sClient.Dynamic(), coInfoUpdater, &coReadySignal))
+	components = append(components, coInfoUpdater, complianceoperator.NewRequestHandler(cfg.k8sClient.Dynamic(), coInfoUpdater, &coReadySignal, internalMessageDispatcher))
 
 	if !cfg.localSensor {
 		upgradeCmdHandler, err := upgrade.NewCommandHandler(clusterID, configHandler)


### PR DESCRIPTION
## Description
  
  Migrates the Compliance Operator handler's `ComplianceRequest` routing to the internal PubSub system, gated by `features.SensorInternalPubSub`
  (`ROX_SENSOR_PUBSUB`, default-enabled).

  - `ProcessMessage()` publishes a new `ComplianceOperatorRequestEvent` on a dedicated `ComplianceOperatorRequestTopic`/`ComplianceOperatorRequestLane`
  instead of writing to the unbuffered `request` channel, when the flag is enabled.
  - When disabled, the existing `ctx.Done()` / `request <-` / `stopSignal.Done()` select is untouched.
  - `run()`'s dispatch switch (`EnableCompliance`/`DisableCompliance`/`ApplyScanConfig`/`DeleteScanConfig` + the `commandsFromCentral` metric) is
  extracted into `handleRequest()`, shared by the legacy select loop and the new `handleComplianceRequestEvent` PubSub consumer callback, per the epic's
  "extract shared handler logic" rule.
  - `run()`'s legacy goroutine is still started unconditionally in PubSub mode — it simply never receives anything once `ProcessMessage()` stops writing
  to `request`. Same precedent as ROX-35978's Node Inventory Handler inbound intake: a harmless idle loop is simpler than adding start/stop branching.
  - `ComplianceRequest_SyncScanConfigs` handling (routed to a separate method before reaching the channel) is unaffected.

  No dependency on the Central-bound bridge (ROX-35640) — this is a `[central-in]` migration (Central → internal handoff), not a
  `ResponsesC()`/`[central-out]` one, so it branches directly off master.

  🤖 This change was partially generated with the assistance of AI.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**
  is not needed

  ## Testing and quality

  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is
  gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - Added `handler_impl_pubsub_test.go`: `TestPubSubComplianceRequestRouted` sends a `DisableCompliance` request through `ProcessMessage()` with a real
  dispatcher and `ROX_SENSOR_PUBSUB=true`, and verifies the response comes back correctly via `ResponsesC()` — proving the full Publish → lane →
  `handleComplianceRequestEvent` → `handleRequest` → response path. `TestPubSubComplianceRequest_WrongEventType` verifies `handleComplianceRequestEvent`
  rejects an unexpected event type instead of panicking or silently ignoring it.
  - The existing ~25-scenario `HandlerTestSuite` (all `TestProcess*` cases) passes unchanged against the legacy path — only its `NewRequestHandler(...)`
  call site needed a `nil` dispatcher arg.