### PR TITLE
ROX-36424: Add prescan-slow-path burst test mode

### DIFF
--- a/tools/admission-control/README.md
+++ b/tools/admission-control/README.md
@@ -7,7 +7,8 @@ Central around image cache and reprocessor ("reassess all") workflows.
 
 - Kubernetes/OpenShift cluster with StackRox deployed
 - `admissionControl.enforcement` enabled in the SecuredCluster CR
-- `spec.monitoring.exposeEndpoint: Enabled` in the SecuredCluster CR
+- `spec.monitoring.exposeEndpoint: Enabled` on **both** the SecuredCluster and Central CRs
+  (AC metrics for all modes; Central metrics required for `prescan-slow-path`)
 
 ## Common Environment Variables
 
@@ -49,6 +50,58 @@ All scripts follow the same pattern:
 3. Run again, save output
 4. `diff` the two outputs (or use `go tool pprof -diff_base` for profiles)
 
+### Example: prescan-slow-path comparison
+
+This workflow proves whether Central skips Scanner `GetScan` for tag-only
+admission after a Central pre-scan (`ScanImageInternalForAdmission`).
+
+**Policy (required):** enable **90-Day Image Age**, Deploy lifecycle, **Fail**
+on admission. Spec-only policies (Privileged Container, Latest tag) will not
+fetch images and the run is invalid.
+
+**Why these flags:** `UNIQUE_PCT=100` and `PARALLEL=1` make every review a
+Central fetch of a distinct pre-scanned tag. Cache hits and coalescing no
+longer move the averages. Failed prescans are dropped from the burst so the
+PR cannot pick up extra Scanner calls for uncached tags.
+
+Scrape happens **after** prescan so `scan_duration_count` from
+`POST /v1/images/scan` is not counted in the burst delta.
+
+```bash
+# 1. Deploy master image. Enforce 90-Day Image Age (Fail on admission).
+ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=<host:port> \
+  BURST_SIZE=20 UNIQUE_PCT=100 PARALLEL=1 \
+  ./tools/admission-control/burst-test.sh prescan-slow-path \
+  | tee /tmp/prescan-master.txt
+
+# 2. Redeploy Central + Sensor with PR branch image
+#    (AC pods will be restarted by the script itself).
+#    Re-export ROX_PASSWORD if the redeploy minted a new one.
+
+# 3. Run again on PR branch
+ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=<host:port> \
+  BURST_SIZE=20 UNIQUE_PCT=100 PARALLEL=1 \
+  ./tools/admission-control/burst-test.sh prescan-slow-path \
+  | tee /tmp/prescan-pr.txt
+
+# 4. Compare
+diff -y /tmp/prescan-master.txt /tmp/prescan-pr.txt
+```
+
+Pass bar (both runs must have `image_fetch_total` ≈ unique images):
+
+| Metric | Master | PR branch |
+|--------|--------|-----------|
+| `scan_duration_count` (Central) | ≈ unique images | **~0** |
+| `image_fetch_duration (avg)` | metadata + GetScan | metadata only (lower) |
+| `image_fetch_total` | ≈ unique | ≈ unique |
+| `review_duration_seconds (avg)` | ignore | ignore (diluted by hits) |
+
+`scan_duration_count` is the Scanner-trip proof. Fetch duration is supporting
+latency. Do not treat `review_duration_seconds` as a Scanner proxy: after
+prescan, Scanner's index is warm so GetScan can be cheap, and review avg mixes
+in cache hits.
+
 ---
 
 ### `burst-test.sh`
@@ -60,6 +113,7 @@ Run with `-h` for all options.
 |------|---------------|-------------------|
 | `fast-path` | Spec-only evaluation (no image fetching) | Privileged Container, Latest tag |
 | `slow-path` | Image coalescing + caching (enrichment) | Any enrichment-required (e.g. Image Age) |
+| `prescan-slow-path` | Scan reuse for pre-scanned tag-only images | Any enrichment-required (e.g. Image Age) |
 
 Slow-path runs two phases automatically: **cold cache** (pods restarted) then
 **warm cache** (immediate re-burst).
