### PR TITLE
ROX-36422: Add ForceRefetchMetadataOnly enricher option

### DIFF
--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -38,10 +38,10 @@ const (
 	UseImageNamesRefetchCachedValues
 	// ForceRefetchMetadataOnly forces a registry metadata refresh (bypassing the
 	// in-memory metadata cache) but allows reusing an existing scan from the
-	// database if the resolved digest already has one. This is the hybrid
+	// database if the resolved image ID already has one. This is the hybrid
 	// option used by admission-controller tag-only requests: always confirm the
 	// current tag→digest mapping via registry, yet skip Scanner when Central
-	// already holds scan data for that digest.
+	// already holds scan data for that image ID.
 	ForceRefetchMetadataOnly
 )
 

--- a/pkg/images/enricher/enricher.go
+++ b/pkg/images/enricher/enricher.go
@@ -36,6 +36,13 @@ const (
 	ForceRefetchSignaturesOnly
 	ForceRefetchCachedValuesOnly
 	UseImageNamesRefetchCachedValues
+	// ForceRefetchMetadataOnly forces a registry metadata refresh (bypassing the
+	// in-memory metadata cache) but allows reusing an existing scan from the
+	// database if the resolved digest already has one. This is the hybrid
+	// option used by admission-controller tag-only requests: always confirm the
+	// current tag→digest mapping via registry, yet skip Scanner when Central
+	// already holds scan data for that digest.
+	ForceRefetchMetadataOnly
 )
 
 // forceRefetchCachedValues implies whether the cached values within the database should be skipped and refetched.
@@ -86,7 +93,7 @@ type EnrichmentContext struct {
 // FetchOnlyIfMetadataEmpty checks the fetch opts and return whether or not we can used a cached or saved
 // version of the external metadata
 func (e EnrichmentContext) FetchOnlyIfMetadataEmpty() bool {
-	return e.FetchOpt != IgnoreExistingImages && e.FetchOpt != ForceRefetch
+	return e.FetchOpt != IgnoreExistingImages && e.FetchOpt != ForceRefetch && e.FetchOpt != ForceRefetchMetadataOnly
 }
 
 // FetchOnlyIfScanEmpty will use the scan that exists in the image unless the fetch opts prohibit it

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -447,7 +447,8 @@ func (e *enricherImpl) enrichWithMetadata(ctx context.Context, enrichmentContext
 	}
 
 	if !enrichmentContext.FetchOpt.forceRefetchCachedValues() &&
-		enrichmentContext.FetchOpt != UseImageNamesRefetchCachedValues {
+		enrichmentContext.FetchOpt != UseImageNamesRefetchCachedValues &&
+		enrichmentContext.FetchOpt != ForceRefetchMetadataOnly {
 		// The metadata in the cache is always up-to-date with respect to the current metadataVersion
 		if metadataValue, ok := e.metadataCache.Get(getRef(image)); ok {
 			e.metrics.IncrementMetadataCacheHit()

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -1804,14 +1804,3 @@ func TestHasScanData(t *testing.T) {
 		})
 	}
 }
-
-func TestForceRefetchMetadataOnly_Predicates(t *testing.T) {
-	ctx := EnrichmentContext{FetchOpt: ForceRefetchMetadataOnly}
-
-	assert.False(t, ctx.FetchOnlyIfMetadataEmpty(),
-		"ForceRefetchMetadataOnly must force metadata refetch (same as ForceRefetch)")
-	assert.True(t, ctx.FetchOnlyIfScanEmpty(),
-		"ForceRefetchMetadataOnly must allow scan reuse from DB")
-	assert.False(t, ctx.FetchOpt.forceRefetchCachedValues(),
-		"ForceRefetchMetadataOnly must not force refetch of cached DB values")
-}

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -79,6 +79,7 @@ func TestEnricherFlow(t *testing.T) {
 		result                 EnrichmentResult
 		errorExpected          bool
 		expectedBaseImageCalls int
+		expectScanCall         *bool
 	}{
 		{
 			name: "nothing in the cache",
@@ -157,6 +158,36 @@ func TestEnricherFlow(t *testing.T) {
 				ScanResult:   ScanSucceeded,
 			},
 			expectedBaseImageCalls: 1,
+		},
+		{
+			name: "data in both caches but force refetch metadata only",
+			ctx: EnrichmentContext{
+				FetchOpt: ForceRefetchMetadataOnly,
+			},
+			inMetadataCache: true,
+			image: &storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+				Metadata: &storage.ImageMetadata{
+					LayerShas: []string{"SHA1"},
+				},
+			},
+			imageGetter: imageGetterFromImage(&storage.Image{
+				Id:    "id",
+				Name:  &storage.ImageName{Registry: "reg"},
+				Names: []*storage.ImageName{{Registry: "reg"}},
+				Scan:  &storage.ImageScan{}}),
+			fsr: newFakeRegistryScanner(opts{
+				requestedMetadata: true,
+				requestedScan:     false,
+			}),
+			result: EnrichmentResult{
+				ImageUpdated: false,
+				ScanResult:   ScanReused,
+			},
+			expectedBaseImageCalls: 1,
+			expectScanCall:         new(bool),
 		},
 		{
 			name: " data in both caches but force refetch use names",
@@ -411,6 +442,9 @@ func TestEnricherFlow(t *testing.T) {
 
 			assert.Equal(t, c.result, result)
 			assert.Equal(t, c.expectedBaseImageCalls, mockBaseGetter.callCount, "Mismatch in: %s", c.name)
+			if c.expectScanCall != nil {
+				assert.Equal(t, *c.expectScanCall, fsr.scanner.requestedScan, "scan call mismatch in: %s", c.name)
+			}
 		})
 	}
 }
