### PR TITLE
ROX-36225: Allow MintMaker updates between 0-7:59 every day

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,14 +63,16 @@
     ],
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
-      "* 0-8 * * *",
+      // Between 0a.m. and 7:59a.m. every day.
+      "* 0-7 * * *",
     ],
   },
   "rpm-lockfile": {
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
       // Note that MintMaker will create security updates outside of schedule.
-      "* 0-8 * * *",
+      // Between 0a.m. and 7:59a.m. every day.
+      "* 0-7 * * *",
     ],
   },
   "enabledManagers": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,14 +32,16 @@
     // hours from Germany to US West Coast. This way, after we merge a PR, a new one does not pop up immediately after
     // that. Another reason for this schedule is to include at least one 4 hour interval from the moment of scheduled
     // MintMaker execution
-    "* 0-8 * * *",
+    // Between 0a.m. and 7:59a.m. every day.
+    "* 0-7 * * *",
   ],
   // Tell Renovate not to update PRs when outside of schedule.
   "updateNotScheduled": false,
   "tekton": {
     "schedule": [
       // Override Konflux custom schedule for this manager to our intended one.
-      "* 0-8 * * *",
+      // Between 0a.m. and 7:59a.m. every day.
+      "* 0-7 * * *",
     ],
     "packageRules": [
       // Note: the packageRules from the Konflux config (find URL in comments above) get merged with these.


### PR DESCRIPTION
## Description

Per title. Follow-up to https://github.com/stackrox/stackrox/pull/22174

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Renovate config validator passed.
