### PR TITLE
ROX-36384: Removes auto-margins on sunburst component

### DIFF
--- a/ui/apps/platform/src/Components/visuals/Sunburst.jsx
+++ b/ui/apps/platform/src/Components/visuals/Sunburst.jsx
@@ -149,7 +149,7 @@ class Sunburst extends Component {
             // TODO: factor out into dimension mapping
             width: this.props.small ? 200 : 265,
             height: this.props.small ? 200 : 271,
-            className: 'cursor-pointer pointer-events-none my-auto',
+            className: 'cursor-pointer pointer-events-none',
             onValueMouseOver: this.onValueMouseOverHandler,
             onValueMouseOut: this.onValueMouseOutHandler,
             onValueClick: this.onValueClickHandler,


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When rendering the sunburst component with auto margins, if when you hover over a part of the sunburst and the legend changes, the height of the surrounding container will then cause the sunburst to move up or down, which changes the mouse selection under the starburst, changing the values and height of the legend which moves the starburst and... well, you get it.

Removing the auto-margins as a default makes it always render at the top of the container, which prevents the jumping.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

* Spin up a test cluster.
* roxctl image scan --image docker.io/grafana/grafana:12.4.1
* Navigate to Vulnerability Management > Dashboard (Deprecated)
* Find the docker.io/grafana/grafana:12.4.1 image and click on it
* Resize browser window to ~880px wide
* Run your mouse around the outside of the sunburst until you find a CVE that resizes the legend.
* Observe that the sunburst does not jump around

<details>
<summary>Gifs. The before one jumps around. Be warned</summary>

Before Fix:

<img width="624" height="356" alt="CleanShot 2026-08-19 at 16 38 17" src="https://github.com/user-attachments/assets/cf8c1343-df55-4aeb-9292-f60952ec926d" />

After Fix: 

<img width="624" height="324" alt="CleanShot 2026-08-19 at 16 36 21" src="https://github.com/user-attachments/assets/309e539b-523f-4281-981d-2b3370ffbdab" />
</details>