### PR TITLE
ROX-35509: Create and Populate Vuln Origin

### DIFF
--- a/central/cve/converter/utils/convert_utils_v2.go
+++ b/central/cve/converter/utils/convert_utils_v2.go
@@ -36,6 +36,7 @@ func ImageCVEV2ToEmbeddedVulnerability(vuln *storage.ImageCVEV2) *storage.Embedd
 		VulnerabilityTypes:    []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
 		State:                 vuln.GetState(),
 		Datasource:            vuln.GetDatasource(),
+		Origin:                vuln.GetOrigin(),
 	}
 
 	if vuln.GetIsFixable() {
@@ -111,6 +112,7 @@ func EmbeddedVulnerabilityToImageCVEV2(imageID string, componentID string, index
 		ImpactScore:           impactScore,
 		Advisory:              from.GetAdvisory(),
 		Datasource:            from.GetDatasource(),
+		Origin:                from.GetOrigin(),
 	}
 	if !features.FlattenImageData.Enabled() {
 		ret.ImageId = imageID

--- a/central/cve/converter/utils/convert_utils_v2_test.go
+++ b/central/cve/converter/utils/convert_utils_v2_test.go
@@ -101,6 +101,7 @@ var (
 			},
 			CisaKev:    true,
 			Datasource: "test-ds",
+			Origin:     storage.VulnOrigin_VULN_ORIGIN_RED_HAT,
 		},
 		{
 			Cve:     "cve2",
@@ -244,6 +245,7 @@ func getTestCVEs(t *testing.T) []*storage.ImageCVEV2 {
 		HasFixedBy:           nil,
 		ComponentId:          getTestComponentID(0),
 		Datasource:           "test-ds",
+		Origin:               storage.VulnOrigin_VULN_ORIGIN_RED_HAT,
 	}
 
 	cve2 := &storage.ImageCVEV2{

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -1575,6 +1575,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"type: String!",
 	}))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.Volume_MountPropagation(0)))
+	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.VulnOrigin(0)))
 	utils.Must(builder.AddInput("VulnReqGlobalScope", []string{
 		"images: VulnReqImageScope",
 	}))
@@ -16912,6 +16913,24 @@ func toVolume_MountPropagations(values *[]string) []storage.Volume_MountPropagat
 	output := make([]storage.Volume_MountPropagation, len(*values))
 	for i, v := range *values {
 		output[i] = toVolume_MountPropagation(&v)
+	}
+	return output
+}
+
+func toVulnOrigin(value *string) storage.VulnOrigin {
+	if value != nil {
+		return storage.VulnOrigin(storage.VulnOrigin_value[*value])
+	}
+	return storage.VulnOrigin(0)
+}
+
+func toVulnOrigins(values *[]string) []storage.VulnOrigin {
+	if values == nil {
+		return nil
+	}
+	output := make([]storage.VulnOrigin, len(*values))
+	for i, v := range *values {
+		output[i] = toVulnOrigin(&v)
 	}
 	return output
 }

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -1040,9 +1040,13 @@
         },
         "cisaKev": {
           "type": "boolean"
+        },
+        "origin": {
+          "$ref": "#/definitions/storageVulnOrigin",
+          "description": "origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV)."
         }
       },
-      "title": "Next Tag: 29"
+      "title": "Next Tag: 30"
     },
     "storageExploit": {
       "type": "object",
@@ -1482,6 +1486,22 @@
           "type": "string"
         }
       }
+    },
+    "storageVulnOrigin": {
+      "type": "string",
+      "enum": [
+        "VULN_ORIGIN_OTHER",
+        "VULN_ORIGIN_OSV",
+        "VULN_ORIGIN_ALPINE",
+        "VULN_ORIGIN_AMAZON",
+        "VULN_ORIGIN_DEBIAN",
+        "VULN_ORIGIN_ORACLE",
+        "VULN_ORIGIN_PHOTON",
+        "VULN_ORIGIN_RED_HAT",
+        "VULN_ORIGIN_SUSE",
+        "VULN_ORIGIN_UBUNTU"
+      ],
+      "default": "VULN_ORIGIN_OTHER"
     },
     "storageVulnerabilitySeverity": {
       "type": "string",

--- a/generated/api/v1/node_service.swagger.json
+++ b/generated/api/v1/node_service.swagger.json
@@ -670,9 +670,13 @@
         },
         "cisaKev": {
           "type": "boolean"
+        },
+        "origin": {
+          "$ref": "#/definitions/storageVulnOrigin",
+          "description": "origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV)."
         }
       },
-      "title": "Next Tag: 29"
+      "title": "Next Tag: 30"
     },
     "storageEmbeddedVulnerabilityScoreVersion": {
       "type": "string",
@@ -940,6 +944,22 @@
         "NO_EXECUTE_TAINT_EFFECT"
       ],
       "default": "UNKNOWN_TAINT_EFFECT"
+    },
+    "storageVulnOrigin": {
+      "type": "string",
+      "enum": [
+        "VULN_ORIGIN_OTHER",
+        "VULN_ORIGIN_OSV",
+        "VULN_ORIGIN_ALPINE",
+        "VULN_ORIGIN_AMAZON",
+        "VULN_ORIGIN_DEBIAN",
+        "VULN_ORIGIN_ORACLE",
+        "VULN_ORIGIN_PHOTON",
+        "VULN_ORIGIN_RED_HAT",
+        "VULN_ORIGIN_SUSE",
+        "VULN_ORIGIN_UBUNTU"
+      ],
+      "default": "VULN_ORIGIN_OTHER"
     },
     "storageVulnerabilitySeverity": {
       "type": "string",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -1025,9 +1025,13 @@
         },
         "cisaKev": {
           "type": "boolean"
+        },
+        "origin": {
+          "$ref": "#/definitions/storageVulnOrigin",
+          "description": "origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV)."
         }
       },
-      "title": "Next Tag: 29"
+      "title": "Next Tag: 30"
     },
     "storageExploit": {
       "type": "object",
@@ -1635,6 +1639,22 @@
           "$ref": "#/definitions/VolumeMountPropagation"
         }
       }
