### PR TITLE
ROX-36211: bake signing key watch interval into deploy config

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -503,6 +503,17 @@ function launch_central {
         ROX_NAMESPACE="${central_namespace}" "${unzip_dir}/central/scripts/setup.sh"
       fi
       central_scripts_dir="$unzip_dir/central/scripts"
+
+      # Shorten signing key watcher poll for e2e tests (production default is 4h).
+      # Bake it into the manifest so Central starts with fast polling instead of
+      # requiring a second rollout via a post-launch `set env`.
+      central_deployment="${unzip_dir}/central/01-central-13-deployment.yaml"
+      if [[ -f "${central_deployment}" ]]; then
+        ${ORCH_CMD} set env --local -o yaml -f "${central_deployment}" -c central \
+          ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s > "${central_deployment}.tmp"
+        mv "${central_deployment}.tmp" "${central_deployment}"
+      fi
+
       launch_service "${unzip_dir}" central
       echo
 
@@ -525,9 +536,6 @@ function launch_central {
       if [[ -n $MODULE_LOGLEVELS ]]; then
         ${ORCH_CMD} -n stackrox set env deploy/central MODULE_LOGLEVELS="${MODULE_LOGLEVELS}"
       fi
-
-      # Shorten signing key watcher poll for e2e tests (production default is 4h).
-      ${ORCH_CMD} -n stackrox set env deploy/central ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s
 
       if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
         echo >&2 "ROX_MANAGED_CENTRAL=true is only supported in conjunction with OUTPUT_FORMAT=helm"

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -381,6 +381,9 @@ function launch_central {
         )
       fi
 
+      # Shorten signing key watcher poll for e2e tests (production default is 4h).
+      helm_args+=(--set customize.central.envVars.ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s)
+
       if [[ -n "$POD_SECURITY_POLICIES" ]]; then
         helm_args+=(
           --set system.enablePodSecurityPolicies="${POD_SECURITY_POLICIES}"
@@ -522,6 +525,9 @@ function launch_central {
       if [[ -n $MODULE_LOGLEVELS ]]; then
         ${ORCH_CMD} -n stackrox set env deploy/central MODULE_LOGLEVELS="${MODULE_LOGLEVELS}"
       fi
+
+      # Shorten signing key watcher poll for e2e tests (production default is 4h).
+      ${ORCH_CMD} -n stackrox set env deploy/central ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s
 
       if [[ "$ROX_MANAGED_CENTRAL" == "true" ]]; then
         echo >&2 "ROX_MANAGED_CENTRAL=true is only supported in conjunction with OUTPUT_FORMAT=helm"

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -512,6 +512,8 @@ function launch_central {
         ${ORCH_CMD} set env --local -o yaml -f "${central_deployment}" -c central \
           ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s > "${central_deployment}.tmp"
         mv "${central_deployment}.tmp" "${central_deployment}"
+      else
+        echo >&2 "WARNING: ${central_deployment} not found; Central will deploy with the default signing key watch interval and rely on the test's set env fallback."
       fi
 
       launch_service "${unzip_dir}" central

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -523,6 +523,8 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_TELEMETRY_STORAGE_KEY_V1:-DISABLED}"'"'
     customize_envVars+=$'\n      - name: ROX_RISK_REPROCESSING_INTERVAL'
     customize_envVars+=$'\n        value: "15s"'
+    customize_envVars+=$'\n      - name: ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL'
+    customize_envVars+=$'\n        value: "5s"'
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_ENHANCEMENTS'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_COMPLIANCE_REPORTING'

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -80,7 +80,12 @@ func (s *RedHatSigningKeySuite) SetupSuite() {
 	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
 	defer cancel()
 	s.logf("Ensuring %s=%s on central", watchIntervalEnv, shortWatchInterval)
-	s.mustSetDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
+	currentVal, _ := s.getDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv)
+	if currentVal == shortWatchInterval {
+		s.logf("%s already set to %s, skipping patch", watchIntervalEnv, shortWatchInterval)
+	} else {
+		s.mustSetDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
+	}
 
 	s.conn = centralgrpc.GRPCConnectionToCentral(s.T())
 	s.waitForCentralReady(ctx)

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -71,28 +71,19 @@ func TestRedHatSigningKey(t *testing.T) {
 
 func (s *RedHatSigningKeySuite) SetupSuite() {
 	s.KubernetesSuite.SetupSuite()
-	s.conn = centralgrpc.GRPCConnectionToCentral(s.T())
 
-	// Set once for the whole suite instead of per sub-test: every sub-test
-	// needs the watcher to poll quickly, and each Central restart costs
-	// ~30s, so sharing this one restart across sub-tests instead of paying
-	// it twice per sub-test saves several minutes of suite time.
+	// Deploy scripts (tests/e2e/lib.sh, deploy/common/k8sbased.sh) set
+	// watchIntervalEnv=5s at deploy time, so Central already polls quickly.
+	// This is a same-value no-op safety net for setups that deploy Central
+	// without the baked-in env var (e.g. local dev clusters).
 	ns := namespaces.StackRox
 	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
 	defer cancel()
-	s.logf("Setting %s=%s on central for the whole suite", watchIntervalEnv, shortWatchInterval)
+	s.logf("Ensuring %s=%s on central", watchIntervalEnv, shortWatchInterval)
 	s.mustSetDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
 	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
-}
 
-// TearDownSuite reverts the watch-interval override applied in SetupSuite.
-func (s *RedHatSigningKeySuite) TearDownSuite() {
-	ns := namespaces.StackRox
-	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout+time.Minute)
-	defer cancel()
-	s.logf("Cleanup: removing %s env var", watchIntervalEnv)
-	s.mustDeleteDeploymentEnvVar(ctx, ns, "central", watchIntervalEnv)
-	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
+	s.conn = centralgrpc.GRPCConnectionToCentral(s.T())
 }
 
 func (s *RedHatSigningKeySuite) siClient() v1.SignatureIntegrationServiceClient {

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -81,9 +81,9 @@ func (s *RedHatSigningKeySuite) SetupSuite() {
 	defer cancel()
 	s.logf("Ensuring %s=%s on central", watchIntervalEnv, shortWatchInterval)
 	s.mustSetDeploymentEnvVal(ctx, ns, "central", "central", watchIntervalEnv, shortWatchInterval)
-	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
 
 	s.conn = centralgrpc.GRPCConnectionToCentral(s.T())
+	s.waitForCentralReady(ctx)
 }
 
 func (s *RedHatSigningKeySuite) siClient() v1.SignatureIntegrationServiceClient {

--- a/tests/redhat_signing_key_test.go
+++ b/tests/redhat_signing_key_test.go
@@ -94,6 +94,20 @@ func (s *RedHatSigningKeySuite) listIntegrations(ctx context.Context) (*v1.ListS
 	return s.siClient().ListSignatureIntegrations(ctx, &v1.Empty{})
 }
 
+// waitForCentralReady waits for Central's k8s deployment readiness AND gRPC
+// API responsiveness. On OCP with HAProxy Routes, gRPC connection recovery
+// after a backend restart lags 10-30s beyond k8s deployment readiness.
+func (s *RedHatSigningKeySuite) waitForCentralReady(ctx context.Context) {
+	ns := namespaces.StackRox
+	s.waitUntilK8sDeploymentReady(ctx, ns, "central")
+	mustEventually(s.T(), ctx, func() error {
+		rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_, err := s.listIntegrations(rpcCtx)
+		return err
+	}, 2*time.Second, "Central gRPC API not yet responsive after restart")
+}
+
 // waitForIntegrationKeys polls until the Red Hat integration has exactly the expected key names.
 func (s *RedHatSigningKeySuite) waitForIntegrationKeys(ctx context.Context, expectedNames []string, description string) {
 	t := s.T()
@@ -422,7 +436,7 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 	defer func() {
 		s.logf("Cleanup: removing updater env var from Central")
 		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", bundleURLEnv)
-		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
+		s.waitForCentralReady(overallCtx)
 	}()
 
 	// The update interval isn't set: it always gets clamped to a 5-minute
@@ -430,7 +444,7 @@ func (s *RedHatSigningKeySuite) TestUpdaterDownloadsBundleFromHTTP() {
 	// depends on the unconditional first download at startup (see above).
 	s.logf("Setting %s on central", bundleURLEnv)
 	s.mustSetDeploymentEnvVal(testCtx, ns, "central", "central", bundleURLEnv, bundleURL)
-	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
+	s.waitForCentralReady(testCtx)
 
 	s.logf("Waiting for updater to download the bundle and watcher to upsert keys")
 	s.waitForIntegrationKeys(testCtx, []string{"updater-key-1", "updater-key-2"},
@@ -558,7 +572,7 @@ func (s *RedHatSigningKeySuite) TestOfflineModeIgnoresHTTPUpdater() {
 		s.logf("Cleanup: removing env vars from Central")
 		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", offlineModeEnv)
 		s.mustDeleteDeploymentEnvVar(overallCtx, ns, "central", bundleURLEnv)
-		s.waitUntilK8sDeploymentReady(overallCtx, ns, "central")
+		s.waitForCentralReady(overallCtx)
 	}()
 
 	// The update interval isn't set here for the same reason as in
@@ -569,7 +583,7 @@ func (s *RedHatSigningKeySuite) TestOfflineModeIgnoresHTTPUpdater() {
 
 	// --- Step 3: Wait for Central to restart ---
 
-	s.waitUntilK8sDeploymentReady(testCtx, ns, "central")
+	s.waitForCentralReady(testCtx)
 
 	// --- Step 4: Verify the HTTP updater did NOT fetch the decoy bundle ---
 


### PR DESCRIPTION
## Description

Set `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s` at deploy time (Helm, non-Helm, and operator paths) so Central starts with fast polling. This eliminates 2 Central restarts (SetupSuite + TearDownSuite) that previously cost ~60s on OCP where each rollout + HAProxy recovery takes 30s+.

The test `SetupSuite` still sets the env var as a no-op safety net for local dev clusters that deploy without the baked-in value. The gRPC connection is now created after the deployment readiness check to avoid stale connections through HAProxy.

Refs: 
- https://github.com/stackrox/stackrox/pull/22025

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
