### PR TITLE
ROX-33621: split VSOCK pull outcome metrics by layer

### DIFF
--- a/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
+++ b/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
@@ -261,7 +261,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_vsock_pull_requests_total{status=\"success\"})",
+          "expr": "sum(rox_sensor_vsock_pull_scrape_total{status=\"success\"})",
           "legendFormat": "Success",
           "range": true,
           "refId": "A"
@@ -326,7 +326,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_vsock_pull_requests_total{status=\"unchanged\"})",
+          "expr": "sum(rox_sensor_vsock_pull_get_report_total{status=\"unchanged\"})",
           "legendFormat": "Unchanged",
           "range": true,
           "refId": "A"
@@ -483,7 +483,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Running total of full index reports Sensor sent to Central (rox_sensor_vsock_pull_requests_total{status=\"success\"}). Each step up is one or more forwards. A paced wave is a run of +1 steps a few seconds apart. A dump is one large jump. A Sensor restart resets the counter to 0. Unchanged pulls are not counted.",
+      "description": "Running total of full index reports Sensor sent to Central (rox_sensor_vsock_pull_scrape_total{status=\"success\"}). Each step up is one or more forwards. A paced wave is a run of +1 steps a few seconds apart. A dump is one large jump. A Sensor restart resets the counter to 0. Unchanged pulls are not counted.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -581,7 +581,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_vsock_pull_requests_total{status=\"success\"})",
+          "expr": "sum(rox_sensor_vsock_pull_scrape_total{status=\"success\"})",
           "legendFormat": "success",
           "range": true,
           "refId": "A"
@@ -2517,7 +2517,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of scrape results. success = new report sent to Central. unchanged = agent had nothing new. The rest are errors (dial, timeout, not_ready, busy, and so on). Retryable errors should continue at backoff, not at 1 per tick for the whole fleet.",
+      "description": "Rate of scrape results across the three layered counters (transport, GetReport, scrape). success = new report sent to Central. unchanged = agent had nothing new. The rest are errors (dial, timeout, not_ready, busy, and so on). Retryable errors should continue at backoff, not at 1 per tick for the whole fleet.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2717,6 +2717,96 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "abnormal_close"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unexpected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "internal_error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown_agent_error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "malformed_request"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "request_too_large"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -2750,7 +2840,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status) (rate(rox_sensor_vsock_pull_requests_total[$__rate_interval]))",
+          "expr": "sum by (status) (rate(rox_sensor_vsock_pull_transport_total[$__rate_interval]) or rate(rox_sensor_vsock_pull_get_report_total[$__rate_interval]) or rate(rox_sensor_vsock_pull_scrape_total[$__rate_interval]))",
           "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
@@ -3019,7 +3109,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(rox_sensor_vsock_pull_requests_total{status=~\"success|unchanged\"}[$__rate_interval]))",
+          "expr": "sum(rate(rox_sensor_vsock_pull_scrape_total{status=\"success\"}[$__rate_interval]) or rate(rox_sensor_vsock_pull_get_report_total{status=\"unchanged\"}[$__rate_interval]))",
           "legendFormat": "success+unchanged",
           "range": true,
           "refId": "A"
@@ -3030,7 +3120,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(rox_sensor_vsock_pull_requests_total{status=~\"dial_error|timeout|read_error|not_ready|busy|send_error\"}[$__rate_interval]))",
+          "expr": "sum(rate(rox_sensor_vsock_pull_transport_total{status=~\"dial_error|timeout|read_error|abnormal_close|unexpected\"}[$__rate_interval]) or rate(rox_sensor_vsock_pull_get_report_total{status=~\"not_ready|busy|internal_error|unknown_agent_error\"}[$__rate_interval]) or rate(rox_sensor_vsock_pull_scrape_total{status=\"send_error\"}[$__rate_interval]))",
           "legendFormat": "retryable errors",
           "range": true,
           "refId": "B"
@@ -3041,7 +3131,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(rox_sensor_vsock_pull_requests_total{status=~\"invalid_report|unknown_method\"}[$__rate_interval]))",
+          "expr": "sum(rate(rox_sensor_vsock_pull_scrape_total{status=\"invalid_report\"}[$__rate_interval]) or rate(rox_sensor_vsock_pull_get_report_total{status=~\"unknown_method|malformed_request|request_too_large\"}[$__rate_interval]))",
           "legendFormat": "permanent failures",
           "range": true,
           "refId": "C"

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.23.0
 	github.com/gorilla/schema v1.4.1
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grafana/pyroscope-go v1.4.2
 	github.com/graph-gophers/graphql-go v1.10.3-0.20260702060009-60399cce0c05
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
@@ -320,7 +321,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.19 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.11 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -105,18 +105,36 @@ var IndexReportAcksReceived = prometheus.NewCounterVec(
 	[]string{"action"}, // "ACK" or "NACK"
 )
 
-// Pull-mode request status label values for PullRequestsTotal.
+// Pull-mode outcome labels are split across three counters so transport,
+// GetReport protocol, and scrape-pipeline results stay distinct as more
+// VSOCK RPC methods are added later. Each per-VM pull attempt increments
+// exactly one of these counters (mutually exclusive partition).
+
+// Transport-layer status values for PullTransportTotal.
 const (
-	PullStatusSuccess       = "success"
-	PullStatusUnchanged     = "unchanged"
-	PullStatusDialError     = "dial_error"
-	PullStatusReadError     = "read_error"
-	PullStatusInvalidReport = "invalid_report"
-	PullStatusSendError     = "send_error"
-	PullStatusNotReady      = "not_ready"
-	PullStatusUnknownMethod = "unknown_method"
-	PullStatusTimeout       = "timeout"
-	PullStatusBusy          = "busy"
+	PullTransportDialError     = "dial_error"
+	PullTransportTimeout       = "timeout"
+	PullTransportReadError     = "read_error"
+	PullTransportAbnormalClose = "abnormal_close"
+)
+
+// GetReport protocol status values for PullGetReportTotal.
+const (
+	PullGetReportUnchanged         = "unchanged"
+	PullGetReportNotReady          = "not_ready"
+	PullGetReportUnknownMethod     = "unknown_method"
+	PullGetReportBusy              = "busy"
+	PullGetReportInternalError     = "internal_error"
+	PullGetReportMalformedRequest  = "malformed_request"
+	PullGetReportRequestTooLarge   = "request_too_large"
+	PullGetReportUnknownAgentError = "unknown_agent_error"
+)
+
+// Scrape-pipeline status values for PullScrapeTotal (post-GetReport).
+const (
+	PullScrapeSuccess       = "success"
+	PullScrapeInvalidReport = "invalid_report"
+	PullScrapeSendError     = "send_error"
 )
 
 // PullDialDurationSeconds measures time to establish a websocket connection per VM.
@@ -191,13 +209,40 @@ var PullReportPackages = prometheus.NewHistogram(
 	},
 )
 
-// PullRequestsTotal counts per-VM pull attempts by status.
-var PullRequestsTotal = prometheus.NewCounterVec(
+// PullTransportTotal counts per-VM pull attempts that failed at the VSOCK
+// transport layer (dial / read / abnormal close) before a protocol result.
+var PullTransportTotal = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
-		Name:      "vsock_pull_requests_total",
-		Help:      "Per-VM pull attempts by outcome status",
+		Name:      "vsock_pull_transport_total",
+		Help:      "Per-VM pull attempts that failed at the VSOCK transport layer",
+	},
+	[]string{"status"},
+)
+
+// PullGetReportTotal counts per-VM GetReport protocol outcomes (Unchanged,
+// ErrorCode sentinels). Transport failures are counted on PullTransportTotal
+// instead; successful full reports continue into the scrape pipeline and are
+// counted on PullScrapeTotal.
+var PullGetReportTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_get_report_total",
+		Help:      "Per-VM GetReport protocol outcomes (unchanged and agent ErrorCode results)",
+	},
+	[]string{"status"},
+)
+
+// PullScrapeTotal counts per-VM scrape-pipeline outcomes after a full
+// GetReport payload was received (viability check, send to Central, success).
+var PullScrapeTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_scrape_total",
+		Help:      "Per-VM scrape-pipeline outcomes after a full GetReport payload was received",
 	},
 	[]string{"status"},
 )
@@ -291,7 +336,9 @@ func init() {
 		PullTickDurationSeconds,
 		PullReportBytes,
 		PullReportPackages,
-		PullRequestsTotal,
+		PullTransportTotal,
+		PullGetReportTotal,
+		PullScrapeTotal,
 		PullTicksTotal,
 		PullTrackedVMs,
 		PullDueVMs,

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -116,6 +116,7 @@ const (
 	PullTransportTimeout       = "timeout"
 	PullTransportReadError     = "read_error"
 	PullTransportAbnormalClose = "abnormal_close"
+	PullTransportUnexpected    = "unexpected"
 )
 
 // GetReport protocol status values for PullGetReportTotal.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -652,7 +652,7 @@ func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err er
 		return scrapeRetryable
 	default:
 		log.Warnf("VMScraper: unexpected transport or framing error for %q: %v", key, err)
-		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError).Inc()
+		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportUnexpected).Inc()
 		return scrapeRetryable
 	}
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -76,6 +76,14 @@ type ProtocolClient interface {
 	GetReport(ctx context.Context, stream io.ReadWriteCloser, lastKnownToken string) (*vsockclient.GetReportResult, error)
 }
 
+// closeCoder is satisfied by transport errors carrying a structured close
+// code. Declared locally so VMScraper doesn't need to import a concrete
+// dialer's error type to recognize one.
+type closeCoder interface {
+	error
+	CloseCode() (code int, reason string)
+}
+
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
 type VMScraper struct {
 	store                 RunningVMStore
@@ -453,7 +461,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 		next := s.scheduleAfterAttempt(key, scrapeOK)
 		log.Infof("VMScraper: scrape %q ok outcome=unchanged next=%s", key, next)
 		log.Debugf("VMScraper: unchanged report from roxagent on %q (token=%s)", key, snap.lastToken)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportUnchanged).Inc()
 		return true
 	}
 
