### PR TITLE
ROX-36441: fix flaky AC init container enforcement test

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -143,21 +143,7 @@ class AdmissionControllerTest extends BaseSpecification {
     def "Verify admission controller enforcement on create: #desc"() {
         when:
         "Create a deployment that violates an enforced policy"
-        // Retry to allow time for the admission controller to fetch scan data from
-        // Central. Policies that require image enrichment (e.g. severity) may not
-        // evaluate on the first attempt if the AC pod handling this request hasn't
-        // cached the scan results yet. The retry is harmless for fast-path policies
-        // (latest tag, bypass) since they pass on the first attempt.
-        def created
-        withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
-            created = orchestrator.createDeploymentNoWait(deployment)
-            if (created != launched) {
-                if (created) {
-                    deleteDeploymentWithCaution(deployment)
-                }
-                assert created == launched
-            }
-        }
+        def created = createDeploymentWithEnforcementRetry(deployment, launched)
 
         then:
         "Verify the admission controller allows or blocks based on policy and bypass annotation"
@@ -262,6 +248,25 @@ class AdmissionControllerTest extends BaseSpecification {
         if (!deleted) {
             log.warn "Failed to delete deployment. Subsequent tests may be affected ..."
         }
+    }
+
+    // Retry to allow time for the admission controller to fetch scan data from
+    // Central. Policies that require image enrichment (e.g. severity) may not
+    // evaluate on the first attempt if the AC pod handling this request hasn't
+    // cached the scan results yet. The retry is harmless for fast-path policies
+    // (latest tag, bypass) since they pass on the first attempt.
+    private boolean createDeploymentWithEnforcementRetry(Deployment deployment, boolean expected) {
+        def created
+        withRetry(ClusterService.isOpenShift4() ? 40 : 20, 1) {
+            created = orchestrator.createDeploymentNoWait(deployment)
+            if (created != expected) {
+                if (created) {
+                    deleteDeploymentWithCaution(deployment)
+                }
+                assert created == expected
+            }
+        }
+        return created
     }
 
     @Unroll
@@ -433,7 +438,7 @@ class AdmissionControllerTest extends BaseSpecification {
                 .addLabel("app", "test")
                 .addInitContainer("init-0", initImage)
 
-        def created = orchestrator.createDeploymentNoWait(deployment)
+        def created = createDeploymentWithEnforcementRetry(deployment, allowed)
 
         then:
         "Verify admission controller allows or blocks based on init container image"

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -239,15 +239,14 @@ class AdmissionControllerTest extends BaseSpecification {
     }
 
     def deleteDeploymentWithCaution(Deployment deployment) {
+        orchestrator.deleteDeployment(deployment)
         def timer = new Timer(30, 1)
-        def deleted = false
-        while (!deleted && timer.IsValid()) {
-            orchestrator.deleteDeployment(deployment)
-            deleted = true
+        while (timer.IsValid()) {
+            if (orchestrator.getOrchestratorDeployment(deployment.namespace, deployment.name) == null) {
+                return
+            }
         }
-        if (!deleted) {
-            log.warn "Failed to delete deployment. Subsequent tests may be affected ..."
-        }
+        log.warn "Failed to confirm deletion of deployment ${deployment.name}. Subsequent tests may be affected ..."
     }
 
     // Retry to allow time for the admission controller to fetch scan data from


### PR DESCRIPTION
## Description

The test `Verify AC enforcement on init containers: blocked with latest tag init container` was calling `createDeploymentNoWait` without any retry, making it susceptible to the same AC policy-propagation timing race documented in the sibling test.

Extract the existing retry pattern from `Verify admission controller enforcement on create` into a shared private helper `createDeploymentWithEnforcementRetry`. The helper retries up to 20/40 attempts, deletes the deployment if it slips through unexpectedly, and returns the final `created` value. Both tests now call the same helper.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Test-only change. The retry logic is identical to the existing pattern already proven effective in the `enforcement on create` test. No new logic introduced — only deduplication.