@@ -1312,6 +1346,13 @@ func TestUpdateFromDatabase_ImageNames(t *testing.T) {
 			},
 			opt: ForceRefetchCachedValuesOnly,
 		},
+		"ForceRefetchMetadataOnly should retain image names": {
+			expectedImageNames: []*storage.ImageName{
+				testImageName,
+				existingTestImageName,
+			},
+			opt: ForceRefetchMetadataOnly,
+		},
 		"UseImageNamesRefetchCachedValues should retain image names": {
 			expectedImageNames: []*storage.ImageName{
 				testImageName,
@@ -1762,4 +1803,15 @@ func TestHasScanData(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.result.HasScanData())
 		})
 	}
+}
+
+func TestForceRefetchMetadataOnly_Predicates(t *testing.T) {
+	ctx := EnrichmentContext{FetchOpt: ForceRefetchMetadataOnly}
+
+	assert.False(t, ctx.FetchOnlyIfMetadataEmpty(),
+		"ForceRefetchMetadataOnly must force metadata refetch (same as ForceRefetch)")
+	assert.True(t, ctx.FetchOnlyIfScanEmpty(),
+		"ForceRefetchMetadataOnly must allow scan reuse from DB")
+	assert.False(t, ctx.FetchOpt.forceRefetchCachedValues(),
+		"ForceRefetchMetadataOnly must not force refetch of cached DB values")
 }

--- a/pkg/images/enricher/enricher_v2_impl.go
+++ b/pkg/images/enricher/enricher_v2_impl.go
@@ -435,7 +435,8 @@ func (e *enricherV2Impl) enrichWithMetadata(ctx context.Context, enrichmentConte
 	}
 
 	if !enrichmentContext.FetchOpt.forceRefetchCachedValues() &&
