### PR TITLE
ROX-36347: Add ability to log something once

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -44,6 +44,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/defaults"
+	"github.com/stackrox/rox/pkg/logging"
 	notifierProcessor "github.com/stackrox/rox/pkg/notifier"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoconv"
@@ -60,6 +61,7 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/pkg/version/productstreams"
 	"github.com/stackrox/rox/pkg/version/versioncompatibility"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -945,13 +947,18 @@ func (ds *datastoreImpl) populateSensorVersionCompatibility(clusters ...*storage
 		if cluster.GetStatus() == nil {
 			continue
 		}
-		sensorXY, err := productstreams.ParseXYFromVersionString(cluster.GetStatus().GetSensorVersion())
+		sensorVersion := cluster.GetStatus().GetSensorVersion()
+		sensorXY, err := productstreams.ParseXYFromVersionString(sensorVersion)
 		if err != nil {
+			logging.LogOncePerKeyf(cluster.GetId(), log, zapcore.WarnLevel,
+				"Failed to parse sensor version %s for cluster %s: %v", sensorVersion, cluster.GetId(), err)
 			cluster.Status.SensorVersionCompatibility = storage.SensorVersionCompatibility_SENSOR_VERSION_COMPATIBILITY_UNKNOWN
 			continue
 		}
 		compat, err := versioncompatibility.ClassifyVersion(sensorXY)
 		if err != nil {
+			logging.LogOncePerKeyf(cluster.GetId(), log, zapcore.WarnLevel,
+				"Failed to determine compatibility status for cluster %s, version %s: %v", cluster.GetId(), sensorVersion, err)
 			cluster.Status.SensorVersionCompatibility = storage.SensorVersionCompatibility_SENSOR_VERSION_COMPATIBILITY_UNKNOWN
 			continue
 		}

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/certwatch"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -33,6 +34,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/pkg/version/versioncompatibility"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 )
 
