### PR TITLE
ROX-36450: Update Grafana VM dashboard for pull-mode scraper

### DIFF
--- a/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
+++ b/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
@@ -267,7 +267,7 @@
           "refId": "A"
         }
       ],
-      "title": "Successful forwards",
+      "title": "Successful forwards to Central",
       "type": "stat"
     },
     {
@@ -483,7 +483,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "How many reports Sensor sent to Central in each ~30s Prometheus scrape. Healthy pacing is mostly bars of 1. A tall bar is several reports in the same scrape (a dump). Unchanged pulls do not appear here. A Sensor restart can make one bar go negative (counter reset).",
+      "description": "Running total of full index reports Sensor sent to Central (rox_sensor_vsock_pull_requests_total{status=\"success\"}). Each step up is one or more forwards. A paced wave is a run of +1 steps a few seconds apart. A dump is one large jump. A Sensor restart resets the counter to 0. Unchanged pulls are not counted.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -496,8 +496,8 @@
             "axisLabel": "forwards",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 60,
+            "drawStyle": "line",
+            "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -505,8 +505,8 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -561,7 +561,7 @@
       "options": {
         "legend": {
           "calcs": [
-            "mean",
+            "lastNotNull",
             "max"
           ],
           "displayMode": "table",
@@ -581,13 +581,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "increase(rox_sensor_vsock_pull_requests_total{status=\"success\"}[$__interval])",
+          "expr": "sum(rox_sensor_vsock_pull_requests_total{status=\"success\"})",
           "legendFormat": "success",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Successful forwards",
+      "title": "Successful forwards to Central",
       "type": "timeseries"
     },
     {
@@ -871,7 +871,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Time on X, how many VMs started in that tick on Y, color = how often that happened. Budget 1 should glow on Y near 1. A bright band at Y near 8 (or 20) is a dump. Idle ticks do not appear.",
+      "description": "Time on X, how many VMs started in that tick on Y, color = how often that happened. Only ticks that had at least one due VM are recorded, so there is no 0 row. Budget 1 should glow on Y near 1. A bright band at Y near 8 (or 20) is a dump. Compare Tick rate if most wall-clock ticks are idle."
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -940,7 +940,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (le) (increase(rox_sensor_vsock_pull_starts_per_tick_bucket[$__rate_interval]))",
+          "expr": "sum by (le) (increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le!=\"0\"}[$__rate_interval]))",
           "legendFormat": "{{le}}",
           "range": true,
           "refId": "A",
@@ -955,7 +955,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Totals over the selected time range: how many ticks started 0, 1, 2, ... VMs. For a small fleet with budget 1, almost everything should sit in the 1 bucket. If this looks empty but tick rate is healthy, most ticks had nobody due.",
+      "description": "How many observed ticks started 1, 2, 3, ... VMs. Idle ticks (nobody due) are not sampled, so there is no 0 bar; those ticks show up on Tick rate instead. For a small fleet with budget 1, mass should sit in 1. Mass in 8 or 20 is a dump."
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -986,21 +986,6 @@
           "unit": "short"
         },
         "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "0"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
           {
             "matcher": {
               "id": "byName",
@@ -1210,17 +1195,6 @@
       },
       "pluginVersion": "10.4.17",
       "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"0\"}[$__range]))",
-          "legendFormat": "0",
-          "range": true,
-          "refId": "A"
-        },
         {
           "datasource": {
             "type": "prometheus",

--- a/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
+++ b/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Monitoring dashboard for Virtual Machine Index Report processing in StackRox Sensor",
+  "description": "Sensor VMScraper pull mode: VSOCK scrape spreading, retries/NACKs, and Handler forward to Central.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -31,7 +31,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 106,
+      "id": 100,
       "panels": [
         {
           "datasource": {
@@ -39,7 +39,7 @@
             "uid": "${datasource}"
           },
           "gridPos": {
-            "h": 16,
+            "h": 12,
             "w": 24,
             "x": 0,
             "y": 1
@@ -51,11 +51,11 @@
               "showLineNumbers": false,
               "showMiniMap": false
             },
-            "content": "```\n# How VM Index Report Processing Works in Sensor\n\n                                    Fake Workloads (scale testing)\n                                              │\n                                              ▼\n┌───────┐        ┌────────────────┐      ┌─────────────────────────────┐      ┌─────────┐      ┌────────────┐\n│ Relay │──GRPC──▶ Sensor Service │──────▶ handlerImpl.indexReports    │──────▶ Process │──────▶ to Central │\n└───────┘        └────────────────┘      │     (buffered channel)      │      └────┬────┘      └────────────┘\n                                         └─────────────────────────────┘           │\n                                                       ▲                           │\n                                                       │                           ▼\n                                                 capacity limit           ┌──────────────────┐\n                                                (blocks if full)          │ Check in-memory  │\n                                                                          │ store if VM is   │\n                                                                          │ known to Sensor  │\n                                                                          └────────┬─────────┘\n                                                                                   │\n                                                                    ┌──────────────┴──────────────┐\n                                                                    ▼                             ▼\n                                                              VM is known                  VM is unknown\n                                                            (outcome=success)         (outcome=vm_unknown_to_sensor)\n                                                                    │                             │\n                                                                    ▼                             ▼\n                                                            Transform & send              Report is dropped\n                                                              to Central\n```\n",
+            "content": "Sensor **pulls** index reports: VMScraper ticks, dials each due VM's roxagent over VSOCK, and forwards a successful report through `vmIndex.Handler` to Central. Central ACK/NACKs. Handler enqueue metrics are a secondary \"send to Central\" story, not the scrape scheduler.\n\n```\n  roxagent (in VM)                    Sensor                         Central\n  ┌─────────────┐     VSOCK      ┌─────────────┐   SensorEvent   ┌─────────┐\n  │ GetReport   │◀──────────────▶│  VMScraper  │────────────────▶│ VM pipe │\n  └─────────────┘   when due     │ per-VM next │                 └────┬────┘\n                                 │ AttemptAt   │                      │\n                                 └──────┬──────┘              SensorACK│\n                                        │                    ACK | NACK│\n                                        └──────────────────────────────┘\n                                   NACK: clear report_generation, shared backoff\n```\n\n**Arrival smoothing** (read `pollInterval` from Sensor env; do not assume 5m):\n\n- First wave / Sensor restart: never-scraped VMs get `nextAttemptAt = now + U(0, catchUpWindow)` where `catchUpWindow = min(20m, pollInterval/3)`.\n- Per-tick start budget: `ceil(nTracked × tick / window)`. Window is catch-up if any never-forwarded VM is due, else steady width `W = pollInterval × spreadFraction` (default 2/3). `n` is tracked fleet size, not leftover due-pile size. `selectDueStarts` still cannot start more than are due. Concurrency (default 20) is a separate overlap cap.\n- Success and permanent failure reschedule at `pollInterval + U(0, W)`.\n- Retryable pull failures and NACKs share exponential backoff (`initialBackoff` default 10s, doubled, cap `min(pollInterval, 30m)`).\n\nDefaults: tick 10s, poll 5m, catch-up 100s, W 200s, concurrency 20. A 1h poll uses catch-up 20m and W 40m.\n",
             "mode": "markdown"
           },
           "pluginVersion": "10.4.17",
-          "title": "How this part of Sensor works",
+          "title": "How VMScraper pull mode works",
           "type": "text"
         }
       ],
@@ -70,9 +70,9 @@
         "x": 0,
         "y": 1
       },
-      "id": 100,
+      "id": 200,
       "panels": [],
-      "title": "📊 Overview",
+      "title": "Overview",
       "type": "row"
     },
     {
@@ -80,72 +80,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total number of VM index reports successfully sent to Central",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 2
-      },
-      "id": 1,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.17",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_reports_sent_total{status=\"success\"})",
-          "legendFormat": "Sent",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "✅ Reports Sent to Central (Success)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Total number of VM index reports received by Sensor",
+      "description": "rox_sensor_vsock_pull_tracked_vms. Fleet size n used in start budget ceil(n × tick / window).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -167,11 +102,11 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 4,
+        "x": 0,
         "y": 2
       },
