### PR TITLE
ROX-36004: Migrate Settings Manager configStream to PubSub

### DIFF
--- a/sensor/common/admissioncontroller/settings_manager_impl.go
+++ b/sensor/common/admissioncontroller/settings_manager_impl.go
@@ -14,11 +14,13 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/gziputil"
 	pkgPolicies "github.com/stackrox/rox/pkg/policies"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/configmap"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -43,6 +45,8 @@ type settingsManager struct {
 	deployments store.DeploymentStore
 	pods        store.PodStore
 	namespaces  store.NamespaceStore
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
 type clusterLabelsGetter interface {
@@ -54,7 +58,7 @@ type clusterIDWaiter interface {
 }
 
 // NewSettingsManager creates a new settings manager for admission control settings.
-func NewSettingsManager(clusterID clusterIDWaiter, clusterLabels clusterLabelsGetter, deployments store.DeploymentStore, pods store.PodStore, namespaces store.NamespaceStore) SettingsManager {
+func NewSettingsManager(clusterID clusterIDWaiter, clusterLabels clusterLabelsGetter, deployments store.DeploymentStore, pods store.PodStore, namespaces store.NamespaceStore, pubSubDispatcher common.PubSubDispatcher) SettingsManager {
 	return &settingsManager{
 		configStream:                 concurrency.NewValueStream[*v1.ConfigMap](nil),
 		settingsStream:               concurrency.NewValueStream[*sensor.AdmissionControlSettings](nil),
@@ -68,6 +72,8 @@ func NewSettingsManager(clusterID clusterIDWaiter, clusterLabels clusterLabelsGe
 		deployments: deployments,
 		pods:        pods,
 		namespaces:  namespaces,
+
+		pubSubDispatcher: pubSubDispatcher,
 	}
 }
 
@@ -149,15 +155,22 @@ func (p *settingsManager) FlushCache() {
 
 func (p *settingsManager) pushSettings(newSettings *sensor.AdmissionControlSettings) {
 	p.settingsStream.Push(newSettings)
-	if config, err := settingsToConfigMap(newSettings); err != nil {
+	config, err := settingsToConfigMap(newSettings)
+	if err != nil {
 		log.Errorf("failed to create config map: %v", err)
-	} else {
-		// the priority is the grpc messages (handled by consumers of the settingsStream)
-		// we make no guarantee the config map and the grpc messages will remain in sync.
-		// however, under normal operation, failures here or in persisting the config map
-		// are unlikely.
-		p.configStream.Push(config)
+		return
 	}
+	// the priority is the grpc messages (handled by consumers of the settingsStream)
+	// we make no guarantee the config map and the grpc messages will remain in sync.
+	// however, under normal operation, failures here or in persisting the config map
+	// are unlikely.
+	if features.SensorInternalPubSub.Enabled() && p.pubSubDispatcher != nil {
+		if err := p.pubSubDispatcher.Publish(&configmap.ConfigMapUpdatedEvent{ConfigMap: config}); err != nil {
+			log.Errorf("failed to publish config map update: %v", err)
+		}
+		return
+	}
+	p.configStream.Push(config)
 }
 
 // pushClusterLabelsIfChangedNoLock pushes cluster labels to admission control if they've changed.

--- a/sensor/common/admissioncontroller/settings_manager_impl_pubsub_test.go
+++ b/sensor/common/admissioncontroller/settings_manager_impl_pubsub_test.go
@@ -1,0 +1,67 @@
+package admissioncontroller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/configmap"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	storeMocks "github.com/stackrox/rox/sensor/common/store/mocks"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestSettingsManagerDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.AdmCtrlConfigMapLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+// TestPubSubPushSettingsPublishesConfigMap verifies pushSettings() publishes a
+// configmap.ConfigMapUpdatedEvent instead of writing to the legacy configStream when PubSub is
+// enabled, and leaves configStream untouched (that's a separate migration, ROX-36003).
+func TestPubSubPushSettingsPublishesConfigMap(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestSettingsManagerDispatcher(t)
+	defer dispatcher.Stop()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	deployments := storeMocks.NewMockDeploymentStore(ctrl)
+	pods := storeMocks.NewMockPodStore(ctrl)
+
+	mgr := NewSettingsManager(&mockClusterIDWaiter{id: "cluster-123"}, &mockClusterLabelsGetter{}, deployments, pods, nil, dispatcher)
+
+	eventC := make(chan *configmap.ConfigMapUpdatedEvent, 1)
+	require.NoError(t, dispatcher.RegisterConsumer(pubsub.AdmCtrlConfigMapConsumer, pubsub.AdmCtrlConfigMapTopic, func(event pubsub.Event) error {
+		e, ok := event.(*configmap.ConfigMapUpdatedEvent)
+		if !ok {
+			return nil
+		}
+		eventC <- e
+		return nil
+	}))
+
+	mgr.UpdatePolicies(nil)
+	mgr.UpdateConfig(&storage.DynamicClusterConfig{})
+
+	select {
+	case event := <-eventC:
+		require.NotNil(t, event.ConfigMap)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for config map update via pubsub")
+	}
+
+	require.Nil(t, mgr.(*settingsManager).configStream.Iterator(false).Value(), "configStream should not receive an update in pubsub mode")
+}

--- a/sensor/common/admissioncontroller/settings_manager_impl_test.go
+++ b/sensor/common/admissioncontroller/settings_manager_impl_test.go
@@ -71,7 +71,7 @@ func TestSettingsManager_GetResourcesForSync(t *testing.T) {
 			},
 		}
 
-		mgr := NewSettingsManager(clusterID, clusterLabels, deployments, pods, namespaces).(*settingsManager)
+		mgr := NewSettingsManager(clusterID, clusterLabels, deployments, pods, namespaces, nil).(*settingsManager)
 
 		resources := mgr.GetResourcesForSync()
 
@@ -97,7 +97,7 @@ func TestSettingsManager_GetResourcesForSync(t *testing.T) {
 		deployments.EXPECT().GetAll().Return(nil).AnyTimes()
 		pods.EXPECT().GetAll().Return(nil).AnyTimes()
 
-		mgr := NewSettingsManager(clusterID, clusterLabels, deployments, pods, nil).(*settingsManager)
+		mgr := NewSettingsManager(clusterID, clusterLabels, deployments, pods, nil, nil).(*settingsManager)
 
 		resources := mgr.GetResourcesForSync()
 
@@ -122,7 +122,7 @@ func TestSettingsManager_UpdateResources_NamespaceEvents(t *testing.T) {
 	pods := storeMocks.NewMockPodStore(ctrl)
 	namespaces := &mockNamespaceGetter{}
 
-	mgr := NewSettingsManager(clusterID, clusterLabels, deployments, pods, namespaces).(*settingsManager)
+	mgr := NewSettingsManager(clusterID, clusterLabels, deployments, pods, namespaces, nil).(*settingsManager)
 
 	// Test that all namespace event types are forwarded (not just deletes)
 	testCases := []struct {

--- a/sensor/common/configmap/event.go
+++ b/sensor/common/configmap/event.go
@@ -1,0 +1,21 @@
+package configmap
+
+import (
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ConfigMapUpdatedEvent carries a freshly computed ConfigMap to be persisted by a configMapPersister.
+type ConfigMapUpdatedEvent struct {
+	ConfigMap *v1.ConfigMap
+}
+
+// Topic implements pubsub.Event.
+func (e *ConfigMapUpdatedEvent) Topic() pubsub.Topic {
+	return pubsub.AdmCtrlConfigMapTopic
+}
+
+// Lane implements pubsub.Event.
+func (e *ConfigMapUpdatedEvent) Lane() pubsub.LaneID {
+	return pubsub.AdmCtrlConfigMapLane
+}

--- a/sensor/common/configmap/persister.go
+++ b/sensor/common/configmap/persister.go
@@ -7,9 +7,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,19 +45,42 @@ type configMapPersister struct {
 	client v1client.ConfigMapInterface
 
 	settingsStreamIt concurrency.ValueStreamIter[*v1.ConfigMap]
+
+	pubSubDispatcher common.PubSubDispatcher
 }
 
-func NewConfigMapPersister(name, namespace string, k8s kubernetes.Interface, settings concurrency.ValueStreamIter[*v1.ConfigMap]) common.SensorComponent {
+// NewConfigMapPersister creates a SensorComponent that persists the values published on settings
+// to a ConfigMap. pubSubDispatcher is only used when PubSub is enabled; pass nil for producers that
+// have not migrated to the PubSub topic yet, which keeps this persister on the legacy settings path
+// unconditionally.
+func NewConfigMapPersister(name, namespace string, k8s kubernetes.Interface, settings concurrency.ValueStreamIter[*v1.ConfigMap], pubSubDispatcher common.PubSubDispatcher) common.SensorComponent {
 	return &configMapPersister{
 		name:             name,
 		client:           k8s.CoreV1().ConfigMaps(namespace),
 		settingsStreamIt: settings,
+		pubSubDispatcher: pubSubDispatcher,
 	}
+}
+
+func (p *configMapPersister) pubSubEnabled() bool {
+	return features.SensorInternalPubSub.Enabled() && p.pubSubDispatcher != nil
 }
 
 func (p *configMapPersister) Start() error {
 	if !p.stopSig.Reset() {
 		return errors.New("config persister was already started")
+	}
+
+	if p.pubSubEnabled() {
+		if err := p.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.AdmCtrlConfigMapConsumer,
+			pubsub.AdmCtrlConfigMapTopic,
+			pubsub.AdmCtrlConfigMapLane,
+			p.handleConfigMapEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register config map consumer")
+		}
+		return nil
 	}
 
 	go p.run()
@@ -86,7 +111,7 @@ func (p *configMapPersister) ctx() context.Context {
 
 func (p *configMapPersister) run() {
 	// Attempt to apply the initial config, if any.
-	if err := p.applyCurrentConfigMap(p.ctx()); err != nil {
+	if err := p.applyCurrentConfigMap(p.ctx(), p.settingsStreamIt.Value()); err != nil {
 		log.Errorf("Could not apply %s config map: %v", p.name, err)
 	}
 
@@ -98,15 +123,26 @@ func (p *configMapPersister) run() {
 		case <-p.settingsStreamIt.Done():
 			p.settingsStreamIt = p.settingsStreamIt.TryNext()
 
-			if err := p.applyCurrentConfigMap(p.ctx()); err != nil {
+			if err := p.applyCurrentConfigMap(p.ctx(), p.settingsStreamIt.Value()); err != nil {
 				log.Errorf("Could not apply %s config map: %v", p.name, err)
 			}
 		}
 	}
 }
 
-func (p *configMapPersister) applyCurrentConfigMap(ctx context.Context) error {
-	configMap := p.settingsStreamIt.Value()
+// handleConfigMapEvent adapts a PubSub ConfigMapUpdatedEvent to applyCurrentConfigMap.
+func (p *configMapPersister) handleConfigMapEvent(event pubsub.Event) error {
+	configMapEvent, ok := event.(*ConfigMapUpdatedEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	if err := p.applyCurrentConfigMap(p.ctx(), configMapEvent.ConfigMap); err != nil {
+		log.Errorf("Could not apply %s config map: %v", p.name, err)
+	}
+	return nil
+}
+
+func (p *configMapPersister) applyCurrentConfigMap(ctx context.Context, configMap *v1.ConfigMap) error {
 	if configMap == nil {
 		return nil
 	}

--- a/sensor/common/configmap/persister_pubsub_test.go
+++ b/sensor/common/configmap/persister_pubsub_test.go
@@ -1,0 +1,78 @@
+package configmap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newTestConfigMapDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
+		[]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.AdmCtrlConfigMapLane),
+		},
+	))
+	require.NoError(t, err)
+	return dispatcher
+}
+
+// TestPubSubConfigMapPersisted verifies that publishing a ConfigMapUpdatedEvent results in the
+// persister creating (and later updating) the ConfigMap via the Kubernetes API, instead of relying
+// on the legacy ValueStream iterator, when PubSub is enabled.
+func TestPubSubConfigMapPersisted(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	dispatcher := newTestConfigMapDispatcher(t)
+	defer dispatcher.Stop()
+
+	k8s := fake.NewSimpleClientset()
+	persister := NewConfigMapPersister("admissionController", "stackrox", k8s, nil, dispatcher)
+	require.NoError(t, persister.Start())
+	defer persister.Stop()
+
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "admission-control"},
+		Data:       map[string]string{"key": "v1"},
+	}
+	require.NoError(t, dispatcher.Publish(&ConfigMapUpdatedEvent{ConfigMap: configMap}))
+
+	require.Eventually(t, func() bool {
+		cm, err := k8s.CoreV1().ConfigMaps("stackrox").Get(t.Context(), "admission-control", metav1.GetOptions{})
+		return err == nil && cm.Data["key"] == "v1"
+	}, 5*time.Second, 10*time.Millisecond, "config map was not created via pubsub")
+
+	updated := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "admission-control"},
+		Data:       map[string]string{"key": "v2"},
+	}
+	require.NoError(t, dispatcher.Publish(&ConfigMapUpdatedEvent{ConfigMap: updated}))
+
+	require.Eventually(t, func() bool {
+		cm, err := k8s.CoreV1().ConfigMaps("stackrox").Get(t.Context(), "admission-control", metav1.GetOptions{})
+		return err == nil && cm.Data["key"] == "v2"
+	}, 5*time.Second, 10*time.Millisecond, "config map was not updated via pubsub")
+}
+
+// TestPubSubConfigMapEvent_WrongEventType verifies handleConfigMapEvent rejects events of an
+// unexpected type instead of silently ignoring or panicking.
+func TestPubSubConfigMapEvent_WrongEventType(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+	persister := NewConfigMapPersister("admissionController", "stackrox", k8s, nil, nil).(*configMapPersister)
+
+	require.Error(t, persister.handleConfigMapEvent(&wrongConfigMapEvent{}))
+}
+
+type wrongConfigMapEvent struct{}
+
+func (*wrongConfigMapEvent) Topic() pubsub.Topic { return pubsub.DefaultTopic }
+func (*wrongConfigMapEvent) Lane() pubsub.LaneID { return pubsub.DefaultLane }

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -19,6 +19,7 @@ const (
 	OutputQueueConsumer
 	NetworkFlowManagerResourceSyncConsumer
 	SensorSoftRestartConsumer
+	AdmCtrlConfigMapConsumer
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 		OutputQueueConsumer:                    "OutputQueue",
 		NetworkFlowManagerResourceSyncConsumer: "NetworkFlowManagerResourceSync",
 		SensorSoftRestartConsumer:              "SensorSoftRestart",
+		AdmCtrlConfigMapConsumer:               "AdmCtrlConfigMap",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventLane
 	SoftRestartLane
 	ResourceSyncFinishedLane
+	AdmCtrlConfigMapLane
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 		SoftRestartLane:                "SoftRestart",
 		ResourceSyncFinishedLane:       "ResourceSyncFinished",
+		AdmCtrlConfigMapLane:           "AdmCtrlConfigMap",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -18,6 +18,7 @@ const (
 	ResolvedResourceEventTopic
 	SoftRestartTopic
 	ResourceSyncFinishedTopic
+	AdmCtrlConfigMapTopic
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 		SoftRestartTopic:                "SoftRestart",
 		ResourceSyncFinishedTopic:       "ResourceSyncFinished",
+		AdmCtrlConfigMapTopic:           "AdmCtrlConfigMap",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -49,6 +49,7 @@ func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher,
 			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			lane.NewBlockingLane(pubsub.SoftRestartLane),
 			lane.NewBlockingLane(pubsub.ResourceSyncFinishedLane),
+			lane.NewBlockingLane(pubsub.AdmCtrlConfigMapLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -91,7 +91,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if features.LabelBasedPolicyScoping.Enabled() {
 		namespaces = storeProvider.Namespaces()
 	}
-	admCtrlSettingsMgr := admissioncontroller.NewSettingsManager(clusterID, storeProvider.ClusterLabels(), storeProvider.Deployments(), storeProvider.Pods(), namespaces)
+	admCtrlSettingsMgr := admissioncontroller.NewSettingsManager(clusterID, storeProvider.ClusterLabels(), storeProvider.Deployments(), storeProvider.Pods(), namespaces, internalMessageDispatcher)
 	var factSettingsMgr *filesystem.FactSettingsManager
 	if features.SensitiveFileActivity.Enabled() {
 		factSettingsMgr = filesystem.NewFactSettingsManager()
@@ -243,6 +243,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 				sensorNamespace,
 				cfg.k8sClient.Kubernetes(),
 				admCtrlSettingsMgr.ConfigMapStream().Iterator(false),
+				internalMessageDispatcher,
 			),
 		)
 	}
@@ -254,6 +255,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 				sensorNamespace,
 				cfg.k8sClient.Kubernetes(),
 				factSettingsMgr.ConfigMapStream().Iterator(false),
+				nil,
 			),
 		)
 	}


### PR DESCRIPTION
## Description

  Migrates the Admission Controller Settings Manager's `configStream` (the ConfigMap-persistence side channel) to the internal PubSub system, gated by
  `features.SensorInternalPubSub` (`ROX_SENSOR_PUBSUB`, default-enabled).

  - `settingsManager.pushSettings()` publishes a new `configmap.ConfigMapUpdatedEvent` on a dedicated `AdmCtrlConfigMapTopic`/`AdmCtrlConfigMapLane`
  instead of `configStream.Push(config)`, when the flag is enabled.
  - When disabled, the existing `configStream`/`ConfigMapStream()` path is untouched.
  - `settingsStream.Push(newSettings)` (the gRPC-push side, a separate ticket — ROX-36003) is untouched either way.
  - `configMapPersister` (`sensor/common/configmap/persister.go`) registers via `RegisterConsumerToLane` instead of spawning its own goroutine that reads
  a `ValueStreamIter`, when the flag is enabled. `applyCurrentConfigMap` was refactored to take the `*v1.ConfigMap` as a parameter so both the legacy
  loop and the new PubSub callback share the same create-or-update logic.
  - **Design note:** the event type lives in `sensor/common/configmap` (the consumer's package), not `sensor/common/admissioncontroller` (the producer's
  package). Unlike the `ComplianceOperatorRequestEvent` precedent — where producer and consumer are the same package — `admissioncontroller` already
  imports `configmap`, so defining the event there would create an import cycle.
  - `configMapPersister` has two call sites in `sensor.go`: `"admissionController"` (migrated, now gets the real dispatcher) and `"fact"` (not in scope —
  gets `nil`, so it stays on the legacy path unconditionally regardless of the flag).

  No dependency on the Central-bound bridge (ROX-35640) — this is an `[inner]` migration (both producer and consumer are in-process Sensor components),
  not a `ResponsesC()`/`[central-out]` one, so it branches directly off master.

  🤖 This change was partially generated with the assistance of AI.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**
  is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is
  gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - Added `settings_manager_impl_pubsub_test.go`: `TestPubSubPushSettingsPublishesConfigMap` drives `UpdatePolicies`/`UpdateConfig` with
  `ROX_SENSOR_PUBSUB=true` and a real dispatcher, asserts the `ConfigMapUpdatedEvent` is published, and asserts `configStream` receives nothing — proving
  the dual-path branch actually branches.
  - Added `persister_pubsub_test.go`: `TestPubSubConfigMapPersisted` publishes two successive `ConfigMapUpdatedEvent`s through a real dispatcher/lane and
  asserts the fake Kubernetes clientset ends up with the ConfigMap created, then updated — proving the full Publish → lane → `handleConfigMapEvent` →
  `applyCurrentConfigMap` path. `TestPubSubConfigMapEvent_WrongEventType` verifies `handleConfigMapEvent` rejects an unexpected event type instead of
  panicking.
  - Existing `settings_manager_impl_test.go` suite passes unchanged against the legacy path — only its `NewSettingsManager(...)` call sites needed a
  trailing `nil` dispatcher arg.