### PR TITLE
ROX-35584: expect Enabled() in TestFeatureFlagSettings

### DIFF
--- a/tests/feature_flag_test.go
+++ b/tests/feature_flag_test.go
@@ -28,6 +28,8 @@ var (
 	}
 )
 
+// TestFeatureFlagSettings asserts Central's live flags match flag.Enabled()
+// computed in this process from the same environment and build type.
 func TestFeatureFlagSettings(t *testing.T) {
 	if os.Getenv("ORCHESTRATOR_FLAVOR") == "openshift" {
 		t.Skip("Skipping on OCP: ci_export uses cci-export which does not set shell variables, causing systemic mismatch between test runner and Central")
@@ -37,23 +39,13 @@ func TestFeatureFlagSettings(t *testing.T) {
 
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 
-	metadataService := v1.NewMetadataServiceClient(conn)
-	metadata, err := metadataService.GetMetadata(ctx, &v1.Empty{})
-	require.NoError(t, err, "failed to retrieve metadata")
-
 	expectedFlagVals := make(map[string]bool)
 	for _, flag := range features.Flags {
 		if skipFeatures[flag.EnvVar()] {
 			continue
 		}
 
-		// For non-release builds, test that feature flag settings match the local environment;
-		// for release builds, test that they match the defaults.
-		expectedVal := flag.Enabled()
-		if metadata.GetReleaseBuild() {
-			expectedVal = flag.Default()
-		}
-		expectedFlagVals[flag.EnvVar()] = expectedVal
+		expectedFlagVals[flag.EnvVar()] = flag.Enabled()
 	}
 
 	featureFlagService := v1.NewFeatureFlagServiceClient(conn)


### PR DESCRIPTION
## Description

TestFeatureFlagSettings failed on release Centrals (nightlies, and PRs with `ci-release-build`). It compared live flags to compile-time defaults. Only `unchangeableInProd` flags ignore env; `ci_export` still overrides the rest, so e.g. `ROX_CISA_KEV` was true while the test expected false.

The test now expects `flag.Enabled()`, which is what Central already reports. The e2e binary uses the same `GOTAGS`, so unchangeable flags still match `Default()`. The recent OCP skip PR is unchanged (https://github.com/stackrox/stackrox/pull/21599). Test-only change.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Image-build: non-release, nongroovy tests: release - result: [TestFeatureFlagSettings PASS](https://github.com/stackrox/stackrox/actions/runs/32232304693/job/96017926386?pr=22364) (the suite failed due to `TestMetadataIsSetCorrectly` - mixup of non-release images and release tests)
- Image-build: release, nongroovy tests: release - result: [All non-groovy target PASS](https://github.com/stackrox/stackrox/actions/runs/32244174445/job/96043161917?pr=22364)

AI-Assisted: cursor, ~70% generated, user reviewed logic