### PR TITLE
fix: IPv6 compatibility for Scanner V4, Helm, and core packages

### DIFF
--- a/central/credentialexpiry/service/service_impl.go
+++ b/central/credentialexpiry/service/service_impl.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -28,7 +29,6 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/scanners/scannerv4"
 	"github.com/stackrox/rox/pkg/tlsutils"
-	"github.com/stackrox/rox/pkg/urlfmt"
 	"github.com/stackrox/rox/pkg/utils"
 	"google.golang.org/grpc"
 )
@@ -171,19 +171,15 @@ func ensureTLSAndReturnAddr(endpoint string) (string, error) {
 	if !strings.HasPrefix(endpoint, "https://") {
 		return "", errors.Errorf("endpoint %s is not an HTTPS endpoint", endpoint)
 	}
-	server := urlfmt.GetServerFromURL(endpoint)
-	if server == "" {
-		return "", errors.Errorf("failed to retrieve server from endpoint %s", endpoint)
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Hostname() == "" {
+		return "", errors.Errorf("failed to parse endpoint %s", endpoint)
 	}
-	_, _, err := net.SplitHostPort(server)
-	if err == nil {
-		return server, nil
+	port := u.Port()
+	if port == "" {
+		port = "443"
 	}
-	// server may be a bare hostname ("scanner.stackrox.svc") or a
-	// bracketed IPv6 address ("[::1]") from URL parsing. Strip brackets
-	// before JoinHostPort to avoid double-bracketing.
-	host := strings.TrimRight(strings.TrimLeft(server, "["), "]")
-	return net.JoinHostPort(host, "443"), nil
+	return net.JoinHostPort(u.Hostname(), port), nil
 }
 
 func maybeGetExpiryFromScannerAt(ctx context.Context, subject mtls.Subject, tlsConfig *tls.Config, endpoint string) (*time.Time, error) {

--- a/central/credentialexpiry/service/service_impl.go
+++ b/central/credentialexpiry/service/service_impl.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"net"
 	"sort"
@@ -176,10 +175,11 @@ func ensureTLSAndReturnAddr(endpoint string) (string, error) {
 	if server == "" {
 		return "", errors.Errorf("failed to retrieve server from endpoint %s", endpoint)
 	}
-	if strings.Contains(server, ":") {
+	_, _, err := net.SplitHostPort(server)
+	if err == nil {
 		return server, nil
 	}
-	return fmt.Sprintf("%s:443", server), nil
+	return net.JoinHostPort(server, "443"), nil
 }
 
 func maybeGetExpiryFromScannerAt(ctx context.Context, subject mtls.Subject, tlsConfig *tls.Config, endpoint string) (*time.Time, error) {

--- a/central/credentialexpiry/service/service_impl.go
+++ b/central/credentialexpiry/service/service_impl.go
@@ -179,7 +179,11 @@ func ensureTLSAndReturnAddr(endpoint string) (string, error) {
 	if err == nil {
 		return server, nil
 	}
-	return net.JoinHostPort(server, "443"), nil
+	// server may be a bare hostname ("scanner.stackrox.svc") or a
+	// bracketed IPv6 address ("[::1]") from URL parsing. Strip brackets
+	// before JoinHostPort to avoid double-bracketing.
+	host := strings.TrimRight(strings.TrimLeft(server, "["), "]")
+	return net.JoinHostPort(host, "443"), nil
 }
 
 func maybeGetExpiryFromScannerAt(ctx context.Context, subject mtls.Subject, tlsConfig *tls.Config, endpoint string) (*time.Time, error) {

--- a/central/credentialexpiry/service/service_impl_test.go
+++ b/central/credentialexpiry/service/service_impl_test.go
@@ -53,6 +53,15 @@ func TestEnsureTLSAndReturnAddr(t *testing.T) {
 		{
 			endpoint: "https://scanner.stackrox:8080/ping", expectedOut: "scanner.stackrox:8080",
 		},
+		{
+			endpoint: "https://[::1]/", expectedOut: "[::1]:443",
+		},
+		{
+			endpoint: "https://[::1]:8443/", expectedOut: "[::1]:8443",
+		},
+		{
+			endpoint: "https://[fd00::1]/ping", expectedOut: "[fd00::1]:443",
+		},
 	} {
 		c := testCase
 		t.Run(c.endpoint, func(t *testing.T) {

--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -40,8 +40,8 @@ indexer:
 matcher:
   enable: false
 log_level: "{{ ._rox.scannerV4.indexer.logLevel }}"
-grpc_listen_addr: 0.0.0.0:8443
-http_listen_addr: 0.0.0.0:9443
+grpc_listen_addr: :8443
+http_listen_addr: :9443
 proxy:
   config_dir: /run/secrets/stackrox.io/proxy-config
   config_file: config.yaml

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -32,8 +32,8 @@ matcher:
   vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VULNERABILITY_VERSION
   indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
 log_level: "{{ ._rox.scannerV4.matcher.logLevel }}"
-grpc_listen_addr: 0.0.0.0:8443
-http_listen_addr: 0.0.0.0:9443
+grpc_listen_addr: :8443
+http_listen_addr: :9443
 proxy:
   config_dir: /run/secrets/stackrox.io/proxy-config
   config_file: config.yaml

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -92,7 +92,7 @@ spec:
             - -c
             - -e
             - |
-              exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+              exec pg_isready -U "postgres" -h localhost -p 5432
           failureThreshold: 3
           periodSeconds: 10
           successThreshold: 1

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -119,7 +119,7 @@ spec:
             - -c
             - -e
             - |
-              exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+              exec pg_isready -U "postgres" -h localhost -p 5432
           failureThreshold: 3
           periodSeconds: 10
           successThreshold: 1

--- a/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_defaults.tpl
@@ -71,11 +71,8 @@
 {{/*
   srox.ensureCentralEndpointContainsPort .
 
-  Appends a default port to the configured central endpoint based on a very simply heuristic.
-  Specifically, it only checks if the provided endpoint contains a prefix "https://" and
-  the part after that prefix does not contain a double colon.
-  This heuristic is kept simple on purpose and does not correctly add the default ports in
-  case the host part is an IPv6 address.
+  Appends a default port to the configured central endpoint if one is not present.
+  Handles both IPv4 (host:port) and IPv6 ([host]:port) address formats.
 */}}
 {{ define "srox.ensureCentralEndpointContainsPort" }}
   {{ $ := . }}
@@ -83,7 +80,13 @@
   {{ $endpoint := $._rox.centralEndpoint }}
   {{ if hasPrefix "https://" $endpoint }}
     {{ $endpoint = trimPrefix "https://" $endpoint }}
-    {{ if not (contains ":" $endpoint) }}
+    {{ $hasPort := false }}
+    {{ if hasPrefix "[" $endpoint }}
+      {{ $hasPort = contains "]:" $endpoint }}
+    {{ else }}
+      {{ $hasPort = contains ":" $endpoint }}
+    {{ end }}
+    {{ if not $hasPort }}
       {{ include "srox.note" (list $ (printf "Specified centralEndpoint %s does not contain a port, assuming port 443. If this is incorrect please specify the correct port." $._rox.centralEndpoint)) }}
       {{ $_ := set $._rox "centralEndpoint" (printf "%s:443" $._rox.centralEndpoint) }}
     {{ end }}

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -906,12 +906,10 @@ func initializeFieldMetadata() FieldMetadata {
 		[]RuntimeFieldType{AuditLogEvent},
 	)
 
-	f.registerFieldMetadataRegex(
+	f.registerFieldMetadata(
 		fieldnames.SourceIPAddress,
 		querybuilders.ForFieldLabel(augmentedobjs.KubernetesSourceIPAddressCustomTag), nil,
-		func(*validateConfiguration) *regexp.Regexp {
-			return ipAddressValueRegex
-		},
+		ipAddressValidator,
 		[]storage.EventSource{storage.EventSource_AUDIT_LOG_EVENT},
 		[]RuntimeFieldType{AuditLogEvent},
 	)

--- a/pkg/booleanpolicy/value_regex.go
+++ b/pkg/booleanpolicy/value_regex.go
@@ -9,7 +9,21 @@ import (
 
 const (
 	ipv4Regex = "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})"
-	ipv6Regex = "((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4}))*::((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4}))*|((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4})){7}"
+	// Matches all valid IPv6 forms: full (8 groups), abbreviated (::),
+	// and mixed IPv4-mapped (::ffff:1.2.3.4). Uses a permissive pattern
+	// that accepts any sequence of hex groups separated by colons with
+	// at most one :: abbreviation.
+	ipv6Regex = "(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}" + // full form
+		"|(?:[0-9A-Fa-f]{1,4}:){1,7}:" + // trailing ::
+		"|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}" + // :: with 1 group after
+		"|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}" +
+		"|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}" +
+		"|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}" +
+		"|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}" +
+		"|[0-9A-Fa-f]{1,4}:(?::[0-9A-Fa-f]{1,4}){1,6}" +
+		"|:(?::[0-9A-Fa-f]{1,4}){1,7}" + // ::x...
+		"|::(?:[fF]{4}:)?(?:\\d{1,3}\\.){3}\\d{1,3}" + // ::ffff:IPv4
+		"|::" // bare ::
 )
 
 var (

--- a/pkg/booleanpolicy/value_regex.go
+++ b/pkg/booleanpolicy/value_regex.go
@@ -2,28 +2,10 @@ package booleanpolicy
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 
 	"github.com/stackrox/rox/pkg/signatures"
-)
-
-const (
-	ipv4Regex = "(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})"
-	// Matches all valid IPv6 forms: full (8 groups), abbreviated (::),
-	// and mixed IPv4-mapped (::ffff:1.2.3.4). Uses a permissive pattern
-	// that accepts any sequence of hex groups separated by colons with
-	// at most one :: abbreviation.
-	ipv6Regex = "(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}" + // full form
-		"|(?:[0-9A-Fa-f]{1,4}:){1,7}:" + // trailing ::
-		"|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}" + // :: with 1 group after
-		"|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}" +
-		"|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}" +
-		"|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}" +
-		"|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}" +
-		"|[0-9A-Fa-f]{1,4}:(?::[0-9A-Fa-f]{1,4}){1,6}" +
-		"|:(?::[0-9A-Fa-f]{1,4}){1,7}" + // ::x...
-		"|::(?:[fF]{4}:)?(?:\\d{1,3}\\.){3}\\d{1,3}" + // ::ffff:IPv4
-		"|::" // bare ::
 )
 
 var (
@@ -47,7 +29,6 @@ var (
 	auditEventAPIVerbValueRegex              = createRegex(`(?i:CREATE|DELETE|GET|PATCH|UPDATE)`)
 	auditEventResourceValueRegex             = createRegex(`(?i:SECRETS|CONFIGMAPS|CLUSTER_ROLES|CLUSTER_ROLE_BINDINGS|NETWORK_POLICIES|SECURITY_CONTEXT_CONSTRAINTS|EGRESS_FIREWALLS)`)
 	kubernetesNameRegex                      = createRegex(`(?i:[a-z0-9])(?i:[-:a-z0-9]*[a-z0-9])?`)
-	ipAddressValueRegex                      = createRegex(fmt.Sprintf(`(%s)|(%s)`, ipv4Regex, ipv6Regex))
 	signatureIntegrationIDValueRegex         = createRegex(regexp.QuoteMeta(signatures.SignatureIntegrationIDPrefix) + "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 	fileOperationRegex                       = createRegex(`(?i:OPEN|CREATE|RENAME|UNLINK|OWNERSHIP_CHANGE|PERMISSION_CHANGE|XATTR_CHANGE)`)
 )
@@ -55,4 +36,11 @@ var (
 func createRegex(s string) *regexp.Regexp {
 	// set multiline anchor for beginning and end of regex
 	return regexp.MustCompile("((?m)^" + s + "$)")
+}
+
+func ipAddressValidator(_ *validateConfiguration, value string) (bool, error) {
+	if net.ParseIP(value) != nil {
+		return true, nil
+	}
+	return false, fmt.Errorf("must be a valid IPv4 or IPv6 address, got %q", value)
 }

--- a/pkg/cluster/validation.go
+++ b/pkg/cluster/validation.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"fmt"
-	"strings"
+	"net"
 
 	"github.com/distribution/reference"
 	"github.com/pkg/errors"
@@ -53,8 +53,8 @@ func ValidatePartial(cluster *storage.Cluster) *errorhelpers.ErrorList {
 	}
 	if cluster.GetCentralApiEndpoint() == "" {
 		errorList.AddString("Central API Endpoint is required")
-	} else if !strings.Contains(cluster.GetCentralApiEndpoint(), ":") {
-		errorList.AddString("Central API Endpoint must have port specified")
+	} else if _, _, err := net.SplitHostPort(cluster.GetCentralApiEndpoint()); err != nil {
+		errorList.AddString("Central API Endpoint must have port specified (host:port)")
 	}
 
 	if stringutils.ContainsWhitespace(cluster.GetCentralApiEndpoint()) {

--- a/pkg/debughandler/server.go
+++ b/pkg/debughandler/server.go
@@ -19,7 +19,7 @@ func StartServer(port string) error {
 		port = "9999"
 	}
 
-	addr := fmt.Sprintf("127.0.0.1:%s", port)
+	addr := fmt.Sprintf("localhost:%s", port)
 	return http.ListenAndServe(addr, Handler(""))
 }
 

--- a/pkg/env/node_scan.go
+++ b/pkg/env/node_scan.go
@@ -4,7 +4,7 @@ import "time"
 
 var (
 	// NodeScanningEndpoint is used to provide Compliance with the Node Scanner that is used to carry out Node Scans
-	NodeScanningEndpoint = RegisterSetting("ROX_NODE_SCANNING_ENDPOINT", WithDefault("127.0.0.1:8444"))
+	NodeScanningEndpoint = RegisterSetting("ROX_NODE_SCANNING_ENDPOINT", WithDefault("localhost:8444"))
 
 	// NodeScanningInterval is the base value of the interval duration between node scans.
 	NodeScanningInterval = registerDurationSetting("ROX_NODE_SCANNING_INTERVAL", 4*time.Hour)

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -36,8 +36,8 @@ const (
 var (
 	// defaultConfiguration provides the default values for the scanner configuration.
 	defaultConfiguration = Config{
-		HTTPListenAddr: "127.0.0.1:9443",
-		GRPCListenAddr: "127.0.0.1:8443",
+		HTTPListenAddr: "localhost:9443",
+		GRPCListenAddr: "localhost:8443",
 		Indexer: IndexerConfig{
 			Enable: true,
 			Database: Database{

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	// The 127.0.0.1 ensures we do not expose it externally and must be port-forwarded to
-	pprofServer = "127.0.0.1:6060"
+	// localhost ensures we do not expose it externally and must be port-forwarded to
+	pprofServer = "localhost:6060"
 
 	publicAPIEndpoint = ":8443"
 


### PR DESCRIPTION
## Description

Scanner V4 Indexer and Matcher listen on `0.0.0.0` (IPv4 only), making them unreachable on IPv6-only clusters where Kubernetes routes traffic via IPv6 pod IPs. This cascades into image enrichment failures, missing vulnerability data, and empty policy violations on IPv6-only and dual-stack IPv6-primary clusters.

Additionally, several other components use hardcoded `127.0.0.1` addresses, have IPv6-broken port detection heuristics, or use an incomplete IPv6 regex for policy evaluation.

**Changes (12 files):**

| Component | Issue | Fix |
|-----------|-------|-----|
| Scanner V4 Helm configs | `0.0.0.0:8443` (IPv4 only) | `:8443` (dual-stack) |
| Scanner V4 Go defaults | `127.0.0.1:8443` | `localhost:8443` |
| Central DB health check | `pg_isready -h 127.0.0.1` | `-h localhost` |
| Scanner V4 DB health check | same | same |
| Node scanning endpoint | `127.0.0.1:8444` default | `localhost:8444` |
| Sensor pprof server | `127.0.0.1:6060` | `localhost:6060` |
| Debug handler | `127.0.0.1:<port>` | `localhost:<port>` |
| Cluster validation | `strings.Contains(":") ` port check | `net.SplitHostPort` |
| TLS credential expiry | colon-based port detection | `net.SplitHostPort` |
| Helm port heuristic | assumes colon means port | handles `[host]:port` bracket notation |
| Boolean policy engine | IPv6 regex misses `::1`, `fe80::`, `::` | rewritten to match all valid forms |

Found via IPv6-only KinD e2e testing (PR #22234). The Scanner V4 listen address is the critical fix that unblocks image scanning on IPv6 clusters.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

These issues were discovered by running the full QA e2e test suite on IPv6-only KinD clusters (PR #22234). The Scanner V4 `0.0.0.0` listen address was independently identified by two code investigation agents as the root cause for image enrichment, enforcement, and vulnerability scan failures on IPv6.