### PR TITLE
fix(ci): disable GKE spot instances for e2e tests

### DIFF
--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -75,7 +75,7 @@ jobs:
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
-        GKE_SPOT: "true"
+        GKE_SPOT: "false"
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -63,7 +63,7 @@ jobs:
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
-        GKE_SPOT: "true"
+        GKE_SPOT: "false"
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -60,7 +60,7 @@ jobs:
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
-        GKE_SPOT: "true"
+        GKE_SPOT: "false"
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
@@ -208,7 +208,7 @@ jobs:
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
-        GKE_SPOT: "true"
+        GKE_SPOT: "false"
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh
@@ -355,7 +355,7 @@ jobs:
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
-        GKE_SPOT: "true"
+        GKE_SPOT: "false"
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -77,7 +77,7 @@ jobs:
       env:
         MACHINE_TYPE: e2-standard-8
         NUM_NODES: "3"
-        GKE_SPOT: "true"
+        GKE_SPOT: "false"
       timeout-minutes: 20
       run: |
         source scripts/ci/gke.sh


### PR DESCRIPTION
## Description

Disable GKE spot instances for (GHA) e2e tests. Spot VM preemptions cause test failures when pods are is rescheduled mid-test — tests don't tolerate the brief outage during restarts.

Set `GKE_SPOT` to `"false"` rather than removing the config so it's easy to re-enable once test resilience and/or a proper non-spot pool solution (PR #22195) are in place.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Config-only change — reverts to the non-spot behavior that was the default before spot was enabled.