@@ -462,7 +470,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 		log.Warnf("VM report from %q: %s", key, warning)
 	}
 	if !viable {
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusInvalidReport).Inc()
+		metrics.PullScrapeTotal.WithLabelValues(metrics.PullScrapeInvalidReport).Inc()
 		next := s.scheduleAfterAttempt(key, scrapeNonRetryable)
 		log.Infof("VMScraper: scrape %q failed non-retryable next=%s", key, next)
 		return false
@@ -474,7 +482,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	logAndRecordDiscoveredFacts(key, result.Meta.GetFacts())
 
 	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
+		metrics.PullScrapeTotal.WithLabelValues(metrics.PullScrapeSendError).Inc()
 		outcome := scrapeRetryable
 		if errors.Is(err, errox.NotImplemented) {
 			logging.GetRateLimitedLogger().WarnL(sendNotImplementedLogLimiter,
@@ -504,7 +512,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	log.Debugf("VMScraper: successfully pulled report for %q: token=%s, packages=%d, size=%d bytes, total=%s",
 		key, newToken, len(result.IndexReport.GetContents().GetPackages()), reportSize,
 		totalElapsed.Truncate(time.Millisecond))
-	metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSuccess).Inc()
+	metrics.PullScrapeTotal.WithLabelValues(metrics.PullScrapeSuccess).Inc()
 	metrics.PullTotalDurationSeconds.Observe(totalElapsed.Seconds())
 	return true
 }
