### PR TITLE
perf: eliminate jsonb_agg from two-phase pagination Phase 1

### DIFF
--- a/central/views/imagecve/two_phase_bench_test.go
+++ b/central/views/imagecve/two_phase_bench_test.go
@@ -1,0 +1,80 @@
+//go:build sql_integration
+
+package imagecve
+
+import (
+	"context"
+	"testing"
+
+	imageDS "github.com/stackrox/rox/central/image/datastore"
+	imageV2DS "github.com/stackrox/rox/central/imagev2/datastore"
+	"github.com/stackrox/rox/central/views"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/fixtures"
+	imageSamples "github.com/stackrox/rox/pkg/fixtures/image"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkTwoPhaseGet(b *testing.B) {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Image),
+		))
+
+	testDB := pgtest.ForT(b)
+	cveView := NewCVEView(testDB.DB)
+
+	if features.FlattenImageData.Enabled() {
+		imageV2Store := imageV2DS.GetTestPostgresDataStore(b, testDB.DB)
+		imagesV2, err := imageSamples.GetTestImagesV2(&testing.T{})
+		require.NoError(b, err)
+		for _, img := range imagesV2 {
+			require.NoError(b, imageV2Store.UpsertImage(ctx, img))
+		}
+		b.Logf("Seeded %d V2 images", len(imagesV2))
+	} else {
+		imageStore := imageDS.GetTestPostgresDataStore(b, testDB.DB)
+		require.NoError(b, imageStore.UpsertImage(ctx, fixtures.GetImageSherlockHolmes1()))
+		require.NoError(b, imageStore.UpsertImage(ctx, fixtures.GetImageDoctorJekyll2()))
+		b.Logf("Seeded 2 V1 images")
+	}
+
+	paginatedQ := search.NewQueryBuilder().
+		AddStrings(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).
+		WithPagination(
+			search.NewPagination().
+				Limit(20).
+				AddSortOption(search.NewSortOption(search.CVSS).AggregateBy(aggregatefunc.Max, false)),
+		).ProtoQuery()
+
+	b.Run("paginated_cvss_sort", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results, err := cveView.Get(ctx, paginatedQ, views.ReadOptions{})
+			require.NoError(b, err)
+			require.NotEmpty(b, results)
+		}
+	})
+
+	severitySortQ := search.NewQueryBuilder().
+		AddStrings(search.VulnerabilityState, storage.VulnerabilityState_OBSERVED.String()).
+		WithPagination(
+			search.NewPagination().
+				Limit(20).
+				AddSortOption(search.NewSortOption(search.CriticalSeverityCount)),
+		).ProtoQuery()
+
+	b.Run("paginated_severity_count_sort", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results, err := cveView.Get(ctx, severitySortQ, views.ReadOptions{})
+			require.NoError(b, err)
+			require.NotEmpty(b, results)
+		}
+	})
+}

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -86,17 +86,15 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	// Update the sort options to use aggregations if necessary as we are grouping by CVEs
 	cloned = common.UpdateSortAggs(cloned)
 
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 	var err error
 	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
-		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
+		cvesToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			return nil, err
 		}
 
 		if cloned.GetPagination() != nil && cloned.GetPagination().GetSortOptions() != nil {
-			// The CVE ID list that we get from the above query is paginated. So when we fetch the details and aggregates for those CVEs,
-			// we do not need to re-apply pagination limit and offset
 			cloned.Pagination = &v1.QueryPagination{SortOptions: cloned.GetPagination().GetSortOptions()}
 		}
 	}
