### PR TITLE
ROX-36509: lazy-init children slice in process filter levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-34804: The machine access configuration for `config-controller` now validates the audience (`aud` claim) of the service account token. The expected audience is `central.stackrox.io`. When users have added their own role bindings to this machine access configuration, the audience check is not enforced by default to keep backwards compatibility. It is recommended to set the expected audience to `central.stackrox.io` after ensuring that all exchange tokens are being created with this audience claim.
 
 - ROX-34535: Fixes an issue where if ScannerV2 is disabled or unavailable on initial startup the central deployment leaks GRPC connections until the scanner becomes available.
+- ROX-36509: Improved Central memory efficiency by optimizing process filter data structures in high-cardinality scenarios. The `ROX_PROCESS_FILTER_FAN_OUT_LEVELS` environment variable now accepts values up to 255; higher values are automatically clamped with a warning.
 
 ## [4.11.0]
 

--- a/pkg/env/process_filter.go
+++ b/pkg/env/process_filter.go
@@ -25,8 +25,9 @@ var (
 	// An empty array "[]" means only unique processes are tracked without argument tracking.
 	// This setting can be overridden by ROX_PROCESS_FILTER_MODE presets.
 	// Default: [8,6,4,2]
+	// TODO(janisz): change maximum element Value to 255 to avoid implicit clamping in filter.go
 	ProcessFilterFanOutLevels = RegisterIntegerArraySetting(
 		"ROX_PROCESS_FILTER_FAN_OUT_LEVELS",
 		[]int{8, 6, 4, 2},
-	).WithMinimumElementValue(1).WithMaximumElementValue(255).WithMinLength(0).WithMaxLength(10)
+	).WithMinimumElementValue(1).WithMaximumElementValue(1000).WithMinLength(0).WithMaxLength(10)
 )