@@ -77,6 +131,31 @@ IMAGES_FILE=/tmp/my-images.txt BURST_SIZE=500 UNIQUE_PCT=50 ./burst-test.sh slow
 # Create persistent deployments (replicas=0) for reprocessor profiling
 BURST_SIZE=1000 UNIQUE_PCT=60 ./burst-test.sh slow-path --no-dry-run
 ```
+
+**Prescan-slow-path** pre-scans unique images via Central's `POST /v1/images/scan`
+API (warming the DB), drops failures, restarts AC (not Scanner), then bursts
+**one tag-only deployment per successful prescan**. Central `scan_duration_count`
+during the burst is the Scanner-trip proof; AC `image_fetch_duration_seconds`
+is the latency proof.
+
+```bash
+# Prescan + one-fetch-per-unique-image burst
+ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=<host:port> \
+  BURST_SIZE=20 UNIQUE_PCT=100 PARALLEL=1 PRESCAN_PARALLEL=5 \
+  ./tools/admission-control/burst-test.sh prescan-slow-path
+```
+
+Requires **90-Day Image Age** (or another enrichment-required policy) enabled
+with **Fail on admission**. `UNIQUE_PCT` is forced to 100.
+
+Additional environment variables for `prescan-slow-path`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ROX_CENTRAL_ADDRESS` | *(required)* | Central host:port |
+| `ROX_PASSWORD` | *(required)* | Central admin password |
+| `ROX_ADMIN_USER` | `admin` | Central admin username |
+| `PRESCAN_PARALLEL` | `5` | Max concurrent prescan API calls |
 
 ---
 

