### PR TITLE
ci: opt-in simulated-merge CI via ci-merge-test label

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/handle-tagged-build
 
@@ -170,7 +170,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -214,7 +214,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -292,7 +292,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -369,7 +369,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -400,7 +400,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
         fetch-depth: 0
-        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+        ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -445,7 +445,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -553,7 +553,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -642,7 +642,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -770,7 +770,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -841,7 +841,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+        ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -930,7 +930,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -1045,7 +1045,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -1132,7 +1132,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+        ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -1196,7 +1196,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+        ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -1237,7 +1237,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
         fetch-depth: 1
-        ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
+        ref: ${{ inputs.commit || (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:
@@ -296,7 +296,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -392,7 +392,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -435,7 +435,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -472,7 +472,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ (!contains(github.event.pull_request.labels.*.name, 'ci-merge-test') && github.event.pull_request.head.sha) || github.sha }}
 
       - uses: ./.github/actions/job-preamble
         with:


### PR DESCRIPTION
## Description

When the `ci-merge-test` label is present on a PR, GHA workflows checkout `github.sha` (the merge commit of PR + master at trigger time) instead of `pull_request.head.sha` (the PR branch tip). This tests the post-merge state rather than the PR branch in isolation.

Without the label, behavior is identical to today.

**Why:** All GHA workflows currently checkout `head.sha`, meaning CI tests the PR branch without merging with master. This misses semantic merge conflicts — two individually-passing PRs that break master when combined. Analysis of 18 months of history found 13 such events totaling 132 hours of broken master. The `head.sha` pattern was introduced in the first GHA workflow (Dec 2022, PR #2916) with no documented rationale — GitHub's default (`github.sha`) is the merge commit, which is what CI should be testing.

**Scope:** 23 `ref:` lines changed across `style.yaml`, `unit-tests.yaml`, and `build.yaml`. The expression `(!contains(labels, 'ci-merge-test') && head.sha) || github.sha` preserves existing behavior by default and switches to the merge commit when the label is present.

**This PR is its own test case** — it carries the `ci-merge-test` label, so all CI runs use the merge-commit checkout. Comparing results with unlabeled PRs will surface edge cases.

## Alternatives considered

- **Merge queue only**: catches issues at merge time but doesn't improve CI signal during development.
- **Always-fresh CI (re-run on every master push)**: correct but expensive (~3,762 extra CI runs/month). The label-gated approach lets us validate behavior first.
- **Separate shadow workflow**: would not test the actual checkout behavior of the production workflows.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

This PR is self-testing: the `ci-merge-test` label is applied at creation, so all CI runs exercise the new checkout behavior. Things to verify from CI results:
- All checks pass (the merge-commit checkout works)
- `make tag` produces a valid version string
- Go/lint caches still hit correctly
- Check statuses appear correctly on the PR