@@ -566,7 +574,7 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	if err != nil {
 		if ctx.Err() != nil {
 			log.Warnf("VMScraper: dialing roxagent on %q timed out: %v", key, err)
-			metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()
+			metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout).Inc()
 			if errors.Is(ctx.Err(), context.Canceled) {
 				// Parent cancel (Sensor stop): do not keep retrying on the short tick.
 				return nil, scrapeNonRetryable
@@ -574,7 +582,7 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 			return nil, scrapeRetryable
 		}
 		log.Warnf("VMScraper: dialing roxagent on %q failed: %v", key, err)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusDialError).Inc()
+		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportDialError).Inc()
 		return nil, scrapeRetryable
 	}
 	defer func() { _ = stream.Close() }()
@@ -594,40 +602,74 @@ func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err er
 	// as timeout (matching the dial path) rather than as a protocol/read error.
 	if ctx.Err() != nil {
 		log.Warnf("VMScraper: reading report from %q timed out: %v", key, err)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout).Inc()
+		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout).Inc()
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return scrapeNonRetryable
 		}
 		return scrapeRetryable
 	}
+	var closeErr closeCoder
 	switch {
 	case errors.Is(err, vsockclient.ErrNotReady):
 		log.Debugf("VMScraper: roxagent on %q has not yet generated a report", key)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusNotReady).Inc()
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportNotReady).Inc()
 		return scrapeRetryable
 	case errors.Is(err, vsockclient.ErrUnknownMethod):
 		log.Warnf("VMScraper: roxagent on %q does not support the GetReport method", key)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnknownMethod).Inc()
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportUnknownMethod).Inc()
 		return scrapeNonRetryable
+	case errors.Is(err, vsockclient.ErrBusy):
+		log.Infof("VMScraper: roxagent on %q is busy with another request: %v", key, err)
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportBusy).Inc()
+		return scrapeRetryable
 	case errors.Is(err, vsockclient.ErrInternal):
 		log.Warnf("VMScraper: roxagent on %q reported an internal error: %v", key, err)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportInternalError).Inc()
+		return scrapeRetryable
+	case errors.Is(err, vsockclient.ErrMalformedRequest):
+		log.Warnf("VMScraper: roxagent on %q rejected the request as malformed: %v", key, err)
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportMalformedRequest).Inc()
+		return scrapeNonRetryable
+	case errors.Is(err, vsockclient.ErrRequestTooLarge):
+		log.Warnf("VMScraper: roxagent on %q rejected the request as too large: %v", key, err)
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportRequestTooLarge).Inc()
+		return scrapeNonRetryable
+	case errors.Is(err, vsockclient.ErrUnknownAgentError):
+		log.Warnf("VMScraper: roxagent on %q returned an error code this Sensor version doesn't recognize (possible version mismatch): %v", key, err)
+		metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportUnknownAgentError).Inc()
+		return scrapeRetryable
+	case isAbnormalClose(err, &closeErr):
+		// e.g. close code 1006, which is what a TLS handshake failure on the
+		// agent's side looks like from Sensor's end.
+		code, reason := closeErr.CloseCode()
+		log.Warnf("VMScraper: roxagent on %q connection closed abnormally (websocket close code %d: %s) — check roxagent's own logs on the VM for the cause",
+			key, code, reason)
+		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportAbnormalClose).Inc()
 		return scrapeRetryable
 	case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
 		log.Debugf("VMScraper: roxagent on %q connection closed (agent may be down or restarting): %v", key, err)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
-		return scrapeRetryable
-	case errors.Is(err, vsockclient.ErrBusy):
-		log.Infof("VMScraper: roxagent on %q is busy with another request: %v", key, err)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy).Inc()
+		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError).Inc()
 		return scrapeRetryable
 	default:
-		log.Warnf("VMScraper: protocol error for %q (possible version mismatch): %v", key, err)
-		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError).Inc()
-		// ErrUnknownMethod, the only permanent sentinel, is handled above, so
-		// any error reaching here is treated as transient.
+		log.Warnf("VMScraper: unexpected transport or framing error for %q: %v", key, err)
+		metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError).Inc()
 		return scrapeRetryable
 	}
+}
+
+// closeCodeNormalClosure is the RFC 6455 status code (1000) for a graceful
+// websocket close. Declared to keep vmscraper decoupled from the transport
+// package.
+const closeCodeNormalClosure = 1000
+
+// isAbnormalClose reports a closeCoder whose close code is neither 0 nor
+// closeCodeNormalClosure (those fall through to the ordinary io.EOF branch).
+func isAbnormalClose(err error, target *closeCoder) bool {
+	if !errors.As(err, target) {
+		return false
+	}
+	code, _ := (*target).CloseCode()
+	return code != 0 && code != closeCodeNormalClosure
 }
 
 type vmStateSnapshot struct {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -772,6 +772,64 @@ func cachedToken(t *testing.T, s *VMScraper, key string) string {
 	})
 }
 
+type pullOutcomeSample struct {
+	vec   *prometheus.CounterVec
+	label string
+}
+
+func allPullOutcomeSamples() []pullOutcomeSample {
+	var out []pullOutcomeSample
+	for _, label := range []string{
+		metrics.PullTransportDialError,
+		metrics.PullTransportTimeout,
+		metrics.PullTransportReadError,
+		metrics.PullTransportAbnormalClose,
+		metrics.PullTransportUnexpected,
+	} {
+		out = append(out, pullOutcomeSample{metrics.PullTransportTotal, label})
+	}
+	for _, label := range []string{
+		metrics.PullGetReportUnchanged,
+		metrics.PullGetReportNotReady,
+		metrics.PullGetReportUnknownMethod,
+		metrics.PullGetReportBusy,
+		metrics.PullGetReportInternalError,
+		metrics.PullGetReportMalformedRequest,
+		metrics.PullGetReportRequestTooLarge,
+		metrics.PullGetReportUnknownAgentError,
+	} {
+		out = append(out, pullOutcomeSample{metrics.PullGetReportTotal, label})
+	}
+	for _, label := range []string{
+		metrics.PullScrapeSuccess,
+		metrics.PullScrapeInvalidReport,
+		metrics.PullScrapeSendError,
+	} {
+		out = append(out, pullOutcomeSample{metrics.PullScrapeTotal, label})
+	}
+	return out
+}
+
+func snapshotPullOutcomes() map[pullOutcomeSample]float64 {
+	snap := make(map[pullOutcomeSample]float64, len(allPullOutcomeSamples()))
+	for _, sample := range allPullOutcomeSamples() {
+		snap[sample] = testutil.ToFloat64(sample.vec.WithLabelValues(sample.label))
+	}
+	return snap
+}
+
+func assertOnlyPullOutcomeIncremented(t *testing.T, before map[pullOutcomeSample]float64, wantVec *prometheus.CounterVec, wantLabel string) {
+	t.Helper()
+	for _, sample := range allPullOutcomeSamples() {
+		got := testutil.ToFloat64(sample.vec.WithLabelValues(sample.label))
+		want := before[sample]
+		if sample.vec == wantVec && sample.label == wantLabel {
+			want++
+		}
+		assert.Equal(t, want, got, "status %q", sample.label)
+	}
+}
+
 // TestHandleGetReportError_ClassifiesEveryErrorCode locks the mapping from
 // each error to its metric label and retry classification.
 func TestHandleGetReportError_ClassifiesEveryErrorCode(t *testing.T) {
@@ -841,10 +899,10 @@ func TestHandleGetReportError_ClassifiesEveryErrorCode(t *testing.T) {
 			wantLabel:   metrics.PullTransportReadError,
 			wantOutcome: scrapeRetryable,
 		},
-		"unrecognized transport/framing error falls back to transport read_error": {
+		"unrecognized transport/framing error maps to transport unexpected": {
 			err:         errors.New("unmarshaling response: unexpected EOF in the middle of a varint"),
 			wantMetric:  metrics.PullTransportTotal,
-			wantLabel:   metrics.PullTransportReadError,
+			wantLabel:   metrics.PullTransportUnexpected,
 			wantOutcome: scrapeRetryable,
 		},
 	}
@@ -852,11 +910,10 @@ func TestHandleGetReportError_ClassifiesEveryErrorCode(t *testing.T) {
 	s := &VMScraper{}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			before := testutil.ToFloat64(tc.wantMetric.WithLabelValues(tc.wantLabel))
+			before := snapshotPullOutcomes()
 			outcome := s.handleGetReportError(t.Context(), "ns/vm", tc.err)
 			assert.Equal(t, tc.wantOutcome, outcome)
-			assert.Equal(t, before+1, testutil.ToFloat64(tc.wantMetric.WithLabelValues(tc.wantLabel)),
-				"expected %v to increment %q exactly once", tc.err, tc.wantLabel)
+			assertOnlyPullOutcomeIncremented(t, before, tc.wantMetric, tc.wantLabel)
 		})
 	}
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -10,6 +10,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -91,6 +92,15 @@ type nopCloser struct{}
 func (nopCloser) Read([]byte) (int, error)  { return 0, io.EOF }
 func (nopCloser) Write([]byte) (int, error) { return 0, nil }
 func (nopCloser) Close() error              { return nil }