--- a/pkg/env/process_filter.go
+++ b/pkg/env/process_filter.go
@@ -28,5 +28,5 @@ var (
 	ProcessFilterFanOutLevels = RegisterIntegerArraySetting(
 		"ROX_PROCESS_FILTER_FAN_OUT_LEVELS",
 		[]int{8, 6, 4, 2},
-	).WithMinimumElementValue(1).WithMaximumElementValue(1000).WithMinLength(0).WithMaxLength(10)
+	).WithMinimumElementValue(1).WithMaximumElementValue(255).WithMinLength(0).WithMaxLength(10)
 )

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -109,9 +109,9 @@ func makeChildren() map[BinaryHash]*level {
 }
 
 type filterImpl struct {
-	maxExactPathMatches int   // maximum number of exact path (same pod + container and same process and args) matches to tolerate
-	maxUniqueProcesses  int   // maximum number of unique process exec file paths
-	maxFanOut           []int // maximum fan out starting at the process level
+	maxExactPathMatches int // maximum number of exact path (same pod + container and same process and args) matches to tolerate
+	maxUniqueProcesses  int // maximum number of unique process exec file paths
+	maxFanOut           []uint8
 
 	containersInDeployment map[string]map[string]*level
 	rootLock               sync.Mutex
@@ -143,7 +143,7 @@ func (f *filterImpl) siftNoLock(level *level, args []string, levelNum int) bool 
 	nextLevel := level.children[argHash]
 	if nextLevel == nil {
 		// If this level has already hit its max fan out then return false
-		if len(level.children) >= f.maxFanOut[levelNum] {
+		if len(level.children) >= int(f.maxFanOut[levelNum]) {
 			return false
 		}
 		nextLevel = newLevel()
@@ -158,11 +158,17 @@ func (f *filterImpl) siftNoLock(level *level, args []string, levelNum int) bool 
 
 // NewFilter returns an empty filter to start loading processes into
 func NewFilter(maxExactPathMatches, maxUniqueProcesses int, fanOut []int) Filter {
+	fo := make([]uint8, len(fanOut))
+	for i, v := range fanOut {
+		if v > 255 {
+			v = 255
+		}
+		fo[i] = uint8(v)
+	}
 	return &filterImpl{
-		maxExactPathMatches: maxExactPathMatches,
-		maxUniqueProcesses:  maxUniqueProcesses,
-		maxFanOut:           fanOut,
-
+		maxExactPathMatches:    maxExactPathMatches,
+		maxUniqueProcesses:     maxUniqueProcesses,
+		maxFanOut:              fo,
 		containersInDeployment: make(map[string]map[string]*level),
 		h:                      xxhash.New(),
 	}

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -175,6 +175,12 @@ func (f *filterImpl) siftNoLock(level *level, args []string, levelNum int) bool 
 func NewFilter(maxExactPathMatches, maxUniqueProcesses int, fanOut []int) Filter {
 	maxFanOut := make([]uint8, len(fanOut))
 	for i, v := range fanOut {
+		if v < 1 {
+			// Guard the boundary: uint8(negative) wraps to a large value (e.g. -1 -> 255).
+			// Mirror the env layer's MinimumElementValue(1) so invalid values cannot become max fan out.
+			utils.Should(fmt.Errorf("fanOut[%d]=%d is below minimum, clamping to 1", i, v))
+			v = 1
+		}
 		if v > 255 {
 			utils.Should(fmt.Errorf("fanOut[%d]=%d exceeds uint8 max, clamping to 255", i, v))
 			v = 255

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -101,9 +101,11 @@ type level struct {
 }
 
 func newLevel() *level {
-	return &level{
-		children: make(map[BinaryHash]*level),
-	}
+	return &level{}
+}
+
+func makeChildren() map[BinaryHash]*level {
+	return make(map[BinaryHash]*level)
 }
 
 type filterImpl struct {
@@ -145,6 +147,9 @@ func (f *filterImpl) siftNoLock(level *level, args []string, levelNum int) bool 
 			return false
 		}
 		nextLevel = newLevel()
+		if level.children == nil {
+			level.children = makeChildren()
+		}
 		level.children[argHash] = nextLevel
 	}
 
@@ -198,6 +203,9 @@ func (f *filterImpl) Add(indicator *storage.ProcessIndicator) bool {
 			return false
 		}
 		processLevel = newLevel()
+		if rootLevel.children == nil {
+			rootLevel.children = make(map[BinaryHash]*level)
+		}
 		rootLevel.children[execFilePathHash] = processLevel
 	}
 

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"fmt"
 	"hash"
 	"strings"
 	"unsafe"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 // BinaryHash represents a 64-bit hash for memory-efficient key storage.
@@ -95,23 +97,33 @@ type Filter interface {
 	DeleteByPod(pod *storage.Pod)
 }
 
+type child struct {
+	hash BinaryHash
+	node *level
+}
+
 type level struct {
 	hits     int
-	children map[BinaryHash]*level
+	children []child
 }
 
 func newLevel() *level {
 	return &level{}
 }
 
-func makeChildren() map[BinaryHash]*level {
-	return make(map[BinaryHash]*level)
+func (l *level) findChild(h BinaryHash) *level {
+	for _, c := range l.children {
+		if c.hash == h {
+			return c.node
+		}
+	}
+	return nil
 }
 
 type filterImpl struct {
-	maxExactPathMatches int // maximum number of exact path (same pod + container and same process and args) matches to tolerate
-	maxUniqueProcesses  int // maximum number of unique process exec file paths
-	maxFanOut           []uint8
+	maxExactPathMatches int     // maximum number of exact path (same pod + container and same process and args) matches to tolerate
+	maxUniqueProcesses  int     // maximum number of unique process exec file paths
+	maxFanOut           []uint8 // maximum fan out starting at the process level
 
 	containersInDeployment map[string]map[string]*level
 	rootLock               sync.Mutex
@@ -140,17 +152,14 @@ func (f *filterImpl) siftNoLock(level *level, args []string, levelNum int) bool 
 	// 2. Using BinaryHash as map key is reducing memory requirements for the filter
 	argHash := hashString(f.h, truncated)
 
-	nextLevel := level.children[argHash]
+	nextLevel := level.findChild(argHash)
 	if nextLevel == nil {
 		// If this level has already hit its max fan out then return false
 		if len(level.children) >= int(f.maxFanOut[levelNum]) {
 			return false
 		}
 		nextLevel = newLevel()
-		if level.children == nil {
-			level.children = makeChildren()
-		}
-		level.children[argHash] = nextLevel
+		level.children = append(level.children, child{hash: argHash, node: nextLevel})
 	}
 
 	return f.siftNoLock(nextLevel, args[1:], levelNum+1)
@@ -158,17 +167,19 @@ func (f *filterImpl) siftNoLock(level *level, args []string, levelNum int) bool 
 
 // NewFilter returns an empty filter to start loading processes into
 func NewFilter(maxExactPathMatches, maxUniqueProcesses int, fanOut []int) Filter {
-	fo := make([]uint8, len(fanOut))
+	maxFanOut := make([]uint8, len(fanOut))
 	for i, v := range fanOut {
 		if v > 255 {
+			utils.Should(fmt.Errorf("fanOut[%d]=%d exceeds uint8 max, clamping to 255", i, v))
 			v = 255
 		}
-		fo[i] = uint8(v)
+		maxFanOut[i] = uint8(v)
 	}
 	return &filterImpl{
-		maxExactPathMatches:    maxExactPathMatches,
-		maxUniqueProcesses:     maxUniqueProcesses,
-		maxFanOut:              fo,
+		maxExactPathMatches: maxExactPathMatches,
+		maxUniqueProcesses:  maxUniqueProcesses,
+		maxFanOut:           maxFanOut,
+
 		containersInDeployment: make(map[string]map[string]*level),
 		h:                      xxhash.New(),
 	}
@@ -203,16 +214,13 @@ func (f *filterImpl) Add(indicator *storage.ProcessIndicator) bool {
 	execFilePathHash := hashString(f.h, execFilePath)
 
 	// Handle the process level independently as we will never reject a new process
-	processLevel := rootLevel.children[execFilePathHash]
+	processLevel := rootLevel.findChild(execFilePathHash)
 	if processLevel == nil {
 		if len(rootLevel.children) >= f.maxUniqueProcesses {
 			return false
 		}
 		processLevel = newLevel()
-		if rootLevel.children == nil {
-			rootLevel.children = make(map[BinaryHash]*level)
-		}
-		rootLevel.children[execFilePathHash] = processLevel
+		rootLevel.children = append(rootLevel.children, child{hash: execFilePathHash, node: processLevel})
 	}
 
 	return f.siftNoLock(processLevel, strings.Fields(indicator.GetSignal().GetArgs()), 0)

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -182,7 +182,7 @@ func NewFilter(maxExactPathMatches, maxUniqueProcesses int, fanOut []int) Filter
 			v = 1
 		}
 		if v > 255 {
-			utils.Should(fmt.Errorf("fanOut[%d]=%d exceeds uint8 max, clamping to 255", i, v))
+			utils.Should(fmt.Errorf("ROX_PROCESS_FILTER_FAN_OUT_LEVELS[%d]=%d exceeds uint8 max, clamping to 255", i, v))
 			v = 255
 		}
 		maxFanOut[i] = uint8(v)

--- a/pkg/process/filter/filter.go
+++ b/pkg/process/filter/filter.go
@@ -120,12 +120,18 @@ func (l *level) findChild(h BinaryHash) *level {
 	return nil
 }
 
+// containerNode is the per-container root of the filter tree, keyed by process
+// executable path. The process layer is unbounded (Sensor sets maxUniqueProcesses
+// to math.MaxInt), so a map keeps lookup and insertion O(1); argument levels below
+// each process are bounded by fanOut and use slices (see level).
+type containerNode = map[BinaryHash]*level
+
 type filterImpl struct {
 	maxExactPathMatches int     // maximum number of exact path (same pod + container and same process and args) matches to tolerate
 	maxUniqueProcesses  int     // maximum number of unique process exec file paths
 	maxFanOut           []uint8 // maximum fan out starting at the process level
 
-	containersInDeployment map[string]map[string]*level
+	containersInDeployment map[string]map[string]containerNode
 	rootLock               sync.Mutex
 
 	// Hash instance for computing BinaryHash keys
@@ -180,21 +186,21 @@ func NewFilter(maxExactPathMatches, maxUniqueProcesses int, fanOut []int) Filter
 		maxUniqueProcesses:  maxUniqueProcesses,
 		maxFanOut:           maxFanOut,
 
-		containersInDeployment: make(map[string]map[string]*level),
+		containersInDeployment: make(map[string]map[string]containerNode),
 		h:                      xxhash.New(),
 	}
 }
 
-func (f *filterImpl) getOrAddRootLevelNoLock(indicator *storage.ProcessIndicator) *level {
+func (f *filterImpl) getOrAddRootLevelNoLock(indicator *storage.ProcessIndicator) containerNode {
 	containerMap := f.containersInDeployment[indicator.GetDeploymentId()]
 	if containerMap == nil {
-		containerMap = make(map[string]*level)
+		containerMap = make(map[string]containerNode)
 		f.containersInDeployment[indicator.GetDeploymentId()] = containerMap
 	}
 
 	rootLevel := containerMap[indicator.GetSignal().GetContainerId()]
 	if rootLevel == nil {
-		rootLevel = newLevel()
+		rootLevel = make(containerNode)
 		containerMap[indicator.GetSignal().GetContainerId()] = rootLevel
 	}
 
@@ -214,13 +220,13 @@ func (f *filterImpl) Add(indicator *storage.ProcessIndicator) bool {
 	execFilePathHash := hashString(f.h, execFilePath)
 
 	// Handle the process level independently as we will never reject a new process
-	processLevel := rootLevel.findChild(execFilePathHash)
+	processLevel := rootLevel[execFilePathHash]
 	if processLevel == nil {
-		if len(rootLevel.children) >= f.maxUniqueProcesses {
+		if len(rootLevel) >= f.maxUniqueProcesses {
 			return false
 		}
 		processLevel = newLevel()
-		rootLevel.children = append(rootLevel.children, child{hash: execFilePathHash, node: processLevel})
+		rootLevel[execFilePathHash] = processLevel
 	}
 
 	return f.siftNoLock(processLevel, strings.Fields(indicator.GetSignal().GetArgs()), 0)

--- a/pkg/process/filter/filter_bench_test.go
+++ b/pkg/process/filter/filter_bench_test.go
@@ -8,45 +8,102 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-// BenchmarkAdd measures performance of adding process indicators
 func BenchmarkAdd(b *testing.B) {
-	filter := NewFilter(100, 1000, []int{100, 100, 100})
-
-	// Create test data
-	indicators := make([]*storage.ProcessIndicator, 1000)
-	for i := range indicators {
-		indicators[i] = &storage.ProcessIndicator{
-			DeploymentId:  fmt.Sprintf("dep%d", i%10),
-			ContainerName: "container",
-			Signal: &storage.ProcessSignal{
-				ContainerId:  fmt.Sprintf("id%d", i%10),
-				ExecFilePath: fmt.Sprintf("/usr/bin/process%d", i%100),
-				Args:         fmt.Sprintf("arg1 arg2 arg3 iteration%d", i),
-			},
-		}
-	}
-
-	for i := 0; b.Loop(); i++ {
-		filter.Add(indicators[i%len(indicators)])
-	}
-}
-
-// BenchmarkAddMemory measures memory allocations
-func BenchmarkAddMemory(b *testing.B) {
-	filter := NewFilter(100, 1000, []int{100, 100, 100})
-
-	pi := &storage.ProcessIndicator{
-		DeploymentId:  "deployment",
-		ContainerName: "container",
-		Signal: &storage.ProcessSignal{
-			ContainerId:  "containerid",
-			ExecFilePath: "/usr/bin/process",
-			Args:         "arg1 arg2 arg3",
+	cases := []struct {
+		name           string
+		fanOut         []int
+		maxExact       int
+		maxUnique      int
+		numIndicators  int
+		numDeployments int
+		numProcesses   int
+	}{
+		{
+			name:           "default_fanout",
+			fanOut:         []int{8, 6, 4, 2},
+			maxExact:       5,
+			maxUnique:      5000,
+			numIndicators:  1000,
+			numDeployments: 10,
+			numProcesses:   100,
+		},
+		{
+			name:           "high_fanout",
+			fanOut:         []int{100, 100, 100},
+			maxExact:       100,
+			maxUnique:      1000,
+			numIndicators:  1000,
+			numDeployments: 10,
+			numProcesses:   100,
 		},
 	}
 
-	for b.Loop() {
-		filter.Add(pi)
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			filter := NewFilter(tc.maxExact, tc.maxUnique, tc.fanOut)
+
+			indicators := make([]*storage.ProcessIndicator, tc.numIndicators)
+			for i := range indicators {
+				indicators[i] = &storage.ProcessIndicator{
+					DeploymentId:  fmt.Sprintf("dep%d", i%tc.numDeployments),
+					ContainerName: "container",
+					Signal: &storage.ProcessSignal{
+						ContainerId:  fmt.Sprintf("id%d", i%tc.numDeployments),
+						ExecFilePath: fmt.Sprintf("/usr/bin/process%d", i%tc.numProcesses),
+						Args:         fmt.Sprintf("arg1 arg2 arg3 iteration%d", i),
+					},
+				}
+			}
+
+			for i := 0; b.Loop(); i++ {
+				filter.Add(indicators[i%len(indicators)])
+			}
+		})
+	}
+}
+
+func BenchmarkLookupInFullLevel(b *testing.B) {
+	cases := []struct {
+		name    string
+		fanOut  []int
+		numArgs int
+	}{
+		{name: "fanout_8", fanOut: []int{8}, numArgs: 8},
+		{name: "fanout_20", fanOut: []int{20}, numArgs: 20},
+		{name: "fanout_100", fanOut: []int{100}, numArgs: 100},
+		{name: "fanout_255", fanOut: []int{255}, numArgs: 255},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			filter := NewFilter(tc.numArgs+1, 5000, tc.fanOut)
+
+			for i := range tc.numArgs {
+				filter.Add(&storage.ProcessIndicator{
+					DeploymentId:  "dep",
+					ContainerName: "container",
+					Signal: &storage.ProcessSignal{
+						ContainerId:  "id",
+						ExecFilePath: "/usr/bin/proc",
+						Args:         fmt.Sprintf("arg%d", i),
+					},
+				})
+			}
+
+			last := &storage.ProcessIndicator{
+				DeploymentId:  "dep",
+				ContainerName: "container",
+				Signal: &storage.ProcessSignal{
+					ContainerId:  "id",
+					ExecFilePath: "/usr/bin/proc",
+					Args:         fmt.Sprintf("arg%d", tc.numArgs-1),
+				},
+			}
+
+			for b.Loop() {
+				filter.Add(last)
+			}
+		})
 	}
 }
 

--- a/pkg/process/filter/filter_bench_test.go
+++ b/pkg/process/filter/filter_bench_test.go
@@ -2,7 +2,7 @@ package filter
 
 import (
 	"fmt"
-	"runtime"
+	"math"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -137,8 +137,64 @@ func BenchmarkBuildIndicatorFilterMemory(b *testing.B) {
 				}
 			}
 		}
+	}
+}
 
-		// Force GC to measure actual memory retained
-		runtime.GC()
+// BenchmarkHighCardinalityProcesses measures a single container accumulating many
+// distinct executable paths. Sensor runs with an unbounded maxUniqueProcesses, so
+// the process level must stay near O(1) per insert rather than degrading to O(n^2).
+// The "maxed" case additionally pushes the configurable parameters to their limits
+// (fanOut 255 across 10 levels, maxExact 1000) with several argument variations per
+// process to also stress the argument-level tree.
+func BenchmarkHighCardinalityProcesses(b *testing.B) {
+	cases := []struct {
+		name         string
+		numProcesses int
+		argsPerProc  int
+		fanOut       []int
+		maxExact     int
+	}{
+		{
+			name:         "10k_processes_default_fanout",
+			numProcesses: 10000,
+			argsPerProc:  1,
+			fanOut:       []int{8, 6, 4, 2},
+			maxExact:     5,
+		},
+		{
+			name:         "10k_processes_maxed_params",
+			numProcesses: 10000,
+			argsPerProc:  20,
+			fanOut:       []int{255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+			maxExact:     1000,
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			indicators := make([]*storage.ProcessIndicator, 0, tc.numProcesses*tc.argsPerProc)
+			for p := range tc.numProcesses {
+				for a := range tc.argsPerProc {
+					indicators = append(indicators, &storage.ProcessIndicator{
+						DeploymentId:  "dep",
+						ContainerName: "container",
+						Signal: &storage.ProcessSignal{
+							ContainerId:  "id",
+							ExecFilePath: fmt.Sprintf("/usr/bin/process%d", p),
+							Args:         fmt.Sprintf("--flag%d value subcommand run", a),
+						},
+					})
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				filter := NewFilter(tc.maxExact, math.MaxInt, tc.fanOut)
+				for _, pi := range indicators {
+					filter.Add(pi)
+				}
+			}
+		})
 	}
 }

--- a/pkg/process/filter/filter_test.go
+++ b/pkg/process/filter/filter_test.go
@@ -21,6 +21,14 @@ func TestBasicFilterFunctions(t *testing.T) {
 	assert.True(t, filter.Add(pi))
 }
 
+func TestNewFilterNegativeFanOut(t *testing.T) {
+	// A negative fanOut must be caught at the NewFilter boundary rather than
+	// silently wrapping through uint8 to 255. utils.Should panics on non-release builds.
+	assert.Panics(t, func() {
+		NewFilter(2, 5, []int{-1})
+	})
+}
+
 func TestBasicFilter(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
## Description

Leaf nodes never use their children map. Deferring allocation until the first child is inserted to eliminate map allocations. Also with fan out limit using a map is an overkill for just 8 elements so let's replace it with a slice and limit max level to 255.

This is the bigest contribuitor to `inuse_objects:count` metric
<img width="1085" height="97" alt="image" src="https://github.com/user-attachments/assets/55e3c922-0c3b-4192-9968-5644efd6d04e" />


```
                                                          │    master    │                 head                 │
                                                          │    sec/op    │    sec/op     vs base                │
  Add/default_fanout-8                                      793.8n ± 40%   530.6n ± 11%  -33.16% (p=0.001 n=10)
  Add/high_fanout-8                                         744.2n ± 27%   548.4n ± 71%        ~ (p=0.247 n=10)
  LookupInFullLevel/fanout_8-8                              324.6n ±  4%   343.5n ± 14%        ~ (p=0.190 n=10)
  LookupInFullLevel/fanout_20-8                             350.3n ±  5%   363.9n ± 15%        ~ (p=0.469 n=10)
  LookupInFullLevel/fanout_100-8                            374.7n ± 17%   474.1n ± 20%  +26.53% (p=0.011 n=10)
  LookupInFullLevel/fanout_255-8                            576.1n ± 42%   692.6n ± 27%        ~ (p=0.165 n=10)
  BuildIndicatorFilterMemory-8                              26.94m ± 30%   24.54m ± 28%        ~ (p=0.218 n=10)
  HighCardinalityProcesses/10k_processes_default_fanout-8   26.26m ± 21%   15.09m ± 40%  -42.55% (p=0.001 n=10)
  HighCardinalityProcesses/10k_processes_maxed_params-8     349.6m ± 20%   301.7m ± 16%        ~ (p=0.052 n=10)
  geomean                                                   24.83µ         22.24µ        -10.40%

                                                          │    B/op       │     B/op      vs base                 │
  BuildIndicatorFilterMemory-8                              14.109Mi ± 0%   7.684Mi ± 0%  -45.54% (p=0.000 n=10)
  HighCardinalityProcesses/10k_processes_default_fanout-8    9.720Mi ± 0%   3.312Mi ± 0%  -65.93% (p=0.000 n=10)
  HighCardinalityProcesses/10k_processes_maxed_params-8     154.91Mi ± 0%   56.26Mi ± 0%  -63.68% (p=0.000 n=10)
  geomean (all)                                              2.594Ki        1.922Ki       -25.90%

                                                          │  allocs/op  │  allocs/op   vs base                  │
  BuildIndicatorFilterMemory-8                              197.6k ± 0%   146.6k ± 0%  -25.81% (p=0.000 n=10)
  HighCardinalityProcesses/10k_processes_default_fanout-8   150.1k ± 0%   100.1k ± 0%  -33.31% (p=0.000 n=10)
  HighCardinalityProcesses/10k_processes_maxed_params-8     2.480M ± 0%   1.670M ± 0%  -32.66% (p=0.000 n=10)
  geomean (all)                                             74.83         66.23       -11.50%
 ```
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

benchmark + CI
