### PR TITLE
ROX-36208: signal roxagent serve readiness via sd_notify

### DIFF
--- a/compliance/virtualmachines/roxagent/cmd/sdnotify.go
+++ b/compliance/virtualmachines/roxagent/cmd/sdnotify.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-systemd/v22/daemon"
+)
+
+// notifySystemdReady sends READY=1 on NOTIFY_SOCKET when set (Type=notify /
+// Quadlet Notify=true). No-op when unset so bare `roxagent serve` still works.
+func notifySystemdReady() error {
+	sent, err := daemon.SdNotify(false, daemon.SdNotifyReady)
+	if err != nil {
+		return fmt.Errorf("sd_notify READY=1: %w", err)
+	}
+	if sent {
+		log.Info("Signaled systemd readiness (READY=1)")
+	}
+	return nil
+}

--- a/compliance/virtualmachines/roxagent/cmd/sdnotify_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/sdnotify_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotifySystemdReady_NoSocketIsNoop covers running without systemd
+// (NOTIFY_SOCKET unset): readiness notify must not error.
+func TestNotifySystemdReady_NoSocketIsNoop(t *testing.T) {
+	t.Setenv("NOTIFY_SOCKET", "")
+	require.NoError(t, notifySystemdReady())
+}
+
+// TestNotifySystemdReady_WritesReady covers the sd_notify protocol against a
+// fake NOTIFY_SOCKET: READY=1 must be written as a unixgram datagram.
+func TestNotifySystemdReady_WritesReady(t *testing.T) {
+	// Prefer a short path under /tmp: macOS AF_UNIX sun_path is small, and
+	// t.TempDir() paths are often too long to bind.
+	f, err := os.CreateTemp("", "rox-sdn-*.sock")
+	require.NoError(t, err)
+	sockPath := f.Name()
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Remove(sockPath))
+	t.Cleanup(func() { _ = os.Remove(sockPath) })
+
+	addr := &net.UnixAddr{Name: sockPath, Net: "unixgram"}
+	ln, err := net.ListenUnixgram("unixgram", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	t.Setenv("NOTIFY_SOCKET", sockPath)
+
+	require.NoError(t, notifySystemdReady())
+
+	_ = ln.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 64)
+	n, _, err := ln.ReadFromUnix(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "READY=1", string(buf[:n]))
+}

--- a/compliance/virtualmachines/roxagent/cmd/serve.go
+++ b/compliance/virtualmachines/roxagent/cmd/serve.go
@@ -108,27 +108,12 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 		return err
 	}
 
-	// The mapping file must exist locally before the first scan can run:
-	// scan() never fetches it itself, so this initial fetch is mandatory.
-	// If it fails, startup fails rather than running a scan against no data.
-	// Start(ctx, true) blocks until that fetch completes, then keeps
-	// refreshing the file in the background.
-	mappingDownloader := newMappingDownloader(cfg.repoCPEURL, mappingCachePath,
-		logMappingDownloadResult(cfg.repoCPEURL, mappingCachePath))
-	if err := mappingDownloader.Start(ctx, true); err != nil {
-		return fmt.Errorf("initial repository-to-CPE mapping fetch: %w", err)
-	}
+	// serveCtx lets early-return paths (mapping/scan failure after listen)
+	// stop Serve instead of leaking the accept loop until process exit.
+	serveCtx, cancelServe := context.WithCancel(ctx)
+	defer cancelServe()
 
 	cache := &vsockserver.ReportCache{}
-	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
-
-	report, err := scan(ctx, cfg.hostPath, mappingCachePath)
-	if err != nil {
-		return fmt.Errorf("initial scan: %w", err)
-	}
-	cache.SetReport(report, discoverFacts(cfg.hostPath))
-	log.Infof("Initial scan complete, report cached. Num packages: %d", len(report.GetContents().GetPackages()))
-
 	handler := vsockserver.NewHandler(cache, agentVersion)
 
 	// TLS is mandatory: sensor always dials with TLS, so a plaintext agent is
