### PR TITLE
feat(be): per-collection scoped notifier mappings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@ This file provides guidance when working with code in this repository.
 ## Repository Information
 
 **Upstream Repository**: https://github.com/stackrox/stackrox
+**Issue Tracker**: https://issues.redhat.com (JIRA, project key: ROX)
 
 ## Workflow
 

--- a/central/notifier/processor/processor_impl.go
+++ b/central/notifier/processor/processor_impl.go
@@ -184,13 +184,15 @@ func matchString(actual, pattern string) bool {
 	if pattern == "" {
 		return true
 	}
-	// Exact match or regex-style prefix match
+	// Strip exact-match quotes added by search.ExactMatchString
+	if len(pattern) >= 2 && pattern[0] == '"' && pattern[len(pattern)-1] == '"' {
+		pattern = pattern[1 : len(pattern)-1]
+	}
 	if actual == pattern {
 		return true
 	}
-	// Handle "r/..." regex patterns from collection rules
 	if len(pattern) > 2 && pattern[:2] == "r/" {
-		return false // regex matching would require a regex engine; fall back to not matching
+		return false
 	}
 	return false
 }

--- a/central/notifier/processor/processor_impl.go
+++ b/central/notifier/processor/processor_impl.go
@@ -11,7 +11,10 @@ import (
 	pkgNotifier "github.com/stackrox/rox/pkg/notifier"
 	"github.com/stackrox/rox/pkg/notifiers"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
+
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 )
 
 var (
@@ -23,8 +26,10 @@ var (
 
 // Processor takes in alerts and sends the notifications tied to that alert
 type processorImpl struct {
-	ns       pkgNotifier.Set
-	reporter integrationhealth.Reporter
+	ns                  pkgNotifier.Set
+	reporter            integrationhealth.Reporter
+	collectionDataStore collectionDS.DataStore
+	collectionResolver  collectionDS.QueryResolver
 }
 
 func (p *processorImpl) HasNotifiers() bool {
@@ -52,10 +57,26 @@ func (p *processorImpl) UpdateNotifier(ctx context.Context, notifier notifiers.N
 
 // ProcessAlert pushes the alert into a channel to be processed
 func (p *processorImpl) ProcessAlert(ctx context.Context, alert *storage.Alert) {
-	if len(alert.GetPolicy().GetNotifiers()) == 0 {
+	policy := alert.GetPolicy()
+	unscopedNotifiers := policy.GetNotifiers()
+	scopedMappings := policy.GetNotifierToCollectionMappings()
+
+	if len(unscopedNotifiers) == 0 && len(scopedMappings) == 0 {
 		return
 	}
-	alertNotifiers := set.NewStringSet(alert.GetPolicy().GetNotifiers()...)
+
+	alertNotifiers := set.NewStringSet(unscopedNotifiers...)
+
+	// For scoped mappings, check if the alert entity matches the collection
+	for _, mapping := range scopedMappings {
+		if p.alertMatchesCollection(ctx, alert, mapping.GetCollectionId()) {
+			alertNotifiers.Add(mapping.GetNotifierId())
+		}
+	}
+
+	if alertNotifiers.Cardinality() == 0 {
+		return
+	}
 
 	p.ns.ForEach(ctx, func(ctx context.Context, notifier notifiers.Notifier, failures pkgNotifier.AlertSet) {
 		if alertNotifiers.Contains(notifier.ProtoNotifier().GetId()) {
@@ -72,11 +93,110 @@ func (p *processorImpl) ProcessAlert(ctx context.Context, alert *storage.Alert) 
 	})
 }
 
+func (p *processorImpl) alertMatchesCollection(ctx context.Context, alert *storage.Alert, collectionID string) bool {
+	if p.collectionDataStore == nil || p.collectionResolver == nil || collectionID == "" {
+		return false
+	}
+
+	collection, exists, err := p.collectionDataStore.Get(ctx, collectionID)
+	if err != nil || !exists {
+		log.Warnf("Could not resolve collection %s for scoped notification: %v", collectionID, err)
+		return false
+	}
+
+	collectionQuery, err := p.collectionResolver.ResolveCollectionQuery(ctx, collection)
+	if err != nil {
+		log.Warnf("Could not resolve collection query for %s: %v", collectionID, err)
+		return false
+	}
+
+	return alertMatchesQuery(alert, collectionQuery)
+}
+
+func alertMatchesQuery(alert *storage.Alert, query *v1.Query) bool {
+	deployment := alert.GetDeployment()
+	if deployment == nil {
+		return false
+	}
+
+	return matchesQueryRecursive(deployment, query)
+}
+
+func matchesQueryRecursive(deployment *storage.Alert_Deployment, query *v1.Query) bool {
+	if query == nil {
+		return true
+	}
+
+	switch q := query.GetQuery().(type) {
+	case *v1.Query_BaseQuery:
+		return matchesBaseQuery(deployment, q.BaseQuery)
+	case *v1.Query_Conjunction:
+		for _, subQuery := range q.Conjunction.GetQueries() {
+			if !matchesQueryRecursive(deployment, subQuery) {
+				return false
+			}
+		}
+		return true
+	case *v1.Query_Disjunction:
+		for _, subQuery := range q.Disjunction.GetQueries() {
+			if matchesQueryRecursive(deployment, subQuery) {
+				return true
+			}
+		}
+		return false
+	case *v1.Query_BooleanQuery:
+		for _, mustQuery := range q.BooleanQuery.GetMust().GetQueries() {
+			if !matchesQueryRecursive(deployment, mustQuery) {
+				return false
+			}
+		}
+		for _, mustNotQuery := range q.BooleanQuery.GetMustNot().GetQueries() {
+			if matchesQueryRecursive(deployment, mustNotQuery) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func matchesBaseQuery(deployment *storage.Alert_Deployment, baseQuery *v1.BaseQuery) bool {
+	matchFieldQuery, ok := baseQuery.GetQuery().(*v1.BaseQuery_MatchFieldQuery)
+	if !ok {
+		return true
+	}
+
+	fieldName := matchFieldQuery.MatchFieldQuery.GetField()
+	value := matchFieldQuery.MatchFieldQuery.GetValue()
+
+	switch search.FieldLabel(fieldName) {
+	case search.Cluster:
+		return matchString(deployment.GetClusterName(), value) || matchString(deployment.GetClusterId(), value)
+	case search.Namespace:
+		return matchString(deployment.GetNamespace(), value)
+	case search.DeploymentName:
+		return matchString(deployment.GetName(), value)
+	}
+	return true
+}
+
+func matchString(actual, pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+	// Exact match or regex-style prefix match
+	if actual == pattern {
+		return true
+	}
+	// Handle "r/..." regex patterns from collection rules
+	if len(pattern) > 2 && pattern[:2] == "r/" {
+		return false // regex matching would require a regex engine; fall back to not matching
+	}
+	return false
+}
+
 // ProcessAuditMessage sends the audit message with all applicable notifiers.
 func (p *processorImpl) ProcessAuditMessage(ctx context.Context, msg *v1.Audit_Message) {
-	// TODO: Turn processorImpl into a work queue and introduce func (p *processorImpl) run(context.Context) error.
-	// With that, we wouldn't have to fan out n go routines (n = # notifiers in p.ns) and ensure ordering
-	// of audit messages.
 	p.ns.ForEach(ctx, func(_ context.Context, notifier notifiers.Notifier, _ pkgNotifier.AlertSet) {
 		go p.tryToSendAudit(ctxBackground, notifier, msg)
 	})
@@ -123,5 +243,15 @@ func New(ns pkgNotifier.Set, reporter integrationhealth.Reporter) pkgNotifier.Pr
 	return &processorImpl{
 		ns:       ns,
 		reporter: reporter,
+	}
+}
+
+// NewWithCollections returns a new Processor with collection-scoped notification support
+func NewWithCollections(ns pkgNotifier.Set, reporter integrationhealth.Reporter, collectionDS collectionDS.DataStore, collectionResolver collectionDS.QueryResolver) pkgNotifier.Processor {
+	return &processorImpl{
+		ns:                  ns,
+		reporter:            reporter,
+		collectionDataStore: collectionDS,
+		collectionResolver:  collectionResolver,
 	}
 }

--- a/central/notifier/processor/singleton.go
+++ b/central/notifier/processor/singleton.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/central/notifier/datastore"
 	encConfigDatastore "github.com/stackrox/rox/central/notifier/encconfig/datastore"
 	notifierUtils "github.com/stackrox/rox/central/notifiers/utils"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/declarativeconfig"
 	"github.com/stackrox/rox/pkg/env"
@@ -47,7 +48,8 @@ func initialize() {
 	ns = notifier.NewNotifierSet(retryAlertsFor)
 
 	// When alerts are generated, we will want to notify.
-	pr = New(ns, reporter.Singleton())
+	collDS, collResolver := collectionDS.Singleton()
+	pr = NewWithCollections(ns, reporter.Singleton(), collDS, collResolver)
 
 	notifierDatastore := datastore.Singleton()
 	var protoNotifiers []*storage.Notifier

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -646,6 +646,25 @@ func (ds *datastoreImpl) removeForeignClusterScopesAndNotifiers(ctx context.Cont
 		}
 		policy.Notifiers = notifiers
 
+		var validMappings []*storage.NotifierToCollectionMapping
+		for _, mapping := range policy.GetNotifierToCollectionMappings() {
+			notifierID := mapping.GetNotifierId()
+			exists, cached := notifierCache[notifierID]
+			if !cached {
+				_, exists, err = ds.notifierDatastore.GetNotifier(ctx, notifierID)
+				if err != nil {
+					return set.NewIntSet(), err
+				}
+				notifierCache[notifierID] = exists
+			}
+			if exists {
+				validMappings = append(validMappings, mapping)
+				continue
+			}
+			modified = true
+		}
+		policy.NotifierToCollectionMappings = validMappings
+
 		var exclusions []*storage.Exclusion
 		for _, exclusion := range policy.GetExclusions() {
 			excludeCluster := exclusion.GetDeployment().GetScope().GetCluster()

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -161,17 +161,18 @@ func convertPoliciesToListPolicies(policies []*storage.Policy) []*storage.ListPo
 	listPolicies := make([]*storage.ListPolicy, 0, len(policies))
 	for _, p := range policies {
 		listPolicies = append(listPolicies, &storage.ListPolicy{
-			Id:              p.GetId(),
-			Name:            p.GetName(),
-			Description:     p.GetDescription(),
-			Severity:        p.GetSeverity(),
-			Disabled:        p.GetDisabled(),
-			LifecycleStages: p.GetLifecycleStages(),
-			Notifiers:       p.GetNotifiers(),
-			LastUpdated:     p.GetLastUpdated(),
-			EventSource:     p.GetEventSource(),
-			IsDefault:       p.GetIsDefault(),
-			Source:          p.GetSource(),
+			Id:                           p.GetId(),
+			Name:                         p.GetName(),
+			Description:                  p.GetDescription(),
+			Severity:                     p.GetSeverity(),
+			Disabled:                     p.GetDisabled(),
+			LifecycleStages:              p.GetLifecycleStages(),
+			Notifiers:                    p.GetNotifiers(),
+			NotifierToCollectionMappings: p.GetNotifierToCollectionMappings(),
+			LastUpdated:                  p.GetLastUpdated(),
+			EventSource:                  p.GetEventSource(),
+			IsDefault:                    p.GetIsDefault(),
+			Source:                       p.GetSource(),
 		})
 	}
 	return listPolicies

--- a/config-controller/api/v1alpha1/policy_types.go
+++ b/config-controller/api/v1alpha1/policy_types.go
@@ -71,6 +71,8 @@ type SecurityPolicySpec struct {
 	EnforcementActions []EnforcementAction `json:"enforcementActions,omitempty"`
 	// Notifiers is a list of IDs or names of the notifiers that should be triggered when a violation from this policy is identified.  IDs should be in the form of a UUID and are found through the Central API.
 	Notifiers []string `json:"notifiers,omitempty"`
+	// NotifierToCollectionMappings maps notifiers to collection scopes for targeted notification routing in multi-tenancy environments.
+	NotifierToCollectionMappings []NotifierToCollectionMapping `json:"notifierToCollectionMappings,omitempty"`
 	// +kubebuilder:validation:MinItems=1
 	// PolicySections define the violation criteria for this policy.
 	PolicySections     []PolicySection      `json:"policySections"`
@@ -85,6 +87,12 @@ type SecurityPolicySpec struct {
 	// +optional
 	// MitreVetorsLocked is unused and deprecated
 	MitreVectorsLocked bool `json:"mitreVectorsLocked,omitempty"`
+}
+
+type NotifierToCollectionMapping struct {
+	NotifierID     string `json:"notifierId"`
+	CollectionID   string `json:"collectionId"`
+	CollectionName string `json:"collectionName,omitempty"`
 }
 
 type Exclusion struct {
@@ -262,6 +270,19 @@ func (p SecurityPolicySpec) ToProtobuf(caches map[CacheType]map[string]string) (
 			return nil, errors.New(fmt.Sprintf("Notifier '%s' does not exist", notifier))
 		}
 		proto.Notifiers = append(proto.Notifiers, id)
+	}
+
+	proto.NotifierToCollectionMappings = make([]*storage.NotifierToCollectionMapping, 0, len(p.NotifierToCollectionMappings))
+	for _, mapping := range p.NotifierToCollectionMappings {
+		notifierID, err := getNotifierID(mapping.NotifierID, caches)
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Notifier '%s' in collection mapping does not exist", mapping.NotifierID))
+		}
+		proto.NotifierToCollectionMappings = append(proto.NotifierToCollectionMappings, &storage.NotifierToCollectionMapping{
+			NotifierId:     notifierID,
+			CollectionId:   mapping.CollectionID,
+			CollectionName: mapping.CollectionName,
+		})
 	}
 
 	for _, ls := range p.LifecycleStages {

--- a/generated/api/v1/alert_service.swagger.json
+++ b/generated/api/v1/alert_service.swagger.json
@@ -1446,6 +1446,20 @@
       "default": "UNKNOWN_TYPE",
       "title": "- INTERNAL_ENTITIES: INTERNAL_ENTITIES is for grouping all internal entities under a single network graph node"
     },
+    "storageNotifierToCollectionMapping": {
+      "type": "object",
+      "properties": {
+        "notifierId": {
+          "type": "string"
+        },
+        "collectionId": {
+          "type": "string"
+        },
+        "collectionName": {
+          "type": "string"
+        }
+      }
+    },
     "storagePolicy": {
       "type": "object",
       "properties": {
@@ -1571,9 +1585,16 @@
         },
         "source": {
           "$ref": "#/definitions/storagePolicySource"
+        },
+        "notifierToCollectionMappings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageNotifierToCollectionMapping"
+          }
         }
       },
-      "title": "Next tag: 28"
+      "title": "Next tag: 29"
     },
     "storagePolicyGroup": {
       "type": "object",

--- a/generated/api/v1/detection_service.swagger.json
+++ b/generated/api/v1/detection_service.swagger.json
@@ -1163,6 +1163,20 @@
       "default": "UNKNOWN_TYPE",
       "title": "- INTERNAL_ENTITIES: INTERNAL_ENTITIES is for grouping all internal entities under a single network graph node"
     },
+    "storageNotifierToCollectionMapping": {
+      "type": "object",
+      "properties": {
+        "notifierId": {
+          "type": "string"
+        },
+        "collectionId": {
+          "type": "string"
+        },
+        "collectionName": {
+          "type": "string"
+        }
+      }
+    },
     "storagePermissionLevel": {
       "type": "string",
       "enum": [
@@ -1301,9 +1315,16 @@
         },
         "source": {
           "$ref": "#/definitions/storagePolicySource"
+        },
+        "notifierToCollectionMappings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageNotifierToCollectionMapping"
+          }
         }
       },
-      "title": "Next tag: 28"
+      "title": "Next tag: 29"
     },
     "storagePolicyGroup": {
       "type": "object",

--- a/generated/api/v1/policy_service.swagger.json
+++ b/generated/api/v1/policy_service.swagger.json
@@ -800,9 +800,16 @@
         },
         "source": {
           "$ref": "#/definitions/storagePolicySource"
+        },
+        "notifierToCollectionMappings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageNotifierToCollectionMapping"
+          }
         }
       },
-      "title": "Next tag: 28"
+      "title": "Next tag: 29"
     },
     "googleRpcStatus": {
       "type": "object",
@@ -949,6 +956,13 @@
         },
         "source": {
           "$ref": "#/definitions/storagePolicySource"
+        },
+        "notifierToCollectionMappings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageNotifierToCollectionMapping"
+          }
         }
       }
     },
