### PR TITLE
ROX-33973: Add role resolver from ACM

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -44,6 +44,7 @@ var (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	GetCluster(ctx context.Context, id string) (*storage.Cluster, bool, error)
+	GetClusterID(ctx context.Context, name string) (string, bool, error)
 	GetClusterName(ctx context.Context, id string) (string, bool, error)
 	GetClusters(ctx context.Context) ([]*storage.Cluster, error)
 	GetClustersForSAC() ([]effectiveaccessscope.Cluster, error)

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -372,6 +372,18 @@ func (ds *datastoreImpl) GetClusterName(ctx context.Context, id string) (string,
 	return val.(string), true, nil
 }
 
+func (ds *datastoreImpl) GetClusterID(ctx context.Context, name string) (string, bool, error) {
+	idVal, ok := ds.nameToIDCache.Get(name)
+	if !ok {
+		return "", false, nil
+	}
+	id := idVal.(string)
+	if allowed, err := clusterSAC.ReadAllowed(ctx, sac.ClusterScopeKey(id)); err != nil || !allowed {
+		return "", false, err
+	}
+	return id, true, nil
+}
+
 // Figure out if an indicator matches provided namespace filter. We consider
 // SAC errors or failure to find the pre-compiled filter regex as not matching
 // cases.

--- a/central/cluster/datastore/mocks/datastore.go
+++ b/central/cluster/datastore/mocks/datastore.go
@@ -122,6 +122,22 @@ func (mr *MockDataStoreMockRecorder) GetCluster(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockDataStore)(nil).GetCluster), ctx, id)
 }
 
+// GetClusterID mocks base method.
+func (m *MockDataStore) GetClusterID(ctx context.Context, name string) (string, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterID", ctx, name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetClusterID indicates an expected call of GetClusterID.
+func (mr *MockDataStoreMockRecorder) GetClusterID(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterID", reflect.TypeOf((*MockDataStore)(nil).GetClusterID), ctx, name)
+}
+
 // GetClusterLabels mocks base method.
 func (m *MockDataStore) GetClusterLabels(ctx context.Context, clusterID string) (map[string]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/auth/tokens/internal_role.go
+++ b/pkg/auth/tokens/internal_role.go
@@ -246,6 +246,9 @@ func NewInternalRoleFromPermissionsAndScope(
 	// Resolve cluster scope
 	output.Clusters = make(ClusterScopes)
 	for _, clusterID := range scope.GetRules().GetIncludedClusterIds() {
+		if clusterID == "" {
+			continue
+		}
 		output.Clusters[clusterID] = []string{"*"}
 	}
 	for _, clusterName := range scope.GetRules().GetIncludedClusters() {
@@ -253,7 +256,7 @@ func NewInternalRoleFromPermissionsAndScope(
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to resolve cluster ID")
 		}
-		if !found {
+		if !found || clusterID == "" {
 			continue
 		}
 		output.Clusters[clusterID] = []string{"*"}

--- a/pkg/auth/tokens/internal_role.go
+++ b/pkg/auth/tokens/internal_role.go
@@ -235,6 +235,7 @@ func NewInternalRoleFromPermissionsAndScope(
 		})
 	}
 
+	// Elevate to READ on Cluster resources solely for name-to-ID resolution; this does not expand the caller's derived permissions.
 	clusterIDResolutionCtx := sac.WithGlobalAccessScopeChecker(
 		ctx,
 		sac.AllowFixedScopes(
@@ -270,6 +271,9 @@ func NewInternalRoleFromPermissionsAndScope(
 				continue
 			}
 			clusterID = idForName
+		}
+		if clusterID == "" {
+			continue
 		}
 		output.Clusters[clusterID] = append(output.Clusters[clusterID], ns)
 	}

--- a/pkg/auth/tokens/internal_role.go
+++ b/pkg/auth/tokens/internal_role.go
@@ -1,12 +1,16 @@
 package tokens
 
 import (
+	"context"
 	"encoding/json"
 	"slices"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/set"
 )
 
@@ -192,4 +196,83 @@ func (r *InternalRole) GetAccessScope() *storage.SimpleAccessScope {
 			IncludedNamespaces: includedNamespaces,
 		},
 	}
+}
+
+type ClusterResolver interface {
+	GetClusterID(ctx context.Context, name string) (string, bool, error)
+}
+
+// NewInternalRoleFromPermissionsAndScope instantiates an InternalRole object
+// based on the input PermissionSet and AccessScope.
+func NewInternalRoleFromPermissionsAndScope(
+	ctx context.Context,
+	roleName string,
+	permissions *storage.PermissionSet,
+	scope *storage.SimpleAccessScope,
+	clusterIDResolver ClusterResolver,
+) (*InternalRole, error) {
+	if clusterIDResolver == nil {
+		return nil, errors.New("missing cluster ID resolver")
+	}
+
+	output := &InternalRole{
+		RoleName: roleName,
+	}
+
+	// Fill permission set
+	reversedPermissionSet := make(map[storage.Access]set.StringSet)
+	for permission, access := range permissions.GetResourceToAccess() {
+		if _, accessFound := reversedPermissionSet[access]; !accessFound {
+			reversedPermissionSet[access] = set.NewStringSet()
+		}
+		permissionsForAccess := reversedPermissionSet[access]
+		permissionsForAccess.Add(permission)
+	}
+	output.Permissions = make(map[storage.Access][]string)
+	for access, permissionSet := range reversedPermissionSet {
+		output.Permissions[access] = permissionSet.AsSortedSlice(func(i, j string) bool {
+			return i < j
+		})
+	}
+
+	clusterIDResolutionCtx := sac.WithGlobalAccessScopeChecker(
+		ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.Cluster),
+		),
+	)
+	// Resolve cluster scope
+	output.Clusters = make(ClusterScopes)
+	for _, clusterID := range scope.GetRules().GetIncludedClusterIds() {
+		output.Clusters[clusterID] = []string{"*"}
+	}
+	for _, clusterName := range scope.GetRules().GetIncludedClusters() {
+		clusterID, found, err := clusterIDResolver.GetClusterID(clusterIDResolutionCtx, clusterName)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to resolve cluster ID")
+		}
+		if !found {
+			continue
+		}
+		output.Clusters[clusterID] = []string{"*"}
+	}
+	for _, namespaceRule := range scope.GetRules().GetIncludedNamespaces() {
+		ns := namespaceRule.GetNamespaceName()
+		clusterID := namespaceRule.GetClusterId()
+		if clusterID == "" {
+			clusterName := namespaceRule.GetClusterName()
+			idForName, found, err := clusterIDResolver.GetClusterID(clusterIDResolutionCtx, clusterName)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to resolve cluster ID")
+			}
+			if !found {
+				continue
+			}
+			clusterID = idForName
+		}
+		output.Clusters[clusterID] = append(output.Clusters[clusterID], ns)
+	}
+
+	return output, nil
 }

