### PR TITLE
ROX-36266: Include local scanner health in cluster health status

### DIFF
--- a/pkg/clusterhealth/status.go
+++ b/pkg/clusterhealth/status.go
@@ -142,29 +142,36 @@ func PopulateLocalScannerStatus(localScannerHealthInfo *storage.ScannerHealthInf
 	return storage.ClusterHealthStatus_HEALTHY
 }
 
-// PopulateOverallClusterStatus returns overall cluster status based on sensor status and collector status.
+// PopulateOverallClusterStatus returns overall cluster status based on sensor, collector,
+// admission control, and local scanner status.
 func PopulateOverallClusterStatus(clusterHealth *storage.ClusterHealthStatus) storage.ClusterHealthStatus_HealthStatusLabel {
 	sensorStatus := clusterHealth.GetSensorHealthStatus()
 	collectorStatus := clusterHealth.GetCollectorHealthStatus()
 	admissionControlStatus := clusterHealth.GetAdmissionControlHealthStatus()
+	scannerStatus := clusterHealth.GetScannerHealthStatus()
 
-	// Collector having states other than default state when sensor is in default state is unlikely, but still check it first.
 	if sensorStatus == storage.ClusterHealthStatus_UNINITIALIZED {
 		return sensorStatus
 	}
 
+	// Scanner is optional (only deployed when local image scanning is enabled),
+	// so it only contributes to overall health when not UNINITIALIZED.
+	scannerActive := scannerStatus != storage.ClusterHealthStatus_UNINITIALIZED
+
 	if collectorStatus == storage.ClusterHealthStatus_UNHEALTHY ||
-		admissionControlStatus == storage.ClusterHealthStatus_UNHEALTHY {
+		admissionControlStatus == storage.ClusterHealthStatus_UNHEALTHY ||
+		(scannerActive && scannerStatus == storage.ClusterHealthStatus_UNHEALTHY) {
 		return storage.ClusterHealthStatus_UNHEALTHY
 	}
 
-	if collectorStatus == storage.ClusterHealthStatus_DEGRADED || admissionControlStatus == storage.ClusterHealthStatus_DEGRADED {
+	if collectorStatus == storage.ClusterHealthStatus_DEGRADED ||
+		admissionControlStatus == storage.ClusterHealthStatus_DEGRADED ||
+		(scannerActive && scannerStatus == storage.ClusterHealthStatus_DEGRADED) {
 		if sensorStatus == storage.ClusterHealthStatus_UNHEALTHY {
 			return storage.ClusterHealthStatus_UNHEALTHY
 		}
 		return storage.ClusterHealthStatus_DEGRADED
 	}
 
-	// If we are here it means collector and admission controller is not unhealthy or degraded. Overall cluster health is determined by sensor status.
 	return sensorStatus
 }

--- a/pkg/clusterhealth/status.go
+++ b/pkg/clusterhealth/status.go
@@ -1,6 +1,7 @@
 package clusterhealth
 
 import (
+	"slices"
 	"time"
 
 	"github.com/stackrox/rox/generated/storage"
@@ -154,19 +155,11 @@ func PopulateOverallClusterStatus(clusterHealth *storage.ClusterHealthStatus) st
 		return sensorStatus
 	}
 
-	// Scanner is optional (only deployed when local image scanning is enabled),
-	// so it only contributes to overall health when not UNINITIALIZED.
-	scannerActive := scannerStatus != storage.ClusterHealthStatus_UNINITIALIZED
-
-	if collectorStatus == storage.ClusterHealthStatus_UNHEALTHY ||
-		admissionControlStatus == storage.ClusterHealthStatus_UNHEALTHY ||
-		(scannerActive && scannerStatus == storage.ClusterHealthStatus_UNHEALTHY) {
+	if isUnhealthy(collectorStatus, admissionControlStatus, scannerStatus) {
 		return storage.ClusterHealthStatus_UNHEALTHY
 	}
 
-	if collectorStatus == storage.ClusterHealthStatus_DEGRADED ||
-		admissionControlStatus == storage.ClusterHealthStatus_DEGRADED ||
-		(scannerActive && scannerStatus == storage.ClusterHealthStatus_DEGRADED) {
+	if isDegraded(collectorStatus, admissionControlStatus, scannerStatus) {
 		if sensorStatus == storage.ClusterHealthStatus_UNHEALTHY {
 			return storage.ClusterHealthStatus_UNHEALTHY
 		}
@@ -174,4 +167,12 @@ func PopulateOverallClusterStatus(clusterHealth *storage.ClusterHealthStatus) st
 	}
 
 	return sensorStatus
+}
+
+func isUnhealthy(statuses ...storage.ClusterHealthStatus_HealthStatusLabel) bool {
+	return slices.Contains(statuses, storage.ClusterHealthStatus_UNHEALTHY)
+}
+
+func isDegraded(statuses ...storage.ClusterHealthStatus_HealthStatusLabel) bool {
+	return slices.Contains(statuses, storage.ClusterHealthStatus_DEGRADED)
 }

--- a/pkg/clusterhealth/status_test.go
+++ b/pkg/clusterhealth/status_test.go
@@ -170,72 +170,103 @@ func podsReady(num int32) *storage.CollectorHealthInfo_TotalReadyPods {
 }
 
 func TestOverallHealth(t *testing.T) {
-	cases := []struct {
-		name     string
+	cases := map[string]struct {
 		health   *storage.ClusterHealthStatus
 		expected storage.ClusterHealthStatus_HealthStatusLabel
 	}{
-		{
-			name: "sensor degraded, collector unhealthy",
+		"sensor degraded, collector unhealthy": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_DEGRADED,
 				CollectorHealthStatus: storage.ClusterHealthStatus_UNHEALTHY,
 			},
 			expected: storage.ClusterHealthStatus_UNHEALTHY,
 		},
-		{
-			name: "sensor unhealthy, collector degraded",
+		"sensor unhealthy, collector degraded": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_UNHEALTHY,
 				CollectorHealthStatus: storage.ClusterHealthStatus_DEGRADED,
 			},
 			expected: storage.ClusterHealthStatus_UNHEALTHY,
 		},
-		{
-			name: "sensor degraded, collector healthy",
+		"sensor degraded, collector healthy": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_DEGRADED,
 				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
 			},
 			expected: storage.ClusterHealthStatus_DEGRADED,
 		},
-		{
-			name: "sensor healthy, collector degraded",
+		"sensor healthy, collector degraded": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
 				CollectorHealthStatus: storage.ClusterHealthStatus_DEGRADED,
 			},
 			expected: storage.ClusterHealthStatus_DEGRADED,
 		},
-		{
-			name: "sensor healthy, collector unavailable",
+		"sensor healthy, collector unavailable": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
 				CollectorHealthStatus: storage.ClusterHealthStatus_UNAVAILABLE,
 			},
 			expected: storage.ClusterHealthStatus_HEALTHY,
 		},
-		{
-			name: "sensor healthy, collector healthy",
+		"sensor healthy, collector healthy": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
 				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
 			},
 			expected: storage.ClusterHealthStatus_HEALTHY,
 		},
