### PR TITLE
ROX-36285: retry empty API token generation in token-file e2e

### DIFF
--- a/tests/roxctl/token-file.sh
+++ b/tests/roxctl/token-file.sh
@@ -30,11 +30,12 @@ token_file_has_token() {
 }
 
 request_api_token() {
+  # wait_for_api_token owns retries; curl --retry would multiply generate POSTs.
   curl -k -f \
     --config <(curl_cfg user "admin:$ROX_ADMIN_PASSWORD") \
     -d '{"name": "test", "role": "Admin"}' \
-    --retry 5 \
-    --retry-connrefused \
+    --connect-timeout 10 \
+    --max-time 30 \
     "https://$API_ENDPOINT/v1/apitokens/generate"
 }
 

--- a/tests/roxctl/token-file.sh
+++ b/tests/roxctl/token-file.sh
@@ -13,22 +13,67 @@ eecho() {
   echo "$@" >&2
 }
 
+die() {
+  eecho "$@"
+  exit 1
+}
+
 curl_cfg() { # Use built-in echo to not expose $2 in the process list.
   echo -n "$1 = \"${2//[\"\\]/\\&}\""
 }
 
-# Retrieve API token
-TOKEN_FILE=$(mktemp)
-curl -k -f \
-  --config <(curl_cfg user "admin:$ROX_ADMIN_PASSWORD") \
-  -d '{"name": "test", "role": "Admin"}' \
-  --retry 5 \
-  --retry-connrefused \
-  "https://$API_ENDPOINT/v1/apitokens/generate" \
-  | jq -r .token \
-  > "$TOKEN_FILE"
+# token_file_has_token rejects jq's "null" for a missing .token field.
+token_file_has_token() {
+  local token
+  token="$(cat "$TOKEN_FILE")"
+  [ -n "$token" ] && [ "$token" != "null" ]
+}
 
-[ -n "$(cat "$TOKEN_FILE")" ]
+request_api_token() {
+  curl -k -f \
+    --config <(curl_cfg user "admin:$ROX_ADMIN_PASSWORD") \
+    -d '{"name": "test", "role": "Admin"}' \
+    --retry 5 \
+    --retry-connrefused \
+    "https://$API_ENDPOINT/v1/apitokens/generate"
+}
+
+write_token_file() {
+  local response
+  response="$(request_api_token)" || return 1
+  printf '%s' "$response" | jq -r .token > "$TOKEN_FILE" || return 1
+  token_file_has_token
+}
+
+# sleep_before_next_attempt waits 1s, 2s, 4s, then 8s after attempts 1-4.
+sleep_before_next_attempt() {
+  case "$1" in
+    1) sleep 1 ;;
+    2) sleep 2 ;;
+    3) sleep 4 ;;
+    4) sleep 8 ;;
+  esac
+}
+
+wait_for_api_token() {
+  local attempt=1
+  local max_attempts=5
+
+  while [ "$attempt" -le "$max_attempts" ]; do
+    if write_token_file; then
+      return 0
+    fi
+    if [ "$attempt" -eq "$max_attempts" ]; then
+      die "Failed to retrieve API token after ${max_attempts} attempts: token file is empty"
+    fi
+    eecho "Token generate attempt ${attempt}/${max_attempts} failed, retrying..."
+    sleep_before_next_attempt "$attempt"
+    attempt=$((attempt + 1))
+  done
+}
+
+TOKEN_FILE=$(mktemp)
+wait_for_api_token
 
 test_roxctl_cmd() {
   echo "Testing command: roxctl " "$@"


### PR DESCRIPTION
## Description

The required GitHub check `e2e-nongroovy-tests / gke-nongroovy-e2e-tests` runs `tests/roxctl/token-file.sh`. That script calls `/v1/apitokens/generate`, writes the token to a temp file, then exercises `roxctl --token-file`.

When generate left an empty file, the script still ran the later assertions. Those failed with `file is empty` and showed up as eight or nine `[FAIL]` lines. `curl --retry` only retries connection errors, so an HTTP 200 with no token was a single shot.

This change retries token generation up to five times, with 1s / 2s / 4s / 8s backoff, and treats an empty or `null` token as a failed attempt. After the last miss it exits once. Curl and jq run as separate steps so a failed curl is a failed attempt without needing `pipefail`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

The change is in the existing bash e2e script; no separate unit tests.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Manually verified on OpenShift Central

<details>
<summary><b>Manual verification: PASS</b> - token-file e2e against a live OpenShift Central</summary>

**Setup:** OpenShift Central route; `ROX_ADMIN_PASSWORD=admin` (usual htpasswd reset). No extra feature flags.

1. `API_ENDPOINT="$(oc -n stackrox get route central -o jsonpath='{.spec.host}'):443" ROX_ADMIN_PASSWORD=admin ./tests/roxctl/token-file.sh` → expect `Passed` after `central whoami` and `central db backup` `[OK]` lines
   ```
   Using API_ENDPOINT <central-route>:443
   Testing command: roxctl  central whoami
   [OK] Specifying only --token-file works
   ...
   Testing command: roxctl  central db backup
   [OK] Specifying only --token-file works
   ...
   Passed
   ```
2. Inject two empty `/v1/apitokens/generate` bodies (PATH `curl` shim), then forward to Central → expect retry logs, then `Passed`
   ```
   Token generate attempt 1/5 failed, retrying...
   Token generate attempt 2/5 failed, retrying...
   Testing command: roxctl  central whoami
   [OK] Specifying only --token-file works
   ...
   Passed
   generate attempts through shim: 3
   ```

</details>

AI-Assisted: cursor, generated retry helpers in `tests/roxctl/token-file.sh`, user reviewed structure and retry behavior.