@@ -155,14 +140,47 @@ func runServe(ctx context.Context, cfg serveConfig) error {
 	log.Infof("Listening on VSOCK port %d (pull mode)", cfg.port)
 
 	var wg sync.WaitGroup
-	wg.Go(func() { srv.Serve(ctx, ln) })
-	wg.Go(func() { vmRescanner.Run(ctx) })
+	wg.Go(func() { srv.Serve(serveCtx, ln) })
 
-	<-ctx.Done()
+	// Report systemd readiness once VSOCK is up.
+	if err := notifySystemdReady(); err != nil {
+		// Exiting, as systemd would kill this service anyway after TimeoutStartSec.
+		cancelServe()
+		wg.Wait()
+		return err
+	}
+
+	// The mapping file must exist locally before the first scan can run:
+	// scan() never fetches it itself, so this initial fetch is mandatory.
+	// If it fails, startup fails rather than running a scan against no data.
+	// Start(serveCtx, true) blocks until that fetch completes, then keeps
+	// refreshing the file in the background.
+	mappingDownloader := newMappingDownloader(cfg.repoCPEURL, mappingCachePath,
+		logMappingDownloadResult(cfg.repoCPEURL, mappingCachePath))
+	if err := mappingDownloader.Start(serveCtx, true); err != nil {
+		cancelServe()
+		wg.Wait()
+		return fmt.Errorf("initial repository-to-CPE mapping fetch: %w", err)
+	}
+
+	report, err := scan(serveCtx, cfg.hostPath, mappingCachePath)
+	if err != nil {
+		cancelServe()
+		wg.Wait()
+		mappingDownloader.Stop()
+		return fmt.Errorf("initial scan: %w", err)
+	}
+	cache.SetReport(report, discoverFacts(cfg.hostPath))
+	log.Infof("Initial scan complete, report cached. Num packages: %d", len(report.GetContents().GetPackages()))
+
+	vmRescanner := newRescanner(cache, cfg.hostPath, mappingCachePath, cfg.rescanInterval)
+	wg.Go(func() { vmRescanner.Run(serveCtx) })
+
+	<-serveCtx.Done()
 	// Wait for Serve's graceful drain (in-flight connections) and the
 	// rescan loop to finish before returning, so the process doesn't exit
 	// mid-drain or mid-scan. mappingDownloader.Stop waits for its own
-	// background refresh loop the same way, once ctx is already done.
+	// background refresh loop the same way, once serveCtx is already done.
 	wg.Wait()
 	mappingDownloader.Stop()
 	return nil

--- a/compliance/virtualmachines/roxagent/quadlet/README.md
+++ b/compliance/virtualmachines/roxagent/quadlet/README.md
@@ -6,6 +6,8 @@ Run roxagent on RHEL VMs with Podman Quadlet: a systemd-managed container that s
 
 [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) turns `roxagent.container` into a systemd unit that runs `roxagent serve`. The agent scans installed packages, caches the report, and listens on a VSOCK port. Sensor dials in when it needs a report. The agent rescans on its own schedule (default: every 4 hours).
 
+`Notify=true` makes Podman pass systemd's notify socket into the container, so `systemctl status roxagent` becomes `active` only after the agent has bound the VSOCK listener (not merely when the container process starts).
+
 ### Components
 
 | File | Description |

--- a/compliance/virtualmachines/roxagent/quadlet/roxagent.container
+++ b/compliance/virtualmachines/roxagent/quadlet/roxagent.container
@@ -11,6 +11,8 @@ Image=quay.io/stackrox-io/main:latest
 Pull=newer
 Exec=serve --host-path /host
 Network=host
+# Pass NOTIFY_SOCKET into the container so roxagent can READY=1 after VSOCK listen.
+Notify=true
 
 # Privileged for vsock access
 # Use PodmanArgs for entrypoint (RHEL 8 Quadlet doesn't support Entrypoint key)

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -17,7 +17,6 @@ const (
 	// Transient systemd unit started by EnsureRoxagentServing (systemd-run --unit=...).
 	roxagentE2EUnit            = "roxagent-e2e.service"
 	roxagentE2EUnitName        = "roxagent-e2e"
-	roxagentListenReadyMarker  = "Listening on VSOCK port"
 	roxagentListenPollInterval = 5 * time.Second
 )
 
@@ -68,33 +67,27 @@ func VerifyRoxagentInstalled(ctx context.Context, virt Virtctl, namespace, vm st
 }
 
 // EnsureRoxagentServing starts `roxagent serve` on the guest via a transient systemd
-// unit if it is not already active, then waits until the VSOCK listener is up.
-// Sensor pulls reports from this long-running process; the test does not push
-// index reports.
+// unit if it is not already active, then waits until the unit is active.
+// With Type=notify, active means roxagent has bound the VSOCK listener and sent
+// READY=1 to systemd. Sensor then pulls reports from this long-running process.
 //
 // repo2cpeURL is passed as --repo-cpe-url (serve does not read ROXAGENT_REPO2CPE_URL).
 func EnsureRoxagentServing(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeURL string) error {
-	invocationID, err := startRoxagentServeIfNeeded(ctx, virt, namespace, vm, repo2cpeURL)
-	if err != nil {
+	if err := startRoxagentServeIfNeeded(ctx, virt, namespace, vm, repo2cpeURL); err != nil {
 		return err
 	}
-	return waitRoxagentListening(ctx, virt, namespace, vm, invocationID)
+	return waitRoxagentActive(ctx, virt, namespace, vm)
 }
 
-// startRoxagentServeIfNeeded starts the e2e unit if it isn't already active/activating,
-// and returns its current InvocationID so waitRoxagentListening can scope its journal
-// query to exactly this activation.
-func startRoxagentServeIfNeeded(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeURL string) (string, error) {
-	var invocationID string
-	err := retryOnSSHTransport(ctx, virt.Logf, "start roxagent serve", func(ctx context.Context) error {
+func startRoxagentServeIfNeeded(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeURL string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "start roxagent serve", func(ctx context.Context) error {
 		state, err := roxagentServeState(ctx, virt, namespace, vm)
 		if err != nil {
 			return err
 		}
 		if state == "active" || state == "activating" {
 			virt.Logf("roxagent serve: %s already %s", roxagentE2EUnit, state)
-			invocationID, err = roxagentInvocationID(ctx, virt, namespace, vm)
-			return err
+			return nil
 		}
 
 		// systemd-run refuses to reuse a unit name that still exists (failed or
@@ -113,7 +106,7 @@ func startRoxagentServeIfNeeded(ctx context.Context, virt Virtctl, namespace, vm
 			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
 		}, "sudo", "systemd-run",
 			"--unit="+roxagentE2EUnitName,
-			"--property=Type=simple",
+			"--property=Type=notify",
 			DefaultRoxagentInstallPath, "serve",
 			"--port", roxagentServePort,
 			"--host-path", "/",
@@ -131,23 +124,24 @@ func startRoxagentServeIfNeeded(ctx context.Context, virt Virtctl, namespace, vm
 		}
 
 		virt.Logf("roxagent serve: systemd-run accepted %s", roxagentE2EUnit)
-		invocationID, err = roxagentInvocationID(ctx, virt, namespace, vm)
-		return err
+		return nil
 	})
-	return invocationID, err
 }
 
-// waitRoxagentListening polls until the unit identified by invocationID is both active
-// and reports the VSOCK listen marker in its journal.
-func waitRoxagentListening(ctx context.Context, virt Virtctl, namespace, vm, invocationID string) error {
+// waitRoxagentActive polls until the e2e unit's ActiveState is active.
+// Type=notify keeps the unit in activating until READY=1 after VSOCK listen.
+func waitRoxagentActive(ctx context.Context, virt Virtctl, namespace, vm string) error {
 	for {
 		state, err := roxagentServeState(ctx, virt, namespace, vm)
 		if err != nil {
 			return err
 		}
 		switch state {
-		case "active", "activating":
-			// keep waiting for the listen log line
+		case "active":
+			virt.Logf("roxagent serve is active (VSOCK listener ready)")
+			return nil
+		case "activating":
+			virt.Logf("roxagent serve still starting (unit=%s, waiting for Type=notify READY)", state)
 		default:
 			logs := fetchRoxagentServeJournal(ctx, virt, namespace, vm)
 			if isVsockUnavailableOutput(logs) {
@@ -157,21 +151,11 @@ func waitRoxagentListening(ctx context.Context, virt Virtctl, namespace, vm, inv
 			return fmt.Errorf("roxagent serve unit %q (journal: %s)", state, logs)
 		}
 
-		listening, err := roxagentServeListening(ctx, virt, namespace, vm, invocationID)
-		if err != nil {
-			return err
-		}
-		if listening {
-			virt.Logf("roxagent serve is listening on VSOCK")
-			return nil
-		}
-		virt.Logf("roxagent serve still starting (unit=%s, waiting for %q)", state, roxagentListenReadyMarker)
-
 		timer := time.NewTimer(roxagentListenPollInterval)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return fmt.Errorf("timed out waiting for roxagent serve to listen: %w", ctx.Err())
+			return fmt.Errorf("timed out waiting for roxagent serve to become active: %w", ctx.Err())
 		case <-timer.C:
 		}
 	}
@@ -182,8 +166,8 @@ func waitRoxagentListening(ctx context.Context, virt Virtctl, namespace, vm, inv
 // for any unit systemd knows about — loaded or not, active or not — so a non-zero exit here
 // reliably means a genuine remote-command problem, not an expected state value. That makes it
 // the preferred way to read any systemd unit property from the guest; add new lookups (like
-// roxagentServeState and roxagentInvocationID below) on top of it rather than parsing the
-// output or exit code of state-specific subcommands such as `is-active`.
+// roxagentServeState below) on top of it rather than parsing the output or exit code of
+// state-specific subcommands such as `is-active`.
 func systemctlShowProperty(ctx context.Context, virt Virtctl, namespace, vm, unit, property string) (string, error) {
 	stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
 		description:            fmt.Sprintf("systemctl show -p %s %s", property, unit),
@@ -206,31 +190,6 @@ func roxagentServeState(ctx context.Context, virt Virtctl, namespace, vm string)
 		return "unknown", nil
 	}
 	return state, nil
-}
-
-// roxagentInvocationID returns the e2e unit's current InvocationID, a per-activation UUID.
-// Filtering journalctl on it (instead of `-u <unit> -b`) scopes a query to exactly this run,
-// so a stale marker line from an earlier activation of the same reused transient unit name
-// (stopped/failed, then restarted by startRoxagentServeIfNeeded) can't produce a false positive.
-func roxagentInvocationID(ctx context.Context, virt Virtctl, namespace, vm string) (string, error) {
-	return systemctlShowProperty(ctx, virt, namespace, vm, roxagentE2EUnit, "InvocationID")
-}
-
-// roxagentServeListening reports whether the journal for the activation identified by
-// invocationID contains the VSOCK listen marker. A plain dump exits 0 regardless of whether
-// the marker is present, so a non-zero exit here always means a genuine SSH or remote-command
-// problem rather than "not listening yet". The dump is unbounded (no `-n` tail) so a chatty
-// agent cannot scroll the marker out of a fixed window between polls.
-func roxagentServeListening(ctx context.Context, virt Virtctl, namespace, vm, invocationID string) (bool, error) {
-	stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
-		description:            "journalctl roxagent listening check",
-		transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
-	}, "sudo", "journalctl", "_SYSTEMD_INVOCATION_ID="+invocationID, "--no-pager", "-o", "cat")
-	if err != nil {
-		return false, fmt.Errorf("journalctl _SYSTEMD_INVOCATION_ID=%s: %w (stdout: %s; stderr: %s)",
-			invocationID, err, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
-	}
-	return strings.Contains(stdout, roxagentListenReadyMarker), nil
 }
 
 // fetchRoxagentServeJournal returns a short recent journal dump for error messages.


### PR DESCRIPTION
This PR is also included (cherry-picked) in: #22345 

## Description

`roxagent serve` under systemd/`Type=simple` (and Quadlet without app-level notify) became `active` as soon as the process started, before the VSOCK listener was bound. E2E readiness therefore scraped the journal for a specific "Listening on VSOCK port" log line, which is brittle and gives operators no better signal from `systemctl status` than the tests had.

This change defines readiness as "VSOCK is accepting connections":

1. After a successful `vsock.Listen`, `roxagent serve` sends `sd_notify(READY=1)` when `NOTIFY_SOCKET` is set (no-op otherwise). Mapping fetch and the initial scan run after that. Early Sensor pulls still get `ERROR_CODE_NOT_READY` until a report is cached.
2. Quadlet packaging sets `Notify=true` so Podman passes the notify socket into the container; `systemctl` reflects app readiness, not just container process start.
3. VM e2e helpers start the transient unit with `Type=notify` and wait for `ActiveState=active`, dropping journal log-line polling.

Notify failures are fatal when the socket is present: under `Type=notify` / Quadlet `Notify=true`, a missed `READY=1` leaves the unit stuck in `activating` until systemd's start timeout kills it anyway.

When `NOTIFY_SOCKET` is unset, the `sd_notify` call itself is a pure no-op, but startup order still changes for every path (including bare `roxagent serve`): listen and accept happen before mapping fetch and the initial scan. Early clients can connect and get `ERROR_CODE_NOT_READY` instead of connection refused; if mapping/scan fails, the process may have already been listening briefly before shutting down.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI - e2e VM scanning tests are sufficient: [run1](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22278/pull-ci-stackrox-stackrox-master-ocp-4-22-vm-scanning-e2e-tests/2087830276473360384)
- [ ] Manually verified on a cluster:

1. Deploy updated image + Quadlet with `Notify=true` on a RHEL VM.
2. `systemctl start roxagent` and watch `ActiveState`: should stay `activating` until the listen log, then active before "Initial scan complete".
3. Confirm `systemctl status` is active while Sensor would still get `NOT_READY` until the first report is cached.

AI-Assisted: cursor, ~80% generated, user reviewed readiness semantics and packaging