-      "id": 2,
+      "id": 201,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -196,13 +131,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_reports_received_total)",
-          "legendFormat": "Received",
+          "expr": "rox_sensor_vsock_pull_tracked_vms",
+          "legendFormat": "Tracked",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "📥 Reports Received from Relay",
+      "title": "Tracked VMs",
       "type": "stat"
     },
     {
@@ -210,7 +145,72 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Number of times enqueue was blocked due to full channel",
+      "description": "rox_sensor_vsock_pull_due_vms. Eligible VMs at the start of the last tick, before the start budget. Persistently high with small starts means the budget is pacing a backlog.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 2
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rox_sensor_vsock_pull_due_vms",
+          "legendFormat": "Due",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Due VMs (last tick)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative rox_sensor_vsock_pull_requests_total{status=\"success\"}. Full reports forwarded to Central, not unchanged pulls.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -223,18 +223,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 100
-              },
-              {
-                "color": "orange",
-                "value": 1000
-              },
-              {
-                "color": "red",
-                "value": 10000
               }
             ]
           },
@@ -244,11 +232,11 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
+        "w": 4,
+        "x": 8,
         "y": 2
       },
-      "id": 3,
+      "id": 203,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -273,13 +261,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_enqueue_blocked_total)",
-          "legendFormat": "Blocked",
+          "expr": "sum(rox_sensor_vsock_pull_requests_total{status=\"success\"})",
+          "legendFormat": "Success",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "⚠️ Enqueue Blocked Count",
+      "title": "Successful forwards",
       "type": "stat"
     },
     {
@@ -287,7 +275,137 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total reports processed (sum of all outcomes)",
+      "description": "Cumulative status=\"unchanged\": agent had nothing newer; no new forward. Still a successful pull.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 2
+      },
+      "id": 204,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rox_sensor_vsock_pull_requests_total{status=\"unchanged\"})",
+          "legendFormat": "Unchanged",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unchanged pulls",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative SensorACK NACK. Ongoing NACKs with success pulls means Sensor is retrying full reports after Central reject (common while Scanner V4 matcher is still initializing).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 2
+      },
+      "id": 205,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rox_sensor_virtual_machine_index_report_acks_received_total{action=\"NACK\"})",
+          "legendFormat": "NACK",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NACKs from Central",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rate(rox_sensor_vsock_pull_ticks_total). Scheduler heartbeat; default tick 10s ≈ 0.1/s. Gaps mean the scraper loop is not running.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -303,17 +421,17 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
+        "w": 4,
+        "x": 20,
         "y": 2
       },
-      "id": 4,
+      "id": 206,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -338,13 +456,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count)",
-          "legendFormat": "Total Processed",
+          "expr": "rate(rox_sensor_vsock_pull_ticks_total[$__rate_interval])",
+          "legendFormat": "Ticks/s",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "🔄 Total Processed Index Reports",
+      "title": "Tick rate",
       "type": "stat"
     },
     {
@@ -355,9 +473,9 @@
         "x": 0,
         "y": 6
       },
-      "id": 101,
+      "id": 300,
       "panels": [],
-      "title": "📈 Throughput & Rates",
+      "title": "Arrival smoothing",
       "type": "row"
     },
     {
@@ -365,7 +483,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of reports sent per second over time",
+      "description": "Wall-clock picture of scrapes: rate(rox_sensor_vsock_pull_requests_total{status=\"success\"}). Healthy: low, fairly flat (paced). Clump: a spike (many reports in a short window). There is no scrape-timestamp metric; this rate is that picture. Scale depends on pollInterval and fleet size, not a fixed 5m cadence.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -375,7 +493,7 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Reports/sec",
+            "axisLabel": "forwards/s",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -413,17 +531,33 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "ops"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 16,
         "x": 0,
         "y": 7
       },
