### PR TITLE
ROX-36237: Change namespace selector key in VWC

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -255,7 +255,7 @@ webhooks:
         {{- toYaml ._rox.admissionControl.namespaceSelector | nindent 6 }}
       {{- else }}
       matchExpressions:
-      - key: namespace.metadata.stackrox.io/name
+      - key: kubernetes.io/metadata.name
         operator: NotIn
         values:
           - {{ ._rox._namespace }}

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -218,7 +218,7 @@
 #  # If the admission controller webhook needs a specific namespaceSelector, you can specify it here.
 #  namespaceSelector:
 #    matchExpressions:
-#    - key: namespace.metadata.stackrox.io/name
+#    - key: kubernetes.io/metadata.name
 #      operator: NotIn
 #      values:
 #        - {{ ._rox._namespace }}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -109,6 +109,7 @@ tests:
           listenOnEvents: false
       expect: |
         .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .namespaceSelector.matchExpressions | assertThat(length == 1)
+        .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .namespaceSelector.matchExpressions[0].key | assertThat(. == "kubernetes.io/metadata.name")
     - name: "override namespace selector"
       values:
         admissionControl:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -119,11 +119,11 @@ tests:
           listenOnEvents: false
           namespaceSelector:
             matchExpressions:
-            - key: namespace.metadata.stackrox.io/name
+            - key: kubernetes.io/metadata.name
               operator: NotIn
               values:
                 - default
-            - key: namespace.metadata.stackrox.io/name
+            - key: kubernetes.io/metadata.name
               operator: NotIn
               values:
                 - stackrox2


### PR DESCRIPTION
## Description

The `ValidatingWebhookConfiguration` "stackrox" uses `namespace.metadata.stackrox.io/name` in its `namespaceSelector` to exclude system namespaces (`kube-system`, `kube-public`, `istio-system`, RHACS namespace) from admission control evaluation. However, this custom label is never applied on K8s 1.21+ because Sensor's namespace patcher skips namespaces that already have the built-in `kubernetes.io/metadata.name` label (since [https://github.com/stackrox/rox/pull/9095](https://github.com/stackrox/rox/pull/9095)). Since `NotIn` with an absent key is vacuously satisfied, the exclusion is a no-op and all namespaces are evaluated.

This changes the default label key to `kubernetes.io/metadata.name`, which is guaranteed present on all supported K8s versions (1.25+). Custom policies that don't explicitly exclude system namespaces could have blocked system workloads.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change
On an openshift 4.x infra cluster with debug logging enabled on the admission controller:
```
admission-control/manager: 2026/08/12 20:21:04.692620 evaluate_deploytime.go:104: Debug: Evaluating admission request (uid=31be8242-0887-4f36-bb77-338fee9bdd22, ns=openshift-machine-config-operator, name=machine-config-server, op=UPDATE, kind=apps/v1, Kind=DaemonSet)
admission-control/manager: 2026/08/12 20:21:04.692687 evaluate_deploytime.go:36: Debug: Action affects system namespace, bypassing UPDATE request on openshift-machine-config-operator/machine-config-server [apps/v1, Kind=DaemonSet
```
