### PR TITLE
ROX-35849: Smooth VMScraper arrivals over catch-up and steady bands

### DIFF
--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -80,4 +80,11 @@ var (
 	// vulnerability definitions, mirroring ROX_REPROCESSING_INTERVAL and ROX_NODE_SCANNING_INTERVAL's
 	// role for image and node scanning.
 	VirtualMachinesScraperMandatoryRefreshInterval = registerDurationSetting("ROX_VIRTUAL_MACHINES_SCRAPER_MANDATORY_REFRESH_INTERVAL", 4*time.Hour)
+
+	// VirtualMachinesScraperSteadySpreadFraction is the fraction of the poll interval used as the
+	// one-sided post-poll random band W for cadence reschedule (nextAttemptAt =
+	// now + pollInterval + U(0, W)). Default 2/3. Internal Sensor env only; not Operator/Helm-exposed.
+	// Valid range is (0, 1]; out-of-range values fall back to the default.
+	VirtualMachinesScraperSteadySpreadFraction = RegisterFloatSetting("ROX_VIRTUAL_MACHINES_SCRAPER_STEADY_SPREAD_FRACTION", 2.0/3).
+							WithMinimum(0.01).WithMaximum(1)
 )

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -84,7 +84,7 @@ var (
 	// VirtualMachinesScraperSteadySpreadFraction is the fraction of the poll interval used as the
 	// one-sided post-poll random band W for cadence reschedule (nextAttemptAt =
 	// now + pollInterval + U(0, W)). Default 2/3. Internal Sensor env only; not Operator/Helm-exposed.
-	// Valid range is (0, 1]; out-of-range values fall back to the default.
+	// Valid range is [0.01, 1] so W is not effectively zero; out-of-range values fall back to the default.
 	VirtualMachinesScraperSteadySpreadFraction = RegisterFloatSetting("ROX_VIRTUAL_MACHINES_SCRAPER_STEADY_SPREAD_FRACTION", 2.0/3).
 							WithMinimum(0.01).WithMaximum(1)
 )

--- a/sensor/common/virtualmachine/ACK_MODEL.md
+++ b/sensor/common/virtualmachine/ACK_MODEL.md
@@ -4,7 +4,7 @@ VM index reports flow directly from Sensor to Central; Compliance is not involve
 
 `VMScraper` pulls reports from each running VM's roxagent over VSOCK and forwards successful reports to Central through `vmIndex.Handler`, the same handler used by every other producer of `v1.IndexReport`s.
 
-A short tick (`ROX_VIRTUAL_MACHINES_SCRAPER_TICK_INTERVAL`, default 10s) walks the per-VM schedule. Each VM is due at its own `nextAttemptAt`. Success and permanent failures reschedule at `ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL`. Retryable pull failures and NACKs share one exponential backoff (`ROX_VIRTUAL_MACHINES_SCRAPER_INITIAL_BACKOFF`, default 10s, doubled each time, capped at `min(poll interval, 30m)`).
+A short tick (`ROX_VIRTUAL_MACHINES_SCRAPER_TICK_INTERVAL`, default 10s) walks the per-VM schedule. Each VM is due at its own `nextAttemptAt`. Success and permanent failures reschedule at pollInterval + U(0, W), where W is `ROX_VIRTUAL_MACHINES_SCRAPER_STEADY_SPREAD_FRACTION` times the poll interval (default 2/3). Retryable pull failures and NACKs share one exponential backoff (`ROX_VIRTUAL_MACHINES_SCRAPER_INITIAL_BACKOFF`, default 10s, doubled each time, capped at `min(poll interval, 30m)`).
 
 Central's `SensorACK` is delivered to Sensor components whose `Accepts()` matches. Only `VMScraper` accepts `SensorACK_VM_INDEX_REPORT`; `Handler` does not.
 

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -223,6 +223,75 @@ var PullTrackedVMs = prometheus.NewGauge(
 	},
 )
 
+// PullDueVMs is how many VMs were ready to scrape at the start of the last
+// tick, before the scraper limited how many of them may actually start.
+var PullDueVMs = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_due_vms",
+		Help: "How many VMs were eligible to scrape at the beginning of the last " +
+			"scraper tick (their next attempt time had arrived and they were not " +
+			"already in flight). This is the size of the due pile before the " +
+			"per-tick start budget is applied, so it can be larger than the number " +
+			"of scrapes that tick actually starts. A persistently high value with " +
+			"low starts-per-tick usually means the budget is pacing a backlog " +
+			"(first-wave catch-up, aligned retries, or unlucky cadence clump).",
+	},
+)
+
+// PullStartsPerTick is how many VM scrapes each tick actually launches after
+// the start budget and never-scraped preference are applied.
+var PullStartsPerTick = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_starts_per_tick",
+		Help: "How many VM scrapes the scraper starts in a single tick after " +
+			"applying the arrival-smoothing start budget (and preferring " +
+			"never-scraped VMs). Compare with vsock_pull_due_vms: when due is " +
+			"large but starts stay small, the Sensor is draining a backlog " +
+			"gradually instead of dumping every due VM into Central at once. " +
+			"Concurrency is a separate hard cap on overlapping scrapes.",
+		Buckets: []float64{0, 1, 2, 3, 5, 8, 10, 15, 20, 30, 50, 100},
+	},
+)
+
+// PullForwardInterarrivalSeconds is the Sensor-level gap between consecutive
+// successful forwards to Central (not per-VM).
+var PullForwardInterarrivalSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_forward_interarrival_seconds",
+		Help: "Seconds between consecutive successful VM index-report forwards " +
+			"from this Sensor to Central (for all VMs, Sensor-wide). Healthy " +
+			"arrival smoothing produces a spread of gaps; a burst of near-zero " +
+			"gaps means many reports left this Sensor in a short wall-clock " +
+			"window (a spike of many reports in a short time). The " +
+			"first forward after Sensor start does not count to this metric.",
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 16), // 10ms to ~5.5min
+	},
+)
+
+// PullScheduleOffsetSeconds is the random extra delay drawn when a VM returns
+// to normal poll cadence after a successful or permanent non-retry outcome.
+var PullScheduleOffsetSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_schedule_offset_seconds",
+		Help: "Random extra delay (seconds) added on top of the poll interval " +
+			"when scheduling a VM's next attempt after a successful scrape or " +
+			"other return-to-cadence outcome. That offset is drawn uniformly in " +
+			"[0, W], where W is spreadFraction times the poll interval (default " +
+			"fraction 2/3), so next due times fan out across a wide post-poll " +
+			"band instead of lining up on the same wall-clock minute. Retry and " +
+			"NACK backoff paths do not use this offset.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 14), // 1s to ~4.5h
+	},
+)
+
 func init() {
 	prometheus.MustRegister(
 		IndexReportsSent,
@@ -240,5 +309,9 @@ func init() {
 		PullRequestsTotal,
 		PullTicksTotal,
 		PullTrackedVMs,
+		PullDueVMs,
+		PullStartsPerTick,
+		PullForwardInterarrivalSeconds,
+		PullScheduleOffsetSeconds,
 	)
 }

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -270,7 +270,8 @@ var PullForwardInterarrivalSeconds = prometheus.NewHistogram(
 			"gaps means many reports left this Sensor in a short wall-clock " +
 			"window (a spike of many reports in a short time). The " +
 			"first forward after Sensor start does not count to this metric.",
-		Buckets: prometheus.ExponentialBuckets(0.01, 2, 16), // 10ms to ~5.5min
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 18), // 10ms to ~22min; covers pollInterval+W (~8min default)
+
 	},
 )
 

--- a/sensor/common/virtualmachine/vmscraper/budget.go
+++ b/sensor/common/virtualmachine/vmscraper/budget.go
@@ -9,19 +9,23 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 )
 
-// tickStartBudget is how many due scrapes may start this tick without dumping
-// the whole due pile at once. Never-scraped dues pace over the catch-up
-// window; cadenced-only dues pace over the steady width. concurrency is a
-// hard ceiling.
+// tickStartBudget is how many due scrapes may start this tick. Never-scraped
+// and cadenced piles each use their own window formula and the results sum,
+// capped by concurrency, so a mixed pile does not stall cadence.
 func tickStartBudget(nUrgent, nDue, concurrency int, tick, catchUpWindow, steadyWidth time.Duration) int {
 	if concurrency < 1 {
 		concurrency = 1
 	}
+	nCadenced := max(nDue-nUrgent, 0)
 	var budget int
 	if nUrgent > 0 {
-		budget = startBudget(nUrgent, tick, catchUpWindow)
-	} else {
-		budget = startBudget(nDue, tick, steadyWidth)
+		budget += startBudget(nUrgent, tick, catchUpWindow)
+	}
+	if nCadenced > 0 {
+		budget += startBudget(nCadenced, tick, steadyWidth)
+	}
+	if budget < 1 {
+		return 0
 	}
 	return min(budget, concurrency)
 }

--- a/sensor/common/virtualmachine/vmscraper/budget.go
+++ b/sensor/common/virtualmachine/vmscraper/budget.go
@@ -37,11 +37,11 @@ func budgetTickDuration(nominal, elapsed time.Duration) time.Duration {
 	return max(nominal, elapsed)
 }
 
-// startBudget is max(1, ceil(n × tick / window)). n is tracked fleet size so
-// leftover due VMs do not reset the window each tick.
+// startBudget is max(1, ceil(n × tick / window)) for positive n, tick, and
+// window. Zero otherwise so a missing window does not start a scrape.
 func startBudget(n int, tick, window time.Duration) int {
 	if n <= 0 || tick <= 0 || window <= 0 {
-		return 1
+		return 0
 	}
 	num := int64(n) * int64(tick)
 	den := int64(window)

--- a/sensor/common/virtualmachine/vmscraper/budget.go
+++ b/sensor/common/virtualmachine/vmscraper/budget.go
@@ -1,0 +1,95 @@
+package vmscraper
+
+import (
+	"cmp"
+	"hash/fnv"
+	"slices"
+	"time"
+
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+)
+
+// tickStartBudget is how many due scrapes may start this tick without dumping
+// the whole due pile at once. Never-scraped dues pace over the catch-up
+// window; cadenced-only dues pace over the steady width. concurrency is a
+// hard ceiling.
+func tickStartBudget(nUrgent, nDue, concurrency int, tick, catchUpWindow, steadyWidth time.Duration) int {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	var budget int
+	if nUrgent > 0 {
+		budget = startBudget(nUrgent, tick, catchUpWindow)
+	} else {
+		budget = startBudget(nDue, tick, steadyWidth)
+	}
+	return min(budget, concurrency)
+}
+
+// startBudget is how many of n already-due VMs may begin scraping this tick
+// when spreading them evenly across window at tick granularity:
+// max(1, ceil(n × tick / window)).
+func startBudget(n int, tick, window time.Duration) int {
+	if n <= 0 || tick <= 0 || window <= 0 {
+		return 1
+	}
+	num := int64(n) * int64(tick)
+	den := int64(window)
+	b := int((num + den - 1) / den)
+	if b < 1 {
+		return 1
+	}
+	return b
+}
+
+type dueCandidate struct {
+	key          string
+	neverScraped bool
+	hash         uint64
+}
+
+// selectDueStarts picks up to budget keys from the due set, preferring
+// never-scraped VMs so first-wave work is not starved by cadenced peers.
+func selectDueStarts(cands []dueCandidate, budget int) []string {
+	if budget < 1 || len(cands) == 0 {
+		return nil
+	}
+	sorted := slices.Clone(cands)
+	slices.SortFunc(sorted, cmpDueCandidate)
+
+	if budget > len(sorted) {
+		budget = len(sorted)
+	}
+	out := make([]string, 0, budget)
+	for i := range budget {
+		out = append(out, sorted[i].key)
+	}
+	return out
+}
+
+func cmpDueCandidate(a, b dueCandidate) int {
+	switch {
+	case a.neverScraped && !b.neverScraped:
+		return -1
+	case !a.neverScraped && b.neverScraped:
+		return 1
+	}
+	if c := cmp.Compare(a.hash, b.hash); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.key, b.key)
+}
+
+// hashVMID returns a stable 64-bit hash for ordering. Prefers VM ID; falls back
+// to schedule key. Callers should cache the result (e.g. on vmState) so empty-ID
+// fallback is not logged on every tick.
+func hashVMID(id virtualmachine.VMID, key string) uint64 {
+	s := string(id)
+	if s == "" {
+		log.Warnf("VMScraper: empty VM ID for schedule key %q; hashing namespace/name fallback", key)
+		s = key
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
+}

--- a/sensor/common/virtualmachine/vmscraper/budget.go
+++ b/sensor/common/virtualmachine/vmscraper/budget.go
@@ -26,6 +26,13 @@ func tickStartBudget(nUrgent, nDue, concurrency int, tick, catchUpWindow, steady
 	return min(budget, concurrency)
 }
 
+// budgetTickDuration is the time base for this tick's start budget: the
+// nominal tick, or the wall-clock gap since the last tick if that was longer
+// (a scrape Wait that overran the ticker).
+func budgetTickDuration(nominal, elapsed time.Duration) time.Duration {
+	return max(nominal, elapsed)
+}
+
 // startBudget is how many of n already-due VMs may begin scraping this tick
 // when spreading them evenly across window at tick granularity:
 // max(1, ceil(n × tick / window)).

--- a/sensor/common/virtualmachine/vmscraper/budget.go
+++ b/sensor/common/virtualmachine/vmscraper/budget.go
@@ -9,21 +9,21 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 )
 
-// tickStartBudget is how many due scrapes may start this tick. Never-scraped
-// and cadenced piles each use their own window formula and the results sum,
-// capped by concurrency, so a mixed pile does not stall cadence.
-func tickStartBudget(nUrgent, nDue, concurrency int, tick, catchUpWindow, steadyWidth time.Duration) int {
+// tickStartBudget is the per-tick start cap from tracked fleet size, not the
+// current due pile: leftovers must not shrink the rate. Catch-up if any
+// never-forwarded VM is due, else the steady width; concurrency is a hard cap.
+func tickStartBudget(nTracked, nUrgentDue, concurrency int, tick, catchUpWindow, steadyWidth time.Duration) int {
 	if concurrency < 1 {
 		concurrency = 1
 	}
-	nCadenced := max(nDue-nUrgent, 0)
-	var budget int
-	if nUrgent > 0 {
-		budget += startBudget(nUrgent, tick, catchUpWindow)
+	if nTracked < 1 {
+		return 0
 	}
-	if nCadenced > 0 {
-		budget += startBudget(nCadenced, tick, steadyWidth)
+	window := steadyWidth
+	if nUrgentDue > 0 {
+		window = catchUpWindow
 	}
+	budget := startBudget(nTracked, tick, window)
 	if budget < 1 {
 		return 0
 	}
@@ -37,9 +37,8 @@ func budgetTickDuration(nominal, elapsed time.Duration) time.Duration {
 	return max(nominal, elapsed)
 }
 
-// startBudget is how many of n already-due VMs may begin scraping this tick
-// when spreading them evenly across window at tick granularity:
-// max(1, ceil(n × tick / window)).
+// startBudget is max(1, ceil(n × tick / window)). n is tracked fleet size so
+// leftover due VMs do not reset the window each tick.
 func startBudget(n int, tick, window time.Duration) int {
 	if n <= 0 || tick <= 0 || window <= 0 {
 		return 1

--- a/sensor/common/virtualmachine/vmscraper/budget_test.go
+++ b/sensor/common/virtualmachine/vmscraper/budget_test.go
@@ -74,19 +74,53 @@ func TestTickStartBudget(t *testing.T) {
 	t.Parallel()
 
 	tick := 10 * time.Second
-	catchUp := 20 * time.Minute
-	steadyWidth := 40 * time.Minute
+	catchUp20m := 20 * time.Minute
+	steady40m := 40 * time.Minute
+	catchUp100s := 100 * time.Second
+	steady200s := 200 * time.Second
 
-	assert.Equal(t, 1, tickStartBudget(100, 100, 20, tick, catchUp, steadyWidth),
-		"100 urgent over 20m catch-up should yield 1 start, not concurrency 20")
-	assert.Equal(t, 1, tickStartBudget(0, 100, 20, tick, catchUp, steadyWidth),
-		"100 cadenced over 40m steady width should yield 1 start")
-	assert.Equal(t, 1, tickStartBudget(0, 100, 1, tick, catchUp, steadyWidth),
-		"a cadenced pile with concurrency 1 should yield 1 start")
-	assert.Equal(t, 4, tickStartBudget(100, 100, 20, tick, 5*time.Minute, steadyWidth),
-		"100 urgent over a 5m catch-up window should yield 4 starts (ceil(100×10s/5m))")
-	assert.Equal(t, 2, tickStartBudget(1, 101, 20, tick, catchUp, steadyWidth),
-		"1 urgent + 100 cadenced should yield 2 starts (catch-up 1 plus steady 1)")
+	cases := map[string]struct {
+		nTracked, nUrgentDue, concurrency int
+		catchUp, steady                   time.Duration
+		want                              int
+	}{
+		"100 tracked all urgent over 20m catch-up should yield 1 start": {
+			nTracked: 100, nUrgentDue: 100, concurrency: 20,
+			catchUp: catchUp20m, steady: steady40m, want: 1,
+		},
+		"100 tracked cadenced-only over 40m steady should yield 1 start": {
+			nTracked: 100, nUrgentDue: 0, concurrency: 20,
+			catchUp: catchUp20m, steady: steady40m, want: 1,
+		},
+		"cadenced pile with concurrency 1 should yield 1 start": {
+			nTracked: 100, nUrgentDue: 0, concurrency: 1,
+			catchUp: catchUp20m, steady: steady40m, want: 1,
+		},
+		"100 tracked urgent over a 5m catch-up window should yield 4 starts": {
+			nTracked: 100, nUrgentDue: 100, concurrency: 20,
+			catchUp: 5 * time.Minute, steady: steady40m, want: 4,
+		},
+		"one urgent due should use the fleet catch-up rate, not 1": {
+			nTracked: 101, nUrgentDue: 1, concurrency: 20,
+			catchUp: catchUp100s, steady: steady200s, want: 11,
+		},
+		"leftover due must not shrink a 100-VM catch-up rate": {
+			nTracked: 100, nUrgentDue: 55, concurrency: 20,
+			catchUp: catchUp100s, steady: steady200s, want: 10,
+		},
+		"zero tracked should yield no starts": {
+			nTracked: 0, nUrgentDue: 0, concurrency: 20,
+			catchUp: catchUp100s, steady: steady200s, want: 0,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tickStartBudget(
+				tc.nTracked, tc.nUrgentDue, tc.concurrency, tick, tc.catchUp, tc.steady,
+			))
+		})
+	}
 }
 
 func TestSelectDueStarts(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/budget_test.go
+++ b/sensor/common/virtualmachine/vmscraper/budget_test.go
@@ -1,0 +1,132 @@
+package vmscraper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartBudget(t *testing.T) {
+	t.Parallel()
+
+	tick := 10 * time.Second
+	cases := map[string]struct {
+		n      int
+		tick   time.Duration
+		window time.Duration
+		want   int
+	}{
+		"n=100 catchUp=20m -> 1": {
+			n: 100, tick: tick, window: 20 * time.Minute, want: 1,
+		},
+		"n=100 steadyWidth=40m -> 1": {
+			n: 100, tick: tick, window: 40 * time.Minute, want: 1,
+		},
+		"n=100 window=5m -> ceil(100*10/300)=4": {
+			n: 100, tick: tick, window: 5 * time.Minute, want: 4,
+		},
+		"n=0 -> 1": {
+			n: 0, tick: tick, window: 20 * time.Minute, want: 1,
+		},
+		"zero window -> 1": {
+			n: 10, tick: tick, window: 0, want: 1,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, startBudget(tc.n, tc.tick, tc.window))
+		})
+	}
+}
+
+func TestTickStartBudget(t *testing.T) {
+	t.Parallel()
+
+	tick := 10 * time.Second
+	catchUp := 20 * time.Minute
+	steadyWidth := 40 * time.Minute
+
+	assert.Equal(t, 1, tickStartBudget(100, 100, 20, tick, catchUp, steadyWidth),
+		"urgent uses catch-up budget, not full concurrency")
+	assert.Equal(t, 1, tickStartBudget(0, 100, 20, tick, catchUp, steadyWidth),
+		"cadenced uses steady width budget capped by concurrency")
+	assert.Equal(t, 1, tickStartBudget(0, 100, 1, tick, catchUp, steadyWidth))
+	assert.Equal(t, 4, tickStartBudget(100, 100, 20, tick, 5*time.Minute, steadyWidth))
+}
+
+func TestSelectDueStarts(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		cands     []dueCandidate
+		budget    int
+		wantOrder []string
+	}{
+		"preferring never-scraped then lower hash should yield new-a, new-z, cadenced-b": {
+			cands: []dueCandidate{
+				{key: "ns/cadenced-a", neverScraped: false, hash: 10},
+				{key: "ns/new-z", neverScraped: true, hash: 90},
+				{key: "ns/new-a", neverScraped: true, hash: 5},
+				{key: "ns/cadenced-b", neverScraped: false, hash: 1},
+			},
+			budget:    3,
+			wantOrder: []string{"ns/new-a", "ns/new-z", "ns/cadenced-b"},
+		},
+		"budget 0 should yield no starts": {
+			cands: []dueCandidate{
+				{key: "a", neverScraped: true, hash: 1},
+				{key: "b", neverScraped: true, hash: 2},
+				{key: "c", neverScraped: true, hash: 3},
+			},
+			budget:    0,
+			wantOrder: nil,
+		},
+		"budget 1 among three never-scraped should yield only the lowest hash": {
+			cands: []dueCandidate{
+				{key: "a", neverScraped: true, hash: 1},
+				{key: "b", neverScraped: true, hash: 2},
+				{key: "c", neverScraped: true, hash: 3},
+			},
+			budget:    1,
+			wantOrder: []string{"a"},
+		},
+		"budget above candidate count should yield every candidate in hash order": {
+			cands: []dueCandidate{
+				{key: "a", neverScraped: true, hash: 1},
+				{key: "b", neverScraped: true, hash: 2},
+				{key: "c", neverScraped: true, hash: 3},
+			},
+			budget:    10,
+			wantOrder: []string{"a", "b", "c"},
+		},
+		"stable VM-ID hashes should yield the same order on every call": {
+			cands: []dueCandidate{
+				{key: "ns/vm-c", neverScraped: true, hash: hashVMID(virtualmachine.VMID("id-c"), "ns/vm-c")},
+				{key: "ns/vm-a", neverScraped: true, hash: hashVMID(virtualmachine.VMID("id-a"), "ns/vm-a")},
+				{key: "ns/vm-b", neverScraped: true, hash: hashVMID(virtualmachine.VMID("id-b"), "ns/vm-b")},
+			},
+			budget:    3,
+			wantOrder: []string{"ns/vm-c", "ns/vm-b", "ns/vm-a"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := selectDueStarts(tc.cands, tc.budget)
+			assert.Equal(t, tc.wantOrder, got)
+			assert.Equal(t, got, selectDueStarts(tc.cands, tc.budget),
+				"repeated selection should be deterministic")
+		})
+	}
+}
+
+func TestHashVMID_Stable(t *testing.T) {
+	t.Parallel()
+	a := hashVMID(virtualmachine.VMID("abc"), "ns/name")
+	b := hashVMID(virtualmachine.VMID("abc"), "other/key")
+	assert.Equal(t, a, b, "hash should key off VM ID when present")
+	assert.NotEqual(t, hashVMID("", "ns/a"), hashVMID("", "ns/b"))
+}

--- a/sensor/common/virtualmachine/vmscraper/budget_test.go
+++ b/sensor/common/virtualmachine/vmscraper/budget_test.go
@@ -42,6 +42,34 @@ func TestStartBudget(t *testing.T) {
 	}
 }
 
+func TestBudgetTickDuration(t *testing.T) {
+	t.Parallel()
+	tick := 10 * time.Second
+	cases := map[string]struct {
+		elapsed time.Duration
+		want    time.Duration
+	}{
+		"first tick (no elapsed) uses nominal": {
+			elapsed: 0, want: tick,
+		},
+		"on-time tick uses nominal": {
+			elapsed: tick, want: tick,
+		},
+		"early tick still uses nominal": {
+			elapsed: time.Second, want: tick,
+		},
+		"overrun uses elapsed": {
+			elapsed: 30 * time.Second, want: 30 * time.Second,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, budgetTickDuration(tick, tc.elapsed))
+		})
+	}
+}
+
 func TestTickStartBudget(t *testing.T) {
 	t.Parallel()
 

--- a/sensor/common/virtualmachine/vmscraper/budget_test.go
+++ b/sensor/common/virtualmachine/vmscraper/budget_test.go
@@ -78,11 +78,15 @@ func TestTickStartBudget(t *testing.T) {
 	steadyWidth := 40 * time.Minute
 
 	assert.Equal(t, 1, tickStartBudget(100, 100, 20, tick, catchUp, steadyWidth),
-		"urgent uses catch-up budget, not full concurrency")
+		"100 urgent over 20m catch-up should yield 1 start, not concurrency 20")
 	assert.Equal(t, 1, tickStartBudget(0, 100, 20, tick, catchUp, steadyWidth),
-		"cadenced uses steady width budget capped by concurrency")
-	assert.Equal(t, 1, tickStartBudget(0, 100, 1, tick, catchUp, steadyWidth))
-	assert.Equal(t, 4, tickStartBudget(100, 100, 20, tick, 5*time.Minute, steadyWidth))
+		"100 cadenced over 40m steady width should yield 1 start")
+	assert.Equal(t, 1, tickStartBudget(0, 100, 1, tick, catchUp, steadyWidth),
+		"a cadenced pile with concurrency 1 should yield 1 start")
+	assert.Equal(t, 4, tickStartBudget(100, 100, 20, tick, 5*time.Minute, steadyWidth),
+		"100 urgent over a 5m catch-up window should yield 4 starts (ceil(100×10s/5m))")
+	assert.Equal(t, 2, tickStartBudget(1, 101, 20, tick, catchUp, steadyWidth),
+		"1 urgent + 100 cadenced should yield 2 starts (catch-up 1 plus steady 1)")
 }
 
 func TestSelectDueStarts(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/budget_test.go
+++ b/sensor/common/virtualmachine/vmscraper/budget_test.go
@@ -27,11 +27,14 @@ func TestStartBudget(t *testing.T) {
 		"n=100 window=5m -> ceil(100*10/300)=4": {
 			n: 100, tick: tick, window: 5 * time.Minute, want: 4,
 		},
-		"n=0 -> 1": {
-			n: 0, tick: tick, window: 20 * time.Minute, want: 1,
+		"n=0 -> 0": {
+			n: 0, tick: tick, window: 20 * time.Minute, want: 0,
 		},
-		"zero window -> 1": {
-			n: 10, tick: tick, window: 0, want: 1,
+		"zero window -> 0": {
+			n: 10, tick: tick, window: 0, want: 0,
+		},
+		"zero tick -> 0": {
+			n: 10, tick: 0, window: 20 * time.Minute, want: 0,
 		},
 	}
 	for name, tc := range cases {

--- a/sensor/common/virtualmachine/vmscraper/schedule.go
+++ b/sensor/common/virtualmachine/vmscraper/schedule.go
@@ -10,6 +10,8 @@ const (
 	maxReconcile   = 5 * time.Minute
 	// defaultTickInterval is the scraper scheduler step. Independent of retry-backoff.
 	defaultTickInterval = 10 * time.Second
+	// catchUpBound is the upper operand in catchUpWindow = min(bound, pollInterval/3).
+	catchUpBound = 20 * time.Minute
 )
 
 func backoffCap(pollInterval time.Duration) time.Duration {
@@ -27,4 +29,36 @@ func nextBackoff(current, pollInterval, initial time.Duration) time.Duration {
 		return min(initial, limit)
 	}
 	return min(current*2, limit)
+}
+
+// steadySpreadWidth is how wide the post-poll random band is when a VM
+// returns to normal cadence (spreadFraction × pollInterval).
+func steadySpreadWidth(pollInterval time.Duration, spreadFraction float64) time.Duration {
+	if pollInterval <= 0 || spreadFraction <= 0 {
+		return 0
+	}
+	return time.Duration(float64(pollInterval) * spreadFraction)
+}
+
+// catchUpWindow is how long a mass first-wave of never-scraped VMs may be
+// spread over (min(20m, pollInterval/3)), not the steady band.
+func catchUpWindow(pollInterval time.Duration) time.Duration {
+	if pollInterval <= 0 {
+		return 0
+	}
+	return min(catchUpBound, pollInterval/3)
+}
+
+// randOffset draws a delay in [0, max] from a unit sample in [0, 1].
+func randOffset(max time.Duration, unit float64) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	if unit < 0 {
+		unit = 0
+	}
+	if unit > 1 {
+		unit = 1
+	}
+	return time.Duration(float64(max) * unit)
 }

--- a/sensor/common/virtualmachine/vmscraper/schedule.go
+++ b/sensor/common/virtualmachine/vmscraper/schedule.go
@@ -8,7 +8,9 @@ const (
 	initialBackoff = 10 * time.Second
 	maxBackoffCap  = 30 * time.Minute
 	maxReconcile   = 5 * time.Minute
-	// defaultTickInterval is the scraper scheduler step. Independent of retry-backoff.
+	// defaultTickInterval is the scraper scheduler step and the time base for
+	// the per-tick start budget. Independent of retry backoff so it can change
+	// without retuning NACK/failure delays.
 	defaultTickInterval = 10 * time.Second
 	// catchUpBound is the upper operand in catchUpWindow = min(bound, pollInterval/3).
 	catchUpBound = 20 * time.Minute

--- a/sensor/common/virtualmachine/vmscraper/schedule_test.go
+++ b/sensor/common/virtualmachine/vmscraper/schedule_test.go
@@ -64,3 +64,26 @@ func TestReconcilePeriod(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, reconcilePeriod(time.Hour))
 	assert.Equal(t, time.Minute, reconcilePeriod(time.Minute))
 }
+
+func TestSteadySpreadWidth(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 40*time.Minute, steadySpreadWidth(time.Hour, 2.0/3))
+	assert.Equal(t, 0, int(steadySpreadWidth(time.Hour, 0)))
+	assert.Equal(t, 0, int(steadySpreadWidth(0, 2.0/3)))
+}
+
+func TestCatchUpWindow(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 20*time.Minute, catchUpWindow(time.Hour))
+	assert.Equal(t, 100*time.Second, catchUpWindow(5*time.Minute))
+	assert.Equal(t, time.Duration(0), catchUpWindow(0))
+}
+
+func TestRandOffset(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, time.Duration(0), randOffset(0, 0.5))
+	assert.Equal(t, 20*time.Minute, randOffset(40*time.Minute, 0.5))
+	assert.Equal(t, time.Duration(0), randOffset(40*time.Minute, 0))
+	assert.Equal(t, 40*time.Minute, randOffset(40*time.Minute, 1))
+	assert.Equal(t, time.Duration(0), randOffset(40*time.Minute, -1))
+}

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -316,8 +316,9 @@ func (s *VMScraper) selectStartsForTick(due []string, budgetTick time.Duration) 
 		return nil
 	}
 	var cands []dueCandidate
