### PR TITLE
ROX-36140: per-bundle error isolation in runMultiBundleUpdate

### DIFF
--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -446,14 +446,24 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 	slog.InfoContext(ctx, "pre-registered vulnerability bundles", "count", len(bundles))
 
 	// Process each vulnerability bundle in the .zip archive.
+	// Errors are collected so all bundles are attempted even when some fail.
+	var bundleErrs []error
+	succeeded := 0
 	for _, bundleF := range bundles {
 		bundleCtx := log.With(ctx, "bundle", bundleF.Name)
 		slog.InfoContext(bundleCtx, "starting bundle update")
 		if err := u.updateBundle(bundleCtx, bundleF, zipTime, prevTime); err != nil {
 			slog.ErrorContext(bundleCtx, "updating bundle failed", "reason", err)
-			return false, fmt.Errorf("updating bundle %s: %w", bundleF.Name, err)
+			bundleErrs = append(bundleErrs, fmt.Errorf("bundle %s: %w", bundleF.Name, err))
+			continue
 		}
 		slog.InfoContext(bundleCtx, "completed bundle update")
+		succeeded++
+	}
+
+	// Skip GC and distribution update when every bundle failed.
+	if succeeded == 0 && len(bundles) > 0 {
+		return false, errors.Join(bundleErrs...)
 	}
 
 	// Clean updaters that were deleted (not in the zip and older than this update).
@@ -474,7 +484,7 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 
 	_ = u.Initialized(ctx)
 
-	return true, nil
+	return true, errors.Join(bundleErrs...)
 }
 
 func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time.Time, prevTime time.Time) error {

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -373,9 +373,6 @@ func (u *Updater) Update(ctx context.Context) error {
 		err     error
 	)
 	updated, err = u.runMultiBundleUpdate(ctx)
-	if err != nil {
-		return err
-	}
 
 	// Only bother running the GC when it's not disabled
 	// and when the vulnerabilities have been updated.
@@ -386,7 +383,7 @@ func (u *Updater) Update(ctx context.Context) error {
 		slog.InfoContext(ctx, "no vulnerability updates: skipping GC")
 	}
 
-	return nil
+	return err
 }
 
 // runMultiBundleUpdate updates the vulnerability data with a multi-bundle and

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -444,6 +444,10 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 
 	// Process each vulnerability bundle in the .zip archive.
 	// Errors are collected so all bundles are attempted even when some fail.
+	//
+	// TODO(ROX-36437): succeeded counts lock-skipped and already-current
+	// bundles as successes; distinguish genuinely imported bundles from
+	// skipped ones.
 	var bundleErrs []error
 	succeeded := 0
 	for _, bundleF := range bundles {

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -476,12 +476,12 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 	}
 	err = u.metadataStore.GCVulnerabilityUpdates(ctx, names, zipTime)
 	if err != nil {
-		return false, fmt.Errorf("cleaning vuln updates: %w", err)
+		return false, errors.Join(fmt.Errorf("cleaning vuln updates: %w", err), errors.Join(bundleErrs...))
 	}
 
 	err = u.distManager.update(ctx)
 	if err != nil {
-		return false, fmt.Errorf("updating known-distributions: %w", err)
+		return false, errors.Join(fmt.Errorf("updating known-distributions: %w", err), errors.Join(bundleErrs...))
 	}
 
 	_ = u.Initialized(ctx)

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -458,8 +458,9 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 		succeeded++
 	}
 
-	// Skip GC and distribution update when every bundle failed.
-	if succeeded == 0 && len(bundles) > 0 {
+	// Skip GC and distribution update only when every bundle that was
+	// attempted returned an error (i.e., no partial success to build on).
+	if len(bundleErrs) > 0 && succeeded == 0 {
 		return false, errors.Join(bundleErrs...)
 	}
 

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -525,7 +525,7 @@ func TestRunMultiBundleUpdate_PartialFailure(t *testing.T) {
 		Return(now, nil)
 
 	err := u.Update(test.Logging(t))
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "nvd.json.zst")
 	assert.Equal(t, 3, importCallCount, "all three bundles must be attempted")
 }
 

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/klauspost/compress/zstd"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/datastore"
 	"github.com/quay/claircore/libvuln/driver"
@@ -424,6 +425,108 @@ func TestIsBundleAllowed(t *testing.T) {
 			assert.Equal(t, tc.want, u.isBundleAllowed(tc.filename))
 		})
 	}