-      "id": 5,
+      "id": 301,
       "options": {
         "legend": {
           "calcs": [
@@ -439,7 +573,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "10.4.17",
       "targets": [
         {
           "datasource": {
@@ -447,13 +581,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(rox_sensor_virtual_machine_index_reports_sent_total{status=\"success\"}[$__rate_interval]))",
-          "legendFormat": "Sent Rate",
+          "expr": "rate(rox_sensor_vsock_pull_requests_total{status=\"success\"}[$__rate_interval])",
+          "legendFormat": "success",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "📤 Reports Sent to Central Rate",
+      "title": "Successful forward rate",
       "type": "timeseries"
     },
     {
@@ -461,7 +595,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of processing by outcome",
+      "description": "rox_sensor_vsock_pull_tracked_vms. Needed to interpret budget ceil(n × tick / window). Window is catch-up if any never-forwarded VM is due, else W = pollInterval × spreadFraction.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -471,11 +605,1893 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Reports/sec",
+            "axisLabel": "VMs",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "tracked"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "id": 302,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rox_sensor_vsock_pull_tracked_vms",
+          "legendFormat": "tracked",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fleet size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Budget is pacing a backlog when due stays high while starts stay small. Dump: due and starts both jump toward fleet size (or concurrency). due_vms is the last-tick gauge. Avg/P95 starts come from rox_sensor_vsock_pull_starts_per_tick (observed only when len(due) > 0; idle ticks are omitted). Compare starts-per-tick _count to ticks_total if the histogram looks empty.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "VMs",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "due (last tick)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "avg starts / observed tick"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P95 starts / observed tick"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 303,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rox_sensor_vsock_pull_due_vms",
+          "legendFormat": "due (last tick)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(rox_sensor_vsock_pull_starts_per_tick_sum[$__rate_interval]) / rate(rox_sensor_vsock_pull_starts_per_tick_count[$__rate_interval])",
+          "legendFormat": "avg starts / observed tick",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_starts_per_tick_bucket[$__rate_interval])))",
+          "legendFormat": "P95 starts / observed tick",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Due pile vs starts per tick",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rox_sensor_vsock_pull_starts_per_tick (buckets 0,1,2,3,5,…). Observed only when len(due) > 0; idle ticks are omitted, so compare _count to rox_sensor_vsock_pull_ticks_total. A small fleet with budget 1 should pile on le=\"1\". Healthy catch-up: mass on low buckets while due_vms is high. Dump: mass on fleet-size or concurrency buckets.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 304,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "short"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (increase(rox_sensor_vsock_pull_starts_per_tick_bucket[$__rate_interval]))",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ],
+      "title": "Starts per tick heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Snapshot of starts-per-tick buckets over the dashboard range (increase over $__range). Idle ticks are not sampled. Budget 1 piles on the 1 bucket. Compare sample count (le=+Inf) with tick rate if this looks empty.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "0"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4-5"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "6-8"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "9-10"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "11-15"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "16-20"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "21-30"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "31-50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "51-100"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": ">100"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 305,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"0\"}[$__range]))",
+          "legendFormat": "0",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"1\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"0\"}[$__range]))",
+          "legendFormat": "1",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"2\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"1\"}[$__range]))",
+          "legendFormat": "2",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"3\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"2\"}[$__range]))",
+          "legendFormat": "3",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"5\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"3\"}[$__range]))",
+          "legendFormat": "4-5",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"8\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"5\"}[$__range]))",
+          "legendFormat": "6-8",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"10\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"8\"}[$__range]))",
+          "legendFormat": "9-10",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"15\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"10\"}[$__range]))",
+          "legendFormat": "11-15",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"20\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"15\"}[$__range]))",
+          "legendFormat": "16-20",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"30\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"20\"}[$__range]))",
+          "legendFormat": "21-30",
+          "range": true,
+          "refId": "J"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"50\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"30\"}[$__range]))",
+          "legendFormat": "31-50",
+          "range": true,
+          "refId": "K"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"100\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"50\"}[$__range]))",
+          "legendFormat": "51-100",
+          "range": true,
+          "refId": "L"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"+Inf\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_starts_per_tick_bucket{le=\"100\"}[$__range]))",
+          "legendFormat": ">100",
+          "range": true,
+          "refId": "M"
+        }
+      ],
+      "title": "Starts per tick distribution",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rox_sensor_vsock_pull_forward_interarrival_seconds: Sensor-wide gaps between consecutive successful forwards (not per-VM). Spread fills a range of buckets. A dump fills near-zero. First forward after Sensor start is not observed.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 306,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "short"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket[$__rate_interval]))",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ],
+      "title": "Forward interarrival heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Percentiles of Sensor-wide gaps between consecutive successful forwards. Healthy pacing sits well above ~0. Clump: P50 glued to near-zero. Empty until the second successful forward after Sensor start.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "gap",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 307,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Forward interarrival percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative histogram of Sensor-wide forward gaps over the dashboard range. Dump: mass in ≤0.1s. Spread: mass across seconds-to-minutes depending on pollInterval and fleet size.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "≤0.08s (dump)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "0.08-1.3s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1.3-10s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "10-41s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "41s-2.7m"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2.7-5.5m"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5.5-11m"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": ">11m"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 308,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"0.08\"}[$__range]))",
+          "legendFormat": "≤0.08s (dump)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"1.28\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"0.08\"}[$__range]))",
+          "legendFormat": "0.08-1.3s",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"10.24\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"1.28\"}[$__range]))",
+          "legendFormat": "1.3-10s",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"40.96\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"10.24\"}[$__range]))",
+          "legendFormat": "10-41s",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"163.84\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"40.96\"}[$__range]))",
+          "legendFormat": "41s-2.7m",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"327.68\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"163.84\"}[$__range]))",
+          "legendFormat": "2.7-5.5m",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"655.36\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"327.68\"}[$__range]))",
+          "legendFormat": "5.5-11m",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"+Inf\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"655.36\"}[$__range]))",
+          "legendFormat": ">11m",
+          "range": true,
+          "refId": "H"
+        }
+      ],
+      "title": "Forward interarrival distribution",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "rox_sensor_vsock_pull_schedule_offset_seconds: extra delay U(0, W) on return-to-cadence only (success / permanent failure). Catch-up offsets in reconcile are NOT recorded. NACK/retry backoff is NOT recorded. Empty after Sensor restart until the first cadence reschedule — that is expected, not a missing scrape. Samples can sit in large buckets when poll is 1h (W=40m).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 309,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "short"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket[$__rate_interval]))",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ],
+      "title": "Schedule offset heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "U(0, W) extra delay on success / permanent failure only. Empty until the first cadence reschedule after Sensor start (catch-up and NACK/retry backoff do not observe this metric). With poll=1h, W=40m, percentiles can sit in the thousands of seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "offset",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "P99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 310,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_schedule_offset_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(rox_sensor_vsock_pull_schedule_offset_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_schedule_offset_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(rox_sensor_vsock_pull_schedule_offset_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Schedule offset percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Return-to-cadence U(0, W) only. Default W≈200s piles in 128–256s. Poll=1h (W=40m) piles in 1024–4096s. Empty until the first success/permanent-failure reschedule after Sensor start; do not treat empty as a scraper bug.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "≤32s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "32-128s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "128-256s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "256-512s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "512-1024s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1024-2048s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2048-4096s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": ">4096s"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 311,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"32\"}[$__range]))",
+          "legendFormat": "≤32s",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"128\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"32\"}[$__range]))",
+          "legendFormat": "32-128s",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"256\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"128\"}[$__range]))",
+          "legendFormat": "128-256s",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"512\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"256\"}[$__range]))",
+          "legendFormat": "256-512s",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"1024\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"512\"}[$__range]))",
+          "legendFormat": "512-1024s",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"2048\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"1024\"}[$__range]))",
+          "legendFormat": "1024-2048s",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"4096\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"2048\"}[$__range]))",
+          "legendFormat": "2048-4096s",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"+Inf\"}[$__range])) - sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"4096\"}[$__range]))",
+          "legendFormat": ">4096s",
+          "range": true,
+          "refId": "H"
+        }
+      ],
+      "title": "Schedule offset distribution",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Retries and NACKs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "sum by (status) (rate(rox_sensor_vsock_pull_requests_total)). Statuses: success, unchanged, dial_error, read_error, invalid_report, send_error, not_ready, unknown_method, timeout, busy. Retryable failures (dial_error, timeout, read_error, not_ready, busy, send_error) should keep ticking on backoff, not stall and not tight-loop at 1/tick for the whole fleet. unchanged is a successful pull that did not need a new forward.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "pulls/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -509,7 +2525,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "ops"
         },
         "overrides": [
           {
@@ -530,7 +2546,22 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "vm_unknown_to_sensor"
+              "options": "unchanged"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dial_error"
             },
             "properties": [
               {
@@ -541,102 +2572,11 @@
                 }
               }
             ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 7
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (outcome) (rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count[$__rate_interval]))",
-          "legendFormat": "{{outcome}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "🔄 Processing Rate by Outcome",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 102,
-      "panels": [],
-      "title": "🥧 Processing Outcome Distribution",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Distribution of processing outcomes - shows what percentage of reports succeeded vs failed",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "success"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "vm_unknown_to_sensor"
+              "options": "timeout"
             },
             "properties": [
               {
@@ -647,92 +2587,17 @@
                 }
               }
             ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 16
-      },
-      "id": 7,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "sum by (outcome) (rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count)",
-          "legendFormat": "{{outcome}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "🎯 Processing Outcome Distribution",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Shows the distribution of blocking enqueue wait times across latency buckets",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "≤1ms"
+              "options": "read_error"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "green",
+                  "fixedColor": "orange",
                   "mode": "fixed"
                 }
               }