-		{
-			name: "sensor unintialized, collector unhealthy: unexpected states",
+		"sensor uninitialized, collector unhealthy: unexpected states": {
 			health: &storage.ClusterHealthStatus{
 				SensorHealthStatus:    storage.ClusterHealthStatus_UNINITIALIZED,
 				CollectorHealthStatus: storage.ClusterHealthStatus_UNHEALTHY,
 			},
 			expected: storage.ClusterHealthStatus_UNINITIALIZED,
 		},
+		"scanner uninitialized does not affect overall health": {
+			health: &storage.ClusterHealthStatus{
+				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
+				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+				ScannerHealthStatus:   storage.ClusterHealthStatus_UNINITIALIZED,
+			},
+			expected: storage.ClusterHealthStatus_HEALTHY,
+		},
+		"scanner healthy does not degrade overall health": {
+			health: &storage.ClusterHealthStatus{
+				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
+				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+				ScannerHealthStatus:   storage.ClusterHealthStatus_HEALTHY,
+			},
+			expected: storage.ClusterHealthStatus_HEALTHY,
+		},
+		"scanner unhealthy makes overall unhealthy": {
+			health: &storage.ClusterHealthStatus{
+				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
+				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+				ScannerHealthStatus:   storage.ClusterHealthStatus_UNHEALTHY,
+			},
+			expected: storage.ClusterHealthStatus_UNHEALTHY,
+		},
+		"scanner degraded makes overall degraded": {
+			health: &storage.ClusterHealthStatus{
+				SensorHealthStatus:    storage.ClusterHealthStatus_HEALTHY,
+				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+				ScannerHealthStatus:   storage.ClusterHealthStatus_DEGRADED,
+			},
+			expected: storage.ClusterHealthStatus_DEGRADED,
+		},
+		"scanner degraded with sensor unhealthy makes overall unhealthy": {
+			health: &storage.ClusterHealthStatus{
+				SensorHealthStatus:    storage.ClusterHealthStatus_UNHEALTHY,
+				CollectorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+				ScannerHealthStatus:   storage.ClusterHealthStatus_DEGRADED,
+			},
+			expected: storage.ClusterHealthStatus_UNHEALTHY,
+		},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, c.expected, PopulateOverallClusterStatus(c.health))
 		})
 	}
-
 }


### PR DESCRIPTION
## Description

The overall cluster health status (`PopulateOverallClusterStatus` in `pkg/clusterhealth/status.go`) only considered Sensor, Collector, and Admission Control. Scanner health was computed via `PopulateLocalScannerStatus` and stored in `scanner_health_status`, but never factored into `OverallHealthStatus`. This meant a secured cluster with an unhealthy local scanner would still report as Healthy.

This change includes scanner health in the overall computation, treating it the same as Collector and Admission Control: UNHEALTHY or DEGRADED scanner status propagates to overall status. Scanner is optional (`ROX_LOCAL_IMAGE_SCANNING_ENABLED` defaults to `false`), so it is only considered when not UNINITIALIZED — clusters without local scanning are unaffected.

Partially generated by AI.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests added covering scanner UNINITIALIZED (no impact), HEALTHY (no impact), UNHEALTHY, DEGRADED, and DEGRADED combined with sensor UNHEALTHY.
- Existing tests for Sensor/Collector/Admission Control behavior continue to pass unchanged.

Made with [Cursor](https://cursor.com)