@@ -991,6 +1005,20 @@
           "type": "string"
         },
         "description": {
+          "type": "string"
+        }
+      }
+    },
+    "storageNotifierToCollectionMapping": {
+      "type": "object",
+      "properties": {
+        "notifierId": {
+          "type": "string"
+        },
+        "collectionId": {
+          "type": "string"
+        },
+        "collectionName": {
           "type": "string"
         }
       }
@@ -1120,9 +1148,16 @@
         },
         "source": {
           "$ref": "#/definitions/storagePolicySource"
+        },
+        "notifierToCollectionMappings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageNotifierToCollectionMapping"
+          }
         }
       },
-      "title": "Next tag: 28"
+      "title": "Next tag: 29"
     },
     "storagePolicyGroup": {
       "type": "object",

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -307,8 +307,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/policy.pb.go
+++ b/generated/storage/policy.pb.go
@@ -392,7 +392,67 @@ func (Comparator) EnumDescriptor() ([]byte, []int) {
 	return file_storage_policy_proto_rawDescGZIP(), []int{6}
 }
 
-// Next tag: 28
+type NotifierToCollectionMapping struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	NotifierId     string                 `protobuf:"bytes,1,opt,name=notifier_id,json=notifierId,proto3" json:"notifier_id,omitempty"`
+	CollectionId   string                 `protobuf:"bytes,2,opt,name=collection_id,json=collectionId,proto3" json:"collection_id,omitempty"`
+	CollectionName string                 `protobuf:"bytes,3,opt,name=collection_name,json=collectionName,proto3" json:"collection_name,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *NotifierToCollectionMapping) Reset() {
+	*x = NotifierToCollectionMapping{}
+	mi := &file_storage_policy_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NotifierToCollectionMapping) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NotifierToCollectionMapping) ProtoMessage() {}
+
+func (x *NotifierToCollectionMapping) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_policy_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NotifierToCollectionMapping.ProtoReflect.Descriptor instead.
+func (*NotifierToCollectionMapping) Descriptor() ([]byte, []int) {
+	return file_storage_policy_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *NotifierToCollectionMapping) GetNotifierId() string {
+	if x != nil {
+		return x.NotifierId
+	}
+	return ""
+}
+
+func (x *NotifierToCollectionMapping) GetCollectionId() string {
+	if x != nil {
+		return x.CollectionId
+	}
+	return ""
+}
+
+func (x *NotifierToCollectionMapping) GetCollectionName() string {
+	if x != nil {
+		return x.CollectionName
+	}
+	return ""
+}
+
+// Next tag: 29
 type Policy struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Policy ID,hidden" sql:"pk,index=btree" crYaml:"-"` // @gotags: search:"Policy ID,hidden" sql:"pk,index=btree" crYaml:"-"
@@ -440,15 +500,16 @@ type Policy struct {
 	// Read-only field. If true, the policy's MITRE ATT&CK fields are rendered read-only.
 	MitreVectorsLocked bool `protobuf:"varint,25,opt,name=mitre_vectors_locked,json=mitreVectorsLocked,proto3" json:"mitre_vectors_locked,omitempty" crYaml:"mitreVectorsLocked"` // @gotags: crYaml:"mitreVectorsLocked"
 	// Read-only field. Indicates the policy is a default policy if true and a custom policy if false.
-	IsDefault     bool         `protobuf:"varint,26,opt,name=is_default,json=isDefault,proto3" json:"is_default,omitempty" crYaml:"isDefault"`    // @gotags: crYaml:"isDefault"
-	Source        PolicySource `protobuf:"varint,27,opt,name=source,proto3,enum=storage.PolicySource" json:"source,omitempty" crYaml:"-"` // @gotags: crYaml:"-"
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	IsDefault                    bool                           `protobuf:"varint,26,opt,name=is_default,json=isDefault,proto3" json:"is_default,omitempty" crYaml:"isDefault"`                                                             // @gotags: crYaml:"isDefault"
+	Source                       PolicySource                   `protobuf:"varint,27,opt,name=source,proto3,enum=storage.PolicySource" json:"source,omitempty" crYaml:"-"`                                                          // @gotags: crYaml:"-"
+	NotifierToCollectionMappings []*NotifierToCollectionMapping `protobuf:"bytes,28,rep,name=notifier_to_collection_mappings,json=notifierToCollectionMappings,proto3" json:"notifier_to_collection_mappings,omitempty" crYaml:"notifierToCollectionMappings,omitempty"` // @gotags: crYaml:"notifierToCollectionMappings,omitempty"
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *Policy) Reset() {
 	*x = Policy{}
-	mi := &file_storage_policy_proto_msgTypes[0]
+	mi := &file_storage_policy_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +521,7 @@ func (x *Policy) String() string {
 func (*Policy) ProtoMessage() {}
 
 func (x *Policy) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[0]
+	mi := &file_storage_policy_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +534,7 @@ func (x *Policy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy.ProtoReflect.Descriptor instead.
 func (*Policy) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{0}
+	return file_storage_policy_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *Policy) GetId() string {
@@ -651,6 +712,13 @@ func (x *Policy) GetSource() PolicySource {
 	return PolicySource_IMPERATIVE
 }
 
+func (x *Policy) GetNotifierToCollectionMappings() []*NotifierToCollectionMapping {
+	if x != nil {
+		return x.NotifierToCollectionMappings
+	}
+	return nil
+}
+
 type PolicySection struct {
 	state       protoimpl.MessageState `protogen:"open.v1"`
 	SectionName string                 `protobuf:"bytes,1,opt,name=section_name,json=sectionName,proto3" json:"section_name,omitempty" crYaml:"sectionName,omitempty"` // @gotags: crYaml:"sectionName,omitempty"
@@ -662,7 +730,7 @@ type PolicySection struct {
 
 func (x *PolicySection) Reset() {
 	*x = PolicySection{}
-	mi := &file_storage_policy_proto_msgTypes[1]
+	mi := &file_storage_policy_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -674,7 +742,7 @@ func (x *PolicySection) String() string {
 func (*PolicySection) ProtoMessage() {}
 
 func (x *PolicySection) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[1]
+	mi := &file_storage_policy_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -687,7 +755,7 @@ func (x *PolicySection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicySection.ProtoReflect.Descriptor instead.
 func (*PolicySection) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{1}
+	return file_storage_policy_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PolicySection) GetSectionName() string {
@@ -720,7 +788,7 @@ type PolicyGroup struct {
 
 func (x *PolicyGroup) Reset() {
 	*x = PolicyGroup{}
-	mi := &file_storage_policy_proto_msgTypes[2]
+	mi := &file_storage_policy_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -732,7 +800,7 @@ func (x *PolicyGroup) String() string {
 func (*PolicyGroup) ProtoMessage() {}
 
 func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[2]
+	mi := &file_storage_policy_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -745,7 +813,7 @@ func (x *PolicyGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyGroup.ProtoReflect.Descriptor instead.
 func (*PolicyGroup) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{2}
+	return file_storage_policy_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *PolicyGroup) GetFieldName() string {
@@ -785,7 +853,7 @@ type PolicyValue struct {
 
 func (x *PolicyValue) Reset() {
 	*x = PolicyValue{}
-	mi := &file_storage_policy_proto_msgTypes[3]
+	mi := &file_storage_policy_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -797,7 +865,7 @@ func (x *PolicyValue) String() string {
 func (*PolicyValue) ProtoMessage() {}
 
 func (x *PolicyValue) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[3]
+	mi := &file_storage_policy_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -810,7 +878,7 @@ func (x *PolicyValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyValue.ProtoReflect.Descriptor instead.
 func (*PolicyValue) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{3}
+	return file_storage_policy_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PolicyValue) GetValue() string {
@@ -829,7 +897,7 @@ type PolicyList struct {
 
 func (x *PolicyList) Reset() {
 	*x = PolicyList{}
-	mi := &file_storage_policy_proto_msgTypes[4]
+	mi := &file_storage_policy_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -841,7 +909,7 @@ func (x *PolicyList) String() string {
 func (*PolicyList) ProtoMessage() {}
 
 func (x *PolicyList) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[4]
+	mi := &file_storage_policy_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -854,7 +922,7 @@ func (x *PolicyList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyList.ProtoReflect.Descriptor instead.
 func (*PolicyList) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{4}
+	return file_storage_policy_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *PolicyList) GetPolicies() []*Policy {
@@ -865,25 +933,26 @@ func (x *PolicyList) GetPolicies() []*Policy {
 }
 
 type ListPolicy struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Id              string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name            string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Description     string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
-	Severity        Severity               `protobuf:"varint,4,opt,name=severity,proto3,enum=storage.Severity" json:"severity,omitempty"`
-	Disabled        bool                   `protobuf:"varint,5,opt,name=disabled,proto3" json:"disabled,omitempty"`
-	LifecycleStages []LifecycleStage       `protobuf:"varint,6,rep,packed,name=lifecycle_stages,json=lifecycleStages,proto3,enum=storage.LifecycleStage" json:"lifecycle_stages,omitempty"`
-	Notifiers       []string               `protobuf:"bytes,7,rep,name=notifiers,proto3" json:"notifiers,omitempty"`
-	LastUpdated     *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty"`
-	EventSource     EventSource            `protobuf:"varint,9,opt,name=event_source,json=eventSource,proto3,enum=storage.EventSource" json:"event_source,omitempty"`
-	IsDefault       bool                   `protobuf:"varint,10,opt,name=is_default,json=isDefault,proto3" json:"is_default,omitempty"`
-	Source          PolicySource           `protobuf:"varint,11,opt,name=source,proto3,enum=storage.PolicySource" json:"source,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state                        protoimpl.MessageState         `protogen:"open.v1"`
+	Id                           string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name                         string                         `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Description                  string                         `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Severity                     Severity                       `protobuf:"varint,4,opt,name=severity,proto3,enum=storage.Severity" json:"severity,omitempty"`
+	Disabled                     bool                           `protobuf:"varint,5,opt,name=disabled,proto3" json:"disabled,omitempty"`
+	LifecycleStages              []LifecycleStage               `protobuf:"varint,6,rep,packed,name=lifecycle_stages,json=lifecycleStages,proto3,enum=storage.LifecycleStage" json:"lifecycle_stages,omitempty"`
+	Notifiers                    []string                       `protobuf:"bytes,7,rep,name=notifiers,proto3" json:"notifiers,omitempty"`
+	LastUpdated                  *timestamppb.Timestamp         `protobuf:"bytes,8,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty"`
+	EventSource                  EventSource                    `protobuf:"varint,9,opt,name=event_source,json=eventSource,proto3,enum=storage.EventSource" json:"event_source,omitempty"`
+	IsDefault                    bool                           `protobuf:"varint,10,opt,name=is_default,json=isDefault,proto3" json:"is_default,omitempty"`
+	Source                       PolicySource                   `protobuf:"varint,11,opt,name=source,proto3,enum=storage.PolicySource" json:"source,omitempty"`
+	NotifierToCollectionMappings []*NotifierToCollectionMapping `protobuf:"bytes,12,rep,name=notifier_to_collection_mappings,json=notifierToCollectionMappings,proto3" json:"notifier_to_collection_mappings,omitempty"`
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *ListPolicy) Reset() {
 	*x = ListPolicy{}
-	mi := &file_storage_policy_proto_msgTypes[5]
+	mi := &file_storage_policy_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -895,7 +964,7 @@ func (x *ListPolicy) String() string {
 func (*ListPolicy) ProtoMessage() {}
 
 func (x *ListPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[5]
+	mi := &file_storage_policy_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -908,7 +977,7 @@ func (x *ListPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPolicy.ProtoReflect.Descriptor instead.
 func (*ListPolicy) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{5}
+	return file_storage_policy_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListPolicy) GetId() string {
@@ -988,6 +1057,13 @@ func (x *ListPolicy) GetSource() PolicySource {
 	return PolicySource_IMPERATIVE
 }
 
+func (x *ListPolicy) GetNotifierToCollectionMappings() []*NotifierToCollectionMapping {
+	if x != nil {
+		return x.NotifierToCollectionMappings
+	}
+	return nil
+}
+
 type Exclusion struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty" crYaml:",omitempty"`             // @gotags: crYaml:",omitempty"
@@ -1000,7 +1076,7 @@ type Exclusion struct {
 
 func (x *Exclusion) Reset() {
 	*x = Exclusion{}
-	mi := &file_storage_policy_proto_msgTypes[6]
+	mi := &file_storage_policy_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1012,7 +1088,7 @@ func (x *Exclusion) String() string {
 func (*Exclusion) ProtoMessage() {}
 
 func (x *Exclusion) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[6]
+	mi := &file_storage_policy_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1025,7 +1101,7 @@ func (x *Exclusion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exclusion.ProtoReflect.Descriptor instead.
 func (*Exclusion) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{6}
+	return file_storage_policy_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Exclusion) GetName() string {
@@ -1067,7 +1143,7 @@ type ExportPoliciesResponse struct {
 
 func (x *ExportPoliciesResponse) Reset() {
 	*x = ExportPoliciesResponse{}
-	mi := &file_storage_policy_proto_msgTypes[7]
+	mi := &file_storage_policy_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1079,7 +1155,7 @@ func (x *ExportPoliciesResponse) String() string {
 func (*ExportPoliciesResponse) ProtoMessage() {}
 
 func (x *ExportPoliciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[7]
+	mi := &file_storage_policy_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1092,7 +1168,7 @@ func (x *ExportPoliciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportPoliciesResponse.ProtoReflect.Descriptor instead.
 func (*ExportPoliciesResponse) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{7}
+	return file_storage_policy_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ExportPoliciesResponse) GetPolicies() []*Policy {
@@ -1112,7 +1188,7 @@ type Policy_MitreAttackVectors struct {
 
 func (x *Policy_MitreAttackVectors) Reset() {
 	*x = Policy_MitreAttackVectors{}
-	mi := &file_storage_policy_proto_msgTypes[8]
+	mi := &file_storage_policy_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1124,7 +1200,7 @@ func (x *Policy_MitreAttackVectors) String() string {
 func (*Policy_MitreAttackVectors) ProtoMessage() {}
 
 func (x *Policy_MitreAttackVectors) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[8]
+	mi := &file_storage_policy_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1137,7 +1213,7 @@ func (x *Policy_MitreAttackVectors) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Policy_MitreAttackVectors.ProtoReflect.Descriptor instead.
 func (*Policy_MitreAttackVectors) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{0, 0}
+	return file_storage_policy_proto_rawDescGZIP(), []int{1, 0}
 }
 
 func (x *Policy_MitreAttackVectors) GetTactic() string {
@@ -1163,7 +1239,7 @@ type Exclusion_Container struct {
 
 func (x *Exclusion_Container) Reset() {
 	*x = Exclusion_Container{}
-	mi := &file_storage_policy_proto_msgTypes[9]
+	mi := &file_storage_policy_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1175,7 +1251,7 @@ func (x *Exclusion_Container) String() string {
 func (*Exclusion_Container) ProtoMessage() {}
 
 func (x *Exclusion_Container) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[9]
+	mi := &file_storage_policy_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1188,7 +1264,7 @@ func (x *Exclusion_Container) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exclusion_Container.ProtoReflect.Descriptor instead.
 func (*Exclusion_Container) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{6, 0}
+	return file_storage_policy_proto_rawDescGZIP(), []int{7, 0}
 }
 
 func (x *Exclusion_Container) GetImageName() *ImageName {
@@ -1208,7 +1284,7 @@ type Exclusion_Deployment struct {
 
 func (x *Exclusion_Deployment) Reset() {
 	*x = Exclusion_Deployment{}
-	mi := &file_storage_policy_proto_msgTypes[10]
+	mi := &file_storage_policy_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1296,7 @@ func (x *Exclusion_Deployment) String() string {
 func (*Exclusion_Deployment) ProtoMessage() {}
 
 func (x *Exclusion_Deployment) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[10]
+	mi := &file_storage_policy_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1233,7 +1309,7 @@ func (x *Exclusion_Deployment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exclusion_Deployment.ProtoReflect.Descriptor instead.
 func (*Exclusion_Deployment) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{6, 1}
+	return file_storage_policy_proto_rawDescGZIP(), []int{7, 1}
 }
 
 func (x *Exclusion_Deployment) GetName() string {
@@ -1259,7 +1335,7 @@ type Exclusion_Image struct {
 
 func (x *Exclusion_Image) Reset() {
 	*x = Exclusion_Image{}
-	mi := &file_storage_policy_proto_msgTypes[11]
+	mi := &file_storage_policy_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1271,7 +1347,7 @@ func (x *Exclusion_Image) String() string {
 func (*Exclusion_Image) ProtoMessage() {}
 
 func (x *Exclusion_Image) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_policy_proto_msgTypes[11]
+	mi := &file_storage_policy_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1284,7 +1360,7 @@ func (x *Exclusion_Image) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exclusion_Image.ProtoReflect.Descriptor instead.
 func (*Exclusion_Image) Descriptor() ([]byte, []int) {
-	return file_storage_policy_proto_rawDescGZIP(), []int{6, 2}
+	return file_storage_policy_proto_rawDescGZIP(), []int{7, 2}
 }
 
 func (x *Exclusion_Image) GetName() string {
@@ -1298,7 +1374,13 @@ var File_storage_policy_proto protoreflect.FileDescriptor
 
 const file_storage_policy_proto_rawDesc = "" +
 	"\n" +
-	"\x14storage/policy.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x13storage/image.proto\x1a\x13storage/scope.proto\"\xb4\t\n" +
+	"\x14storage/policy.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x13storage/image.proto\x1a\x13storage/scope.proto\"\x8c\x01\n" +
+	"\x1bNotifierToCollectionMapping\x12\x1f\n" +
+	"\vnotifier_id\x18\x01 \x01(\tR\n" +
+	"notifierId\x12#\n" +
+	"\rcollection_id\x18\x02 \x01(\tR\fcollectionId\x12'\n" +
+	"\x0fcollection_name\x18\x03 \x01(\tR\x0ecollectionName\"\xa1\n" +
+	"\n" +
 	"\x06Policy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -1329,7 +1411,8 @@ const file_storage_policy_proto_rawDesc = "" +
 	"\x14mitre_vectors_locked\x18\x19 \x01(\bR\x12mitreVectorsLocked\x12\x1d\n" +
 	"\n" +
 	"is_default\x18\x1a \x01(\bR\tisDefault\x12-\n" +
-	"\x06source\x18\x1b \x01(\x0e2\x15.storage.PolicySourceR\x06source\x1aL\n" +
+	"\x06source\x18\x1b \x01(\x0e2\x15.storage.PolicySourceR\x06source\x12k\n" +
+	"\x1fnotifier_to_collection_mappings\x18\x1c \x03(\v2$.storage.NotifierToCollectionMappingR\x1cnotifierToCollectionMappings\x1aL\n" +
 	"\x12MitreAttackVectors\x12\x16\n" +
 	"\x06tactic\x18\x01 \x01(\tR\x06tactic\x12\x1e\n" +
 	"\n" +
@@ -1349,7 +1432,7 @@ const file_storage_policy_proto_rawDesc = "" +
 	"\x05value\x18\x01 \x01(\tR\x05value\"9\n" +
 	"\n" +
 	"PolicyList\x12+\n" +
-	"\bpolicies\x18\x01 \x03(\v2\x0f.storage.PolicyR\bpolicies\"\xc5\x03\n" +
+	"\bpolicies\x18\x01 \x03(\v2\x0f.storage.PolicyR\bpolicies\"\xb2\x04\n" +
 	"\n" +
 	"ListPolicy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -1364,7 +1447,8 @@ const file_storage_policy_proto_rawDesc = "" +
 	"\n" +
 	"is_default\x18\n" +
 	" \x01(\bR\tisDefault\x12-\n" +
-	"\x06source\x18\v \x01(\x0e2\x15.storage.PolicySourceR\x06source\"\xf5\x02\n" +
+	"\x06source\x18\v \x01(\x0e2\x15.storage.PolicySourceR\x06source\x12k\n" +
+	"\x1fnotifier_to_collection_mappings\x18\f \x03(\v2$.storage.NotifierToCollectionMappingR\x1cnotifierToCollectionMappings\"\xf5\x02\n" +
 	"\tExclusion\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12=\n" +
 	"\n" +
@@ -1441,62 +1525,65 @@ func file_storage_policy_proto_rawDescGZIP() []byte {
 }
 
 var file_storage_policy_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_storage_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_storage_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_storage_policy_proto_goTypes = []any{
-	(PolicySource)(0),                 // 0: storage.PolicySource
-	(EventSource)(0),                  // 1: storage.EventSource
-	(BooleanOperator)(0),              // 2: storage.BooleanOperator
-	(EnforcementAction)(0),            // 3: storage.EnforcementAction
-	(Severity)(0),                     // 4: storage.Severity
-	(LifecycleStage)(0),               // 5: storage.LifecycleStage
-	(Comparator)(0),                   // 6: storage.Comparator
-	(*Policy)(nil),                    // 7: storage.Policy
-	(*PolicySection)(nil),             // 8: storage.PolicySection
-	(*PolicyGroup)(nil),               // 9: storage.PolicyGroup
-	(*PolicyValue)(nil),               // 10: storage.PolicyValue
-	(*PolicyList)(nil),                // 11: storage.PolicyList
-	(*ListPolicy)(nil),                // 12: storage.ListPolicy
-	(*Exclusion)(nil),                 // 13: storage.Exclusion
-	(*ExportPoliciesResponse)(nil),    // 14: storage.ExportPoliciesResponse
-	(*Policy_MitreAttackVectors)(nil), // 15: storage.Policy.MitreAttackVectors
-	(*Exclusion_Container)(nil),       // 16: storage.Exclusion.Container
-	(*Exclusion_Deployment)(nil),      // 17: storage.Exclusion.Deployment
-	(*Exclusion_Image)(nil),           // 18: storage.Exclusion.Image
-	(*Scope)(nil),                     // 19: storage.Scope
-	(*timestamppb.Timestamp)(nil),     // 20: google.protobuf.Timestamp
-	(*ImageName)(nil),                 // 21: storage.ImageName
+	(PolicySource)(0),                   // 0: storage.PolicySource
+	(EventSource)(0),                    // 1: storage.EventSource
+	(BooleanOperator)(0),                // 2: storage.BooleanOperator
+	(EnforcementAction)(0),              // 3: storage.EnforcementAction
+	(Severity)(0),                       // 4: storage.Severity
+	(LifecycleStage)(0),                 // 5: storage.LifecycleStage
+	(Comparator)(0),                     // 6: storage.Comparator
+	(*NotifierToCollectionMapping)(nil), // 7: storage.NotifierToCollectionMapping
+	(*Policy)(nil),                      // 8: storage.Policy
+	(*PolicySection)(nil),               // 9: storage.PolicySection
+	(*PolicyGroup)(nil),                 // 10: storage.PolicyGroup
+	(*PolicyValue)(nil),                 // 11: storage.PolicyValue
+	(*PolicyList)(nil),                  // 12: storage.PolicyList
+	(*ListPolicy)(nil),                  // 13: storage.ListPolicy
+	(*Exclusion)(nil),                   // 14: storage.Exclusion
+	(*ExportPoliciesResponse)(nil),      // 15: storage.ExportPoliciesResponse
+	(*Policy_MitreAttackVectors)(nil),   // 16: storage.Policy.MitreAttackVectors
+	(*Exclusion_Container)(nil),         // 17: storage.Exclusion.Container
+	(*Exclusion_Deployment)(nil),        // 18: storage.Exclusion.Deployment
+	(*Exclusion_Image)(nil),             // 19: storage.Exclusion.Image
+	(*Scope)(nil),                       // 20: storage.Scope
+	(*timestamppb.Timestamp)(nil),       // 21: google.protobuf.Timestamp
+	(*ImageName)(nil),                   // 22: storage.ImageName
 }
 var file_storage_policy_proto_depIdxs = []int32{
 	5,  // 0: storage.Policy.lifecycle_stages:type_name -> storage.LifecycleStage
 	1,  // 1: storage.Policy.event_source:type_name -> storage.EventSource
-	13, // 2: storage.Policy.exclusions:type_name -> storage.Exclusion
-	19, // 3: storage.Policy.scope:type_name -> storage.Scope
+	14, // 2: storage.Policy.exclusions:type_name -> storage.Exclusion
+	20, // 3: storage.Policy.scope:type_name -> storage.Scope
 	4,  // 4: storage.Policy.severity:type_name -> storage.Severity
 	3,  // 5: storage.Policy.enforcement_actions:type_name -> storage.EnforcementAction
-	20, // 6: storage.Policy.last_updated:type_name -> google.protobuf.Timestamp
-	8,  // 7: storage.Policy.policy_sections:type_name -> storage.PolicySection
-	15, // 8: storage.Policy.mitre_attack_vectors:type_name -> storage.Policy.MitreAttackVectors
+	21, // 6: storage.Policy.last_updated:type_name -> google.protobuf.Timestamp
+	9,  // 7: storage.Policy.policy_sections:type_name -> storage.PolicySection
+	16, // 8: storage.Policy.mitre_attack_vectors:type_name -> storage.Policy.MitreAttackVectors
 	0,  // 9: storage.Policy.source:type_name -> storage.PolicySource
-	9,  // 10: storage.PolicySection.policy_groups:type_name -> storage.PolicyGroup
-	2,  // 11: storage.PolicyGroup.boolean_operator:type_name -> storage.BooleanOperator
-	10, // 12: storage.PolicyGroup.values:type_name -> storage.PolicyValue
-	7,  // 13: storage.PolicyList.policies:type_name -> storage.Policy
-	4,  // 14: storage.ListPolicy.severity:type_name -> storage.Severity
-	5,  // 15: storage.ListPolicy.lifecycle_stages:type_name -> storage.LifecycleStage
-	20, // 16: storage.ListPolicy.last_updated:type_name -> google.protobuf.Timestamp
-	1,  // 17: storage.ListPolicy.event_source:type_name -> storage.EventSource
-	0,  // 18: storage.ListPolicy.source:type_name -> storage.PolicySource
-	17, // 19: storage.Exclusion.deployment:type_name -> storage.Exclusion.Deployment
-	18, // 20: storage.Exclusion.image:type_name -> storage.Exclusion.Image
-	20, // 21: storage.Exclusion.expiration:type_name -> google.protobuf.Timestamp
-	7,  // 22: storage.ExportPoliciesResponse.policies:type_name -> storage.Policy
-	21, // 23: storage.Exclusion.Container.image_name:type_name -> storage.ImageName
-	19, // 24: storage.Exclusion.Deployment.scope:type_name -> storage.Scope
-	25, // [25:25] is the sub-list for method output_type
-	25, // [25:25] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	7,  // 10: storage.Policy.notifier_to_collection_mappings:type_name -> storage.NotifierToCollectionMapping
+	10, // 11: storage.PolicySection.policy_groups:type_name -> storage.PolicyGroup
+	2,  // 12: storage.PolicyGroup.boolean_operator:type_name -> storage.BooleanOperator
+	11, // 13: storage.PolicyGroup.values:type_name -> storage.PolicyValue
+	8,  // 14: storage.PolicyList.policies:type_name -> storage.Policy
+	4,  // 15: storage.ListPolicy.severity:type_name -> storage.Severity
+	5,  // 16: storage.ListPolicy.lifecycle_stages:type_name -> storage.LifecycleStage
+	21, // 17: storage.ListPolicy.last_updated:type_name -> google.protobuf.Timestamp
+	1,  // 18: storage.ListPolicy.event_source:type_name -> storage.EventSource
+	0,  // 19: storage.ListPolicy.source:type_name -> storage.PolicySource
+	7,  // 20: storage.ListPolicy.notifier_to_collection_mappings:type_name -> storage.NotifierToCollectionMapping
+	18, // 21: storage.Exclusion.deployment:type_name -> storage.Exclusion.Deployment
+	19, // 22: storage.Exclusion.image:type_name -> storage.Exclusion.Image
+	21, // 23: storage.Exclusion.expiration:type_name -> google.protobuf.Timestamp
+	8,  // 24: storage.ExportPoliciesResponse.policies:type_name -> storage.Policy
+	22, // 25: storage.Exclusion.Container.image_name:type_name -> storage.ImageName
+	20, // 26: storage.Exclusion.Deployment.scope:type_name -> storage.Scope
+	27, // [27:27] is the sub-list for method output_type
+	27, // [27:27] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_storage_policy_proto_init() }
@@ -1512,7 +1599,7 @@ func file_storage_policy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_policy_proto_rawDesc), len(file_storage_policy_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/storage/policy_vtproto.pb.go
+++ b/generated/storage/policy_vtproto.pb.go
@@ -22,6 +22,25 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *NotifierToCollectionMapping) CloneVT() *NotifierToCollectionMapping {
+	if m == nil {
+		return (*NotifierToCollectionMapping)(nil)
+	}
+	r := new(NotifierToCollectionMapping)
+	r.NotifierId = m.NotifierId
+	r.CollectionId = m.CollectionId
+	r.CollectionName = m.CollectionName
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *NotifierToCollectionMapping) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *Policy_MitreAttackVectors) CloneVT() *Policy_MitreAttackVectors {
 	if m == nil {
 		return (*Policy_MitreAttackVectors)(nil)
@@ -113,6 +132,13 @@ func (m *Policy) CloneVT() *Policy {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.MitreAttackVectors = tmpContainer
+	}
+	if rhs := m.NotifierToCollectionMappings; rhs != nil {
+		tmpContainer := make([]*NotifierToCollectionMapping, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.NotifierToCollectionMappings = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -239,6 +265,13 @@ func (m *ListPolicy) CloneVT() *ListPolicy {
 		copy(tmpContainer, rhs)
 		r.Notifiers = tmpContainer
 	}
+	if rhs := m.NotifierToCollectionMappings; rhs != nil {
+		tmpContainer := make([]*NotifierToCollectionMapping, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.NotifierToCollectionMappings = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -345,6 +378,31 @@ func (m *ExportPoliciesResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (this *NotifierToCollectionMapping) EqualVT(that *NotifierToCollectionMapping) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.NotifierId != that.NotifierId {
+		return false
+	}
+	if this.CollectionId != that.CollectionId {
+		return false
+	}
+	if this.CollectionName != that.CollectionName {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *NotifierToCollectionMapping) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*NotifierToCollectionMapping)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *Policy_MitreAttackVectors) EqualVT(that *Policy_MitreAttackVectors) bool {
 	if this == that {
 		return true
@@ -533,6 +591,23 @@ func (this *Policy) EqualVT(that *Policy) bool {
 	}
 	if this.Source != that.Source {
 		return false
+	}
+	if len(this.NotifierToCollectionMappings) != len(that.NotifierToCollectionMappings) {
+		return false
+	}
+	for i, vx := range this.NotifierToCollectionMappings {
+		vy := that.NotifierToCollectionMappings[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &NotifierToCollectionMapping{}
+			}
+			if q == nil {
+				q = &NotifierToCollectionMapping{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -725,6 +800,23 @@ func (this *ListPolicy) EqualVT(that *ListPolicy) bool {
 	if this.Source != that.Source {
 		return false
 	}
+	if len(this.NotifierToCollectionMappings) != len(that.NotifierToCollectionMappings) {
+		return false
+	}
+	for i, vx := range this.NotifierToCollectionMappings {
+		vy := that.NotifierToCollectionMappings[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &NotifierToCollectionMapping{}
+			}
+			if q == nil {
+				q = &NotifierToCollectionMapping{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -856,6 +948,60 @@ func (this *ExportPoliciesResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (m *NotifierToCollectionMapping) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NotifierToCollectionMapping) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *NotifierToCollectionMapping) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.CollectionName) > 0 {
+		i -= len(m.CollectionName)
+		copy(dAtA[i:], m.CollectionName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CollectionName)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.CollectionId) > 0 {
+		i -= len(m.CollectionId)
+		copy(dAtA[i:], m.CollectionId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CollectionId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.NotifierId) > 0 {
+		i -= len(m.NotifierId)
+		copy(dAtA[i:], m.NotifierId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.NotifierId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Policy_MitreAttackVectors) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -934,6 +1080,20 @@ func (m *Policy) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.NotifierToCollectionMappings) > 0 {
+		for iNdEx := len(m.NotifierToCollectionMappings) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.NotifierToCollectionMappings[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xe2
+		}
 	}
 	if m.Source != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Source))
@@ -1435,6 +1595,18 @@ func (m *ListPolicy) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.NotifierToCollectionMappings) > 0 {
+		for iNdEx := len(m.NotifierToCollectionMappings) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.NotifierToCollectionMappings[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x62
+		}
+	}
 	if m.Source != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Source))
 		i--
@@ -1782,6 +1954,28 @@ func (m *ExportPoliciesResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *NotifierToCollectionMapping) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.NotifierId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CollectionId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CollectionName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *Policy_MitreAttackVectors) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1918,6 +2112,12 @@ func (m *Policy) SizeVT() (n int) {
 	if m.Source != 0 {
 		n += 2 + protohelpers.SizeOfVarint(uint64(m.Source))
 	}
+	if len(m.NotifierToCollectionMappings) > 0 {
+		for _, e := range m.NotifierToCollectionMappings {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2048,6 +2248,12 @@ func (m *ListPolicy) SizeVT() (n int) {
 	if m.Source != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Source))
 	}
+	if len(m.NotifierToCollectionMappings) > 0 {
+		for _, e := range m.NotifierToCollectionMappings {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -2140,6 +2346,153 @@ func (m *ExportPoliciesResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *NotifierToCollectionMapping) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NotifierToCollectionMapping: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NotifierToCollectionMapping: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotifierId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NotifierId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CollectionId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CollectionName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *Policy_MitreAttackVectors) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3071,6 +3424,40 @@ func (m *Policy) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 28:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotifierToCollectionMappings", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NotifierToCollectionMappings = append(m.NotifierToCollectionMappings, &NotifierToCollectionMapping{})
+			if err := m.NotifierToCollectionMappings[len(m.NotifierToCollectionMappings)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -3893,6 +4280,40 @@ func (m *ListPolicy) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotifierToCollectionMappings", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NotifierToCollectionMappings = append(m.NotifierToCollectionMappings, &NotifierToCollectionMapping{})
+			if err := m.NotifierToCollectionMappings[len(m.NotifierToCollectionMappings)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -4457,6 +4878,165 @@ func (m *ExportPoliciesResponse) UnmarshalVT(dAtA []byte) error {
 			if err := m.Policies[len(m.Policies)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NotifierToCollectionMapping) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NotifierToCollectionMapping: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NotifierToCollectionMapping: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotifierId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.NotifierId = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CollectionId = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CollectionName = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5459,6 +6039,40 @@ func (m *Policy) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 28:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotifierToCollectionMappings", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NotifierToCollectionMappings = append(m.NotifierToCollectionMappings, &NotifierToCollectionMapping{})
+			if err := m.NotifierToCollectionMappings[len(m.NotifierToCollectionMappings)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -6309,6 +6923,40 @@ func (m *ListPolicy) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotifierToCollectionMappings", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NotifierToCollectionMappings = append(m.NotifierToCollectionMappings, &NotifierToCollectionMapping{})
+			if err := m.NotifierToCollectionMappings[len(m.NotifierToCollectionMappings)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/storage/policy.proto
+++ b/proto/storage/policy.proto
@@ -13,7 +13,13 @@ option java_package = "io.stackrox.proto.storage";
 // in `config-controller/api/v1alpha1/policy_types.go` and the ToProtobuf() function
 // to account for the new field, and its conversion.
 
-//Next tag: 28
+message NotifierToCollectionMapping {
+  string notifier_id = 1;
+  string collection_id = 2;
+  string collection_name = 3;
+}
+
+//Next tag: 29
 message Policy {
   string id = 1; // @gotags: search:"Policy ID,hidden" sql:"pk,index=btree" crYaml:"-"
   // Name of the policy.  Must be unique.
@@ -77,6 +83,8 @@ message Policy {
   bool is_default = 26; // @gotags: crYaml:"isDefault"
 
   PolicySource source = 27; // @gotags: crYaml:"-"
+
+  repeated NotifierToCollectionMapping notifier_to_collection_mappings = 28; // @gotags: crYaml:"notifierToCollectionMappings,omitempty"
 }
 
 enum PolicySource {
@@ -133,6 +141,7 @@ message ListPolicy {
   EventSource event_source = 9;
   bool is_default = 10;
   PolicySource source = 11;
+  repeated NotifierToCollectionMapping notifier_to_collection_mappings = 12;
 }
 
 // Please ensure any changes to the following are reflected in comment of top-level policy field `enforcement_actions`.

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyOverview.tsx
@@ -7,6 +7,7 @@ import {
     Divider,
     Grid,
     GridItem,
+    Label,
     Title,
 } from '@patternfly/react-core';
 
@@ -16,8 +17,7 @@ import type { NotifierIntegration } from 'types/notifier.proto';
 import type { BasePolicy } from 'types/policy.proto';
 import MitreAttackVectorsViewContainer from 'Containers/MitreAttackVectors/MitreAttackVectorsViewContainer';
 
-import { formatCategories, getPolicyOriginLabel } from '../policies.utils';
-import Notifier from './Notifier';
+import { formatCategories, getPolicyOriginLabel, getNotifierTypeLabel } from '../policies.utils';
 
 type PolicyOverviewProps = {
     notifiers: NotifierIntegration[];
@@ -34,11 +34,23 @@ function PolicyOverview({
         categories,
         description,
         notifiers: notifierIds,
+        notifierToCollectionMappings,
         rationale,
         remediation,
         severity,
         name,
     } = policy;
+
+    const hasUnscopedNotifiers = notifierIds?.length > 0;
+    const hasScopedNotifiers = notifierToCollectionMappings?.length > 0;
+    const hasAnyNotifiers = hasUnscopedNotifiers || hasScopedNotifiers;
+
+    function getNotifierInfo(notifierId: string) {
+        const notifier = notifiers.find(({ id }) => id === notifierId);
+        const typeLabel = getNotifierTypeLabel(notifier?.type ?? '');
+        return { name: notifier?.name ?? notifierId, typeLabel };
+    }
+
     return (
         <Card isFlat>
             {isReview && (
@@ -60,25 +72,79 @@ function PolicyOverview({
                     <DescriptionListItem term="Rationale" desc={rationale} />
                     <DescriptionListItem term="Guidance" desc={remediation} />
                 </DescriptionList>
-                {notifierIds?.length !== 0 && (
+                {hasAnyNotifiers && (
                     <>
                         <Divider component="div" className="pf-v5-u-mt-md" />
                         <Title headingLevel="h3" className="pf-v5-u-pt-md pf-v5-u-pb-sm">
-                            Notifiers
+                            Notification routes
                         </Title>
                         <Grid hasGutter sm={12} md={6}>
-                            {notifierIds?.map((notifierId) => (
-                                <GridItem key={notifierId}>
-                                    <Card isFlat>
-                                        <CardBody>
-                                            <Notifier
-                                                notifierId={notifierId}
-                                                notifiers={notifiers}
-                                            />
-                                        </CardBody>
-                                    </Card>
-                                </GridItem>
-                            ))}
+                            {notifierIds?.map((notifierId) => {
+                                const { name: notifierName, typeLabel } =
+                                    getNotifierInfo(notifierId);
+                                return (
+                                    <GridItem key={notifierId}>
+                                        <Card isFlat>
+                                            <CardBody>
+                                                <DescriptionList isCompact isHorizontal>
+                                                    <DescriptionListItem
+                                                        term="Notifier"
+                                                        desc={notifierName}
+                                                    />
+                                                    {typeLabel && (
+                                                        <DescriptionListItem
+                                                            term="Type"
+                                                            desc={typeLabel}
+                                                        />
+                                                    )}
+                                                    <DescriptionListItem
+                                                        term="Scope"
+                                                        desc={
+                                                            <Label color="blue">All scopes</Label>
+                                                        }
+                                                    />
+                                                </DescriptionList>
+                                            </CardBody>
+                                        </Card>
+                                    </GridItem>
+                                );
+                            })}
+                            {notifierToCollectionMappings?.map((binding) => {
+                                const { name: notifierName, typeLabel } = getNotifierInfo(
+                                    binding.notifierId
+                                );
+                                return (
+                                    <GridItem
+                                        key={`${binding.notifierId}-${binding.collectionId}`}
+                                    >
+                                        <Card isFlat>
+                                            <CardBody>
+                                                <DescriptionList isCompact isHorizontal>
+                                                    <DescriptionListItem
+                                                        term="Notifier"
+                                                        desc={notifierName}
+                                                    />
+                                                    {typeLabel && (
+                                                        <DescriptionListItem
+                                                            term="Type"
+                                                            desc={typeLabel}
+                                                        />
+                                                    )}
+                                                    <DescriptionListItem
+                                                        term="Scope"
+                                                        desc={
+                                                            <Label color="green">
+                                                                {binding.collectionName ||
+                                                                    binding.collectionId}
+                                                            </Label>
+                                                        }
+                                                    />
+                                                </DescriptionList>
+                                            </CardBody>
+                                        </Card>
+                                    </GridItem>
+                                );
+                            })}
                         </Grid>
                     </>
                 )}

--- a/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/Modal/PolicyImport.utils.test.ts
@@ -545,6 +545,7 @@ function getPolicy(errors: { id?: boolean; name?: boolean } = {}): ImportPolicie
                     severity: 'HIGH_SEVERITY',
                     enforcementActions: ['FAIL_BUILD_ENFORCEMENT'],
                     notifiers: [],
+                    notifierToCollectionMappings: [],
                     lastUpdated: null,
                     SORTName: 'Fixable CVSS >= 9',
                     SORTLifecycleStage: 'BUILD,DEPLOY',

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -415,14 +415,21 @@ function PoliciesTable({
                                         lifecycleStages,
                                         name,
                                         notifiers: notifierIds,
+                                        notifierToCollectionMappings,
                                         severity,
                                     } = policy;
                                     const isExpanded = expandedRowSet.has(id);
 
+                                    const allNotifierIds = [
+                                        ...notifierIds,
+                                        ...(notifierToCollectionMappings ?? []).map(
+                                            (m) => m.notifierId
+                                        ),
+                                    ];
                                     const notifierCountsWithLabelStrings =
                                         formatNotifierCountsWithLabelStrings(
                                             labelAndNotifierIdsForTypes,
-                                            notifierIds
+                                            allNotifierIds
                                         );
                                     const exportPolicyAction: IAction = {
                                         title: 'Export policy to JSON',

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.utils.ts
@@ -1,4 +1,4 @@
-import { sortAsciiCaseInsensitive, sortSeverity, sortValueByLength } from 'sorters/sorters';
+import { sortAsciiCaseInsensitive, sortSeverity } from 'sorters/sorters';
 import type { ListPolicy } from 'types/policy.proto';
 import { getPolicyOriginLabel } from '../policies.utils';
 
@@ -21,7 +21,13 @@ export const columns = [
     {
         Header: 'Notifiers',
         accessor: 'notifiers',
-        sortMethod: (a: ListPolicy, b: ListPolicy) => sortValueByLength(a.notifiers, b.notifiers),
+        sortMethod: (a: ListPolicy, b: ListPolicy) => {
+            const aCount =
+                a.notifiers.length + (a.notifierToCollectionMappings?.length ?? 0);
+            const bCount =
+                b.notifiers.length + (b.notifierToCollectionMappings?.length ?? 0);
+            return aCount - bCount;
+        },
     },
     {
         Header: 'Severity',

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
@@ -1,43 +1,137 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { Form } from '@patternfly/react-core';
+import {
+    Alert,
+    Button,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+    MenuToggle,
+    Select,
+    SelectList,
+    SelectOption,
+} from '@patternfly/react-core';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { useField } from 'formik';
 
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import useRestQuery from 'hooks/useRestQuery';
 import { integrationsPath } from 'routePaths';
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
+import { listCollections } from 'services/CollectionsService';
+import type { CollectionSlim } from 'services/CollectionsService';
 import { getTableUIState } from 'utils/getTableUIState';
+import type { NotifierCollectionBinding } from 'types/policy.proto';
+
+import {
+    buildNotificationRoutes,
+    hasDuplicateRoute,
+    splitNotificationRoutes,
+} from '../../policies.utils';
+import type { NotificationRoute } from '../../policies.utils';
+
+const ALL_SCOPES = '';
 
 function NotifiersForm() {
-    const [field, , helpers] = useField('notifiers');
+    const [notifiersField, , notifiersHelpers] = useField<string[]>('notifiers');
+    const [mappingsField, , mappingsHelpers] = useField<NotifierCollectionBinding[]>(
+        'notifierToCollectionMappings'
+    );
+
+    const routes = buildNotificationRoutes(notifiersField.value, mappingsField.value);
+
+    const [isAddingRoute, setIsAddingRoute] = useState(false);
+    const [newNotifierId, setNewNotifierId] = useState('');
+    const [newCollectionId, setNewCollectionId] = useState(ALL_SCOPES);
+    const [isNotifierSelectOpen, setIsNotifierSelectOpen] = useState(false);
+    const [isCollectionSelectOpen, setIsCollectionSelectOpen] = useState(false);
+    const [duplicateError, setDuplicateError] = useState('');
 
     const fetchNotifiers = useCallback(() => fetchNotifierIntegrations(), []);
-    const { data: notifiers = [], isLoading, error } = useRestQuery(fetchNotifiers);
+    const { data: notifiers = [], isLoading: isLoadingNotifiers, error: notifiersError } =
+        useRestQuery(fetchNotifiers);
+
+    const fetchCollections = useCallback(
+        () => listCollections({}, { field: 'Collection Name', reversed: false }, 0, 0),
+        []
+    );
+    const { data: collectionsRaw = [] } = useRestQuery(fetchCollections);
+    const collections: CollectionSlim[] = collectionsRaw.map((c) => ({
+        id: c.id,
+        name: c.name,
+        description: c.description,
+    }));
 
     const tableState = getTableUIState({
-        isLoading,
-        data: notifiers,
-        error,
+        isLoading: isLoadingNotifiers,
+        data: routes,
+        error: notifiersError,
         searchFilter: {},
     });
 
-    function onSelectNotifier(e, isSelected, rowIndex) {
-        const selectedNotifiers = field.value ?? [];
-        if (isSelected) {
-            helpers.setValue([...selectedNotifiers, notifiers[rowIndex].id]);
-        } else {
-            helpers.setValue(selectedNotifiers.filter((id) => id !== notifiers[rowIndex].id));
-        }
+    function getNotifierName(notifierId: string): string {
+        return notifiers.find((n) => n.id === notifierId)?.name ?? notifierId;
     }
 
-    function onSelectAllNotifiers(e, isSelected) {
-        if (isSelected) {
-            helpers.setValue(notifiers.map((notifier) => notifier.id));
-        } else {
-            helpers.setValue([]);
+    function getNotifierType(notifierId: string): string {
+        return notifiers.find((n) => n.id === notifierId)?.type ?? '';
+    }
+
+    function getCollectionName(collectionId: string): string {
+        if (!collectionId) {
+            return 'All scopes';
         }
+        return collections.find((c) => c.id === collectionId)?.name ?? collectionId;
+    }
+
+    function applyRoutes(updatedRoutes: NotificationRoute[]) {
+        const { notifiers: updatedNotifiers, notifierToCollectionMappings } =
+            splitNotificationRoutes(updatedRoutes);
+        notifiersHelpers.setValue(updatedNotifiers);
+        mappingsHelpers.setValue(notifierToCollectionMappings);
+    }
+
+    function handleRemoveRoute(index: number) {
+        const updatedRoutes = routes.filter((_, i) => i !== index);
+        applyRoutes(updatedRoutes);
+    }
+
+    function handleAddRoute() {
+        if (!newNotifierId) {
+            return;
+        }
+
+        const collectionName = newCollectionId
+            ? collections.find((c) => c.id === newCollectionId)?.name ?? ''
+            : '';
+        const newRoute: NotificationRoute = {
+            notifierId: newNotifierId,
+            collectionId: newCollectionId,
+            collectionName,
+        };
+
+        if (hasDuplicateRoute(routes, newRoute)) {
+            setDuplicateError('This notifier and scope combination already exists.');
+            return;
+        }
+
+        applyRoutes([...routes, newRoute]);
+        setNewNotifierId('');
+        setNewCollectionId(ALL_SCOPES);
+        setIsAddingRoute(false);
+        setDuplicateError('');
+    }
+
+    function handleCancelAdd() {
+        setIsAddingRoute(false);
+        setNewNotifierId('');
+        setNewCollectionId(ALL_SCOPES);
+        setDuplicateError('');
     }
 
     return (
@@ -45,27 +139,21 @@ function NotifiersForm() {
             <Table borders>
                 <Thead>
                     <Tr>
-                        <Th
-                            select={{
-                                onSelect: onSelectAllNotifiers,
-                                isSelected:
-                                    notifiers.length > 0 && notifiers.length === field.value.length,
-                            }}
-                            modifier="nowrap"
-                        />
                         <Th>Notifier</Th>
                         <Th>Type</Th>
+                        <Th>Scope</Th>
+                        <Th />
                     </Tr>
                 </Thead>
                 <TbodyUnified
                     tableState={tableState}
-                    colSpan={3}
+                    colSpan={4}
                     errorProps={{
                         title: 'There was an error loading notifiers',
                     }}
                     emptyProps={{
                         message:
-                            'No notifiers found. Add notifiers in the Integrations Page to add them to this policy.',
+                            'No notification routes configured. Add a route to forward policy violations to a notifier.',
                         children: (
                             <Link to={integrationsPath} target="_blank" rel="noopener noreferrer">
                                 Go to integrations
@@ -74,25 +162,157 @@ function NotifiersForm() {
                     }}
                     renderer={({ data }) => (
                         <Tbody>
-                            {data.map((notifier, rowIndex) => {
-                                return (
-                                    <Tr key={notifier.id}>
-                                        <Td
-                                            select={{
-                                                rowIndex,
-                                                onSelect: onSelectNotifier,
-                                                isSelected: field.value.includes(notifier.id),
-                                            }}
-                                        />
-                                        <Td dataLabel="Notifier">{notifier.name}</Td>
-                                        <Td dataLabel="Type">{notifier.type}</Td>
-                                    </Tr>
-                                );
-                            })}
+                            {data.map((route, rowIndex) => (
+                                <Tr key={`${route.notifierId}-${route.collectionId}`}>
+                                    <Td dataLabel="Notifier">
+                                        {getNotifierName(route.notifierId)}
+                                    </Td>
+                                    <Td dataLabel="Type">{getNotifierType(route.notifierId)}</Td>
+                                    <Td dataLabel="Scope">
+                                        {getCollectionName(route.collectionId)}
+                                    </Td>
+                                    <Td isActionCell>
+                                        <Button
+                                            variant="plain"
+                                            aria-label="Remove notification route"
+                                            onClick={() => handleRemoveRoute(rowIndex)}
+                                        >
+                                            <MinusCircleIcon />
+                                        </Button>
+                                    </Td>
+                                </Tr>
+                            ))}
                         </Tbody>
                     )}
                 />
             </Table>
+
+            {isAddingRoute && (
+                <Flex
+                    direction={{ default: 'column' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    className="pf-v5-u-mt-md pf-v5-u-p-md"
+                    style={{ border: '1px solid var(--pf-v5-global--BorderColor--100)' }}
+                >
+                    <FormGroup label="Notifier" isRequired fieldId="new-route-notifier">
+                        <Select
+                            id="new-route-notifier"
+                            isOpen={isNotifierSelectOpen}
+                            onOpenChange={setIsNotifierSelectOpen}
+                            toggle={(toggleRef) => (
+                                <MenuToggle
+                                    ref={toggleRef}
+                                    onClick={() => setIsNotifierSelectOpen(!isNotifierSelectOpen)}
+                                    isExpanded={isNotifierSelectOpen}
+                                    style={{ width: '100%' }}
+                                >
+                                    {newNotifierId
+                                        ? getNotifierName(newNotifierId)
+                                        : 'Select a notifier'}
+                                </MenuToggle>
+                            )}
+                            onSelect={(_event, value) => {
+                                setNewNotifierId(value as string);
+                                setIsNotifierSelectOpen(false);
+                                setDuplicateError('');
+                            }}
+                            selected={newNotifierId}
+                        >
+                            <SelectList>
+                                {notifiers.map((notifier) => (
+                                    <SelectOption key={notifier.id} value={notifier.id}>
+                                        {notifier.name} ({notifier.type})
+                                    </SelectOption>
+                                ))}
+                            </SelectList>
+                        </Select>
+                        {notifiers.length === 0 && (
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant="warning">
+                                        No notifiers available.{' '}
+                                        <Link
+                                            to={integrationsPath}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            Configure integrations
+                                        </Link>{' '}
+                                        first.
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
+                        )}
+                    </FormGroup>
+
+                    <FormGroup label="Scope" fieldId="new-route-collection">
+                        <Select
+                            id="new-route-collection"
+                            isOpen={isCollectionSelectOpen}
+                            onOpenChange={setIsCollectionSelectOpen}
+                            toggle={(toggleRef) => (
+                                <MenuToggle
+                                    ref={toggleRef}
+                                    onClick={() =>
+                                        setIsCollectionSelectOpen(!isCollectionSelectOpen)
+                                    }
+                                    isExpanded={isCollectionSelectOpen}
+                                    style={{ width: '100%' }}
+                                >
+                                    {getCollectionName(newCollectionId)}
+                                </MenuToggle>
+                            )}
+                            onSelect={(_event, value) => {
+                                setNewCollectionId(value as string);
+                                setIsCollectionSelectOpen(false);
+                                setDuplicateError('');
+                            }}
+                            selected={newCollectionId}
+                        >
+                            <SelectList>
+                                <SelectOption value="">All scopes</SelectOption>
+                                {collections.map((collection) => (
+                                    <SelectOption key={collection.id} value={collection.id}>
+                                        {collection.name}
+                                    </SelectOption>
+                                ))}
+                            </SelectList>
+                        </Select>
+                    </FormGroup>
+
+                    {duplicateError && (
+                        <Alert variant="warning" isInline isPlain title={duplicateError} />
+                    )}
+
+                    <Flex>
+                        <FlexItem>
+                            <Button
+                                variant="primary"
+                                isDisabled={!newNotifierId}
+                                onClick={handleAddRoute}
+                            >
+                                Add
+                            </Button>
+                        </FlexItem>
+                        <FlexItem>
+                            <Button variant="link" onClick={handleCancelAdd}>
+                                Cancel
+                            </Button>
+                        </FlexItem>
+                    </Flex>
+                </Flex>
+            )}
+
+            {!isAddingRoute && (
+                <Button
+                    variant="link"
+                    icon={<PlusCircleIcon />}
+                    className="pf-v5-u-mt-sm"
+                    onClick={() => setIsAddingRoute(true)}
+                >
+                    Add notification route
+                </Button>
+            )}
         </Form>
     );
 }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
@@ -94,8 +94,9 @@ function PolicyActionsForm() {
                     <FlexItem flex={{ default: 'flex_1' }}>
                         <Title headingLevel="h3">Notifiers</Title>
                         <div className="pf-v5-u-mt-sm">
-                            Forward policy violations to external tooling by selecting one or more
-                            notifiers from existing integrations.
+                            Route policy violation notifications to external tooling. Optionally
+                            scope each notifier to a deployment collection so different teams
+                            receive alerts only for their namespaces.
                         </div>
                     </FlexItem>
                 </Flex>

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.test.ts
@@ -1,10 +1,14 @@
-import type { ClientPolicy, Policy } from 'types/policy.proto';
+import type { ClientPolicy, NotifierCollectionBinding, Policy } from 'types/policy.proto';
 import {
+    buildNotificationRoutes,
     getClientWizardPolicy,
     getLifeCyclesUpdates,
     getPolicyOriginLabel,
     getServerPolicy,
+    hasDuplicateRoute,
+    splitNotificationRoutes,
 } from './policies.utils';
+import type { NotificationRoute } from './policies.utils';
 
 describe('policies.utils', () => {
     describe('getClientWizardPolicy', () => {
@@ -61,6 +65,7 @@ describe('policies.utils', () => {
                 severity: 'LOW_SEVERITY',
                 enforcementActions: [],
                 notifiers: ['10a830c7-dc0b-4d9e-9505-4ae3b72d6b50'],
+                notifierToCollectionMappings: [],
                 lastUpdated: '2024-08-08T19:27:43.987955873Z',
                 SORTName: 'Test policy',
                 SORTLifecycleStage: 'BUILD,DEPLOY',
@@ -181,6 +186,7 @@ describe('policies.utils', () => {
                 severity: 'LOW_SEVERITY',
                 enforcementActions: [],
                 notifiers: ['10a830c7-dc0b-4d9e-9505-4ae3b72d6b50'],
+                notifierToCollectionMappings: [],
                 lastUpdated: '2024-08-08T19:27:43.987955873Z',
                 SORTName: 'Test policy',
                 SORTLifecycleStage: 'BUILD,DEPLOY',
@@ -379,6 +385,7 @@ describe('policies.utils', () => {
                 severity: 'LOW_SEVERITY',
                 enforcementActions: [],
                 notifiers: ['10a830c7-dc0b-4d9e-9505-4ae3b72d6b50'],
+                notifierToCollectionMappings: [],
                 lastUpdated: '2024-08-08T19:27:43.987955873Z',
                 SORTName: 'Test policy',
                 SORTLifecycleStage: 'BUILD,DEPLOY',
@@ -499,6 +506,7 @@ describe('policies.utils', () => {
                 severity: 'LOW_SEVERITY',
                 enforcementActions: [],
                 notifiers: ['10a830c7-dc0b-4d9e-9505-4ae3b72d6b50'],
+                notifierToCollectionMappings: [],
                 lastUpdated: '2024-08-08T19:27:43.987955873Z',
                 SORTName: 'Test policy',
                 SORTLifecycleStage: 'BUILD,DEPLOY',
@@ -720,6 +728,179 @@ describe('policies.utils', () => {
                 enforcementActions: ['FAIL_BUILD_ENFORCEMENT'],
                 excludedImageNames: ['docker.io/library/archlinux:latest'],
             });
+        });
+    });
+
+    describe('buildNotificationRoutes', () => {
+        it('should combine unscoped notifiers and scoped bindings into a flat route list', () => {
+            const unscopedNotifierIds = ['notifier-1', 'notifier-2'];
+            const scopedBindings: NotifierCollectionBinding[] = [
+                {
+                    notifierId: 'notifier-3',
+                    collectionId: 'collection-a',
+                    collectionName: 'Frontend',
+                },
+            ];
+
+            const routes = buildNotificationRoutes(unscopedNotifierIds, scopedBindings);
+
+            expect(routes).toEqual([
+                { notifierId: 'notifier-1', collectionId: '', collectionName: '' },
+                { notifierId: 'notifier-2', collectionId: '', collectionName: '' },
+                {
+                    notifierId: 'notifier-3',
+                    collectionId: 'collection-a',
+                    collectionName: 'Frontend',
+                },
+            ]);
+        });
+
+        it('should return empty array when no notifiers or bindings exist', () => {
+            expect(buildNotificationRoutes([], [])).toEqual([]);
+        });
+
+        it('should handle only unscoped notifiers', () => {
+            const routes = buildNotificationRoutes(['notifier-1'], []);
+            expect(routes).toEqual([
+                { notifierId: 'notifier-1', collectionId: '', collectionName: '' },
+            ]);
+        });
+
+        it('should handle only scoped bindings', () => {
+            const bindings: NotifierCollectionBinding[] = [
+                {
+                    notifierId: 'notifier-1',
+                    collectionId: 'collection-a',
+                    collectionName: 'Frontend',
+                },
+            ];
+            const routes = buildNotificationRoutes([], bindings);
+            expect(routes).toEqual([
+                {
+                    notifierId: 'notifier-1',
+                    collectionId: 'collection-a',
+                    collectionName: 'Frontend',
+                },
+            ]);
+        });
+    });
+
+    describe('splitNotificationRoutes', () => {
+        it('should split routes into unscoped notifiers and scoped bindings', () => {
+            const routes: NotificationRoute[] = [
+                { notifierId: 'notifier-1', collectionId: '', collectionName: '' },
+                { notifierId: 'notifier-2', collectionId: 'collection-a', collectionName: 'FE' },
+                { notifierId: 'notifier-3', collectionId: '', collectionName: '' },
+                { notifierId: 'notifier-4', collectionId: 'collection-b', collectionName: 'BE' },
+            ];
+
+            const { notifiers, notifierToCollectionMappings } = splitNotificationRoutes(routes);
+
+            expect(notifiers).toEqual(['notifier-1', 'notifier-3']);
+            expect(notifierToCollectionMappings).toEqual([
+                {
+                    notifierId: 'notifier-2',
+                    collectionId: 'collection-a',
+                    collectionName: 'FE',
+                },
+                {
+                    notifierId: 'notifier-4',
+                    collectionId: 'collection-b',
+                    collectionName: 'BE',
+                },
+            ]);
+        });
+
+        it('should return empty arrays when routes are empty', () => {
+            const { notifiers, notifierToCollectionMappings } = splitNotificationRoutes([]);
+            expect(notifiers).toEqual([]);
+            expect(notifierToCollectionMappings).toEqual([]);
+        });
+
+        it('should be the inverse of buildNotificationRoutes for a round-trip', () => {
+            const originalNotifiers = ['notifier-1', 'notifier-2'];
+            const originalBindings: NotifierCollectionBinding[] = [
+                {
+                    notifierId: 'notifier-3',
+                    collectionId: 'collection-a',
+                    collectionName: 'Frontend',
+                },
+            ];
+
+            const routes = buildNotificationRoutes(originalNotifiers, originalBindings);
+            const { notifiers, notifierToCollectionMappings } = splitNotificationRoutes(routes);
+
+            expect(notifiers).toEqual(originalNotifiers);
+            expect(notifierToCollectionMappings).toEqual([
+                {
+                    notifierId: 'notifier-3',
+                    collectionId: 'collection-a',
+                    collectionName: 'Frontend',
+                },
+            ]);
+        });
+    });
+
+    describe('hasDuplicateRoute', () => {
+        it('should return true when the same notifier-collection pair exists', () => {
+            const routes: NotificationRoute[] = [
+                { notifierId: 'notifier-1', collectionId: 'collection-a', collectionName: 'FE' },
+                { notifierId: 'notifier-2', collectionId: '', collectionName: '' },
+            ];
+
+            expect(
+                hasDuplicateRoute(routes, {
+                    notifierId: 'notifier-1',
+                    collectionId: 'collection-a',
+                    collectionName: 'FE',
+                })
+            ).toBe(true);
+        });
+
+        it('should return false when the notifier-collection pair does not exist', () => {
+            const routes: NotificationRoute[] = [
+                { notifierId: 'notifier-1', collectionId: 'collection-a', collectionName: 'FE' },
+            ];
+
+            expect(
+                hasDuplicateRoute(routes, {
+                    notifierId: 'notifier-1',
+                    collectionId: 'collection-b',
+                    collectionName: 'BE',
+                })
+            ).toBe(false);
+        });
+
+        it('should return false for an empty route list', () => {
+            expect(
+                hasDuplicateRoute([], {
+                    notifierId: 'notifier-1',
+                    collectionId: '',
+                    collectionName: '',
+                })
+            ).toBe(false);
+        });
+
+        it('should distinguish between scoped and unscoped routes for the same notifier', () => {
+            const routes: NotificationRoute[] = [
+                { notifierId: 'notifier-1', collectionId: '', collectionName: '' },
+            ];
+
+            expect(
+                hasDuplicateRoute(routes, {
+                    notifierId: 'notifier-1',
+                    collectionId: 'collection-a',
+                    collectionName: 'FE',
+                })
+            ).toBe(false);
+
+            expect(
+                hasDuplicateRoute(routes, {
+                    notifierId: 'notifier-1',
+                    collectionId: '',
+                    collectionName: '',
+                })
+            ).toBe(true);
         });
     });
 });

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -13,6 +13,7 @@ import type {
     EnforcementAction,
     LifecycleStage,
     ListPolicy,
+    NotifierCollectionBinding,
     Policy,
     PolicyDeploymentExclusion,
     PolicyEventSource,
@@ -48,6 +49,7 @@ export const initialPolicy: ClientPolicy = {
     disabled: false,
     lifecycleStages: [],
     notifiers: [],
+    notifierToCollectionMappings: [],
     lastUpdated: null,
     eventSource: 'NOT_APPLICABLE',
     isDefault: false,
@@ -255,6 +257,63 @@ export function getLabelAndNotifierIdsForTypes(
         label,
         notifiers.filter((notifier) => notifier.type === type).map(({ id }) => id),
     ]);
+}
+
+// notifier-to-collection mappings
+
+export type NotificationRoute = {
+    notifierId: string;
+    collectionId: string;
+    collectionName: string;
+};
+
+export function buildNotificationRoutes(
+    unscopedNotifierIds: string[],
+    scopedBindings: NotifierCollectionBinding[] | undefined
+): NotificationRoute[] {
+    const unscopedRoutes: NotificationRoute[] = (unscopedNotifierIds ?? []).map((notifierId) => ({
+        notifierId,
+        collectionId: '',
+        collectionName: '',
+    }));
+
+    const scopedRoutes: NotificationRoute[] = (scopedBindings ?? []).map(
+        ({ notifierId, collectionId, collectionName }) => ({
+            notifierId,
+            collectionId,
+            collectionName,
+        })
+    );
+
+    return [...unscopedRoutes, ...scopedRoutes];
+}
+
+export function splitNotificationRoutes(routes: NotificationRoute[]): {
+    notifiers: string[];
+    notifierToCollectionMappings: NotifierCollectionBinding[];
+} {
+    const notifiers: string[] = [];
+    const notifierToCollectionMappings: NotifierCollectionBinding[] = [];
+
+    for (const route of routes) {
+        if (route.collectionId) {
+            notifierToCollectionMappings.push({
+                notifierId: route.notifierId,
+                collectionId: route.collectionId,
+                collectionName: route.collectionName,
+            });
+        } else {
+            notifiers.push(route.notifierId);
+        }
+    }
+
+    return { notifiers, notifierToCollectionMappings };
+}
+
+export function hasDuplicateRoute(routes: NotificationRoute[], route: NotificationRoute): boolean {
+    return routes.some(
+        (r) => r.notifierId === route.notifierId && r.collectionId === route.collectionId
+    );
 }
 
 // scope

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -1,3 +1,9 @@
+export type NotifierCollectionBinding = {
+    notifierId: string;
+    collectionId: string;
+    collectionName: string;
+};
+
 export type ListPolicy = {
     id: string;
     name: string;
@@ -6,6 +12,7 @@ export type ListPolicy = {
     disabled: boolean;
     lifecycleStages: LifecycleStage[];
     notifiers: string[];
+    notifierToCollectionMappings: NotifierCollectionBinding[];
     lastUpdated: string | null; // ISO 8601 date string
     eventSource: PolicyEventSource;
     readonly isDefault: boolean; // Indicates the policy is a default policy if true and a custom policy if false.


### PR DESCRIPTION
## Description

Adds per-collection scoped notifier-to-collection mappings on policies, allowing teams to route policy violation notifications to different notifiers based on deployment collection scope (e.g., different teams get alerts only for their namespaces).

**Changes:**
- New `NotifierToCollectionMapping` proto message (fields: `notifier_id`, `collection_id`, `collection_name`) added to `Policy` and `ListPolicy`
- Notifier processor evaluates collection-scoped mappings at alert time by resolving the collection query and matching against the alert's deployment
- Policy datastore validates scoped mapping notifier IDs on save (same pattern as unscoped notifiers)
- ListPolicy conversion includes scoped mappings
- Config controller CRD types updated
- UI: routes-based notifier form with notifier + collection scope dropdowns, policy detail view, policies table count, import utils, and tests

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Deployed custom Central image to OpenShift sandbox cluster
- Verified scoped notifier mappings persist through policy save/load cycle
- Confirmed unscoped (all-scope) notifications fire on policy toggle
- Confirmed scoped notifications match collection queries against alert deployments
- UI tested: adding/removing notification routes with collection scope, policy detail view showing scoped vs unscoped routes, policies table notifier count

Partially generated by AI.