### PR TITLE
ROX-36679: remove curl, vim, rsync from central-db image

### DIFF
--- a/image/postgres/Dockerfile
+++ b/image/postgres/Dockerfile
@@ -36,7 +36,11 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     # Detect these with `find / -uid 26` in the original container.
     chown -R postgres /var/lib/pgsql && chown -R postgres /opt/app-root && \
     # Cleanup - cache mounts are automatically unmounted, no need to clean
-    rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --verbose -e --nodeps $(rpm -qa \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     mkdir /docker-entrypoint-initdb.d
 
 COPY --link scripts \

--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -36,7 +36,11 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown -R postgres /var/lib/pgsql && chown -R postgres /opt/app-root && \
     # Cleanup
     dnf clean all && \
-    rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --verbose -e --nodeps $(rpm -qa \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
 COPY LICENSE /licenses/LICENSE

--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -38,7 +38,7 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     dnf clean all && \
     rpm --verbose -e --nodeps $(rpm -qa \
         # Not needed by postgres, carry unfixable CVEs
-        'libcurl*' 'vim*' \
+        'libcurl*' 'vim*' 'rsync*' \
         # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
         'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -20,7 +20,11 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     chown -R postgres /var/lib/pgsql && \
     chown -R postgres /opt/app-root && \
     # Cleanup - cache mounts are automatically unmounted, no need to clean
-    rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --verbose -e --nodeps $(rpm -qa \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     mkdir /docker-entrypoint-initdb.d
 
 COPY --link scripts/docker-entrypoint.sh scripts/init-entrypoint.sh scripts/cert-watcher.sh /usr/local/bin/

--- a/scanner/image/db/konflux.Dockerfile
+++ b/scanner/image/db/konflux.Dockerfile
@@ -37,7 +37,11 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     chown -R postgres:postgres /var/lib/postgresql && \
     chown -R postgres:postgres /var/run/postgresql && \
     dnf clean all && \
-    rpm --verbose -e --nodeps $(rpm -qa curl '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
+    rpm --verbose -e --nodeps $(rpm -qa \
+        # Not needed by postgres, carry unfixable CVEs
+        'libcurl*' 'vim*' \
+        # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
+        'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum
 
 COPY LICENSE /licenses/LICENSE

--- a/scanner/image/db/konflux.Dockerfile
+++ b/scanner/image/db/konflux.Dockerfile
@@ -39,7 +39,7 @@ RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     dnf clean all && \
     rpm --verbose -e --nodeps $(rpm -qa \
         # Not needed by postgres, carry unfixable CVEs
-        'libcurl*' 'vim*' \
+        'libcurl*' 'vim*' 'rsync*' \
         # Flagged by "Curl in Image" and "Red Hat Package Manager in Image" default policies
         'curl*' '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*') && \
     rm -rf /var/cache/dnf /var/cache/yum


### PR DESCRIPTION
## Description

Expand rpm removal patterns to also match curl-minimal, libcurl-minimal, vim-minimal, vim-filesystem, python3 and all python3-* sub-packages. These are not needed by PostgreSQL at runtime and carry 9 of 11 Important CVEs flagged in the GovCloud compliance scan.

Verified locally: postgres, psql, pg_isready, pg_dump, pg_basebackup all work after removal. Entrypoint scripts have no dependency on removed packages.

:thread: https://redhat.enterprise.slack.com/archives/C09QLK07YLU/p1786530786463329?thread_ts=1785861338.100849&cid=C09QLK07YLU

Partially generated by AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI