### PR TITLE
ci: experiment — exclude rhel-vex bundle from OCP qa-e2e

### DIFF
--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -21,4 +21,19 @@ enable_sfa_for_ocp()
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
+# EXPERIMENT: exclude rhel-vex (51.7 MB, largest bundle) to identify which
+# tests depend on it. If tests pass without it, this bundle is unnecessary
+# for QA e2e and can be permanently excluded — saving ~5 min of import time.
+# See bundle sizes in gs://definitions.stackrox.io/v4/vulnerability-bundles/v3/
+#   rhel-vex:          51.7 MB (EXCLUDED)
+#   nvd:               36.8 MB
+#   osv:               27.0 MB
+#   ubuntu:            18.5 MB
+#   debian:            13.1 MB
+#   epss:               4.3 MB
+#   stackrox-rhel-csaf: 0.8 MB
+#   manual:             0.0 MB
+#   alpine:             1.1 MB (EXCLUDED)
+os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "alpine,debian,epss,manual,nvd,osv,stackrox-rhel-csaf,ubuntu"
+
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

**EXPERIMENT: Do not merge.** Testing which QA e2e tests depend on the `rhel-vex` vulnerability bundle.

`rhel-vex` is the largest bundle at 51.7 MB and likely takes ~5 min to import. This PR excludes it from the OCP qa-e2e allowlist to identify which tests fail without it.

The goal: understand per-bundle test dependencies so we can load only the bundles needed for each test shard — potentially saving significant scanner initialization time.

### Bundle sizes (from vulnerabilities.zip v3)

| Bundle | Size | In this experiment? |
|---|---|---|
| suse | 54.7 MB | no (not in CI default) |
| **rhel-vex** | **51.7 MB** | **EXCLUDED** |
| nvd | 36.8 MB | yes |
| osv | 27.0 MB | yes |
| ubuntu | 18.5 MB | yes |
| debian | 13.1 MB | yes |
| oracle | 11.5 MB | no (not in CI default) |
| epss | 4.3 MB | yes |
| aws | 3.1 MB | no (not in CI default) |
| photon | 2.0 MB | no (not in CI default) |
| alpine | 1.1 MB | yes |
| stackrox-rhel-csaf | 0.8 MB | yes |
| manual | 0.0 MB | yes |

### What to look for in CI results

Tests that fail with errors about missing RHEL vulnerabilities, missing fixable vulns on RHEL-based images, or scan results with zero vulnerabilities for RHEL content.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

This IS the validation — watching which OCP qa-e2e tests fail without rhel-vex to map bundle→test dependencies.