### PR TITLE
ROX-35080: set default URL for Red Hat signing key bundle

### DIFF
--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -71,7 +71,7 @@ func startKeyBundleUpdater() {
 
 	rawURL := env.RedHatSigningKeyBundleURL.Setting()
 	if rawURL == "" {
-		log.Info("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL not set, key bundle updater will not start")
+		log.Info("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL is empty, key bundle updater will not start")
 		return
 	}
 	bundleURL := urlfmt.FormatURL(rawURL, urlfmt.HTTPS, urlfmt.HonorInputSlash)

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -8,7 +8,8 @@ var (
 
 	// RedHatSigningKeyBundleURL is the remote URL of the key bundle JSON.
 	// If empty, the key bundle updater does not start.
-	RedHatSigningKeyBundleURL = RegisterSetting("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL", AllowEmpty())
+	RedHatSigningKeyBundleURL = RegisterSetting("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL",
+		WithDefault("https://definitions.stackrox.io/signing-keys/bundle.json"), AllowEmpty())
 
 	// RedHatSigningKeyUpdateInterval controls how often the updater re-downloads the bundle.
 	RedHatSigningKeyUpdateInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL", 4*time.Hour)


### PR DESCRIPTION
## Description

Set the default value of `ROX_REDHAT_SIGNING_KEY_BUNDLE_URL` to `https://definitions.stackrox.io/signing-keys/bundle.json` so the key bundle updater starts automatically on every Central instance without requiring explicit configuration.

Previously the env var had no default (`AllowEmpty()` only), meaning the updater never ran unless an operator explicitly set the variable. With this change, automatic signing key rotation works out of the box. Operators can still disable it by setting the env var to an empty string.

This is the final piece of ROX-35080: the GCS-hosted bundle was verified working via the upload workflow added in #21408, and this PR points Central at it by default.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Existing tests cover all scenarios and pass with this change:
- `TestStartKeyBundleUpdaterOnlineWithURL` — updater starts with explicit URL
- `TestStartKeyBundleUpdaterOnlineWithoutURL` — updater does not start when env var is explicitly empty (validates `AllowEmpty()` still works)
- `TestStartKeyBundleUpdaterOfflineMode` — updater does not start in offline mode regardless of URL

No new tests needed: the two-line change only sets a default value and adjusts a log message. The existing test matrix already covers default-overridden-by-explicit-empty (`t.Setenv(..., "")`).

### How I validated my change

- Ran `go test ./central/signatureintegration/datastore/... -count=1 -v` — all tests pass
- Verified the GCS endpoint is live: `curl -sS https://definitions.stackrox.io/signing-keys/bundle.json` returns HTTP 200 with valid bundle JSON (upload workflow #21408 was triggered and succeeded)