### PR TITLE
ROX-36378: Add Lightspeed AI integration form

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AiIntegrations/LightspeedIntegrationForm.test.ts
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AiIntegrations/LightspeedIntegrationForm.test.ts
@@ -1,0 +1,44 @@
+import { defaultValues, validationSchema } from './LightspeedIntegrationForm';
+import type { AiIntegrationFormValues } from './LightspeedIntegrationForm';
+
+function makeIntegration(
+    overrides: Partial<AiIntegrationFormValues> = {}
+): AiIntegrationFormValues {
+    return {
+        id: '',
+        name: 'OpenShift Lightspeed',
+        type: 'AI_INTEGRATION_TYPE_OLS',
+        serviceUrl: 'https://lightspeed.example.com',
+        ...overrides,
+    };
+}
+
+describe('LightspeedIntegrationForm validationSchema', () => {
+    it('passes with a name and a service URL', () => {
+        expect(validationSchema.isValidSync(makeIntegration())).toBe(true);
+    });
+
+    it('passes when the service URL is empty because it is optional', () => {
+        expect(validationSchema.isValidSync(makeIntegration({ serviceUrl: '' }))).toBe(true);
+    });
+
+    it('fails when the name is missing', () => {
+        expect(validationSchema.isValidSync(makeIntegration({ name: '' }))).toBe(false);
+    });
+
+    it('fails when the name is only whitespace', () => {
+        expect(validationSchema.isValidSync(makeIntegration({ name: '   ' }))).toBe(false);
+    });
+
+    it('fails when the type is not the OLS type', () => {
+        expect(
+            validationSchema.isValidSync(
+                makeIntegration({ type: 'AI_INTEGRATION_TYPE_UNSPECIFIED' })
+            )
+        ).toBe(false);
+    });
+
+    it('rejects the empty default values because a name is required', () => {
+        expect(validationSchema.isValidSync(defaultValues)).toBe(false);
+    });
+});

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AiIntegrations/LightspeedIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/AiIntegrations/LightspeedIntegrationForm.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from 'react';
+import * as yup from 'yup';
+import { Form, PageSection, TextInput } from '@patternfly/react-core';
+import merge from 'lodash/merge';
+
+import FormMessage from 'Components/PatternFly/FormMessage';
+import FormSaveButton from 'Components/PatternFly/FormSaveButton';
+import FormCancelButton from 'Components/PatternFly/FormCancelButton';
+import FormTestButton from 'Components/PatternFly/FormTestButton';
+import type { AiIntegration } from 'services/AiIntegrationsService';
+
+import FormLabelGroup from '../../FormLabelGroup';
+import IntegrationFormActions from '../../IntegrationFormActions';
+import useIntegrationForm from '../../useIntegrationForm';
+import type { IntegrationFormProps } from '../../integrationFormTypes';
+
+export const validationSchema = yup.object().shape({
+    name: yup.string().trim().required('Integration name is required'),
+    type: yup.string().oneOf(['AI_INTEGRATION_TYPE_OLS']).required(),
+    serviceUrl: yup.string().trim(),
+});
+
+export type AiIntegrationFormValues = AiIntegration;
+
+export const defaultValues: AiIntegrationFormValues = {
+    id: '',
+    name: '',
+    type: 'AI_INTEGRATION_TYPE_OLS',
+    serviceUrl: '',
+};
+
+function LightspeedIntegrationForm({
+    initialValues = null,
+    isEditable = false,
+}: IntegrationFormProps<AiIntegration>): ReactElement {
+    const formInitialValues = structuredClone(defaultValues);
+    if (initialValues) {
+        merge(formInitialValues, initialValues);
+    }
+
+    const {
+        values,
+        touched,
+        errors,
+        dirty,
+        isValid,
+        setFieldValue,
+        handleBlur,
+        isSubmitting,
+        isTesting,
+        onSave,
+        onTest,
+        onCancel,
+        message,
+    } = useIntegrationForm<AiIntegrationFormValues>({
+        initialValues: formInitialValues,
+        validationSchema,
+    });
+
+    function onChange(value, event) {
+        return setFieldValue(event.target.id, value);
+    }
+
+    return (
+        <>
+            <PageSection isFilled hasOverflowScroll>
+                <FormMessage message={message} />
+                <Form isWidthLimited>
+                    <FormLabelGroup
+                        isRequired
+                        label="Integration name"
+                        fieldId="name"
+                        touched={touched}
+                        errors={errors}
+                    >
+                        <TextInput
+                            isRequired
+                            type="text"
+                            id="name"
+                            value={values.name}
+                            onChange={(event, value) => onChange(value, event)}
+                            onBlur={handleBlur}
+                            isDisabled={!isEditable}
+                        />
+                    </FormLabelGroup>
+                    <FormLabelGroup
+                        label="Service URL"
+                        fieldId="serviceUrl"
+                        touched={touched}
+                        errors={errors}
+                    >
+                        <TextInput
+                            type="text"
+                            id="serviceUrl"
+                            value={values.serviceUrl}
+                            onChange={(event, value) => onChange(value, event)}
+                            onBlur={handleBlur}
+                            isDisabled={!isEditable}
+                        />
+                    </FormLabelGroup>
+                </Form>
+            </PageSection>
+            {isEditable && (
+                <IntegrationFormActions>
+                    <FormSaveButton
+                        onSave={onSave}
+                        isSubmitting={isSubmitting}
+                        isTesting={isTesting}
+                        isDisabled={!dirty || !isValid}
+                    >
+                        Save
+                    </FormSaveButton>
+                    <FormTestButton
+                        onTest={onTest}
+                        isSubmitting={isSubmitting}
+                        isTesting={isTesting}
+                        isDisabled={!isValid}
+                    >
+                        Test
+                    </FormTestButton>
+                    <FormCancelButton onCancel={onCancel}>Cancel</FormCancelButton>
+                </IntegrationFormActions>
+            )}
+        </>
+    );
+}
+
+export default LightspeedIntegrationForm;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/IntegrationForm.tsx
@@ -51,6 +51,9 @@ import SignatureIntegrationForm from './Forms/SignatureIntegrationForm';
 import OcmIntegrationForm from './Forms/CloudSourceIntegrations/OcmIntegrationForm';
 import PaladinCloudIntegrationForm from './Forms/CloudSourceIntegrations/PaladinCloudIntegrationForm';
 
