### PR TITLE
ROX-36469: Fix pubsub concurrent lane goroutine leak

### DIFF
--- a/pkg/testutils/goleak/assert_no_leak.go
+++ b/pkg/testutils/goleak/assert_no_leak.go
@@ -6,15 +6,39 @@ import (
 	"go.uber.org/goleak"
 )
 
+// Option re-exports goleak.Option so callers don't need to import
+// go.uber.org/goleak directly (disallowed by roxvet, see validateimports).
+type Option = goleak.Option
+
+// IgnoreCurrent re-exports goleak.IgnoreCurrent, for tests that need to check
+// for leaks before test cleanup runs rather than via AssertNoGoroutineLeaks.
+func IgnoreCurrent() Option {
+	return goleak.IgnoreCurrent()
+}
+
+// Find re-exports goleak.Find, for tests that need to check for leaks before
+// test cleanup runs rather than via AssertNoGoroutineLeaks.
+func Find(options ...Option) error {
+	return goleak.Find(options...)
+}
+
+// CommonIgnores returns the goleak options for known, unrelated background
+// goroutines. Shared so that tests calling IgnoreCurrent/Find directly stay in
+// sync with AssertNoGoroutineLeaks instead of maintaining their own copy of
+// this list.
+func CommonIgnores() []Option {
+	return []goleak.Option{
+		// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
+		goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
+		// Ignore a known leak caused by importing the GCP cscc SDK.
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		// Ignore a known leak from https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L77-L80
+		goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),
+	}
+}
+
 func AssertNoGoroutineLeaks(t testing.TB) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t,
-			// Ignore a known leak: https://github.com/DataDog/dd-trace-go/issues/1469
-			goleak.IgnoreTopFunction("github.com/golang/glog.(*fileSink).flushDaemon"),
-			// Ignore a known leak caused by importing the GCP cscc SDK.
-			goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
-			// Ignore a known leak from https://github.com/hashicorp/golang-lru/blob/v2.0.7/expirable/expirable_lru.go#L77-L80
-			goleak.IgnoreTopFunction("github.com/hashicorp/golang-lru/v2/expirable.NewLRU[...].func1"),
-		)
+		goleak.VerifyNone(t, CommonIgnores()...)
 	})
 }

