### PR TITLE
fix(Makefile): Fix related image exports in operator quick-run target

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -310,10 +310,10 @@ run: check-ci-setup manifests generate ensure-rox-main-image-exists fmt vet quic
 quick-run: ## Same as run, but without ensuring dependencies.
 	@if [[ -n "$$MAIN_IMAGE_TAG" ]]; then \
 		echo "MAIN_IMAGE_TAG=$$MAIN_IMAGE_TAG specified, using related images with this tag."; \
-		IMAGE_REGISTRY=$(IMAGE_REPO) ./hack/related-images-with-main-tags.sh | while read -r line; do \
+		while read -r line; do \
 			echo " * $$line"; \
 			export "$$line"; \
-		done; \
+		done < <(IMAGE_REGISTRY=$(IMAGE_REPO) ./hack/related-images-with-main-tags.sh); \
 	fi ;\
 	../scripts/go-run.sh ./cmd/main.go
 


### PR DESCRIPTION
## Description

Fix the `quick-run` target: The previous version didn't actually export the values in a way that made them accessible to the next command, reason being that the pipe semantics caused the loop to execute in a sub shell.


## User-facing documentation

Nothing user facing.

## Testing and quality

This target is for manual tests.

### Automated testing

No production code path -- there are no tests for this.

### How I validated my change

```
MAIN_IMAGE_TAG=4.11.2 make -C operator quick-run
```