@@ -741,22 +2606,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "1-10ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "10-100ms"
+              "options": "not_ready"
             },
             "properties": [
               {
@@ -771,7 +2621,22 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "100-500ms"
+              "options": "busy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "send_error"
             },
             "properties": [
               {
@@ -786,7 +2651,22 @@
           {
             "matcher": {
               "id": "byName",
-              "options": ">500ms"
+              "options": "invalid_report"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown_method"
             },
             "properties": [
               {
@@ -802,39 +2682,27 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 16
+        "w": 16,
+        "x": 0,
+        "y": 56
       },
-      "id": 8,
+      "id": 401,
       "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
         "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "mean",
+            "max"
           ],
-          "fields": "",
-          "values": false
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "10.4.17",
       "targets": [
         {
           "datasource": {
@@ -842,85 +2710,75 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"1\"})",
-          "legendFormat": "≤1ms",
+          "expr": "sum by (status) (rate(rox_sensor_vsock_pull_requests_total[$__rate_interval]))",
+          "legendFormat": "{{status}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"10\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"1\"})",
-          "legendFormat": "1-10ms",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"100\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"10\"})",
-          "legendFormat": "10-100ms",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"500\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"100\"})",
-          "legendFormat": "100-500ms",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"+Inf\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"500\"})",
-          "legendFormat": ">500ms",
-          "range": true,
-          "refId": "E"
         }
       ],
-      "title": "⏱️ Blocking Enqueue Duration Distribution",
-      "type": "piechart"
+      "title": "Pull outcomes by status",
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows the distribution of processing times for successful operations",
+      "description": "sum by (action) (rate(rox_sensor_virtual_machine_index_report_acks_received_total)). NACK volume with ongoing success pulls means Sensor is retrying full reports after Central reject (common while Scanner V4 matcher is still initializing). NACK also clears cached report_generation.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "acks/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
             }
           },
           "mappings": [],
-          "unit": "short"
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "≤10ms"
+              "options": "ACK"
             },
             "properties": [
               {
@@ -935,22 +2793,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "10-40ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": ">40ms"
+              "options": "NACK"
             },
             "properties": [
               {
@@ -968,37 +2811,25 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 16
+        "y": 56
       },
-      "id": 9,
+      "id": 402,
       "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
         "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value",
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "mean",
+            "max"
           ],
-          "fields": "",
-          "values": false
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "10.4.17",
       "targets": [
         {
           "datasource": {
@@ -1006,56 +2837,21 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\",le=\"10\"})",
-          "legendFormat": "≤10ms",
+          "expr": "sum by (action) (rate(rox_sensor_virtual_machine_index_report_acks_received_total[$__rate_interval]))",
+          "legendFormat": "{{action}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\",le=\"40\"}) - sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\",le=\"10\"})",
-          "legendFormat": "10-40ms",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\",le=\"+Inf\"}) - sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\",le=\"40\"})",
-          "legendFormat": ">40ms",
-          "range": true,
-          "refId": "C"
         }
       ],
-      "title": "⚡ Processing Duration Distribution (Success)",
-      "type": "piechart"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 103,
-      "panels": [],
-      "title": "📊 Latency Percentiles",
-      "type": "row"
+      "title": "ACK vs NACK",
+      "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "P50, P90, P95, and P99 latencies for blocking enqueue duration",
+      "description": "Stacked rates: success+unchanged (good pulls), retryable errors (dial_error, timeout, read_error, not_ready, busy, send_error), and permanent failures (invalid_report, unknown_method). Retryable should stay a modest fraction and decay on backoff. A retryable stack equal to fleet×1/tick is a tight loop, not backoff.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1065,7 +2861,171 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Latency (ms)",
+            "axisLabel": "pulls/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success+unchanged"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "retryable errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "permanent failures"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 64
+      },
+      "id": 403,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.17",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rox_sensor_vsock_pull_requests_total{status=~\"success|unchanged\"}[$__rate_interval]))",
+          "legendFormat": "success+unchanged",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rox_sensor_vsock_pull_requests_total{status=~\"dial_error|timeout|read_error|not_ready|busy|send_error\"}[$__rate_interval]))",
+          "legendFormat": "retryable errors",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(rox_sensor_vsock_pull_requests_total{status=~\"invalid_report|unknown_method\"}[$__rate_interval]))",
+          "legendFormat": "permanent failures",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Retryable errors vs success+unchanged",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Running totals of Central ACK vs NACK. Use with the rate panel: a climbing NACK line plus ongoing success pulls is the retry-after-reject pattern, not a silent stall.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -1100,379 +3060,6 @@
               {
                 "color": "green",
                 "value": null
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P50"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P90"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P95"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P99"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 25
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "P50",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "P90",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "P95",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "P99",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "⏱️ Blocking Enqueue Duration Percentiles",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "P50, P90, P95, and P99 latencies for processing duration",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Latency (ms)",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P50"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P90"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P95"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "P99"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 25
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])) by (le))",
-          "legendFormat": "P50",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])) by (le))",
-          "legendFormat": "P90",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])) by (le))",
-          "legendFormat": "P95",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])) by (le))",
-          "legendFormat": "P99",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "⚡ Processing Duration Percentiles (Success)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 104,
-      "panels": [],
-      "title": "📉 Detailed Histogram View",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Bar gauge showing the count of operations in each latency bucket for blocking enqueue",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1000
-              },
-              {
-                "color": "orange",
-                "value": 5000
-              },
-              {
-                "color": "red",
-                "value": 10000
               }
             ]
           },
