### PR TITLE
ROX-35606: add signingKeyBundle.configMapName field

### DIFF
--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -86,6 +86,8 @@ central:
     mounts:
       configMaps: null # [string]
       secrets: null # [string]
+  signingKeyBundle:
+    configMapName: null # string
   extraMounts: null # [dict]
   db:
     nodeSelector: null # string | dict

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -215,6 +215,11 @@ spec:
           mountPath: /run/secrets/stackrox.io/ocp-tls
           readOnly: true
         {{- end }}
+        {{- if ._rox.central.signingKeyBundle.configMapName }}
+        - name: signing-key-bundle
+          mountPath: /tmp/redhat-signing-keys
+          readOnly: true
+        {{- end }}
         {{- range $extraMount := (default list ._rox.central.extraMounts) }}
         - name: {{ $extraMount.name }}
           {{- $extraMount.mount | toYaml | nindent 10 }}
@@ -306,6 +311,12 @@ spec:
       - name: ocp-tls
         secret:
           secretName: central-ocp-tls
+      {{- end }}
+      {{- if ._rox.central.signingKeyBundle.configMapName }}
+      - name: signing-key-bundle
+        configMap:
+          name: {{ ._rox.central.signingKeyBundle.configMapName }}
+          optional: true
       {{- end }}
       {{- range $extraMount := (default list ._rox.central.extraMounts) }}
       - name: {{ $extraMount.name }}

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -226,19 +226,20 @@
 #       reencrypt:
 #         enabled: true
 #
-#     # Offline signing key bundle: mount a pre-created ConfigMap containing the
-#     # Red Hat signing key bundle. This allows air-gapped customers to update the
-#     # baked-in signing keys without internet access.
-#     # Steps:
-#     #   1. Copy the bundle format from /tmp/redhat-signing-keys/bundle.example.json
-#     #      inside the Central container (or see documentation for the JSON schema).
-#     #   2. Create the ConfigMap:
-#     #      kubectl create configmap redhat-signing-key-bundle \
-#     #        --from-file=bundle.json=<your-bundle-file> -n stackrox
-#     #   3. Uncomment the line below and run helm upgrade.
-#     # To rotate keys, edit the ConfigMap directly — no helm upgrade needed.
-#     signingKeyBundle:
-#       configMapName: "redhat-signing-key-bundle"
+#
+#   # Offline signing key bundle: mount a pre-created ConfigMap containing the
+#   # Red Hat signing key bundle. This allows air-gapped customers to update the
+#   # baked-in signing keys without internet access.
+#   # Steps:
+#   #   1. Copy the bundle format from /tmp/redhat-signing-keys/bundle.example.json
+#   #      inside the Central container (or see documentation for the JSON schema).
+#   #   2. Create the ConfigMap:
+#   #      kubectl create configmap redhat-signing-key-bundle \
+#   #        --from-file=bundle.json=<your-bundle-file> -n stackrox
+#   #   3. Uncomment the line below and run helm upgrade.
+#   # To rotate keys, edit the ConfigMap directly — no helm upgrade needed.
+#   signingKeyBundle:
+#     configMapName: "redhat-signing-key-bundle"
 #
 #     # Additional volume mounts for the Central container. Only few people will require this.
 #     extraMounts:

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -227,17 +227,9 @@
 #         enabled: true
 #
 #
-#   # Offline signing key bundle: mount a pre-created ConfigMap containing the
-#   # Red Hat signing key bundle. This allows air-gapped customers to update the
-#   # baked-in signing keys without internet access.
-#   # Steps:
-#   #   1. Copy the bundle format from /tmp/redhat-signing-keys/bundle.example.json
-#   #      inside the Central container (or see documentation for the JSON schema).
-#   #   2. Create the ConfigMap:
-#   #      kubectl create configmap redhat-signing-key-bundle \
-#   #        --from-file=bundle.json=<your-bundle-file> -n stackrox
-#   #   3. Uncomment the line below and run helm upgrade.
-#   # To rotate keys, edit the ConfigMap directly — no helm upgrade needed.
+#   # Name of a ConfigMap containing a Red Hat signing key bundle (bundle.json).
+#   # When set, the ConfigMap is mounted into Central at /tmp/redhat-signing-keys/.
+#   # To rotate keys, update the ConfigMap directly — no helm upgrade needed.
 #   signingKeyBundle:
 #     configMapName: "redhat-signing-key-bundle"
 #

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -233,8 +233,8 @@
 #   signingKeyBundle:
 #     configMapName: "redhat-signing-key-bundle"
 #
