### PR TITLE
ROX-36136: add bundler workflow for vulnerability zip assembly

### DIFF
--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -1,0 +1,159 @@
+name: Scanner updater bundle
+# This workflow assembles per-stream vulnerabilities.zip bundles from the
+# per-source exports produced by scanner-updater-schedule.yaml and stored in
+# GCS.  It is the second stage of the split vulnerability pipeline.
+# Auto-triggering directly from completed per-source exports is a future
+# concern; the bundler runs on its own schedule in the meantime.
+# This workflow writes to the test bucket while under validation.
+# TODO(ROX-36127): production cutover — update storage.bucket in
+# source-config.yaml to definitions.stackrox.io and remove the schedule from
+# scanner-versioned-definitions-update.yaml.
+
+on:
+  schedule:
+  - cron: "47 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-matrix:
+    if: github.repository_owner == 'stackrox'
+    runs-on: ubuntu-latest
+    outputs:
+      streams: ${{ steps.emit.outputs.streams }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Authenticate with GCS
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
+        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+
+    - name: Build stream matrix
+      id: emit
+      run: |
+        set -euo pipefail
+        streams=$(./.github/workflows/scripts/scanner-get-released-tags.sh | jq -c '[.[].version]')
+        echo "streams=${streams}" >> "$GITHUB_OUTPUT"
+
+  bundle:
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.11@sha256:cea78f2b3a5a38c9ccda678712daaed90b7c372d6b5df963feb758b32dccebe1
+      volumes:
+      - /tmp:/tmp
+      - /usr:/mnt/usr
+      - /opt:/mnt/opt
+    strategy:
+      fail-fast: false
+      matrix:
+        stream: ${{ fromJson(needs.build-matrix.outputs.streams) }}
+    concurrency:
+      group: scanner-updater-bundle-${{ matrix.stream }}
+      cancel-in-progress: false
+    env:
+      STREAM: ${{ matrix.stream }}
+      SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Authenticate with GCS
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
+        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
+        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+
+    - name: Download sources
+      run: |
+        set -euo pipefail
+
+        bucket=$(yq '.storage.bucket' "$SOURCE_CONFIG")
+        prefix=$(yq '.storage.prefix' "$SOURCE_CONFIG")
+
+        echo "GCS_BUCKET=$bucket" >> "$GITHUB_ENV"
+        echo "GCS_PREFIX=$prefix" >> "$GITHUB_ENV"
+
+        mkdir -p bundles
+        gcloud storage cp "gs://${bucket}/${prefix}/${STREAM}/sources/*.json.zst" bundles/
+
+    - name: Validate sources
+      id: download-validate
+      run: |
+        set -euo pipefail
+
+        valid_files=()
+        failed_sources=()
+        while IFS= read -r source; do
+            dest="bundles/${source}.json.zst"
+            if [ ! -f "$dest" ] || [ ! -s "$dest" ]; then
+                echo "::error::${source}: missing or empty"
+                failed_sources+=("$source")
+            else
+                echo "source '${source}': OK"
+                valid_files+=("$dest")
+            fi
+        done < <(yq ".bundles.${STREAM}[]" "$SOURCE_CONFIG")
+
+        ( IFS=','; echo "failed=${failed_sources[*]}" >> "$GITHUB_OUTPUT" )
+
+        if [ "${#valid_files[@]}" -eq 0 ]; then
+            echo "::error::no valid source files found for stream '${STREAM}'; cannot assemble bundle"
+            exit 1
+        fi
+
+        printf '%s\n' "${valid_files[@]}" > valid-files.txt
+        echo "Validated: ${#valid_files[@]} of $(( ${#valid_files[@]} + ${#failed_sources[@]} )) source(s) OK"
+
+    - name: Assemble and upload bundle
+      run: |
+        set -euo pipefail
+
+        zip vulnerabilities.zip -@ < valid-files.txt
+
+        bundle_obj="gs://${GCS_BUCKET}/${GCS_PREFIX}/${STREAM}/vulnerabilities.zip"
+        gcloud storage cp vulnerabilities.zip "$bundle_obj"
+        echo "Uploaded bundle for stream '${STREAM}' -> ${bundle_obj}"
+
+    - name: Notify on partial failure
+      if: always() && steps.download-validate.outcome == 'success'
+      env:
+        FAILED: ${{ steps.download-validate.outputs.failed }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        [ -n "$FAILED" ] || exit 0
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"Vulnerability bundler: validation failures for stream '${STREAM}' (sources: ${FAILED}): <${RUN_URL}|View logs>\"}" \
+          "$SLACK_WEBHOOK"
+
+  notify:
+    needs: [bundle]
+    if: always() && needs.bundle.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify on failure
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        curl -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\"Vulnerability bundler failed: <${RUN_URL}|View logs>\"}" \
+          "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -28,15 +28,6 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
-    - name: Authenticate with GCS
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
-      with:
-        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
-
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
-
     - name: Build stream matrix
       id: emit
       run: |

--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -138,7 +138,8 @@ jobs:
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
         [ -n "$FAILED" ] || exit 0
-        curl -X POST -H 'Content-type: application/json' \
+        curl --fail --show-error --max-time 10 \
+          -X POST -H 'Content-type: application/json' \
           --data "{\"text\":\"Vulnerability bundler: validation failures for stream '${STREAM}' (sources: ${FAILED}): <${RUN_URL}|View logs>\"}" \
           "$SLACK_WEBHOOK"
 
@@ -152,6 +153,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_ONCALL_SCANNER_WEBHOOK }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
-        curl -X POST -H 'Content-type: application/json' \
+        curl --fail --show-error --max-time 10 \
+          -X POST -H 'Content-type: application/json' \
           --data "{\"text\":\"Vulnerability bundler failed: <${RUN_URL}|View logs>\"}" \
           "$SLACK_WEBHOOK"

--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -1,10 +1,8 @@
 name: Scanner updater bundle
-# This workflow assembles per-stream vulnerabilities.zip bundles from the
-# per-source exports produced by scanner-updater-schedule.yaml and stored in
-# GCS.  It is the second stage of the split vulnerability pipeline.
-# Auto-triggering directly from completed per-source exports is a future
-# concern; the bundler runs on its own schedule in the meantime.
-# This workflow writes to the test bucket while under validation.
+# Downloads per-source vulnerability data from GCS, validates each source,
+# and assembles vulnerabilities.zip for each bundle stream defined in
+# VULNERABILITY_BUNDLE_VERSION. Missing or empty sources are skipped with a
+# Slack notification; if no sources are valid the job fails.
 # TODO(ROX-36127): production cutover — update storage.bucket in
 # source-config.yaml to definitions.stackrox.io and remove the schedule from
 # scanner-versioned-definitions-update.yaml.

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       object:
-        description: "Full GCS object path (gs://bucket/prefix/stream/sources/updater/data.json.zst)"
+        description: "Full GCS object path (gs://bucket/prefix/stream/sources/updater.json.zst)"
         required: true
         type: string
       manual_url:

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -83,7 +83,7 @@ jobs:
         set -euo pipefail
         bucket=$(yq '.storage.bucket' "$SOURCE_CONFIG")
         prefix=$(yq '.storage.prefix' "$SOURCE_CONFIG")
-        matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual/data.json.zst\"}]}"
+        matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual.json.zst\"}]}"
         printf '{"has_due":true,"has_errors":false,"errors":[],"matrix":%s}\n' "$matrix" > matrix-result.json
 
     - name: Validate matrix builder (PR)

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -43,7 +43,7 @@ prefix=$(yq '.storage.prefix' "$config")
                 done
       done \
     | while read -r stream ref updater; do
-          object="gs://${bucket}/${prefix}/${stream}/sources/${updater}/data.json.zst"
+          object="gs://${bucket}/${prefix}/${stream}/sources/${updater}.json.zst"
 
           # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
           if GCS_OBJECT="$object" \

--- a/scanner/updater/ci/source-config.yaml
+++ b/scanner/updater/ci/source-config.yaml
@@ -1,7 +1,7 @@
 # Per-updater configuration for the vulnerability update workflow.
 #
 # storage: GCS location for per-updater data objects. The object path
-# pattern is gs://<bucket>/<prefix>/<stream>/sources/<updater>/data.json.zst,
+# pattern is gs://<bucket>/<prefix>/<stream>/sources/<updater>.json.zst,
 # constructed by the matrix builder and passed to all downstream consumers.
 #
 # bundles: defines which updaters to include in each version stream's bundle.


### PR DESCRIPTION
## Description

Add `scanner-updater-bundle.yaml`, the second stage of the split vulnerability pipeline. The first stage (per-source export, merged in #21689) writes individual `<source>.json.zst` files to GCS. This workflow assembles them into `vulnerabilities.zip` and uploads it to the stream path where Scanner V4 reads it — preserving the existing bundle format so no Scanner changes are required.

This PR also flattens the GCS object path from `sources/<source>/data.json.zst` to `sources/<source>.json.zst`, enabling the bundler to download all sources in a single `gcloud storage cp` glob call instead of one call per source.

The bundler runs on its own schedule (minute 47, offset from the exporter at minute 17). It does not auto-trigger from export completion; racing exports is intentional and correct — the bundler publishes whatever is current in GCS and converges on the next run. Streams are read dynamically from `VULNERABILITY_BUNDLE_VERSION` via the existing `scanner-get-released-tags.sh` script.

Missing or empty sources are not blockers: the bundle is published without them and a Slack notification is sent listing the failures. If no sources are valid, the job fails and the `notify` job fires.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Workflow has no PR trigger. Validation is via `workflow_dispatch` on this branch after the test bucket has per-source data from the export workflow. Two runs required: first confirms bundle production, second confirms idempotency (same content re-uploaded, no errors).