### PR TITLE
ROX-36422: Add ScanImageInternalForAdmission RPC

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -71,6 +71,7 @@ var (
 		},
 		or.SensorOr(idcheck.AdmissionControlOnly()): {
 			v1.ImageService_ScanImageInternal_FullMethodName,
+			v1.ImageService_ScanImageInternalForAdmission_FullMethodName,
 		},
 		idcheck.SensorsOnly(): {
 			v1.ImageService_GetImageVulnerabilitiesInternal_FullMethodName,
@@ -302,8 +303,24 @@ func (s *serviceImpl) saveImageV2(img *storage.ImageV2) error {
 
 // ScanImageInternal handles an image request from Sensor and Admission Controller.
 func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanImageInternalRequest) (*v1.ScanImageInternalResponse, error) {
+	return s.scanImageInternalWithOpt(ctx, request, enricher.ForceRefetch)
+}
+
+// ScanImageInternalForAdmission handles admission-controller image requests.
+// For tag-only images it refreshes registry metadata but reuses an existing
+// scan from Central's DB when the resolved digest is already known, avoiding
+// a redundant Scanner round-trip. For digest-based images it behaves
+// identically to ScanImageInternal.
+func (s *serviceImpl) ScanImageInternalForAdmission(ctx context.Context, request *v1.ScanImageInternalRequest) (*v1.ScanImageInternalResponse, error) {
+	return s.scanImageInternalWithOpt(ctx, request, enricher.ForceRefetchMetadataOnly)
+}
+
+// scanImageInternalWithOpt is the shared implementation for ScanImageInternal
+// and ScanImageInternalForAdmission. tagOnlyFetchOpt controls the enricher
+// FetchOption used when the request has no digest (tag-only image).
+func (s *serviceImpl) scanImageInternalWithOpt(ctx context.Context, request *v1.ScanImageInternalRequest, tagOnlyFetchOpt enricher.FetchOption) (*v1.ScanImageInternalResponse, error) {
 	if features.FlattenImageData.Enabled() {
-		return s.scanImageV2Internal(ctx, request)
+		return s.scanImageV2InternalWithOpt(ctx, request, tagOnlyFetchOpt)
 	}
 
 	if err := s.acquireScanSemaphore(ctx); err != nil {
@@ -380,8 +397,8 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 		fetchOpt = enricher.UseCachesIfPossible
 		if request.GetCachedOnly() {
 			fetchOpt = enricher.NoExternalMetadata
-		} else if imgID == "" { // If no ID, then don't use caches as they could return stale data.
-			fetchOpt = enricher.ForceRefetch
+		} else if imgID == "" {
+			fetchOpt = tagOnlyFetchOpt
 		}
 		img = types.ToImage(request.GetImage())
 	}
@@ -400,7 +417,7 @@ func (s *serviceImpl) ScanImageInternal(ctx context.Context, request *v1.ScanIma
 	return internalScanRespFromImage(img), nil
 }
 
-func (s *serviceImpl) scanImageV2Internal(ctx context.Context, request *v1.ScanImageInternalRequest) (*v1.ScanImageInternalResponse, error) {
+func (s *serviceImpl) scanImageV2InternalWithOpt(ctx context.Context, request *v1.ScanImageInternalRequest, tagOnlyFetchOpt enricher.FetchOption) (*v1.ScanImageInternalResponse, error) {
 	imgID := request.GetImage().GetIdV2()
 	if imgID == "" {
 		imgID = utils.NewImageV2ID(request.GetImage().GetName(), request.GetImage().GetId())
@@ -465,8 +482,8 @@ func (s *serviceImpl) scanImageV2Internal(ctx context.Context, request *v1.ScanI
 		fetchOpt = enricher.UseCachesIfPossible
 		if request.GetCachedOnly() {
 			fetchOpt = enricher.NoExternalMetadata
-		} else if imgID == "" { // If no ID, then don't use caches as they could return stale data.
-			fetchOpt = enricher.ForceRefetch
+		} else if imgID == "" {
+			fetchOpt = tagOnlyFetchOpt
 		}
 		imgV2 = types.ToImageV2(request.GetImage())
 		if imgV2.GetId() == "" {

--- a/central/image/service/service_impl_test.go
+++ b/central/image/service/service_impl_test.go
@@ -405,6 +405,193 @@ func TestResetClusterLocal(t *testing.T) {
 	}
 }
 
+// TestScanImageInternalForAdmission_FetchOpt verifies that the admission RPC
+// uses ForceRefetchMetadataOnly for tag-only requests and behaves identically
+// to ScanImageInternal for digest-based requests.
+func TestScanImageInternalForAdmission_FetchOpt(t *testing.T) {
+	name, _, err := utils.GenerateImageNameFromString("reg.invalid/some/image:latest")
+	require.NoError(t, err)
+
+	names := []*storage.ImageName{name}
+
+	tcs := map[string]struct {
+		request          *v1.ScanImageInternalRequest
+		existingImg      *storage.Image
+		existingImgV2    *storage.ImageV2
+		expectedFetchOpt enricher.FetchOption
+		expectEnrich     bool
+	}{
+		"tag-only uses ForceRefetchMetadataOnly": {
+			request: &v1.ScanImageInternalRequest{
+				Image: &storage.ContainerImage{Name: name},
+			},
+			expectedFetchOpt: enricher.ForceRefetchMetadataOnly,
+			expectEnrich:     true,
+		},
+		"digest request, image in DB, skips enricher entirely": {
+			request: &v1.ScanImageInternalRequest{
+				Image: &storage.ContainerImage{Id: "sha256:abc", Name: name},
+			},
+			existingImg: &storage.Image{
+				Id: "sha256:abc", Name: name, Names: names,
+				Scan: &storage.ImageScan{},
+			},
+			existingImgV2: &storage.ImageV2{
+				Id: utils.NewImageV2ID(name, "sha256:abc"), Digest: "sha256:abc",
+				Name: name, Scan: &storage.ImageScan{},
+			},
+			expectEnrich: false,
+		},
+		"digest request, image NOT in DB, uses UseCachesIfPossible": {
+			request: &v1.ScanImageInternalRequest{
+				Image: &storage.ContainerImage{Id: "sha256:abc", Name: name},
+			},
+			expectedFetchOpt: enricher.UseCachesIfPossible,
+			expectEnrich:     true,
+		},
+	}
+
+	for desc, tc := range tcs {
+		t.Run(desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			riskManagerMock := riskManagerMocks.NewMockManager(ctrl)
+
+			var s *serviceImpl
+			if features.FlattenImageData.Enabled() {
+				imageEnricherV2Mock := enricherMocks.NewMockImageEnricherV2(ctrl)
+				if tc.expectEnrich {
+					fetchOptMatcher := gomock.Cond(func(eCtx enricher.EnrichmentContext) bool {
+						return eCtx.FetchOpt == tc.expectedFetchOpt
+					})
+					imageEnricherV2Mock.EXPECT().
+						EnrichImage(gomock.Any(), fetchOptMatcher, gomock.Any()).
+						Return(enricher.EnrichmentResult{}, nil).Times(1)
+				}
+
+				riskManagerMock.EXPECT().
+					CalculateRiskAndUpsertImageV2(gomock.Any()).
+					Return(nil).AnyTimes()
+
+				imageV2DSMock := imageV2DSMocks.NewMockDataStore(ctrl)
+				imageV2DSMock.EXPECT().
+					GetImage(gomock.Any(), gomock.Any()).
+					Return(tc.existingImgV2, tc.existingImgV2 != nil, nil).AnyTimes()
+				imageV2DSMock.EXPECT().
+					GetImageNames(gomock.Any(), gomock.Any()).
+					Return(names, nil).AnyTimes()
+
+				connMgrMock := connMgrMocks.NewMockManager(ctrl)
+				connMgrMock.EXPECT().AllSensorsHaveCapability(gomock.Any()).AnyTimes().Return(false)
+
+				s = &serviceImpl{
+					internalScanSemaphore: semaphore.NewWeighted(int64(env.MaxParallelImageScanInternal.IntegerSetting())),
+					enricherV2:            imageEnricherV2Mock,
+					datastoreV2:           imageV2DSMock,
+					riskManager:           riskManagerMock,
+					connManager:           connMgrMock,
+				}
+			} else {
+				imageEnricherMock := enricherMocks.NewMockImageEnricher(ctrl)
+				if tc.expectEnrich {
+					fetchOptMatcher := gomock.Cond(func(eCtx enricher.EnrichmentContext) bool {
+						return eCtx.FetchOpt == tc.expectedFetchOpt
+					})
+					imageEnricherMock.EXPECT().
+						EnrichImage(gomock.Any(), fetchOptMatcher, gomock.Any()).
+						Return(enricher.EnrichmentResult{}, nil).Times(1)
+				}
+
+				riskManagerMock.EXPECT().
+					CalculateRiskAndUpsertImage(gomock.Any()).
+					Return(nil).AnyTimes()
+
+				imageDSMock := imageDSMocks.NewMockDataStore(ctrl)
+				imageDSMock.EXPECT().
+					GetImage(gomock.Any(), gomock.Any()).
+					Return(tc.existingImg, tc.existingImg != nil, nil).AnyTimes()
+
+				s = &serviceImpl{
+					internalScanSemaphore: semaphore.NewWeighted(int64(env.MaxParallelImageScanInternal.IntegerSetting())),
+					enricher:              imageEnricherMock,
+					datastore:             imageDSMock,
+					riskManager:           riskManagerMock,
+				}
+			}
+
+			resp, err := s.ScanImageInternalForAdmission(context.Background(), tc.request)
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+		})
+	}
+}
+
+// TestScanImageInternalForAdmission_DigestParity ensures the admission RPC
+// produces the same result as ScanImageInternal for digest-based requests.
+func TestScanImageInternalForAdmission_DigestParity(t *testing.T) {
+	name, _, err := utils.GenerateImageNameFromString("reg.invalid/some/image:latest")
+	require.NoError(t, err)
+
+	names := []*storage.ImageName{name}
+	req := &v1.ScanImageInternalRequest{
+		Image: &storage.ContainerImage{Id: "sha256:abc", Name: name},
+	}
+
+	curScan := &storage.ImageScan{ScanTime: timestamppb.New(time.Now())}
+
+	buildService := func(ctrl *gomock.Controller) *serviceImpl {
+		riskManagerMock := riskManagerMocks.NewMockManager(ctrl)
+		if features.FlattenImageData.Enabled() {
+			existingImgV2 := &storage.ImageV2{
+				Id: utils.NewImageV2ID(name, "sha256:abc"), Digest: "sha256:abc",
+				Name: name, Scan: curScan,
+			}
+			imageV2DSMock := imageV2DSMocks.NewMockDataStore(ctrl)
+			imageV2DSMock.EXPECT().
+				GetImage(gomock.Any(), gomock.Any()).
+				Return(existingImgV2, true, nil).AnyTimes()
+			imageV2DSMock.EXPECT().
+				GetImageNames(gomock.Any(), gomock.Any()).
+				Return(names, nil).AnyTimes()
+
+			connMgrMock := connMgrMocks.NewMockManager(ctrl)
+			connMgrMock.EXPECT().AllSensorsHaveCapability(gomock.Any()).AnyTimes().Return(false)
+
+			return &serviceImpl{
+				internalScanSemaphore: semaphore.NewWeighted(int64(env.MaxParallelImageScanInternal.IntegerSetting())),
+				datastoreV2:           imageV2DSMock,
+				riskManager:           riskManagerMock,
+				connManager:           connMgrMock,
+			}
+		}
+		existingImg := &storage.Image{
+			Id: "sha256:abc", Name: name, Names: names, Scan: curScan,
+		}
+		imageDSMock := imageDSMocks.NewMockDataStore(ctrl)
+		imageDSMock.EXPECT().
+			GetImage(gomock.Any(), gomock.Any()).
+			Return(existingImg, true, nil).AnyTimes()
+
+		return &serviceImpl{
+			internalScanSemaphore: semaphore.NewWeighted(int64(env.MaxParallelImageScanInternal.IntegerSetting())),
+			datastore:             imageDSMock,
+			riskManager:           riskManagerMock,
+		}
+	}
+
+	ctrl1 := gomock.NewController(t)
+	ctrl2 := gomock.NewController(t)
+
+	s1 := buildService(ctrl1)
+	s2 := buildService(ctrl2)
+
+	resp1, err1 := s1.ScanImageInternal(context.Background(), req)
+	resp2, err2 := s2.ScanImageInternalForAdmission(context.Background(), req)
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	protoassert.Equal(t, resp1.GetImage(), resp2.GetImage())
+}
+
 // TestEnrichLocalImageInternal_ImageNames ensures that image names are
 // populated from the existing image in Central DB when the image
 // requires re-enrichment. (ie: when scan has expired)

--- a/generated/api/v1/image_service.pb.go
+++ b/generated/api/v1/image_service.pb.go
@@ -1309,7 +1309,8 @@ const file_api_v1_image_service_proto_rawDesc = "" +
 	"\atimeout\x18\x01 \x01(\x05R\atimeout\x12\x14\n" +
 	"\x05query\x18\x02 \x01(\tR\x05query\";\n" +
 	"\x13ExportImageResponse\x12$\n" +
-	"\x05image\x18\x01 \x01(\v2\x0e.storage.ImageR\x05image2\xce\t\n" +
+	"\x05image\x18\x01 \x01(\v2\x0e.storage.ImageR\x05image2\xac\n" +
+	"\n" +
 	"\fImageService\x12H\n" +
 	"\bGetImage\x12\x13.v1.GetImageRequest\x1a\x0e.storage.Image\"\x17\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/images/{id}\x12M\n" +
 	"\vCountImages\x12\f.v1.RawQuery\x1a\x17.v1.CountImagesResponse\"\x17\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/imagescount\x12F\n" +
@@ -1317,7 +1318,8 @@ const file_api_v1_image_service_proto_rawDesc = "" +
 	"ListImages\x12\f.v1.RawQuery\x1a\x16.v1.ListImagesResponse\"\x12\x82\xd3\xe4\x93\x02\f\x12\n" +
 	"/v1/images\x12M\n" +
 	"\tScanImage\x12\x14.v1.ScanImageRequest\x1a\x0e.storage.Image\"\x1a\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/images/scan\x12P\n" +
-	"\x11ScanImageInternal\x12\x1c.v1.ScanImageInternalRequest\x1a\x1d.v1.ScanImageInternalResponse\x12q\n" +
+	"\x11ScanImageInternal\x12\x1c.v1.ScanImageInternalRequest\x1a\x1d.v1.ScanImageInternalResponse\x12\\\n" +
+	"\x1dScanImageInternalForAdmission\x12\x1c.v1.ScanImageInternalRequest\x1a\x1d.v1.ScanImageInternalResponse\x12q\n" +
 	"\x1fGetImageVulnerabilitiesInternal\x12*.v1.GetImageVulnerabilitiesInternalRequest\x1a\x1d.v1.ScanImageInternalResponse\"\x03\x88\x02\x01\x12^\n" +
 	"\x18EnrichLocalImageInternal\x12#.v1.EnrichLocalImageInternalRequest\x1a\x1d.v1.ScanImageInternalResponse\x12T\n" +
 	"\x1dUpdateLocalScanStatusInternal\x12(.v1.UpdateLocalScanStatusInternalRequest\x1a\t.v1.Empty\x12\\\n" +
@@ -1406,31 +1408,33 @@ var file_api_v1_image_service_proto_depIdxs = []int32{
 	31, // 21: v1.ImageService.ListImages:input_type -> v1.RawQuery
 	4,  // 22: v1.ImageService.ScanImage:input_type -> v1.ScanImageRequest
 	5,  // 23: v1.ImageService.ScanImageInternal:input_type -> v1.ScanImageInternalRequest
-	7,  // 24: v1.ImageService.GetImageVulnerabilitiesInternal:input_type -> v1.GetImageVulnerabilitiesInternalRequest
-	8,  // 25: v1.ImageService.EnrichLocalImageInternal:input_type -> v1.EnrichLocalImageInternalRequest
-	9,  // 26: v1.ImageService.UpdateLocalScanStatusInternal:input_type -> v1.UpdateLocalScanStatusInternalRequest
-	33, // 27: v1.ImageService.InvalidateScanAndRegistryCaches:input_type -> v1.Empty
-	10, // 28: v1.ImageService.DeleteImages:input_type -> v1.DeleteImagesRequest
-	12, // 29: v1.ImageService.WatchImage:input_type -> v1.WatchImageRequest
-	14, // 30: v1.ImageService.UnwatchImage:input_type -> v1.UnwatchImageRequest
-	33, // 31: v1.ImageService.GetWatchedImages:input_type -> v1.Empty
-	17, // 32: v1.ImageService.ExportImages:input_type -> v1.ExportImageRequest
-	23, // 33: v1.ImageService.GetImage:output_type -> storage.Image
-	3,  // 34: v1.ImageService.CountImages:output_type -> v1.CountImagesResponse
-	2,  // 35: v1.ImageService.ListImages:output_type -> v1.ListImagesResponse
-	23, // 36: v1.ImageService.ScanImage:output_type -> storage.Image
-	6,  // 37: v1.ImageService.ScanImageInternal:output_type -> v1.ScanImageInternalResponse
-	6,  // 38: v1.ImageService.GetImageVulnerabilitiesInternal:output_type -> v1.ScanImageInternalResponse
-	6,  // 39: v1.ImageService.EnrichLocalImageInternal:output_type -> v1.ScanImageInternalResponse
-	33, // 40: v1.ImageService.UpdateLocalScanStatusInternal:output_type -> v1.Empty
-	33, // 41: v1.ImageService.InvalidateScanAndRegistryCaches:output_type -> v1.Empty
-	11, // 42: v1.ImageService.DeleteImages:output_type -> v1.DeleteImagesResponse
-	13, // 43: v1.ImageService.WatchImage:output_type -> v1.WatchImageResponse
-	33, // 44: v1.ImageService.UnwatchImage:output_type -> v1.Empty
-	15, // 45: v1.ImageService.GetWatchedImages:output_type -> v1.GetWatchedImagesResponse
-	18, // 46: v1.ImageService.ExportImages:output_type -> v1.ExportImageResponse
-	33, // [33:47] is the sub-list for method output_type
-	19, // [19:33] is the sub-list for method input_type
+	5,  // 24: v1.ImageService.ScanImageInternalForAdmission:input_type -> v1.ScanImageInternalRequest
+	7,  // 25: v1.ImageService.GetImageVulnerabilitiesInternal:input_type -> v1.GetImageVulnerabilitiesInternalRequest
+	8,  // 26: v1.ImageService.EnrichLocalImageInternal:input_type -> v1.EnrichLocalImageInternalRequest
+	9,  // 27: v1.ImageService.UpdateLocalScanStatusInternal:input_type -> v1.UpdateLocalScanStatusInternalRequest
+	33, // 28: v1.ImageService.InvalidateScanAndRegistryCaches:input_type -> v1.Empty
+	10, // 29: v1.ImageService.DeleteImages:input_type -> v1.DeleteImagesRequest
+	12, // 30: v1.ImageService.WatchImage:input_type -> v1.WatchImageRequest
+	14, // 31: v1.ImageService.UnwatchImage:input_type -> v1.UnwatchImageRequest
+	33, // 32: v1.ImageService.GetWatchedImages:input_type -> v1.Empty
+	17, // 33: v1.ImageService.ExportImages:input_type -> v1.ExportImageRequest
+	23, // 34: v1.ImageService.GetImage:output_type -> storage.Image
+	3,  // 35: v1.ImageService.CountImages:output_type -> v1.CountImagesResponse
+	2,  // 36: v1.ImageService.ListImages:output_type -> v1.ListImagesResponse
+	23, // 37: v1.ImageService.ScanImage:output_type -> storage.Image
+	6,  // 38: v1.ImageService.ScanImageInternal:output_type -> v1.ScanImageInternalResponse
+	6,  // 39: v1.ImageService.ScanImageInternalForAdmission:output_type -> v1.ScanImageInternalResponse
+	6,  // 40: v1.ImageService.GetImageVulnerabilitiesInternal:output_type -> v1.ScanImageInternalResponse
+	6,  // 41: v1.ImageService.EnrichLocalImageInternal:output_type -> v1.ScanImageInternalResponse
+	33, // 42: v1.ImageService.UpdateLocalScanStatusInternal:output_type -> v1.Empty
+	33, // 43: v1.ImageService.InvalidateScanAndRegistryCaches:output_type -> v1.Empty
+	11, // 44: v1.ImageService.DeleteImages:output_type -> v1.DeleteImagesResponse
+	13, // 45: v1.ImageService.WatchImage:output_type -> v1.WatchImageResponse
+	33, // 46: v1.ImageService.UnwatchImage:output_type -> v1.Empty
+	15, // 47: v1.ImageService.GetWatchedImages:output_type -> v1.GetWatchedImagesResponse
+	18, // 48: v1.ImageService.ExportImages:output_type -> v1.ExportImageResponse
+	34, // [34:49] is the sub-list for method output_type
+	19, // [19:34] is the sub-list for method input_type
 	19, // [19:19] is the sub-list for extension type_name
 	19, // [19:19] is the sub-list for extension extendee
 	0,  // [0:19] is the sub-list for field type_name

--- a/generated/api/v1/image_service_grpc.pb.go
+++ b/generated/api/v1/image_service_grpc.pb.go
@@ -25,6 +25,7 @@ const (
 	ImageService_ListImages_FullMethodName                      = "/v1.ImageService/ListImages"
 	ImageService_ScanImage_FullMethodName                       = "/v1.ImageService/ScanImage"
 	ImageService_ScanImageInternal_FullMethodName               = "/v1.ImageService/ScanImageInternal"
+	ImageService_ScanImageInternalForAdmission_FullMethodName   = "/v1.ImageService/ScanImageInternalForAdmission"
 	ImageService_GetImageVulnerabilitiesInternal_FullMethodName = "/v1.ImageService/GetImageVulnerabilitiesInternal"
 	ImageService_EnrichLocalImageInternal_FullMethodName        = "/v1.ImageService/EnrichLocalImageInternal"
 	ImageService_UpdateLocalScanStatusInternal_FullMethodName   = "/v1.ImageService/UpdateLocalScanStatusInternal"
@@ -52,6 +53,12 @@ type ImageServiceClient interface {
 	ScanImage(ctx context.Context, in *ScanImageRequest, opts ...grpc.CallOption) (*storage.Image, error)
 	// ScanImageInternal is used solely by the Sensor and Admission Controller to send scan requests
 	ScanImageInternal(ctx context.Context, in *ScanImageInternalRequest, opts ...grpc.CallOption) (*ScanImageInternalResponse, error)
+	// ScanImageInternalForAdmission is used solely by the Admission Controller
+	// (via Sensor or directly) to send scan requests. For tag-only images it
+	// refreshes registry metadata but reuses an existing Central scan when
+	// the resolved digest is already known. For digest-based images it
+	// behaves identically to ScanImageInternal.
+	ScanImageInternalForAdmission(ctx context.Context, in *ScanImageInternalRequest, opts ...grpc.CallOption) (*ScanImageInternalResponse, error)
 	// Deprecated: Do not use.
 	// Deprecated: GetImageVulnerabilities is used solely by the Sensor to send vulnerability matching requests.
 	GetImageVulnerabilitiesInternal(ctx context.Context, in *GetImageVulnerabilitiesInternalRequest, opts ...grpc.CallOption) (*ScanImageInternalResponse, error)
@@ -129,6 +136,16 @@ func (c *imageServiceClient) ScanImageInternal(ctx context.Context, in *ScanImag
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ScanImageInternalResponse)
 	err := c.cc.Invoke(ctx, ImageService_ScanImageInternal_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *imageServiceClient) ScanImageInternalForAdmission(ctx context.Context, in *ScanImageInternalRequest, opts ...grpc.CallOption) (*ScanImageInternalResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ScanImageInternalResponse)
+	err := c.cc.Invoke(ctx, ImageService_ScanImageInternalForAdmission_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -251,6 +268,12 @@ type ImageServiceServer interface {
 	ScanImage(context.Context, *ScanImageRequest) (*storage.Image, error)
 	// ScanImageInternal is used solely by the Sensor and Admission Controller to send scan requests
 	ScanImageInternal(context.Context, *ScanImageInternalRequest) (*ScanImageInternalResponse, error)
+	// ScanImageInternalForAdmission is used solely by the Admission Controller
+	// (via Sensor or directly) to send scan requests. For tag-only images it
+	// refreshes registry metadata but reuses an existing Central scan when
+	// the resolved digest is already known. For digest-based images it
+	// behaves identically to ScanImageInternal.
+	ScanImageInternalForAdmission(context.Context, *ScanImageInternalRequest) (*ScanImageInternalResponse, error)
 	// Deprecated: Do not use.
 	// Deprecated: GetImageVulnerabilities is used solely by the Sensor to send vulnerability matching requests.
 	GetImageVulnerabilitiesInternal(context.Context, *GetImageVulnerabilitiesInternalRequest) (*ScanImageInternalResponse, error)
@@ -297,6 +320,9 @@ func (UnimplementedImageServiceServer) ScanImage(context.Context, *ScanImageRequ
 }
 func (UnimplementedImageServiceServer) ScanImageInternal(context.Context, *ScanImageInternalRequest) (*ScanImageInternalResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ScanImageInternal not implemented")
+}
+func (UnimplementedImageServiceServer) ScanImageInternalForAdmission(context.Context, *ScanImageInternalRequest) (*ScanImageInternalResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ScanImageInternalForAdmission not implemented")
 }
 func (UnimplementedImageServiceServer) GetImageVulnerabilitiesInternal(context.Context, *GetImageVulnerabilitiesInternalRequest) (*ScanImageInternalResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetImageVulnerabilitiesInternal not implemented")
@@ -431,6 +457,24 @@ func _ImageService_ScanImageInternal_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ImageServiceServer).ScanImageInternal(ctx, req.(*ScanImageInternalRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ImageService_ScanImageInternalForAdmission_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ScanImageInternalRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ImageServiceServer).ScanImageInternalForAdmission(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ImageService_ScanImageInternalForAdmission_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ImageServiceServer).ScanImageInternalForAdmission(ctx, req.(*ScanImageInternalRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -616,6 +660,10 @@ var ImageService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ScanImageInternal",
 			Handler:    _ImageService_ScanImageInternal_Handler,
+		},
+		{
+			MethodName: "ScanImageInternalForAdmission",
+			Handler:    _ImageService_ScanImageInternalForAdmission_Handler,
 		},
 		{
 			MethodName: "GetImageVulnerabilitiesInternal",

--- a/proto/api/v1/image_service.proto
+++ b/proto/api/v1/image_service.proto
@@ -177,6 +177,13 @@ service ImageService {
   // ScanImageInternal is used solely by the Sensor and Admission Controller to send scan requests
   rpc ScanImageInternal(ScanImageInternalRequest) returns (ScanImageInternalResponse);
 
+  // ScanImageInternalForAdmission is used solely by the Admission Controller
+  // (via Sensor or directly) to send scan requests. For tag-only images it
+  // refreshes registry metadata but reuses an existing Central scan when
+  // the resolved digest is already known. For digest-based images it
+  // behaves identically to ScanImageInternal.
+  rpc ScanImageInternalForAdmission(ScanImageInternalRequest) returns (ScanImageInternalResponse);
+
   // Deprecated: GetImageVulnerabilities is used solely by the Sensor to send vulnerability matching requests.
   rpc GetImageVulnerabilitiesInternal(GetImageVulnerabilitiesInternalRequest) returns (ScanImageInternalResponse) {
     option deprecated = true;

--- a/roxctl/central/export/images/images_test.go
+++ b/roxctl/central/export/images/images_test.go
@@ -88,6 +88,10 @@ func (s *fakeImageService) ScanImageInternal(_ context.Context, _ *v1.ScanImageI
 	return nil, errox.NotImplemented
 }
 
+func (s *fakeImageService) ScanImageInternalForAdmission(_ context.Context, _ *v1.ScanImageInternalRequest) (*v1.ScanImageInternalResponse, error) {
+	return nil, errox.NotImplemented
+}
+
 func (s *fakeImageService) ScanImage(_ context.Context, _ *v1.ScanImageRequest) (*storage.Image, error) {
 	return nil, errox.NotImplemented
 }


### PR DESCRIPTION
## Description

Add a new internal gRPC RPC `ScanImageInternalForAdmission` to `ImageService`. This RPC is used exclusively by the Admission Controller (via Sensor or directly) for image scan requests.

For tag-only images, it uses `ForceRefetchMetadataOnly` to refresh the tag-to-digest mapping from the registry while reusing existing scan data from Central's DB -- avoiding a redundant Scanner round-trip when the digest is
already scanned.

For digest-based images, it behaves identically to `ScanImageInternal` (unchanged).

Changes:
- Proto: new `ScanImageInternalForAdmission` RPC reusing existing request/response types
- Central: refactored `ScanImageInternal` into shared `scanImageInternalWithOpt` helper; new RPC delegates with `ForceRefetchMetadataOnly` for tag-only requests
- Authz: new RPC authorized under `SensorOr(AdmissionControlOnly())`
- Unit tests: `FetchOpt` verification and digest-parity invariant tests

The existing `ScanImageInternal` path is unchanged in behavior.

**Stack**: PR 2 of 4 -- depends on [#22286](https://github.com/stackrox/stackrox/pull/22286).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests verify correct `FetchOption` selection for tag-only vs digest requests
- Digest-parity invariant test confirms identical behavior to `ScanImageInternal` for digest-based requests
- `ScanImageInternal` behavior verified unchanged