-	var nUrgent int
+	var nUrgent, nTracked int
 	concurrency.WithLock(&s.mu, func() {
+		nTracked = len(s.vmState)
 		cands = make([]dueCandidate, 0, len(due))
 		for _, key := range due {
 			st, ok := s.vmState[key]
@@ -336,7 +337,7 @@ func (s *VMScraper) selectStartsForTick(due []string, budgetTick time.Duration) 
 		}
 	})
 	budget := tickStartBudget(
-		nUrgent, len(cands), s.concurrency, budgetTick,
+		nTracked, nUrgent, s.concurrency, budgetTick,
 		catchUpWindow(s.interval), steadySpreadWidth(s.interval, s.spreadFraction),
 	)
 	return selectDueStarts(cands, budget)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -243,6 +243,9 @@ func (s *VMScraper) run() {
 	// First tick forces reconcile so vmState is populated without waiting
 	// reconcileEvery; only VMs already due (catch-up offset 0) start now.
 	s.tick(ctx, true)
+	// lastTickAt is the start of that tick; reset so the first ticker fire
+	// does not count pre-ticker scrape time as an overrun.
+	s.lastTickAt = s.now()
 
 	ticker := time.NewTicker(s.tickInterval)
 	defer ticker.Stop()
@@ -280,7 +283,9 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	due := s.dueKeys()
 	metrics.PullDueVMs.Set(float64(len(due)))
 	toStart := s.selectStartsForTick(due, budgetTick)
-	metrics.PullStartsPerTick.Observe(float64(len(toStart)))
+	if len(due) > 0 {
+		metrics.PullStartsPerTick.Observe(float64(len(toStart)))
+	}
 	log.Debugf("VMScraper: tick: %d due, starting %d (concurrency=%d, reconcile=%v)",
 		len(due), len(toStart), s.concurrency, reconcile)
 	metrics.PullTicksTotal.Inc()

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -240,7 +240,8 @@ func (s *VMScraper) run() {
 	defer s.stopper.Flow().ReportStopped()
 	ctx := concurrency.AsContext(s.stopper.LowLevel().GetStopRequestSignal())
 
-	// Reconcile + scrape immediately so VMs don't wait a full tick on start.
+	// First tick forces reconcile so vmState is populated without waiting
+	// reconcileEvery; only VMs already due (catch-up offset 0) start now.
 	s.tick(ctx, true)
 
 	ticker := time.NewTicker(s.tickInterval)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -72,11 +72,12 @@ type ProtocolClient interface {
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
 type VMScraper struct {
-	store                 RunningVMStore
-	sender                IndexReportSender
-	dialer                VMDialer
-	client                ProtocolClient
-	interval              time.Duration
+	store    RunningVMStore
+	sender   IndexReportSender
+	dialer   VMDialer
+	client   ProtocolClient
+	interval time.Duration
+	// tickInterval is the scheduler step and the start-budget time base.
 	tickInterval          time.Duration
 	initialBackoff        time.Duration
 	reconcileEvery        time.Duration

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -80,6 +80,7 @@ type VMScraper struct {
 	// tickInterval is the scheduler step and the start-budget time base.
 	tickInterval          time.Duration
 	initialBackoff        time.Duration
+	lastTickAt            time.Time
 	reconcileEvery        time.Duration
 	perVMTimeout          time.Duration
 	mandatoryRefreshAfter time.Duration
@@ -259,6 +260,12 @@ func (s *VMScraper) run() {
 // start a budgeted subset, and wait for those scrapes to finish.
 func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	tickStart := s.now()
+	var sinceLast time.Duration
+	if !s.lastTickAt.IsZero() {
+		sinceLast = tickStart.Sub(s.lastTickAt)
+	}
+	budgetTick := budgetTickDuration(s.tickInterval, sinceLast)
+	s.lastTickAt = tickStart
 	reconcile := forceReconcile
 	if !reconcile {
 		concurrency.WithLock(&s.mu, func() {
@@ -271,7 +278,7 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 
 	due := s.dueKeys()
 	metrics.PullDueVMs.Set(float64(len(due)))
-	toStart := s.selectStartsForTick(due)
+	toStart := s.selectStartsForTick(due, budgetTick)
 	metrics.PullStartsPerTick.Observe(float64(len(toStart)))
 	log.Debugf("VMScraper: tick: %d due, starting %d (concurrency=%d, reconcile=%v)",
 		len(due), len(toStart), s.concurrency, reconcile)
@@ -303,7 +310,7 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 // selectStartsForTick chooses which due VMs may start now so forwards do not
 // clump: never-scraped first, then at most the per-tick budget (concurrency
 // still caps overlap in the errgroup).
-func (s *VMScraper) selectStartsForTick(due []string) []string {
+func (s *VMScraper) selectStartsForTick(due []string, budgetTick time.Duration) []string {
 	if len(due) == 0 {
 		return nil
 	}
@@ -328,7 +335,7 @@ func (s *VMScraper) selectStartsForTick(due []string) []string {
 		}
 	})
 	budget := tickStartBudget(
-		nUrgent, len(cands), s.concurrency, s.tickInterval,
+		nUrgent, len(cands), s.concurrency, budgetTick,
 		catchUpWindow(s.interval), steadySpreadWidth(s.interval, s.spreadFraction),
 	)
 	return selectDueStarts(cands, budget)

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -82,15 +83,19 @@ type VMScraper struct {
 	perVMTimeout          time.Duration
 	mandatoryRefreshAfter time.Duration
 	concurrency           int
+	spreadFraction        float64
 	warnMaxBytes          int
 	stopper               concurrency.Stopper
 	started               atomic.Bool
 	now                   func() time.Time
+	// randFloat64 returns a unit sample in [0, 1] for schedule offsets; tests inject a fixed source.
+	randFloat64 func() float64
 
-	mu            sync.Mutex
-	vmState       map[string]*vmState
-	lastReconcile time.Time
-	inFlight      set.StringSet
+	mu              sync.Mutex
+	vmState         map[string]*vmState
+	lastReconcile   time.Time
+	inFlight        set.StringSet
+	lastForwardTime time.Time // Sensor-level; for forward interarrival metric
 }
 
 type vmState struct {
@@ -100,6 +105,7 @@ type vmState struct {
 	nextAttemptAt   time.Time
 	backoff         time.Duration
 	vmID            virtualmachine.VMID
+	orderHash       uint64 // stable selection hash; refreshed when vmID changes
 }
 
 var _ common.SensorComponent = (*VMScraper)(nil)
@@ -119,6 +125,7 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		perVMTimeout:          env.VirtualMachinesScraperPerVMTimeout.DurationSetting(),
 		mandatoryRefreshAfter: env.VirtualMachinesScraperMandatoryRefreshInterval.DurationSetting(),
 		concurrency:           env.VirtualMachinesScraperConcurrency.IntegerSetting(),
+		spreadFraction:        env.VirtualMachinesScraperSteadySpreadFraction.FloatSetting(),
 		// Warn once a report is halfway to the hard response-size ceiling,
 		// so operators get advance notice before reports start actually
 		// being rejected at that limit.
@@ -126,6 +133,7 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		vmState:      make(map[string]*vmState),
 		inFlight:     set.NewStringSet(),
 		now:          time.Now,
+		randFloat64:  rand.Float64,
 	}
 }
 
@@ -246,6 +254,8 @@ func (s *VMScraper) run() {
 	}
 }
 
+// tick is one scheduler step: optionally refresh the VM set, find due VMs,
+// start a budgeted subset, and wait for those scrapes to finish.
 func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	tickStart := s.now()
 	reconcile := forceReconcile
@@ -259,7 +269,11 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	}
 
 	due := s.dueKeys()
-	log.Debugf("VMScraper: tick: %d due VMs %v (concurrency=%d, reconcile=%v)", len(due), due, s.concurrency, reconcile)
+	metrics.PullDueVMs.Set(float64(len(due)))
+	toStart := s.selectStartsForTick(due)
+	metrics.PullStartsPerTick.Observe(float64(len(toStart)))
+	log.Debugf("VMScraper: tick: %d due, starting %d (concurrency=%d, reconcile=%v)",
+		len(due), len(toStart), s.concurrency, reconcile)
 	metrics.PullTicksTotal.Inc()
 	concurrency.WithLock(&s.mu, func() {
 		metrics.PullTrackedVMs.Set(float64(len(s.vmState)))
@@ -269,7 +283,7 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(s.concurrency)
 
-	for _, key := range due {
+	for _, key := range toStart {
 		g.Go(func() error {
 			if s.scrapeKey(gCtx, key) {
 				successCount.Add(1)
@@ -280,24 +294,70 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	_ = g.Wait()
 
 	elapsed := s.now().Sub(tickStart)
-	log.Debugf("VMScraper: tick done: %d/%d due VMs succeeded in %s", successCount.Load(), len(due), elapsed.Truncate(time.Millisecond))
+	log.Debugf("VMScraper: tick done: %d due, %d/%d started succeeded in %s",
+		len(due), successCount.Load(), len(toStart), elapsed.Truncate(time.Millisecond))
 	metrics.PullTickDurationSeconds.Observe(elapsed.Seconds())
 }
 
+// selectStartsForTick chooses which due VMs may start now so forwards do not
+// clump: never-scraped first, then at most the per-tick budget (concurrency
+// still caps overlap in the errgroup).
+func (s *VMScraper) selectStartsForTick(due []string) []string {
+	if len(due) == 0 {
+		return nil
+	}
+	var cands []dueCandidate
+	var nUrgent int
+	concurrency.WithLock(&s.mu, func() {
+		cands = make([]dueCandidate, 0, len(due))
+		for _, key := range due {
+			st, ok := s.vmState[key]
+			if !ok {
+				continue
+			}
+			never := st.lastForwardedAt.IsZero()
+			if never {
+				nUrgent++
+			}
+			cands = append(cands, dueCandidate{
+				key:          key,
+				neverScraped: never,
+				hash:         st.orderHash,
+			})
+		}
+	})
+	budget := tickStartBudget(
+		nUrgent, len(cands), s.concurrency, s.tickInterval,
+		catchUpWindow(s.interval), steadySpreadWidth(s.interval, s.spreadFraction),
+	)
+	return selectDueStarts(cands, budget)
+}
+
+// reconcile syncs vmState with currently running VMs: drop gone ones, and
+// schedule first attempts for new ones spread over the catch-up window (new guests are
+// often still booting; Sensor restart rehydrates many at once).
 func (s *VMScraper) reconcile() {
 	vms := s.store.ListRunning()
 	liveKeys := set.NewStringSet()
 	concurrency.WithLock(&s.mu, func() {
 		now := s.now()
+		catchUp := catchUpWindow(s.interval)
 		for _, vm := range vms {
 			key := vm.Key()
 			liveKeys.Add(key)
 			st, ok := s.vmState[key]
 			if !ok {
-				st = &vmState{nextAttemptAt: now, vmID: vm.ID}
-				s.vmState[key] = st
+				s.vmState[key] = &vmState{
+					nextAttemptAt: now.Add(randOffset(catchUp, s.randFloat64())),
+					vmID:          vm.ID,
+					orderHash:     hashVMID(vm.ID, key),
+				}
+				continue
 			}
-			st.vmID = vm.ID
+			if st.vmID != vm.ID {
+				st.vmID = vm.ID
+				st.orderHash = hashVMID(vm.ID, key)
+			}
 		}
 		for key := range s.vmState {
 			if !liveKeys.Contains(key) {
@@ -308,6 +368,8 @@ func (s *VMScraper) reconcile() {
 	})
 }
 
+// dueKeys lists tracked VMs whose nextAttemptAt has arrived and that are not
+// already mid-scrape.
 func (s *VMScraper) dueKeys() []string {
 	return concurrency.WithLock1(&s.mu, func() []string {
 		now := s.now()
@@ -426,6 +488,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 
 	newGen := result.Meta.GetReportGeneration()
 	s.commitVMState(key, newGen, result.Meta.GetEpoch())
+	s.observeForwardInterarrival()
 	next := s.scheduleAfterAttempt(key, scrapeOK)
 
 	log.Infof("VMScraper: scrape %q ok outcome=forwarded next=%s", key, next)
@@ -438,6 +501,18 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	return true
 }
 
+// observeForwardInterarrival records the Sensor-level gap between successful
+// forwards. The first forward after start does not observe a sample.
+func (s *VMScraper) observeForwardInterarrival() {
+	concurrency.WithLock(&s.mu, func() {
+		now := s.now()
+		if !s.lastForwardTime.IsZero() {
+			metrics.PullForwardInterarrivalSeconds.Observe(now.Sub(s.lastForwardTime).Seconds())
+		}
+		s.lastForwardTime = now
+	})
+}
+
 type scrapeOutcome int
 
 const (
@@ -446,8 +521,9 @@ const (
 	scrapeNonRetryable
 )
 
-// scheduleAfterAttempt updates nextAttemptAt/backoff for key and returns the
-// delay until the next attempt (0 if the slot was dropped).
+// scheduleAfterAttempt sets when this VM may be tried again and returns that
+// delay. Retries use short exponential backoff; success / permanent failure
+// return to poll cadence with a random offset in [0, steadyWidth].
 func (s *VMScraper) scheduleAfterAttempt(key string, outcome scrapeOutcome) time.Duration {
 	return concurrency.WithLock1(&s.mu, func() time.Duration {
 		st, ok := s.vmState[key]
@@ -461,10 +537,14 @@ func (s *VMScraper) scheduleAfterAttempt(key string, outcome scrapeOutcome) time
 			st.nextAttemptAt = now.Add(st.backoff)
 			return st.backoff
 		case scrapeOK, scrapeNonRetryable:
-			// Both return to the normal poll cadence without growing backoff.
+			// Return to cadence with a fresh post-poll random offset in [0, steadyWidth].
 			st.backoff = 0
-			st.nextAttemptAt = now.Add(s.interval)
-			return s.interval
+			steadyWidth := steadySpreadWidth(s.interval, s.spreadFraction)
+			offset := randOffset(steadyWidth, s.randFloat64())
+			metrics.PullScheduleOffsetSeconds.Observe(offset.Seconds())
+			delay := s.interval + offset
+			st.nextAttemptAt = now.Add(delay)
+			return delay
 		default:
 			return 0
 		}

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -783,7 +783,7 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 		client:   client,
 		interval: interval,
 		// Match catch-up window so default urgent due sets drain in one tick
-		// under concurrency (production uses initialBackoff; pacing tests override).
+		// under concurrency (production uses defaultTickInterval; pacing tests override).
 		tickInterval:          catchUpWindow(interval),
 		initialBackoff:        initialBackoff,
 		reconcileEvery:        reconcilePeriod(interval),

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -232,12 +232,29 @@ func TestVMScraper_PollsRunningVMs(t *testing.T) {
 	}
 
 	s, _ := newTestScraper(store, sender, dialer, client)
+	setTickToDrain(s)
 	discoveredBefore := testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE"))
 	s.pollOnce(context.Background())
 
 	assert.Len(t, sender.sent, 2)
 	assert.Len(t, client.calls, 2)
 	assert.Equal(t, discoveredBefore+2, testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE")))
+}
+
+func TestVMScraper_ProductionTickPacesTwoDueVMs(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+		makeVM("ns2", "vm-b", 200),
+	}}
+	sender := &mockSender{}
+	s, _ := newTestScraper(store, sender, &mockDialer{}, &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1), makeReport(1)},
+	})
+	require.Equal(t, defaultTickInterval, s.tickInterval)
+
+	s.pollOnce(context.Background())
+	assert.Len(t, sender.sent, 1, "production 10s tick over 100s catch-up should start 1 of 2 due VMs")
+	assert.Len(t, s.dueKeys(), 1, "the other VM should stay due for a later tick")
 }
 
 func TestVMScraper_SkipsUnchangedGeneration(t *testing.T) {
@@ -631,6 +648,7 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 				errQueue:    tc.errQueue,
 			}
 			s, _ := newTestScraper(&mockStore{vms: vms}, sender, tc.dialer, client)
+			setTickToDrain(s)
 			if tc.perVMTimeout > 0 {
 				s.perVMTimeout = tc.perVMTimeout
 			}
@@ -737,6 +755,7 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
+	setTickToDrain(s)
 	s.pollOnce(context.Background())
 	assert.Len(t, s.vmState, 2)
 	assert.True(t, hasScheduleSlot(t, s, "ns1/vm-a"))
@@ -782,9 +801,9 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 		dialer:   dialer,
 		client:   client,
 		interval: interval,
-		// Match catch-up window so default urgent due sets drain in one tick
-		// under concurrency (production uses defaultTickInterval; pacing tests override).
-		tickInterval:          catchUpWindow(interval),
+		// Production scheduler step. Tests that must scrape every due VM in
+		// one pollOnce call setTickToDrain.
+		tickInterval:          defaultTickInterval,
 		initialBackoff:        initialBackoff,
 		reconcileEvery:        reconcilePeriod(interval),
 		perVMTimeout:          10 * time.Second,
@@ -805,6 +824,12 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 // pollOnce forces a reconcile and scrapes every due slot.
 func (s *VMScraper) pollOnce(ctx context.Context) {
 	s.tick(ctx, true)
+}
+
+// setTickToDrain sets tickInterval to the catch-up window so one tick can
+// start every never-scraped due VM under concurrency.
+func setTickToDrain(s *VMScraper) {
+	s.tickInterval = catchUpWindow(s.interval)
 }
 
 // --- Thread-safe mocks for concurrent tests ---

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -821,7 +821,7 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 	}, clock
 }
 
-// pollOnce forces a reconcile and scrapes every due slot.
+// pollOnce forces a reconcile and starts a budgeted subset of due VMs.
 func (s *VMScraper) pollOnce(ctx context.Context) {
 	s.tick(ctx, true)
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -55,12 +55,15 @@ func (m *mockStore) Get(id virtualmachine.VMID) *virtualmachine.Info {
 }
 
 type mockDialer struct {
+	mu       sync.Mutex
 	err      error
 	errQueue []error
 	callIdx  int
 }
 
 func (m *mockDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	idx := m.callIdx
 	m.callIdx++
 	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
@@ -88,6 +91,7 @@ func (nopCloser) Write([]byte) (int, error) { return 0, nil }
 func (nopCloser) Close() error              { return nil }
 
 type mockProtocolClient struct {
+	mu          sync.Mutex
 	resultQueue []*vsockclient.GetReportResult
 	errQueue    []error
 	calls       []protocolCall
@@ -100,6 +104,8 @@ type protocolCall struct {
 }
 
 func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.calls = append(m.calls, protocolCall{ifNewerThan: ifNewerThan, knownEpoch: knownEpoch})
 	idx := m.callIdx
 	m.callIdx++
@@ -113,16 +119,21 @@ func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, 
 }
 
 func (m *mockProtocolClient) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.calls = nil
 	m.callIdx = 0
 }
 
 type mockSender struct {
+	mu   sync.Mutex
 	sent []*v4.IndexReport
 	err  error
 }
 
 func (m *mockSender) Send(_ context.Context, _ *virtualmachine.Info, report *v4.IndexReport) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.err != nil {
 		return m.err
 	}
@@ -588,19 +599,21 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 		wantSent     int
 	}{
 		"should still send for vm-b when vm-a hits a protocol error": {
-			dialer:      &mockDialer{},
+			dialer: &mockDialer{},
+			// Start order is hash-based; fail the first GetReport call so one VM
+			// errors and the other still forwards.
 			resultQueue: []*vsockclient.GetReportResult{nil, makeReport(1)},
 			errQueue:    []error{errors.New("connection refused"), nil},
 			wantCalls:   2,
 			wantSent:    1,
 		},
 		"should still send for vm-b when vm-a dial fails": {
-			dialer: &mockDialer{
-				errQueue: []error{errors.New("dial failed"), nil},
+			dialer: &nameFailDialer{failName: "vm-a"},
+			resultQueue: []*vsockclient.GetReportResult{
+				makeReport(1),
 			},
-			resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
-			wantCalls:   1,
-			wantSent:    1,
+			wantCalls: 1,
+			wantSent:  1,
 		},
 		"should forward nothing when every dial times out": {
 			dialer:       blockingDialer{},
@@ -627,6 +640,19 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 			assert.Len(t, sender.sent, tc.wantSent)
 		})
 	}
+}
+
+// nameFailDialer fails Dial for a single VM name so multi-VM tests need not
+// depend on hash start order for errQueue alignment.
+type nameFailDialer struct {
+	failName string
+}
+
+func (d nameFailDialer) Dial(_ context.Context, _, name string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	if name == d.failName {
+		return nil, errors.New("dial failed")
+	}
+	return nopCloser{}, nil
 }
 
 func TestVMScraper_StartRejectsSecondCall(t *testing.T) {
@@ -751,23 +777,28 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 	clock := newTestClock()
 	interval := 5 * time.Minute
 	return &VMScraper{
-		store:                 store,
-		sender:                sender,
-		dialer:                dialer,
-		client:                client,
-		interval:              interval,
-		tickInterval:          defaultTickInterval,
+		store:    store,
+		sender:   sender,
+		dialer:   dialer,
+		client:   client,
+		interval: interval,
+		// Match catch-up window so default urgent due sets drain in one tick
+		// under concurrency (production uses initialBackoff; pacing tests override).
+		tickInterval:          catchUpWindow(interval),
 		initialBackoff:        initialBackoff,
 		reconcileEvery:        reconcilePeriod(interval),
 		perVMTimeout:          10 * time.Second,
 		mandatoryRefreshAfter: 4 * time.Hour,
-		concurrency:           1,
+		concurrency:           20,
+		spreadFraction:        2.0 / 3,
 		// Half of the 16MiB default pull response-size ceiling — same
 		// derivation New() uses from env.VirtualMachinesPullMaxResponseSizeKB.
 		warnMaxBytes: 8 << 20,
 		vmState:      make(map[string]*vmState),
 		inFlight:     set.NewStringSet(),
 		now:          clock.Now,
+		// Zero offset keeps default schedule assertions deterministic - no randomization of the scrape schedule
+		randFloat64: func() float64 { return 0 },
 	}, clock
 }
 
@@ -845,6 +876,11 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 
 	s, _ := newTestScraper(store, sender, dialer, client)
 	s.concurrency = concurrency
+	// Catch-up budget is ceil(nUrgent × tick / catchUp); set tick >= catchUp
+	// so one tick can start the whole fleet and exercise errgroup concurrency.
+	s.interval = 30 * time.Second
+	s.tickInterval = 10 * time.Second // catchUp = interval/3 = 10s → budget = numVMs
+	s.reconcileEvery = reconcilePeriod(s.interval)
 	// This test measures real dial overlap via delayDialer's timers, so it
 	// needs the wall clock rather than the fake test clock.
 	s.now = time.Now

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -1,0 +1,365 @@
+package vmscraper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingDialer counts Dial calls for start-budget assertions.
+type recordingDialer struct {
+	calls atomic.Int32
+}
+
+func (d *recordingDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io.ReadWriteCloser, error) {
+	d.calls.Add(1)
+	return nopCloser{}, nil
+}
+
+// sequencedRand returns successive values from seq, then the last value.
+func sequencedRand(seq []float64) func() float64 {
+	var i atomic.Int32
+	return func() float64 {
+		idx := int(i.Add(1) - 1)
+		if idx >= len(seq) {
+			return seq[len(seq)-1]
+		}
+		return seq[idx]
+	}
+}
+
+func TestVMScraper_CadenceRescheduleUsesSteadyBand(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "vm-a", 1)}}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	})
+	s.spreadFraction = 2.0 / 3
+	// First draw (reconcile insert) keeps the VM due now; second is the cadence offset.
+	s.randFloat64 = sequencedRand([]float64{0, 0.5})
+
+	start := clock.Now()
+	s.pollOnce(context.Background())
+
+	steadyWidth := steadySpreadWidth(s.interval, s.spreadFraction)
+	want := start.Add(s.interval + steadyWidth/2)
+	assert.Equal(t, want, cachedNextAttemptAt(t, s, "ns/vm-a"))
+	assert.Greater(t, histogramSampleCount(t, metrics.PullScheduleOffsetSeconds), uint64(0))
+}
+
+func TestVMScraper_ManyCadencedSuccessesSpanSteadyBand(t *testing.T) {
+	const numVMs = 5
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(10+i)))
+	}
+	store := &mockStore{vms: vms}
+	s, clock := newTestScraper(store, &safeSender{}, &recordingDialer{}, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.interval = time.Hour
+	s.spreadFraction = 2.0 / 3
+	// Drain the urgent due pile in one tick; RNG is only used on cadence write.
+	s.tickInterval = catchUpWindow(s.interval)
+	s.reconcileEvery = reconcilePeriod(s.interval)
+	s.randFloat64 = sequencedRand([]float64{0, 0.25, 0.5, 0.75, 1})
+
+	now := clock.Now()
+	concurrency.WithLock(&s.mu, func() {
+		for _, vm := range vms {
+			key := vm.Key()
+			s.vmState[key] = &vmState{
+				vmID:          vm.ID,
+				nextAttemptAt: now,
+				orderHash:     hashVMID(vm.ID, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+
+	s.tick(context.Background(), false)
+
+	steadyWidth := steadySpreadWidth(s.interval, s.spreadFraction)
+	minNext, maxNext := now.Add(s.interval), now.Add(s.interval+steadyWidth)
+	var earliest, latest time.Time
+	concurrency.WithLock(&s.mu, func() {
+		for _, st := range s.vmState {
+			if earliest.IsZero() || st.nextAttemptAt.Before(earliest) {
+				earliest = st.nextAttemptAt
+			}
+			if latest.IsZero() || st.nextAttemptAt.After(latest) {
+				latest = st.nextAttemptAt
+			}
+			assert.False(t, st.nextAttemptAt.Before(minNext))
+			assert.False(t, st.nextAttemptAt.After(maxNext))
+		}
+	})
+	assert.GreaterOrEqual(t, latest.Sub(earliest), steadyWidth/2,
+		"distinct RNG draws should spread nextAttemptAt across a wide band")
+}
+
+func TestVMScraper_MassFirstInsertSpansCatchUpWindow(t *testing.T) {
+	const numVMs = 10
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	store := &mockStore{vms: vms}
+	s, clock := newTestScraper(store, &mockSender{}, &recordingDialer{}, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.interval = time.Hour
+	units := make([]float64, numVMs)
+	for i := range units {
+		units[i] = float64(i) / float64(numVMs-1)
+	}
+	s.randFloat64 = sequencedRand(units)
+
+	s.reconcile()
+
+	catchUp := catchUpWindow(s.interval)
+	now := clock.Now()
+	var earliest, latest time.Time
+	concurrency.WithLock(&s.mu, func() {
+		require.Len(t, s.vmState, numVMs)
+		for _, st := range s.vmState {
+			assert.False(t, st.nextAttemptAt.Before(now))
+			assert.False(t, st.nextAttemptAt.After(now.Add(catchUp)))
+			if earliest.IsZero() || st.nextAttemptAt.Before(earliest) {
+				earliest = st.nextAttemptAt
+			}
+			if latest.IsZero() || st.nextAttemptAt.After(latest) {
+				latest = st.nextAttemptAt
+			}
+		}
+	})
+	assert.Greater(t, latest.Sub(earliest), time.Duration(0),
+		"mass insert must not schedule every VM at exactly now")
+	assert.GreaterOrEqual(t, latest.Sub(earliest), catchUp/2)
+}
+
+func TestVMScraper_SingleInsertUsesCatchUpSpread(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "only", 1)}}
+	s, clock := newTestScraper(store, &mockSender{}, &recordingDialer{}, &safeProtocolClient{gen: 1})
+	s.concurrency = 20
+	s.randFloat64 = func() float64 { return 0.5 }
+
+	s.reconcile()
+
+	catchUp := catchUpWindow(s.interval)
+	assert.Equal(t, clock.Now().Add(catchUp/2), cachedNextAttemptAt(t, s, "ns/only"),
+		"every first schedule uses catchUp, including a lone insert with free slots")
+}
+
+func TestVMScraper_MultiInsertUsesCatchUpSpread(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns", "a", 1),
+		makeVM("ns", "b", 2),
+	}}
+	s, clock := newTestScraper(store, &mockSender{}, &recordingDialer{}, &safeProtocolClient{gen: 1})
+	s.concurrency = 20
+	s.randFloat64 = sequencedRand([]float64{0.25, 0.75})
+
+	s.reconcile()
+
+	catchUp := catchUpWindow(s.interval)
+	assert.Equal(t, clock.Now().Add(catchUp/4), cachedNextAttemptAt(t, s, "ns/a"))
+	assert.Equal(t, clock.Now().Add(3*catchUp/4), cachedNextAttemptAt(t, s, "ns/b"))
+}
+
+func TestVMScraper_UrgentDuePileIsPacedByCatchUpBudget(t *testing.T) {
+	const numVMs = 10
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.interval = time.Hour
+	s.tickInterval = 10 * time.Second
+	s.reconcileEvery = reconcilePeriod(s.interval)
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		for _, vm := range vms {
+			key := vm.Key()
+			s.vmState[key] = &vmState{
+				vmID:          vm.ID,
+				nextAttemptAt: now,
+				orderHash:     hashVMID(vm.ID, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+
+	catchUp := catchUpWindow(s.interval)
+	wantBudget := startBudget(numVMs, s.tickInterval, catchUp)
+	require.Equal(t, 1, wantBudget)
+	require.Less(t, wantBudget, s.concurrency)
+
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(wantBudget), dialer.calls.Load())
+	assert.Equal(t, float64(numVMs), testutil.ToFloat64(metrics.PullDueVMs))
+
+	dialer.calls.Store(0)
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(wantBudget), dialer.calls.Load(), "leftovers stay due for later ticks")
+}
+
+func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns", "old-a", 1),
+		makeVM("ns", "old-b", 2),
+		makeVM("ns", "new-x", 3),
+		makeVM("ns", "new-y", 4),
+	}}
+	dialer := &recordingDialer{}
+	s, _ := newTestScraper(store, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = 2
+	s.interval = time.Hour
+	s.tickInterval = 10 * time.Second
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		s.vmState["ns/old-a"] = &vmState{
+			vmID:            virtualmachine.VMID("ns/old-a"),
+			lastForwardedAt: now.Add(-time.Hour),
+			nextAttemptAt:   now,
+			orderHash:       hashVMID(virtualmachine.VMID("ns/old-a"), "ns/old-a"),
+		}
+		s.vmState["ns/old-b"] = &vmState{
+			vmID:            virtualmachine.VMID("ns/old-b"),
+			lastForwardedAt: now.Add(-time.Hour),
+			nextAttemptAt:   now,
+			orderHash:       hashVMID(virtualmachine.VMID("ns/old-b"), "ns/old-b"),
+		}
+		s.vmState["ns/new-x"] = &vmState{
+			vmID:          virtualmachine.VMID("ns/new-x"),
+			nextAttemptAt: now,
+			orderHash:     hashVMID(virtualmachine.VMID("ns/new-x"), "ns/new-x"),
+		}
+		s.vmState["ns/new-y"] = &vmState{
+			vmID:          virtualmachine.VMID("ns/new-y"),
+			nextAttemptAt: now,
+			orderHash:     hashVMID(virtualmachine.VMID("ns/new-y"), "ns/new-y"),
+		}
+		s.lastReconcile = now
+	})
+
+	// nUrgent=2, catchUp=20m, tick=10s → budget=1; never-scraped must win the slot.
+	s.tick(context.Background(), false)
+	require.Equal(t, int32(1), dialer.calls.Load())
+
+	dueOld := 0
+	concurrency.WithLock(&s.mu, func() {
+		for _, key := range []string{"ns/old-a", "ns/old-b"} {
+			if !s.vmState[key].nextAttemptAt.After(s.now()) {
+				dueOld++
+			}
+		}
+	})
+	assert.Equal(t, 2, dueOld, "cadenced VMs remain due when urgent fills the budget")
+}
+
+func TestVMScraper_CadencedDuePileUsesSteadyBudget(t *testing.T) {
+	const numVMs = 10
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.interval = time.Hour
+	s.spreadFraction = 2.0 / 3
+	s.tickInterval = 10 * time.Second
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		for _, vm := range vms {
+			key := vm.Key()
+			s.vmState[key] = &vmState{
+				vmID:            vm.ID,
+				lastForwardedAt: now.Add(-time.Hour),
+				nextAttemptAt:   now,
+				orderHash:       hashVMID(vm.ID, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+
+	steadyWidth := steadySpreadWidth(s.interval, s.spreadFraction)
+	wantBudget := startBudget(numVMs, s.tickInterval, steadyWidth)
+	require.Equal(t, 1, wantBudget)
+
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(wantBudget), dialer.calls.Load())
+	assert.Equal(t, float64(numVMs), testutil.ToFloat64(metrics.PullDueVMs))
+
+	dialer.calls.Store(0)
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(wantBudget), dialer.calls.Load(), "leftovers stay due for later ticks")
+}
+
+func TestVMScraper_RetryPathDoesNotUseSteadyBand(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
+	client := &mockProtocolClient{errQueue: []error{vsockclient.ErrNotReady}}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+	// Insert due now; a later unit of 1 would be full steadyWidth if cadence used RNG.
+	s.randFloat64 = sequencedRand([]float64{0, 1})
+
+	start := clock.Now()
+	s.pollOnce(context.Background())
+	assert.Equal(t, initialBackoff, cachedNextAttemptAt(t, s, "ns1/vm-a").Sub(start),
+		"retryable path must use short backoff, not pollInterval+steadyWidth")
+	assert.Equal(t, initialBackoff, cachedBackoff(t, s, "ns1/vm-a"))
+}
+
+func TestVMScraper_NACKPathDoesNotUseSteadyBand(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	store := &mockStore{vms: []*virtualmachine.Info{vm}}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	})
+	s.randFloat64 = sequencedRand([]float64{0, 1})
+	s.pollOnce(context.Background())
+
+	start := clock.Now()
+	s.handleNACK(string(vm.ID) + ":1")
+	assert.Equal(t, initialBackoff, cachedNextAttemptAt(t, s, "ns1/vm-a").Sub(start))
+	assert.Equal(t, initialBackoff, cachedBackoff(t, s, "ns1/vm-a"))
+}
+
+func TestVMScraper_ForwardInterarrivalObservesAfterFirst(t *testing.T) {
+	s, _ := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	before := histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds)
+	s.observeForwardInterarrival()
+	assert.Equal(t, before, histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds),
+		"first forward does not observe a gap")
+	s.observeForwardInterarrival()
+	assert.Equal(t, before+1, histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds))
+}
+
+func TestSpreadFractionEnvDefault(t *testing.T) {
+	assert.InDelta(t, 2.0/3, env.VirtualMachinesScraperSteadySpreadFraction.DefaultValue(), 1e-9)
+	assert.InDelta(t, 2.0/3, env.VirtualMachinesScraperSteadySpreadFraction.FloatSetting(), 1e-9)
+}
+
+func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	return m.GetHistogram().GetSampleCount()
+}

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -318,9 +319,9 @@ func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 		s.lastReconcile = now
 	})
 