+    },
+    "storageVulnOrigin": {
+      "type": "string",
+      "enum": [
+        "VULN_ORIGIN_OTHER",
+        "VULN_ORIGIN_OSV",
+        "VULN_ORIGIN_ALPINE",
+        "VULN_ORIGIN_AMAZON",
+        "VULN_ORIGIN_DEBIAN",
+        "VULN_ORIGIN_ORACLE",
+        "VULN_ORIGIN_PHOTON",
+        "VULN_ORIGIN_RED_HAT",
+        "VULN_ORIGIN_SUSE",
+        "VULN_ORIGIN_UBUNTU"
+      ],
+      "default": "VULN_ORIGIN_OTHER"
     },
     "storageVulnerabilitySeverity": {
       "type": "string",

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/cve.pb.go
+++ b/generated/storage/cve.pb.go
@@ -179,6 +179,76 @@ func (Source) EnumDescriptor() ([]byte, []int) {
 	return file_storage_cve_proto_rawDescGZIP(), []int{2}
 }
 
+type VulnOrigin int32
+
+const (
+	VulnOrigin_VULN_ORIGIN_OTHER   VulnOrigin = 0
+	VulnOrigin_VULN_ORIGIN_OSV     VulnOrigin = 1
+	VulnOrigin_VULN_ORIGIN_ALPINE  VulnOrigin = 2
+	VulnOrigin_VULN_ORIGIN_AMAZON  VulnOrigin = 3
+	VulnOrigin_VULN_ORIGIN_DEBIAN  VulnOrigin = 4
+	VulnOrigin_VULN_ORIGIN_ORACLE  VulnOrigin = 5
+	VulnOrigin_VULN_ORIGIN_PHOTON  VulnOrigin = 6
+	VulnOrigin_VULN_ORIGIN_RED_HAT VulnOrigin = 7
+	VulnOrigin_VULN_ORIGIN_SUSE    VulnOrigin = 8
+	VulnOrigin_VULN_ORIGIN_UBUNTU  VulnOrigin = 9
+)
+
+// Enum value maps for VulnOrigin.
+var (
+	VulnOrigin_name = map[int32]string{
+		0: "VULN_ORIGIN_OTHER",
+		1: "VULN_ORIGIN_OSV",
+		2: "VULN_ORIGIN_ALPINE",
+		3: "VULN_ORIGIN_AMAZON",
+		4: "VULN_ORIGIN_DEBIAN",
+		5: "VULN_ORIGIN_ORACLE",
+		6: "VULN_ORIGIN_PHOTON",
+		7: "VULN_ORIGIN_RED_HAT",
+		8: "VULN_ORIGIN_SUSE",
+		9: "VULN_ORIGIN_UBUNTU",
+	}
+	VulnOrigin_value = map[string]int32{
+		"VULN_ORIGIN_OTHER":   0,
+		"VULN_ORIGIN_OSV":     1,
+		"VULN_ORIGIN_ALPINE":  2,
+		"VULN_ORIGIN_AMAZON":  3,
+		"VULN_ORIGIN_DEBIAN":  4,
+		"VULN_ORIGIN_ORACLE":  5,
+		"VULN_ORIGIN_PHOTON":  6,
+		"VULN_ORIGIN_RED_HAT": 7,
+		"VULN_ORIGIN_SUSE":    8,
+		"VULN_ORIGIN_UBUNTU":  9,
+	}
+)
+
+func (x VulnOrigin) Enum() *VulnOrigin {
+	p := new(VulnOrigin)
+	*p = x
+	return p
+}
+
+func (x VulnOrigin) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (VulnOrigin) Descriptor() protoreflect.EnumDescriptor {
+	return file_storage_cve_proto_enumTypes[3].Descriptor()
+}
+
+func (VulnOrigin) Type() protoreflect.EnumType {
+	return &file_storage_cve_proto_enumTypes[3]
+}
+
+func (x VulnOrigin) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use VulnOrigin.Descriptor instead.
+func (VulnOrigin) EnumDescriptor() ([]byte, []int) {
+	return file_storage_cve_proto_rawDescGZIP(), []int{3}
+}
+
 // Added this score version for nvd cvss score. moving out and re using score version from cveinfo will cause backward compatibility issue
 type CvssScoreVersion int32
 
@@ -213,11 +283,11 @@ func (x CvssScoreVersion) String() string {
 }
 
 func (CvssScoreVersion) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[3].Descriptor()
+	return file_storage_cve_proto_enumTypes[4].Descriptor()
 }
 
 func (CvssScoreVersion) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[3]
+	return &file_storage_cve_proto_enumTypes[4]
 }
 
 func (x CvssScoreVersion) Number() protoreflect.EnumNumber {
@@ -226,7 +296,7 @@ func (x CvssScoreVersion) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CvssScoreVersion.Descriptor instead.
 func (CvssScoreVersion) EnumDescriptor() ([]byte, []int) {
-	return file_storage_cve_proto_rawDescGZIP(), []int{3}
+	return file_storage_cve_proto_rawDescGZIP(), []int{4}
 }
 
 type CVE_CVEType int32
@@ -271,11 +341,11 @@ func (x CVE_CVEType) String() string {
 }
 
 func (CVE_CVEType) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[4].Descriptor()
+	return file_storage_cve_proto_enumTypes[5].Descriptor()
 }
 
 func (CVE_CVEType) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[4]
+	return &file_storage_cve_proto_enumTypes[5]
 }
 
 func (x CVE_CVEType) Number() protoreflect.EnumNumber {
@@ -320,11 +390,11 @@ func (x CVE_ScoreVersion) String() string {
 }
 
 func (CVE_ScoreVersion) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[5].Descriptor()
+	return file_storage_cve_proto_enumTypes[6].Descriptor()
 }
 
 func (CVE_ScoreVersion) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[5]
+	return &file_storage_cve_proto_enumTypes[6]
 }
 
 func (x CVE_ScoreVersion) Number() protoreflect.EnumNumber {
@@ -370,11 +440,11 @@ func (x CVEInfo_ScoreVersion) String() string {
 }
 
 func (CVEInfo_ScoreVersion) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[6].Descriptor()
+	return file_storage_cve_proto_enumTypes[7].Descriptor()
 }
 
 func (CVEInfo_ScoreVersion) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[6]
+	return &file_storage_cve_proto_enumTypes[7]
 }
 
 func (x CVEInfo_ScoreVersion) Number() protoreflect.EnumNumber {
@@ -419,11 +489,11 @@ func (x CVSSV2_Impact) String() string {
 }
 
 func (CVSSV2_Impact) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[7].Descriptor()
+	return file_storage_cve_proto_enumTypes[8].Descriptor()
 }
 
 func (CVSSV2_Impact) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[7]
+	return &file_storage_cve_proto_enumTypes[8]
 }
 
 func (x CVSSV2_Impact) Number() protoreflect.EnumNumber {
@@ -468,11 +538,11 @@ func (x CVSSV2_AttackVector) String() string {
 }
 
 func (CVSSV2_AttackVector) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[8].Descriptor()
+	return file_storage_cve_proto_enumTypes[9].Descriptor()
 }
 
 func (CVSSV2_AttackVector) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[8]
+	return &file_storage_cve_proto_enumTypes[9]
 }
 
 func (x CVSSV2_AttackVector) Number() protoreflect.EnumNumber {
@@ -517,11 +587,11 @@ func (x CVSSV2_AccessComplexity) String() string {
 }
 
 func (CVSSV2_AccessComplexity) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[9].Descriptor()
+	return file_storage_cve_proto_enumTypes[10].Descriptor()
 }
 
 func (CVSSV2_AccessComplexity) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[9]
+	return &file_storage_cve_proto_enumTypes[10]
 }
 
 func (x CVSSV2_AccessComplexity) Number() protoreflect.EnumNumber {
@@ -566,11 +636,11 @@ func (x CVSSV2_Authentication) String() string {
 }
 
 func (CVSSV2_Authentication) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[10].Descriptor()
+	return file_storage_cve_proto_enumTypes[11].Descriptor()
 }
 
 func (CVSSV2_Authentication) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[10]
+	return &file_storage_cve_proto_enumTypes[11]
 }
 
 func (x CVSSV2_Authentication) Number() protoreflect.EnumNumber {
@@ -618,11 +688,11 @@ func (x CVSSV2_Severity) String() string {
 }
 
 func (CVSSV2_Severity) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[11].Descriptor()
+	return file_storage_cve_proto_enumTypes[12].Descriptor()
 }
 
 func (CVSSV2_Severity) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[11]
+	return &file_storage_cve_proto_enumTypes[12]
 }
 
 func (x CVSSV2_Severity) Number() protoreflect.EnumNumber {
@@ -667,11 +737,11 @@ func (x CVSSV3_Impact) String() string {
 }
 
 func (CVSSV3_Impact) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[12].Descriptor()
+	return file_storage_cve_proto_enumTypes[13].Descriptor()
 }
 
 func (CVSSV3_Impact) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[12]
+	return &file_storage_cve_proto_enumTypes[13]
 }
 
 func (x CVSSV3_Impact) Number() protoreflect.EnumNumber {
@@ -719,11 +789,11 @@ func (x CVSSV3_AttackVector) String() string {
 }
 
 func (CVSSV3_AttackVector) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[13].Descriptor()
+	return file_storage_cve_proto_enumTypes[14].Descriptor()
 }
 
 func (CVSSV3_AttackVector) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[13]
+	return &file_storage_cve_proto_enumTypes[14]
 }
 
 func (x CVSSV3_AttackVector) Number() protoreflect.EnumNumber {
@@ -765,11 +835,11 @@ func (x CVSSV3_Complexity) String() string {
 }
 
 func (CVSSV3_Complexity) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[14].Descriptor()
+	return file_storage_cve_proto_enumTypes[15].Descriptor()
 }
 
 func (CVSSV3_Complexity) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[14]
+	return &file_storage_cve_proto_enumTypes[15]
 }
 
 func (x CVSSV3_Complexity) Number() protoreflect.EnumNumber {
@@ -814,11 +884,11 @@ func (x CVSSV3_Privileges) String() string {
 }
 
 func (CVSSV3_Privileges) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[15].Descriptor()
+	return file_storage_cve_proto_enumTypes[16].Descriptor()
 }
 
 func (CVSSV3_Privileges) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[15]
