### PR TITLE
ROX-36195: retry network graph API call for flaky deployment node

### DIFF
--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -6,6 +6,7 @@ import {
     selectDeployment,
     selectNamespace,
     visitNetworkGraph,
+    waitForDeploymentNodeInGraph,
 } from './networkGraph.helpers';
 import { networkGraphSelectors } from './networkGraph.selectors';
 
@@ -21,10 +22,7 @@ describe('Network Graph deployment sidebar', () => {
         selectNamespace('stackrox');
         selectDeployment('collector');
 
-        // confirm that the graph only contains collector and other StackRox deployments it communiticates with
-        cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("sensor")`
-        );
+        waitForDeploymentNodeInGraph('sensor');
 
         // With the addition of the compliance node indexer, it is possible for a flow to exist between central and collector
         // https://github.com/stackrox/stackrox/pull/12573

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.helpers.js
@@ -55,6 +55,26 @@ export function selectDeployment(deployment) {
     }, routeMatcherMapForClusterInNetworkGraph);
 }
 
+export function waitForDeploymentNodeInGraph(deploymentName, maxRetries = 5, delay = 3000) {
+    const selector = networkGraphSelectors.deploymentNode(deploymentName);
+    cy.get('body').then(($body) => {
+        if ($body.find(selector).length > 0) {
+            return;
+        }
+        if (maxRetries <= 0) {
+            cy.get(selector);
+            return;
+        }
+        cy.wait(delay);
+        cy.intercept(routeMatcherMapForClusterInNetworkGraph[networkGraphClusterAlias]).as(
+            networkGraphClusterAlias
+        );
+        cy.reload();
+        cy.wait(`@${networkGraphClusterAlias}`);
+        waitForDeploymentNodeInGraph(deploymentName, maxRetries - 1, delay);
+    });
+}
+
 export function selectFilter(filterKey, filterValue) {
     cy.get('.react-select__value-container').click();
     cy.get(`.react-select__menu-list .react-select__option:contains("${filterKey}")`).click();


### PR DESCRIPTION

## Description

The `networkDeploymentSidebar` E2E test selects collector and expects sensor to appear as a neighbor node. Sensor only appears if network flows between collector and sensor exist in the database. On CI the flow pipeline may not have delivered flows by test time, causing a flake (ROX-36195, previously ROX-26121).

Add `waitForDeploymentNodeInGraph` helper that reloads the page to trigger a fresh API call when the expected node is not found.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI