### PR TITLE
ROX-36344: Fix compat test sensor registry mismatch

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -331,8 +331,10 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
             exit 1
         fi
         ci_export SENSOR_CHART_DIR_OVERRIDE "${charts_dir}/${chart_name}"
-        roxctl helm output secured-cluster-services --image-defaults=opensource --output-dir "${SENSOR_CHART_DIR_OVERRIDE}" --remove
-        echo "Downloaded ${chart_name} helm chart for version ${sensor_version} to ${SENSOR_CHART_DIR_OVERRIDE}"
+        local sensor_image_flavor
+        sensor_image_flavor="${ROXCTL_ROX_IMAGE_FLAVOR:-$(make --quiet --no-print-directory -C "${TEST_ROOT}" image-flavor)}"
+        roxctl helm output secured-cluster-services --image-defaults="${sensor_image_flavor}" --output-dir "${SENSOR_CHART_DIR_OVERRIDE}" --remove
+        echo "Downloaded ${chart_name} helm chart for version ${sensor_version} to ${SENSOR_CHART_DIR_OVERRIDE} (image-defaults=${sensor_image_flavor})"
     else
         echo >&2 "${chart_name} helm chart for version ${sensor_version} not found in ${helm_repo_name} repo nor is it the latest tag."
         exit 1


### PR DESCRIPTION
## Description

  `gke-version-compatibility-tests` has been failing on every reverse-compatibility leg (old Central + current/nightly Sensor) with Sensor stuck in `Init:ImagePullBackOff`.

  Root cause: `deploy_stackrox_with_custom_central_and_sensor_versions()` in `tests/e2e/lib.sh` generates the Sensor chart on the fly whenever the Sensor version under test is the current build (not yet published to the Helm repo), using:

  ```bash
  roxctl helm output secured-cluster-services --image-defaults=opensource ...
  ```

  `--image-defaults=opensource` hardcodes `registry: quay.io/stackrox-io`. Nightly builds are only ever pushed to `quay.io/rhacs-eng`, so the generated chart pointed Sensor at an image that doesn't exist in that registry.

  Central doesn't hit this bug because its normal deploy path (`deploy_central()` → `deploy/common/deploy.sh` → `deploy/common/k8sbased.sh`) already resolves the image flavor dynamically via `ROXCTL_ROX_IMAGE_FLAVOR`/`make image-flavor`. Only this special-cased Sensor branch bypassed that and hardcoded `opensource`.

  **Fix:** resolve the flavor the same way `deploy/common/deploy.sh` does, instead of hardcoding `opensource`

  🤖 This change was partially generated with the assistance of AI.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR**
  is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  This is a fix to test infrastructure itself (`tests/e2e/lib.sh`), not product code — no unit/e2e/regression tests apply. Correctness is validated by the compatibility test suite this change fixes.

  - [ ] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [x] added compatibility tests
  - [ ] modified existing tests

  ### How I validated my change
  
  - Confirmed `deploy/common/k8sbased.sh` uses the generated chart as-is for `helm install`/`upgrade` (no later override of `image.main.registry`), so the registry baked in at generation time is what actually gets deployed.
  - Ran the compatibility tests in CI