+// AI integrations
+import LightspeedIntegrationForm from './Forms/AiIntegrations/LightspeedIntegrationForm';
+
 import './IntegrationForm.css';
 
 type IntegrationFormProps = {
@@ -74,6 +77,9 @@ const ComponentFormMap = {
         gcs: GcsIntegrationForm,
         s3: S3IntegrationForm,
         s3compatible: S3CompatibleIntegrationForm,
+    },
+    aiIntegrations: {
+        lightspeed: LightspeedIntegrationForm,
     },
     cloudSources: {
         ocm: OcmIntegrationForm,

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationUtils.ts
@@ -52,6 +52,10 @@ export function getIsCloudSource(source: IntegrationSource): boolean {
     return source === 'cloudSources';
 }
 
+export function getIsAiIntegration(source: IntegrationSource): boolean {
+    return source === 'aiIntegrations';
+}
+
 export function getGoogleCredentialsPlaceholder(
     useWorkloadId: boolean,
     updatePassword: boolean

--- a/ui/apps/platform/src/services/AiIntegrationsService.ts
+++ b/ui/apps/platform/src/services/AiIntegrationsService.ts
@@ -40,6 +40,10 @@ export function deleteAiIntegration(id: string): Promise<Empty> {
     return axios.delete<Empty>(`${aiIntegrationsUrl}/${id}`).then((response) => response.data);
 }
 
+export function deleteAiIntegrations(ids: string[]): Promise<Empty[]> {
+    return Promise.all(ids.map(deleteAiIntegration));
+}
+
 export function testAiIntegration(data: AiIntegration): Promise<Empty> {
     return axios.post<Empty>(`${aiIntegrationsUrl}/test`, data).then((response) => response.data);
 }

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -12,6 +12,7 @@ export const serviceIntegrationSources = [
     'notifiers',
     'signatureIntegrations',
     'cloudSources',
+    'aiIntegrations',
 ] as const;
 
 export type IntegrationSource = (typeof serviceIntegrationSources)[number];
@@ -34,6 +35,8 @@ function getPath(source: IntegrationSource): string {
             return '/v1/auth/m2m';
         case 'cloudSources':
             return '/v1/cloud-sources';
+        case 'aiIntegrations':
+            return '/v2/ai-integrations';
         default:
             return '';
     }


### PR DESCRIPTION
## Description

Adds the create/edit form for the OpenShift Lightspeed AI integration (ROX-36378). Builds on the AI tab/tile/list from #22332.

- New `LightspeedIntegrationForm` (name required, service URL optional, type fixed to OLS), registered in `IntegrationForm`'s `ComponentFormMap` under `aiIntegrations.lightspeed`, replacing the temporary fallback added in the prior PR.
- Wires create/update/test through the v2 `AiIntegrationsService`, and delete on the list page, all gated behind `getIsAiIntegration(source)` so no other integration type is affected.
- Adds a `deleteAiIntegrations` bulk helper and a `getIsAiIntegration` predicate.
- Unit tests for the form's Yup validation schema.

The whole feature remains gated behind the `ROX_AI_INTEGRATIONS` feature flag.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

Unit tests cover the Lightspeed form's Yup validation schema. Broader e2e/component coverage is tracked in ROX-36379.

### How I validated my change

With a mock server:
<img width="1454" height="679" alt="image" src="https://github.com/user-attachments/assets/64d2edb4-39f9-49e2-945f-0df340332529" />
<img width="1454" height="679" alt="image" src="https://github.com/user-attachments/assets/3ce7b023-f485-47eb-a1d6-524db541be50" />
<img width="1454" height="679" alt="image" src="https://github.com/user-attachments/assets/c7140298-90ef-462d-b9d5-19c5b2c184d5" />
<img width="1454" height="679" alt="image" src="https://github.com/user-attachments/assets/72a01f14-edeb-45f6-9f44-24ad4034e28a" />
<img width="1454" height="679" alt="image" src="https://github.com/user-attachments/assets/459abf93-f8fa-4839-b307-fdfd03e4f279" />
