### PR TITLE
ROX-36126: flatten GCS per-source object path format

### DIFF
--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       object:
-        description: "Full GCS object path (gs://bucket/prefix/stream/sources/updater/data.json.zst)"
+        description: "Full GCS object path (gs://bucket/prefix/stream/sources/updater.json.zst)"
         required: true
         type: string
       manual_url:

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -83,7 +83,7 @@ jobs:
         set -euo pipefail
         bucket=$(yq '.storage.bucket' "$SOURCE_CONFIG")
         prefix=$(yq '.storage.prefix' "$SOURCE_CONFIG")
-        matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual/data.json.zst\"}]}"
+        matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual.json.zst\"}]}"
         printf '{"has_due":true,"has_errors":false,"errors":[],"matrix":%s}\n' "$matrix" > matrix-result.json
 
     - name: Validate matrix builder (PR)

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -43,7 +43,7 @@ prefix=$(yq '.storage.prefix' "$config")
                 done
       done \
     | while read -r stream ref updater; do
-          object="gs://${bucket}/${prefix}/${stream}/sources/${updater}/data.json.zst"
+          object="gs://${bucket}/${prefix}/${stream}/sources/${updater}.json.zst"
 
           # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
           if GCS_OBJECT="$object" \

--- a/scanner/updater/ci/source-config.yaml
+++ b/scanner/updater/ci/source-config.yaml
@@ -1,7 +1,7 @@
 # Per-updater configuration for the vulnerability update workflow.
 #
 # storage: GCS location for per-updater data objects. The object path
-# pattern is gs://<bucket>/<prefix>/<stream>/sources/<updater>/data.json.zst,
+# pattern is gs://<bucket>/<prefix>/<stream>/sources/<updater>.json.zst,
 # constructed by the matrix builder and passed to all downstream consumers.
 #
 # bundles: defines which updaters to include in each version stream's bundle.


### PR DESCRIPTION
## Description

Change the GCS object path for per-source vulnerability data from
`sources/<source>/data.json.zst` to `sources/<source>.json.zst`.

The directory-per-source layout offered no advantage over the flat layout
and prevented downloading all sources in a single `gcloud storage cp` glob
call. The flat format enables that optimization without closing the door on
sibling files (e.g. `sources/<source>.status.json` for future per-source
health metadata).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Path format is constructed in a single template expression in each affected
file. Change is mechanical and consistent across matrix builder, PR path
override, export workflow description, and source config comment. No
existing GCS objects in the test bucket require migration — the pipeline
will write to the new paths on the next scheduled export run.