-	// nUrgent=2, catchUp=20m, production tick → budget=1; never-scraped must win the slot.
+	// nUrgent=2, nCadenced=2 → catch-up 1 + steady 1. Never-scraped take both slots.
 	s.tick(context.Background(), false)
-	require.Equal(t, int32(1), dialer.calls.Load())
+	require.Equal(t, int32(2), dialer.calls.Load())
 
 	dueOld := 0
 	concurrency.WithLock(&s.mu, func() {
@@ -330,7 +331,70 @@ func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 			}
 		}
 	})
-	assert.Equal(t, 2, dueOld, "cadenced VMs remain due when urgent fills the budget")
+	assert.Equal(t, 2, dueOld, "cadenced VMs remain due when never-scraped fill the combined budget")
+}
+
+// TestVMScraper_MixedDuePileStartsCadencedToo covers one never-scraped due VM
+// next to a cadenced clump: cadence must keep its steady-width starts, not
+// drop to zero because nUrgent > 0.
+func TestVMScraper_MixedDuePileStartsCadencedToo(t *testing.T) {
+	const (
+		nUrgent   = 1
+		nCadenced = 100
+	)
+	vms := []*virtualmachine.Info{makeVM("ns", "new", 1)}
+	for i := range nCadenced {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("old-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = nUrgent + nCadenced
+	s.tickInterval = defaultTickInterval
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		s.vmState["ns/new"] = &vmState{
+			vmID:          virtualmachine.VMID("ns/new"),
+			nextAttemptAt: now,
+			orderHash:     hashVMID(virtualmachine.VMID("ns/new"), "ns/new"),
+		}
+		for i := range nCadenced {
+			key := fmt.Sprintf("ns/old-%d", i)
+			id := virtualmachine.VMID(key)
+			s.vmState[key] = &vmState{
+				vmID:            id,
+				lastForwardedAt: now.Add(-time.Hour),
+				nextAttemptAt:   now,
+				orderHash:       hashVMID(id, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+	require.Len(t, s.dueKeys(), nUrgent+nCadenced)
+
+	catchUp := catchUpWindow(s.interval)
+	steadyWidth := steadySpreadWidth(s.interval, s.spreadFraction)
+	wantUrgent := startBudget(nUrgent, s.tickInterval, catchUp)
+	wantCadenced := startBudget(nCadenced, s.tickInterval, steadyWidth)
+	wantTotal := wantUrgent + wantCadenced
+	require.Equal(t, 1, wantUrgent, "ceil(1 × 10s / 100s) = 1")
+	require.Equal(t, 5, wantCadenced, "ceil(100 × 10s / 200s) = 5")
+	require.Equal(t, 6, wantTotal)
+
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(wantTotal), dialer.calls.Load(),
+		"cadenced steady-width starts must run alongside the one urgent slot")
+
+	due := s.dueKeys()
+	assert.False(t, slices.Contains(due, "ns/new"), "the never-scraped VM used the urgent slot")
+	nCadencedDue := 0
+	for i := range nCadenced {
+		if slices.Contains(due, fmt.Sprintf("ns/old-%d", i)) {
+			nCadencedDue++
+		}
+	}
+	assert.Equal(t, nCadenced-wantCadenced, nCadencedDue,
+		"five cadenced VMs should have left the due pile this tick")
 }
 
 func TestVMScraper_CadencedDuePileUsesSteadyBudget(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -72,8 +72,7 @@ func TestVMScraper_ManyCadencedSuccessesSpanSteadyBand(t *testing.T) {
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	s.spreadFraction = 2.0 / 3
-	// Drain the urgent due pile in one tick; RNG is only used on cadence write.
-	s.tickInterval = catchUpWindow(s.interval)
+	setTickToDrain(s)
 	s.reconcileEvery = reconcilePeriod(s.interval)
 	s.randFloat64 = sequencedRand([]float64{0, 0.25, 0.5, 0.75, 1})
 

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -265,9 +265,9 @@ func TestVMScraper_StartBudgetUsesElapsedWhenTickOverruns(t *testing.T) {
 	assert.Len(t, s.dueKeys(), remaining,
 		"30s is still inside the 1h cadence of the VM that already ran")
 
-	wantOverrun := startBudget(remaining, overrun, catchUp)
-	wantNominal := startBudget(remaining, s.tickInterval, catchUp)
-	require.Equal(t, 3, wantOverrun, "ceil(99 × 30s / 20m) = 3")
+	wantOverrun := startBudget(numVMs, overrun, catchUp)
+	wantNominal := startBudget(numVMs, s.tickInterval, catchUp)
+	require.Equal(t, 3, wantOverrun, "ceil(100 × 30s / 20m) = 3")
 	require.Equal(t, 1, wantNominal, "the same pile would stay at 1 if the budget ignored the gap")
 	require.Greater(t, wantOverrun, wantNominal)
 
@@ -318,24 +318,30 @@ func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 		s.lastReconcile = now
 	})
 
-	// nUrgent=2, nCadenced=2 → catch-up 1 + steady 1. Never-scraped take both slots.
-	s.tick(context.Background(), false)
-	require.Equal(t, int32(2), dialer.calls.Load())
+	// 4 tracked over 20m catch-up → 1 start; never-scraped take it.
+	s.tick(t.Context(), false)
+	require.Equal(t, int32(1), dialer.calls.Load())
 
-	dueOld := 0
+	dueOld, dueNew := 0, 0
 	concurrency.WithLock(&s.mu, func() {
 		for _, key := range []string{"ns/old-a", "ns/old-b"} {
 			if !s.vmState[key].nextAttemptAt.After(s.now()) {
 				dueOld++
 			}
 		}
+		for _, key := range []string{"ns/new-x", "ns/new-y"} {
+			if !s.vmState[key].nextAttemptAt.After(s.now()) {
+				dueNew++
+			}
+		}
 	})
-	assert.Equal(t, 2, dueOld, "cadenced VMs remain due when never-scraped fill the combined budget")
+	assert.Equal(t, 2, dueOld, "cadenced VMs remain due when never-scraped take the fleet slot")
+	assert.Equal(t, 1, dueNew, "exactly one never-scraped VM should have used the slot")
 }
 
 // TestVMScraper_MixedDuePileStartsCadencedToo covers one never-scraped due VM
-// next to a cadenced clump: cadence must keep its steady-width starts, not
-// drop to zero because nUrgent > 0.
+// next to a cadenced clump: the fleet catch-up rate leaves leftover slots
+// for cadence instead of shrinking to 1.
 func TestVMScraper_MixedDuePileStartsCadencedToo(t *testing.T) {
 	const (
 		nUrgent   = 1
@@ -371,29 +377,109 @@ func TestVMScraper_MixedDuePileStartsCadencedToo(t *testing.T) {
 	})
 	require.Len(t, s.dueKeys(), nUrgent+nCadenced)
 
+	nTracked := nUrgent + nCadenced
 	catchUp := catchUpWindow(s.interval)
-	steadyWidth := steadySpreadWidth(s.interval, s.spreadFraction)
-	wantUrgent := startBudget(nUrgent, s.tickInterval, catchUp)
-	wantCadenced := startBudget(nCadenced, s.tickInterval, steadyWidth)
-	wantTotal := wantUrgent + wantCadenced
-	require.Equal(t, 1, wantUrgent, "ceil(1 × 10s / 100s) = 1")
-	require.Equal(t, 5, wantCadenced, "ceil(100 × 10s / 200s) = 5")
-	require.Equal(t, 6, wantTotal)
+	wantBudget := startBudget(nTracked, s.tickInterval, catchUp)
+	require.Equal(t, 11, wantBudget, "ceil(101 × 10s / 100s) = 11")
 
-	s.tick(context.Background(), false)
-	assert.Equal(t, int32(wantTotal), dialer.calls.Load(),
-		"cadenced steady-width starts must run alongside the one urgent slot")
+	s.tick(t.Context(), false)
+	assert.Equal(t, int32(wantBudget), dialer.calls.Load(),
+		"fleet catch-up rate must leave leftover slots for cadenced VMs")
 
 	due := s.dueKeys()
-	assert.False(t, slices.Contains(due, "ns/new"), "the never-scraped VM used the urgent slot")
+	assert.False(t, slices.Contains(due, "ns/new"), "the never-scraped VM used one slot")
 	nCadencedDue := 0
 	for i := range nCadenced {
 		if slices.Contains(due, fmt.Sprintf("ns/old-%d", i)) {
 			nCadencedDue++
 		}
 	}
-	assert.Equal(t, nCadenced-wantCadenced, nCadencedDue,
-		"five cadenced VMs should have left the due pile this tick")
+	assert.Equal(t, nCadenced-(wantBudget-nUrgent), nCadencedDue,
+		"leftover fleet slots should start cadenced VMs this tick")
+}
+
+// TestVMScraper_AllDueClumpDrainsWithinCatchUpWindow catches a shrinking-n
+// budget: leftover due VMs must not reset the catch-up window each tick.
+func TestVMScraper_AllDueClumpDrainsWithinCatchUpWindow(t *testing.T) {
+	const numVMs = 100
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.tickInterval = defaultTickInterval
+	s.reconcileEvery = reconcilePeriod(s.interval)
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		for _, vm := range vms {
+			key := vm.Key()
+			s.vmState[key] = &vmState{
+				vmID:          vm.ID,
+				nextAttemptAt: now,
+				orderHash:     hashVMID(vm.ID, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+
+	catchUp := catchUpWindow(s.interval)
+	require.Equal(t, 100*time.Second, catchUp)
+	perTick := startBudget(numVMs, s.tickInterval, catchUp)
+	require.Equal(t, 10, perTick, "ceil(100 × 10s / 100s) = 10")
+	ticks := (numVMs + perTick - 1) / perTick
+	require.Equal(t, 10, ticks)
+
+	for range ticks {
+		s.tick(t.Context(), false)
+	}
+	assert.Equal(t, int32(numVMs), dialer.calls.Load(),
+		"a shrinking-n budget would start only 55 of 100 in 10 ticks (10+9+…+1)")
+	assert.Empty(t, s.dueKeys(), "the clump should have left the due pile within the catch-up window")
+}
+
+// TestVMScraper_SpreadDuePileStartsAtFleetRate covers VMs already spread by
+// nextAttemptAt: the due snapshot is smaller than the fleet, but the rate
+// must still be the fleet catch-up cap so every currently-due VM can start.
+func TestVMScraper_SpreadDuePileStartsAtFleetRate(t *testing.T) {
+	const (
+		numVMs = 100
+		nDue   = 10
+	)
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.tickInterval = defaultTickInterval
+	s.reconcileEvery = reconcilePeriod(s.interval)
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		for i, vm := range vms {
+			key := vm.Key()
+			st := &vmState{
+				vmID:          vm.ID,
+				nextAttemptAt: now.Add(time.Hour),
+				orderHash:     hashVMID(vm.ID, key),
+			}
+			if i < nDue {
+				st.nextAttemptAt = now
+			}
+			s.vmState[key] = st
+		}
+		s.lastReconcile = now
+	})
+	require.Len(t, s.dueKeys(), nDue)
+
+	s.tick(t.Context(), false)
+	assert.Equal(t, int32(nDue), dialer.calls.Load(),
+		"a due-pile budget would start 1 (ceil(10 × 10s / 100s)), not all 10 due")
+	assert.Empty(t, s.dueKeys())
 }
 
 func TestVMScraper_CadencedDuePileUsesSteadyBudget(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -218,6 +218,66 @@ func TestVMScraper_UrgentDuePileIsPacedByCatchUpBudget(t *testing.T) {
 	assert.Equal(t, int32(wantBudget), dialer.calls.Load(), "leftovers stay due for later ticks")
 }
 
+// TestVMScraper_StartBudgetUsesElapsedWhenTickOverruns covers a due pile
+// whose previous tick blocked longer than tickInterval: the next budget
+// must use that wall-clock gap, not the nominal 10s tick.
+func TestVMScraper_StartBudgetUsesElapsedWhenTickOverruns(t *testing.T) {
+	const numVMs = 100
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, clock := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	// Hour poll → catch-up 20m, so 10s vs 30s actually changes the integer budget.
+	s.interval = time.Hour
+	s.tickInterval = defaultTickInterval
+	s.reconcileEvery = reconcilePeriod(s.interval)
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		for _, vm := range vms {
+			key := vm.Key()
+			s.vmState[key] = &vmState{
+				vmID:          vm.ID,
+				nextAttemptAt: now,
+				orderHash:     hashVMID(vm.ID, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+	require.Len(t, s.dueKeys(), numVMs, "seed: every VM is never-scraped and already due")
+
+	catchUp := catchUpWindow(s.interval)
+	require.Equal(t, 20*time.Minute, catchUp)
+	first := startBudget(numVMs, s.tickInterval, catchUp)
+	require.Equal(t, 1, first, "ceil(100 × 10s / 20m) = 1 at the nominal tick")
+
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(first), dialer.calls.Load(), "first tick starts the nominal budget")
+	remaining := numVMs - first
+	assert.Len(t, s.dueKeys(), remaining,
+		"the started VM returns to cadence (interval+offset); leftovers stay due")
+
+	overrun := 3 * s.tickInterval
+	clock.Advance(overrun)
+	assert.Len(t, s.dueKeys(), remaining,
+		"30s is still inside the 1h cadence of the VM that already ran")
+
+	wantOverrun := startBudget(remaining, overrun, catchUp)
+	wantNominal := startBudget(remaining, s.tickInterval, catchUp)
+	require.Equal(t, 3, wantOverrun, "ceil(99 × 30s / 20m) = 3")
+	require.Equal(t, 1, wantNominal, "the same pile would stay at 1 if the budget ignored the gap")
+	require.Greater(t, wantOverrun, wantNominal)
+
+	dialer.calls.Store(0)
+	s.tick(context.Background(), false)
+	assert.Equal(t, int32(wantOverrun), dialer.calls.Load(),
+		"second tick must start 3, not 1, because the 30s Wait counts as the budget tick")
+	assert.Len(t, s.dueKeys(), remaining-wantOverrun, "the extra starts leave the due pile")
+}
+
 func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns", "old-a", 1),

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -188,7 +188,7 @@ func TestVMScraper_UrgentDuePileIsPacedByCatchUpBudget(t *testing.T) {
 	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
 	s.concurrency = numVMs
 	s.interval = time.Hour
-	s.tickInterval = 10 * time.Second
+	s.tickInterval = defaultTickInterval
 	s.reconcileEvery = reconcilePeriod(s.interval)
 
 	now := s.now()
@@ -229,7 +229,7 @@ func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 	s, _ := newTestScraper(store, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
 	s.concurrency = 2
 	s.interval = time.Hour
-	s.tickInterval = 10 * time.Second
+	s.tickInterval = defaultTickInterval
 
 	now := s.now()
 	concurrency.WithLock(&s.mu, func() {
@@ -258,7 +258,7 @@ func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 		s.lastReconcile = now
 	})
 
-	// nUrgent=2, catchUp=20m, tick=10s → budget=1; never-scraped must win the slot.
+	// nUrgent=2, catchUp=20m, production tick → budget=1; never-scraped must win the slot.
 	s.tick(context.Background(), false)
 	require.Equal(t, int32(1), dialer.calls.Load())
 
@@ -284,7 +284,7 @@ func TestVMScraper_CadencedDuePileUsesSteadyBudget(t *testing.T) {
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	s.spreadFraction = 2.0 / 3
-	s.tickInterval = 10 * time.Second
+	s.tickInterval = defaultTickInterval
 
 	now := s.now()
 	concurrency.WithLock(&s.mu, func() {

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -278,6 +278,52 @@ func TestVMScraper_StartBudgetUsesElapsedWhenTickOverruns(t *testing.T) {
 	assert.Len(t, s.dueKeys(), remaining-wantOverrun, "the extra starts leave the due pile")
 }
 
+// TestVMScraper_FirstTickDurationDoesNotInflateNextBudget covers run()'s
+// post-first-tick lastTickAt reset: scrape time before the ticker exists
+// must not count as an overrun on the first ticker fire.
+func TestVMScraper_FirstTickDurationDoesNotInflateNextBudget(t *testing.T) {
+	const numVMs = 100
+	vms := make([]*virtualmachine.Info, 0, numVMs)
+	for i := range numVMs {
+		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
+	}
+	dialer := &recordingDialer{}
+	s, clock := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s.concurrency = numVMs
+	s.interval = time.Hour
+	s.tickInterval = defaultTickInterval
+	s.reconcileEvery = reconcilePeriod(s.interval)
+
+	now := s.now()
+	concurrency.WithLock(&s.mu, func() {
+		for _, vm := range vms {
+			key := vm.Key()
+			s.vmState[key] = &vmState{
+				vmID:          vm.ID,
+				nextAttemptAt: now,
+				orderHash:     hashVMID(vm.ID, key),
+			}
+		}
+		s.lastReconcile = now
+	})
+
+	catchUp := catchUpWindow(s.interval)
+	nominal := startBudget(numVMs, s.tickInterval, catchUp)
+	require.Equal(t, 1, nominal)
+
+	s.tick(t.Context(), false)
+	assert.Equal(t, int32(nominal), dialer.calls.Load())
+
+	clock.Advance(3 * s.tickInterval)
+	s.lastTickAt = s.now()
+	clock.Advance(s.tickInterval)
+
+	dialer.calls.Store(0)
+	s.tick(t.Context(), false)
+	assert.Equal(t, int32(nominal), dialer.calls.Load(),
+		"first-tick scrape time before the ticker starts must not inflate the next budget")
+}
+
 func TestVMScraper_UrgentPreferredOverCadenced(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns", "old-a", 1),


### PR DESCRIPTION
⚠️ Consider the stack starting at https://github.com/stackrox/stackrox/pull/22402 as a lighter (no fairness) alternative to this PR.

## Description

After #22153, each VM has its own `nextAttemptAt` and Sensor scrapes due keys on a short tick. A tick still started every due VM at once (up to concurrency). A Sensor restart, or a cadence clump (many VMs becoming due at the same time), sent those reports to Central in a short window. The rate limiter rejected the overflow and Sensor saw NACKs.

This PR spreads arrivals by writing different `nextAttemptAt` values, then uses a per-tick start budget as a backstop when too many VMs are already due. There is no due-time queue: we did not want that extra complexity.

## How arrival smoothing works

The #22153 scheduler is unchanged. Every 10 seconds (`defaultTickInterval`, not retry backoff) Sensor lists VMs whose `nextAttemptAt` has arrived and that are not already scraping, starts some of them, and waits for those scrapes to finish. Retry and NACK still use short exponential backoff. This PR only changes when a VM becomes due after it is first tracked or after it returns to cadence, and how many already-due VMs may start on one tick.

Two windows do the spreading. Catch-up `C = min(20m, pollInterval/3)` is for VMs that have never forwarded a report (Sensor restart, new guests). Steady width `W = spreadFraction × pollInterval` (default 2/3) is the extra random band after a successful scrape or a permanent non-retry failure.

The poll interval in code is set to 4 hours, **but in the validation of this PR, I lowered it to 20 minutes**. That results in `C = 400s`, and `W = 800s`.  The rest of this section uses 4 hours, so you can see the 20-minute cap on `C`.

`ROX_VIRTUAL_MACHINES_SCRAPER_STEADY_SPREAD_FRACTION` is an internal Sensor env in `[0.01, 1]`. It is the fraction of the poll that becomes `W`. At a 4h poll, `W` is 2 hours 40 minutes. After a successful scrape, the next due time is 4 hours plus a random extra in `[0, W]`, so somewhere in `[4h, 6h40m]` from when that scrape finished.

The primary spreader is the schedule write. When reconcile first tracks a VM (a new guest, or every running VM after a Sensor restart), it sets `nextAttemptAt` to now plus a uniform random delay in `[0, C]` (`U(0, C)`). Success and non-retryable failure set now plus the poll interval plus `U(0, W)`. If those random offsets work, a tick sees only a small share of the VMs that Sensor handles. The start budget is the backstop when more VMs land on one tick: a clump of planned scrapes, a restart that drew unlucky offsets, or retries that lined up near each other.

On each tick the budget is `ceil(n × tick / window)`, at least 1, then capped by concurrency. VMs that have never forwarded a report use window `C`. Cadenced VMs (those that have forwarded at least one report) use window `W`. A mixed pile sums both, so one new VM does not stall cadence. Selection fills that budget preferring never-forwarded VMs, then a stable hash of VM ID cached on `vmState`. If two hashes match, the schedule key breaks the tie. Leftovers stay due for the next tick.

`tick()` still waits for the scrapes it started. If that wait overruns the 10s ticker (for example a VSOCK call hitting the 30s timeout), the next budget uses `max(tickInterval, gap since last tick)` so catch-up still tracks `C` in wall-clock time.

Sensor restarts and finds 100 VMs that have never sent a report. The poll interval is 4 hours. Each VM gets a random first due time somewhere in the next 20 minutes: catch-up `C` is `min(20m, poll/3)`, and at 4h that cap is 20 minutes, not the 80 minutes that `poll/3` would be. If that randomness fails and all 100 become due together, a 10-second tick starts about one of them (`ceil(100 × 10s / 20m) = 1`). Concurrency 20 still limits how many scrapes can run at once, but it is not what paces this catch-up. After a successful scrape, that VM is due again in 4 hours plus a random extra of up to 2 hours 40 minutes (`W = 2/3 × 4h`), so the fleet does not all come back at the same 4-hour mark.

Read in this order: `schedule.go` (`C`, `W`, `randOffset`), `budget.go` (formulas and selection), `scraper.go` (`reconcile`, `tick`, `scheduleAfterAttempt`), then `spreading_test.go` as the spec. Metrics: `vsock_pull_due_vms`, `vsock_pull_starts_per_tick`, `vsock_pull_forward_interarrival_seconds`, `vsock_pull_schedule_offset_seconds`.

AI-Assisted: cursor, implementation and tests with user design review

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

#### Manual test on cluster:

<details>
<summary><b>Manual verification: PASS</b> - 8 CNV VMs paced at 1 scrape/tick; offsets in [0, W]; no near-zero forward bursts</summary>

**Setup:** `ROX_VIRTUAL_MACHINES=true` on OpenShift+CNV. 8 Running RHEL9 VMs. Sensor `quay.io/stackrox-io/main:4.12.x-798-g0b9aff1f73`. Default poll 5m, tick 10s, catch-up 100s → fleet budget `ceil(8×10s/100s)=1`.

1. `kubectl -n stackrox port-forward svc/sensor 9090:9090` then `curl -s http://127.0.0.1:9090/metrics | grep vsock_pull_` → tracked=8, every start observation is 1, idle ticks omitted, due > starts.
   ```
   rox_sensor_vsock_pull_tracked_vms 8
   rox_sensor_vsock_pull_due_vms 7
   rox_sensor_vsock_pull_starts_per_tick_bucket{le="1"} 20
   rox_sensor_vsock_pull_starts_per_tick_sum 20
   rox_sensor_vsock_pull_starts_per_tick_count 20
   rox_sensor_vsock_pull_ticks_total 53
   ```
2. Same metrics: forward gaps ~tick, not a dump; cadence offsets fill W.
   ```
   rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le="5.12"} 0
   rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le="10.24"} 19
   rox_sensor_vsock_pull_forward_interarrival_seconds_sum 189.99  # mean ~10s
   rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le="64"} 2
   rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le="256"} 16
   rox_sensor_vsock_pull_schedule_offset_seconds_sum 1986.42     # mean ~99s, W=200s
   ```
3. `kubectl -n stackrox logs -l app=sensor | grep VMScraper` → one scrape per tick, `next=` = poll+offset.
   ```
   VMScraper: scraping "openshift-cnv/rhel9-8" (reason=poll backoff=0s)
   VMScraper: scrape "openshift-cnv/rhel9-8" ok outcome=forwarded next=6m21s
   ```

Central `/v2/virtualmachines` lists all 8 as RUNNING. `scan` is still null: Scanner V4 matcher was still loading (`the matcher is not initialized`). Pulls and forwards succeeded (`vsock_pull_requests_total{status="success"}` 20); NACKs retry and stay paced at 1/tick.

</details>


#### Grafana

Starred at the grafana chart from https://github.com/stackrox/stackrox/pull/22365 for a while 

Cluster1 overnight: 8 RHEL9 VMs, Sensor poll 20m, tick 10s, spread 2/3. Grafana dashboard **VM Index Report - Sensor Metrics**, last 24 hours. Prometheus was not restarted.

### Overview

<img width="1508" height="197" alt="graf1" src="https://github.com/user-attachments/assets/73c954cd-deb6-466f-954f-5c87d49bf6f6" />



On this screenshot we see the fleet size and lifetime scrape totals.

The data means Sensor tracked 8 VMs for the whole run. Due is 0 most of the time because the next attempts are still in the future. 50 full reports went to Central and 311 pulls were unchanged (guest contents did not change). Central NACKed twice. Tick rate stays about 0.1/s (1 per 10s), so the scraper loop kept running.

### Starts per tick

<img width="1504" height="1059" alt="graf2" src="https://github.com/user-attachments/assets/c849cd78-4fc8-4e8f-839a-70d9c1233927" />

**Successful forwards to Central** (top left, green) is the running total of full index reports Sensor sent to Central (`status="success"`). Unchanged VSOCK polls do not move this series. The run used poll interval 20m, tick 10s, spread fraction 2/3 (so W ≈ 13m), eight VMs, and the default 4h mandatory refresh: after `lastForwardedAt` is older than 4h, the next due poll requests a full report even if the agent has nothing new.

Prediction: each VM still polls every 20m + U(0, W) ∈ [20m, 33m], but this counter should stay flat between refreshes. About every 4h the fleet should produce eight full forwards. Those eight should not share one timestamp. If their due times are staggered by the cadence offsets, the wave lasts on the order of one poll-plus-band (up to ~33m). If they all became due at once, the start budget is still 1 per tick, so the backstop would drain them in 8 × 10s = 80s. A failure of spreading is a single vertical jump of +8.

Observation: three such waves, about 4h apart (~01:00, ~05:00, ~09:00). Each raises the counter by 8 (one per VM): ~25→33, ~34→42, ~42→50. Inside a wave the line rises as unit steps over about 40 minutes, not as one jump and not as 80s of 10s ticks. The plateau between waves is unchanged polling. That matches a 4h mandatory refresh of an 8-VM fleet whose per-VM due times remain spread across the 20m poll band (the ~40m width is the previous wave's stagger plus each VM's next poll after the 4h threshold).

**Fleet size** stays at 8 VMs for the whole window, so the start budget is computed from a constant fleet.

**Due pile vs starts per tick** is the budget test. The orange series **due (last tick)** spikes to 1 and occasionally 2 when VMs become eligible. The green **avg starts / observed tick** and red **P95 starts / observed tick** sit on 1 whenever a tick actually started work. Arrival smoothing is working here because a due pile of 2 never becomes 2 starts: Sensor launches one scrape per tick and leaves the rest due.

**Starts per tick heatmap** records that same fact over time. Colour appears only on the `1` row of the Y-axis (how many VMs that tick started). The `2`, `8`, and `20` rows stay empty, which is the dump that would appear if every due VM started at once.

**Starts per tick distribution** totals those ticks: **217** observations in bucket `1`, and **0** in every higher bucket. That is the same pacing as the staircase: one start per 10s tick.

### Forward interarrival

<img width="1509" height="614" alt="graf3" src="https://github.com/user-attachments/assets/7935c09b-2501-4b69-b495-5a6e4305598d" />

These three panels measure the Sensor-wide gap between consecutive **full** forwards to Central (unchanged pulls do not appear).

**Forward interarrival heatmap** plots that gap on Y (seconds) against wall-clock time. Colour shows up around minutes. A dump would light the bottom of the heatmap: many reports leaving Sensor in the same instant.

**Forward interarrival distribution** is the same histogram over the selected range. Bucket **≤0.08s (dump)** and two others <10s are **0**. This means that in each tick there was maximally 1 forward and the tick interval is at least 10s (which we know is exactly 10s). The rest of the data means that 9 forwards to Central happened 41s-2.7m apart from each other. The tightest gap between two sends was between 10-41s in two cases. 

**Forward interarrival percentiles** agree: P50 mean **7.64 min**, so 50% of forwards were spaced at least 7.64 min apart. Max **21.8 min** shows the biggest time gap between two forwards. 

The red dot close to 0s shortly after 5 AM is a Prometheus artifact: That series is `histogram_quantile(0.99, rate(...))`. Overnight there are no successful forwards for hours, so most windows are empty and Grafana draws nothing. When the ~05:00 mandatory-refresh wave starts, one scrape window finally has a sample, and you get an isolated red point. That point sits on ~0 because rate() on histogram buckets with one or two observations is a bad estimator. The per-bucket rates stop being monotonic, Prometheus treats the quantile as falling in the first bucket (10ms), and P99 interpolates to ~0. P50/P90 often land in the same place.

### Schedule offset

<img width="1508" height="613" alt="graf4" src="https://github.com/user-attachments/assets/fb820b53-b662-4001-add2-8521a4b2ba0e" />

These panels are the random extra delay added **on top of the 20m poll** when a VM returns to cadence after a successful scrape (or a permanent failure). They do not record the forwards to central, but the precise schedules when to pull next index report from a VM (changed or unchanged does not matter here).

**Schedule offset heatmap** puts that extra delay on Y. Colour sits between about **1 min** and **17 min**, inside W = 20m × 2/3 ≈ 13m (samples can reach the next histogram bucket above W). The 1h / 2h rows stay empty.

**Schedule offset percentiles**: P50 mean **7.60 min** (max 12.8 min), P95 mean **10.2 min** (max 16.6 min). A uniform draw on [0, W] should land near W/2 on average; 7.6 min is that centre (W is 13min20s in our case because it is the 2/3 of 20 minutes poll interval).

**Schedule offset distribution** counts the same samples: **89** in **512–1024s** (~8.5–17 min), **69** in **256–512s**, fewer in the shorter buckets, and **0** above 1024s. Cadence spreading is working because next due times are fanned across the post-poll band instead of lining up on the same 20-minute mark.

### Retries and NACKs

<img width="1504" height="646" alt="graf5" src="https://github.com/user-attachments/assets/e02256ac-ca79-469a-b99f-8c0b471a9868" />

**Pull outcomes by status** is scrape results over time. The dense blue series is **unchanged** (mean 0.00444 pulls/s): Sensor kept polling, the agent had nothing newer, and Central did not get a new report. The sparse green series is **success** (mean 0.000578 pulls/s), the occasional full forward.

**Retryable errors vs success+unchanged** stacks the same traffic as good pulls (green) against retryable and permanent errors. The green series tracks the poll cadence (peaks near 0.067/s). No retryable stack appears, so VSOCK scrapes were not tight-looping on dial/timeout failures.

**ACK vs NACK** is Central's reply rate. Green **ACK** spikes line up with the success forwards. Red **NACK** is almost absent (mean 4.6e-5/s).

**ACK / NACK cumulative** makes the count obvious: **ACK** steps to **48**; **NACK** steps to **2** around 01:30 and stays flat. The retry path is working because two Central rejects did not stall the scraper or produce a NACK storm. The reject reason (Scanner V4 `GetVulnerabilities` `Unavailable` / `EOF` on the first NACK) is in Central logs, not on these panels.