+}
+
+func TestRunMultiBundleUpdate_PartialFailure(t *testing.T) {
+	bundleNames := []string{"alpine.json.zst", "nvd.json.zst", "rhel-vex.json.zst"}
+
+	// Create a minimal valid zstd frame around empty content.
+	makeZstd := func() []byte {
+		var buf bytes.Buffer
+		w, err := zstd.NewWriter(&buf)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		return buf.Bytes()
+	}
+
+	srv, now := testHTTPServer(t, func(_ *http.Request) io.ReadSeeker {
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		for _, name := range bundleNames {
+			f, err := zw.Create(name)
+			require.NoError(t, err)
+			_, err = f.Write(makeZstd())
+			require.NoError(t, err)
+		}
+		require.NoError(t, zw.Close())
+		return bytes.NewReader(buf.Bytes())
+	})
+
+	ctrl := gomock.NewController(t)
+	store := mocks.NewMockMatcherStore(ctrl)
+	metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
+
+	prevTime := now.Add(-time.Minute)
+
+	// importFunc fails for the second call (nvd), succeeds for the others.
+	importCallCount := 0
+	u := &Updater{
+		locker:        &testLocker{locker: updates.NewLocalLockSource()},
+		store:         store,
+		metadataStore: metadataStore,
+		client:        srv.Client(),
+		urls:          []string{srv.URL},
+		root:          t.TempDir(),
+		skipGC:        true,
+		importFunc: func(_ context.Context, _ io.Reader) error {
+			importCallCount++
+			if importCallCount == 2 {
+				return errors.New("fake import error")
+			}
+			return nil
+		},
+		retryDelay:  1 * time.Second,
+		retryMax:    1,
+		distManager: newDistManager(store),
+	}
+
+	// Start of runMultiBundleUpdate.
+	metadataStore.EXPECT().
+		GetLastVulnerabilityUpdate(gomock.Any()).
+		Return(prevTime, nil)
+
+	// Pre-registration phase: one call per bundle.
+	preReg := make([]*gomock.Call, len(bundleNames))
+	for i, name := range bundleNames {
+		preReg[i] = metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), name, prevTime).
+			Return(prevTime, nil)
+	}
+
+	// Processing phase: return prevTime so each bundle proceeds to import.
+	for _, name := range bundleNames {
+		call := metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), name, prevTime).
+			Return(prevTime, nil)
+		for _, pre := range preReg {
+			call.After(pre)
+		}
+	}
+
+	// SetLastVulnerabilityUpdate is called only for the two bundles that succeed.
+	metadataStore.EXPECT().
+		SetLastVulnerabilityUpdate(gomock.Any(), "alpine.json.zst", now).
+		Return(nil)
+	metadataStore.EXPECT().
+		SetLastVulnerabilityUpdate(gomock.Any(), "rhel-vex.json.zst", now).
+		Return(nil)
+
+	// GC and distribution update run because at least one bundle succeeded.
+	metadataStore.EXPECT().
+		GCVulnerabilityUpdates(gomock.Any(), gomock.Any(), now).
+		Return(nil)
+	store.EXPECT().
+		Distributions(gomock.Any()).
+		Return(nil, nil)
+
+	// Initialized check at end of runMultiBundleUpdate.
+	metadataStore.EXPECT().
+		GetLastVulnerabilityUpdate(gomock.Any()).
+		Return(now, nil)
+
+	err := u.Update(test.Logging(t))
+	assert.Error(t, err)
+	assert.Equal(t, 3, importCallCount, "all three bundles must be attempted")
 }
 
 func TestIsRetryableDialError(t *testing.T) {


### PR DESCRIPTION
## Description

The import loop in `runMultiBundleUpdate` returned immediately on the first bundle error, leaving all remaining bundles unprocessed. A single failing source blocked all others.

The loop now collects per-bundle errors and continues to the next bundle regardless. GC and distribution update still run when at least one bundle succeeded. The joined error is returned so the caller can observe failures without silently dropping them.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

`TestRunMultiBundleUpdate_PartialFailure`: three bundles served in a ZIP, the middle one's import fails. Asserts all three are attempted, the two healthy ones are imported, GC runs, and the function returns a non-nil error.

`go test ./scanner/matcher/updater/vuln/...` passes. `golangci-lint run ./scanner/matcher/updater/vuln/...` reports 0 issues.