+	return &file_storage_cve_proto_enumTypes[16]
 }
 
 func (x CVSSV3_Privileges) Number() protoreflect.EnumNumber {
@@ -860,11 +930,11 @@ func (x CVSSV3_UserInteraction) String() string {
 }
 
 func (CVSSV3_UserInteraction) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[16].Descriptor()
+	return file_storage_cve_proto_enumTypes[17].Descriptor()
 }
 
 func (CVSSV3_UserInteraction) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[16]
+	return &file_storage_cve_proto_enumTypes[17]
 }
 
 func (x CVSSV3_UserInteraction) Number() protoreflect.EnumNumber {
@@ -906,11 +976,11 @@ func (x CVSSV3_Scope) String() string {
 }
 
 func (CVSSV3_Scope) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[17].Descriptor()
+	return file_storage_cve_proto_enumTypes[18].Descriptor()
 }
 
 func (CVSSV3_Scope) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[17]
+	return &file_storage_cve_proto_enumTypes[18]
 }
 
 func (x CVSSV3_Scope) Number() protoreflect.EnumNumber {
@@ -964,11 +1034,11 @@ func (x CVSSV3_Severity) String() string {
 }
 
 func (CVSSV3_Severity) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_cve_proto_enumTypes[18].Descriptor()
+	return file_storage_cve_proto_enumTypes[19].Descriptor()
 }
 
 func (CVSSV3_Severity) Type() protoreflect.EnumType {
-	return &file_storage_cve_proto_enumTypes[18]
+	return &file_storage_cve_proto_enumTypes[19]
 }
 
 func (x CVSSV3_Severity) Number() protoreflect.EnumNumber {
@@ -1684,8 +1754,10 @@ type ImageCVEV2 struct {
 	// Timestamp when the fix for this CVE was made available according to the sources.
 	FixAvailableTimestamp *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=fix_available_timestamp,json=fixAvailableTimestamp,proto3" json:"fix_available_timestamp,omitempty" search:"CVE Fix Available Timestamp,hidden"` // @gotags: search:"CVE Fix Available Timestamp,hidden"
 	Datasource            string                 `protobuf:"bytes,17,opt,name=datasource,proto3" json:"datasource,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV).
+	Origin        VulnOrigin `protobuf:"varint,18,opt,name=origin,proto3,enum=storage.VulnOrigin" json:"origin,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ImageCVEV2) Reset() {
@@ -1845,6 +1917,13 @@ func (x *ImageCVEV2) GetDatasource() string {
 		return x.Datasource
 	}
 	return ""
+}
+
+func (x *ImageCVEV2) GetOrigin() VulnOrigin {
+	if x != nil {
+		return x.Origin
+	}
+	return VulnOrigin_VULN_ORIGIN_OTHER
 }
 
 type isImageCVEV2_HasFixedBy interface {
@@ -2807,7 +2886,7 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\anvdcvss\x18\n" +
 	" \x01(\x02R\anvdcvss\x125\n" +
 	"\fcvss_metrics\x18\v \x03(\v2\x12.storage.CVSSScoreR\vcvssMetrics\x12E\n" +
-	"\x11nvd_score_version\x18\f \x01(\x0e2\x19.storage.CvssScoreVersionR\x0fnvdScoreVersion:\x02\x18\x01\"\xfc\x05\n" +
+	"\x11nvd_score_version\x18\f \x01(\x0e2\x19.storage.CvssScoreVersionR\x0fnvdScoreVersion:\x02\x18\x01\"\xa9\x06\n" +
 	"\n" +
 	"ImageCVEV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
@@ -2830,7 +2909,8 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\x17fix_available_timestamp\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\x15fixAvailableTimestamp\x12\x1e\n" +
 	"\n" +
 	"datasource\x18\x11 \x01(\tR\n" +
-	"datasourceB\x0e\n" +
+	"datasource\x12+\n" +
+	"\x06origin\x18\x12 \x01(\x0e2\x13.storage.VulnOriginR\x06originB\x0e\n" +
 	"\fhas_fixed_by\"\xe4\x03\n" +
 	"\aNodeCVE\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x124\n" +
@@ -2968,7 +3048,19 @@ const file_storage_cve_proto_rawDesc = "" +
 	"\n" +
 	"SOURCE_OSV\x10\x02\x12\x0e\n" +
 	"\n" +
-	"SOURCE_NVD\x10\x03*7\n" +
+	"SOURCE_NVD\x10\x03*\xf7\x01\n" +
+	"\n" +
+	"VulnOrigin\x12\x15\n" +
+	"\x11VULN_ORIGIN_OTHER\x10\x00\x12\x13\n" +
+	"\x0fVULN_ORIGIN_OSV\x10\x01\x12\x16\n" +
+	"\x12VULN_ORIGIN_ALPINE\x10\x02\x12\x16\n" +
+	"\x12VULN_ORIGIN_AMAZON\x10\x03\x12\x16\n" +
+	"\x12VULN_ORIGIN_DEBIAN\x10\x04\x12\x16\n" +
+	"\x12VULN_ORIGIN_ORACLE\x10\x05\x12\x16\n" +
+	"\x12VULN_ORIGIN_PHOTON\x10\x06\x12\x17\n" +
+	"\x13VULN_ORIGIN_RED_HAT\x10\a\x12\x14\n" +
+	"\x10VULN_ORIGIN_SUSE\x10\b\x12\x16\n" +
+	"\x12VULN_ORIGIN_UBUNTU\x10\t*7\n" +
 	"\x10CvssScoreVersion\x12\x13\n" +
 	"\x0fUNKNOWN_VERSION\x10\x00\x12\x06\n" +
 	"\x02V2\x10\x01\x12\x06\n" +
@@ -2987,125 +3079,127 @@ func file_storage_cve_proto_rawDescGZIP() []byte {
 	return file_storage_cve_proto_rawDescData
 }
 
-var file_storage_cve_proto_enumTypes = make([]protoimpl.EnumInfo, 19)
+var file_storage_cve_proto_enumTypes = make([]protoimpl.EnumInfo, 20)
 var file_storage_cve_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_storage_cve_proto_goTypes = []any{
 	(VulnerabilityState)(0),       // 0: storage.VulnerabilityState
 	(VulnerabilitySeverity)(0),    // 1: storage.VulnerabilitySeverity
 	(Source)(0),                   // 2: storage.Source
-	(CvssScoreVersion)(0),         // 3: storage.CvssScoreVersion
-	(CVE_CVEType)(0),              // 4: storage.CVE.CVEType
-	(CVE_ScoreVersion)(0),         // 5: storage.CVE.ScoreVersion
-	(CVEInfo_ScoreVersion)(0),     // 6: storage.CVEInfo.ScoreVersion
-	(CVSSV2_Impact)(0),            // 7: storage.CVSSV2.Impact
-	(CVSSV2_AttackVector)(0),      // 8: storage.CVSSV2.AttackVector
-	(CVSSV2_AccessComplexity)(0),  // 9: storage.CVSSV2.AccessComplexity
-	(CVSSV2_Authentication)(0),    // 10: storage.CVSSV2.Authentication
-	(CVSSV2_Severity)(0),          // 11: storage.CVSSV2.Severity
-	(CVSSV3_Impact)(0),            // 12: storage.CVSSV3.Impact
-	(CVSSV3_AttackVector)(0),      // 13: storage.CVSSV3.AttackVector
-	(CVSSV3_Complexity)(0),        // 14: storage.CVSSV3.Complexity
-	(CVSSV3_Privileges)(0),        // 15: storage.CVSSV3.Privileges
-	(CVSSV3_UserInteraction)(0),   // 16: storage.CVSSV3.UserInteraction
-	(CVSSV3_Scope)(0),             // 17: storage.CVSSV3.Scope
-	(CVSSV3_Severity)(0),          // 18: storage.CVSSV3.Severity
-	(*EPSS)(nil),                  // 19: storage.EPSS
-	(*Exploit)(nil),               // 20: storage.Exploit
-	(*CVE)(nil),                   // 21: storage.CVE
-	(*CVEInfo)(nil),               // 22: storage.CVEInfo
-	(*Advisory)(nil),              // 23: storage.Advisory
-	(*ImageCVE)(nil),              // 24: storage.ImageCVE
-	(*ImageCVEV2)(nil),            // 25: storage.ImageCVEV2
-	(*NodeCVE)(nil),               // 26: storage.NodeCVE
-	(*ClusterCVE)(nil),            // 27: storage.ClusterCVE
-	(*CVSSScore)(nil),             // 28: storage.CVSSScore
-	(*CVSSV2)(nil),                // 29: storage.CVSSV2
-	(*CVSSV3)(nil),                // 30: storage.CVSSV3
-	(*ImageCVEInfo)(nil),          // 31: storage.ImageCVEInfo
-	(*CVE_DistroSpecific)(nil),    // 32: storage.CVE.DistroSpecific
-	(*CVE_Reference)(nil),         // 33: storage.CVE.Reference
-	nil,                           // 34: storage.CVE.DistroSpecificsEntry
-	(*CVEInfo_Reference)(nil),     // 35: storage.CVEInfo.Reference
-	(*timestamppb.Timestamp)(nil), // 36: google.protobuf.Timestamp
+	(VulnOrigin)(0),               // 3: storage.VulnOrigin
+	(CvssScoreVersion)(0),         // 4: storage.CvssScoreVersion
+	(CVE_CVEType)(0),              // 5: storage.CVE.CVEType
+	(CVE_ScoreVersion)(0),         // 6: storage.CVE.ScoreVersion
+	(CVEInfo_ScoreVersion)(0),     // 7: storage.CVEInfo.ScoreVersion
+	(CVSSV2_Impact)(0),            // 8: storage.CVSSV2.Impact
+	(CVSSV2_AttackVector)(0),      // 9: storage.CVSSV2.AttackVector
+	(CVSSV2_AccessComplexity)(0),  // 10: storage.CVSSV2.AccessComplexity
+	(CVSSV2_Authentication)(0),    // 11: storage.CVSSV2.Authentication
+	(CVSSV2_Severity)(0),          // 12: storage.CVSSV2.Severity
+	(CVSSV3_Impact)(0),            // 13: storage.CVSSV3.Impact
+	(CVSSV3_AttackVector)(0),      // 14: storage.CVSSV3.AttackVector
+	(CVSSV3_Complexity)(0),        // 15: storage.CVSSV3.Complexity
+	(CVSSV3_Privileges)(0),        // 16: storage.CVSSV3.Privileges
+	(CVSSV3_UserInteraction)(0),   // 17: storage.CVSSV3.UserInteraction
+	(CVSSV3_Scope)(0),             // 18: storage.CVSSV3.Scope
+	(CVSSV3_Severity)(0),          // 19: storage.CVSSV3.Severity
+	(*EPSS)(nil),                  // 20: storage.EPSS
+	(*Exploit)(nil),               // 21: storage.Exploit
+	(*CVE)(nil),                   // 22: storage.CVE
+	(*CVEInfo)(nil),               // 23: storage.CVEInfo
+	(*Advisory)(nil),              // 24: storage.Advisory
+	(*ImageCVE)(nil),              // 25: storage.ImageCVE
+	(*ImageCVEV2)(nil),            // 26: storage.ImageCVEV2
+	(*NodeCVE)(nil),               // 27: storage.NodeCVE
+	(*ClusterCVE)(nil),            // 28: storage.ClusterCVE
+	(*CVSSScore)(nil),             // 29: storage.CVSSScore
+	(*CVSSV2)(nil),                // 30: storage.CVSSV2
+	(*CVSSV3)(nil),                // 31: storage.CVSSV3
+	(*ImageCVEInfo)(nil),          // 32: storage.ImageCVEInfo
+	(*CVE_DistroSpecific)(nil),    // 33: storage.CVE.DistroSpecific
+	(*CVE_Reference)(nil),         // 34: storage.CVE.Reference
+	nil,                           // 35: storage.CVE.DistroSpecificsEntry
+	(*CVEInfo_Reference)(nil),     // 36: storage.CVEInfo.Reference
+	(*timestamppb.Timestamp)(nil), // 37: google.protobuf.Timestamp
 }
 var file_storage_cve_proto_depIdxs = []int32{
-	4,  // 0: storage.CVE.type:type_name -> storage.CVE.CVEType
-	4,  // 1: storage.CVE.types:type_name -> storage.CVE.CVEType
-	36, // 2: storage.CVE.published_on:type_name -> google.protobuf.Timestamp
-	36, // 3: storage.CVE.created_at:type_name -> google.protobuf.Timestamp
-	36, // 4: storage.CVE.last_modified:type_name -> google.protobuf.Timestamp
-	33, // 5: storage.CVE.references:type_name -> storage.CVE.Reference
-	5,  // 6: storage.CVE.score_version:type_name -> storage.CVE.ScoreVersion
-	29, // 7: storage.CVE.cvss_v2:type_name -> storage.CVSSV2
-	30, // 8: storage.CVE.cvss_v3:type_name -> storage.CVSSV3
-	36, // 9: storage.CVE.suppress_activation:type_name -> google.protobuf.Timestamp
-	36, // 10: storage.CVE.suppress_expiry:type_name -> google.protobuf.Timestamp
-	34, // 11: storage.CVE.distro_specifics:type_name -> storage.CVE.DistroSpecificsEntry
+	5,  // 0: storage.CVE.type:type_name -> storage.CVE.CVEType
+	5,  // 1: storage.CVE.types:type_name -> storage.CVE.CVEType
+	37, // 2: storage.CVE.published_on:type_name -> google.protobuf.Timestamp
+	37, // 3: storage.CVE.created_at:type_name -> google.protobuf.Timestamp
+	37, // 4: storage.CVE.last_modified:type_name -> google.protobuf.Timestamp
+	34, // 5: storage.CVE.references:type_name -> storage.CVE.Reference
+	6,  // 6: storage.CVE.score_version:type_name -> storage.CVE.ScoreVersion
+	30, // 7: storage.CVE.cvss_v2:type_name -> storage.CVSSV2
+	31, // 8: storage.CVE.cvss_v3:type_name -> storage.CVSSV3
+	37, // 9: storage.CVE.suppress_activation:type_name -> google.protobuf.Timestamp
+	37, // 10: storage.CVE.suppress_expiry:type_name -> google.protobuf.Timestamp
+	35, // 11: storage.CVE.distro_specifics:type_name -> storage.CVE.DistroSpecificsEntry
 	1,  // 12: storage.CVE.severity:type_name -> storage.VulnerabilitySeverity
-	36, // 13: storage.CVEInfo.published_on:type_name -> google.protobuf.Timestamp
-	36, // 14: storage.CVEInfo.created_at:type_name -> google.protobuf.Timestamp
-	36, // 15: storage.CVEInfo.last_modified:type_name -> google.protobuf.Timestamp
-	6,  // 16: storage.CVEInfo.score_version:type_name -> storage.CVEInfo.ScoreVersion
-	29, // 17: storage.CVEInfo.cvss_v2:type_name -> storage.CVSSV2
-	30, // 18: storage.CVEInfo.cvss_v3:type_name -> storage.CVSSV3
-	35, // 19: storage.CVEInfo.references:type_name -> storage.CVEInfo.Reference
-	28, // 20: storage.CVEInfo.cvss_metrics:type_name -> storage.CVSSScore
-	19, // 21: storage.CVEInfo.epss:type_name -> storage.EPSS
-	20, // 22: storage.CVEInfo.exploit:type_name -> storage.Exploit
-	22, // 23: storage.ImageCVE.cve_base_info:type_name -> storage.CVEInfo
+	37, // 13: storage.CVEInfo.published_on:type_name -> google.protobuf.Timestamp
+	37, // 14: storage.CVEInfo.created_at:type_name -> google.protobuf.Timestamp
+	37, // 15: storage.CVEInfo.last_modified:type_name -> google.protobuf.Timestamp
+	7,  // 16: storage.CVEInfo.score_version:type_name -> storage.CVEInfo.ScoreVersion
+	30, // 17: storage.CVEInfo.cvss_v2:type_name -> storage.CVSSV2
+	31, // 18: storage.CVEInfo.cvss_v3:type_name -> storage.CVSSV3
+	36, // 19: storage.CVEInfo.references:type_name -> storage.CVEInfo.Reference
+	29, // 20: storage.CVEInfo.cvss_metrics:type_name -> storage.CVSSScore
+	20, // 21: storage.CVEInfo.epss:type_name -> storage.EPSS
+	21, // 22: storage.CVEInfo.exploit:type_name -> storage.Exploit
+	23, // 23: storage.ImageCVE.cve_base_info:type_name -> storage.CVEInfo
 	1,  // 24: storage.ImageCVE.severity:type_name -> storage.VulnerabilitySeverity
-	36, // 25: storage.ImageCVE.snooze_start:type_name -> google.protobuf.Timestamp
-	36, // 26: storage.ImageCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
-	28, // 27: storage.ImageCVE.cvss_metrics:type_name -> storage.CVSSScore
-	3,  // 28: storage.ImageCVE.nvd_score_version:type_name -> storage.CvssScoreVersion
-	22, // 29: storage.ImageCVEV2.cve_base_info:type_name -> storage.CVEInfo
+	37, // 25: storage.ImageCVE.snooze_start:type_name -> google.protobuf.Timestamp
+	37, // 26: storage.ImageCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
+	29, // 27: storage.ImageCVE.cvss_metrics:type_name -> storage.CVSSScore
+	4,  // 28: storage.ImageCVE.nvd_score_version:type_name -> storage.CvssScoreVersion
+	23, // 29: storage.ImageCVEV2.cve_base_info:type_name -> storage.CVEInfo
 	1,  // 30: storage.ImageCVEV2.severity:type_name -> storage.VulnerabilitySeverity
-	3,  // 31: storage.ImageCVEV2.nvd_score_version:type_name -> storage.CvssScoreVersion
-	36, // 32: storage.ImageCVEV2.first_image_occurrence:type_name -> google.protobuf.Timestamp
+	4,  // 31: storage.ImageCVEV2.nvd_score_version:type_name -> storage.CvssScoreVersion
+	37, // 32: storage.ImageCVEV2.first_image_occurrence:type_name -> google.protobuf.Timestamp
 	0,  // 33: storage.ImageCVEV2.state:type_name -> storage.VulnerabilityState
-	23, // 34: storage.ImageCVEV2.advisory:type_name -> storage.Advisory
-	36, // 35: storage.ImageCVEV2.fix_available_timestamp:type_name -> google.protobuf.Timestamp
-	22, // 36: storage.NodeCVE.cve_base_info:type_name -> storage.CVEInfo
-	1,  // 37: storage.NodeCVE.severity:type_name -> storage.VulnerabilitySeverity
-	36, // 38: storage.NodeCVE.snooze_start:type_name -> google.protobuf.Timestamp
-	36, // 39: storage.NodeCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
-	36, // 40: storage.NodeCVE.orphaned_time:type_name -> google.protobuf.Timestamp
-	22, // 41: storage.ClusterCVE.cve_base_info:type_name -> storage.CVEInfo
-	1,  // 42: storage.ClusterCVE.severity:type_name -> storage.VulnerabilitySeverity
-	36, // 43: storage.ClusterCVE.snooze_start:type_name -> google.protobuf.Timestamp
-	36, // 44: storage.ClusterCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
-	4,  // 45: storage.ClusterCVE.type:type_name -> storage.CVE.CVEType
-	2,  // 46: storage.CVSSScore.source:type_name -> storage.Source
-	29, // 47: storage.CVSSScore.cvssv2:type_name -> storage.CVSSV2
-	30, // 48: storage.CVSSScore.cvssv3:type_name -> storage.CVSSV3
-	8,  // 49: storage.CVSSV2.attack_vector:type_name -> storage.CVSSV2.AttackVector
-	9,  // 50: storage.CVSSV2.access_complexity:type_name -> storage.CVSSV2.AccessComplexity
-	10, // 51: storage.CVSSV2.authentication:type_name -> storage.CVSSV2.Authentication
-	7,  // 52: storage.CVSSV2.confidentiality:type_name -> storage.CVSSV2.Impact
-	7,  // 53: storage.CVSSV2.integrity:type_name -> storage.CVSSV2.Impact
-	7,  // 54: storage.CVSSV2.availability:type_name -> storage.CVSSV2.Impact
-	11, // 55: storage.CVSSV2.severity:type_name -> storage.CVSSV2.Severity
-	13, // 56: storage.CVSSV3.attack_vector:type_name -> storage.CVSSV3.AttackVector
-	14, // 57: storage.CVSSV3.attack_complexity:type_name -> storage.CVSSV3.Complexity
-	15, // 58: storage.CVSSV3.privileges_required:type_name -> storage.CVSSV3.Privileges
-	16, // 59: storage.CVSSV3.user_interaction:type_name -> storage.CVSSV3.UserInteraction
-	17, // 60: storage.CVSSV3.scope:type_name -> storage.CVSSV3.Scope
-	12, // 61: storage.CVSSV3.confidentiality:type_name -> storage.CVSSV3.Impact
-	12, // 62: storage.CVSSV3.integrity:type_name -> storage.CVSSV3.Impact
-	12, // 63: storage.CVSSV3.availability:type_name -> storage.CVSSV3.Impact
-	18, // 64: storage.CVSSV3.severity:type_name -> storage.CVSSV3.Severity
-	36, // 65: storage.ImageCVEInfo.fix_available_timestamp:type_name -> google.protobuf.Timestamp
-	36, // 66: storage.ImageCVEInfo.first_system_occurrence:type_name -> google.protobuf.Timestamp
-	1,  // 67: storage.CVE.DistroSpecific.severity:type_name -> storage.VulnerabilitySeverity
-	5,  // 68: storage.CVE.DistroSpecific.score_version:type_name -> storage.CVE.ScoreVersion
-	29, // 69: storage.CVE.DistroSpecific.cvss_v2:type_name -> storage.CVSSV2
-	30, // 70: storage.CVE.DistroSpecific.cvss_v3:type_name -> storage.CVSSV3
-	32, // 71: storage.CVE.DistroSpecificsEntry.value:type_name -> storage.CVE.DistroSpecific
-	72, // [72:72] is the sub-list for method output_type
-	72, // [72:72] is the sub-list for method input_type
-	72, // [72:72] is the sub-list for extension type_name
-	72, // [72:72] is the sub-list for extension extendee
-	0,  // [0:72] is the sub-list for field type_name
+	24, // 34: storage.ImageCVEV2.advisory:type_name -> storage.Advisory
+	37, // 35: storage.ImageCVEV2.fix_available_timestamp:type_name -> google.protobuf.Timestamp
+	3,  // 36: storage.ImageCVEV2.origin:type_name -> storage.VulnOrigin
+	23, // 37: storage.NodeCVE.cve_base_info:type_name -> storage.CVEInfo
+	1,  // 38: storage.NodeCVE.severity:type_name -> storage.VulnerabilitySeverity
+	37, // 39: storage.NodeCVE.snooze_start:type_name -> google.protobuf.Timestamp
+	37, // 40: storage.NodeCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
+	37, // 41: storage.NodeCVE.orphaned_time:type_name -> google.protobuf.Timestamp
+	23, // 42: storage.ClusterCVE.cve_base_info:type_name -> storage.CVEInfo
+	1,  // 43: storage.ClusterCVE.severity:type_name -> storage.VulnerabilitySeverity
+	37, // 44: storage.ClusterCVE.snooze_start:type_name -> google.protobuf.Timestamp
+	37, // 45: storage.ClusterCVE.snooze_expiry:type_name -> google.protobuf.Timestamp
+	5,  // 46: storage.ClusterCVE.type:type_name -> storage.CVE.CVEType
+	2,  // 47: storage.CVSSScore.source:type_name -> storage.Source
+	30, // 48: storage.CVSSScore.cvssv2:type_name -> storage.CVSSV2
+	31, // 49: storage.CVSSScore.cvssv3:type_name -> storage.CVSSV3
+	9,  // 50: storage.CVSSV2.attack_vector:type_name -> storage.CVSSV2.AttackVector
+	10, // 51: storage.CVSSV2.access_complexity:type_name -> storage.CVSSV2.AccessComplexity
+	11, // 52: storage.CVSSV2.authentication:type_name -> storage.CVSSV2.Authentication
+	8,  // 53: storage.CVSSV2.confidentiality:type_name -> storage.CVSSV2.Impact
+	8,  // 54: storage.CVSSV2.integrity:type_name -> storage.CVSSV2.Impact
+	8,  // 55: storage.CVSSV2.availability:type_name -> storage.CVSSV2.Impact
+	12, // 56: storage.CVSSV2.severity:type_name -> storage.CVSSV2.Severity
+	14, // 57: storage.CVSSV3.attack_vector:type_name -> storage.CVSSV3.AttackVector
+	15, // 58: storage.CVSSV3.attack_complexity:type_name -> storage.CVSSV3.Complexity
+	16, // 59: storage.CVSSV3.privileges_required:type_name -> storage.CVSSV3.Privileges
+	17, // 60: storage.CVSSV3.user_interaction:type_name -> storage.CVSSV3.UserInteraction
+	18, // 61: storage.CVSSV3.scope:type_name -> storage.CVSSV3.Scope
+	13, // 62: storage.CVSSV3.confidentiality:type_name -> storage.CVSSV3.Impact
+	13, // 63: storage.CVSSV3.integrity:type_name -> storage.CVSSV3.Impact
+	13, // 64: storage.CVSSV3.availability:type_name -> storage.CVSSV3.Impact
+	19, // 65: storage.CVSSV3.severity:type_name -> storage.CVSSV3.Severity
+	37, // 66: storage.ImageCVEInfo.fix_available_timestamp:type_name -> google.protobuf.Timestamp
+	37, // 67: storage.ImageCVEInfo.first_system_occurrence:type_name -> google.protobuf.Timestamp
+	1,  // 68: storage.CVE.DistroSpecific.severity:type_name -> storage.VulnerabilitySeverity
+	6,  // 69: storage.CVE.DistroSpecific.score_version:type_name -> storage.CVE.ScoreVersion
+	30, // 70: storage.CVE.DistroSpecific.cvss_v2:type_name -> storage.CVSSV2
+	31, // 71: storage.CVE.DistroSpecific.cvss_v3:type_name -> storage.CVSSV3
+	33, // 72: storage.CVE.DistroSpecificsEntry.value:type_name -> storage.CVE.DistroSpecific
+	73, // [73:73] is the sub-list for method output_type
+	73, // [73:73] is the sub-list for method input_type
+	73, // [73:73] is the sub-list for extension type_name
+	73, // [73:73] is the sub-list for extension extendee
+	0,  // [0:73] is the sub-list for field type_name
 }
 
 func init() { file_storage_cve_proto_init() }
@@ -3125,7 +3219,7 @@ func file_storage_cve_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_cve_proto_rawDesc), len(file_storage_cve_proto_rawDesc)),
-			NumEnums:      19,
+			NumEnums:      20,
 			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/generated/storage/cve_vtproto.pb.go