+
+// fakeCloseCoder is a minimal closeCoder for testing without a real dialer.
+type fakeCloseCoder struct {
+	code   int
+	reason string
+}
+
+func (e *fakeCloseCoder) Error() string            { return "connection closed" }
+func (e *fakeCloseCoder) CloseCode() (int, string) { return e.code, e.reason }
 
 type mockProtocolClient struct {
 	mu          sync.Mutex
@@ -662,8 +672,8 @@ func TestVMScraper_GetReportTimeoutClassified(t *testing.T) {
 	}
 	s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
 
-	timeoutBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout))
-	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
+	timeoutBefore := testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout))
+	readErrBefore := testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -671,8 +681,8 @@ func TestVMScraper_GetReportTimeoutClassified(t *testing.T) {
 
 	assert.Equal(t, scrapeNonRetryable, outcome,
 		"parent cancellation must not schedule a retry on the short tick")
-	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout)))
-	assert.Equal(t, readErrBefore, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError)),
+	assert.Equal(t, timeoutBefore+1, testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportTimeout)))
+	assert.Equal(t, readErrBefore, testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError)),
 		"timed-out read must not be counted as a protocol/read error")
 }
 
@@ -703,14 +713,14 @@ func TestVMScraper_GetReportBusyClassified(t *testing.T) {
 	}
 	s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
 
-	busyBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy))
-	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
+	busyBefore := testutil.ToFloat64(metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportBusy))
+	readErrBefore := testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError))
 
 	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
 	assert.Equal(t, scrapeRetryable, outcome)
-	assert.Equal(t, busyBefore+1, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy)))
-	assert.Equal(t, readErrBefore, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError)),
+	assert.Equal(t, busyBefore+1, testutil.ToFloat64(metrics.PullGetReportTotal.WithLabelValues(metrics.PullGetReportBusy)))
+	assert.Equal(t, readErrBefore, testutil.ToFloat64(metrics.PullTransportTotal.WithLabelValues(metrics.PullTransportReadError)),
 		"a busy response must not be counted as a generic protocol/read error")
 }
 
@@ -760,6 +770,127 @@ func cachedToken(t *testing.T, s *VMScraper, key string) string {
 		require.True(t, ok, "no cached state for %q", key)
 		return st.lastToken
 	})