-#     # Additional volume mounts for the Central container. Only few people will require this.
-#     extraMounts:
+#   # Additional volume mounts for the Central container. Only few people will require this.
+#   extraMounts:
 #     - name: my-configmap  # the name of the volume
 #       # The source of the volume. This will be embedded as-is in the `volume:` section of the
 #       # pod spec.

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -227,7 +227,7 @@
 #         enabled: true
 #
 #
-#   # Name of a ConfigMap containing a Red Hat signing key bundle (bundle.json).
+#   # Name of a ConfigMap containing a Red Hat signing key bundle. The bundle must be stored with the key `bundle.json`.
 #   # When set, the ConfigMap is mounted into Central at /tmp/redhat-signing-keys/.
 #   # To rotate keys, update the ConfigMap directly — no helm upgrade needed.
 #   signingKeyBundle:

--- a/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
+++ b/image/templates/helm/stackrox-central/values-public.yaml.example.htpl
@@ -226,6 +226,20 @@
 #       reencrypt:
 #         enabled: true
 #
+#     # Offline signing key bundle: mount a pre-created ConfigMap containing the
+#     # Red Hat signing key bundle. This allows air-gapped customers to update the
+#     # baked-in signing keys without internet access.
+#     # Steps:
+#     #   1. Copy the bundle format from /tmp/redhat-signing-keys/bundle.example.json
+#     #      inside the Central container (or see documentation for the JSON schema).
+#     #   2. Create the ConfigMap:
+#     #      kubectl create configmap redhat-signing-key-bundle \
+#     #        --from-file=bundle.json=<your-bundle-file> -n stackrox
+#     #   3. Uncomment the line below and run helm upgrade.
+#     # To rotate keys, edit the ConfigMap directly — no helm upgrade needed.
+#     signingKeyBundle:
+#       configMapName: "redhat-signing-key-bundle"
+#
 #     # Additional volume mounts for the Central container. Only few people will require this.
 #     extraMounts:
 #     - name: my-configmap  # the name of the volume

--- a/operator/api/v1alpha1/central_types.go
+++ b/operator/api/v1alpha1/central_types.go
@@ -168,8 +168,15 @@ type CentralComponentSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=7,displayName="Declarative Configuration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	DeclarativeConfiguration *DeclarativeConfiguration `json:"declarativeConfiguration,omitempty"`
 
+	// References a ConfigMap containing the Red Hat signing key bundle. The ConfigMap must
+	// contain a key named `bundle.json`. This allows air-gapped customers to provide or
+	// update the signing keys used for image signature verification. The ConfigMap is
+	// managed externally; key rotation requires only editing the ConfigMap, not a CR update.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Signing Key Bundle",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	SigningKeyBundle *SigningKeyBundleSpec `json:"signingKeyBundle,omitempty"`
+
 	// Configures the encryption of notifier secrets stored in the Central DB.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Notifier Secrets Encryption",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=9,displayName="Notifier Secrets Encryption",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	NotifierSecretsEncryption *NotifierSecretsEncryption `json:"notifierSecretsEncryption,omitempty"`
 
 	// Configures the rollout strategy for the Central deployment.