+++ b/generated/storage/cve_vtproto.pb.go
@@ -294,6 +294,7 @@ func (m *ImageCVEV2) CloneVT() *ImageCVEV2 {
 	r.ImageIdV2 = m.ImageIdV2
 	r.FixAvailableTimestamp = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.FixAvailableTimestamp).CloneVT())
 	r.Datasource = m.Datasource
+	r.Origin = m.Origin
 	if m.HasFixedBy != nil {
 		r.HasFixedBy = m.HasFixedBy.(interface {
 			CloneVT() isImageCVEV2_HasFixedBy
@@ -974,6 +975,9 @@ func (this *ImageCVEV2) EqualVT(that *ImageCVEV2) bool {
 		return false
 	}
 	if this.Datasource != that.Datasource {
+		return false
+	}
+	if this.Origin != that.Origin {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2193,6 +2197,13 @@ func (m *ImageCVEV2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 	}
+	if m.Origin != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Origin))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x90
+	}
 	if len(m.Datasource) > 0 {
 		i -= len(m.Datasource)
 		copy(dAtA[i:], m.Datasource)
@@ -3333,6 +3344,9 @@ func (m *ImageCVEV2) SizeVT() (n int) {
 	l = len(m.Datasource)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Origin != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.Origin))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6466,6 +6480,25 @@ func (m *ImageCVEV2) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Datasource = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 18:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Origin", wireType)
+			}
+			m.Origin = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Origin |= VulnOrigin(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10970,6 +11003,25 @@ func (m *ImageCVEV2) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.Datasource = stringValue
 			iNdEx = postIndex
+		case 18:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Origin", wireType)
+			}
+			m.Origin = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Origin |= VulnOrigin(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/storage/vulnerability.pb.go
+++ b/generated/storage/vulnerability.pb.go
@@ -127,7 +127,7 @@ func (EmbeddedVulnerability_VulnerabilityType) EnumDescriptor() ([]byte, []int) 
 	return file_storage_vulnerability_proto_rawDescGZIP(), []int{0, 1}
 }
 
