### PR TITLE
fix(telemetry): query V2 stores when enhanced VM model is on

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -178,7 +178,9 @@ import (
 	"github.com/stackrox/rox/central/version"
 	vStore "github.com/stackrox/rox/central/version/store"
 	virtualMachineDS "github.com/stackrox/rox/central/virtualmachine/datastore"
+	virtualMachineScanV2DS "github.com/stackrox/rox/central/virtualmachine/scan/v2/datastore"
 	virtualmachineService "github.com/stackrox/rox/central/virtualmachine/service"
+	virtualMachineV2DS "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
 	virtualmachineV2Service "github.com/stackrox/rox/central/virtualmachine/v2/service"
 	vulnMgmtService "github.com/stackrox/rox/central/vulnmgmt/service"
 	vulnRequestManager "github.com/stackrox/rox/central/vulnmgmt/vulnerabilityrequest/manager/requestmgr"
@@ -716,6 +718,10 @@ func addCentralIdentityGatherers(c *phonehomeClient.CentralClient) {
 	add(roleDataStore.Gather)
 	add(signatureIntegrationDS.Gather)
 	add(virtualMachineDS.Gather(virtualMachineDS.Singleton()))
+	add(virtualMachineDS.GatherV2(
+		virtualMachineV2DS.Singleton(),
+		virtualMachineScanV2DS.Singleton(),
+	))
 }
 
 func registerDelayedIntegrations(integrationsInput []iiStore.DelayedIntegration) {

--- a/central/virtualmachine/datastore/telemetry.go
+++ b/central/virtualmachine/datastore/telemetry.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"time"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 )
@@ -98,6 +100,75 @@ func gatherWithTime(ds DataStore, nowFunc func() time.Time) phonehome.GatherFunc
 			metricVMsWithActiveAgents: vmsWithActiveAgents,
 		}
 		log.Debugf("Virtual machines telemetry update: %v", props)
