### PR TITLE
fix(operator): Disable scanner-db-password generation in  SC reconcile

### DIFF
--- a/operator/internal/securedcluster/values/translation/base-values.yaml
+++ b/operator/internal/securedcluster/values/translation/base-values.yaml
@@ -10,6 +10,9 @@ meta:
   useLookup: false
 allowNonstandardReleaseName: true
 allowNonstandardNamespace: true
+scanner:
+  dbPassword:
+    generate: false
 scannerV4:
   indexer:
     serviceTLS:


### PR DESCRIPTION
## Description

### Problem

The `scanner-db-password` secret in SecuredCluster deployments lacks an `ownerReference` to the SecuredCluster CR, unlike the same secret in Central deployments. This prevents garbage collection on CR deletion.

**Root cause:** The SecuredCluster `base-values.yaml` does not set `scanner.dbPassword.generate: false`. During reconciliation, the pre-extension creates the secret on the cluster with an ownerReference. Then Helm renders the same secret as a `pre-install` hook (because `generate` defaults to true on install). The post-renderer sees `helm.sh/resource-policy: keep` on the rendered secret and skips adding an ownerReference. Helm's hook execution then overwrites the pre-extension's secret, losing the ownerReference.

Central does not have this problem because its `base-values.yaml` sets `scanner.dbPassword.generate: false`, preventing Helm from rendering and overwriting the secret.

### Fix

Add `scanner.dbPassword.generate: false` to the SecuredCluster `base-values.yaml`, matching Central's approach.

### Note on `resource-policy: keep`

The shared Helm template for this secret (`02-scanner-02-db-password-secret.yaml`) carries `helm.sh/resource-policy: keep`, which is unnecessary — the legacy scanner-db uses `emptyDir`, so there is no persistent storage that could get out of sync with a regenerated password. However, since the legacy scanner is deprecated and will be removed in a future version, we don't intend to change this.


## User-facing documentation

We don't currently include this kind of technical details in user-facing docs.

## Testing and quality

- [x] the change is production ready
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No tests changed or added.

### How I validated my change

Manual verification:
```
$ roxie deploy --single-namespace --envrc /dev/null -t 4.12.x-708-g619e8ac0d8 \
  && kubectl get secrets -n stackrox -o custom-columns='NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].name' \
  && roxie teardown all \
  && kubectl get secrets -n stackrox -o custom-columns='NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].name'
```

and (different namespaces):

```
$ roxie deploy --envrc /dev/null -t 4.12.x-708-g619e8ac0d8 \
  && kubectl get secrets -n acs-sensor -o custom-columns='NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].name' \
  && roxie teardown all \
  && kubectl get secrets -n acs-sensor -o custom-columns='NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].name'
```

