### PR TITLE
perf: add missing pullNumber field to Orion cluster-density config

### DIFF
--- a/tests/performance/scale/config/orion-acs-cluster-density-v2.yml
+++ b/tests/performance/scale/config/orion-acs-cluster-density-v2.yml
@@ -13,6 +13,7 @@ tests :
       ocpVersion: {{ version }}
       networkType: OVNKubernetes
       jobType: {{ jobtype | default('periodic') }}
+      pullNumber: "{{ pull_number | default(0) }}"
       not:
         stream: okd
 


### PR DESCRIPTION
## What and why

This adds one line to the Orion configuration for the ACS cluster-density-v2 performance test:

```yaml
pullNumber: "{{ pull_number | default(0) }}"
```

### The field was apparently missed when the config was first created

The config file was introduced in https://github.com/stackrox/stackrox/pull/16962. The standard Orion example configs used by other teams include this field — see for example the [QE cluster-density example](https://github.com/cloud-bulldozer/orion/blob/main/examples/cluster-density.yaml#L17-L18) which has had it from the start.

### The CI shell script already supports it

The `openshift-qe-orion-commands.sh` script (shared across all teams) already exports `pull_number` specifically for this purpose — see [the relevant code](https://github.com/openshift/release/blob/main/ci-operator/step-registry/openshift-qe/orion/openshift-qe-orion-commands.sh). When a PR rehearsal runs, `pull_number` is set to the PR number; for periodic runs it is `0`. The Jinja2 template then renders it into the Orion metadata filter.

### Without it, other PRs' rehearsal data pollutes the comparison history

Orion's change-point detection compares the current run against all historical runs matching the metadata filter. With `pullNumber` missing, the filter only uses `jobType` — so **every rehearsal from every PR ever run** against this job accumulates in the comparison pool. A PR that introduces a genuine performance regression can rehearse N times, each run building up a "new normal" in the pool, until Orion stops flagging it. The regression only surfaces after the PR merges and the first nightly periodic run compares against the clean pre-merge baseline.

This is exactly what happened with [openshift/release#81322](https://github.com/openshift/release/pull/81322) (replacing the Helm installer with Roxie). Rehearsals passed, the PR merged, the nightly caught a 52% sensor-CPU regression, and the PR had to be [reverted](https://github.com/openshift/release/pull/83319).

With `pullNumber` present, Orion restricts the rehearsal comparison pool to:
- periodic runs (`pullNumber=0`) — the clean baseline
- runs from the current PR only (`pullNumber=<pr>`) — the in-progress change

Previous rehearsal iterations of other PRs are excluded, so a regression introduced by the current change will be detected on the first rehearsal rather than being masked.

### One caveat

Even with this fix, after many rehearsal iterations of a single PR the pool will contain multiple data points from that PR, each potentially reflecting different states of the code. A fresh PR (or a re-base) is needed to get a truly clean single-run comparison against the periodic baseline. It's not clear to me how to avoid this without a lot of complexity (such as retrieving every relevant UUID in first "dry-run" pass, and then performing an exclusively UUID-based second pass).

## Testing

https://github.com/openshift/release/pull/83735 created to point at this config, and [a rehearsal](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/83735/rehearse-83735-periodic-ci-stackrox-stackrox-nightlies-perf-scale-24nodes-scale-scannerv4-test/2090412919270412288) was triggered. Last column of the [orion CSV output](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/83735/rehearse-83735-periodic-ci-stackrox-stackrox-nightlies-perf-scale-24nodes-scale-scannerv4-test/2090412919270412288/artifacts/24nodes-scale-scannerv4-test/openshift-qe-orion-cluster-density/artifacts/data-24-node-scale-cdv2.csv) shows that the only rehearsal is that very run. Previously it would have contained ~15 entries from various PRs' rehearsal histories.