+}
+
+// TestHandleGetReportError_ClassifiesEveryErrorCode locks the mapping from
+// each error to its metric label and retry classification.
+func TestHandleGetReportError_ClassifiesEveryErrorCode(t *testing.T) {
+	cases := map[string]struct {
+		err         error
+		wantMetric  *prometheus.CounterVec
+		wantLabel   string
+		wantOutcome scrapeOutcome
+	}{
+		"NOT_READY maps to get_report not_ready": {
+			err:         fmt.Errorf("%w: still scanning", vsockclient.ErrNotReady),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportNotReady,
+			wantOutcome: scrapeRetryable,
+		},
+		"UNKNOWN_METHOD maps to get_report unknown_method": {
+			err:         fmt.Errorf("%w: no get_report", vsockclient.ErrUnknownMethod),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportUnknownMethod,
+			wantOutcome: scrapeNonRetryable,
+		},
+		"BUSY maps to get_report busy": {
+			err:         fmt.Errorf("%w: another request in flight", vsockclient.ErrBusy),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportBusy,
+			wantOutcome: scrapeRetryable,
+		},
+		"INTERNAL maps to get_report internal_error": {
+			err:         fmt.Errorf("%w: panic recovered", vsockclient.ErrInternal),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportInternalError,
+			wantOutcome: scrapeRetryable,
+		},
+		"MALFORMED_REQUEST maps to get_report malformed_request": {
+			err:         fmt.Errorf("%w: empty request_id", vsockclient.ErrMalformedRequest),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportMalformedRequest,
+			wantOutcome: scrapeNonRetryable,
+		},
+		"REQUEST_TOO_LARGE maps to get_report request_too_large": {
+			err:         fmt.Errorf("%w: payload too big", vsockclient.ErrRequestTooLarge),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportRequestTooLarge,
+			wantOutcome: scrapeNonRetryable,
+		},
+		"unrecognized agent error code maps to get_report unknown_agent_error": {
+			err:         fmt.Errorf("%w: agent error (99): ?", vsockclient.ErrUnknownAgentError),
+			wantMetric:  metrics.PullGetReportTotal,
+			wantLabel:   metrics.PullGetReportUnknownAgentError,
+			wantOutcome: scrapeRetryable,
+		},
+		"abnormal websocket close maps to transport abnormal_close": {
+			err:         fmt.Errorf("reading response: %w", &fakeCloseCoder{code: 1006, reason: "abnormal closure"}),
+			wantMetric:  metrics.PullTransportTotal,
+			wantLabel:   metrics.PullTransportAbnormalClose,
+			wantOutcome: scrapeRetryable,
+		},
+		"plain io.EOF maps to transport read_error": {
+			err:         io.EOF,
+			wantMetric:  metrics.PullTransportTotal,
+			wantLabel:   metrics.PullTransportReadError,
+			wantOutcome: scrapeRetryable,
+		},
+		"io.ErrUnexpectedEOF maps to transport read_error": {
+			err:         io.ErrUnexpectedEOF,
+			wantMetric:  metrics.PullTransportTotal,
+			wantLabel:   metrics.PullTransportReadError,
+			wantOutcome: scrapeRetryable,
+		},
+		"unrecognized transport/framing error falls back to transport read_error": {
+			err:         errors.New("unmarshaling response: unexpected EOF in the middle of a varint"),
+			wantMetric:  metrics.PullTransportTotal,
+			wantLabel:   metrics.PullTransportReadError,
+			wantOutcome: scrapeRetryable,
+		},
+	}
+
+	s := &VMScraper{}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			before := testutil.ToFloat64(tc.wantMetric.WithLabelValues(tc.wantLabel))
+			outcome := s.handleGetReportError(t.Context(), "ns/vm", tc.err)
+			assert.Equal(t, tc.wantOutcome, outcome)
+			assert.Equal(t, before+1, testutil.ToFloat64(tc.wantMetric.WithLabelValues(tc.wantLabel)),
+				"expected %v to increment %q exactly once", tc.err, tc.wantLabel)
+		})
+	}
+}
+
+// TestIsAbnormalClose locks which close codes take the abnormal-close path
+// versus the ordinary EOF path.
+func TestIsAbnormalClose(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"normal closure (1000) is not abnormal": {
+			err:  &fakeCloseCoder{code: closeCodeNormalClosure, reason: "bye"},
+			want: false,
+		},
+		"zero code (no structured signal) is not abnormal": {
+			err:  &fakeCloseCoder{code: 0},
+			want: false,
+		},
+		"abnormal closure (1006) is abnormal": {
+			err:  &fakeCloseCoder{code: 1006, reason: "abnormal closure"},
+			want: true,
+		},
+		"a plain io.EOF is not a closeCoder at all": {
+			err:  io.EOF,
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var target closeCoder
+			assert.Equal(t, tc.want, isAbnormalClose(tc.err, &target))
+		})
+	}
 }
 
 func newTestScraper(t *testing.T, store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) (*VMScraper, *testClock) {
@@ -980,6 +1111,18 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 			sender:      &mockSender{},
 			wantBackoff: 0,
 			wantGap:     5 * time.Minute, // matches newTestScraper interval
+		},
+		"ErrMalformedRequest should not retry using backoff": {
+			client:      &mockProtocolClient{errQueue: []error{vsockclient.ErrMalformedRequest}},
+			sender:      &mockSender{},
+			wantBackoff: 0,
+			wantGap:     5 * time.Minute,
+		},
+		"ErrRequestTooLarge should not retry using backoff": {
+			client:      &mockProtocolClient{errQueue: []error{vsockclient.ErrRequestTooLarge}},
+			sender:      &mockSender{},
+			wantBackoff: 0,
+			wantGap:     5 * time.Minute,
 		},
 		"invalid report should not retry using backoff": {
 			client: &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{{

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -27,8 +27,15 @@ var (
 	ErrUnknownMethod = errors.New("agent does not support the requested method")
 	// ErrInternal indicates the agent encountered an internal error.
 	ErrInternal = errors.New("agent internal error")
+	// ErrMalformedRequest indicates the agent rejected the request as invalid.
+	ErrMalformedRequest = errors.New("agent rejected request as malformed")
+	// ErrRequestTooLarge indicates the request exceeded the agent's size limit.
+	ErrRequestTooLarge = errors.New("agent rejected request as too large")
 	// ErrBusy indicates the agent's single connection slot is held by another request.
 	ErrBusy = errors.New("agent is busy with another request")
+	// ErrUnknownAgentError indicates a well-formed ErrorResponse whose code
+	// this client doesn't recognize (e.g. a future ErrorCode value).
+	ErrUnknownAgentError = errors.New("unrecognized agent error code")
 )
 
 // GetReportResult holds the parsed response from a GetReport call.
@@ -141,9 +148,13 @@ func errorFromResponse(e *pb.ErrorResponse) error {
 		return fmt.Errorf("%w: %s", ErrUnknownMethod, e.GetMessage())
 	case pb.ErrorCode_ERROR_CODE_INTERNAL:
 		return fmt.Errorf("%w: %s", ErrInternal, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_MALFORMED_REQUEST:
+		return fmt.Errorf("%w: %s", ErrMalformedRequest, e.GetMessage())
+	case pb.ErrorCode_ERROR_CODE_REQUEST_TOO_LARGE:
+		return fmt.Errorf("%w: %s", ErrRequestTooLarge, e.GetMessage())
 	case pb.ErrorCode_ERROR_CODE_BUSY:
 		return fmt.Errorf("%w: %s", ErrBusy, e.GetMessage())
 	default:
-		return fmt.Errorf("agent error (%s): %s", e.GetCode(), e.GetMessage())
+		return fmt.Errorf("%w: agent error (%s): %s", ErrUnknownAgentError, e.GetCode(), e.GetMessage())
 	}
 }

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -120,10 +120,28 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 			wantErr:   ErrInternal,
 			wantInMsg: "scan crashed",
 		},
+		"should wrap ErrMalformedRequest for MALFORMED_REQUEST": {
+			code:      pb.ErrorCode_ERROR_CODE_MALFORMED_REQUEST,
+			message:   "empty request_id",
+			wantErr:   ErrMalformedRequest,
+			wantInMsg: "empty request_id",
+		},
+		"should wrap ErrRequestTooLarge for REQUEST_TOO_LARGE": {
+			code:      pb.ErrorCode_ERROR_CODE_REQUEST_TOO_LARGE,
+			message:   "payload exceeds 10MB limit",
+			wantErr:   ErrRequestTooLarge,
+			wantInMsg: "10MB",
+		},
 		"should wrap ErrBusy for BUSY": {
-			code:    pb.ErrorCode_ERROR_CODE_BUSY,
-			message: "agent is already serving another request",
-			wantErr: ErrBusy,
+			code:      pb.ErrorCode_ERROR_CODE_BUSY,
+			message:   "agent is already serving another request",
+			wantErr:   ErrBusy,
+			wantInMsg: "another request",
+		},
+		"should wrap ErrUnknownAgentError for UNSPECIFIED": {
+			code:    pb.ErrorCode_ERROR_CODE_UNSPECIFIED,
+			message: "",
+			wantErr: ErrUnknownAgentError,
 		},
 	}
 	for name, tc := range cases {

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer.go
@@ -6,11 +6,14 @@ package vsockdialer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"strconv"
 
+	"github.com/gorilla/websocket"
 	"github.com/stackrox/rox/pkg/k8sutil"
 	"k8s.io/client-go/rest"
 	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
@@ -53,5 +56,73 @@ func (d *MultiDialer) Dial(ctx context.Context, namespace, name string, port uin
 	if deadline, ok := ctx.Deadline(); ok {
 		_ = conn.SetDeadline(deadline)
 	}
-	return conn, nil
+	return &closeCodeConn{Conn: conn}, nil
+}
+
+// closeCodeConn remaps kubevirt AsConn() close errors into closedError so
+// callers can recover the websocket close code via errors.As against their
+// own CloseCode() interface, without importing this package.
+type closeCodeConn struct {
+	net.Conn
+}
+
+func (c *closeCodeConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if closeErr := transportClosedErr(err); closeErr != nil {
+		return n, closeErr
+	}
+	return n, err //nolint:wrapcheck // implements io.Reader
+}
+
+func (c *closeCodeConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if closeErr := transportClosedErr(err); closeErr != nil {
+		return n, closeErr
+	}
+	return n, err //nolint:wrapcheck // implements io.Writer
+}
+
+// transportClosedErr returns a *closedError if err represents a closed
+// connection, or nil if it's some other read failure.
+func transportClosedErr(err error) *closedError {
+	if err == nil {
+		return nil
+	}
+	if ce, ok := errors.AsType[*websocket.CloseError](err); ok {
+		return &closedError{code: ce.Code, reason: ce.Text}
+	}
+	if errors.Is(err, io.EOF) {
+		return &closedError{}
+	}
+	return nil
+}
+
+// closedError indicates the websocket connection closed before a complete
+// VMServiceResponse could be read. Kept unexported and dependency-free so
+// callers recover it structurally (via errors.As against their own
+// CloseCode() interface) rather than importing this package.
+type closedError struct {
+	code   int
+	reason string
+}
+
+func (e *closedError) Error() string {
+	if e.code == 0 {
+		return "websocket connection closed"
+	}
+	return fmt.Sprintf("websocket connection closed (code %d): %s", e.code, e.reason)
+}
+
+// Is reports whether this close is an io.EOF-equivalent (no code, or a
+// normal 1000 close). Abnormal codes such as 1006 are not EOF.
+func (e *closedError) Is(target error) bool {
+	if target != io.EOF {
+		return false
+	}
+	return e.code == 0 || e.code == websocket.CloseNormalClosure
+}
+
+// CloseCode returns the close code and reason; code is 0 if unstructured.
+func (e *closedError) CloseCode() (code int, reason string) {
+	return e.code, e.reason
 }

--- a/sensor/kubernetes/virtualmachine/vsockdialer/dialer_test.go
+++ b/sensor/kubernetes/virtualmachine/vsockdialer/dialer_test.go
@@ -1,0 +1,57 @@
+package vsockdialer
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportClosedErr(t *testing.T) {
+	cases := map[string]struct {
+		err      error
+		wantNil  bool
+		wantCode int
+		wantEOF  bool
+	}{
+		"should return nil for a non-close error": {
+			err:     errors.New("boom"),
+			wantNil: true,
+		},
+		"should classify a plain io.EOF with no structured code": {
+			err:      io.EOF,
+			wantCode: 0,
+			wantEOF:  true,
+		},
+		"should preserve the close code from a websocket.CloseError": {
+			err:      &websocket.CloseError{Code: websocket.CloseAbnormalClosure, Text: "abnormal closure"},
+			wantCode: websocket.CloseAbnormalClosure,
+		},
+		"should treat a normal closure as io.EOF": {
+			err:      fmt.Errorf("read: %w", &websocket.CloseError{Code: websocket.CloseNormalClosure, Text: "bye"}),
+			wantCode: websocket.CloseNormalClosure,
+			wantEOF:  true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := transportClosedErr(tc.err)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			code, _ := got.CloseCode()
+			assert.Equal(t, tc.wantCode, code)
+			if tc.wantEOF {
+				assert.ErrorIs(t, got, io.EOF)
+				return
+			}
+			assert.NotErrorIs(t, got, io.EOF)
+		})
+	}
+}


### PR DESCRIPTION
Part of ROX-33621 as it contributes towards better debuggability of the feature.

## Description

`vsock_pull_requests_total{status=...}` mixed three layers in one label: VSOCK transport failures, GetReport protocol results, and post-report scrape-pipeline outcomes. That is hard to extend once more VSOCK RPC methods appear, and it made `success` (end-to-end scrape) look like the same kind of thing as `unchanged` (GetReport-only).

This PR replaces that counter with a mutually exclusive partition (each per-VM pull attempt increments exactly one):

| Counter | What it counts |
|---|---|
| `vsock_pull_transport_total` | Dial / read / abnormal websocket close failures |
| `vsock_pull_get_report_total` | GetReport protocol outcomes (`unchanged`, agent `ErrorCode`s) |
| `vsock_pull_scrape_total` | Post-report pipeline (`invalid_report`, `send_error`, `success`) |

Also finishes `vsockclient` ErrorCode sentinels and preserves websocket close codes in `vsockdialer` so abnormal closes (e.g. 1006) are distinct from plain EOF.

**BREAKING:** dashboards and alerts on `vsock_pull_requests_total` must move to the three new counters -> There are none yet, so we can do the breaking changes.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<details>
<summary><b>Manual verification: PASS</b> - layered vsock pull counters on OpenShift/CNV pull-mode VM</summary>

**Setup:** Sensor image built from this branch, VM scanning enabled.

1. `kubectl -n stackrox port-forward deploy/sensor 9090:9090` then `curl -sS localhost:9090/metrics | grep -E 'vsock_pull_(transport|get_report|scrape|requests)_total'` → old counter absent; scrape success moves while agent is healthy
   ```
   rox_sensor_vsock_pull_scrape_total{status="success"} 3
   # no rox_sensor_vsock_pull_requests_total samples
   ```
2. On the guest: `sudo systemctl stop roxagent.service`, wait ≥1 scrape interval, re-curl metrics → transport increments; scrape stays flat
   ```
   rox_sensor_vsock_pull_scrape_total{status="success"} 3
   rox_sensor_vsock_pull_transport_total{status="abnormal_close"} 2
   ```
   Sensor log for those cycles: `cycle done: 0/1 VMs scraped successfully`
3. `sudo systemctl start roxagent.service`, wait ≥1 interval → scrape success resumes; transport stays at prior value (partition holds)
   ```
   rox_sensor_vsock_pull_scrape_total{status="success"} 4
   rox_sensor_vsock_pull_transport_total{status="abnormal_close"} 2
   ```
   Sensor log: `cycle done: 1/1 VMs scraped successfully`

</details>