-// Next Tag: 29
+// Next Tag: 30
 type EmbeddedVulnerability struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Cve      string                 `protobuf:"bytes,1,opt,name=cve,proto3" json:"cve,omitempty" search:"CVE"` // @gotags: search:"CVE"
@@ -166,9 +166,11 @@ type EmbeddedVulnerability struct {
 	NvdCvss     float32      `protobuf:"fixed32,22,opt,name=nvd_cvss,json=nvdCvss,proto3" json:"nvd_cvss,omitempty" search:"NVD CVSS"` // @gotags: search:"NVD CVSS"
 	Epss        *EPSS        `protobuf:"bytes,23,opt,name=epss,proto3" json:"epss,omitempty"`
 	// datasource is for internal use only
-	Datasource    string   `protobuf:"bytes,26,opt,name=datasource,proto3" json:"-" hash:"ignore"` // @gotags: json:"-" hash:"ignore"
-	Exploit       *Exploit `protobuf:"bytes,27,opt,name=exploit,proto3" json:"exploit,omitempty"`
-	CisaKev       bool     `protobuf:"varint,28,opt,name=cisa_kev,json=cisaKev,proto3" json:"cisa_kev,omitempty" policy:"CISA KEV"` // @gotags: policy:"CISA KEV"
+	Datasource string   `protobuf:"bytes,26,opt,name=datasource,proto3" json:"-" hash:"ignore"` // @gotags: json:"-" hash:"ignore"
+	Exploit    *Exploit `protobuf:"bytes,27,opt,name=exploit,proto3" json:"exploit,omitempty"`
+	CisaKev    bool     `protobuf:"varint,28,opt,name=cisa_kev,json=cisaKev,proto3" json:"cisa_kev,omitempty" policy:"CISA KEV"` // @gotags: policy:"CISA KEV"
+	// origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV).
+	Origin        VulnOrigin `protobuf:"varint,29,opt,name=origin,proto3,enum=storage.VulnOrigin" json:"origin,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -401,6 +403,13 @@ func (x *EmbeddedVulnerability) GetCisaKev() bool {
 	return false
 }
 
+func (x *EmbeddedVulnerability) GetOrigin() VulnOrigin {
+	if x != nil {
+		return x.Origin
+	}
+	return VulnOrigin_VULN_ORIGIN_OTHER
+}
+
 type isEmbeddedVulnerability_SetFixedBy interface {
 	isEmbeddedVulnerability_SetFixedBy()
 }
@@ -529,7 +538,7 @@ var File_storage_vulnerability_proto protoreflect.FileDescriptor
 
 const file_storage_vulnerability_proto_rawDesc = "" +
 	"\n" +
-	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xfd\f\n" +
+	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xaa\r\n" +
 	"\x15EmbeddedVulnerability\x12\x10\n" +
 	"\x03cve\x18\x01 \x01(\tR\x03cve\x12-\n" +
 	"\badvisory\x18\x18 \x01(\v2\x11.storage.AdvisoryR\badvisory\x12\x12\n" +
@@ -562,7 +571,8 @@ const file_storage_vulnerability_proto_rawDesc = "" +
 	"datasource\x18\x1a \x01(\tR\n" +
 	"datasource\x12*\n" +
 	"\aexploit\x18\x1b \x01(\v2\x10.storage.ExploitR\aexploit\x12\x19\n" +
-	"\bcisa_kev\x18\x1c \x01(\bR\acisaKev\"\x1e\n" +
+	"\bcisa_kev\x18\x1c \x01(\bR\acisaKev\x12+\n" +
+	"\x06origin\x18\x1d \x01(\x0e2\x13.storage.VulnOriginR\x06origin\"\x1e\n" +
 	"\fScoreVersion\x12\x06\n" +
 	"\x02V2\x10\x00\x12\x06\n" +
 	"\x02V3\x10\x01\"\xac\x01\n" +
@@ -613,7 +623,8 @@ var file_storage_vulnerability_proto_goTypes = []any{
 	(*CVSSScore)(nil),                            // 10: storage.CVSSScore
 	(*EPSS)(nil),                                 // 11: storage.EPSS
 	(*Exploit)(nil),                              // 12: storage.Exploit
-	(*CVEInfo)(nil),                              // 13: storage.CVEInfo
+	(VulnOrigin)(0),                              // 13: storage.VulnOrigin
+	(*CVEInfo)(nil),                              // 14: storage.CVEInfo
 }
 var file_storage_vulnerability_proto_depIdxs = []int32{
 	4,  // 0: storage.EmbeddedVulnerability.advisory:type_name -> storage.Advisory
@@ -634,15 +645,16 @@ var file_storage_vulnerability_proto_depIdxs = []int32{
 	10, // 15: storage.EmbeddedVulnerability.cvss_metrics:type_name -> storage.CVSSScore
 	11, // 16: storage.EmbeddedVulnerability.epss:type_name -> storage.EPSS
 	12, // 17: storage.EmbeddedVulnerability.exploit:type_name -> storage.Exploit
-	13, // 18: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
-	8,  // 19: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
-	7,  // 20: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
-	7,  // 21: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
-	22, // [22:22] is the sub-list for method output_type
-	22, // [22:22] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	13, // 18: storage.EmbeddedVulnerability.origin:type_name -> storage.VulnOrigin
+	14, // 19: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
+	8,  // 20: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
+	7,  // 21: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
+	7,  // 22: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_storage_vulnerability_proto_init() }

--- a/generated/storage/vulnerability_vtproto.pb.go
+++ b/generated/storage/vulnerability_vtproto.pb.go
@@ -53,6 +53,7 @@ func (m *EmbeddedVulnerability) CloneVT() *EmbeddedVulnerability {
 	r.Datasource = m.Datasource
 	r.Exploit = m.Exploit.CloneVT()
 	r.CisaKev = m.CisaKev
+	r.Origin = m.Origin
 	if m.SetFixedBy != nil {
 		r.SetFixedBy = m.SetFixedBy.(interface {
 			CloneVT() isEmbeddedVulnerability_SetFixedBy
@@ -242,6 +243,9 @@ func (this *EmbeddedVulnerability) EqualVT(that *EmbeddedVulnerability) bool {
 	if this.CisaKev != that.CisaKev {
 		return false
 	}
+	if this.Origin != that.Origin {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -370,6 +374,13 @@ func (m *EmbeddedVulnerability) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 			return 0, err
 		}
 		i -= size
+	}
+	if m.Origin != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Origin))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe8
 	}
 	if m.CisaKev {
 		i--
@@ -861,6 +872,9 @@ func (m *EmbeddedVulnerability) SizeVT() (n int) {
 	}
 	if m.CisaKev {
 		n += 3
+	}
+	if m.Origin != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.Origin))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1782,6 +1796,25 @@ func (m *EmbeddedVulnerability) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.CisaKev = bool(v != 0)
+		case 29:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Origin", wireType)
+			}
+			m.Origin = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Origin |= VulnOrigin(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2927,6 +2960,25 @@ func (m *EmbeddedVulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.CisaKev = bool(v != 0)
+		case 29:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Origin", wireType)
+			}
+			m.Origin = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Origin |= VulnOrigin(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -295,6 +295,7 @@ func buildEmbeddedVulnerability(ccVuln *v4.VulnerabilityReport_Vulnerability, en
 		CisaKev:               cisaKevEnabled(ccVuln),
 		FixAvailableTimestamp: ccVuln.GetFixedDate(),
 		Datasource:            vulnDataSource(ccVuln, envOS),
+		Origin:                vulnOrigin(ccVuln.GetUpdater()),
 	}
 	if err := setScoresAndScoreVersions(vuln, ccVuln.GetCvssMetrics()); err != nil {
 		utils.Should(err)
@@ -867,4 +868,33 @@ func mergeScoringFields(dst, src *storage.EmbeddedVulnerability) {
 	dst.Epss = src.GetEpss()
 	dst.Exploit = src.GetExploit()
 	dst.CisaKev = src.GetExploit() != nil
+	dst.Origin = src.GetOrigin()
+}
+
+var updaterOrigins = []struct {
+	prefix string
+	origin storage.VulnOrigin
+}{
+	{"alpine-", storage.VulnOrigin_VULN_ORIGIN_ALPINE},
+	{"aws-", storage.VulnOrigin_VULN_ORIGIN_AMAZON},
+	{"debian/", storage.VulnOrigin_VULN_ORIGIN_DEBIAN},
+	{"oracle-", storage.VulnOrigin_VULN_ORIGIN_ORACLE},
+	{"osv/", storage.VulnOrigin_VULN_ORIGIN_OSV},
+	{"photon-", storage.VulnOrigin_VULN_ORIGIN_PHOTON},
+	{"rhel-", storage.VulnOrigin_VULN_ORIGIN_RED_HAT},
+	{"suse-", storage.VulnOrigin_VULN_ORIGIN_SUSE},
+	{"ubuntu/", storage.VulnOrigin_VULN_ORIGIN_UBUNTU},
+}
+
+// vulnOrigin translates a Claircore updater name into VulnOrigin.
+//
+// TODO(ROX-36340): Replace this prefix based translation with something
+// more stable.
+func vulnOrigin(updater string) storage.VulnOrigin {
+	for _, e := range updaterOrigins {
+		if strings.HasPrefix(updater, e.prefix) {
+			return e.origin
+		}
+	}
+	return storage.VulnOrigin_VULN_ORIGIN_OTHER
 }

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -845,6 +845,11 @@ func splitVersionNumbers(v string) []int {
 // mergeScoringFields overwrites scoring-related fields on dst when src has more
 // complete or higher-severity scoring data. Priority: more CVSS metrics, higher
 // severity, higher CVSS base score.
+//
+// Origin is set here defensively so that if in the future multiple updaters
+// report the same CVE, Origin reflects the source that won the scoring
+// comparison, keeping the assignment deterministic rather than dependent
+// on input order.
 func mergeScoringFields(dst, src *storage.EmbeddedVulnerability) {
 	c := cmp.Or(
 		cmp.Compare(len(src.GetCvssMetrics()), len(dst.GetCvssMetrics())),
@@ -888,7 +893,11 @@ var updaterOrigins = []struct {
 
 // vulnOrigin translates a Claircore updater name into VulnOrigin.
 //
-// TODO(ROX-36340): Replace this prefix based translation with something
+// ASSUMPTION: updater names follow prefix conventions observed in Claircore.
+// These names are exposed via the API but their values are not guaranteed
+// to be stable.
+//
+// TODO(ROX-36340): Replace this prefix-based translation with something
 // more stable.
 func vulnOrigin(updater string) storage.VulnOrigin {
 	for _, e := range updaterOrigins {

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -3567,3 +3567,38 @@ func TestCompareNumericSegments(t *testing.T) {
 		})
 	}
 }
+
+func TestVulnOrigin(t *testing.T) {
+	testcases := map[string]struct {
+		updater  string
+		expected storage.VulnOrigin
+	}{
+		"empty":                     {"", storage.VulnOrigin_VULN_ORIGIN_OTHER},
+		"unknown updater":           {"something-else", storage.VulnOrigin_VULN_ORIGIN_OTHER},
+		"alpine main":               {"alpine-main-v3.18-updater", storage.VulnOrigin_VULN_ORIGIN_ALPINE},
+		"alpine community":          {"alpine-community-v3.21-updater", storage.VulnOrigin_VULN_ORIGIN_ALPINE},
+		"alpine edge":               {"alpine-main-edge-updater", storage.VulnOrigin_VULN_ORIGIN_ALPINE},
+		"aws AL2":                   {"aws-AL2-updater", storage.VulnOrigin_VULN_ORIGIN_AMAZON},
+		"aws AL2023":                {"aws-AL2023-updater", storage.VulnOrigin_VULN_ORIGIN_AMAZON},
+		"debian":                    {"debian/updater", storage.VulnOrigin_VULN_ORIGIN_DEBIAN},
+		"oracle":                    {"oracle-2024-updater", storage.VulnOrigin_VULN_ORIGIN_ORACLE},
+		"osv go":                    {"osv/go", storage.VulnOrigin_VULN_ORIGIN_OSV},
+		"osv maven":                 {"osv/maven", storage.VulnOrigin_VULN_ORIGIN_OSV},
+		"osv npm":                   {"osv/npm", storage.VulnOrigin_VULN_ORIGIN_OSV},
+		"photon":                    {"photon-updater-photon3", storage.VulnOrigin_VULN_ORIGIN_PHOTON},
+		"rhel vex":                  {"rhel-vex", storage.VulnOrigin_VULN_ORIGIN_RED_HAT},
+		"suse leap":                 {"suse-updater-opensuse.leap.15.6", storage.VulnOrigin_VULN_ORIGIN_SUSE},
+		"suse enterprise":           {"suse-updater-suse.linux.enterprise.server.15", storage.VulnOrigin_VULN_ORIGIN_SUSE},
+		"ubuntu focal":              {"ubuntu/updater/focal", storage.VulnOrigin_VULN_ORIGIN_UBUNTU},
+		"ubuntu noble":              {"ubuntu/updater/noble", storage.VulnOrigin_VULN_ORIGIN_UBUNTU},
+		"prefix only alpine":        {"alpine-", storage.VulnOrigin_VULN_ORIGIN_ALPINE},
+		"near miss alpine no dash":  {"alpine", storage.VulnOrigin_VULN_ORIGIN_OTHER},
+		"near miss debian no slash": {"debian-updater", storage.VulnOrigin_VULN_ORIGIN_OTHER},
+	}
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := vulnOrigin(tt.updater)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/proto/storage/cve.proto
+++ b/proto/storage/cve.proto
@@ -29,6 +29,19 @@ enum Source {
   SOURCE_NVD = 3;
 }
 
+enum VulnOrigin {
+  VULN_ORIGIN_OTHER = 0;
+  VULN_ORIGIN_OSV = 1;
+  VULN_ORIGIN_ALPINE = 2;
+  VULN_ORIGIN_AMAZON = 3;
+  VULN_ORIGIN_DEBIAN = 4;
+  VULN_ORIGIN_ORACLE = 5;
+  VULN_ORIGIN_PHOTON = 6;
+  VULN_ORIGIN_RED_HAT = 7;
+  VULN_ORIGIN_SUSE = 8;
+  VULN_ORIGIN_UBUNTU = 9;
+}
+
 //Added this score version for nvd cvss score. moving out and re using score version from cveinfo will cause backward compatibility issue
 enum CvssScoreVersion {
   UNKNOWN_VERSION = 0;
@@ -211,6 +224,8 @@ message ImageCVEV2 {
   // Timestamp when the fix for this CVE was made available according to the sources.
   google.protobuf.Timestamp fix_available_timestamp = 16; // @gotags: search:"CVE Fix Available Timestamp,hidden"
   string datasource = 17;
+  // origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV).
+  VulnOrigin origin = 18;
 }
 
 message NodeCVE {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -6071,6 +6071,50 @@
             ]
           },
           {
+            "name": "VulnOrigin",
+            "enum_fields": [
+              {
+                "name": "VULN_ORIGIN_OTHER"
+              },
+              {
+                "name": "VULN_ORIGIN_OSV",
+                "integer": 1
+              },
+              {
+                "name": "VULN_ORIGIN_ALPINE",
+                "integer": 2
+              },
+              {
+                "name": "VULN_ORIGIN_AMAZON",
+                "integer": 3
+              },
+              {
+                "name": "VULN_ORIGIN_DEBIAN",
+                "integer": 4
+              },
+              {
+                "name": "VULN_ORIGIN_ORACLE",
+                "integer": 5
+              },
+              {
+                "name": "VULN_ORIGIN_PHOTON",
+                "integer": 6
+              },
+              {
+                "name": "VULN_ORIGIN_RED_HAT",
+                "integer": 7
+              },
+              {
+                "name": "VULN_ORIGIN_SUSE",
+                "integer": 8
+              },
+              {
+                "name": "VULN_ORIGIN_UBUNTU",
+                "integer": 9
+              }
+            ]
+          },
+          {
             "name": "CvssScoreVersion",
             "enum_fields": [
               {
@@ -6846,6 +6890,11 @@
                 "id": 17,
                 "name": "datasource",
                 "type": "string"
+              },
+              {
+                "id": 18,
+                "name": "origin",
+                "type": "VulnOrigin"
               }
             ]
           },
@@ -21048,6 +21097,11 @@
                 "id": 28,
                 "name": "cisa_kev",
                 "type": "bool"
+              },
+              {
+                "id": 29,
+                "name": "origin",
+                "type": "VulnOrigin"
               }
             ],
             "reserved_ids": [

--- a/proto/storage/vulnerability.proto
+++ b/proto/storage/vulnerability.proto
@@ -8,7 +8,7 @@ import "storage/cve.proto";
 option go_package = "./storage;storage";
 option java_package = "io.stackrox.proto.storage";
 
-// Next Tag: 29
+// Next Tag: 30
 message EmbeddedVulnerability {
   // ScoreVersion can be deprecated ROX-26066
   enum ScoreVersion {
@@ -66,6 +66,8 @@ message EmbeddedVulnerability {
   string datasource = 26; // @gotags: json:"-" hash:"ignore"
   Exploit exploit = 27;
   bool cisa_kev = 28; // @gotags: policy:"CISA KEV"
+  // origin indicates where vulnerability details came from, origin may be an aggregator (such as OSV).
+  VulnOrigin origin = 29;
 }
 
 message NodeVulnerability {


### PR DESCRIPTION
## Description

Adds a new `origin` field to Stackrox vulnerability types. This field will be leveraged in future PRs for showing and filtering CVEs in reports and the UI.

The field is populated by translating the Scanner V4 / Claircore `updater` name. 

The main functional changes are in `pkg/scanners/scannerv4/convert.go`, the remaining changes are passing the new field around, generated code, and tests.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

CI, unit tests, and manual tests as follows:

Forced Scan (bypasses Central DB store/retrieval):

```sh
$ export IMAGE=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:89db126b1ec3feaef7cddabc3af861860ccc27eed4c86b6c700b90f98657f73c

$ rctl image scan --image=$IMAGE --force 2>/dev/null | jq -r '.scan.components[]?.vulns[]?.origin' | sort | uniq -c
  30 VULN_ORIGIN_OSV
  46 VULN_ORIGIN_RED_HAT
```

Cached Scan (leverages Central DB store/retrieval):

```sh
$ rctl image scan --image=$IMAGE 2>/dev/null | jq -r '.scan.components[]?.vulns[]?.origin' | sort | uniq -c
  30 VULN_ORIGIN_OSV
  46 VULN_ORIGIN_RED_HAT
```

Direct REST API retrieval:

```sh
$ curl -ksS -H "Authorization: Bearer $ROX_API_TOKEN" https://$ROX_ENDPOINT/v1/images/sha256:89db126b1ec3feaef7cddabc3af861860ccc27eed4c86b6c700b90f98657f73c | jq -r '.scan.components[]?.vulns[]?.origin' | sort | uniq -c
  30 VULN_ORIGIN_OSV
  46 VULN_ORIGIN_RED_HAT
```

