### PR TITLE
ROX-35959: Fix tests for release case

### DIFF
--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -3,6 +3,7 @@ package versioncompatibility
 import (
 	"testing"
 
+	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/version/productstreams"
 	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
@@ -348,20 +349,41 @@ func TestClassifyVersion(t *testing.T) {
 	assert.Equal(t, CompatibleBehind, compat)
 }
 
-func TestCompatibleVersionsPanicsOnInvalidVersion(t *testing.T) {
+func TestCompatibleVersionsOnInvalidVersion(t *testing.T) {
 	testutils.SetMainVersion(t, "invalid")
-	assert.Panics(t, func() { _, _ = CompatibleVersions() })
+
+	if buildinfo.ReleaseBuild {
+		v, err := CompatibleVersions()
+		assert.Empty(t, v)
+		assert.Error(t, err)
+	} else {
+		assert.Panics(t, func() { _, _ = CompatibleVersions() })
+	}
 }
 
-func TestClassifyVersionPanicsOnInvalidVersion(t *testing.T) {
+func TestClassifyVersionOnInvalidVersion(t *testing.T) {
 	testutils.SetMainVersion(t, "invalid")
-	assert.Panics(t, func() { _, _ = ClassifyVersion(xy(4, 9)) })
+
+	if buildinfo.ReleaseBuild {
+		c, err := ClassifyVersion(xy(4, 9))
+		assert.Equal(t, Unknown, c)
+		assert.Error(t, err)
+	} else {
+		assert.Panics(t, func() { _, _ = ClassifyVersion(xy(4, 9)) })
+	}
 }
 
-func TestCompatibleVersionsPanicsOnMissingBumpData(t *testing.T) {
+func TestCompatibleVersionsOnMissingBumpData(t *testing.T) {
 	productstreams.OverrideBumpsForTesting(t, `bumps: []`)
 	testutils.SetMainVersion(t, "4.2.0-testing")
-	assert.Panics(t, func() { _, _ = CompatibleVersions() })
+
+	if buildinfo.ReleaseBuild {
+		v, err := CompatibleVersions()
+		assert.Empty(t, v)
+		assert.Error(t, err)
+	} else {
+		assert.Panics(t, func() { _, _ = CompatibleVersions() })
+	}
 }
 
 func overrideTestBumps(t *testing.T) {

--- a/pkg/version/versioncompatibility/compatibility_test.go
+++ b/pkg/version/versioncompatibility/compatibility_test.go
@@ -349,7 +349,7 @@ func TestClassifyVersion(t *testing.T) {
 	assert.Equal(t, CompatibleBehind, compat)
 }
 
-func TestCompatibleVersionsOnInvalidVersion(t *testing.T) {
+func TestCompatibleVersionsWhenInvalidVersion(t *testing.T) {
 	testutils.SetMainVersion(t, "invalid")
 
 	if buildinfo.ReleaseBuild {
@@ -361,7 +361,7 @@ func TestCompatibleVersionsOnInvalidVersion(t *testing.T) {
 	}
 }
 
-func TestClassifyVersionOnInvalidVersion(t *testing.T) {
+func TestClassifyVersionWhenInvalidVersion(t *testing.T) {
 	testutils.SetMainVersion(t, "invalid")
 
 	if buildinfo.ReleaseBuild {
@@ -373,7 +373,7 @@ func TestClassifyVersionOnInvalidVersion(t *testing.T) {
 	}
 }
 
-func TestCompatibleVersionsOnMissingBumpData(t *testing.T) {
+func TestCompatibleVersionsWhenMissingBumpData(t *testing.T) {
 	productstreams.OverrideBumpsForTesting(t, `bumps: []`)
 	testutils.SetMainVersion(t, "4.2.0-testing")
 


### PR DESCRIPTION
## Description

https://redhat-internal.slack.com/archives/CELUQKESC/p1787070774330269

See https://github.com/stackrox/stackrox/actions/runs/32140815085/job/95722797411#step:5:33932

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran in IDE with defined `release test` gotags, saw tests fail before fixes and pass after.
Added the label which should trigger `go (GOTAGS=relese)` tests. CI will tell.