### PR TITLE
ROX-36377: Add AI risk summary UI plumbing

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -151,6 +151,12 @@ var (
 
 	// LegacyScanner enables the legacy scanner (Scanner V2) integration.
 	LegacyScanner = registerFeature("Enable legacy scanner (Scanner V2) integration", "ROX_LEGACY_SCANNER", enabled)
+
+	// AIIntegrations enables AI integrations management
+	AIIntegrations = registerFeature("Enable AI integrations management", "ROX_AI_INTEGRATIONS")
+
+	// LightspeedRiskSummary enables Lightspeed AI risk summary
+	LightspeedRiskSummary = registerFeature("Enable Lightspeed AI risk summary", "ROX_LIGHTSPEED_RISK_SUMMARY")
 )
 
 // The following feature flags are related to Scanner V4.

--- a/ui/apps/platform/src/services/AiIntegrationsService.ts
+++ b/ui/apps/platform/src/services/AiIntegrationsService.ts
@@ -1,0 +1,61 @@
+import axios from './instance';
+import type { Empty } from './types';
+
+const aiIntegrationsUrl = '/v2/ai-integrations';
+
+export type AiIntegrationType = 'AI_INTEGRATION_TYPE_UNSPECIFIED' | 'AI_INTEGRATION_TYPE_OLS';
+
+export type AiIntegration = {
+    id: string;
+    name: string;
+    type: AiIntegrationType;
+    serviceUrl: string;
+};
+
+type AiIntegrationsResponse = {
+    integrations: AiIntegration[];
+};
+
+/**
+ * Fetches all AI integrations.
+ */
+export function fetchAiIntegrations(): Promise<AiIntegration[]> {
+    return axios
+        .get<AiIntegrationsResponse>(aiIntegrationsUrl)
+        .then((response) => response.data.integrations);
+}
+
+/**
+ * Fetches a single AI integration by ID.
+ */
+export function fetchAiIntegration(id: string): Promise<AiIntegration> {
+    return axios.get<AiIntegration>(`${aiIntegrationsUrl}/${id}`).then((response) => response.data);
+}
+
+/**
+ * Creates a new AI integration.
+ */
+export function createAiIntegration(data: AiIntegration): Promise<AiIntegration> {
+    return axios.post<AiIntegration>(aiIntegrationsUrl, data).then((response) => response.data);
+}
+
+/**
+ * Updates an existing AI integration.
+ */
+export function updateAiIntegration(data: AiIntegration): Promise<AiIntegration> {
+    return axios.put<AiIntegration>(aiIntegrationsUrl, data).then((response) => response.data);
+}
+
+/**
+ * Deletes an AI integration by ID.
+ */
+export function deleteAiIntegration(id: string): Promise<Empty> {
+    return axios.delete<Empty>(`${aiIntegrationsUrl}/${id}`).then((response) => response.data);
+}
+
+/**
+ * Tests an AI integration connection.
+ */
+export function testAiIntegration(data: AiIntegration): Promise<Empty> {
+    return axios.post<Empty>(`${aiIntegrationsUrl}/test`, data).then((response) => response.data);
+}

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -154,3 +154,19 @@ export type DeploymentWithRisk = {
     deployment: Deployment;
     risk?: Risk;
 };
+
+export type DeploymentRiskSummary = {
+    summary: string;
+};
+
+/**
+ * Fetches an AI-generated risk summary for a deployment by ID.
+ */
+export function fetchDeploymentRiskSummary(id: string): Promise<DeploymentRiskSummary> {
+    if (!id) {
+        throw new Error('Deployment ID must be specified');
+    }
+    return axios
+        .get<DeploymentRiskSummary>(`${deploymentWithRiskUrl}/${id}/ai-summary`)
+        .then((response) => response.data);
+}

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -2,6 +2,7 @@
 // However, add strings in alphabetical order to minimize merge conflicts when multiple people add or delete strings.
 // prettier-ignore
 export type FeatureFlagEnvVar =
+    | 'ROX_AI_INTEGRATIONS'
     | 'ROX_BASE_IMAGE_DETECTION'
     | 'ROX_CISA_KEV'
     | 'ROX_CVE_FIX_TIMESTAMP'
@@ -11,6 +12,7 @@ export type FeatureFlagEnvVar =
     | 'ROX_INIT_CONTAINER_SUPPORT'
     | 'ROX_LABEL_BASED_POLICY_SCOPING'
     | 'ROX_LEGACY_SCANNER'
+    | 'ROX_LIGHTSPEED_RISK_SUMMARY'
     | 'ROX_NODE_INDEX_ENABLED'
     | 'ROX_NODE_VULNERABILITY_REPORTS'
     | 'ROX_POLICY_CRITERIA_MODAL'


### PR DESCRIPTION
## Description

This is the foundation ticket for epic ROX-29193 (OpenShift Lightspeed AI risk summary). It adds the necessary UI plumbing with no user-visible changes:

- Adds two feature flags: `ROX_AI_INTEGRATIONS` and `ROX_LIGHTSPEED_RISK_SUMMARY` (both in TypeScript and Go)
- Creates new `AiIntegrationsService.ts` with full CRUD + test endpoints for the v2 AI integrations API
- Adds `fetchDeploymentRiskSummary()` to `DeploymentsService.ts` for retrieving AI-generated risk summaries
- All types match the mock API server contract

This work was AI-assisted.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed (no user-visible changes)
- [x] documentation PR is created and is linked above **OR** is not needed (internal plumbing only)

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag (gated by `ROX_AI_INTEGRATIONS` and `ROX_LIGHTSPEED_RISK_SUMMARY`)
- [ ] CI results are inspected

### Automated testing

No unit tests added per ticket scope - these are thin service wrappers following existing patterns.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified TypeScript lint passes on all modified files
- Verified Go build succeeds for `pkg/features` package
- Confirmed all types match the mock API server contract at `/Users/dvail/projects/mock-api-stackrox/src/services/AiIntegrationService.ts`
