### PR TITLE
fix(ci): drop obsolete OpenShift Sensor CPU patch

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -653,14 +653,6 @@ deploy_sensor() {
         ROX_CA_CERT_FILE="" # force sensor.sh to fetch the actual cert.
         CENTRAL_NAMESPACE="${central_namespace}" SENSOR_NAMESPACE="${sensor_namespace}" "${ROOT}/${DEPLOY_DIR}/sensor.sh"
     fi
-
-    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then
-        # Sensor is CPU starved under OpenShift causing all manner of test failures:
-        # https://stack-rox.atlassian.net/browse/ROX-5334
-        # https://stack-rox.atlassian.net/browse/ROX-6891
-        # et al.
-        retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
-    fi
 }
 
 # shellcheck disable=SC2120


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This patching of resources for Sensor on CI (that this PR removes) was done in https://github.com/stackrox/stackrox/pull/1715, when the default CPU resources for Sensor were still `requests: 1` and `limits: 2`. Back then there were also no Operator deployments.

Afterwards the Sensor resources were raised to `requests: 2` and `limits: 4` and this line became a no-op for most cases. One month ago, after [this PR](https://github.com/stackrox/stackrox/pull/21503), it started to not be a no-op anymore, because now Sensor is patched to request `cpu: "300m"` (see https://github.com/stackrox/stackrox/blob/62725aedcc78df5e644f871843deb0ec8a3d0e57/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml#L17)

Then Operator deployments were introduced, where this patch basically triggers two Sensor pods restarts (once after applying the patch, another after the Operator reverts the change). These restarts are Mostly Harmless, but for example they also cause this flake: https://redhat.atlassian.net/browse/ROX-35897.

I believe that since now the limits for Sensor are 4G anyway, there should be no issues with removing this patch (this applies for the OpenShift + Helm case, used only in the `scanner-v4-install` tests afaik)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

TBD - waiting for CI