@@ -104,7 +102,7 @@ func (v *imageCVECoreViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	defer cancel()
 
 	ret := make([]CveCore, 0, paginated.GetLimit(q.GetPagination().GetLimit(), 100))
-	err = pgSearch.RunSelectRequestForSchemaFn[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVECoreResponseQuery(cloned, cveIDsToFilter, options), func(r *imageCVECoreResponse) error {
+	err = pgSearch.RunSelectRequestForSchemaFn[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVECoreResponseQuery(cloned, cvesToFilter, options), func(r *imageCVECoreResponse) error {
 		// For each record, sort the IDs so that result looks consistent.
 		sort.SliceStable(r.CVEIDs, func(i, j int) bool {
 			return r.CVEIDs[i] < r.CVEIDs[j]
@@ -181,7 +179,7 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	}
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{
-		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
+		search.NewQuerySelect(search.CVE).Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
 		Fields: []string{search.CVE.String()},
@@ -203,10 +201,10 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	return cloned
 }
 
-func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, options views.ReadOptions) *v1.Query {
+func withSelectCVECoreResponseQuery(q *v1.Query, cvesToFilter []string, options views.ReadOptions) *v1.Query {
 	cloned := q.CloneVT()
-	if len(cveIDsToFilter) > 0 {
-		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddDocIDs(cveIDsToFilter...).ProtoQuery())
+	if len(cvesToFilter) > 0 {
+		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddExactMatches(search.CVE, cvesToFilter...).ProtoQuery())
 		cloned.Pagination = q.GetPagination()
 	}
 	searchField := search.ImageSHA
@@ -244,22 +242,23 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	return cloned
 }
 
+type cveNameResponse struct {
+	CVE string `db:"cve"`
+}
+
 func (v *imageCVECoreViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
-	// TODO(@charmik) : Update the SQL query generator to not include 'ORDER BY' and 'GROUP BY' fields in the select clause (before where).
-	//  SQL syntax does not need those fields in the select clause. The below query for example would work fine
-	//  "SELECT JSONB_AGG(DISTINCT(image_cves.Id)) AS cve_id FROM image_cves GROUP BY image_cves.CveBaseInfo_Cve ORDER BY MAX(image_cves.Cvss) DESC LIMIT 20;"
-	err := pgSearch.RunSelectRequestForSchemaFn[imageCVECoreResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *imageCVECoreResponse) error {
-		cveIDsToFilter = append(cveIDsToFilter, r.CVEIDs...)
+	err := pgSearch.RunSelectRequestForSchemaFn[cveNameResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *cveNameResponse) error {
+		cvesToFilter = append(cvesToFilter, r.CVE)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return cveIDsToFilter, nil
+	return cvesToFilter, nil
 }

--- a/central/views/imagecveflat/view_impl.go
+++ b/central/views/imagecveflat/view_impl.go
@@ -52,19 +52,16 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	// Update the sort options to use aggregations if necessary as we are grouping by CVEs
 	cloned = common.UpdateSortAggs(cloned)
 
-	// Performance improvements to narrow aggregations performed
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 	var err error
 	if cloned.GetPagination().GetLimit() > 0 || cloned.GetPagination().GetOffset() > 0 {
-		cveIDsToFilter, err = v.getFilteredCVEs(ctx, cloned)
+		cvesToFilter, err = v.getFilteredCVEs(ctx, cloned)
 		if err != nil {
 			log.Error(err)
 			return nil, err
 		}
 
 		if cloned.GetPagination() != nil && cloned.GetPagination().GetSortOptions() != nil {
-			// The CVE ID list that we get from the above query is paginated. So when we fetch the details and aggregates for those CVEs,
-			// we do not need to re-apply pagination limit and offset
 			cloned.Pagination = &v1.QueryPagination{SortOptions: cloned.GetPagination().GetSortOptions()}
 		}
 	}
@@ -73,7 +70,7 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 	defer cancel()
 
 	var ret []CveFlat
-	err = pgSearch.RunSelectRequestForSchemaFn[imageCVEFlatResponse](queryCtx, v.db, v.schema, withSelectCVEFlatResponseQuery(cloned, cveIDsToFilter, options), func(r *imageCVEFlatResponse) error {
+	err = pgSearch.RunSelectRequestForSchemaFn[imageCVEFlatResponse](queryCtx, v.db, v.schema, withSelectCVEFlatResponseQuery(cloned, cvesToFilter, options), func(r *imageCVEFlatResponse) error {
 		// For each record, sort the IDs so that result looks consistent.
 		sort.SliceStable(r.CVEIDs, func(i, j int) bool {
 			return r.CVEIDs[i] < r.CVEIDs[j]
@@ -91,7 +88,7 @@ func (v *imageCVEFlatViewImpl) Get(ctx context.Context, q *v1.Query, options vie
 func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{
-		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
+		search.NewQuerySelect(search.CVE).Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
 		Fields: []string{search.CVE.String()},
@@ -100,10 +97,10 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	return cloned
 }
 
-func withSelectCVEFlatResponseQuery(q *v1.Query, cveIDsToFilter []string, options views.ReadOptions) *v1.Query {
+func withSelectCVEFlatResponseQuery(q *v1.Query, cvesToFilter []string, options views.ReadOptions) *v1.Query {
 	cloned := q.CloneVT()
-	if len(cveIDsToFilter) > 0 {
-		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddDocIDs(cveIDsToFilter...).ProtoQuery())
+	if len(cvesToFilter) > 0 {
+		cloned = search.ConjunctionQuery(cloned, search.NewQueryBuilder().AddExactMatches(search.CVE, cvesToFilter...).ProtoQuery())
 		cloned.Pagination = q.GetPagination()
 	}
 
@@ -145,17 +142,18 @@ func withSelectCVEFlatResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	return cloned
 }
 
+type cveNameResponse struct {
+	CVE string `db:"cve"`
+}
+
 func (v *imageCVEFlatViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
-	var cveIDsToFilter []string
+	var cvesToFilter []string
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
-	// TODO(@charmik) : Update the SQL query generator to not include 'ORDER BY' and 'GROUP BY' fields in the select clause (before where).
-	//  SQL syntax does not need those fields in the select clause. The below query for example would work fine
-	//  "SELECT JSONB_AGG(DISTINCT(image_cves.Id)) AS cve_id FROM image_cves GROUP BY image_cves.CveBaseInfo_Cve ORDER BY MAX(image_cves.Cvss) DESC LIMIT 20;"
-	err := pgSearch.RunSelectRequestForSchemaFn[imageCVEFlatResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *imageCVEFlatResponse) error {
-		cveIDsToFilter = append(cveIDsToFilter, r.CVEIDs...)
+	err := pgSearch.RunSelectRequestForSchemaFn[cveNameResponse](queryCtx, v.db, v.schema, withSelectCVEIdentifiersQuery(q), func(r *cveNameResponse) error {
+		cvesToFilter = append(cvesToFilter, r.CVE)
 		return nil
 	})
 	if err != nil {
@@ -163,5 +161,5 @@ func (v *imageCVEFlatViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query)
 		return nil, err
 	}
 
-	return cveIDsToFilter, nil
+	return cvesToFilter, nil
 }


### PR DESCRIPTION
Phase 1 of the two-phase CVE pagination query previously selected
CVEID (row IDs) which the search framework wraps in jsonb_agg()
when GROUP BY targets a non-PK field. On a 1.6M row table this
forced PostgreSQL into single-threaded GroupAggregate with a 160MB
disk-spilling sort (37s). Now selects CVE names directly — part of
the GROUP BY, no aggregation needed — enabling parallel hash
aggregate with in-memory quicksort (1s). Phase 2 filters by
cvebaseinfo_cve IN (...) using the existing btree index (218ms).

EXPLAIN ANALYZE on production cluster (1.6M rows, 16k unique CVEs):
  Phase 1 before: 37,026ms (disk sort, no parallelism)
  Phase 1 after:     993ms (in-memory, 2 parallel workers)
  Phase 2:           218ms (bitmap index scan, unchanged)

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