@@ -1482,7 +3069,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "≤1ms"
+              "options": "ACK"
             },
             "properties": [
               {
@@ -1497,82 +3084,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "1-5ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "5-10ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "10-50ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "50-100ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "100-500ms"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": ">500ms"
+              "options": "NACK"
             },
             "properties": [
               {
@@ -1588,28 +3100,25 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 34
+        "w": 8,
+        "x": 16,
+        "y": 64
       },
-      "id": 12,
+      "id": 404,
       "options": {
-        "displayMode": "gradient",
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
+        "legend": {
           "calcs": [
-            "lastNotNull"
+            "mean",
+            "max"
           ],
-          "fields": "",
-          "values": false
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "10.4.17",
       "targets": [
@@ -1619,8 +3128,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"1\"})",
-          "legendFormat": "≤1ms",
+          "expr": "sum(rox_sensor_virtual_machine_index_report_acks_received_total{action=\"ACK\"})",
+          "legendFormat": "ACK",
           "range": true,
           "refId": "A"
         },
@@ -1630,392 +3139,1629 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"5\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"1\"})",
-          "legendFormat": "1-5ms",
+          "expr": "sum(rox_sensor_virtual_machine_index_report_acks_received_total{action=\"NACK\"})",
+          "legendFormat": "NACK",
           "range": true,
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"10\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"5\"})",
-          "legendFormat": "5-10ms",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"50\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"10\"})",
-          "legendFormat": "10-50ms",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"100\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"50\"})",
-          "legendFormat": "50-100ms",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"500\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"100\"})",
-          "legendFormat": "100-500ms",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"+Inf\"}) - sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket{le=\"500\"})",
-          "legendFormat": ">500ms",
-          "range": true,
-          "refId": "G"
         }
       ],
-      "title": "📊 Blocking Enqueue Duration - Histogram Buckets",
-      "type": "bargauge"
+      "title": "ACK / NACK cumulative",
+      "type": "timeseries"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 72
       },
-      "id": 105,
-      "panels": [],
-      "title": "📈 Average Latencies",
+      "id": 500,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Why this panel: separates timeouts from slow agents. Dial is websocket setup (rox_sensor_vsock_pull_dial_duration_seconds). Read is waiting for the full agent response. Total is dial+read+send to Central. A high read P99 with a healthy dial points at a slow or stuck agent, not VSOCK connect.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "seconds",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 16,
+            "x": 0,
+            "y": 73
+          },
+          "id": 501,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_dial_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "dial P50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_dial_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "dial P95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_read_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "read P50",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_read_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "read P95",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_total_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "total P50",
+              "range": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_total_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "total P95",
+              "range": true,
+              "refId": "F"
+            }
+          ],
+          "title": "Pull latency: dial / read / total",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Why this panel: tick overrun inflates the next start budget via budgetTickDuration = max(tick, elapsed). If P50 sits far above the configured tick (default 10s), the scraper is waiting on in-flight scrapes and the next tick may start more VMs than the nominal budget.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "tick",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P50"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P95"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 73
+          },
+          "id": 502,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_tick_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "P50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_tick_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "P95",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Tick duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Why this panel: payload size vs the 16MB response-size ceiling (env.VirtualMachinesPullMaxResponseSizeKB). P95 climbing through several MB is early warning before reports are rejected as too large.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "bytes",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P50"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P90"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P95"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P99"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 81
+          },
+          "id": 503,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_report_bytes_bucket[$__rate_interval])))",
+              "legendFormat": "P50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_report_bytes_bucket[$__rate_interval])))",
+              "legendFormat": "P95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(rox_sensor_vsock_pull_report_bytes_bucket[$__rate_interval])))",
+              "legendFormat": "P99",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Report payload bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Why this panel: package count per index report (rox_sensor_vsock_pull_report_packages). Complements payload bytes when diagnosing oversized reports.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "packages",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P50"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P90"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P95"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P99"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 81
+          },
+          "id": 504,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_vsock_pull_report_packages_bucket[$__rate_interval])))",
+              "legendFormat": "P50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_vsock_pull_report_packages_bucket[$__rate_interval])))",
+              "legendFormat": "P95",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(rox_sensor_vsock_pull_report_packages_bucket[$__rate_interval])))",
+              "legendFormat": "P99",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Packages per report",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Why this panel: starts-per-tick is omitted on idle ticks (len(due)==0). tick rate should be ~1/tickInterval. A large gap between ticks_total and starts_per_tick_count means most ticks had an empty due pile (steady state), not a broken histogram.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ticks"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "starts-per-tick samples"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 81
+          },
+          "id": 505,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "rate(rox_sensor_vsock_pull_ticks_total[$__rate_interval])",
+              "legendFormat": "ticks",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "rate(rox_sensor_vsock_pull_starts_per_tick_count[$__rate_interval])",
+              "legendFormat": "starts-per-tick samples",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Ticks vs starts-per-tick samples",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Pull latency and payload",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Average blocking enqueue duration in milliseconds",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
-                "color": "orange",
-                "value": 100
-              },
-              {
-                "color": "red",
-                "value": 500
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
+      "collapsed": true,
       "gridPos": {
-        "h": 5,
-        "w": 6,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 43
+        "y": 73
       },
-      "id": 13,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.17",
-      "targets": [
+      "id": 600,
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_sum) / sum(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_count)",
-          "legendFormat": "Avg",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "⏱️ Avg Blocking Enqueue Duration",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Average processing duration for successful operations",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "description": "Why this panel: after a successful pull, Handler still sends to Central. Outcomes diagnose drops after dequeue (success, vm_unknown_to_sensor, invalid_vsock_cid, nil_report). Not the scrape scheduler.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 40,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
               {
-                "color": "green",
-                "value": null
+                "matcher": {
+                  "id": "byName",
+                  "options": "success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "yellow",
-                "value": 20
+                "matcher": {
+                  "id": "byName",
+                  "options": "vm_unknown_to_sensor"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "orange",
-                "value": 50
+                "matcher": {
+                  "id": "byName",
+                  "options": "invalid_vsock_cid"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "red",
-                "value": 100
+                "matcher": {
+                  "id": "byName",
+                  "options": "nil_report"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               }
             ]
           },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 6,
-        "y": 43
-      },
-      "id": 14,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 74
+          },
+          "id": 601,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (outcome) (rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count[$__rate_interval]))",
+              "legendFormat": "{{outcome}}",
+              "range": true,
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": false
+          "title": "Handler processing rate by outcome",
+          "type": "timeseries"
         },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.17",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_sum{outcome=\"success\"}) / sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count{outcome=\"success\"})",
-          "legendFormat": "Avg",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "⚡ Avg Processing Duration (Success)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Percentage of reports that encountered blocking during enqueue",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "description": "Why this panel: Handler-side send counter (rox_sensor_virtual_machine_index_reports_sent_total), distinct from vsock_pull success. Divergence vs pull success points at enqueue/send failure after a good scrape.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": [
               {
-                "color": "green",
-                "value": null
+                "matcher": {
+                  "id": "byName",
+                  "options": "success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "yellow",
-                "value": 10
-              },
-              {
-                "color": "orange",
-                "value": 30
-              },
-              {
-                "color": "red",
-                "value": 50
+                "matcher": {
+                  "id": "byName",
+                  "options": "error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               }
             ]
           },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 43
-      },
-      "id": 15,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 74
+          },
+          "id": 602,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (status) (rate(rox_sensor_virtual_machine_index_reports_sent_total[$__rate_interval]))",
+              "legendFormat": "{{status}}",
+              "range": true,
+              "refId": "A"
+            }
           ],
-          "fields": "",
-          "values": false
+          "title": "Handler reports sent to Central",
+          "type": "timeseries"
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "10.4.17",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "(sum(rox_sensor_virtual_machine_index_report_enqueue_blocked_total) / sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count)) * 100",
-          "legendFormat": "Block Rate",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "🚫 Enqueue Block Rate",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Percentage of processed reports where VM was unknown to sensor",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+          "description": "Why this panel: Central send backpressure. Time waiting after the indexReports channel is full. Pull-mode spreading should keep this near zero; a rising P95 means Handler cannot drain as fast as VMScraper forwards.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": [
               {
-                "color": "green",
-                "value": null
+                "matcher": {
+                  "id": "byName",
+                  "options": "P50"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "yellow",
-                "value": 5
+                "matcher": {
+                  "id": "byName",
+                  "options": "P90"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "orange",
-                "value": 10
+                "matcher": {
+                  "id": "byName",
+                  "options": "P95"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               },
               {
-                "color": "red",
-                "value": 20
+                "matcher": {
+                  "id": "byName",
+                  "options": "P99"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
               }
             ]
           },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 18,
-        "y": 43
-      },
-      "id": 16,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 82
+          },
+          "id": 603,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])))",
+              "legendFormat": "P50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum by (le) (rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])))",
+              "legendFormat": "P90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])))",
+              "legendFormat": "P95",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(rox_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds_bucket[$__rate_interval])))",
+              "legendFormat": "P99",
+              "range": true,
+              "refId": "D"
+            }
           ],
-          "fields": "",
-          "values": false
+          "title": "Handler blocking enqueue percentiles",
+          "type": "timeseries"
         },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "10.4.17",
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "editorMode": "code",
-          "expr": "(sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count{outcome=\"vm_unknown_to_sensor\"}) / sum(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_count)) * 100",
-          "legendFormat": "Unknown VM Rate",
-          "range": true,
-          "refId": "A"
+          "description": "Why this panel: how often enqueue found the channel full (rox_sensor_virtual_machine_index_report_enqueue_blocked_total). Secondary to spreading; a climb here is Handler/Central backpressure, not a due-pile dump by itself.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "blocked/s"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "blocked total"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 82
+          },
+          "id": 604,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(rox_sensor_virtual_machine_index_report_enqueue_blocked_total[$__rate_interval]))",
+              "legendFormat": "blocked/s",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rox_sensor_virtual_machine_index_report_enqueue_blocked_total)",
+              "legendFormat": "blocked total",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Enqueue blocked count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Why this panel: time from dequeue to Central send on the success path. Spikes here delay the next Handler slot and can back up enqueue even when scrape spreading is healthy.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ms"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P50"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P90"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P95"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "P99"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 90
+          },
+          "id": 605,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.17",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])))",
+              "legendFormat": "P50",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.90, sum by (le) (rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])))",
+              "legendFormat": "P90",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])))",
+              "legendFormat": "P95",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(rox_sensor_virtual_machine_index_report_processing_duration_milliseconds_bucket{outcome=\"success\"}[$__rate_interval])))",
+              "legendFormat": "P99",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Handler processing duration (success)",
+          "type": "timeseries"
         }
       ],
-      "title": "❓ Unknown VM Rate",
-      "type": "gauge"
+      "title": "Forward to Central (handler)",
+      "type": "row"
     }
   ],
   "refresh": "30s",