@@ -207,10 +209,13 @@ func (s *serviceImpl) GetMetadata(ctx context.Context, _ *v1.Empty) (*v1.Metadat
 	// Only return version information to logged-in users, not anonymous users.
 	if authn.IdentityFromContextOrNil(ctx) != nil {
 		metadata.Version = version.GetMainVersion()
-		if versions, err := versioncompatibility.CompatibleVersions(); err == nil {
+		versions, err := versioncompatibility.CompatibleVersions()
+		if err == nil {
 			for _, xy := range versions {
 				metadata.CompatibleSensorVersions = append(metadata.CompatibleSensorVersions, xy.String())
 			}
+		} else {
+			logging.LogOncef(log, zapcore.WarnLevel, "Failed to determine compatible Sensor versions: %v", err)
 		}
 	}
 	return metadata, nil

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -8,13 +8,17 @@ import (
 )
 
 // maxLogOnceMemory sets the maximum number of unique entries to track.
-// When the code exceeds this amount, some previously logOnceSeen entries will be randomly dropped from tracking and so
-// subsequent calls to LogOnce* will result in messages appearing in the log.
+// When the use exceeds this amount, some previously logOnceSeen entries will be randomly dropped and so subsequent
+// calls to LogOnce* will result in previously seen messages again appearing in the log.
+// If we see a warning in the logs (ref logOnceLimitNotified) that we reached this limit, we should check our use of
+// LogOncef / LogOncePerKeyf and remove any cases when the same line sends varying templates, or bump the limit if
+// there are no such cases.
 const maxLogOnceMemory = 10_000
 
 var (
-	logOnceSeen       sync.Map
-	logOnceMemoryUsed atomic.Int64
+	logOnceSeen          sync.Map
+	logOnceMemoryUsed    atomic.Int64
+	logOnceLimitNotified atomic.Bool
 )
 
 // LogOncef logs a message only once per template string (before formatting message).
@@ -29,6 +33,7 @@ var (
 // (capped by maxLogOnceMemory in a somewhat relaxed manner). If you want to prevent repeated varied messages
 // considering args, LogOncef and LogOncePerKeyf are not for you, and you should look at RateLimitedLogger or invent
 // something else.
+// Note that level also does not participate in de-duplication (similar to args).
 func LogOncef(logger Logger, level zapcore.Level, template string, args ...any) {
 	LogOncePerKeyf("", logger, level, template, args...)
 }
@@ -49,6 +54,9 @@ func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template str
 		logger.Logf(level, template, args...)
 
 		if logOnceMemoryUsed.Add(1) > maxLogOnceMemory {
+			if logOnceLimitNotified.Swap(true) == false {
+				logger.Warnf("maxLogOnceMemory=%d limit reached", maxLogOnceMemory)
+			}
 			// This is a best-effort deletion. It's possible that multiple threads try to delete the same item but only
 			// one succeeds, thought both decrement the counter. Trying to do this consistently would require more
 			// heavy-weight synchronization or data structures which defeats the idea of this log-once functionality

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -1,0 +1,46 @@
+package logging
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// maxLogOnceMemory sets the maximum number of unique entries to track.
+// When the code exceeds this amount, some previously logOnceSeen entries will be dropped from tracking and so subsequent
+// calls to LogOnce* will result in messages appearing in the log.
+const maxLogOnceMemory = 10_000
+
+var (
+	logOnceSeen       sync.Map
+	logOnceMemoryUsed atomic.Int64
+)
+
+// LogOncef logs a message only once per template string (before formatting message).
+// Use this in cases when subsequent calls should not result in new log messages, i.e. to prevent log spam.
+func LogOncef(logger Logger, level zapcore.Level, template string, args ...any) {
+	LogOncePerKeyf("", logger, level, template, args...)
+}
+
+// LogOncePerKeyf logs a message only once per template string (before formatting message) and provided arbitrary key.
+// Use this in cases when subsequent calls should not result in new log messages, i.e. to prevent log spam.
+func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template string, args ...any) {
+	fullKey := template
+	if key != "" {
+		fullKey = key + "|" + template
+	}
+
+	_, seenBefore := logOnceSeen.LoadOrStore(fullKey, nil)
+	if !seenBefore {
+		logger.Logf(level, template, args...)
+
+		if logOnceMemoryUsed.Add(1) > maxLogOnceMemory {
+			logOnceSeen.Range(func(key, _ any) bool {
+				logOnceSeen.Delete(key)
+				return false
+			})
+			logOnceMemoryUsed.Add(-1)
+		}
+	}
+}

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -28,7 +28,7 @@ func LogOncef(logger Logger, level zapcore.Level, template string, args ...any) 
 func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template string, args ...any) {
 	fullKey := template
 	if key != "" {
-		fullKey = key + "|" + template
+		fullKey = key + "\x00" + template
 	}
 
 	_, seen := logOnceSeen.LoadOrStore(fullKey, nil)

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -42,6 +42,9 @@ func LogOncef(logger Logger, level zapcore.Level, template string, args ...any) 
 // The combination of the key and the template string would be the thing which prevents logging the same message
 // multiple times. Use this function when you want to log once for a certain object that can be identified by the key.
 // Make sure you understand when to use and not to use this function - read doc/comment for LogOncef.
+// It's important to make sure the number of keys is bounded. For example, the use of cluster IDs is ok there as we
+// know that the number of clusters is limited, but the use of container IDs is not because many new containers are
+// likely to appear during the run time of the process.
 func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template string, args ...any) {
 	fullKey := template
 	if key != "" {
@@ -58,12 +61,12 @@ func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template str
 			}
 			logOnceSeen.Range(func(randomKey, _ any) bool {
 				if randomKey == fullKey {
-					// Don't forget what we just added.
+					// Don't forget what we just added, iterate to try another randomKey.
 					return true
 				}
 				if _, deleted := logOnceSeen.LoadAndDelete(randomKey); deleted {
 					logOnceMemoryUsed.Add(-1)
-					return false
+					return false // Stop iterating.
 				}
 				// Some other thread deleted the same randomKey, keep iterating to try another one.
 				return true

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -8,8 +8,8 @@ import (
 )
 
 // maxLogOnceMemory sets the maximum number of unique entries to track.
-// When the code exceeds this amount, some previously logOnceSeen entries will be dropped from tracking and so subsequent
-// calls to LogOnce* will result in messages appearing in the log.
+// When the code exceeds this amount, some previously logOnceSeen entries will be randomly dropped from tracking and so
+// subsequent calls to LogOnce* will result in messages appearing in the log.
 const maxLogOnceMemory = 10_000
 
 var (
@@ -31,8 +31,8 @@ func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template str
 		fullKey = key + "|" + template
 	}
 
-	_, seenBefore := logOnceSeen.LoadOrStore(fullKey, nil)
-	if !seenBefore {
+	_, seen := logOnceSeen.LoadOrStore(fullKey, nil)
+	if !seen {
 		logger.Logf(level, template, args...)
 
 		if logOnceMemoryUsed.Add(1) > maxLogOnceMemory {

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -18,13 +18,26 @@ var (
 )
 
 // LogOncef logs a message only once per template string (before formatting message).
+//
 // Use this in cases when subsequent calls should not result in new log messages, i.e. to prevent log spam.
+// The idea is that you can call LogOncef in some code that may get called repeatedly and should log something useful,
+// but the conditions don't change. You would use this function if you want to avoid producing the same repeated
+// message to logs over and over.
+// It is important that repeated messages are prevented for the same template string which is used before formatting
+// args into it. This is intentional compromise: LogOncef and LogOncePerKeyf are more performant than RateLimitedLogger
+// because they don't rely on heavy synchronization with Mutex and use relatively small memory of seen messages
+// (capped by maxLogOnceMemory in a somewhat relaxed manner). If you want to prevent repeated varied messages
+// considering args, LogOncef and LogOncePerKeyf are not for you, and you should look at RateLimitedLogger or invent
+// something else.
 func LogOncef(logger Logger, level zapcore.Level, template string, args ...any) {
 	LogOncePerKeyf("", logger, level, template, args...)
 }
 
 // LogOncePerKeyf logs a message only once per template string (before formatting message) and provided arbitrary key.
-// Use this in cases when subsequent calls should not result in new log messages, i.e. to prevent log spam.
+//
+// The combination of the key and the template string would be the thing which prevents logging the same message
+// multiple times. Use this function when you want to log once for a certain object that can be identified by the key.
+// Make sure you understand when to use and not to use this function - read doc/comment for LogOncef.
 func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template string, args ...any) {
 	fullKey := template
 	if key != "" {
@@ -36,8 +49,12 @@ func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template str
 		logger.Logf(level, template, args...)
 
 		if logOnceMemoryUsed.Add(1) > maxLogOnceMemory {
-			logOnceSeen.Range(func(key, _ any) bool {
-				logOnceSeen.Delete(key)
+			// This is a best-effort deletion. It's possible that multiple threads try to delete the same item but only
+			// one succeeds, thought both decrement the counter. Trying to do this consistently would require more
+			// heavy-weight synchronization or data structures which defeats the idea of this log-once functionality
+			// being computationally cheap. We should try to avoid filling up all memory to the limit anyway.
+			logOnceSeen.Range(func(randomKey, _ any) bool {
+				logOnceSeen.Delete(randomKey)
 				return false
 			})
 			logOnceMemoryUsed.Add(-1)

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -1,9 +1,9 @@
 package logging
 
 import (
-	"sync"
 	"sync/atomic"
 
+	"github.com/stackrox/rox/pkg/sync"
 	"go.uber.org/zap/zapcore"
 )
 

--- a/pkg/logging/log_once.go
+++ b/pkg/logging/log_once.go
@@ -30,9 +30,8 @@ var (
 // It is important that repeated messages are prevented for the same template string which is used before formatting
 // args into it. This is intentional compromise: LogOncef and LogOncePerKeyf are more performant than RateLimitedLogger
 // because they don't rely on heavy synchronization with Mutex and use relatively small memory of seen messages
-// (capped by maxLogOnceMemory in a somewhat relaxed manner). If you want to prevent repeated varied messages
-// considering args, LogOncef and LogOncePerKeyf are not for you, and you should look at RateLimitedLogger or invent
-// something else.
+// (capped by maxLogOnceMemory). If you want to prevent repeated varied messages considering args, LogOncef and
+// LogOncePerKeyf are not for you, and you should look at RateLimitedLogger or invent something else.
 // Note that level also does not participate in de-duplication (similar to args).
 func LogOncef(logger Logger, level zapcore.Level, template string, args ...any) {
 	LogOncePerKeyf("", logger, level, template, args...)
@@ -54,18 +53,21 @@ func LogOncePerKeyf(key string, logger Logger, level zapcore.Level, template str
 		logger.Logf(level, template, args...)
 
 		if logOnceMemoryUsed.Add(1) > maxLogOnceMemory {
-			if logOnceLimitNotified.Swap(true) == false {
+			if !logOnceLimitNotified.Swap(true) {
 				logger.Warnf("maxLogOnceMemory=%d limit reached", maxLogOnceMemory)
 			}
-			// This is a best-effort deletion. It's possible that multiple threads try to delete the same item but only
-			// one succeeds, thought both decrement the counter. Trying to do this consistently would require more
-			// heavy-weight synchronization or data structures which defeats the idea of this log-once functionality
-			// being computationally cheap. We should try to avoid filling up all memory to the limit anyway.
 			logOnceSeen.Range(func(randomKey, _ any) bool {
-				logOnceSeen.Delete(randomKey)
-				return false
+				if randomKey == fullKey {
+					// Don't forget what we just added.
+					return true
+				}
+				if _, deleted := logOnceSeen.LoadAndDelete(randomKey); deleted {
+					logOnceMemoryUsed.Add(-1)
+					return false
+				}
+				// Some other thread deleted the same randomKey, keep iterating to try another one.
+				return true
 			})
-			logOnceMemoryUsed.Add(-1)
 		}
 	}
 }

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -17,11 +17,6 @@ func TestLogOnce(t *testing.T) {
 type logOnceTestSuite struct {
 	suite.Suite
 	mockLogger *logMocks.MockLogger
-	realLogger Logger
-}
-
-func (s *logOnceTestSuite) SetupSuite() {
-	s.realLogger = LoggerForModule()
 }
 
 func (s *logOnceTestSuite) SetupTest() {
@@ -66,7 +61,36 @@ func (s *logOnceTestSuite) TestLogOncefSizeLimit() {
 	s.Equal(maxLogOnceMemory, inMap)
 }
 
-func (s *logOnceTestSuite) TestLogOncefReal() {
-	LogOncef(s.realLogger, zapcore.InfoLevel, "this message is only logged once")
-	LogOncef(s.realLogger, zapcore.InfoLevel, "this message is only logged once")
+func TestRealLogOncef(t *testing.T) {
+	logger := LoggerForModule()
+	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
+	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
+}
+
+func BenchmarkLogOncef(b *testing.B) {
+	logger := LoggerForModule()
+
+	b.Run("cold start", func(b *testing.B) {
+		for i := range b.N {
+			LogOncef(logger, zapcore.InfoLevel, "first benchmark message %d", i)
+		}
+	})
+
+	b.Run("warm start", func(b *testing.B) {
+		LogOncef(logger, zapcore.InfoLevel, "second benchmark message %d", 0)
+		b.ResetTimer()
+		for i := range b.N {
+			LogOncef(logger, zapcore.InfoLevel, "second benchmark message %d", i)
+		}
+	})
+
+	b.Run("warm start - parallel", func(b *testing.B) {
+		LogOncef(logger, zapcore.InfoLevel, "third benchmark message %d", 0)
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				LogOncef(logger, zapcore.InfoLevel, "third benchmark message %d", 0)
+			}
+		})
+	})
 }

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -58,6 +58,7 @@ func (s *logOnceTestSuite) TestLogOncePerKeyf() {
 func (s *logOnceTestSuite) TestLogOncefSizeLimit() {
 	testCount := maxLogOnceMemory * 2
 	s.mockLogger.EXPECT().Logf(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockLogger.EXPECT().Warnf("maxLogOnceMemory=%d limit reached", maxLogOnceMemory).MinTimes(1).MaxTimes(1)
 	for i := range testCount {
 		LogOncef(s.mockLogger, zapcore.WarnLevel, "test message "+strconv.Itoa(i)) //nolint:govet
 	}
@@ -76,6 +77,7 @@ func (s *logOnceTestSuite) TestLogOncefSizeLimit() {
 func clearMemory() {
 	logOnceSeen.Clear()
 	logOnceMemoryUsed.Store(0)
+	logOnceLimitNotified.Store(false)
 }
 
 func BenchmarkLogOnce(b *testing.B) {

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -22,8 +22,7 @@ type logOnceTestSuite struct {
 func (s *logOnceTestSuite) SetupTest() {
 	mockController := gomock.NewController(s.T())
 	s.mockLogger = logMocks.NewMockLogger(mockController)
-	logOnceSeen.Clear()
-	logOnceMemoryUsed.Store(0)
+	clearMemory()
 }
 
 func (s *logOnceTestSuite) TestLogOncef() {
@@ -52,13 +51,18 @@ func (s *logOnceTestSuite) TestLogOncefSizeLimit() {
 
 	s.Equal(int64(maxLogOnceMemory), logOnceMemoryUsed.Load())
 
-	inMap := 0
+	countInMap := 0
 	logOnceSeen.Range(func(_ any, _ any) bool {
-		inMap++
+		countInMap++
 		return true
 	})
 
-	s.Equal(maxLogOnceMemory, inMap)
+	s.Equal(maxLogOnceMemory, countInMap)
+}
+
+func clearMemory() {
+	logOnceSeen.Clear()
+	logOnceMemoryUsed.Store(0)
 }
 
 func TestRealLogOncef(t *testing.T) {
@@ -67,16 +71,26 @@ func TestRealLogOncef(t *testing.T) {
 	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
 }
 
-func BenchmarkLogOncef(b *testing.B) {
+func TestRealLogOncePerKeyf(t *testing.T) {
+	logger := LoggerForModule()
+	LogOncePerKeyf("key1", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key1")
+	LogOncePerKeyf("key2", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key2")
+	LogOncePerKeyf("key1", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key1")
+}
+
+func BenchmarkLogOnce(b *testing.B) {
 	logger := LoggerForModule()
 
 	b.Run("cold start", func(b *testing.B) {
+		clearMemory()
+		b.ResetTimer()
 		for i := range b.N {
 			LogOncef(logger, zapcore.InfoLevel, "first benchmark message %d", i)
 		}
 	})
 
 	b.Run("warm start", func(b *testing.B) {
+		clearMemory()
 		LogOncef(logger, zapcore.InfoLevel, "second benchmark message %d", 0)
 		b.ResetTimer()
 		for i := range b.N {
@@ -85,11 +99,23 @@ func BenchmarkLogOncef(b *testing.B) {
 	})
 
 	b.Run("warm start - parallel", func(b *testing.B) {
+		clearMemory()
 		LogOncef(logger, zapcore.InfoLevel, "third benchmark message %d", 0)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				LogOncef(logger, zapcore.InfoLevel, "third benchmark message %d", 0)
+			}
+		})
+	})
+
+	b.Run("with key", func(b *testing.B) {
+		clearMemory()
+		LogOncePerKeyf("mykey", logger, zapcore.InfoLevel, "fourth benchmark message %d", 0)
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				LogOncePerKeyf("mykey", logger, zapcore.InfoLevel, "fourth benchmark message %d", 0)
 			}
 		})
 	})

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -46,13 +46,13 @@ func (s *logOnceTestSuite) TestLogOncef() {
 }
 
 func (s *logOnceTestSuite) TestLogOncePerKeyf() {
-	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 1", 4).MinTimes(1).MaxTimes(1)
-	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 2", 1).MinTimes(1).MaxTimes(1)
+	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "This sensor %s is unhealthy %d seconds", "sensor 1", 4).MinTimes(1).MaxTimes(1)
+	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "This sensor %s is unhealthy %d seconds", "sensor 2", 1).MinTimes(1).MaxTimes(1)
 
-	LogOncePerKeyf("sensor 1", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 1", 4)
-	LogOncePerKeyf("sensor 1", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 1", 34)
+	LogOncePerKeyf("sensor 1", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unhealthy %d seconds", "sensor 1", 4)
+	LogOncePerKeyf("sensor 1", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unhealthy %d seconds", "sensor 1", 34)
 
-	LogOncePerKeyf("sensor 2", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 2", 1)
+	LogOncePerKeyf("sensor 2", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unhealthy %d seconds", "sensor 2", 1)
 }
 
 func (s *logOnceTestSuite) TestLogOncefSizeLimit() {

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -46,7 +46,7 @@ func (s *logOnceTestSuite) TestLogOncefSizeLimit() {
 	testCount := maxLogOnceMemory * 2
 	s.mockLogger.EXPECT().Logf(gomock.Any(), gomock.Any()).AnyTimes()
 	for i := range testCount {
-		LogOncef(s.mockLogger, zapcore.WarnLevel, "test message "+strconv.Itoa(i))
+		LogOncef(s.mockLogger, zapcore.WarnLevel, "test message "+strconv.Itoa(i)) //nolint:govet
 	}
 
 	s.Equal(int64(maxLogOnceMemory), logOnceMemoryUsed.Load())

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -1,0 +1,72 @@
+package logging
+
+import (
+	"strconv"
+	"testing"
+
+	logMocks "github.com/stackrox/rox/pkg/logging/mocks"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLogOnce(t *testing.T) {
+	suite.Run(t, new(logOnceTestSuite))
+}
+
+type logOnceTestSuite struct {
+	suite.Suite
+	mockLogger *logMocks.MockLogger
+	realLogger Logger
+}
+
+func (s *logOnceTestSuite) SetupSuite() {
+	s.realLogger = LoggerForModule()
+}
+
+func (s *logOnceTestSuite) SetupTest() {
+	mockController := gomock.NewController(s.T())
+	s.mockLogger = logMocks.NewMockLogger(mockController)
+	logOnceSeen.Clear()
+	logOnceMemoryUsed.Store(0)
+}
+
+func (s *logOnceTestSuite) TestLogOncef() {
+	s.mockLogger.EXPECT().Logf(zapcore.WarnLevel, "hello world %d, %s", 6, "yes!").MinTimes(1).MaxTimes(1)
+
+	LogOncef(s.mockLogger, zapcore.WarnLevel, "hello world %d, %s", 6, "yes!")
+	LogOncef(s.mockLogger, zapcore.WarnLevel, "hello world %d, %s", 500, "really?")
+}
+
+func (s *logOnceTestSuite) TestLogOncePerKeyf() {
+	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 1", 4).MinTimes(1).MaxTimes(1)
+	s.mockLogger.EXPECT().Logf(zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 2", 1).MinTimes(1).MaxTimes(1)
+
+	LogOncePerKeyf("sensor 1", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 1", 4)
+	LogOncePerKeyf("sensor 1", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 1", 34)
+
+	LogOncePerKeyf("sensor 2", s.mockLogger, zapcore.InfoLevel, "This sensor %s is unealthy %d seconds", "sensor 2", 1)
+}
+
+func (s *logOnceTestSuite) TestLogOncefSizeLimit() {
+	testCount := maxLogOnceMemory * 2
+	s.mockLogger.EXPECT().Logf(gomock.Any(), gomock.Any()).AnyTimes()
+	for i := range testCount {
+		LogOncef(s.mockLogger, zapcore.WarnLevel, "test message "+strconv.Itoa(i))
+	}
+
+	s.Equal(int64(maxLogOnceMemory), logOnceMemoryUsed.Load())
+
+	inMap := 0
+	logOnceSeen.Range(func(_ any, _ any) bool {
+		inMap++
+		return true
+	})
+
+	s.Equal(maxLogOnceMemory, inMap)
+}
+
+func (s *logOnceTestSuite) TestLogOncefReal() {
+	LogOncef(s.realLogger, zapcore.InfoLevel, "this message is only logged once")
+	LogOncef(s.realLogger, zapcore.InfoLevel, "this message is only logged once")
+}

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -10,6 +10,19 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+func TestLogOncefReal(t *testing.T) {
+	logger := LoggerForModule()
+	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
+	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
+}
+
+func TestLogOncePerKeyfReal(t *testing.T) {
+	logger := LoggerForModule()
+	LogOncePerKeyf("key1", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key1")
+	LogOncePerKeyf("key2", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key2")
+	LogOncePerKeyf("key1", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key1")
+}
+
 func TestLogOnce(t *testing.T) {
 	suite.Run(t, new(logOnceTestSuite))
 }
@@ -65,23 +78,10 @@ func clearMemory() {
 	logOnceMemoryUsed.Store(0)
 }
 
-func TestRealLogOncef(t *testing.T) {
-	logger := LoggerForModule()
-	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
-	LogOncef(logger, zapcore.InfoLevel, "this message is only %s", "logged once")
-}
-
-func TestRealLogOncePerKeyf(t *testing.T) {
-	logger := LoggerForModule()
-	LogOncePerKeyf("key1", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key1")
-	LogOncePerKeyf("key2", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key2")
-	LogOncePerKeyf("key1", logger, zapcore.InfoLevel, "this message is only logged once per %s", "key1")
-}
-
 func BenchmarkLogOnce(b *testing.B) {
 	logger := LoggerForModule()
 
-	b.Run("cold start", func(b *testing.B) {
+	b.Run("including cold start", func(b *testing.B) {
 		clearMemory()
 		b.ResetTimer()
 		for i := range b.N {
@@ -89,7 +89,7 @@ func BenchmarkLogOnce(b *testing.B) {
 		}
 	})
 
-	b.Run("warm start", func(b *testing.B) {
+	b.Run("when suppressed", func(b *testing.B) {
 		clearMemory()
 		LogOncef(logger, zapcore.InfoLevel, "second benchmark message %d", 0)
 		b.ResetTimer()
@@ -98,7 +98,7 @@ func BenchmarkLogOnce(b *testing.B) {
 		}
 	})
 
-	b.Run("warm start - parallel", func(b *testing.B) {
+	b.Run("when suppressed - parallel", func(b *testing.B) {
 		clearMemory()
 		LogOncef(logger, zapcore.InfoLevel, "third benchmark message %d", 0)
 		b.ResetTimer()

--- a/pkg/logging/log_once_test.go
+++ b/pkg/logging/log_once_test.go
@@ -91,7 +91,7 @@ func BenchmarkLogOnce(b *testing.B) {
 		}
 	})
 
-	b.Run("when suppressed", func(b *testing.B) {
+	b.Run("when already seen", func(b *testing.B) {
 		clearMemory()
 		LogOncef(logger, zapcore.InfoLevel, "second benchmark message %d", 0)
 		b.ResetTimer()
@@ -100,7 +100,7 @@ func BenchmarkLogOnce(b *testing.B) {
 		}
 	})
 
-	b.Run("when suppressed - parallel", func(b *testing.B) {
+	b.Run("when already seen - parallel", func(b *testing.B) {
 		clearMemory()
 		LogOncef(logger, zapcore.InfoLevel, "third benchmark message %d", 0)
 		b.ResetTimer()


### PR DESCRIPTION
## Description

Triggered by https://github.com/stackrox/stackrox/pull/22075#discussion_r3769265036

A few times I felt this is needed and a bit surprised it does not yet exist.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Just ran new tests locally and relying on CI.