--- a/pkg/auth/tokens/internal_role_test.go
+++ b/pkg/auth/tokens/internal_role_test.go
@@ -1,9 +1,11 @@
 package tokens
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -375,6 +377,446 @@ func TestInternalRoleJSONEncoding(t *testing.T) {
 			assert.Equal(it, tc.role.RoleName, unmarshaledRole.RoleName)
 			assert.Equal(it, tc.role.GetPermissions(), unmarshaledRole.GetPermissions())
 			protoassert.Equal(it, tc.role.GetAccessScope(), unmarshaledRole.GetAccessScope())
+		})
+	}
+}
+
+// mockClusterResolver is a test implementation of ClusterResolver
+type mockClusterResolver struct {
+	clusters map[string]string // map of cluster name -> cluster ID
+	err      error             // error to return from GetClusterID
+}
+
+func (m *mockClusterResolver) GetClusterID(ctx context.Context, name string) (string, bool, error) {
+	if m.err != nil {
+		return "", false, m.err
+	}
+	id, found := m.clusters[name]
+	return id, found, nil
+}
+
+func TestNewInternalRoleFromPermissionsAndScope(t *testing.T) {
+	const deploymentResource = "Deployment"
+	const imageResource = "Image"
+	const namespaceA = "namespace-a"
+	const namespaceB = "namespace-b"
+	const clusterNameDev = "dev-cluster"
+	const clusterNameProd = "prod-cluster"
+
+	for name, tc := range map[string]struct {
+		roleName      string
+		permissions   *storage.PermissionSet
+		scope         *storage.SimpleAccessScope
+		resolver      ClusterResolver
+		expectedRole  *InternalRole
+		expectedError string
+	}{
+		"Nil resolver returns error": {
+			roleName: "test-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{},
+			},
+			resolver:      nil,
+			expectedError: "missing cluster ID resolver",
+		},
+		"Empty permissions and scope": {
+			roleName: "empty-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName:    "empty-role",
+				Permissions: map[storage.Access][]string{},
+				Clusters:    ClusterScopes{},
+			},
+		},
+		"Role with read permissions only": {
+			roleName: "reader-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+					imageResource:      storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName: "reader-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource, imageResource},
+				},
+				Clusters: ClusterScopes{},
+			},
+		},
+		"Role with write permissions only": {
+			roleName: "writer-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_WRITE_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName: "writer-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_WRITE_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{},
+			},
+		},
+		"Role with mixed read and write permissions": {
+			roleName: "mixed-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+					imageResource:      storage.Access_READ_WRITE_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName: "mixed-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS:       {deploymentResource},
+					storage.Access_READ_WRITE_ACCESS: {imageResource},
+				},
+				Clusters: ClusterScopes{},
+			},
+		},
+		"Scope with cluster IDs only": {
+			roleName: "cluster-id-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusterIds: []string{fixtureconsts.Cluster1, fixtureconsts.Cluster2},
+				},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName: "cluster-id-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {"*"},
+					fixtureconsts.Cluster2: {"*"},
+				},
+			},
+		},
+		"Scope with cluster names that resolve": {
+			roleName: "cluster-name-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusters: []string{clusterNameDev, clusterNameProd},
+				},
+			},
+			resolver: &mockClusterResolver{
+				clusters: map[string]string{
+					clusterNameDev:  fixtureconsts.Cluster1,
+					clusterNameProd: fixtureconsts.Cluster2,
+				},
+			},
+			expectedRole: &InternalRole{
+				RoleName: "cluster-name-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {"*"},
+					fixtureconsts.Cluster2: {"*"},
+				},
+			},
+		},
+		"Scope with cluster names that don't resolve are skipped": {
+			roleName: "missing-cluster-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusters: []string{clusterNameDev, "unknown-cluster"},
+				},
+			},
+			resolver: &mockClusterResolver{
+				clusters: map[string]string{
+					clusterNameDev: fixtureconsts.Cluster1,
+					// "unknown-cluster" not in map
+				},
+			},
+			expectedRole: &InternalRole{
+				RoleName: "missing-cluster-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {"*"},
+					// unknown-cluster is skipped
+				},
+			},
+		},
+		"Cluster name resolution error propagates": {
+			roleName: "error-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusters: []string{clusterNameDev},
+				},
+			},
+			resolver: &mockClusterResolver{
+				err: errors.New("resolver error"),
+			},
+			expectedError: "failed to resolve cluster ID",
+		},
+		"Scope with namespace rules using cluster IDs": {
+			roleName: "namespace-id-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+						{
+							ClusterId:     fixtureconsts.Cluster1,
+							NamespaceName: namespaceA,
+						},
+						{
+							ClusterId:     fixtureconsts.Cluster1,
+							NamespaceName: namespaceB,
+						},
+					},
+				},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName: "namespace-id-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {namespaceA, namespaceB},
+				},
+			},
+		},
+		"Scope with namespace rules using cluster names": {
+			roleName: "namespace-name-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+						{
+							ClusterName:   clusterNameDev,
+							NamespaceName: namespaceA,
+						},
+						{
+							ClusterName:   clusterNameProd,
+							NamespaceName: namespaceB,
+						},
+					},
+				},
+			},
+			resolver: &mockClusterResolver{
+				clusters: map[string]string{
+					clusterNameDev:  fixtureconsts.Cluster1,
+					clusterNameProd: fixtureconsts.Cluster2,
+				},
+			},
+			expectedRole: &InternalRole{
+				RoleName: "namespace-name-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {namespaceA},
+					fixtureconsts.Cluster2: {namespaceB},
+				},
+			},
+		},
+		"Namespace with unresolved cluster name is skipped": {
+			roleName: "namespace-missing-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+						{
+							ClusterName:   clusterNameDev,
+							NamespaceName: namespaceA,
+						},
+						{
+							ClusterName:   "unknown-cluster",
+							NamespaceName: namespaceB,
+						},
+					},
+				},
+			},
+			resolver: &mockClusterResolver{
+				clusters: map[string]string{
+					clusterNameDev: fixtureconsts.Cluster1,
+					// "unknown-cluster" not in map
+				},
+			},
+			expectedRole: &InternalRole{
+				RoleName: "namespace-missing-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {namespaceA},
+					// namespace with unknown cluster is skipped
+				},
+			},
+		},
+		"Namespace cluster name resolution error propagates": {
+			roleName: "namespace-error-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+						{
+							ClusterName:   clusterNameDev,
+							NamespaceName: namespaceA,
+						},
+					},
+				},
+			},
+			resolver: &mockClusterResolver{
+				err: errors.New("namespace resolver error"),
+			},
+			expectedError: "failed to resolve cluster ID",
+		},
+		"Mixed scope with cluster IDs, cluster names, and namespace rules": {
+			roleName: "complex-scope-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+					imageResource:      storage.Access_READ_WRITE_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusterIds: []string{fixtureconsts.Cluster1},
+					IncludedClusters:   []string{clusterNameProd},
+					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+						{
+							ClusterId:     fixtureconsts.Cluster3,
+							NamespaceName: namespaceA,
+						},
+					},
+				},
+			},
+			resolver: &mockClusterResolver{
+				clusters: map[string]string{
+					clusterNameProd: fixtureconsts.Cluster2,
+				},
+			},
+			expectedRole: &InternalRole{
+				RoleName: "complex-scope-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS:       {deploymentResource},
+					storage.Access_READ_WRITE_ACCESS: {imageResource},
+				},
+				Clusters: ClusterScopes{
+					fixtureconsts.Cluster1: {"*"},
+					fixtureconsts.Cluster2: {"*"},
+					fixtureconsts.Cluster3: {namespaceA},
+				},
+			},
+		},
+		"Namespace appends to existing cluster scope": {
+			roleName: "namespace-append-role",
+			permissions: &storage.PermissionSet{
+				ResourceToAccess: map[string]storage.Access{
+					deploymentResource: storage.Access_READ_ACCESS,
+				},
+			},
+			scope: &storage.SimpleAccessScope{
+				Rules: &storage.SimpleAccessScope_Rules{
+					IncludedClusterIds: []string{fixtureconsts.Cluster1},
+					IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+						{
+							ClusterId:     fixtureconsts.Cluster1,
+							NamespaceName: namespaceA,
+						},
+					},
+				},
+			},
+			resolver: &mockClusterResolver{clusters: map[string]string{}},
+			expectedRole: &InternalRole{
+				RoleName: "namespace-append-role",
+				Permissions: map[storage.Access][]string{
+					storage.Access_READ_ACCESS: {deploymentResource},
+				},
+				Clusters: ClusterScopes{
+					// Cluster1 has both wildcard and namespace - appended
+					fixtureconsts.Cluster1: {"*", namespaceA},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(it *testing.T) {
+			ctx := context.Background()
+			role, err := NewInternalRoleFromPermissionsAndScope(
+				ctx,
+				tc.roleName,
+				tc.permissions,
+				tc.scope,
+				tc.resolver,
+			)
+
+			if tc.expectedError != "" {
+				assert.Error(it, err)
+				assert.Contains(it, err.Error(), tc.expectedError)
+				return
+			}
+
+			assert.NoError(it, err)
+			assert.Equal(it, tc.expectedRole.RoleName, role.RoleName)
+			assert.Equal(it, tc.expectedRole.Permissions, role.Permissions)
+			assert.Equal(it, tc.expectedRole.Clusters, role.Clusters)
 		})
 	}
 }