@@ -2024,7 +4770,8 @@
     "stackrox",
     "sensor",
     "virtual-machine",
-    "index-report"
+    "index-report",
+    "vmscraper"
   ],
   "templating": {
     "list": [
@@ -2050,13 +4797,13 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "VM Index Report - Sensor Metrics",
   "uid": "vm-index-report-sensor",
-  "version": 8,
+  "version": 9,
   "weekStart": ""
 }

--- a/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
+++ b/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
@@ -483,7 +483,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Wall-clock picture of scrapes: rate(rox_sensor_vsock_pull_requests_total{status=\"success\"}). Healthy: low, fairly flat (paced). Clump: a spike (many reports in a short window). There is no scrape-timestamp metric; this rate is that picture. Scale depends on pollInterval and fleet size, not a fixed 5m cadence.",
+      "description": "How many successful forwards landed in each graph step: increase(rox_sensor_vsock_pull_requests_total{status=\"success\"}[$__interval]). Y is a count, not a per-second rate, so a dump is a tall bar (near fleet size) and pacing is short bars spread across the poll window. There is no scrape-timestamp metric; this is that picture. Zoom in to shrink the step. Bucket width follows the graph interval, not a fixed 5m cadence.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -493,20 +493,20 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "forwards/s",
+            "axisLabel": "forwards",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "opacity",
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
@@ -531,7 +531,7 @@
               }
             ]
           },