--- a/sensor/common/pubsub/consumer/buffered.go
+++ b/sensor/common/pubsub/consumer/buffered.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/safe"
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	pubsubErrors "github.com/stackrox/rox/sensor/common/pubsub/errors"
@@ -13,6 +14,8 @@ import (
 
 const (
 	defaultBufferSize = 1000
+
+	bufferedConsumerLoggingRateLimiter = "pubsub-buffered-consumer"
 )
 
 // bufferedEvent wraps an event with its error channel to pipe callback errors back to the caller
@@ -155,6 +158,7 @@ func (c *BufferedConsumer) handleEvent(wrappedEv *bufferedEvent) {
 		// Callback completed - send error if present, otherwise just close errC
 		if err != nil {
 			operation = metrics.ConsumerError
+			logging.GetRateLimitedLogger().ErrorL(bufferedConsumerLoggingRateLimiter, "unable to handle event on lane %s, topic %s: %v", c.laneID, c.topic, err)
 			wrappedEv.errC <- err
 		}
 		// On success (err == nil), defer close handles it without sending

--- a/sensor/common/pubsub/consumer/buffered_test.go
+++ b/sensor/common/pubsub/consumer/buffered_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/safe"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/testutils/goleak"
@@ -57,6 +58,12 @@ func TestBufferedConsumer_ConsumeSuccess(t *testing.T) {
 
 func TestBufferedConsumer_CallbackError(t *testing.T) {
 	defer goleak.AssertNoGoroutineLeaks(t)
+
+	// Initialize the rate-limited logger before entering the synctest bubble.
+	// It uses a hashicorp LRU that spawns a background timer goroutine;
+	// if created inside the bubble, synctest panics on exit because the
+	// goroutine remains blocked.
+	logging.GetRateLimitedLogger()
 
 	synctest.Test(t, func(t *testing.T) {
 		expectedErr := errors.New("callback error")

--- a/sensor/common/pubsub/consumer/default.go
+++ b/sensor/common/pubsub/consumer/default.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	pubsubErrors "github.com/stackrox/rox/sensor/common/pubsub/errors"
 	"github.com/stackrox/rox/sensor/common/pubsub/metrics"
 )
+
+const defaultConsumerLoggingRateLimiter = "pubsub-default-consumer"
 
 func NewDefaultConsumer() pubsub.NewConsumer {
 	return func(laneID pubsub.LaneID, topic pubsub.Topic, consumerID pubsub.ConsumerID, callback pubsub.EventCallback) (pubsub.Consumer, error) {
@@ -32,7 +35,10 @@ type DefaultConsumer struct {
 }
 
 func (c *DefaultConsumer) Consume(waitable concurrency.Waitable, event pubsub.Event) <-chan error {
-	errC := make(chan error)
+	// Buffered so the send below never blocks on a reader: callers (e.g. concurrentLane)
+	// are not required to drain this channel, and must not need to in order for this
+	// goroutine to exit.
+	errC := make(chan error, 1)
 	go func() {
 		defer close(errC)
 		start := time.Now()
@@ -43,6 +49,7 @@ func (c *DefaultConsumer) Consume(waitable concurrency.Waitable, event pubsub.Ev
 			err := c.callback(event)
 			if err != nil {
 				operation = metrics.ConsumerError
+				logging.GetRateLimitedLogger().ErrorL(defaultConsumerLoggingRateLimiter, "unable to handle event on lane %s, topic %s: %v", c.laneID, c.topic, err)
 			}
 			return err
 		}():

--- a/sensor/common/pubsub/consumer/default_test.go
+++ b/sensor/common/pubsub/consumer/default_test.go
@@ -27,22 +27,26 @@ func (s *defaultConsumerSuite) TestConsume() {
 		s.Assert().Error(err)
 		s.Assert().Nil(c)
 	})
-	s.Run("should unblock if waitable is done", func() {
+	s.Run("should not leak even if nobody ever reads errC", func() {
+		// concurrentLane fires Consume() and discards the returned channel without
+		// reading it, relying on the consumer to report its own errors. The internal
+		// goroutine must still exit on its own (errC is buffered so the send never
+		// blocks on a reader) rather than depend on the waitable firing.
 		callbackDone := concurrency.NewSignal()
 		c, err := NewDefaultConsumer()(pubsub.DefaultLane, pubsub.DefaultTopic, pubsub.DefaultConsumer, func(_ pubsub.Event) error {
 			defer callbackDone.Signal()
 			return errors.New("some error")
 		})
 		s.Assert().NoError(err)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx := context.Background()
 		_ = c.Consume(ctx, &testEvent{})
 		select {
 		case <-callbackDone.Done():
 		case <-time.After(500 * time.Millisecond):
 			s.FailNow("callback should be done")
 		}
-		cancel()
-		// The test will fail if there are goroutine leaks
+		// errC is intentionally never read here.
+		// The test will fail if there are goroutine leaks.
 	})
 	s.Run("consume event error", func() {
 		data := "some data"

--- a/sensor/common/pubsub/interfaces.go
+++ b/sensor/common/pubsub/interfaces.go
@@ -28,6 +28,13 @@ type Lane interface {
 type NewConsumer func(laneID LaneID, topic Topic, consumerID ConsumerID, callback EventCallback) (Consumer, error)
 
 type Consumer interface {
+	// Consume processes event and reports the outcome on the returned channel.
+	// Implementations must not rely on that channel being read: concurrentLane
+	// dispatches Consume() without waiting on or draining the result, so a
+	// consumer that only reports errors through this channel will have them
+	// silently dropped there. Implementations should report their own errors
+	// (e.g. logging/metrics) rather than depending solely on the caller reading
+	// this channel.
 	Consume(concurrency.Waitable, Event) <-chan error
 	Stop()
 }

--- a/sensor/common/pubsub/lane/concurrent.go
+++ b/sensor/common/pubsub/lane/concurrent.go
@@ -120,22 +120,11 @@ func (l *concurrentLane) handleEvent(event pubsub.Event) {
 		return
 	}
 	for _, c := range consumers {
-		errC := c.Consume(l.stopper.Client().Stopped(), event)
-		// Spawning go routine here to not block other consumers
-		go l.handleConsumerError(errC)
-	}
-}
-
-func (l *concurrentLane) handleConsumerError(errC <-chan error) {
-	// This blocks until the consumer finishes the processing
-	// TODO: Consider adding a timeout here
-	select {
-	case err := <-errC:
-		if err != nil {
-			// TODO: consider adding a callback to inform of the error
-			rateLimitedLog.ErrorL(l.id.String(), "unable to handle event: %v", err)
-		}
-	case <-l.stopper.Flow().StopRequested():
+		// Consume() is expected to return promptly; consumers are responsible for
+		// reporting their own errors (metrics/logs), so the result is not awaited here.
+		// Waiting on it would require a per-event goroutine that outlives this call
+		// whenever the consumer stalls, with no way to bound how many accumulate.
+		c.Consume(l.stopper.Client().Stopped(), event)
 	}
 }
 

--- a/sensor/common/pubsub/lane/concurrent_test.go
+++ b/sensor/common/pubsub/lane/concurrent_test.go
@@ -316,6 +316,20 @@ func TestErrorHandling(t *testing.T) {
 	})
 }
 
+func TestHandleEvent_StalledConsumerDoesNotLeakGoroutines(t *testing.T) {
+	defer goleak.AssertNoGoroutineLeaks(t)
+	lane := NewConcurrentLane(pubsub.DefaultLane, WithConcurrentLaneConsumer(newStalledConsumer)).NewLane()
+	assert.NotNil(t, lane)
+	for range 50 {
+		require.NoError(t, lane.Publish(&concurrentTestEvent{}))
+	}
+	// Give handleEvent a chance to run for every published event before stopping.
+	// If it spawned a goroutine per event to watch stalledConsumer's never-resolving
+	// errC, goleak would catch the leak below regardless of this sleep's length.
+	time.Sleep(50 * time.Millisecond)
+	lane.Stop()
+}
+
 func TestStop(t *testing.T) {
 	defer goleak.AssertNoGoroutineLeaks(t)
 	t.Run("stop should clean up resources", func(t *testing.T) {
@@ -382,3 +396,18 @@ func (m *mockConsumer) Stop() {
 		m.stopFn()
 	}
 }
+
+// newStalledConsumer builds a consumer whose Consume() returns a channel that is
+// never written to and never closed, simulating a consumer whose processing never
+// resolves.
+func newStalledConsumer(_ pubsub.LaneID, _ pubsub.Topic, _ pubsub.ConsumerID, _ pubsub.EventCallback) (pubsub.Consumer, error) {
+	return &stalledConsumer{}, nil
+}
+
+type stalledConsumer struct{}
+
+func (c *stalledConsumer) Consume(_ concurrency.Waitable, _ pubsub.Event) <-chan error {
+	return make(chan error)
+}
+
+func (c *stalledConsumer) Stop() {}

--- a/sensor/common/pubsub/lane/concurrent_test.go
+++ b/sensor/common/pubsub/lane/concurrent_test.go
@@ -3,7 +3,6 @@ package lane
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"testing"
 	"time"
 
@@ -323,14 +322,17 @@ func TestHandleEvent_StalledConsumerDoesNotLeakGoroutines(t *testing.T) {
 	const numEvents = 50
 	consumeCalled := make(chan struct{}, numEvents)
 	lane := NewConcurrentLane(pubsub.DefaultLane, WithConcurrentLaneConsumer(newStalledConsumer(consumeCalled))).NewLane()
-	assert.NotNil(t, lane)
+	require.NotNil(t, lane)
 	defer lane.Stop()
 
 	require.NoError(t, lane.RegisterConsumer(pubsub.DefaultConsumer, pubsub.DefaultTopic, func(_ pubsub.Event) error {
 		return nil
 	}))
 
-	before := runtime.NumGoroutine()
+	// Snapshot after the lane's own goroutines exist (run loop). Find must run
+	// before Stop(): the old watcher also selected on the stop signal, so
+	// checking only after Stop() would hide a reintroduced leak.
+	ignoreExisting := goleak.IgnoreCurrent()
 
 	for range numEvents {
 		require.NoError(t, lane.Publish(&concurrentTestEvent{}))
@@ -348,14 +350,10 @@ func TestHandleEvent_StalledConsumerDoesNotLeakGoroutines(t *testing.T) {
 	}
 
 	// This must be checked while the lane is still running, i.e. before Stop().
-	// stalledConsumer's errC is never resolved, and Stop() also releases any
-	// per-event watcher goroutine (they select on the same stop signal), which
-	// would hide a reintroduced leak if checked only after Stop() returns. The
-	// threshold is generous (half of numEvents) to absorb unrelated goroutine
-	// noise while still failing hard against a real one-per-event leak.
-	after := runtime.NumGoroutine()
-	assert.Less(t, after, before+numEvents/2,
-		"concurrentLane must not spawn a goroutine per event for a stalled consumer (before=%d after=%d)", before, after)
+	// stalledConsumer's errC is never resolved, so any per-event watcher
+	// goroutine would still be alive here.
+	require.NoError(t, goleak.Find(append([]goleak.Option{ignoreExisting}, goleak.CommonIgnores()...)...),
+		"concurrentLane must not spawn a goroutine per stalled consumer event")
 }
 
 func TestStop(t *testing.T) {

--- a/sensor/common/pubsub/lane/concurrent_test.go
+++ b/sensor/common/pubsub/lane/concurrent_test.go
@@ -3,6 +3,7 @@ package lane
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -318,16 +319,43 @@ func TestErrorHandling(t *testing.T) {
 
 func TestHandleEvent_StalledConsumerDoesNotLeakGoroutines(t *testing.T) {
 	defer goleak.AssertNoGoroutineLeaks(t)
-	lane := NewConcurrentLane(pubsub.DefaultLane, WithConcurrentLaneConsumer(newStalledConsumer)).NewLane()
+
+	const numEvents = 50
+	consumeCalled := make(chan struct{}, numEvents)
+	lane := NewConcurrentLane(pubsub.DefaultLane, WithConcurrentLaneConsumer(newStalledConsumer(consumeCalled))).NewLane()
 	assert.NotNil(t, lane)
-	for range 50 {
+	defer lane.Stop()
+
+	require.NoError(t, lane.RegisterConsumer(pubsub.DefaultConsumer, pubsub.DefaultTopic, func(_ pubsub.Event) error {
+		return nil
+	}))
+
+	before := runtime.NumGoroutine()
+
+	for range numEvents {
 		require.NoError(t, lane.Publish(&concurrentTestEvent{}))
 	}
-	// Give handleEvent a chance to run for every published event before stopping.
-	// If it spawned a goroutine per event to watch stalledConsumer's never-resolving
-	// errC, goleak would catch the leak below regardless of this sleep's length.
-	time.Sleep(50 * time.Millisecond)
-	lane.Stop()
+
+	// Wait until the lane has actually dispatched Consume() for every published
+	// event before checking for leaks - otherwise the check could race ahead of
+	// dispatch and pass trivially regardless of what handleEvent does.
+	for i := range numEvents {
+		select {
+		case <-consumeCalled:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for stalledConsumer.Consume to be called for event %d/%d", i+1, numEvents)
+		}
+	}
+
+	// This must be checked while the lane is still running, i.e. before Stop().
+	// stalledConsumer's errC is never resolved, and Stop() also releases any
+	// per-event watcher goroutine (they select on the same stop signal), which
+	// would hide a reintroduced leak if checked only after Stop() returns. The
+	// threshold is generous (half of numEvents) to absorb unrelated goroutine
+	// noise while still failing hard against a real one-per-event leak.
+	after := runtime.NumGoroutine()
+	assert.Less(t, after, before+numEvents/2,
+		"concurrentLane must not spawn a goroutine per event for a stalled consumer (before=%d after=%d)", before, after)
 }
 
 func TestStop(t *testing.T) {
@@ -397,16 +425,22 @@ func (m *mockConsumer) Stop() {
 	}
 }
 
-// newStalledConsumer builds a consumer whose Consume() returns a channel that is
-// never written to and never closed, simulating a consumer whose processing never
-// resolves.
-func newStalledConsumer(_ pubsub.LaneID, _ pubsub.Topic, _ pubsub.ConsumerID, _ pubsub.EventCallback) (pubsub.Consumer, error) {
-	return &stalledConsumer{}, nil
+// newStalledConsumer builds a pubsub.NewConsumer factory whose Consume() returns
+// a channel that is never written to and never closed, simulating a consumer
+// whose processing never resolves. Every Consume() call is reported on
+// consumeCalled, so callers can deterministically wait for dispatch.
+func newStalledConsumer(consumeCalled chan<- struct{}) pubsub.NewConsumer {
+	return func(_ pubsub.LaneID, _ pubsub.Topic, _ pubsub.ConsumerID, _ pubsub.EventCallback) (pubsub.Consumer, error) {
+		return &stalledConsumer{consumeCalled: consumeCalled}, nil
+	}
 }
 
-type stalledConsumer struct{}
+type stalledConsumer struct {
+	consumeCalled chan<- struct{}
+}
 
 func (c *stalledConsumer) Consume(_ concurrency.Waitable, _ pubsub.Event) <-chan error {
+	c.consumeCalled <- struct{}{}
 	return make(chan error)
 }
 


### PR DESCRIPTION
## Description

  Sensor's PubSub `concurrentLane` spawned a new goroutine per event, per consumer, solely to wait on and log an eventual error, with no bound or timeout on how many could pile up. Under sustained load, when a downstream consumer (e.g. the detector's file-access consumer) stalled, thousands of these goroutines accumulated faster than they could ever resolve, crashing Sensor with a Go runtime deadlock. This removes that goroutine spawn entirely — consumers now report their own errors directly — so a stalled consumer can no longer cause unbounded goroutine growth.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above
  **OR** is not needed

  ## Testing and quality
  
  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality
  is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing
  
  - [x] added unit tests
  - [ ] added e2e tests
  - [x] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - Added a `goleak`-backed regression test asserting `concurrentLane` spawns no goroutines even when a consumer never resolves.
  - Could not reproduce the original crash locally (requires sustained real file-activity load against a live cluster); correctness rests on the goleak-backed tests plus the structural fact that the goroutine-spawn site no longer exists.
  - I have a long running cluster running that has run longer than the cluster where this problem was found and has not crashed