--- a/tools/admission-control/bench-reassess.sh
+++ b/tools/admission-control/bench-reassess.sh
@@ -79,7 +79,7 @@ read_metric() {
 
 # metric_delta <phase_a> <phase_b> <component-short> <metric> [labels]
 metric_delta() {
-    echo "$(read_metric "$2" "$3" "$4" "${5:-}") - $(read_metric "$1" "$3" "$4" "${5:-}")" | bc
+    delta "$(read_metric "$1" "$3" "$4" "${5:-}")" "$(read_metric "$2" "$3" "$4" "${5:-}")"
 }
 
 # trigger_and_wait_for_reprocessor is now in lib.sh

--- a/tools/admission-control/burst-test.sh
+++ b/tools/admission-control/burst-test.sh
@@ -5,12 +5,18 @@
 # a live cluster, scrapes admission controller Prometheus metrics before and
 # after, and reports deltas.
 #
-# Two modes:
-#   fast-path  - Tests spec-only policy evaluation (no image fetching).
-#                Requires: Privileged Container + Latest tag policies enforced.
-#   slow-path  - Tests image coalescing and caching in the enrichment path.
-#                Runs two phases (cold cache, then warm cache).
-#                Requires: at least one enrichment-required policy (e.g. Image Age).
+# Three modes:
+#   fast-path          - Tests spec-only policy evaluation (no image fetching).
+#                        Requires: Privileged Container + Latest tag policies enforced.
+#   slow-path          - Tests image coalescing and caching in the enrichment path.
+#                        Runs two phases (cold cache, then warm cache).
+#                        Requires: at least one enrichment-required policy (e.g. Image Age).
+#   prescan-slow-path  - Pre-scans unique images via Central API, then bursts
+#                        one tag-only deployment per pre-scanned image.
+#                        Proves Scanner skip via Central scan_duration_count
+#                        and fetch latency via AC image_fetch_duration_seconds.
+#                        Run on master vs PR branch to compare.
+#                        Requires: ROX_CENTRAL_ADDRESS, ROX_PASSWORD, enrichment policy.
 #
 # See README.md for full prerequisites and cross-branch comparison workflow.
 set -euo pipefail
@@ -37,6 +43,8 @@ export DRY_RUN
 : "${METRICS_PORT:=9090}"
 : "${LOCAL_PORT:=9090}"
 : "${PARALLEL:=50}"
+: "${PRESCAN_PARALLEL:=5}"
+: "${ROX_ADMIN_USER:=admin}"
 
 WORK_DIR=$(mktemp -d)
 
@@ -48,11 +56,18 @@ usage() {
 Usage: ./burst-test.sh <mode> [options]
 
 Modes:
-  fast-path    Test spec-only policy evaluation (no image fetching).
-               Requires: Privileged Container + Latest tag policies enforced.
-  slow-path    Test image coalescing and caching in the enrichment path.
-               Runs two phases: cold cache (pods restarted) then warm cache.
-               Requires: at least one enrichment-required policy (e.g. Image Age).
+  fast-path           Test spec-only policy evaluation (no image fetching).
+                      Requires: Privileged Container + Latest tag policies enforced.
+  slow-path           Test image coalescing and caching in the enrichment path.
+                      Runs two phases: cold cache (pods restarted) then warm cache.
+                      Requires: at least one enrichment-required policy (e.g. Image Age).
+  prescan-slow-path   Pre-scan unique images via Central API, restart AC, then
+                      burst one tag-only deployment per pre-scanned image.
+                      PRIMARY: Central scan_duration_count (Scanner GetScan calls).
+                      SECONDARY: AC image_fetch_duration_seconds (per-fetch latency).
+                      Forces UNIQUE_PCT=100. Use PARALLEL=1 for a clean comparison.
+                      Requires: ROX_CENTRAL_ADDRESS, ROX_PASSWORD, enrichment policy
+                      (e.g. 90-Day Image Age with Fail on admission).
 
 Options:
   --no-dry-run Apply deployments for real (replicas=0). Useful for creating
@@ -60,18 +75,23 @@ Options:
   -h, --help   Show this help message.
 
 Environment variables:
-  BURST_SIZE       Number of deployments to create           (default: 500)
-  VIOLATION_PCT    % that violate policy (fast-path only)    (default: 50)
-  UNIQUE_PCT       % of BURST_SIZE used as distinct images   (default: 25)
-                   Unique count = BURST_SIZE * UNIQUE_PCT / 100.
-  IMAGES_FILE      Path to a file with one image per line.
-                   Overrides automatic pool generation.
-  NAMESPACE        Namespace for test deployments            (default: burst-test)
-  IMAGES           Comma-separated images (fast-path only)   (default: quay.io/centos/centos:7,...)
-  ROX_NAMESPACE    StackRox namespace                        (default: stackrox)
-  METRICS_PORT     Admission controller metrics port         (default: 9090)
-  LOCAL_PORT       Local port for kubectl port-forward       (default: 9090)
-  PARALLEL         Max concurrent kubectl creates            (default: 50)
+  BURST_SIZE         Number of deployments to create           (default: 500)
+  VIOLATION_PCT      % that violate policy (fast-path only)    (default: 50)
+  UNIQUE_PCT         % of BURST_SIZE used as distinct images   (default: 25)
+                     Unique count = BURST_SIZE * UNIQUE_PCT / 100.
+  IMAGES_FILE        Path to a file with one image per line.
+                     Overrides automatic pool generation.
+  NAMESPACE          Namespace for test deployments            (default: burst-test)
+  IMAGES             Comma-separated images (fast-path only)   (default: quay.io/centos/centos:7,...)
+  ROX_NAMESPACE      StackRox namespace                        (default: stackrox)
+  METRICS_PORT       Admission controller metrics port         (default: 9090)
+  LOCAL_PORT         Local port for kubectl port-forward       (default: 9090)
+  PARALLEL           Max concurrent kubectl creates            (default: 50;
+                     prescan-slow-path: use 1)
+  PRESCAN_PARALLEL   Max concurrent prescan API calls          (default: 5)
+  ROX_CENTRAL_ADDRESS  Central host:port (prescan-slow-path)
+  ROX_PASSWORD         Central admin password (prescan-slow-path)
+  ROX_ADMIN_USER       Central admin username                  (default: admin)
 
 fast-path mode:
   Violating deployments use privileged: true + :latest tags.
@@ -85,6 +105,17 @@ slow-path mode:
   Phase 2 reuses warm caches from phase 1.
   Reports coalesce ratio, cache hit rate, and fetch counts.
   With --no-dry-run, deployments are created with replicas=0.
+
+prescan-slow-path mode:
+  Forces UNIQUE_PCT=100 (one unique tag-only image per review). Failed
+  prescans are dropped so the burst only uses images stored in Central.
+  Restarts AC (not Scanner), then scrapes Central AND AC metrics AFTER
+  prescan and BEFORE the burst so prescan GetScan calls are excluded.
+  PRIMARY proof: rox_central_scan_duration_count delta (~unique on master,
+  ~0 on PR). SECONDARY: AC image_fetch_duration_seconds avg.
+  Do not use review_duration_seconds — cache hits dilute it.
+  Recommended: BURST_SIZE=20 PARALLEL=1
+  Requires 90-Day Image Age (or similar) with Fail on admission.
 EOF
     exit 0
 }
@@ -93,10 +124,22 @@ if [[ "${MODE}" == "-h" || "${MODE}" == "--help" ]]; then
     usage
 fi
 
-if [[ "${MODE}" != "fast-path" && "${MODE}" != "slow-path" ]]; then
-    echo "ERROR: mode must be 'fast-path' or 'slow-path'" >&2
+if [[ "${MODE}" != "fast-path" && "${MODE}" != "slow-path" && "${MODE}" != "prescan-slow-path" ]]; then
+    echo "ERROR: mode must be 'fast-path', 'slow-path', or 'prescan-slow-path'" >&2
     echo "Run with -h for usage." >&2
     exit 1
+fi
+
+if [[ "${MODE}" == "prescan-slow-path" ]]; then
+    : "${ROX_CENTRAL_ADDRESS:?ROX_CENTRAL_ADDRESS must be set for prescan-slow-path}"
+    : "${ROX_PASSWORD:?ROX_PASSWORD must be set for prescan-slow-path}"
+    if [[ "$UNIQUE_PCT" != "100" ]]; then
+        echo "NOTE: prescan-slow-path forces UNIQUE_PCT=100 (one unique image per review)."
+        UNIQUE_PCT=100
+    fi
+    if [[ "$PARALLEL" -gt 1 ]]; then
+        echo "WARN: PARALLEL=${PARALLEL}. Use PARALLEL=1 so fetch/hit mix does not move averages."
+    fi
 fi
 
 for cmd in kubectl curl bc awk; do
@@ -104,6 +147,7 @@ for cmd in kubectl curl bc awk; do
 done
 
 readonly METRICS_NETPOL="admission-control-metrics-allow"
+readonly CENTRAL_METRICS_NETPOL="central-metrics-allow"
 trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
@@ -114,12 +158,18 @@ cleanup() {
     kill_port_forwards
     kubectl -n "$ROX_NAMESPACE" delete networkpolicy "$METRICS_NETPOL" \
         --ignore-not-found &>/dev/null || true
+    kubectl -n "$ROX_NAMESPACE" delete networkpolicy "$CENTRAL_METRICS_NETPOL" \
+        --ignore-not-found &>/dev/null || true
     kubectl delete namespace "$NAMESPACE" --ignore-not-found &>/dev/null || true
     [[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"
 }
 
 allow_metrics_ingress() {
     allow_metrics_netpol "$METRICS_NETPOL" "admission-control"
+}
+
+allow_central_metrics_ingress() {
+    allow_metrics_netpol "$CENTRAL_METRICS_NETPOL" "central"
 }
 
 restart_admission_control() {
@@ -147,6 +197,18 @@ restart_admission_control() {
 
 scrape_metrics() {
     scrape_component "admission-control" "$LOCAL_PORT" "$1"
+}
+
+scrape_central_metrics() {
+    scrape_component "central" "$LOCAL_PORT" "$1"
+}
+
+# scrape_prescan_pair <ac-outfile> <central-outfile>
+#   Sequential scrapes (same LOCAL_PORT). Must run AFTER prescan so Central
+#   scan_duration from POST /v1/images/scan is in the baseline.
+scrape_prescan_pair() {
+    scrape_metrics "$1"
+    scrape_central_metrics "$2"
 }
 
 # Backward-compatible wrapper used by reports.
@@ -344,6 +406,101 @@ EOF
     echo ""
 }
 
+report_prescan_slow_path() {
+    local ac_before="$1" ac_after="$2" central_before="$3" central_after="$4"
+    local prescan_ok="$5" prescan_fail="$6"
+    compute_common_deltas "$ac_before" "$ac_after"
+
+    local review_total
+    review_total=$(echo "${DENIED_D} + ${ALLOWED_D}" | bc)
+
+    local scan_count_d scan_sum_d scan_avg_ms
+    scan_count_d=$(delta \
+        "$(extract "$central_before" "rox_central_scan_duration_count")" \
+        "$(extract "$central_after"  "rox_central_scan_duration_count")")
+    scan_sum_d=$(delta \
+        "$(extract "$central_before" "rox_central_scan_duration_sum")" \
+        "$(extract "$central_after"  "rox_central_scan_duration_sum")")
+    scan_avg_ms=$(avg_or_na "$scan_sum_d" "$scan_count_d")
+
+    local fetch_dur_count_d fetch_dur_sum_d fetch_dur_avg
+    fetch_dur_count_d=$(delta \
+        "$(extract "$ac_before" "rox_admission_control_image_fetch_duration_seconds_count")" \
+        "$(extract "$ac_after"  "rox_admission_control_image_fetch_duration_seconds_count")")
+    fetch_dur_sum_d=$(delta \
+        "$(extract "$ac_before" "rox_admission_control_image_fetch_duration_seconds_sum")" \
+        "$(extract "$ac_after"  "rox_admission_control_image_fetch_duration_seconds_sum")")
+    fetch_dur_avg=$(avg_or_na "$fetch_dur_sum_d" "$fetch_dur_count_d")
+
+    cat <<EOF
+
+================================================
+  PRESCAN SLOW-PATH BURST TEST REPORT
+================================================
+  Burst size:        ${BURST_SIZE}
+  Unique images:     ${UNIQUE_COUNT} (of ${POOL_SIZE} in pool)
+  Pre-scanned OK:    ${prescan_ok}
+  Pre-scanned FAIL:  ${prescan_fail}
+  Total img refs:    ${TOTAL_IMAGE_REFS}
+================================================
+
+EOF
+    printf "  %-42s %s\n" "Metric" "Delta"
+    printf "  %-42s %s\n" "------" "-----"
+    printf "  %-42s %s\n" "scan_duration_count (Central)"    "$scan_count_d"
+    printf "  %-42s %s\n" "scan_duration avg (Central, ms)"  "${scan_avg_ms}"
+    printf "  %-42s %s\n" "image_fetch_total"                "$FETCH_D"
+    printf "  %-42s %s\n" "image_fetch_duration (avg, s)"    "$fetch_dur_avg"
+    printf "  %-42s %s\n" "image_fetches_per_review (avg)"   "$FPR_AVG"
+    printf "  %-42s %s\n" "policyeval_review_total{denied}"  "$DENIED_D"
+    printf "  %-42s %s\n" "policyeval_review_total{allowed}" "$ALLOWED_D"
+    printf "  %-42s %s\n" "image_cache_operations{hit}"      "$HIT_D"
+    printf "  %-42s %s\n" "image_cache_operations{miss}"     "$MISS_D"
+    printf "  %-42s %s\n" "image_cache_operations{skip}"     "$SKIP_D"
+    printf "  %-42s %s\n" "reviews completed"                "$review_total"
+    printf "  %-42s %s\n" "review_duration_seconds (avg)"    "${DUR_AVG}s"
+    echo ""
+
+    cat <<EOF
+  PRIMARY:  scan_duration_count = ${scan_count_d}
+            Master: ~unique images (Scanner GetScan called).
+            PR:     ~0 (existing Central scan reused).
+  SECONDARY: image_fetch_duration avg = ${fetch_dur_avg}s
+            Per GetImage/Central RPC (cache hits excluded).
+            PR should be lower (metadata only vs metadata+GetScan).
+  Do not use review_duration_seconds (${DUR_AVG}s) as proof — it averages
+  in cache hits and is not a Scanner proxy.
+
+EOF
+
+    if awk -v n="$scan_count_d" 'BEGIN{exit !(n+0 > 0)}'; then
+        echo "  Scanner GetScan was invoked ${scan_count_d} times during the burst."
+        echo "  Expected on master; unexpected on PR if prescan succeeded."
+    else
+        echo "  Scanner GetScan was NOT invoked during the burst."
+        echo "  Expected on PR; unexpected on master."
+    fi
+    echo ""
+
+    local pass=true
+    if [[ "$prescan_fail" -gt 0 ]]; then
+        echo "  WARN: ${prescan_fail} images failed to pre-scan and were dropped from the burst."
+    fi
+    if [[ "$FETCH_D" -eq 0 ]]; then
+        echo "  FAIL: image_fetch_total delta is 0. Enforce an enrichment-required policy"
+        echo "        (90-Day Image Age, Fail on admission) and retry."
+        pass=false
+    fi
+    if [[ "$review_total" -ne "$BURST_SIZE" ]]; then
+        echo "  FAIL: expected ${BURST_SIZE} reviews, got ${review_total}"
+        pass=false
+    fi
+    if $pass; then
+        echo "  PASS: ${review_total} reviews, ${FETCH_D} fetches, scan_duration_count=${scan_count_d}"
+    fi
+    echo ""
+}
+
 # ---------------------------------------------------------------------------
 # Main flow
 # ---------------------------------------------------------------------------
@@ -464,4 +621,62 @@ EOF
 
     report_slow_path_phase "PHASE 2: WARM CACHE" \
         "${WORK_DIR}/warm_before.prom" "${WORK_DIR}/warm_after.prom"
+
+elif [[ "$MODE" == "prescan-slow-path" ]]; then
+    allow_central_metrics_ingress
+
+    UNIQUE_COUNT=$BURST_SIZE
+    [[ "$UNIQUE_COUNT" -lt 1 ]] && UNIQUE_COUNT=1
+    load_image_pool "$UNIQUE_COUNT"
+
+    cat <<EOF
+
+==============================================
+  PRESCAN SLOW-PATH BURST TEST
+==============================================
+  Burst size:        ${BURST_SIZE} (1:1 unique after successful prescan)
+  Unique pct:        ${UNIQUE_PCT}% (forced)
+  Unique images:     ${UNIQUE_COUNT} (of ${POOL_SIZE} in pool)
+  Parallel:          ${PARALLEL}
+  Prescan parallel:  ${PRESCAN_PARALLEL}
+  Central:           ${ROX_CENTRAL_ADDRESS}
+==============================================
+EOF
+
+    # --- Phase 1: Pre-scan unique images via Central API ---
+    echo ""
+    echo "=== Phase 1: Pre-scanning ${UNIQUE_COUNT} images via Central API ==="
+    prescan_pool "$PRESCAN_PARALLEL"
+
+    PRESCAN_OK=$(grep -c "^ok " "${WORK_DIR}/prescan.log" 2>/dev/null || true)
+    PRESCAN_FAIL=$(grep -c "^fail " "${WORK_DIR}/prescan.log" 2>/dev/null || true)
+
+    filter_pool_to_prescan_success
+    write_slow_path_manifests
+    TOTAL_IMAGE_REFS=$BURST_SIZE
+
+    # --- Phase 2: Cold-cache burst (Central scrape AFTER prescan) ---
+    echo ""
+    echo "=== Phase 2: Restart AC (cold cache) + burst ==="
+    restart_admission_control
+
+    echo "Scraping baseline AC + Central metrics (post-prescan)..."
+    scrape_prescan_pair \
+        "${WORK_DIR}/prescan_before.prom" \
+        "${WORK_DIR}/prescan_central_before.prom"
+
+    run_burst "Prescan burst (cold cache)"
+
+    echo "Waiting for metrics to settle..."
+    sleep 10
+
+    echo "Scraping post-burst AC + Central metrics..."
+    scrape_prescan_pair \
+        "${WORK_DIR}/prescan_after.prom" \
+        "${WORK_DIR}/prescan_central_after.prom"
+
+    report_prescan_slow_path \
+        "${WORK_DIR}/prescan_before.prom" "${WORK_DIR}/prescan_after.prom" \
+        "${WORK_DIR}/prescan_central_before.prom" "${WORK_DIR}/prescan_central_after.prom" \
+        "$PRESCAN_OK" "$PRESCAN_FAIL"
 fi

--- a/tools/admission-control/lib.sh
+++ b/tools/admission-control/lib.sh
@@ -155,6 +155,18 @@ scrape_component() {
 # Metric math
 # ---------------------------------------------------------------------------
 
+# Print n in fixed-point form. awk's default OFMT (%.6g) emits 1.23e+06 for
+# values >= 1e6, and bc cannot parse the '+' ("Parse error: bad character '+'").
+_awk_fmt='
+function fmt(n) {
+    x = sprintf("%.6f", n+0)
+    sub(/0+$/, "", x)
+    sub(/\.$/, "", x)
+    if (x == "" || x == "-" || x == "-0") x = "0"
+    return x
+}
+'
+
 # Sum a Prometheus counter/gauge across all lines matching metric + optional labels.
 extract() {
     local file="$1" metric="$2" labels="${3:-}"
@@ -164,31 +176,29 @@ extract() {
     fi
     if [[ -n "$labels" ]]; then
         { grep "^${metric}[{ ]" "$file" 2>/dev/null | grep "$labels" || true; } \
-            | awk '{s+=$NF} END{print s+0}'
+            | awk "${_awk_fmt}"'{s+=$NF} END{print fmt(s)}'
     else
         { grep "^${metric}[{ ]" "$file" 2>/dev/null || true; } \
-            | awk '{s+=$NF} END{print s+0}'
+            | awk "${_awk_fmt}"'{s+=$NF} END{print fmt(s)}'
     fi
 }
 
-delta() { echo "$2 - $1" | bc; }
+delta() {
+    awk -v a="$1" -v b="$2" "${_awk_fmt}"'BEGIN{print fmt(b-a)}'
+}
 
 avg_or_na() {
-    local sum_d="$1" count_d="$2"
-    if (( $(echo "$count_d > 0" | bc -l) )); then
-        echo "scale=4; $sum_d / $count_d" | bc
-    else
-        echo "N/A"
-    fi
+    awk -v s="$1" -v c="$2" 'BEGIN{
+        if (c+0 > 0) printf "%.4f\n", s/c
+        else print "N/A"
+    }'
 }
 
 pct_or_na() {
-    local numerator="$1" denominator="$2"
-    if (( $(echo "$denominator > 0" | bc -l) )); then
-        echo "scale=1; $numerator * 100 / $denominator" | bc
-    else
-        echo "N/A"
-    fi
+    awk -v n="$1" -v d="$2" 'BEGIN{
+        if (d+0 > 0) printf "%.1f\n", n*100/d
+        else print "N/A"
+    }'
 }
 
 row() { printf "  %-50s %s\n" "$1" "$2"; }
@@ -244,18 +254,23 @@ YAML
     } > "$outfile"
 }
 
-generate_slow_path_manifests() {
-    UNIQUE_COUNT=$(( BURST_SIZE * UNIQUE_PCT / 100 ))
-    [[ "$UNIQUE_COUNT" -lt 1 ]] && UNIQUE_COUNT=1
-
-    load_image_pool "$UNIQUE_COUNT"
-
+# write_slow_path_manifests writes BURST_SIZE deployments from SCANNABLE_POOL.
+# Requires: BURST_SIZE, UNIQUE_COUNT, SCANNABLE_POOL, WORK_DIR, NAMESPACE
+write_slow_path_manifests() {
     for (( i = 0; i < BURST_SIZE; i++ )); do
         generate_slow_path_deployment "burst-${i}" \
             "${WORK_DIR}/deploy-${i}.yaml" \
             "${SCANNABLE_POOL[$(( i % UNIQUE_COUNT ))]}"
     done
     echo "  Generated ${BURST_SIZE} manifests (${UNIQUE_COUNT} unique images)."
+}
+
+generate_slow_path_manifests() {
+    UNIQUE_COUNT=$(( BURST_SIZE * UNIQUE_PCT / 100 ))
+    [[ "$UNIQUE_COUNT" -lt 1 ]] && UNIQUE_COUNT=1
+
+    load_image_pool "$UNIQUE_COUNT"
+    write_slow_path_manifests
 }
 
 # ---------------------------------------------------------------------------
@@ -322,6 +337,87 @@ trigger_and_wait_for_reprocessor() {
 
     kill "$log_pid" 2>/dev/null || true
     wait "$log_pid" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Pre-scan helpers (warm Central DB via REST API)
+# ---------------------------------------------------------------------------
+
+# prescan_image <image-ref>
+#   Triggers a ScanImage request to Central to populate scan data in the DB.
+#   Requires: ROX_CENTRAL_ADDRESS, ROX_ADMIN_USER, ROX_PASSWORD
+# Prints the HTTP status code on stdout. Returns 0 only for HTTP 200.
+prescan_image() {
+    local image="$1"
+    local http_code
+    http_code=$(curl -sk -o /dev/null -w '%{http_code}' \
+        -u "${ROX_ADMIN_USER}:${ROX_PASSWORD}" \
+        --max-time 120 \
+        -X POST "https://${ROX_CENTRAL_ADDRESS}/v1/images/scan" \
+        -H "Content-Type: application/json" \
+        -d "{\"image_name\": \"${image}\", \"force\": true}")
+    echo "$http_code"
+    [[ "$http_code" == "200" ]]
+}
+
+# prescan_pool <parallel>
+#   Pre-scans SCANNABLE_POOL[0..UNIQUE_COUNT-1] via Central's ScanImage API.
+#   Requires: ROX_CENTRAL_ADDRESS, ROX_ADMIN_USER, ROX_PASSWORD,
+#             SCANNABLE_POOL, UNIQUE_COUNT
+prescan_pool() {
+    local parallel="${1:-5}"
+    local completed=0 failed=0
+    local pids=()
+
+    for (( i = 0; i < UNIQUE_COUNT; i++ )); do
+        local img="${SCANNABLE_POOL[$i]}"
+        (
+            if code=$(prescan_image "$img"); then
+                echo "ok ${img}"
+            else
+                echo "fail ${img} http=${code}"
+            fi
+        ) >> "${WORK_DIR}/prescan.log" &
+        pids+=($!)
+
+        if [[ "${#pids[@]}" -ge "$parallel" ]]; then
+            wait "${pids[@]}" 2>/dev/null || true
+            pids=()
+        fi
+    done
+    if [[ "${#pids[@]}" -gt 0 ]]; then
+        wait "${pids[@]}" 2>/dev/null || true
+    fi
+
+    completed=$(grep -c "^ok " "${WORK_DIR}/prescan.log" 2>/dev/null || true)
+    failed=$(grep -c "^fail " "${WORK_DIR}/prescan.log" 2>/dev/null || true)
+    echo "  Pre-scan complete: ${completed} succeeded, ${failed} failed (of ${UNIQUE_COUNT})."
+
+    if [[ "$failed" -gt 0 ]]; then
+        echo "  Failed images:" >&2
+        grep "^fail " "${WORK_DIR}/prescan.log" | while read -r _ rest; do
+            echo "    ${rest}" >&2
+        done
+    fi
+}
+
+# filter_pool_to_prescan_success keeps only images that returned HTTP 200.
+# Sets SCANNABLE_POOL, UNIQUE_COUNT, BURST_SIZE, and POOL_SIZE to that set so
+# the burst never includes tags that were not stored in Central's DB.
+filter_pool_to_prescan_success() {
+    local ok_file="${WORK_DIR}/prescan.ok"
+    grep "^ok " "${WORK_DIR}/prescan.log" 2>/dev/null | awk '{print $2}' > "$ok_file" || true
+    mapfile -t SCANNABLE_POOL < "$ok_file"
+    UNIQUE_COUNT=${#SCANNABLE_POOL[@]}
+    if [[ "$UNIQUE_COUNT" -eq 0 ]]; then
+        echo "ERROR: every prescan failed. Check ROX_PASSWORD, ROX_CENTRAL_ADDRESS, and Scanner health." >&2
+        echo "  Sample failures:" >&2
+        grep "^fail " "${WORK_DIR}/prescan.log" | head -5 >&2 || true
+        exit 1
+    fi
+    BURST_SIZE=$UNIQUE_COUNT
+    POOL_SIZE=$UNIQUE_COUNT
+    echo "  Bursting ${BURST_SIZE} unique pre-scanned images (failed prescans dropped)."
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Add `prescan-slow-path` to the admission controller burst rig to prove `ScanImageInternalForAdmission` skips Scanner `GetScan` for pre-scanned tag-only admits.

Problem: averaging `review_duration_seconds` across a mixed cache-hit burst does not prove Scanner skip. After prescan, Scanner's index is warm, so master's `ForceRefetch` GetScan can be cheap and the average moves with hit/skip mix.

Approach:
1. Pre-scan unique images via `POST /v1/images/scan` (warm Central DB)
2. Drop failed prescans from the burst
3. Force `UNIQUE_PCT=100` (one unique tag per review)
4. Restart AC only, scrape **Central and AC after prescan**
5. Burst, scrape again, report deltas

Primary signal: `rox_central_scan_duration_count` (GetScan calls during the burst). Secondary: `image_fetch_duration_seconds` (per-fetch latency). `review_duration_seconds` is reported but is not proof.

Existing `fast-path` and `slow-path` modes are unchanged.

**Stack**: PR 4 of 4 — depends on [#22288](https://github.com/stackrox/stackrox/pull/22288).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

Dev-only burst scripts. No product test target. `fast-path` / `slow-path` code paths were not changed.

### How I validated my change

- `bash -n` on `burst-test.sh` and `lib.sh`
- Live cluster: earlier `UNIQUE_PCT=100 BURST_SIZE=20` run showed  PR makes no unwanted scanner calls and uses Central Data.

Results are documented [here](https://docs.google.com/document/d/12QTxqD4PYtnSuK2rJgUPmazCaDqf5avMOD4Uo-sMjN8/edit?tab=t.0).
