### PR TITLE
ROX-36423: Wire admission control to new scan reuse RPC

### DIFF
--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -125,7 +125,7 @@ func (m *manager) getImageFromSensorOrCentral(ctx context.Context, s *state, img
 	// Note: Sensor is required to scan images in the local registry.
 	if !m.sensorConnStatus.Get() && s.centralConn != nil && s.centralConn.GetState() != connectivity.Shutdown {
 		start := time.Now()
-		resp, err := v1.NewImageServiceClient(s.centralConn).ScanImageInternal(ctx, &v1.ScanImageInternalRequest{
+		resp, err := v1.NewImageServiceClient(s.centralConn).ScanImageInternalForAdmission(ctx, &v1.ScanImageInternalRequest{
 			Image:      img,
 			CachedOnly: !s.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline(),
 		})

--- a/sensor/common/image/interfaces.go
+++ b/sensor/common/image/interfaces.go
@@ -20,6 +20,7 @@ type registryStore interface {
 
 type centralClient interface {
 	ScanImageInternal(context.Context, *v1.ScanImageInternalRequest, ...grpc.CallOption) (*v1.ScanImageInternalResponse, error)
+	ScanImageInternalForAdmission(context.Context, *v1.ScanImageInternalRequest, ...grpc.CallOption) (*v1.ScanImageInternalResponse, error)
 	EnrichLocalImageInternal(context.Context, *v1.EnrichLocalImageInternalRequest, ...grpc.CallOption) (*v1.ScanImageInternalResponse, error)
 }
 

--- a/sensor/common/image/mocks/interfaces.go
+++ b/sensor/common/image/mocks/interfaces.go
@@ -167,6 +167,26 @@ func (mr *MockcentralClientMockRecorder) ScanImageInternal(arg0, arg1 any, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanImageInternal", reflect.TypeOf((*MockcentralClient)(nil).ScanImageInternal), varargs...)
 }
 
+// ScanImageInternalForAdmission mocks base method.
+func (m *MockcentralClient) ScanImageInternalForAdmission(arg0 context.Context, arg1 *v1.ScanImageInternalRequest, arg2 ...grpc.CallOption) (*v1.ScanImageInternalResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ScanImageInternalForAdmission", varargs...)
+	ret0, _ := ret[0].(*v1.ScanImageInternalResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ScanImageInternalForAdmission indicates an expected call of ScanImageInternalForAdmission.
+func (mr *MockcentralClientMockRecorder) ScanImageInternalForAdmission(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanImageInternalForAdmission", reflect.TypeOf((*MockcentralClient)(nil).ScanImageInternalForAdmission), varargs...)
+}
+
 // MocklocalScan is a mock of localScan interface.
 type MocklocalScan struct {
 	ctrl     *gomock.Controller

--- a/sensor/common/image/service_impl.go
+++ b/sensor/common/image/service_impl.go
@@ -110,7 +110,7 @@ func (s *serviceImpl) GetImage(ctx context.Context, req *sensor.GetImageRequest)
 
 	// Ask Central to scan the image if the image is neither internal nor local
 	if !req.GetImage().GetIsClusterLocal() {
-		scanResp, err := s.centralClient.ScanImageInternal(ctx, &v1.ScanImageInternalRequest{
+		scanResp, err := s.centralClient.ScanImageInternalForAdmission(ctx, &v1.ScanImageInternalRequest{
 			Image:      req.GetImage(),
 			CachedOnly: !req.GetScanInline(),
 		})

--- a/sensor/common/image/service_impl_test.go
+++ b/sensor/common/image/service_impl_test.go
@@ -171,7 +171,7 @@ func expectRegistryHelper(mockRegistryStore *imageMocks.MockregistryStore, times
 
 func expectCentralCall(mockCentral *imageMocks.MockcentralClient, times int, retValue *v1.ScanImageInternalResponse, retErr error) expectFn {
 	return func() {
-		mockCentral.EXPECT().ScanImageInternal(gomock.Any(), gomock.Any()).Times(times).
+		mockCentral.EXPECT().ScanImageInternalForAdmission(gomock.Any(), gomock.Any()).Times(times).
 			Return(retValue, retErr)
 	}
 }


### PR DESCRIPTION
## Description

Wire Sensor (only the admission controller path) and Admission Controller callers to use the new `ScanImageInternalForAdmission` RPC instead of `ScanImageInternal`.

Changes:
- `sensor/common/image/service_impl.go`: Sensor proxy calls `ScanImageInternalForAdmission` for AC image requests
- `sensor/admission-control/manager/images.go`: AC direct-to-Central fallback calls `ScanImageInternalForAdmission`
- `sensor/common/image/interfaces.go`: `centralClient` interface updated
- Mock regenerated, existing test updated to expect new RPC

The existing `ScanImageInternal` path remains available for non-AC callers and is unchanged in behavior.

**Stack**: PR 3 of 4 -- depends on [#22287](https://github.com/stackrox/stackrox/pull/22287).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Existing Sensor image service tests updated to expect `ScanImageInternalForAdmission` and pass
- AC direct-to-Central path updated; no new tests needed (existing AC manager tests cover the call path)