+		return props, nil
+	}
+}
+
+// vmV2Walker is the subset of the VM V2 datastore this gatherer needs.
+type vmV2Walker interface {
+	Walk(ctx context.Context, fn func(vm *storage.VirtualMachineV2) error) error
+}
+
+// scanV2Counter is the subset of the scan V2 datastore this gatherer needs.
+type scanV2Counter interface {
+	Count(ctx context.Context, q *v1.Query) (int, error)
+}
+
+// GatherV2 returns a gatherer that queries the V2 VM and scan datastores.
+func GatherV2(vmV2DS vmV2Walker, scanV2DS scanV2Counter) phonehome.GatherFunc {
+	return gatherV2WithTime(vmV2DS, scanV2DS, time.Now)
+}
+
+func gatherV2WithTime(vmV2DS vmV2Walker, scanV2DS scanV2Counter, nowFunc func() time.Time) phonehome.GatherFunc {
+	return func(ctx context.Context) (map[string]any, error) {
+		if !features.VirtualMachines.Enabled() || !features.VirtualMachinesEnhancedDataModel.Enabled() {
+			return map[string]any{}, nil
+		}
+
+		ctx = sac.WithGlobalAccessScopeChecker(ctx,
+			sac.AllowFixedScopes(
+				sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+				sac.ResourceScopeKeys(resources.VirtualMachine),
+			),
+		)
+
+		clusterIDsWithRunningVMs := set.NewStringSet()
+		totalVMs := 0
+
+		err := vmV2DS.Walk(ctx, func(vm *storage.VirtualMachineV2) error {
+			totalVMs++
+			if vm.GetState() == storage.VirtualMachineV2_RUNNING {
+				clusterID := vm.GetClusterId()
+				if clusterID == "" {
+					log.Debugf("Virtual machine V2 %s has empty cluster_id", vm.GetId())
+				} else {
+					clusterIDsWithRunningVMs.Add(clusterID)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		now := nowFunc()
+		cutoff := now.Add(-activeVMAgentMaxAgeLimitTelemetry)
+		cutoffTS := protocompat.ConvertTimeToTimestampOrNil(&cutoff)
+		q := search.NewQueryBuilder().
+			AddStrings(search.VirtualMachineScanTime, ">"+protocompat.ConvertTimestampToString(cutoffTS, time.RFC3339Nano)).
+			ProtoQuery()
+
+		vmsWithActiveAgents, err := scanV2DS.Count(ctx, q)
+		if err != nil {
+			return nil, err
+		}
+
+		props := map[string]any{
+			metricClustersWithVMs:     clusterIDsWithRunningVMs.Cardinality(),
+			metricTotalVMs:            totalVMs,
+			metricVMsWithActiveAgents: vmsWithActiveAgents,
+		}
+		log.Debugf("Virtual machines V2 telemetry update: %v", props)
 		return props, nil
 	}
 }

--- a/central/virtualmachine/datastore/telemetry.go
+++ b/central/virtualmachine/datastore/telemetry.go
@@ -153,9 +153,8 @@ func gatherV2WithTime(vmV2DS vmV2Walker, scanV2DS scanV2Counter, nowFunc func() 
 
 		now := nowFunc()
 		cutoff := now.Add(-activeVMAgentMaxAgeLimitTelemetry)
-		cutoffTS := protocompat.ConvertTimeToTimestampOrNil(&cutoff)
 		q := search.NewQueryBuilder().
-			AddStrings(search.VirtualMachineScanTime, ">"+protocompat.ConvertTimestampToString(cutoffTS, time.RFC3339Nano)).
+			AddTimeRangeField(search.VirtualMachineScanTime, cutoff, now).
 			ProtoQuery()
 
 		vmsWithActiveAgents, err := scanV2DS.Count(ctx, q)

--- a/central/virtualmachine/datastore/telemetry.go
+++ b/central/virtualmachine/datastore/telemetry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
+	"github.com/stackrox/rox/pkg/timestamp"
 )
 
 const (
@@ -153,7 +154,7 @@ func gatherV2WithTime(vmV2DS vmV2Walker, scanV2DS scanV2Counter, nowFunc func() 
 		now := nowFunc()
 		cutoff := now.Add(-activeVMAgentMaxAgeLimitTelemetry)
 		q := search.NewQueryBuilder().
-			AddTimeRangeField(search.VirtualMachineScanTime, cutoff, now).
+			AddTimeRangeField(search.VirtualMachineScanTime, cutoff, timestamp.InfiniteFuture.GoTime()).
 			ProtoQuery()
 
 		vmsWithActiveAgents, err := scanV2DS.Count(ctx, q)

--- a/central/virtualmachine/datastore/telemetry.go
+++ b/central/virtualmachine/datastore/telemetry.go
@@ -37,8 +37,8 @@ var (
 // 2. Total number of virtual machines
 // 3. Number of VMs with active agents (received IndexReport within last 24 hours)
 //
-// When the ROX_VIRTUAL_MACHINES feature flag is disabled, this function returns
-// an empty map without performing any database queries, ensuring no performance impact.
+// When ROX_VIRTUAL_MACHINES is off, or the enhanced data model is on (GatherV2
+// owns these metric names), Gather returns an empty map and does not query storage.
 func Gather(ds DataStore) phonehome.GatherFunc {
 	return gatherWithTime(ds, time.Now)
 }
@@ -46,8 +46,7 @@ func Gather(ds DataStore) phonehome.GatherFunc {
 // gatherWithTime allows injecting a time function for deterministic testing.
 func gatherWithTime(ds DataStore, nowFunc func() time.Time) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
-		// Early return if virtual machines feature is disabled - zero performance impact
-		if !features.VirtualMachines.Enabled() {
+		if !features.VirtualMachines.Enabled() || features.VirtualMachinesEnhancedDataModel.Enabled() {
 			return map[string]any{}, nil
 		}
 

--- a/central/virtualmachine/datastore/telemetry_test.go
+++ b/central/virtualmachine/datastore/telemetry_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -183,29 +184,42 @@ func TestVirtualMachineTelemetry(t *testing.T) {
 	}
 }
 
-func TestVirtualMachineTelemetryWithFeatureFlagDisabled(t *testing.T) {
-	// Disable the feature flag using t.Setenv for automatic cleanup
-	t.Setenv(features.VirtualMachines.EnvVar(), "false")
-
-	ctx := sac.WithAllAccess(context.Background())
-
-	// Create a mock datastore with VMs (which should NOT be queried)
-	ds := &mockDataStore{
-		vms: []*storage.VirtualMachine{
-			{Id: "vm1", ClusterId: "cluster1", Name: "test-vm", State: storage.VirtualMachine_RUNNING, Scan: createScanWithAge(1 * time.Hour)},
-			{Id: "vm2", ClusterId: "cluster2", Name: "test-vm2", State: storage.VirtualMachine_RUNNING, Scan: createScanWithAge(1 * time.Hour)},
+func TestVirtualMachineTelemetrySkipGather(t *testing.T) {
+	tests := map[string]struct {
+		virtualMachinesEnabled bool
+		enhancedDataModel      bool
+	}{
+		"should return empty map when virtual machines flag is disabled": {
+			virtualMachinesEnabled: false,
+			enhancedDataModel:      false,
+		},
+		"should return empty map when enhanced data model is enabled": {
+			virtualMachinesEnabled: true,
+			enhancedDataModel:      true,
 		},
 	}
 
-	gatherer := gatherWithTime(ds, arbitraryNowFunc)
-	props, err := gatherer(ctx)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.VirtualMachines.EnvVar(), strconv.FormatBool(tc.virtualMachinesEnabled))
+			t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), strconv.FormatBool(tc.enhancedDataModel))
 
-	require.NoError(t, err)
-	require.NotNil(t, props)
+			ctx := sac.WithAllAccess(context.Background())
+			ds := &mockDataStore{
+				vms: []*storage.VirtualMachine{
+					{Id: "vm1", ClusterId: "cluster1", Name: "test-vm", State: storage.VirtualMachine_RUNNING, Scan: createScanWithAge(1 * time.Hour)},
+				},
+			}
 
-	// When feature flag is disabled, should return empty map
-	// No database query should have been performed
-	assert.Empty(t, props, "Should return empty map when feature flag is disabled")
+			gatherer := gatherWithTime(ds, arbitraryNowFunc)
+			props, err := gatherer(ctx)
+
+			require.NoError(t, err)
+			require.NotNil(t, props)
+			assert.Empty(t, props)
+			assert.False(t, ds.walked)
+		})
+	}
 }
 
 // createScanWithAge creates a scan with a timestamp at the specified duration before arbitraryNow.
@@ -218,8 +232,9 @@ func createScanWithAge(age time.Duration) *storage.VirtualMachineScan {
 }
 
 type mockDataStore struct {
-	vms []*storage.VirtualMachine
-	err error
+	vms    []*storage.VirtualMachine
+	err    error
+	walked bool
 }
 
 func (m *mockDataStore) CountVirtualMachines(ctx context.Context, query *v1.Query) (int, error) {
@@ -254,6 +269,7 @@ func (m *mockDataStore) SearchRawVirtualMachines(ctx context.Context, query *v1.
 }
 
 func (m *mockDataStore) Walk(ctx context.Context, fn func(vm *storage.VirtualMachine) error) error {
+	m.walked = true
 	if m.err != nil {
 		return m.err
 	}

--- a/central/virtualmachine/datastore/telemetry_test.go
+++ b/central/virtualmachine/datastore/telemetry_test.go
@@ -2,17 +2,19 @@ package datastore
 
 import (
 	"context"
+	"errors"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -382,10 +384,6 @@ func TestVirtualMachineTelemetryV2(t *testing.T) {
 		},
 	}
 
-	expectedScanQuery := search.NewQueryBuilder().
-		AddTimeRangeField(search.VirtualMachineScanTime, arbitraryNow.Add(-activeVMAgentMaxAgeLimitTelemetry), arbitraryNow).
-		ProtoQuery()
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx := sac.WithAllAccess(context.Background())
@@ -401,8 +399,73 @@ func TestVirtualMachineTelemetryV2(t *testing.T) {
 			assert.Equal(t, tc.expectedClustersWithRunningVMs, props[metricClustersWithVMs])
 			assert.Equal(t, tc.expectedTotalVMs, props[metricTotalVMs])
 			assert.Equal(t, tc.expectedVMsWithActiveAgents, props[metricVMsWithActiveAgents])
-			require.NotNil(t, scanV2DS.lastQuery)
-			protoassert.Equal(t, expectedScanQuery, scanV2DS.lastQuery)
+			assertActiveAgentScanQuery(t, scanV2DS.lastQuery)
 		})
 	}
+}
+
+func TestVirtualMachineTelemetryV2Errors(t *testing.T) {
+	t.Setenv(features.VirtualMachines.EnvVar(), "true")
+	t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
+
+	walkErr := errors.New("walk failed")
+	countErr := errors.New("count failed")
+
+	tests := map[string]struct {
+		walkErr  error
+		countErr error
+		wantErr  error
+	}{
+		"should return Walk error and nil props": {
+			walkErr: walkErr,
+			wantErr: walkErr,
+		},
+		"should return Count error and nil props": {
+			countErr: countErr,
+			wantErr:  countErr,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := sac.WithAllAccess(context.Background())
+			vmV2DS := &mockVMV2DataStore{
+				vms: []*storage.VirtualMachineV2{
+					{Id: "vm1", ClusterId: "cluster1", Name: "vm-1", State: storage.VirtualMachineV2_RUNNING},
+				},
+				err: tc.walkErr,
+			}
+			scanV2DS := &mockScanV2DataStore{count: 1, err: tc.countErr}
+
+			props, err := gatherV2WithTime(vmV2DS, scanV2DS, arbitraryNowFunc)(ctx)
+
+			require.ErrorIs(t, err, tc.wantErr)
+			assert.Nil(t, props)
+			if tc.walkErr != nil {
+				assert.Nil(t, scanV2DS.lastQuery)
+				return
+			}
+			assertActiveAgentScanQuery(t, scanV2DS.lastQuery)
+		})
+	}
+}
+
+func assertActiveAgentScanQuery(t *testing.T, q *v1.Query) {
+	t.Helper()
+	require.NotNil(t, q)
+	mfq := q.GetBaseQuery().GetMatchFieldQuery()
+	require.NotNil(t, mfq)
+	assert.Equal(t, search.VirtualMachineScanTime.String(), mfq.GetField())
+
+	value, ok := strings.CutPrefix(mfq.GetValue(), search.TimeRangePrefix)
+	require.True(t, ok)
+	fromStr, toStr, ok := strings.Cut(value, "-")
+	require.True(t, ok)
+	from, err := strconv.ParseInt(fromStr, 10, 64)
+	require.NoError(t, err)
+	to, err := strconv.ParseInt(toStr, 10, 64)
+	require.NoError(t, err)
+
+	assert.Equal(t, arbitraryNow.Add(-activeVMAgentMaxAgeLimitTelemetry).UnixMilli(), from)
+	assert.Equal(t, timestamp.InfiniteFuture.GoTime().UnixMilli(), to)
 }

--- a/central/virtualmachine/datastore/telemetry_test.go
+++ b/central/virtualmachine/datastore/telemetry_test.go
@@ -8,8 +8,10 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -283,11 +285,13 @@ func (m *mockVMV2DataStore) Walk(_ context.Context, fn func(vm *storage.VirtualM
 }
 
 type mockScanV2DataStore struct {
-	count int
-	err   error
+	count     int
+	err       error
+	lastQuery *v1.Query
 }
 
-func (m *mockScanV2DataStore) Count(_ context.Context, _ *v1.Query) (int, error) {
+func (m *mockScanV2DataStore) Count(_ context.Context, q *v1.Query) (int, error) {
+	m.lastQuery = q
 	return m.count, m.err
 }
 
@@ -362,6 +366,10 @@ func TestVirtualMachineTelemetryV2(t *testing.T) {
 		},
 	}
 
+	expectedScanQuery := search.NewQueryBuilder().
+		AddTimeRangeField(search.VirtualMachineScanTime, arbitraryNow.Add(-activeVMAgentMaxAgeLimitTelemetry), arbitraryNow).
+		ProtoQuery()
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx := sac.WithAllAccess(context.Background())
@@ -377,6 +385,8 @@ func TestVirtualMachineTelemetryV2(t *testing.T) {
 			assert.Equal(t, tc.expectedClustersWithRunningVMs, props[metricClustersWithVMs])
 			assert.Equal(t, tc.expectedTotalVMs, props[metricTotalVMs])
 			assert.Equal(t, tc.expectedVMsWithActiveAgents, props[metricVMsWithActiveAgents])
+			require.NotNil(t, scanV2DS.lastQuery)
+			protoassert.Equal(t, expectedScanQuery, scanV2DS.lastQuery)
 		})
 	}
 }

--- a/central/virtualmachine/datastore/telemetry_test.go
+++ b/central/virtualmachine/datastore/telemetry_test.go
@@ -262,3 +262,121 @@ func (m *mockDataStore) Walk(ctx context.Context, fn func(vm *storage.VirtualMac
 	}
 	return nil
 }
+
+// --- V2 mock types ---
+
+type mockVMV2DataStore struct {
+	vms []*storage.VirtualMachineV2
+	err error
+}
+
+func (m *mockVMV2DataStore) Walk(_ context.Context, fn func(vm *storage.VirtualMachineV2) error) error {
+	if m.err != nil {
+		return m.err
+	}
+	for _, vm := range m.vms {
+		if err := fn(vm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type mockScanV2DataStore struct {
+	count int
+	err   error
+}
+
+func (m *mockScanV2DataStore) Count(_ context.Context, _ *v1.Query) (int, error) {
+	return m.count, m.err
+}
+
+func TestVirtualMachineTelemetryV2(t *testing.T) {
+	t.Setenv(features.VirtualMachines.EnvVar(), "true")
+	t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
+
+	tests := map[string]struct {
+		vms                            []*storage.VirtualMachineV2
+		scanCount                      int
+		expectedClustersWithRunningVMs int
+		expectedTotalVMs               int
+		expectedVMsWithActiveAgents    int
+	}{
+		"should return zero for all metrics when no V2 VMs exist": {
+			vms:                            nil,
+			scanCount:                      0,
+			expectedClustersWithRunningVMs: 0,
+			expectedTotalVMs:               0,
+			expectedVMsWithActiveAgents:    0,
+		},
+		"should count single cluster with one running V2 VM and one recent scan": {
+			vms: []*storage.VirtualMachineV2{
+				{Id: "vm1", ClusterId: "cluster1", Name: "test-vm", State: storage.VirtualMachineV2_RUNNING},
+			},
+			scanCount:                      1,
+			expectedClustersWithRunningVMs: 1,
+			expectedTotalVMs:               1,
+			expectedVMsWithActiveAgents:    1,
+		},
+		"should count total V2 VMs including stopped ones": {
+			vms: []*storage.VirtualMachineV2{
+				{Id: "vm1", ClusterId: "cluster1", Name: "vm-1", State: storage.VirtualMachineV2_RUNNING},
+				{Id: "vm2", ClusterId: "cluster1", Name: "vm-2", State: storage.VirtualMachineV2_STOPPED},
+				{Id: "vm3", ClusterId: "cluster2", Name: "vm-3", State: storage.VirtualMachineV2_UNKNOWN},
+			},
+			scanCount:                      0,
+			expectedClustersWithRunningVMs: 1,
+			expectedTotalVMs:               3,
+			expectedVMsWithActiveAgents:    0,
+		},
+		"should count multiple distinct clusters with running V2 VMs": {
+			vms: []*storage.VirtualMachineV2{
+				{Id: "vm1", ClusterId: "cluster1", Name: "vm-1", State: storage.VirtualMachineV2_RUNNING},
+				{Id: "vm2", ClusterId: "cluster2", Name: "vm-2", State: storage.VirtualMachineV2_RUNNING},
+				{Id: "vm3", ClusterId: "cluster3", Name: "vm-3", State: storage.VirtualMachineV2_RUNNING},
+			},
+			scanCount:                      2,
+			expectedClustersWithRunningVMs: 3,
+			expectedTotalVMs:               3,
+			expectedVMsWithActiveAgents:    2,
+		},
+		"should exclude V2 VMs with empty cluster id from cluster count": {
+			vms: []*storage.VirtualMachineV2{
+				{Id: "vm1", ClusterId: "cluster1", Name: "vm-1", State: storage.VirtualMachineV2_RUNNING},
+				{Id: "vm2", ClusterId: "", Name: "vm-orphan", State: storage.VirtualMachineV2_RUNNING},
+			},
+			scanCount:                      1,
+			expectedClustersWithRunningVMs: 1,
+			expectedTotalVMs:               2,
+			expectedVMsWithActiveAgents:    1,
+		},
+		"should handle V2 VM with no scan row yet (never scanned)": {
+			vms: []*storage.VirtualMachineV2{
+				{Id: "vm1", ClusterId: "cluster1", Name: "vm-1", State: storage.VirtualMachineV2_RUNNING},
+				{Id: "vm2", ClusterId: "cluster1", Name: "vm-2", State: storage.VirtualMachineV2_RUNNING},
+			},
+			scanCount:                      0,
+			expectedClustersWithRunningVMs: 1,
+			expectedTotalVMs:               2,
+			expectedVMsWithActiveAgents:    0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := sac.WithAllAccess(context.Background())
+
+			vmV2DS := &mockVMV2DataStore{vms: tc.vms}
+			scanV2DS := &mockScanV2DataStore{count: tc.scanCount}
+
+			gatherer := gatherV2WithTime(vmV2DS, scanV2DS, arbitraryNowFunc)
+			props, err := gatherer(ctx)
+
+			require.NoError(t, err)
+			require.NotNil(t, props)
+			assert.Equal(t, tc.expectedClustersWithRunningVMs, props[metricClustersWithVMs])
+			assert.Equal(t, tc.expectedTotalVMs, props[metricTotalVMs])
+			assert.Equal(t, tc.expectedVMsWithActiveAgents, props[metricVMsWithActiveAgents])
+		})
+	}
+}


### PR DESCRIPTION
## Description

Central's phonehome gatherer reports three install-wide VM metrics: clusters with a running VM, total VMs, and VMs scanned in the last 24 hours. It walks the V1 `storage.VirtualMachine` store. When `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL` is enabled, the index pipeline writes VMs and scans to the V2 stores and never updates V1, so those metrics go to zero (or leftover V1 rows).

This adds `GatherV2`, registered next to the existing gatherer. It walks the VM V2 datastore for totals and running-cluster IDs, and counts `VirtualMachineScanV2` rows whose `scan_time` is in `[now-24h, now)` via `AddTimeRangeField`. The three metric names stay the same.

Both gatherers write the same keys, and phonehome copies later results over earlier ones. If `GatherV2` fails, phonehome keeps V1's zeros, and V1 still walks a stale table on every gather. When the enhanced model is on, V1 `Gather` returns an empty map and does not query storage.

`GatherV2` no-ops unless both VM flags are on. The V2 datastore `Singleton()` functions return nil when the enhanced flag is off, so registration is unconditional.

The scan-time filter uses the search millisecond range (`tr/<from>-<to>`). Postgres search does not parse RFC3339Nano, so a string timestamp query makes `Count` fail on every V2 gather.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Manually verified on a cluster

<details>
<summary><b>Manual verification: PASS</b> - GatherV2 reports V2 VM totals when the enhanced data model is on</summary>

**Setup:** OpenShift + CNV, running VMs. Central only: `ROX_VIRTUAL_MACHINES=true`, `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL=true`, `ROX_TELEMETRY_STORAGE_KEY_V1=<key>`, `MODULE_LOGLEVELS=virtualmachine/datastore=debug`.  After enabling the enhanced flag, Sensor does not resend unchanged VMs; bump `kubevirt.io/description` on the VM CRs so Central writes them to V2, then restart Central so gather runs against V2 (startup gather can race an empty store). Identity traits go to Amplitude as Central’s installation ID from the “Telemetry Client Configuration” log; this check used the gatherer debug line instead of the Amplitude UI.

1. `kubectl -n stackrox logs deploy/central | grep 'Virtual machines V2 telemetry update'` → 1 cluster, 8 VMs, 0 active agents; no `gatherer … failure`
   ```
   virtualmachine/datastore: … telemetry.go:170: Debug: Virtual machines V2 telemetry update: map[Total Secured Clusters With Virtual Machines:1 Total Virtual Machines:8 Total Virtual Machines With Active Agents (Last 24h):0]
   ```
2. `kubectl -n stackrox logs deploy/central | grep 'Virtual machines telemetry update'` → no V1 gatherer line (enhanced model on)
   ```
   (no V1 gatherer line)
   ```
3. Postgres: `virtual_machine_v2` has 8 RUNNING rows / 1 cluster; `virtual_machine_scan_v2` is empty, which matches the 0 in step 1 (Count succeeded rather than failing the gather)
   ```
    v2_vms | v2_running | v2_running_clusters | v2_scans | v1_vms
   --------+------------+---------------------+----------+--------
         8 |          8 |                   1 |        0 |      8
   ```

</details>

AI-Assisted: cursor, generated, user reviewed query format, V1/V2 gating, and tests.