--- a/pkg/sac/externalrolebroker/acm_resolver.go
+++ b/pkg/sac/externalrolebroker/acm_resolver.go
@@ -1,0 +1,65 @@
+package externalrolebroker
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/auth/tokens"
+	clusterviewv1alpha1 "github.com/stolostron/cluster-lifecycle-api/clusterview/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ACMClient interface {
+	ListUserPermissions(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error)
+	GetUserPermission(ctx context.Context, name string, opts metav1.GetOptions) (*clusterviewv1alpha1.UserPermission, error)
+}
+
+// GetResolvedRolesFromACM retrieves UserPermissions from ACM, filters them for supported Kubernetes resources,
+// and converts each to a permissions.ResolvedRole.
+//
+// The function:
+//   - Calls ListUserPermissions on the ACM client
+//   - Filters the results to only include UserPermissions managing supported K8s resources
+//   - Converts each UserPermission's ClusterRoleDefinition to a PermissionSet
+//   - Converts each UserPermission's Bindings to a SimpleAccessScope
+//   - Creates a ResolvedRole for each UserPermission
+//
+// The role name is derived from the UserPermission metadata name
+func GetResolvedRolesFromACM(
+	ctx context.Context,
+	client ACMClient,
+	clusterIDResolver tokens.ClusterResolver,
+) ([]tokens.InternalRole, error) {
+	// Retrieve all user permissions from ACM
+	userPermissionList, err := client.ListUserPermissions(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list user permissions")
+	}
+
+	// Filter to only permissions managing supported Kubernetes resources
+	filteredPermissions := FilterUserPermissionsForSupportedK8sResources(userPermissionList.Items)
+
+	// Convert each filtered UserPermission to a ResolvedRole
+	resolvedRoles := make([]permissions.ResolvedRole, 0, len(filteredPermissions))
+	for _, userPermission := range filteredPermissions {
+		// Convert ClusterRoleDefinition to PermissionSet
+		permissionSet := ConvertClusterRoleToPermissionSet(userPermission.Status.ClusterRoleDefinition)
+
+		// Convert Bindings to SimpleAccessScope
+		accessScope := ConvertBindingsToSimpleAccessScope(userPermission.Status.Bindings)
+
+		resolvedRole, roleErr := tokens.NewInternalRoleFromPermissionsAndScope(
+			ctx,
+			userPermission.Name,
+			permissionSet,
+			accessScope,
+			clusterIDResolver,
+		)
+		if roleErr != nil {
+			return nil, errors.Wrap(roleErr, "failed to create role")
+		}
+		resolvedRoles = append(resolvedRoles, resolvedRole)
+	}
+	return resolvedRoles, nil
+}

