### PR TITLE
ROX-36297, ROX-36298: drop Splunk TCP readiness probe in e2e

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/SplunkUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/SplunkUtil.groovy
@@ -191,6 +191,8 @@ class SplunkUtil {
         Service syslogSvc
         LocalPortForward splunkPortForward
         try {
+            // No TCP readiness probe: Splunk binds 8089 after the container is
+            // running, and waitForSplunkBoot already waits on the health API.
             deployment =
                     new Deployment()
                             .setNamespace(namespace)
@@ -204,7 +206,6 @@ class SplunkUtil {
                             .addLabel("app", deploymentName)
                             .addRequest("cpu", "500m")
                             .addLimits("memory", "3Gi")
-                            .setReadinessProbeTcpPort(8089)
             orchestrator.createDeployment(deployment)
 
             collectorSvc = new Service("splunk-collector-" + uid, namespace)

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -185,12 +185,16 @@ class IntegrationsTest extends BaseSpecification {
     def "Verify Splunk Integration"() {
         given:
         "the integration is tested"
-        SplunkUtil.SplunkDeployment parts = SplunkUtil.createSplunk(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
+        SplunkUtil.SplunkDeployment parts = null
+        SplunkNotifier notifier = null
+        String policyId = null
+        Deployment nginxdeployment = null
+        parts = SplunkUtil.createSplunk(orchestrator, Constants.ORCHESTRATOR_NAMESPACE)
         SplunkUtil.waitForSplunkBoot(parts.splunkPortForward.localPort)
 
         when:
         "call the grpc API for the splunk integration."
-        SplunkNotifier notifier = new SplunkNotifier(parts.collectorSvc.name, parts.splunkPortForward.localPort)
+        notifier = new SplunkNotifier(parts.collectorSvc.name, parts.splunkPortForward.localPort)
         notifier.createNotifier()
 
         and:
@@ -205,11 +209,11 @@ class IntegrationsTest extends BaseSpecification {
                   .setKey("app")
                   .setValue(nginxName)))
               .addNotifiers(notifier.getId())
-        def policyId = PolicyService.createNewPolicy(policy.build())
+        policyId = PolicyService.createNewPolicy(policy.build())
 
         and:
         "Create a new deployment to trigger the violation against the policy"
-        Deployment nginxdeployment =
+        nginxdeployment =
                 new Deployment()
                         .setName(nginxName)
                         .setImage("quay.io/rhacs-eng/qa-multi-arch-nginx:latest")
@@ -223,16 +227,16 @@ class IntegrationsTest extends BaseSpecification {
 
         cleanup:
         "remove Deployment and services"
-        if (parts.deployment != null) {
+        if (nginxdeployment) {
             orchestrator.deleteDeployment(nginxdeployment)
         }
-        if (policy != null) {
+        if (policyId) {
             PolicyService.deletePolicy(policyId)
         }
         if (parts) {
             SplunkUtil.tearDownSplunk(orchestrator, parts)
         }
-        notifier.deleteNotifier()
+        notifier?.deleteNotifier()
     }
 
     @Unroll


### PR DESCRIPTION
While waiting for PR reviews, I decided to pick some flakes and try to fix them. Here is one of them.

## Description

`createSplunk` waits for the Kubernetes deployment to report Ready before it returns. The Splunk fixture set a TCP readiness probe on port 8089, and Splunk does not bind that port until well after the container is running. `createDeployment` gives that wait about three minutes. CI logs show the pod Running in about two seconds and still 0/1 Ready when the timer expires.

The tests already wait for a usable Splunk after create: `waitForSplunkBoot` and `waitForSplunkReady` retry the Splunk health API for about five minutes. That wait never ran because create failed first.

Dropping the TCP readiness probe lets Kubernetes mark the pod Ready once the container is running. Create then returns, the port-forward is set up, and the existing health wait owns boot. That is the same failure in IntegrationsTest (ROX-36297) and IntegrationsSplunkViolationsTest setup (ROX-36298).

Cleanup in IntegrationsTest also threw when create failed (`parts` was null). Locals start as null and teardown only touches what was created.

The exception text mentions image prefetch. The image is already in the prefetch list and the pod is Running, so prefetch is not the failure.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

This is a timing flake; reproducing the Kubernetes Ready timeout locally would not add confidence over the qa-e2e jobs.

- [ ] CI: running ~15 times the `gke-qa-e2e-tests` target - this needs the label `ci-all-qa-tests`, so I added it after the 5th retest and increased the `retest-times` from 10 to 20. Even if we see it green 15 times, it does not meant that it works.
- [x] Single evidence from CI comparing before and after:

#### Evidence from CI

This change works. CI already shows that Kubernetes Ready and Splunk boot are decoupled, which is the whole point of dropping the TCP probe.

On the [failing master merge job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-master-merge-gke-qa-e2e-tests/2090392049114157056), the Splunk pod was Running at 12:54:10 and still `0/1` Ready three minutes later. Create then gave up. The line `Waiting for Splunk to boot` never appears in that log: the test died on Ready and never asked Splunk if it was up.

```
12:54:13  ContainerStateRunning(startedAt=2026-08-20T12:54:10Z)
12:54:13  0/1 are in the ready state for splunk-d297b1e5-...
… same pair every 3s …
12:57:09  ContainerStateRunning(startedAt=2026-08-20T12:54:10Z)   # still that start time
12:57:09  0/1 are in the ready state for splunk-d297b1e5-...
12:57:09  The deployment did not start or reach replica ready state
          IntegrationsSplunkViolationsTest > initializationError FAILED
```

On [this PR's first full-suite job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22387/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/2090684610009632768), Kubernetes marked the pod Ready in three seconds. Splunk was still not healthy: TLS handshake retries continued until 08:09:29. Then the test body ran and passed.

```
08:06:17  Told the orchestrator to createOrReplace splunk-88d56756-...
08:06:20  All 1 replicas found in ready state
08:06:20  Took 3 seconds for k8s deployment splunk-88d56756-...
08:06:21  Waiting for Splunk to boot...
          SSLHandshakeException (retries)
08:09:29  Splunk has completed booting
          … test body …
          PASSED
```

Those three minutes between Ready (08:06:20) and `Splunk has completed booting` (08:09:29) are the proof. The failing job spent them reprinting `0/1 are in the ready state` until the test was killed. This job spent them in `Waiting for Splunk to boot`, which is allowed to retry, and then the test ran.

If Ready were still waiting on Splunk's port, Ready and boot would land close together. They do not. Ready is immediate; boot is still slow. Kubernetes Ready is no longer the Splunk health check.

A [second full-suite job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22387/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/2090732730949046272) on this PR repeated that sequence (`splunk-53040f70` Ready at 11:22:40, booted at 11:26:01). Both Splunk tests passed again. The jobs can still fail on unrelated tests.

More green jobs would speak to other residual flakes. They are not needed to show this probe is gone.




AI-Assisted: cursor, ~70% generated, user reviewed logic