-		enrichmentContext.FetchOpt != UseImageNamesRefetchCachedValues {
+		enrichmentContext.FetchOpt != UseImageNamesRefetchCachedValues &&
+		enrichmentContext.FetchOpt != ForceRefetchMetadataOnly {
 		// The metadata in the cache is always up-to-date with respect to the current metadataVersion
 		if metadataValue, ok := e.metadataCache.Get(getRefV2(imageV2)); ok {
 			e.metrics.IncrementMetadataCacheHit()

--- a/pkg/images/enricher/enricher_v2_impl_test.go
+++ b/pkg/images/enricher/enricher_v2_impl_test.go
@@ -1450,6 +1450,17 @@ func TestEnrichImageWithBaseImagesV2(t *testing.T) {
 	assert.Equal(t, expectedDigest, img.GetBaseImageInfo()[0].GetBaseImageDigest())
 }
 
+func TestForceRefetchMetadataOnly_Predicates(t *testing.T) {
+	ctx := EnrichmentContext{FetchOpt: ForceRefetchMetadataOnly}
+
+	assert.False(t, ctx.FetchOnlyIfMetadataEmpty(),
+		"ForceRefetchMetadataOnly must force metadata refetch (same as ForceRefetch)")
+	assert.True(t, ctx.FetchOnlyIfScanEmpty(),
+		"ForceRefetchMetadataOnly must allow scan reuse from DB")
+	assert.False(t, ctx.FetchOpt.forceRefetchCachedValues(),
+		"ForceRefetchMetadataOnly must not force refetch of cached DB values")
+}
+
 func newEnricherV2(set *mocks.MockSet, mockReporter *reporterMocks.MockReporter) ImageEnricherV2 {
 	return NewV2(&fakeCVESuppressorV2{}, nil, set, pkgMetrics.CentralSubsystem,
 		newCache(),

--- a/pkg/images/enricher/enricher_v2_impl_test.go
+++ b/pkg/images/enricher/enricher_v2_impl_test.go
@@ -83,6 +83,7 @@ func TestEnricherV2Flow(t *testing.T) {
 		result                 EnrichmentResult
 		errorExpected          bool
 		expectedBaseImageCalls int // track Base Image logic
+		expectScanCall         *bool
 	}{
 		{
 			name: "nothing in the cache",
@@ -162,6 +163,36 @@ func TestEnricherV2Flow(t *testing.T) {
 				ScanResult:   ScanSucceeded,
 			},
 			expectedBaseImageCalls: 1,
+		},
+		{
+			name: "data in both caches but force refetch metadata only",
+			ctx: EnrichmentContext{
+				FetchOpt: ForceRefetchMetadataOnly,
+			},
+			inMetadataCache: true,
+			image: &storage.ImageV2{
+				Id:     utils.NewImageV2ID(&storage.ImageName{Registry: "reg", FullName: "reg"}, "sha"),
+				Digest: "sha",
+				Name:   &storage.ImageName{Registry: "reg", FullName: "reg"},
+				Metadata: &storage.ImageMetadata{
+					LayerShas: []string{"SHA1"},
+				},
+			},
+			imageGetter: imageGetterV2FromImage(&storage.ImageV2{
+				Id:     utils.NewImageV2ID(&storage.ImageName{Registry: "reg", FullName: "reg"}, "sha"),
+				Digest: "sha",
+				Name:   &storage.ImageName{Registry: "reg", FullName: "reg"},
+				Scan:   &storage.ImageScan{}}),
+			fsr: newFakeRegistryScanner(opts{
+				requestedMetadata: true,
+				requestedScan:     false,
+			}),
+			result: EnrichmentResult{
+				ImageUpdated: false,
+				ScanResult:   ScanReused,
+			},
+			expectedBaseImageCalls: 1,
+			expectScanCall:         new(bool),
 		},
 		{
 			name: " data in both caches but force refetch use names",
@@ -424,6 +455,9 @@ func TestEnricherV2Flow(t *testing.T) {
 
 			assert.Equal(t, c.result, result)
 			assert.Equal(t, c.expectedBaseImageCalls, mockBaseGetter.callCount, "Mismatch in: %s", c.name)
+			if c.expectScanCall != nil {
+				assert.Equal(t, *c.expectScanCall, fsr.scanner.requestedScan, "scan call mismatch in: %s", c.name)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

Add `ForceRefetchMetadataOnly` `FetchOption` to the image enricher. This option forces a registry metadata refresh (bypassing the in-memory metadata cache) but allows reusing an existing scan from the database if the resolved digest already has one.

This is the foundation for avoiding redundant Scanner round-trips during tag-only admission-controller requests,  when Central already holds scan data for the resolved digest. This ensures admission controller enforcement on the correct scan data without additional latency due to an unnecessary Scanner call.

**Stack**: PR 1 of 4 — enricher option, proto+RPC, caller wiring, burst test.

Includes unit tests for:
- `ForceRefetchMetadataOnly` predicate behavior (`FetchOnlyIfMetadataEmpty`, `FetchOnlyIfScanEmpty`, `forceRefetchCachedValues`)
- V1 and V2 enricher flow: metadata cache bypass + scan reuse from DB

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests for predicate behavior and enricher flow pass locally
- No behavioral change to existing `FetchOption` paths (new enum value only)