-          "unit": "ops"
+          "unit": "short"
         },
         "overrides": [
           {
@@ -581,13 +581,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(rox_sensor_vsock_pull_requests_total{status=\"success\"}[$__rate_interval])",
+          "expr": "increase(rox_sensor_vsock_pull_requests_total{status=\"success\"}[$__interval])",
           "legendFormat": "success",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Successful forward rate",
+      "title": "Successful forwards",
       "type": "timeseries"
     },
     {

--- a/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
+++ b/deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Sensor VMScraper pull mode: VSOCK scrape spreading, retries/NACKs, and Handler forward to Central.",
+  "description": "Sensor pull-mode VM scanning: Sensor dials each VM's agent when that VM is due, optionally forwards a new index report to Central, and retries on NACK. Use this board to see whether those Central sends are paced, and whether scrapes are failing or only unchanged.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -51,7 +51,7 @@
               "showLineNumbers": false,
               "showMiniMap": false
             },
-            "content": "Sensor **pulls** index reports: VMScraper ticks, dials each due VM's roxagent over VSOCK, and forwards a successful report through `vmIndex.Handler` to Central. Central ACK/NACKs. Handler enqueue metrics are a secondary \"send to Central\" story, not the scrape scheduler.\n\n```\n  roxagent (in VM)                    Sensor                         Central\n  ┌─────────────┐     VSOCK      ┌─────────────┐   SensorEvent   ┌─────────┐\n  │ GetReport   │◀──────────────▶│  VMScraper  │────────────────▶│ VM pipe │\n  └─────────────┘   when due     │ per-VM next │                 └────┬────┘\n                                 │ AttemptAt   │                      │\n                                 └──────┬──────┘              SensorACK│\n                                        │                    ACK | NACK│\n                                        └──────────────────────────────┘\n                                   NACK: clear report_generation, shared backoff\n```\n\n**Arrival smoothing** (read `pollInterval` from Sensor env; do not assume 5m):\n\n- First wave / Sensor restart: never-scraped VMs get `nextAttemptAt = now + U(0, catchUpWindow)` where `catchUpWindow = min(20m, pollInterval/3)`.\n- Per-tick start budget: `ceil(nTracked × tick / window)`. Window is catch-up if any never-forwarded VM is due, else steady width `W = pollInterval × spreadFraction` (default 2/3). `n` is tracked fleet size, not leftover due-pile size. `selectDueStarts` still cannot start more than are due. Concurrency (default 20) is a separate overlap cap.\n- Success and permanent failure reschedule at `pollInterval + U(0, W)`.\n- Retryable pull failures and NACKs share exponential backoff (`initialBackoff` default 10s, doubled, cap `min(pollInterval, 30m)`).\n\nDefaults: tick 10s, poll 5m, catch-up 100s, W 200s, concurrency 20. A 1h poll uses catch-up 20m and W 40m.\n",
+            "content": "Sensor **pulls** index reports: VMScraper ticks, dials each due VM's roxagent over VSOCK, and forwards a successful report through `vmIndex.Handler` to Central. Central ACK/NACKs. Handler enqueue metrics are a secondary \"send to Central\" story, not the scrape scheduler.\n\n```\n  roxagent (in VM)                    Sensor                         Central\n  \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510     VSOCK      \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510   SensorEvent   \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n  \u2502 GetReport   \u2502\u25c0\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u25b6\u2502  VMScraper  \u2502\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u25b6\u2502 VM pipe \u2502\n  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518   when due     \u2502 per-VM next \u2502                 \u2514\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2518\n                                 \u2502 AttemptAt   \u2502                      \u2502\n                                 \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u252c\u2500\u2500\u2500\u2500\u2500\u2500\u2518              SensorACK\u2502\n                                        \u2502                    ACK | NACK\u2502\n                                        \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n                                   NACK: clear report_generation, shared backoff\n```\n\n**Arrival smoothing** (read `pollInterval` from Sensor env; do not assume 5m):\n\n- First wave / Sensor restart: never-scraped VMs get `nextAttemptAt = now + U(0, catchUpWindow)` where `catchUpWindow = min(20m, pollInterval/3)`.\n- Per-tick start budget: `ceil(nTracked \u00d7 tick / window)`. Window is catch-up if any never-forwarded VM is due, else steady width `W = pollInterval \u00d7 spreadFraction` (default 2/3). `n` is tracked fleet size, not leftover due-pile size. `selectDueStarts` still cannot start more than are due. Concurrency (default 20) is a separate overlap cap.\n- Success and permanent failure reschedule at `pollInterval + U(0, W)`.\n- Retryable pull failures and NACKs share exponential backoff (`initialBackoff` default 10s, doubled, cap `min(pollInterval, 30m)`).\n\nDefaults: tick 10s, poll 5m, catch-up 100s, W 200s, concurrency 20. A 1h poll uses catch-up 20m and W 40m.\n",
             "mode": "markdown"
           },
           "pluginVersion": "10.4.17",
@@ -80,7 +80,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rox_sensor_vsock_pull_tracked_vms. Fleet size n used in start budget ceil(n × tick / window).",
+      "description": "How many VMs Sensor is currently scheduling. The start budget is computed from this fleet size, not from how many happen to be due right now.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -145,7 +145,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rox_sensor_vsock_pull_due_vms. Eligible VMs at the start of the last tick, before the start budget. Persistently high with small starts means the budget is pacing a backlog.",
+      "description": "How many VMs were eligible to scrape on the most recent 10s tick, before the budget capped how many could start. A high number with ~1 start per tick is pacing a backlog. Zero means the next attempts are still in the future.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -210,7 +210,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Cumulative rox_sensor_vsock_pull_requests_total{status=\"success\"}. Full reports forwarded to Central, not unchanged pulls.",
+      "description": "Lifetime count of full index reports Sensor sent to Central. Unchanged pulls are not included. This number stays flat while guests do not change.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -275,7 +275,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Cumulative status=\"unchanged\": agent had nothing newer; no new forward. Still a successful pull.",
+      "description": "Lifetime count of scrapes where the agent had nothing newer than last time. Sensor still talked to the VM; Central did not get a new report. This is the usual overnight case.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -340,7 +340,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Cumulative SensorACK NACK. Ongoing NACKs with success pulls means Sensor is retrying full reports after Central reject (common while Scanner V4 matcher is still initializing).",
+      "description": "How many times Central rejected a VM index report. Sensor clears the cached generation and retries on a short backoff. The reason (Scanner down, and so on) is in Central logs, not in this number.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -405,7 +405,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rate(rox_sensor_vsock_pull_ticks_total). Scheduler heartbeat; default tick 10s ≈ 0.1/s. Gaps mean the scraper loop is not running.",
+      "description": "How often the scraper loop wakes up. Default 10s tick is about 0.1 per second. A drop to zero means the loop is not running.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -483,7 +483,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "How many successful forwards landed in each graph step: increase(rox_sensor_vsock_pull_requests_total{status=\"success\"}[$__interval]). Y is a count, not a per-second rate, so a dump is a tall bar (near fleet size) and pacing is short bars spread across the poll window. There is no scrape-timestamp metric; this is that picture. Zoom in to shrink the step. Bucket width follows the graph interval, not a fixed 5m cadence.",
+      "description": "How many reports Sensor sent to Central in each ~30s Prometheus scrape. Healthy pacing is mostly bars of 1. A tall bar is several reports in the same scrape (a dump). Unchanged pulls do not appear here. A Sensor restart can make one bar go negative (counter reset).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -595,7 +595,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rox_sensor_vsock_pull_tracked_vms. Needed to interpret budget ceil(n × tick / window). Window is catch-up if any never-forwarded VM is due, else W = pollInterval × spreadFraction.",
+      "description": "How many VMs Sensor is scheduling, as a time series, so you can read the start budget against fleet size.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -707,7 +707,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Budget is pacing a backlog when due stays high while starts stay small. Dump: due and starts both jump toward fleet size (or concurrency). due_vms is the last-tick gauge. Avg/P95 starts come from rox_sensor_vsock_pull_starts_per_tick (observed only when len(due) > 0; idle ticks are omitted). Compare starts-per-tick _count to ticks_total if the histogram looks empty.",
+      "description": "Eligible VMs versus how many scrapes that tick actually started. Healthy catch-up: due stays high, starts stay near 1. A dump: both jump toward the fleet (or the concurrency cap). Starts are only recorded on ticks that had someone due; idle ticks are omitted.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -871,7 +871,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rox_sensor_vsock_pull_starts_per_tick (buckets 0,1,2,3,5,…). Observed only when len(due) > 0; idle ticks are omitted, so compare _count to rox_sensor_vsock_pull_ticks_total. A small fleet with budget 1 should pile on le=\"1\". Healthy catch-up: mass on low buckets while due_vms is high. Dump: mass on fleet-size or concurrency buckets.",
+      "description": "Time on X, how many VMs started in that tick on Y, color = how often that happened. Budget 1 should glow on Y near 1. A bright band at Y near 8 (or 20) is a dump. Idle ticks do not appear.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -955,7 +955,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Snapshot of starts-per-tick buckets over the dashboard range (increase over $__range). Idle ticks are not sampled. Budget 1 piles on the 1 bucket. Compare sample count (le=+Inf) with tick rate if this looks empty.",
+      "description": "Totals over the selected time range: how many ticks started 0, 1, 2, ... VMs. For a small fleet with budget 1, almost everything should sit in the 1 bucket. If this looks empty but tick rate is healthy, most ticks had nobody due.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1362,7 +1362,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rox_sensor_vsock_pull_forward_interarrival_seconds: Sensor-wide gaps between consecutive successful forwards (not per-VM). Spread fills a range of buckets. A dump fills near-zero. First forward after Sensor start is not observed.",
+      "description": "Time on X, gap between consecutive Central sends on Y (seconds), color = how often that gap occurred. This is Sensor-wide, not per VM, and only full forwards (not unchanged pulls). A paced wave is a bright band around ~10s. A dump is bright near 0s. Long quiet stretches show up as rare, large-Y cells, or as darkness if nothing was forwarded. The first forward after Sensor start is not recorded.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1446,7 +1446,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Percentiles of Sensor-wide gaps between consecutive successful forwards. Healthy pacing sits well above ~0. Clump: P50 glued to near-zero. Empty until the second successful forward after Sensor start.",
+      "description": "Typical (P50) and large (P90/P99) gaps between consecutive Central sends over time. Use this to see when pacing changed. With few forwards the lines jump; a single hour-long hole between waves can lift P50 even if each wave was paced. Prefer the heatmap and distribution for gap sizes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1636,7 +1636,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Cumulative histogram of Sensor-wide forward gaps over the dashboard range. Dump: mass in ≤0.1s. Spread: mass across seconds-to-minutes depending on pollInterval and fleet size.",
+      "description": "How many Central-send gaps fell in each size bucket over the selected range. Mass in 0.08s or less means reports left Sensor almost together (a dump). Mass around 10-41s is a paced wave at a 10s tick. Mass in minutes-or-more is the idle time between waves, which is normal when guests do not change.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1670,7 +1670,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "≤0.08s (dump)"
+              "options": "\u22640.08s (dump)"
             },
             "properties": [
               {
@@ -1823,7 +1823,7 @@
           },
           "editorMode": "code",
           "expr": "sum(increase(rox_sensor_vsock_pull_forward_interarrival_seconds_bucket{le=\"0.08\"}[$__range]))",
-          "legendFormat": "≤0.08s (dump)",
+          "legendFormat": "\u22640.08s (dump)",
           "range": true,
           "refId": "A"
         },
@@ -1913,7 +1913,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "rox_sensor_vsock_pull_schedule_offset_seconds: extra delay U(0, W) on return-to-cadence only (success / permanent failure). Catch-up offsets in reconcile are NOT recorded. NACK/retry backoff is NOT recorded. Empty after Sensor restart until the first cadence reschedule — that is expected, not a missing scrape. Samples can sit in large buckets when poll is 1h (W=40m).",
+      "description": "Time on X, extra random delay added on top of the poll interval on Y. Recorded only when a VM returns to normal cadence after a successful scrape or a permanent failure. Catch-up jitter and NACK/retry backoff are not on this chart. Empty after Sensor start until the first cadence reschedule is expected. With poll 20m this should light up somewhere under ~13 minutes (spread 2/3).",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1997,7 +1997,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "U(0, W) extra delay on success / permanent failure only. Empty until the first cadence reschedule after Sensor start (catch-up and NACK/retry backoff do not observe this metric). With poll=1h, W=40m, percentiles can sit in the thousands of seconds.",
+      "description": "Typical extra delay on return-to-cadence, over time. Empty until the first success or permanent-failure reschedule. NACK retries will not move this chart.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2187,7 +2187,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Return-to-cadence U(0, W) only. Default W≈200s piles in 128–256s. Poll=1h (W=40m) piles in 1024–4096s. Empty until the first success/permanent-failure reschedule after Sensor start; do not treat empty as a scraper bug.",
+      "description": "Totals of those extra delays over the selected range. Default poll 5m piles around 0-200s. Poll 20m piles under ~13 minutes. This is the random band on the next poll, not the gap between Central forwards.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2221,7 +2221,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "≤32s"
+              "options": "\u226432s"
             },
             "properties": [
               {
@@ -2374,7 +2374,7 @@
           },
           "editorMode": "code",
           "expr": "sum(increase(rox_sensor_vsock_pull_schedule_offset_seconds_bucket{le=\"32\"}[$__range]))",
-          "legendFormat": "≤32s",
+          "legendFormat": "\u226432s",
           "range": true,
           "refId": "A"
         },
@@ -2477,7 +2477,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "sum by (status) (rate(rox_sensor_vsock_pull_requests_total)). Statuses: success, unchanged, dial_error, read_error, invalid_report, send_error, not_ready, unknown_method, timeout, busy. Retryable failures (dial_error, timeout, read_error, not_ready, busy, send_error) should keep ticking on backoff, not stall and not tight-loop at 1/tick for the whole fleet. unchanged is a successful pull that did not need a new forward.",
+      "description": "Rate of scrape results. success = new report sent to Central. unchanged = agent had nothing new. The rest are errors (dial, timeout, not_ready, busy, and so on). Retryable errors should continue at backoff, not at 1 per tick for the whole fleet.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2724,7 +2724,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "sum by (action) (rate(rox_sensor_virtual_machine_index_report_acks_received_total)). NACK volume with ongoing success pulls means Sensor is retrying full reports after Central reject (common while Scanner V4 matcher is still initializing). NACK also clears cached report_generation.",
+      "description": "Rate of Central acknowledgements. NACKs with ongoing success means Sensor is resending full reports after a reject. The NACK reason is in Central logs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2851,7 +2851,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Stacked rates: success+unchanged (good pulls), retryable errors (dial_error, timeout, read_error, not_ready, busy, send_error), and permanent failures (invalid_report, unknown_method). Retryable should stay a modest fraction and decay on backoff. A retryable stack equal to fleet×1/tick is a tight loop, not backoff.",
+      "description": "Good pulls (success + unchanged) versus retryable errors versus permanent failures. A retryable stack as large as fleet times 1/tick is a tight loop, not backoff.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3015,7 +3015,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Running totals of Central ACK vs NACK. Use with the rate panel: a climbing NACK line plus ongoing success pulls is the retry-after-reject pattern, not a silent stall.",
+      "description": "Running totals of Central ACK vs NACK. A climbing NACK line plus continued success is retry-after-reject, not a silent stall.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3163,7 +3163,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: separates timeouts from slow agents. Dial is websocket setup (rox_sensor_vsock_pull_dial_duration_seconds). Read is waiting for the full agent response. Total is dial+read+send to Central. A high read P99 with a healthy dial points at a slow or stuck agent, not VSOCK connect.",
+          "description": "Time to connect to the agent, time to read the report, and end-to-end (dial + read + send). A high read P99 with a healthy dial points at a slow agent, not a VSOCK connect problem. Total is only recorded on successful forwards.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3314,7 +3314,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: tick overrun inflates the next start budget via budgetTickDuration = max(tick, elapsed). If P50 sits far above the configured tick (default 10s), the scraper is waiting on in-flight scrapes and the next tick may start more VMs than the nominal budget.",
+          "description": "How long a tick spent waiting on the scrapes it started. If this sits well above the configured tick (default 10s), the next tick's budget can grow because Sensor treats the long tick as an overrun.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3452,7 +3452,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: payload size vs the 16MB response-size ceiling (env.VirtualMachinesPullMaxResponseSizeKB). P95 climbing through several MB is early warning before reports are rejected as too large.",
+          "description": "Size of forwarded reports (not unchanged pulls). Watch this against the 16MB response ceiling. Climbing multi-MB P95 is early warning before rejects.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3631,7 +3631,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: package count per index report (rox_sensor_vsock_pull_report_packages). Complements payload bytes when diagnosing oversized reports.",
+          "description": "Package count in forwarded reports. Use with payload bytes when a report is oversized.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3810,7 +3810,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: starts-per-tick is omitted on idle ticks (len(due)==0). tick rate should be ~1/tickInterval. A large gap between ticks_total and starts_per_tick_count means most ticks had an empty due pile (steady state), not a broken histogram.",
+          "description": "Tick rate should stay about 1 per tick interval. Starts-per-tick samples are fewer because idle ticks are omitted. A large gap between the two means most ticks had an empty due pile (steady state), not a broken histogram.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3962,7 +3962,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: after a successful pull, Handler still sends to Central. Outcomes diagnose drops after dequeue (success, vm_unknown_to_sensor, invalid_vsock_cid, nil_report). Not the scrape scheduler.",
+          "description": "After a successful pull, Handler sends to Central. This is dequeue/send outcomes (success, unknown VM, and so on), not the scrape scheduler.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4119,7 +4119,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: Handler-side send counter (rox_sensor_virtual_machine_index_reports_sent_total), distinct from vsock_pull success. Divergence vs pull success points at enqueue/send failure after a good scrape.",
+          "description": "Handler's send counter. If this diverges from pull success, the scrape worked but enqueue/send did not.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4246,7 +4246,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: Central send backpressure. Time waiting after the indexReports channel is full. Pull-mode spreading should keep this near zero; a rising P95 means Handler cannot drain as fast as VMScraper forwards.",
+          "description": "Time spent waiting because the Handler channel was full. Spreading should keep this near zero. Rising P95 means Central/Handler cannot drain as fast as VMScraper forwards.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4436,7 +4436,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: how often enqueue found the channel full (rox_sensor_virtual_machine_index_report_enqueue_blocked_total). Secondary to spreading; a climb here is Handler/Central backpressure, not a due-pile dump by itself.",
+          "description": "How often that channel was full. A climb is Handler/Central backpressure, not a due-pile dump by itself.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4574,7 +4574,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "description": "Why this panel: time from dequeue to Central send on the success path. Spikes here delay the next Handler slot and can back up enqueue even when scrape spreading is healthy.",
+          "description": "Time from dequeue to a successful Central send. Spikes here can fill the enqueue channel even when scrape spreading is healthy.",
           "fieldConfig": {
             "defaults": {
               "color": {


### PR DESCRIPTION
Merge this only if https://github.com/stackrox/stackrox/pull/22306 lands. However, If https://github.com/stackrox/stackrox/pull/22402 is merged, then close this one and merge https://github.com/stackrox/stackrox/pull/22421 instead.

 
## Description

VMScraper pulls each due VM's index report over VSOCK and forwards a successful one through `vmIndex.Handler` to Central. The Grafana dashboard `VM Index Report - Sensor Metrics` (uid `vm-index-report-sensor`) still told the Relay push story: fake workloads, `index_reports_received_total`, and a full Handler channel as the main failure.

This rewrite makes pull mode the main view. Arrival smoothing is the row that shows whether scrapes are paced: success rate over time, due pile versus starts, starts-per-tick, forward interarrival, schedule offset, and fleet size. Each of those panels says what a healthy spread looks like versus a dump, including the histogram caveats (starts-per-tick skips idle ticks; schedule offset is return-to-cadence only).

The Retries and NACKs row plots pull outcomes by status and Central ACK versus NACK, so a retryable error or a matcher-init NACK is visible instead of looking like a stall. Dial, read, and total latency, tick duration, payload size, and a compact Handler enqueue subset sit in collapsed rows.

Helm still loads the file from `deploy/charts/monitoring/dashboards/vm-index-report-dashboard.json` into the `grafana-dashboards` ConfigMap. The dashboard uid is unchanged.

This PR is stacked on the arrival-smoothing branch because the new graphs query scrape-budget metrics added there.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Dashboard JSON only; no Go or e2e tests.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] Manually verified on a cluster (running the code from https://github.com/stackrox/stackrox/pull/22306) - by looking at the charts. Screenshot attached.

<img width="1824" height="3060" alt="VM-Index-Report-Sensor-Metrics-Dashboards-Grafana-08-20-2026_11_36_AM" src="https://github.com/user-attachments/assets/4ac94a63-304b-41d7-804b-8c21dd2deb26" />

(there might be slight variations of chart titles and help texts) 