--- a/pkg/sac/externalrolebroker/acm_resolver.go
+++ b/pkg/sac/externalrolebroker/acm_resolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/auth/tokens"
 	clusterviewv1alpha1 "github.com/stolostron/cluster-lifecycle-api/clusterview/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +29,7 @@ func GetResolvedRolesFromACM(
 	ctx context.Context,
 	client ACMClient,
 	clusterIDResolver tokens.ClusterResolver,
-) ([]tokens.InternalRole, error) {
+) ([]*tokens.InternalRole, error) {
 	// Retrieve all user permissions from ACM
 	userPermissionList, err := client.ListUserPermissions(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -41,7 +40,7 @@ func GetResolvedRolesFromACM(
 	filteredPermissions := FilterUserPermissionsForSupportedK8sResources(userPermissionList.Items)
 
 	// Convert each filtered UserPermission to a ResolvedRole
-	resolvedRoles := make([]permissions.ResolvedRole, 0, len(filteredPermissions))
+	resolvedRoles := make([]*tokens.InternalRole, 0, len(filteredPermissions))
 	for _, userPermission := range filteredPermissions {
 		// Convert ClusterRoleDefinition to PermissionSet
 		permissionSet := ConvertClusterRoleToPermissionSet(userPermission.Status.ClusterRoleDefinition)

--- a/pkg/sac/externalrolebroker/acm_resolver.go
+++ b/pkg/sac/externalrolebroker/acm_resolver.go
@@ -9,9 +9,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type ACMClient interface {
+// acmClient is the consumer-side interface for acm.Client, scoped to what this package uses.
+type acmClient interface {
 	ListUserPermissions(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error)
-	GetUserPermission(ctx context.Context, name string, opts metav1.GetOptions) (*clusterviewv1alpha1.UserPermission, error)
 }
 
 // GetResolvedRolesFromACM retrieves UserPermissions from ACM, filters them for supported Kubernetes resources,
@@ -27,13 +27,16 @@ type ACMClient interface {
 // The role name is derived from the UserPermission metadata name
 func GetResolvedRolesFromACM(
 	ctx context.Context,
-	client ACMClient,
+	client acmClient,
 	clusterIDResolver tokens.ClusterResolver,
 ) ([]*tokens.InternalRole, error) {
 	// Retrieve all user permissions from ACM
 	userPermissionList, err := client.ListUserPermissions(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list user permissions")
+	}
+	if userPermissionList == nil {
+		return nil, errors.New("received nil user permission list from ACM")
 	}
 
 	// Filter to only permissions managing supported Kubernetes resources

--- a/pkg/sac/externalrolebroker/acm_resolver_test.go
+++ b/pkg/sac/externalrolebroker/acm_resolver_test.go
@@ -15,17 +15,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// mockACMClient is a test implementation of the ACM client interface
+// mockACMClient is a test implementation of acmClient.
 type mockACMClient struct {
 	listFunc func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error)
 }
 
 func (m *mockACMClient) ListUserPermissions(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
 	return m.listFunc(ctx, opts)
-}
-
-func (m *mockACMClient) GetUserPermission(ctx context.Context, name string, opts metav1.GetOptions) (*clusterviewv1alpha1.UserPermission, error) {
-	return nil, errors.New("not implemented in mock")
 }
 
 type mockClusterResolver struct{}

--- a/pkg/sac/externalrolebroker/acm_resolver_test.go
+++ b/pkg/sac/externalrolebroker/acm_resolver_test.go
@@ -1,0 +1,318 @@
+package externalrolebroker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	clusterviewv1alpha1 "github.com/stolostron/cluster-lifecycle-api/clusterview/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// mockACMClient is a test implementation of the ACM client interface
+type mockACMClient struct {
+	listFunc func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error)
+}
+
+func (m *mockACMClient) ListUserPermissions(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+	return m.listFunc(ctx, opts)
+}
+
+func (m *mockACMClient) GetUserPermission(ctx context.Context, name string, opts metav1.GetOptions) (*clusterviewv1alpha1.UserPermission, error) {
+	return nil, errors.New("not implemented in mock")
+}
+
+type mockClusterResolver struct{}
+
+func (m *mockClusterResolver) GetClusterID(_ context.Context, clusterName string) (string, bool, error) {
+	return clusterName, true, nil
+}
+
+func TestGetResolvedRolesFromACM(t *testing.T) {
+	tests := map[string]struct {
+		mockListFunc      func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error)
+		expectedRoleCount int
+		expectedError     bool
+		validateRoles     func(t *testing.T, roles []permissions.ResolvedRole)
+	}{
+		"empty list": {
+			mockListFunc: func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+				return &clusterviewv1alpha1.UserPermissionList{
+					Items: []clusterviewv1alpha1.UserPermission{},
+				}, nil
+			},
+			expectedRoleCount: 0,
+			expectedError:     false,
+		},
+		"list with no base k8s resources": {
+			mockListFunc: func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+				return &clusterviewv1alpha1.UserPermissionList{
+					Items: []clusterviewv1alpha1.UserPermission{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "non-base-permission",
+							},
+							Status: clusterviewv1alpha1.UserPermissionStatus{
+								ClusterRoleDefinition: clusterviewv1alpha1.ClusterRoleDefinition{
+									Rules: []rbacv1.PolicyRule{
+										{
+											APIGroups: []string{"apps"},
+											Resources: []string{"deployments", "statefulsets"},
+											Verbs:     []string{"get", "list"},
+										},
+									},
+								},
+								Bindings: []clusterviewv1alpha1.ClusterBinding{
+									{
+										Cluster:    "cluster-1",
+										Scope:      clusterviewv1alpha1.BindingScopeCluster,
+										Namespaces: []string{"*"},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedRoleCount: 0,
+			expectedError:     false,
+		},
+		"list with base k8s resources": {
+			mockListFunc: func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+				return &clusterviewv1alpha1.UserPermissionList{
+					Items: []clusterviewv1alpha1.UserPermission{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "secrets-reader",
+							},
+							Status: clusterviewv1alpha1.UserPermissionStatus{
+								ClusterRoleDefinition: clusterviewv1alpha1.ClusterRoleDefinition{
+									Rules: []rbacv1.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"secrets"},
+											Verbs:     []string{"get", "list"},
+										},
+									},
+								},
+								Bindings: []clusterviewv1alpha1.ClusterBinding{
+									{
+										Cluster:    "cluster-1",
+										Scope:      clusterviewv1alpha1.BindingScopeCluster,
+										Namespaces: []string{"*"},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedRoleCount: 1,
+			expectedError:     false,
+			validateRoles: func(t *testing.T, roles []permissions.ResolvedRole) {
+				require.Len(t, roles, 1)
+				role := roles[0]
+
+				// Verify role name
+				assert.Equal(t, "secrets-reader", role.GetRoleName())
+
+				// Verify permissions
+				permissions := role.GetPermissions()
+				require.NotNil(t, permissions)
+				assert.Equal(t, storage.Access_READ_ACCESS, permissions[string(resources.Secret.GetResource())])
+
+				// Verify access scope
+				accessScope := role.GetAccessScope()
+				require.NotNil(t, accessScope)
+				assert.Contains(t, accessScope.GetRules().GetIncludedClusterIds(), "cluster-1")
+				assert.Empty(t, accessScope.GetRules().GetIncludedNamespaces())
+			},
+		},
+		"multiple permissions with different access levels": {
+			mockListFunc: func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+				return &clusterviewv1alpha1.UserPermissionList{
+					Items: []clusterviewv1alpha1.UserPermission{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "namespace-reader",
+							},
+							Status: clusterviewv1alpha1.UserPermissionStatus{
+								ClusterRoleDefinition: clusterviewv1alpha1.ClusterRoleDefinition{
+									Rules: []rbacv1.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"namespaces"},
+											Verbs:     []string{"get", "list"},
+										},
+									},
+								},
+								Bindings: []clusterviewv1alpha1.ClusterBinding{
+									{
+										Cluster:    "cluster-a",
+										Scope:      clusterviewv1alpha1.BindingScopeNamespace,
+										Namespaces: []string{"default", "kube-system"},
+									},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "secrets-admin",
+							},
+							Status: clusterviewv1alpha1.UserPermissionStatus{
+								ClusterRoleDefinition: clusterviewv1alpha1.ClusterRoleDefinition{
+									Rules: []rbacv1.PolicyRule{
+										{
+											APIGroups: []string{""},
+											Resources: []string{"secrets"},
+											Verbs:     []string{"*"},
+										},
+									},
+								},
+								Bindings: []clusterviewv1alpha1.ClusterBinding{
+									{
+										Cluster:    "cluster-b",
+										Scope:      clusterviewv1alpha1.BindingScopeCluster,
+										Namespaces: []string{"*"},
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			expectedRoleCount: 2,
+			expectedError:     false,
+			validateRoles: func(t *testing.T, roles []permissions.ResolvedRole) {
+				require.Len(t, roles, 2)
+
+				// Verify first role (namespace-reader)
+				var namespaceReader, secretsAdmin permissions.ResolvedRole
+				for _, role := range roles {
+					if role.GetRoleName() == "namespace-reader" {
+						namespaceReader = role
+					} else if role.GetRoleName() == "secrets-admin" {
+						secretsAdmin = role
+					}
+				}
+
+				require.NotNil(t, namespaceReader)
+				assert.Equal(t, storage.Access_READ_ACCESS,
+					namespaceReader.GetPermissions()[string(resources.Namespace.GetResource())])
+				assert.Len(t, namespaceReader.GetAccessScope().GetRules().GetIncludedNamespaces(), 2)
+
+				require.NotNil(t, secretsAdmin)
+				assert.Equal(t, storage.Access_READ_WRITE_ACCESS,
+					secretsAdmin.GetPermissions()[string(resources.Secret.GetResource())])
+				assert.Contains(t, secretsAdmin.GetAccessScope().GetRules().GetIncludedClusterIds(), "cluster-b")
+			},
+		},
+		"acm client returns error": {
+			mockListFunc: func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+				return nil, errors.New("ACM API unavailable")
+			},
+			expectedRoleCount: 0,
+			expectedError:     true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := &mockACMClient{
+				listFunc: tc.mockListFunc,
+			}
+
+			roles, err := GetResolvedRolesFromACM(context.Background(), client, &mockClusterResolver{})
+
+			if tc.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, roles, tc.expectedRoleCount)
+
+			if tc.validateRoles != nil {
+				resolvedRoles := make([]permissions.ResolvedRole, 0, len(roles))
+				for _, role := range roles {
+					resolvedRoles = append(resolvedRoles, role)
+				}
+				tc.validateRoles(t, resolvedRoles)
+			}
+		})
+	}
+}
+
+func TestGetResolvedRolesFromACM_IntegrationExample(t *testing.T) {
+	// This test demonstrates the full integration of all conversion functions
+	client := &mockACMClient{
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*clusterviewv1alpha1.UserPermissionList, error) {
+			return &clusterviewv1alpha1.UserPermissionList{
+				Items: []clusterviewv1alpha1.UserPermission{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "rbac-admin",
+						},
+						Status: clusterviewv1alpha1.UserPermissionStatus{
+							ClusterRoleDefinition: clusterviewv1alpha1.ClusterRoleDefinition{
+								Rules: []rbacv1.PolicyRule{
+									{
+										APIGroups: []string{""},
+										Resources: []string{"namespaces", "secrets", "serviceaccounts"},
+										Verbs:     []string{"get", "list", "create", "update"},
+									},
+									{
+										APIGroups: []string{"rbac.authorization.k8s.io"},
+										Resources: []string{"roles", "rolebindings"},
+										Verbs:     []string{"*"},
+									},
+								},
+							},
+							Bindings: []clusterviewv1alpha1.ClusterBinding{
+								{
+									Cluster:    "prod-cluster",
+									Scope:      clusterviewv1alpha1.BindingScopeCluster,
+									Namespaces: []string{"*"},
+								},
+								{
+									Cluster:    "dev-cluster",
+									Scope:      clusterviewv1alpha1.BindingScopeNamespace,
+									Namespaces: []string{"team-a", "team-b"},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	roles, err := GetResolvedRolesFromACM(context.Background(), client, &mockClusterResolver{})
+
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+
+	role := roles[0]
+	assert.Equal(t, "rbac-admin", role.GetRoleName())
+
+	// Verify all 5 base resources have permissions
+	perms := role.GetPermissions()
+	assert.Len(t, perms, 5)
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, perms[string(resources.Namespace.GetResource())])
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, perms[string(resources.Secret.GetResource())])
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, perms[string(resources.ServiceAccount.GetResource())])
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, perms[string(resources.K8sRole.GetResource())])
+	assert.Equal(t, storage.Access_READ_WRITE_ACCESS, perms[string(resources.K8sRoleBinding.GetResource())])
+
+	// Verify access scope includes cluster and namespaces
+	scope := role.GetAccessScope()
+	require.NotNil(t, scope)
+	assert.Contains(t, scope.GetRules().GetIncludedClusterIds(), "prod-cluster")
+	assert.Len(t, scope.GetRules().GetIncludedNamespaces(), 2)
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The ROX-33973 feature aims, at user login, once the user is authenticated, to :
- obtain an Identity Provider (IdP) token
- use it to retrieve access control information from the ACM UserPermissions API
- filter the ACS-relevant information from the ACM response
- build ACS PermissionSet objects from the ACM response data
- build ACS SimpleAccessScope objects from the ACM response data
- build ACS roles based on the previously built PermissionSet and SimpleAccessScope objects
- issue a ROX token granting the built roles to the authenticated user

```
Flow overview
================================================================================
The part implemented by the current PR is shown in the box
+vvvvv+
>     <
>     <
>     <
+^^^^^+

                      +-----+                 +-----+          +-----+
                      | ACS |                 | IdP |          | ACM |
                      +--+--+                 +--+--+          +--+--+
User  ----  login  ----> |                       |                |
                         | --- authenticate ---> |                |
                         | <---- IdP token  ---- |                |
                         |                       |                |
                         |                                        |
                       +vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv+
                       > |                                        |       <
                       > | --- ListUserPermissions for token ---> |       <
                       > | <---     User Permission List      --- |       <
                       > |                                        |       <
                       > |                                                <
                       > | ---+                                           <
                       > |    | Filter relevant user permissions          <
                       > | <--+                                           <
                       > |                                                <
                       > | ---+                                           <
                       > |    | For each relevant user permission         <
                       > |    |                                           <
                       > |    | ---+                                      <
                       > |    |    | Build PermissionSet                  <
                       > |    | <--+                                      <
                       > |    |                                           <
                       > |    | ---+                                      <
                       > |    |    | Build SimpleAccessScope              <
                       > |    | <--+                                      <
                       > |    |                                           <
                       > |    | ---+                                      <
                       > |    |    | Build Role from previous two objects <
                       > |    | <--+                                      <
                       > |    |                                           <
                       > | <--+                                           <
                       > |                                                <
                       +^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^+
                         |
                         | ---+
                         |    | Issue ROX token with built roles granted
                         | <--+
                         |
User  <--- ROX token --- |
```


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
