### PR TITLE
ROX-36379: Add e2e tests for Lightspeed AI integration

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -156,10 +156,10 @@ var (
 	ACMAccessControlDelegation = registerFeature("Enable ACS access control integration with Red Hat Advanced Cluster Management", "ROX_ACM_ACCESS_CONTROL_DELEGATION")
 
 	// AIIntegrations enables AI integrations management
-	AIIntegrations = registerFeature("Enable AI integrations management", "ROX_AI_INTEGRATIONS")
+	AIIntegrations = registerFeature("Enable AI integrations management", "ROX_AI_INTEGRATIONS", enabled)
 
 	// LightspeedRiskSummary enables Lightspeed AI risk summary
-	LightspeedRiskSummary = registerFeature("Enable Lightspeed AI risk summary", "ROX_LIGHTSPEED_RISK_SUMMARY")
+	LightspeedRiskSummary = registerFeature("Enable Lightspeed AI risk summary", "ROX_LIGHTSPEED_RISK_SUMMARY", enabled)
 )
 
 // The following feature flags are related to Scanner V4.

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # shellcheck disable=SC1091
 
 set -euo pipefail
@@ -445,8 +444,6 @@ export_test_environment() {
     ci_export ROX_INIT_CONTAINER_SUPPORT "${ROX_INIT_CONTAINER_SUPPORT:-true}"
     ci_export ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL "${ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL:-true}"
     ci_export ROX_UI_SECRETS_PAGE_MIGRATION "${ROX_UI_SECRETS_PAGE_MIGRATION:-true}"
-    ci_export ROX_AI_INTEGRATIONS "${ROX_AI_INTEGRATIONS:-true}"
-    ci_export ROX_LIGHTSPEED_RISK_SUMMARY "${ROX_LIGHTSPEED_RISK_SUMMARY:-true}"
     ci_export SCANNER_V4_VULN_READINESS "${SCANNER_V4_VULN_READINESS:-true}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
@@ -627,10 +624,6 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "'"${ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL:-true}"'"'
     customize_envVars+=$'\n      - name: ROX_UI_SECRETS_PAGE_MIGRATION'
     customize_envVars+=$'\n        value: "'"${ROX_UI_SECRETS_PAGE_MIGRATION}"'"'
-    customize_envVars+=$'\n      - name: ROX_AI_INTEGRATIONS'
-    customize_envVars+=$'\n        value: "'"${ROX_AI_INTEGRATIONS}"'"'
-    customize_envVars+=$'\n      - name: ROX_LIGHTSPEED_RISK_SUMMARY'
-    customize_envVars+=$'\n        value: "'"${ROX_LIGHTSPEED_RISK_SUMMARY}"'"'
     if [[ "${ROX_VIRTUAL_MACHINES:-}" == "true" ]]; then
         customize_envVars+=$'\n      - name: ROX_VIRTUAL_MACHINES'
         customize_envVars+=$'\n        value: "true"'

--- a/ui/apps/platform/cypress/integration/integrations/aiIntegrations.test.ts
+++ b/ui/apps/platform/cypress/integration/integrations/aiIntegrations.test.ts
@@ -1,0 +1,122 @@
+import withAuth from '../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../helpers/features';
+import {
+    aiIntegrationTestNamePrefix,
+    cleanupAiIntegrations,
+    clickCreateNewIntegrationInTable,
+    clickIntegrationSourceLinkInForm,
+    deleteIntegrationInTable,
+    saveCreatedIntegrationInForm,
+    testIntegrationInFormWithoutStoredCredentials,
+    visitIntegrationsTable,
+} from './integrations.helpers';
+import { selectors } from './integrations.selectors';
+import {
+    generateNameWithDate,
+    getHelperElementByLabel,
+    getInputByLabel,
+} from '../../helpers/formHelpers';
+
+const integrationSource = 'aiIntegrations';
+const integrationType = 'lightspeed';
+
+describe('AI Integrations - OpenShift Lightspeed', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_AI_INTEGRATIONS')) {
+            this.skip();
+        }
+    });
+
+    beforeEach(() => {
+        cleanupAiIntegrations();
+    });
+
+    afterEach(() => {
+        cleanupAiIntegrations();
+    });
+
+    it('should create a new Lightspeed integration, test it, save, view, and delete', () => {
+        const integrationName = generateNameWithDate(aiIntegrationTestNamePrefix);
+
+        visitIntegrationsTable(integrationSource, integrationType);
+        clickCreateNewIntegrationInTable(integrationSource, integrationType);
+
+        cy.get(selectors.buttons.save).should('be.disabled');
+
+        getInputByLabel('Integration name').type(' ').blur();
+        getHelperElementByLabel('Integration name').contains('Integration name is required');
+        cy.get(selectors.buttons.save).should('be.disabled');
+
+        getInputByLabel('Integration name').clear().type(integrationName);
+        getInputByLabel('Service URL').clear().type('https://lightspeed.example.com');
+
+        cy.get(selectors.buttons.test).should('be.enabled');
+
+        testIntegrationInFormWithoutStoredCredentials(integrationSource, integrationType);
+
+        cy.get('.pf-v6-c-alert.pf-m-success').should('be.visible');
+        cy.get('.pf-v6-c-alert.pf-m-success').contains('The test was successful');
+
+        cy.get(selectors.buttons.save).should('be.enabled');
+
+        saveCreatedIntegrationInForm(integrationSource, integrationType);
+
+        cy.get(`${selectors.tableRowNameLink}:contains("${integrationName}")`).click();
+        cy.get(`${selectors.breadcrumbItem}:contains("${integrationName}")`);
+
+        clickIntegrationSourceLinkInForm(integrationSource, integrationType);
+
+        deleteIntegrationInTable(integrationSource, integrationType, integrationName);
+
+        cy.get(`${selectors.tableRowNameLink}:contains("${integrationName}")`).should('not.exist');
+    });
+
+    it('should show validation error when trying to save without required fields', () => {
+        visitIntegrationsTable(integrationSource, integrationType);
+        clickCreateNewIntegrationInTable(integrationSource, integrationType);
+
+        getInputByLabel('Integration name').focus().blur();
+
+        cy.get(selectors.buttons.save).should('be.disabled');
+
+        getInputByLabel('Service URL').type('https://lightspeed.example.com');
+
+        cy.get(selectors.buttons.save).should('be.disabled');
+
+        cy.get(selectors.buttons.cancel).click();
+    });
+
+    it('should reject creating a second integration when one already exists (singleton enforcement)', () => {
+        const firstIntegrationName = generateNameWithDate(`${aiIntegrationTestNamePrefix} First`);
+        const secondIntegrationName = generateNameWithDate(`${aiIntegrationTestNamePrefix} Second`);
+
+        visitIntegrationsTable(integrationSource, integrationType);
+        clickCreateNewIntegrationInTable(integrationSource, integrationType);
+
+        getInputByLabel('Integration name').clear().type(firstIntegrationName);
+        getInputByLabel('Service URL').clear().type('https://lightspeed-1.example.com');
+
+        saveCreatedIntegrationInForm(integrationSource, integrationType);
+
+        cy.get(`${selectors.tableRowNameLink}:contains("${firstIntegrationName}")`).should('exist');
+
+        clickCreateNewIntegrationInTable(integrationSource, integrationType);
+
+        getInputByLabel('Integration name').clear().type(secondIntegrationName);
+        getInputByLabel('Service URL').clear().type('https://lightspeed-2.example.com');
+
+        cy.get(selectors.buttons.save).click();
+
+        cy.get('.pf-v6-c-alert.pf-m-danger').should('be.visible');
+        cy.get('.pf-v6-c-alert.pf-m-danger').contains('only one AI integration is allowed');
+
+        cy.get(selectors.buttons.cancel).click();
+
+        deleteIntegrationInTable(integrationSource, integrationType, firstIntegrationName);
+        cy.get(`${selectors.tableRowNameLink}:contains("${firstIntegrationName}")`).should(
+            'not.exist'
+        );
+    });
+});

