### PR TITLE
ROX-35926: Add sensor compatibility visual display

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterSummaryGrid.tsx
@@ -8,6 +8,7 @@ import ClusterDeletion from './Components/ClusterDeletion';
 import ClusterHealthPanel from './Components/ClusterHealthPanel';
 import ClusterMetadata from './Components/ClusterMetadata';
 import CredentialExpiration from './Components/CredentialExpiration';
+import SensorCompatibilitySummary from './Components/SensorCompatibilitySummary';
 import SensorUpgradePanel from './Components/SensorUpgradePanel';
 import type { CertExpiryStatus } from './clusterTypes';
 
@@ -36,11 +37,21 @@ export function ClusterSummaryGrid({
             )}
             {clusterInfo.status && !isSensorCompatStatusEnabled && (
                 <GridItem span={12} lg={6} xl={3} className="cluster-status-panel">
-                    <SensorUpgradePanel
-                        centralVersion={centralVersion}
-                        sensorVersion={clusterInfo.status?.sensorVersion}
-                        upgradeStatus={clusterInfo.status?.upgradeStatus}
-                    />
+                    {isSensorCompatStatusEnabled ? (
+                        <ClusterHealthPanel header="Sensor version">
+                            <SensorCompatibilitySummary
+                                compatibility={clusterInfo.status.sensorVersionCompatibility}
+                                sensorVersion={clusterInfo.status.sensorVersion}
+                                centralVersion={centralVersion}
+                            />
+                        </ClusterHealthPanel>
+                    ) : (
+                        <SensorUpgradePanel
+                            centralVersion={centralVersion}
+                            sensorVersion={clusterInfo.status?.sensorVersion}
+                            upgradeStatus={clusterInfo.status?.upgradeStatus}
+                        />
+                    )}
                 </GridItem>
             )}
             {clusterInfo.status && (

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilityPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilityPanel.tsx
@@ -18,6 +18,7 @@ import { HelpIcon } from '@patternfly/react-icons';
 
 import type { SensorVersionCompatibility } from 'types/cluster.proto';
 import { getSensorCompatibilityInfo } from '../cluster.helpers';
+import SensorVersionRangeChart from './SensorVersionRangeChart';
 
 // TODO: add documentation link for guidance text
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -135,7 +136,19 @@ function SensorCompatibilityPanel({
                 header="Sensor version"
                 bodyItems={{
                     version: ['Version', sensorVersion],
-                    range: ['Version range', null],
+                    range: [
+                        'Version range',
+                        compatibleVersions.length > 0 &&
+                        compatibility &&
+                        compatibility !== 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN' ? (
+                            <SensorVersionRangeChart
+                                compatibleVersions={compatibleVersions}
+                                sensorVersion={sensorVersion ?? ''}
+                                centralVersion={centralVersion}
+                                compatibility={compatibility}
+                            />
+                        ) : null,
+                    ],
                 }}
             />
             <SensorCompatibilitySubPanel

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilityPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilityPanel.tsx
@@ -17,7 +17,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 
 import type { SensorVersionCompatibility } from 'types/cluster.proto';
-import { getSensorCompatibilityInfo } from '../cluster.helpers';
+import { getSensorCompatibilityInfo, shouldShowSensorVersionRangeChart } from '../cluster.helpers';
 import SensorVersionRangeChart from './SensorVersionRangeChart';
 
 // TODO: add documentation link for guidance text
@@ -138,9 +138,7 @@ function SensorCompatibilityPanel({
                     version: ['Version', sensorVersion],
                     range: [
                         'Version range',
-                        compatibleVersions.length > 0 &&
-                        compatibility &&
-                        compatibility !== 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN' ? (
+                        shouldShowSensorVersionRangeChart(compatibility, compatibleVersions) ? (
                             <SensorVersionRangeChart
                                 compatibleVersions={compatibleVersions}
                                 sensorVersion={sensorVersion ?? ''}

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilitySummary.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilitySummary.tsx
@@ -1,0 +1,56 @@
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+} from '@patternfly/react-core';
+
+import useMetadata from 'hooks/useMetadata';
+import type { SensorVersionCompatibility } from 'types/cluster.proto';
+
+import SensorVersionRangeChart from './SensorVersionRangeChart';
+
+type SensorCompatibilitySummaryProps = {
+    compatibility?: SensorVersionCompatibility;
+    sensorVersion: string;
+    centralVersion: string;
+};
+
+function SensorCompatibilitySummary({
+    compatibility,
+    sensorVersion,
+    centralVersion,
+}: SensorCompatibilitySummaryProps) {
+    const { compatibleSensorVersions = [] } = useMetadata();
+
+    const showChart =
+        compatibility !== undefined &&
+        compatibility !== 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN' &&
+        compatibleSensorVersions.length > 0;
+
+    return (
+        <DescriptionList>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Version</DescriptionListTerm>
+                <DescriptionListDescription>
+                    {sensorVersion || 'Unknown'}
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+            {showChart && (
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Version range</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        <SensorVersionRangeChart
+                            compatibleVersions={compatibleSensorVersions}
+                            sensorVersion={sensorVersion}
+                            centralVersion={centralVersion}
+                            compatibility={compatibility}
+                        />
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+            )}
+        </DescriptionList>
+    );
+}
+
+export default SensorCompatibilitySummary;

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilitySummary.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilitySummary.tsx
@@ -8,6 +8,7 @@ import {
 import useMetadata from 'hooks/useMetadata';
 import type { SensorVersionCompatibility } from 'types/cluster.proto';
 
+import { shouldShowSensorVersionRangeChart } from '../cluster.helpers';
 import SensorVersionRangeChart from './SensorVersionRangeChart';
 
 type SensorCompatibilitySummaryProps = {
@@ -23,10 +24,7 @@ function SensorCompatibilitySummary({
 }: SensorCompatibilitySummaryProps) {
     const { compatibleSensorVersions = [] } = useMetadata();
 
-    const showChart =
-        compatibility !== undefined &&
-        compatibility !== 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN' &&
-        compatibleSensorVersions.length > 0;
+    const showChart = shouldShowSensorVersionRangeChart(compatibility, compatibleSensorVersions);
 
     return (
         <DescriptionList>

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.test.ts
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.test.ts
@@ -160,7 +160,8 @@ describe('computeVersionRangeData', () => {
     describe('marker/compatibility contradiction', () => {
         // Sensor 4.8 is at index 1, which is behind central (index 3),
         // but the backend says "ahead". The parsed position contradicts
-        // the enum, so we discard it and fall back to the enum-based position.
+        // the enum, so we discard it and fall back to the enum-based
+        // position: the middle of the compatible-ahead zone.
         it('discards the parsed position and falls back when it contradicts the compatibility enum', () => {
             const result = computeVersionRangeData(
                 versions,
@@ -169,8 +170,9 @@ describe('computeVersionRangeData', () => {
                 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD'
             );
 
-            const fallbackRight = ((totalUnits - 0.5) / totalUnits) * 100;
-            expect(result!.markerPercent).toBeCloseTo(fallbackRight);
+            const aheadCount = versions.length - centralIndex - 1;
+            const fallbackAhead = ((1 + centralIndex + 1 + aheadCount / 2) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(fallbackAhead);
         });
     });
 });

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.test.ts
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.test.ts
@@ -1,0 +1,176 @@
+import { computeVersionRangeData } from './SensorVersionRangeChart';
+
+// Central is 5.0, +3/-3 compatible versions
+const versions = ['4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3'];
+const centralVersion = '5.0.x-nightly';
+const centralIndex = 3;
+const totalUnits = versions.length + 2; // 9
+
+describe('computeVersionRangeData', () => {
+    describe('null returns for invalid inputs', () => {
+        it('returns null when compatible versions list is empty', () => {
+            expect(computeVersionRangeData([], '4.9.0', centralVersion, undefined)).toBeNull();
+        });
+
+        it('returns null when central version is not parseable', () => {
+            expect(computeVersionRangeData(versions, '4.9.0', 'latest', undefined)).toBeNull();
+        });
+
+        it('returns null when central X.Y is not in compatible versions', () => {
+            expect(computeVersionRangeData(versions, '4.9.0', '3.0.0', undefined)).toBeNull();
+        });
+    });
+
+    describe('zone structure', () => {
+        it('produces incompatible bookends, compatible behind/ahead, and matched zones', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '4.8.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND'
+            );
+
+            const colors = result!.zones.map((z) => z.color);
+            // incompatible | compatible-behind | matched | compatible-ahead | incompatible
+            expect(colors).toEqual([
+                expect.stringContaining('danger'),
+                expect.stringContaining('info'),
+                expect.stringContaining('success'),
+                expect.stringContaining('info'),
+                expect.stringContaining('danger'),
+            ]);
+        });
+
+        it('zone widths sum to totalUnits (versions.length + 2)', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '5.0.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_MATCHED'
+            );
+
+            const totalWidth = result!.zones.reduce((sum, z) => sum + z.width, 0);
+            expect(totalWidth).toBe(totalUnits);
+        });
+    });
+
+    describe('marker positioning', () => {
+        it('places marker at the parsed sensor position when behind', () => {
+            // Sensor 4.8 is at index 1, behind central 5.0 at index 3
+            const sensor48Index = 1;
+            const result = computeVersionRangeData(
+                versions,
+                '4.8.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND'
+            );
+
+            const expected = ((1 + sensor48Index + 0.5) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(expected);
+        });
+
+        it('places marker at matched position when sensor equals central', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '5.0.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_MATCHED'
+            );
+
+            const expected = ((1 + centralIndex + 0.5) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(expected);
+        });
+
+        it('places marker at parsed sensor position when ahead', () => {
+            // Sensor 5.2 is at index 5, ahead of central 5.0 at index 3
+            const sensor52Index = 5;
+            const result = computeVersionRangeData(
+                versions,
+                '5.2.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD'
+            );
+
+            const expected = ((1 + sensor52Index + 0.5) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(expected);
+        });
+    });
+
+    describe('marker fallback when sensor version is not in the compatible list', () => {
+        it('falls back to the left edge for behind compatibility', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '3.0.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND'
+            );
+
+            const expected = (0.5 / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(expected);
+        });
+
+        it('falls back to the right edge for ahead compatibility', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '99.0.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD'
+            );
+
+            const expected = ((totalUnits - 0.5) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(expected);
+        });
+
+        it('falls back to central position for matched compatibility with unparseable sensor', () => {
+            const result = computeVersionRangeData(
+                versions,
+                'unparseable',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_MATCHED'
+            );
+
+            const expected = ((1 + centralIndex + 0.5) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(expected);
+        });
+
+        it('returns null marker when both compatibility is unknown and sensor version is unparseable', () => {
+            const result = computeVersionRangeData(
+                versions,
+                'unparseable',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_UNKNOWN'
+            );
+
+            expect(result!.markerPercent).toBeNull();
+        });
+
+        // If the sensor version IS parseable, we show the marker even with unknown compatibility
+        it('still shows marker for unknown compatibility when sensor version is parseable', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '5.0.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_UNKNOWN'
+            );
+
+            expect(result!.markerPercent).not.toBeNull();
+        });
+    });
+
+    describe('marker/compatibility contradiction', () => {
+        // Sensor 4.8 is at index 1, which is behind central (index 3),
+        // but the backend says "ahead". The parsed position contradicts
+        // the enum, so we discard it and fall back to the enum-based position.
+        it('discards the parsed position and falls back when it contradicts the compatibility enum', () => {
+            const result = computeVersionRangeData(
+                versions,
+                '4.8.0',
+                centralVersion,
+                'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD'
+            );
+
+            const fallbackRight = ((totalUnits - 0.5) / totalUnits) * 100;
+            expect(result!.markerPercent).toBeCloseTo(fallbackRight);
+        });
+    });
+});

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
@@ -1,6 +1,7 @@
 import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 
 import type { SensorVersionCompatibility } from 'types/cluster.proto';
+import { getVersionMajorMinor } from 'utils/versioning';
 import { getSensorCompatibilityInfo } from '../cluster.helpers';
 
 export type CompatibilityZone = {
@@ -25,11 +26,6 @@ const compatibilityRangeColor = {
     matched: 'var(--pf-t--global--color--status--success--default)',
     marker: 'var(--pf-t--global--text--color--regular)',
 };
-
-function parseSensorVersionXY(version: string): string | null {
-    const match = version.match(/^(\d+\.\d+)/);
-    return match ? match[1] : null;
-}
 
 function getExpectedDirection(
     compatibility: SensorVersionCompatibility | undefined
@@ -68,7 +64,7 @@ function computeMarkerPercent(
     const toPercent = (position: number) => (position / totalUnits) * 100;
 
     // Offset: +1 for the left incompatible zone, +0.5 to center within the unit
-    const sensorXY = parseSensorVersionXY(sensorVersion);
+    const sensorXY = getVersionMajorMinor(sensorVersion);
     if (sensorXY) {
         const sensorIndex = compatibleVersions.indexOf(sensorXY);
         if (sensorIndex !== -1) {
@@ -156,7 +152,7 @@ export function computeVersionRangeData(
         return null;
     }
 
-    const centralXY = parseSensorVersionXY(centralVersion);
+    const centralXY = getVersionMajorMinor(centralVersion);
     if (!centralXY) {
         return null;
     }

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
@@ -1,0 +1,292 @@
+import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+
+import type { SensorVersionCompatibility } from 'types/cluster.proto';
+import { getSensorCompatibilityInfo } from '../cluster.helpers';
+
+type CompatibilityZone = {
+    width: number;
+    color: string;
+    tooltip: string;
+};
+
+type CompatibilityDirection = 'behind' | 'matched' | 'ahead';
+
+type VersionRangeData = {
+    zones: CompatibilityZone[];
+    behindVersions: string[];
+    matchedVersion: string;
+    aheadVersions: string[];
+    markerPercent: number | null;
+};
+
+const compatibilityRangeColor = {
+    incompatible: 'var(--pf-t--global--color--status--danger--default)',
+    compatible: 'var(--pf-t--global--color--status--info--default)',
+    matched: 'var(--pf-t--global--color--status--success--default)',
+    marker: 'var(--pf-t--global--text--color--regular)',
+};
+
+function parseSensorVersionXY(version: string): string | null {
+    const match = version.match(/^(\d+\.\d+)/);
+    return match ? match[1] : null;
+}
+
+function getExpectedDirection(
+    compatibility: SensorVersionCompatibility | undefined
+): CompatibilityDirection | null {
+    switch (compatibility) {
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND':
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND':
+            return 'behind';
+        case 'SENSOR_VERSION_COMPATIBILITY_MATCHED':
+            return 'matched';
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD':
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD':
+            return 'ahead';
+        default:
+            return null;
+    }
+}
+
+function getActualDirection(sensorIndex: number, centralIndex: number): CompatibilityDirection {
+    if (sensorIndex < centralIndex) {
+        return 'behind';
+    }
+    if (sensorIndex > centralIndex) {
+        return 'ahead';
+    }
+    return 'matched';
+}
+
+function computeMarkerPercent(
+    compatibleVersions: string[],
+    sensorVersion: string,
+    centralIndex: number,
+    compatibility: SensorVersionCompatibility | undefined,
+    totalUnits: number
+): number | null {
+    const toPercent = (position: number) => (position / totalUnits) * 100;
+
+    // Offset: +1 for the left incompatible zone, +0.5 to center within the unit
+    const sensorXY = parseSensorVersionXY(sensorVersion);
+    if (sensorXY) {
+        const sensorIndex = compatibleVersions.indexOf(sensorXY);
+        if (sensorIndex !== -1) {
+            // The backend compatibility enum is authoritative; discard the
+            // parsed position if it falls in a zone that contradicts it.
+            const expected = getExpectedDirection(compatibility);
+            const actual = getActualDirection(sensorIndex, centralIndex);
+            if (!expected || expected === actual) {
+                return toPercent(1 + sensorIndex + 0.5);
+            }
+        }
+    }
+
+    switch (compatibility) {
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND':
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND':
+            return toPercent(0.5);
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD':
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD':
+            return toPercent(totalUnits - 0.5);
+        case 'SENSOR_VERSION_COMPATIBILITY_MATCHED':
+            return toPercent(1 + centralIndex + 0.5);
+        default:
+            return null;
+    }
+}
+
+function buildZones(compatibleVersions: string[], centralIndex: number): CompatibilityZone[] {
+    const behindVersions = compatibleVersions.slice(0, centralIndex);
+    const aheadVersions = compatibleVersions.slice(centralIndex + 1);
+
+    const zones: CompatibilityZone[] = [
+        {
+            width: 1,
+            color: compatibilityRangeColor.incompatible,
+            tooltip: `Incompatible sensor versions. < ${compatibleVersions[0]}`,
+        },
+    ];
+
+    if (behindVersions.length > 0) {
+        zones.push({
+            width: behindVersions.length,
+            color: compatibilityRangeColor.compatible,
+            tooltip: `Sensor versions compatible but behind Central. ${behindVersions.join(', ')}`,
+        });
+    }
+
+    zones.push({
+        width: 1,
+        color: compatibilityRangeColor.matched,
+        tooltip: `Sensor version matched with Central. ${compatibleVersions[centralIndex]}`,
+    });
+
+    if (aheadVersions.length > 0) {
+        zones.push({
+            width: aheadVersions.length,
+            color: compatibilityRangeColor.compatible,
+            tooltip: `Sensor versions compatible but ahead of Central. ${aheadVersions.join(', ')}`,
+        });
+    }
+
+    zones.push({
+        width: 1,
+        color: compatibilityRangeColor.incompatible,
+        tooltip: `Incompatible sensor versions. > ${compatibleVersions[compatibleVersions.length - 1]}`,
+    });
+
+    return zones;
+}
+
+function computeVersionRangeData(
+    compatibleVersions: string[],
+    sensorVersion: string,
+    centralVersion: string,
+    compatibility: SensorVersionCompatibility | undefined
+): VersionRangeData | null {
+    if (compatibleVersions.length === 0) {
+        return null;
+    }
+
+    const centralXY = parseSensorVersionXY(centralVersion);
+    if (!centralXY) {
+        return null;
+    }
+
+    const centralIndex = compatibleVersions.indexOf(centralXY);
+    if (centralIndex === -1) {
+        return null;
+    }
+
+    const totalUnits = compatibleVersions.length + 2;
+
+    return {
+        zones: buildZones(compatibleVersions, centralIndex),
+        behindVersions: compatibleVersions.slice(0, centralIndex),
+        matchedVersion: centralXY,
+        aheadVersions: compatibleVersions.slice(centralIndex + 1),
+        markerPercent: computeMarkerPercent(
+            compatibleVersions,
+            sensorVersion,
+            centralIndex,
+            compatibility,
+            totalUnits
+        ),
+    };
+}
+
+function getAriaLabel(compatibility: SensorVersionCompatibility | undefined): string {
+    switch (compatibility) {
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND':
+            return 'Sensor version compatibility chart. Sensor is incompatible and behind Central.';
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND':
+            return 'Sensor version compatibility chart. Sensor is compatible and behind Central.';
+        case 'SENSOR_VERSION_COMPATIBILITY_MATCHED':
+            return 'Sensor version compatibility chart. Sensor is matched with Central.';
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD':
+            return 'Sensor version compatibility chart. Sensor is compatible and ahead of Central.';
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD':
+            return 'Sensor version compatibility chart. Sensor is incompatible and ahead of Central.';
+        default:
+            return 'Sensor version compatibility chart.';
+    }
+}
+
+type SensorVersionRangeChartProps = {
+    compatibleVersions: string[];
+    sensorVersion: string;
+    centralVersion: string;
+    compatibility?: SensorVersionCompatibility;
+};
+
+function SensorVersionRangeChart({
+    compatibleVersions,
+    sensorVersion,
+    centralVersion,
+    compatibility,
+}: SensorVersionRangeChartProps) {
+    const chartData = computeVersionRangeData(
+        compatibleVersions,
+        sensorVersion,
+        centralVersion,
+        compatibility
+    );
+
+    if (!chartData) {
+        return null;
+    }
+
+    const { zones, behindVersions, matchedVersion, aheadVersions, markerPercent } = chartData;
+    const { zoneLabel } = getSensorCompatibilityInfo(compatibility);
+    const versionLabels = ['', ...behindVersions, matchedVersion, ...aheadVersions, ''];
+
+    return (
+        <Flex
+            role="img"
+            aria-label={getAriaLabel(compatibility)}
+            direction={{ default: 'column' }}
+            gap={{ default: 'gapSm' }}
+            className="pf-v6-u-font-size-xs pf-v6-u-text-align-center pf-v6-u-pb-lg"
+        >
+            <Flex gap={{ default: 'gapNone' }}>
+                {versionLabels.map((v) => (
+                    <FlexItem key={v} flex={{ default: 'flex_1' }}>
+                        {v}
+                    </FlexItem>
+                ))}
+            </Flex>
+
+            <FlexItem style={{ position: 'relative' }}>
+                <Flex gap={{ default: 'gapXs' }}>
+                    {zones.map((zone, i) => (
+                        <Tooltip
+                            // eslint-disable-next-line react/no-array-index-key
+                            key={i}
+                            content={zone.tooltip}
+                        >
+                            <FlexItem
+                                style={{
+                                    flex: zone.width,
+                                    height: 16,
+                                    backgroundColor: zone.color,
+                                }}
+                            />
+                        </Tooltip>
+                    ))}
+                </Flex>
+                {markerPercent !== null && (
+                    <>
+                        <div
+                            className="pf-v6-u-box-shadow-sm"
+                            style={{
+                                position: 'absolute',
+                                left: `${markerPercent}%`,
+                                top: '50%',
+                                transform: 'translate(-50%, -50%)',
+                                width: 6,
+                                height: 30,
+                                backgroundColor: compatibilityRangeColor.marker,
+                            }}
+                        />
+                        {zoneLabel && (
+                            <div
+                                className="pf-v6-u-text-nowrap pf-v6-u-mt-sm"
+                                style={{
+                                    position: 'absolute',
+                                    left: `${markerPercent}%`,
+                                    top: '100%',
+                                    transform: 'translateX(-50%)',
+                                }}
+                            >
+                                {zoneLabel}
+                            </div>
+                        )}
+                    </>
+                )}
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default SensorVersionRangeChart;

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
@@ -240,8 +240,9 @@ function SensorVersionRangeChart({
             className="pf-v6-u-font-size-xs pf-v6-u-text-align-center pf-v6-u-pb-lg"
         >
             <Flex gap={{ default: 'gapNone' }}>
-                {versionLabels.map((v) => (
-                    <FlexItem key={v} flex={{ default: 'flex_1' }}>
+                {versionLabels.map((v, i) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <FlexItem key={i} flex={{ default: 'flex_1' }}>
                         {v}
                     </FlexItem>
                 ))}

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
@@ -183,21 +183,19 @@ export function computeVersionRangeData(
     };
 }
 
-function getAriaLabel(compatibility: SensorVersionCompatibility | undefined): string {
-    switch (compatibility) {
-        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND':
-            return 'Sensor version compatibility chart. Sensor is incompatible and behind Central.';
-        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND':
-            return 'Sensor version compatibility chart. Sensor is compatible and behind Central.';
-        case 'SENSOR_VERSION_COMPATIBILITY_MATCHED':
-            return 'Sensor version compatibility chart. Sensor is matched with Central.';
-        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD':
-            return 'Sensor version compatibility chart. Sensor is compatible and ahead of Central.';
-        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD':
-            return 'Sensor version compatibility chart. Sensor is incompatible and ahead of Central.';
-        default:
-            return 'Sensor version compatibility chart.';
-    }
+function buildAriaLabel(
+    compatibility: SensorVersionCompatibility | undefined,
+    sensorVersion: string,
+    centralVersion: string,
+    compatibleVersions: string[]
+): string {
+    const { displayValue } = getSensorCompatibilityInfo(compatibility);
+    const range =
+        compatibleVersions.length > 0
+            ? `${compatibleVersions[0]} to ${compatibleVersions[compatibleVersions.length - 1]}`
+            : 'unknown';
+
+    return `Sensor version compatibility chart. Sensor ${sensorVersion || 'unknown'}, Central ${centralVersion}. Status: ${displayValue}. Compatible range: ${range}.`;
 }
 
 type SensorVersionRangeChartProps = {
@@ -231,7 +229,12 @@ function SensorVersionRangeChart({
     return (
         <Flex
             role="img"
-            aria-label={getAriaLabel(compatibility)}
+            aria-label={buildAriaLabel(
+                compatibility,
+                sensorVersion,
+                centralVersion,
+                compatibleVersions
+            )}
             direction={{ default: 'column' }}
             gap={{ default: 'gapSm' }}
             className="pf-v6-u-font-size-xs pf-v6-u-text-align-center pf-v6-u-pb-lg"

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
@@ -3,7 +3,7 @@ import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import type { SensorVersionCompatibility } from 'types/cluster.proto';
 import { getSensorCompatibilityInfo } from '../cluster.helpers';
 
-type CompatibilityZone = {
+export type CompatibilityZone = {
     width: number;
     color: string;
     tooltip: string;
@@ -11,7 +11,7 @@ type CompatibilityZone = {
 
 type CompatibilityDirection = 'behind' | 'matched' | 'ahead';
 
-type VersionRangeData = {
+export type VersionRangeData = {
     zones: CompatibilityZone[];
     behindVersions: string[];
     matchedVersion: string;
@@ -139,7 +139,7 @@ function buildZones(compatibleVersions: string[], centralIndex: number): Compati
     return zones;
 }
 
-function computeVersionRangeData(
+export function computeVersionRangeData(
     compatibleVersions: string[],
     sensorVersion: string,
     centralVersion: string,

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorVersionRangeChart.tsx
@@ -82,15 +82,22 @@ function computeMarkerPercent(
         }
     }
 
+    const behindCount = centralIndex;
+    const aheadCount = compatibleVersions.length - centralIndex - 1;
+
+    // Determines the percentage position from the left edge of the chart to
+    // match the appropriate zone.
     switch (compatibility) {
         case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND':
-        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND':
             return toPercent(0.5);
-        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD':
-        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD':
-            return toPercent(totalUnits - 0.5);
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND':
+            return toPercent(1 + behindCount / 2);
         case 'SENSOR_VERSION_COMPATIBILITY_MATCHED':
             return toPercent(1 + centralIndex + 0.5);
+        case 'SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD':
+            return toPercent(1 + centralIndex + 1 + aheadCount / 2);
+        case 'SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD':
+            return toPercent(totalUnits - 0.5);
         default:
             return null;
     }

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -609,6 +609,19 @@ export function getSensorCompatibilityInfo(compatibility: SensorVersionCompatibi
         : defaultSensorCompatibility;
 }
 
+// The version range chart can only be rendered when the compatibility state is
+// known and Central has advertised a compatible sensor version range.
+export function shouldShowSensorVersionRangeChart(
+    compatibility: SensorVersionCompatibility | undefined,
+    compatibleVersions: string[]
+): boolean {
+    return (
+        compatibility !== undefined &&
+        compatibility !== 'SENSOR_VERSION_COMPATIBILITY_UNKNOWN' &&
+        compatibleVersions.length > 0
+    );
+}
+
 export default {
     runtimeOptions,
     clusterTypeOptions,

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -204,31 +204,37 @@ export const sensorUpgradeStyles = {
 export const sensorCompatibilityMap = {
     SENSOR_VERSION_COMPATIBILITY_MATCHED: {
         displayValue: 'Matched',
+        zoneLabel: 'Matched',
         Icon: CheckCircleIcon,
         fgColor: 'pf-v6-u-icon-color-status-success',
     },
     SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_BEHIND: {
         displayValue: 'Compatible (Behind)',
+        zoneLabel: 'Behind',
         Icon: InfoCircleIcon,
         fgColor: 'pf-v6-u-icon-color-status-info',
     },
     SENSOR_VERSION_COMPATIBILITY_COMPATIBLE_AHEAD: {
         displayValue: 'Compatible (Ahead)',
+        zoneLabel: 'Ahead',
         Icon: InfoCircleIcon,
         fgColor: 'pf-v6-u-icon-color-status-info',
     },
     SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_BEHIND: {
         displayValue: 'Incompatible (Behind)',
+        zoneLabel: 'Incompatible',
         Icon: ExclamationCircleIcon,
         fgColor: 'pf-v6-u-icon-color-status-danger',
     },
     SENSOR_VERSION_COMPATIBILITY_INCOMPATIBLE_AHEAD: {
         displayValue: 'Incompatible (Ahead)',
+        zoneLabel: 'Incompatible',
         Icon: ExclamationCircleIcon,
         fgColor: 'pf-v6-u-icon-color-status-danger',
     },
     SENSOR_VERSION_COMPATIBILITY_UNKNOWN: {
         displayValue: 'Unknown',
+        zoneLabel: '',
         Icon: UnknownIcon,
         fgColor: 'pf-v6-u-icon-color-subtle',
     },


### PR DESCRIPTION
## Description

Adds a visual display to Sensor Version cards on the cluster page that represents the sensor's compatibility state across central's compatibility range.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1114" height="454" alt="image" src="https://github.com/user-attachments/assets/a69d8591-4107-46d8-9a71-307118172a5a" />
<img width="1114" height="515" alt="image" src="https://github.com/user-attachments/assets/b920ddc2-bcd3-4448-a664-9afac705a129" />
<img width="1114" height="502" alt="image" src="https://github.com/user-attachments/assets/6ffea4b5-88e4-403f-a16a-e5c68d4d7001" />
<img width="1114" height="469" alt="image" src="https://github.com/user-attachments/assets/7ba444f7-869e-45d9-8fb3-c5e38a01ae5f" />