@@ -227,6 +234,14 @@ type DeclarativeConfiguration struct {
 	// List of secrets containing declarative configuration.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secrets containing declarative configuration"
 	Secrets []LocalSecretReference `json:"secrets,omitempty"`
+}
+
+// SigningKeyBundleSpec references a ConfigMap containing the Red Hat signing key bundle.
+type SigningKeyBundleSpec struct {
+	// Name of a ConfigMap in the same namespace containing a `bundle.json` key
+	// with the Red Hat signing key bundle content.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ConfigMap Name",xDescriptors={"urn:alm:descriptor:io.kubernetes:ConfigMap"}
+	ConfigMapName string `json:"configMapName"`
 }
 
 // NotifierSecretsEncryption defines settings for encrypting notifier secrets in the Central DB.

--- a/operator/api/v1alpha1/central_types.go
+++ b/operator/api/v1alpha1/central_types.go
@@ -170,8 +170,8 @@ type CentralComponentSpec struct {
 
 	// References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
 	// This allows air-gapped customers to provide or update the signing keys used for
-	// image signature verification. The ConfigMap is managed externally; key rotation
-	// requires only editing the ConfigMap, not a CR update.
+	// signature verification of Red Hat container images. The ConfigMap is managed
+	// externally; key rotation requires only editing the ConfigMap, not a CR update.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Signing Key Bundle",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	SigningKeyBundle *LocalConfigMapReference `json:"signingKeyBundle,omitempty"`
 

--- a/operator/api/v1alpha1/central_types.go
+++ b/operator/api/v1alpha1/central_types.go
@@ -168,12 +168,12 @@ type CentralComponentSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=7,displayName="Declarative Configuration",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	DeclarativeConfiguration *DeclarativeConfiguration `json:"declarativeConfiguration,omitempty"`
 
-	// References a ConfigMap containing the Red Hat signing key bundle. The ConfigMap must
-	// contain a key named `bundle.json`. This allows air-gapped customers to provide or
-	// update the signing keys used for image signature verification. The ConfigMap is
-	// managed externally; key rotation requires only editing the ConfigMap, not a CR update.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Signing Key Bundle",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
-	SigningKeyBundle *SigningKeyBundleSpec `json:"signingKeyBundle,omitempty"`
+	// References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
+	// This allows air-gapped customers to provide or update the signing keys used for
+	// image signature verification. The ConfigMap is managed externally; key rotation
+	// requires only editing the ConfigMap, not a CR update.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=8,displayName="Signing Key Bundle",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	SigningKeyBundle *LocalConfigMapReference `json:"signingKeyBundle,omitempty"`
 
 	// Configures the encryption of notifier secrets stored in the Central DB.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=9,displayName="Notifier Secrets Encryption",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
@@ -181,7 +181,7 @@ type CentralComponentSpec struct {
 
 	// Configures the rollout strategy for the Central deployment.
 	// The default is: Recreate.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Rollout Strategy",order=9
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Rollout Strategy",order=10
 	RolloutStrategy *RolloutStrategy `json:"rolloutStrategy,omitempty"`
 
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=99
@@ -234,14 +234,6 @@ type DeclarativeConfiguration struct {
 	// List of secrets containing declarative configuration.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secrets containing declarative configuration"
 	Secrets []LocalSecretReference `json:"secrets,omitempty"`
-}
-
-// SigningKeyBundleSpec references a ConfigMap containing the Red Hat signing key bundle.
-type SigningKeyBundleSpec struct {
-	// Name of a ConfigMap in the same namespace containing a `bundle.json` key
-	// with the Red Hat signing key bundle content.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ConfigMap Name",xDescriptors={"urn:alm:descriptor:io.kubernetes:ConfigMap"}
-	ConfigMapName string `json:"configMapName"`
 }
 
 // NotifierSecretsEncryption defines settings for encrypting notifier secrets in the Central DB.

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -217,6 +217,11 @@ func (in *CentralComponentSpec) DeepCopyInto(out *CentralComponentSpec) {
 		*out = new(DeclarativeConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SigningKeyBundle != nil {
+		in, out := &in.SigningKeyBundle, &out.SigningKeyBundle
+		*out = new(LocalConfigMapReference)
+		**out = **in
+	}
 	if in.NotifierSecretsEncryption != nil {
 		in, out := &in.NotifierSecretsEncryption, &out.NotifierSecretsEncryption
 		*out = new(NotifierSecretsEncryption)

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -605,8 +605,8 @@ spec:
                     description: |-
                       References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
                       This allows air-gapped customers to provide or update the signing keys used for
-                      image signature verification. The ConfigMap is managed externally; key rotation
-                      requires only editing the ConfigMap, not a CR update.
+                      signature verification of Red Hat container images. The ConfigMap is managed
+                      externally; key rotation requires only editing the ConfigMap, not a CR update.
                     properties:
                       name:
                         description: The name of the referenced config map.

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -601,6 +601,19 @@ spec:
                     - Recreate
                     - RollingUpdate
                     type: string
+                  signingKeyBundle:
+                    description: |-
+                      References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
+                      This allows air-gapped customers to provide or update the signing keys used for
+                      image signature verification. The ConfigMap is managed externally; key rotation
+                      requires only editing the ConfigMap, not a CR update.
+                    properties:
+                      name:
+                        description: The name of the referenced config map.
+                        type: string
+                    required:
+                    - name
+                    type: object
                   telemetry:
                     description: |-
                       Configures telemetry settings for Central. If enabled, Central transmits telemetry and diagnostic

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -181,6 +181,15 @@ spec:
             path: central.declarativeConfiguration
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: |-
+              References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
+              This allows air-gapped customers to provide or update the signing keys used for
+              image signature verification. The ConfigMap is managed externally; key rotation
+              requires only editing the ConfigMap, not a CR update.
+            displayName: Signing Key Bundle
+            path: central.signingKeyBundle
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:hidden
           - description: Configures the encryption of notifier secrets stored in the Central DB.
             displayName: Notifier Secrets Encryption
             path: central.notifierSecretsEncryption
@@ -480,6 +489,11 @@ spec:
             path: central.persistence.persistentVolumeClaim.storageClassName
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:hidden
+          - description: The name of the referenced config map.
+            displayName: Name
+            path: central.signingKeyBundle.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
           - description: |-
               Specifies whether Telemetry is enabled.
               The default is: true.

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -184,8 +184,8 @@ spec:
           - description: |-
               References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
               This allows air-gapped customers to provide or update the signing keys used for
-              image signature verification. The ConfigMap is managed externally; key rotation
-              requires only editing the ConfigMap, not a CR update.
+              signature verification of Red Hat container images. The ConfigMap is managed
+              externally; key rotation requires only editing the ConfigMap, not a CR update.
             displayName: Signing Key Bundle
             path: central.signingKeyBundle
             x-descriptors:

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -600,6 +600,19 @@ spec:
                     - Recreate
                     - RollingUpdate
                     type: string
+                  signingKeyBundle:
+                    description: |-
+                      References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
+                      This allows air-gapped customers to provide or update the signing keys used for
+                      image signature verification. The ConfigMap is managed externally; key rotation
+                      requires only editing the ConfigMap, not a CR update.
+                    properties:
+                      name:
+                        description: The name of the referenced config map.
+                        type: string
+                    required:
+                    - name
+                    type: object
                   telemetry:
                     description: |-
                       Configures telemetry settings for Central. If enabled, Central transmits telemetry and diagnostic

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -604,8 +604,8 @@ spec:
                     description: |-
                       References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
                       This allows air-gapped customers to provide or update the signing keys used for
-                      image signature verification. The ConfigMap is managed externally; key rotation
-                      requires only editing the ConfigMap, not a CR update.
+                      signature verification of Red Hat container images. The ConfigMap is managed
+                      externally; key rotation requires only editing the ConfigMap, not a CR update.
                     properties:
                       name:
                         description: The name of the referenced config map.

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -570,10 +570,13 @@ spec:
         path: customize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Configures the encryption of notifier secrets stored in the Central
-          DB.
-        displayName: Notifier Secrets Encryption
-        path: central.notifierSecretsEncryption
+      - description: |-
+          References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
+          This allows air-gapped customers to provide or update the signing keys used for
+          image signature verification. The ConfigMap is managed externally; key rotation
+          requires only editing the ConfigMap, not a CR update.
+        displayName: Signing Key Bundle
+        path: central.signingKeyBundle
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Overlays
@@ -581,16 +584,22 @@ spec:
         path: overlays
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - description: |-
-          Configures the rollout strategy for the Central deployment.
-          The default is: Recreate.
-        displayName: Rollout Strategy
-        path: central.rolloutStrategy
+      - description: Configures the encryption of notifier secrets stored in the Central
+          DB.
+        displayName: Notifier Secrets Encryption
+        path: central.notifierSecretsEncryption
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Monitoring configuration.
         displayName: Monitoring
         path: monitoring
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: |-
+          Configures the rollout strategy for the Central deployment.
+          The default is: Recreate.
+        displayName: Rollout Strategy
+        path: central.rolloutStrategy
       - description: Network configuration.
         displayName: Network
         path: network
@@ -925,6 +934,11 @@ spec:
         path: central.persistence.persistentVolumeClaim.storageClassName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: The name of the referenced config map.
+        displayName: Name
+        path: central.signingKeyBundle.name
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:ConfigMap
       - description: The name of the referenced secret.
         displayName: Name
         path: imagePullSecrets[0].name

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -573,8 +573,8 @@ spec:
       - description: |-
           References a ConfigMap containing the Red Hat signing key bundle (key `bundle.json`).
           This allows air-gapped customers to provide or update the signing keys used for
-          image signature verification. The ConfigMap is managed externally; key rotation
-          requires only editing the ConfigMap, not a CR update.
+          signature verification of Red Hat container images. The ConfigMap is managed
+          externally; key rotation requires only editing the ConfigMap, not a CR update.
         displayName: Signing Key Bundle
         path: central.signingKeyBundle
         x-descriptors:

--- a/operator/internal/central/values/translation/translation.go
+++ b/operator/internal/central/values/translation/translation.go
@@ -271,9 +271,9 @@ func getCentralComponentValues(ctx context.Context, c *platform.CentralComponent
 
 	cv.AddChild("declarativeConfiguration", getDeclarativeConfigurationValues(c.DeclarativeConfiguration))
 
-	if c.SigningKeyBundle != nil && c.SigningKeyBundle.ConfigMapName != "" {
+	if c.SigningKeyBundle != nil && c.SigningKeyBundle.Name != "" {
 		signingKeyBundle := translation.NewValuesBuilder()
-		signingKeyBundle.SetStringValue("configMapName", c.SigningKeyBundle.ConfigMapName)
+		signingKeyBundle.SetStringValue("configMapName", c.SigningKeyBundle.Name)
 		cv.AddChild("signingKeyBundle", &signingKeyBundle)
 	}
 

--- a/operator/internal/central/values/translation/translation.go
+++ b/operator/internal/central/values/translation/translation.go
@@ -271,6 +271,12 @@ func getCentralComponentValues(ctx context.Context, c *platform.CentralComponent
 
 	cv.AddChild("declarativeConfiguration", getDeclarativeConfigurationValues(c.DeclarativeConfiguration))
 
+	if c.SigningKeyBundle != nil && c.SigningKeyBundle.ConfigMapName != "" {
+		signingKeyBundle := translation.NewValuesBuilder()
+		signingKeyBundle.SetStringValue("configMapName", c.SigningKeyBundle.ConfigMapName)
+		cv.AddChild("signingKeyBundle", &signingKeyBundle)
+	}
+
 	if c.GetNotifierSecretsEncryptionEnabled() {
 		notifierSecretsEncryption := translation.NewValuesBuilder()
 		notifierSecretsEncryption.SetBoolValue("enabled", true)

--- a/operator/internal/central/values/translation/translation_test.go
+++ b/operator/internal/central/values/translation/translation_test.go
@@ -243,6 +243,41 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 
+		"signing key bundle with empty name is not emitted": {
+			args: args{
+				c: platform.Central{
+					Spec: platform.CentralSpec{
+						Central: &platform.CentralComponentSpec{
+							SigningKeyBundle: &platform.LocalConfigMapReference{
+								Name: "",
+							},
+						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "stackrox",
+					},
+				},
+				pvcs: []*corev1.PersistentVolumeClaim{defaultPvc},
+			},
+			want: chartutil.Values{
+				"monitoring": map[string]interface{}{
+					"openshift": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"central": map[string]interface{}{
+					"exposeMonitoring": false,
+					"db": map[string]interface{}{
+						"persistence": map[string]interface{}{
+							"persistentVolumeClaim": map[string]interface{}{
+								"createClaim": false,
+							},
+						},
+					},
+				},
+			},
+		},
+
 		"empty spec no pvc": {
 			args: args{
 				c: platform.Central{
@@ -389,8 +424,8 @@ func TestTranslate(t *testing.T) {
 									},
 								},
 							},
-							SigningKeyBundle: &platform.SigningKeyBundleSpec{
-								ConfigMapName: "redhat-signing-key-bundle",
+							SigningKeyBundle: &platform.LocalConfigMapReference{
+								Name: "redhat-signing-key-bundle",
 							},
 							NotifierSecretsEncryption: &platform.NotifierSecretsEncryption{
 								Enabled: pointer.Bool(true),

--- a/operator/internal/central/values/translation/translation_test.go
+++ b/operator/internal/central/values/translation/translation_test.go
@@ -389,6 +389,9 @@ func TestTranslate(t *testing.T) {
 									},
 								},
 							},
+							SigningKeyBundle: &platform.SigningKeyBundleSpec{
+								ConfigMapName: "redhat-signing-key-bundle",
+							},
 							NotifierSecretsEncryption: &platform.NotifierSecretsEncryption{
 								Enabled: pointer.Bool(true),
 							},
@@ -651,6 +654,9 @@ func TestTranslate(t *testing.T) {
 								"secret-2",
 							},
 						},
+					},
+					"signingKeyBundle": map[string]interface{}{
+						"configMapName": "redhat-signing-key-bundle",
 					},
 					"notifierSecretsEncryption": map[string]interface{}{
 						"enabled": true,

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/signing-key-bundle.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/signing-key-bundle.test.yaml
@@ -1,0 +1,31 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+tests:
+- name: "No signing key bundle by default"
+  expect: |
+    [.deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "signing-key-bundle")] | assertThat(length == 0)
+    [.deployments.central.spec.template.spec.volumes[]
+      | select(.name == "signing-key-bundle")] | assertThat(length == 0)
+
+- name: "Setting signingKeyBundle.configMapName adds volume and volumeMount"
+  values:
+    central:
+      signingKeyBundle:
+        configMapName: "redhat-signing-key-bundle"
+  expect: |
+    .deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "signing-key-bundle") | assertThat(. != null)
+    .deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "signing-key-bundle") | assertThat(.readOnly == true)
+    .deployments.central.spec.template.spec.containers[0].volumeMounts[]
+      | select(.name == "signing-key-bundle") | assertThat(.mountPath == "/tmp/redhat-signing-keys")
+    .deployments.central.spec.template.spec.volumes[] | select(.name == "signing-key-bundle")
+     | assertThat(. != null)
+    .deployments.central.spec.template.spec.volumes[] | select(.name == "signing-key-bundle")
+     | assertThat(.configMap != null)
+    .deployments.central.spec.template.spec.volumes[] | select(.name == "signing-key-bundle")
+     | assertThat(.configMap.name == "redhat-signing-key-bundle")
+    .deployments.central.spec.template.spec.volumes[] | select(.name == "signing-key-bundle")
+     | assertThat(.configMap.optional == true)


### PR DESCRIPTION
## Description

Add a dedicated `central.signingKeyBundle.configMapName` Helm value and corresponding operator CRD field so air-gapped customers can mount a pre-created ConfigMap containing the Red Hat signing key bundle.

Follows the existing `declarativeConfiguration.mounts.configMaps` pattern: the chart auto-mounts the referenced ConfigMap at `/tmp/redhat-signing-keys/` with `readOnly: true` and `optional: true`. Key rotation requires only editing the ConfigMap directly — no `helm upgrade` or CR update needed.

Alternative considered: relying solely on `extraMounts`/`overlays` documentation. Rejected because every other user-managed external resource in the chart uses a dedicated field with auto-mount and `optional: true` — using `extraMounts` would be inconsistent and requires the customer to remember to set `optional: true` themselves.

### Interaction with the remote updater ###

Central has two mechanisms involved with key bundle updates: a remote updater that periodically downloads the signing keys bundle (`bundle.json`) from the upstream GCS bucket, and a file watcher that reads `/tmp/redhat-signing-keys/bundle.json` and upserts keys into the DB. In offline deployments, the updater is disabled entirely — the watcher still runs and picks up the ConfigMap-mounted file. In online deployments this ConfigMap should not be mounted (the file is downloaded automatically), but if it is the ConfigMap takes precedence: the mount is `readOnly: true`, so the updater's atomic write fails harmlessly (warning log each cycle, no crash) and the ConfigMap contents are preserved. This is the desired behavior — if a customer explicitly provides a key bundle via ConfigMap, it should not be silently overwritten by a remote download.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

#### Automated tests
- Helm chart tests pass: verified the field produces the correct volume, volumeMount, ConfigMap name, `optional: true`, `readOnly: true`, and mount path `/tmp/redhat-signing-keys`
- Helm chart tests pass: verified no volume/volumeMount is added when the field is unset
- Operator translation test passes: verified the CRD field translates to the correct Helm value
- `go build` passes for operator API and translation packages

#### In-cluster verification — Helm (non-operator) path
1. Built roxctl from this branch and rendered the central-services chart with `--debug`
2. Deployed via `helm upgrade` with `central.signingKeyBundle.configMapName: redhat-signing-key-bundle`
3. Verified: Central deployment has `signing-key-bundle` volume (configMap, `optional: true`) and volumeMount at `/tmp/redhat-signing-keys` (`readOnly: true`)
4. Created a ConfigMap with a test `bundle.json`, confirmed the file is visible inside the Central container at `/tmp/redhat-signing-keys/bundle.json`
5. Updated the ConfigMap (added a second key, modified the first) — confirmed the changes propagated into the running container without a pod restart

#### In-cluster verification — Operator path
1. Built the operator image from this branch with the updated CRD and translation code
2. Deployed the custom operator image to the cluster
3. Patched the Central CR with `spec.central.signingKeyBundle.name: redhat-signing-key-bundle`
4. Verified: operator reconciled and the Central deployment received the `signing-key-bundle` volume and mount, matching the Helm path behavior
5. Confirmed `bundle.json` is accessible inside the Central container
6. Tested key rotation: updated the ConfigMap, confirmed new content propagated without pod restart
7. Tested removal: removed `signingKeyBundle` from the CR, confirmed the volume and mount were cleaned up

#### End-to-end ingestion verification
Confirmed that Central's key bundle watcher reads the mounted `bundle.json` and updates the default "Red Hat" signature integration. Created a ConfigMap with a `bundle.json` containing 2 cosign keys (`release-key-3` + a test key `test-key-from-bundle`). After Central started with the volume mounted, the `/v1/signatureintegrations` API showed both keys in the Red Hat integration:

```
Integration: Red Hat
  Key: release-key-3
  Key: test-key-from-bundle
```

Partially generated by AI.