--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -71,6 +71,8 @@ function getIntegrationsEndpointAddress(integrationSource, integrationType) {
             return '/v1/signatureintegrations'; // lowercase in endpoint address
         case 'cloudSources':
             return '/v1/cloud-sources';
+        case 'aiIntegrations':
+            return '/v2/ai-integrations';
         default:
             return '';
     }
@@ -97,6 +99,8 @@ export function getIntegrationsEndpointAlias(integrationSource, integrationType)
             return 'signatureintegrations'; // lowercase in endpoint alias
         case 'cloudSources':
             return '/v1/cloud-sources';
+        case 'aiIntegrations':
+            return '/v2/ai-integrations';
         default:
             return '';
     }
@@ -155,6 +159,12 @@ const routeMatcherMapForIntegrationsTab = {
             url: getIntegrationsEndpointAddressForGET('cloudSources'),
         },
     },
+    aiIntegrations: {
+        [getIntegrationsEndpointAlias('aiIntegrations')]: {
+            method: 'GET',
+            url: getIntegrationsEndpointAddressForGET('aiIntegrations'),
+        },
+    },
     authProviders: {
         [getIntegrationsEndpointAlias('authProviders', 'apitoken')]: {
             method: 'GET',
@@ -172,6 +182,7 @@ const routeMatcherMapForIntegrationsTab = {
 const integrationsTitle = 'Integrations';
 
 const integrationSourceTitleMap = {
+    aiIntegrations: 'AI',
     authProviders: 'Authentication',
     backups: 'Backup',
     cloudSources: 'Cloud source',
@@ -224,6 +235,9 @@ const integrationTitleMap = {
     cloudSources: {
         paladinCloud: 'Paladin Cloud',
         ocm: 'OpenShift Cluster Manager',
+    },
+    aiIntegrations: {
+        lightspeed: 'OpenShift Lightspeed',
     },
 };
 
@@ -394,6 +408,27 @@ export function deleteIntegrationInTable(integrationSource, integrationType, int
         cy.get(`${pf6.dropdownItem}:contains("Delete integration")`).click();
         cy.get('.pf-v6-c-modal-box__footer button:contains("Delete")').click(); // confirmation modal
     }, routeMatcherMap);
+}
+
+export const aiIntegrationTestNamePrefix = 'Cypress AI Integration';
+
+export function cleanupAiIntegrations(namePrefix = aiIntegrationTestNamePrefix) {
+    const endpointAddress = getIntegrationsEndpointAddress('aiIntegrations');
+
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
+
+        cy.request({ url: endpointAddress, auth }).as('listAiIntegrations');
+
+        cy.get('@listAiIntegrations').then((res) => {
+            const integrations = res.body.integrations ?? [];
+            integrations
+                .filter(({ name }) => name?.startsWith(namePrefix))
+                .forEach(({ id }) => {
+                    cy.request({ url: `${endpointAddress}/${id}`, auth, method: 'DELETE' });
+                });
+        });
+    });
 }
 
 export function revokeAuthProvidersIntegrationInTable(integrationType, integrationName) {

--- a/ui/apps/platform/cypress/integration/integrations/integrations.selectors.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.selectors.js
@@ -6,5 +6,6 @@ export const selectors = {
         save: 'button:contains("Save")',
         generate: 'button:contains("Generate")',
         back: 'button:contains("Back")',
+        cancel: 'button:contains("Cancel")',
     },
 };


### PR DESCRIPTION
## Description

Adds Cypress e2e tests for the OpenShift Lightspeed AI integration.

Enables relevant feature flags.

Note! These tests are expected to fail until https://github.com/stackrox/stackrox/pull/22463 is merged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Local test run
<img width="1660" height="856" alt="image" src="https://github.com/user-attachments/assets/36ad6403-3fcc-4ab5-8bb1-80a0ca507f45" />