### PR TITLE
ROX-36432: log node scan rejections, add regression tests

### DIFF
--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -4,8 +4,12 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	nodeCVEDS "github.com/stackrox/rox/central/cve/node/datastore"
 	nodeCVEPostgres "github.com/stackrox/rox/central/cve/node/datastore/store/postgres"
@@ -76,6 +80,91 @@ func (suite *NodePostgresDataStoreTestSuite) SetupTest() {
 func (suite *NodePostgresDataStoreTestSuite) TearDownTest() {
 	suite.mockCtrl.Finish()
 	suite.db.Close()
+}
+
+// TestConcurrentUpsertNode_KeyedMutexPreventsRegression is the datastore-layer counterpart of
+// store_test.go's TestStore_ConcurrentUpsert_BypassingOuterLock. That test proves the store layer alone has
+// a check-then-act race in isUpdated(): the read-old-scan-and-decide step isn't covered by the store's own
+// keyFence lock. This test calls the same workload through UpsertNode instead, i.e. through the
+// production call path, which wraps the entire call (read, decide, and write) in a per-node-ID
+// keyedMutex (see UpsertNode in datastore_impl.go). Since every real caller in this codebase reaches the
+// store exclusively through UpsertNode, and the customer's Central runs as a single replica (confirmed
+// from their diagnostic bundle: one Deployment, replicas: 1, one Central pod), this is the path that
+// actually matters for reproducing their bug. If scan_time never regresses here even under heavy
+// concurrency, the "ccp-fc-ogob01a" symptom is not explained by an in-process concurrency race, and the
+// remaining suspects are either something specific to their exact payload/environment or a defect outside
+// what this workload exercises.
+func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutexPreventsRegression() {
+	allowAllCtx := sac.WithAllAccess(context.Background())
+
+	node := getTestNodeForPostgres(fixtureconsts.Node1, "concurrent-node")
+	baseTime := time.Now().Add(-24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node))
+
+	const iterations = 2000
+	const freshWriters = 4
+	const metaWriters = 4
+	var wg sync.WaitGroup
+
+	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
+	for w := range freshWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				fresh := node.CloneVT()
+				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
+				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
+				_ = suite.datastore.UpsertNode(allowAllCtx, fresh)
+			}
+		})
+	}
+
+	// Simulates the nodes pipeline: frequent metadata-only churn, Scan explicitly nil.
+	for w := range metaWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				metaOnly := node.CloneVT()
+				metaOnly.Scan = nil
+				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
+				_ = suite.datastore.UpsertNode(allowAllCtx, metaOnly)
+			}
+		})
+	}
+
+	var regressions atomic.Int64
+	stop := make(chan struct{})
+	var pollWG sync.WaitGroup
+	for range 4 {
+		pollWG.Go(func() {
+			lastSeen := baseTime
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				current, exists, err := suite.datastore.GetNode(allowAllCtx, node.GetId())
+				if err == nil && exists {
+					st := current.GetScan().GetScanTime().AsTime()
+					if st.Before(lastSeen) {
+						regressions.Add(1)
+					} else {
+						lastSeen = st
+					}
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+	close(stop)
+	pollWG.Wait()
+
+	suite.Zero(regressions.Load(),
+		"scan_time must never regress through UpsertNode, since every real caller (nodeindex and nodes "+
+			"pipelines alike) goes through the per-node-ID keyedMutex that wraps the entire read-decide-write "+
+			"sequence; a non-zero count here would mean the keyedMutex itself has a bug, not just the store "+
+			"layer's already-known gap")
 }
 
 func (suite *NodePostgresDataStoreTestSuite) TestBasicOps() {

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -529,6 +529,12 @@ func (s *storeImpl) isUpdated(ctx context.Context, node *storage.Node) (bool, er
 	// We skip rewriting components and vulnerabilities if the node scan is older.
 	scanUpdated := protocompat.CompareTimestamps(oldNode.GetScan().GetScanTime(), node.GetScan().GetScanTime()) <= 0
 	if !scanUpdated {
+		log.Warnf("Rejecting incoming node scan for node %s (%s) as not newer than the stored one: "+
+			"stored scan_time=%s, incoming scan_time=%s. The incoming scan and its component/CVE data will "+
+			"be discarded and the previously stored scan will be kept.",
+			node.GetId(), node.GetName(),
+			protocompat.ConvertTimestampToString(oldNode.GetScan().GetScanTime(), time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(node.GetScan().GetScanTime(), time.RFC3339Nano))
 		node.Scan = oldNode.GetScan()
 		node.RiskScore = oldNode.GetRiskScore()
 		node.SetComponents = oldNode.GetSetComponents()

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -149,6 +150,129 @@ func (s *NodesStoreSuite) TestStore_UpsertWithoutScan() {
 	// We expect only LastUpdated to have changed.
 	foundNode.LastUpdated = newNode.GetLastUpdated()
 	protoassert.Equal(s.T(), foundNode, newNode)
+}
+
+// TestStore_FreshScanAlwaysWinsSequential is the direct, non-concurrent reproduction attempt for the
+// ccp-fc-ogob01a "scan_time never advances" symptom: upsert an old scan, then upsert a strictly newer
+// one for the same node ID, and confirm the newer one is what gets persisted. This is expected to pass;
+// it establishes the happy path is correct in isolation, which narrows the bug to something that only
+// shows up under concurrency or with specific payload shapes, not to a deterministic single-threaded
+// logic error.
+func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&oldTime)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	fresh := node.CloneVT()
+	freshTime := time.Now()
+	fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&freshTime)
+	fresh.Scan.Components = fresh.GetScan().GetComponents()[:1] // Change the payload shape too, not just the timestamp.
+	s.NoError(store.Upsert(s.ctx, fresh))
+
+	found, exists, err := store.Get(s.ctx, node.GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(freshTime.Unix(), found.GetScan().GetScanTime().AsTime().Unix(),
+		"a strictly newer scan must always replace an older one when applied sequentially")
+	s.Len(found.GetScan().GetComponents(), 1)
+}
+
+// TestStore_ConcurrentUpsert_BypassingOuterLock intentionally calls the store layer directly, without the
+// per-node keyedMutex that central/node/datastore/datastore_impl.go normally wraps around every UpsertNode
+// call. isUpdated() (the read-and-decide step) runs *before* storeImpl.upsert acquires its own keyFence
+// lock, so nothing internal to this package serializes "read old scan, decide, write" as one atomic unit.
+// This test proves that gap is real: with two goroutines hammering the same node ID (one always sending a
+// monotonically fresher scan, the other sending metadata-only updates with Scan=nil that rely on the store
+// preserving the existing scan), the persisted scan_time can be observed to regress mid-run.
+//
+// This does not reproduce the customer's exact deployment (Central runs as a single replica, and in
+// production every call is routed through the outer keyedMutex in datastore_impl.go), but it documents a
+// real defense-in-depth gap: if any current or future caller ever reaches storeImpl.Upsert without going
+// through that outer lock, this exact "scan_time never advances" symptom is reproducible on demand.
+func (s *NodesStoreSuite) TestStore_ConcurrentUpsert_BypassingOuterLock() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+	baseTime := time.Now().Add(-24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	const iterations = 2000
+	const freshWriters = 4
+	const metaWriters = 4
+	var wg sync.WaitGroup
+
+	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
+	// Multiple concurrent writers of this kind widen the race window further (real Central handles many
+	// clusters/nodes worth of concurrent pipeline traffic, not just one goroutine at a time).
+	for w := range freshWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				fresh := node.CloneVT()
+				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
+				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
+				_ = store.Upsert(s.ctx, fresh)
+			}
+		})
+	}
+
+	// Simulates the nodes pipeline: frequent metadata-only churn, Scan explicitly nil.
+	for w := range metaWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				metaOnly := node.CloneVT()
+				metaOnly.Scan = nil
+				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
+				_ = store.Upsert(s.ctx, metaOnly)
+			}
+		})
+	}
+
+	regressed := concurrency.NewSignal()
+	stop := make(chan struct{})
+	var pollWG sync.WaitGroup
+	for range 4 {
+		pollWG.Go(func() {
+			lastSeen := baseTime
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				current, exists, err := store.Get(s.ctx, node.GetId())
+				if err == nil && exists {
+					st := current.GetScan().GetScanTime().AsTime()
+					if st.Before(lastSeen) {
+						regressed.Signal()
+						return
+					}
+					lastSeen = st
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+	close(stop)
+	pollWG.Wait()
+
+	s.True(regressed.IsDone(),
+		"expected scan_time to regress at least once when isUpdated()'s read-decide step races unprotected "+
+			"concurrent upserts for the same node ID; if this now passes without regressing, the store-layer "+
+			"race window may have been closed and this test's assumption should be revisited")
 }
 
 func (s *NodesStoreSuite) TestStore_OrphanedCVEs() {


### PR DESCRIPTION
## Description

Central's node-scanning pipelines periodically send updated vulnerability scan reports for a node. Before persisting an incoming scan, the store compares its timestamp against the currently stored one and discards the incoming scan entirely if it isn't newer (`isUpdated()` in `central/node/datastore/store/postgres/store.go`). That rejection was completely silent: nothing in the logs distinguished "no new scan arrived" from "a scan arrived and was discarded," even though the node's `lastUpdated` timestamp still advances either way (it's set unconditionally on every upsert, independent of whether the scan was accepted). That silence made a real-world symptom, a node's scan timestamp staying frozen for months while every other node field kept updating normally, effectively undiagnosable from logs alone.

This PR adds a warning-level log line in `isUpdated()` whenever it rejects an incoming scan, including the node ID/name and both the stored and incoming scan timestamps, so the next occurrence of this pattern is provable directly from Central's logs instead of only inferable from indirect evidence.

While checking whether the rejection logic itself could be buggy, this also adds tests that pin down a real, narrow gap in the store layer: the read-old-scan-and-decide step inside `isUpdated()` runs before `storeImpl.upsert()` acquires its own lock, so nothing in the store package alone makes "read old scan, decide, write" one atomic operation.

- `TestStore_ConcurrentUpsert_BypassingOuterLock` demonstrates that gap directly: calling the store layer without the datastore's outer per-node mutex, with concurrent writers hammering the same node ID (some sending monotonically fresher scans, others sending metadata-only updates that rely on the store preserving the existing scan), the persisted scan timestamp can be observed regressing mid-run.
- `TestConcurrentUpsertNode_KeyedMutexPreventsRegression` runs the identical workload through the actual production call path (`UpsertNode`), which wraps the entire read-decide-write sequence in a per-node-ID mutex. Result: zero regressions across 16,000 concurrent upserts under Go's race detector.
- `TestStore_FreshScanAlwaysWinsSequential` is a simple non-concurrent baseline confirming the happy path (a strictly newer scan always replaces an older one) is correct in isolation.

Together, these confirm the production call path is safe against this specific race today, and they add regression coverage in case a future caller ever reaches the store layer without going through that outer lock.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] CI
- [ ] Manually verified on a cluster

The new regression tests are inherently about goroutine-scheduling timing, so a manual/live repro wouldn't add confidence beyond running them repeatedly under `-race`, which CI already does. Optional manual check for the log line itself, if a reviewer wants extra confidence before or after rollout:

1. Deploy Central with this change.
2. Trigger two conflicting node scan reports for the same node ID (a newer one followed by an older one).
3. Confirm a `Warn` log appears identifying the node and both scan timestamps when the older one is rejected.