### PR TITLE
ROX-36247: Refactor scheduler for multiple report queues

### DIFF
--- a/central/reports/scheduler/v2/reportqueue/report_queue.go
+++ b/central/reports/scheduler/v2/reportqueue/report_queue.go
@@ -1,0 +1,131 @@
+package reportqueue
+
+import (
+	"container/list"
+	"context"
+
+	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+// ReportQueue is a thread-safe FIFO queue of report requests. It tracks which
+// report configurations are currently running so that at most one report per
+// config executes at a time, and stores cancel functions for running reports
+// to support user-initiated cancellation.
+type ReportQueue struct {
+	mu                sync.Mutex
+	queue             *list.List
+	runningConfigs    set.StringSet
+	jobIDToCancelFunc map[string]context.CancelCauseFunc
+}
+
+// New creates a new empty ReportQueue.
+func New() *ReportQueue {
+	return &ReportQueue{
+		queue:             list.New(),
+		runningConfigs:    set.NewStringSet(),
+		jobIDToCancelFunc: make(map[string]context.CancelCauseFunc),
+	}
+}
+
+// Enqueue adds a report request to the back of the queue.
+func (q *ReportQueue) Enqueue(req *reportGen.ReportRequest) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.queue.PushBack(req)
+}
+
+// Dequeue removes and returns the first runnable report request from the queue.
+// VIEW_BASED reports are always runnable. Config-based reports are runnable only
+// if their config ID is not in the running set. Returns nil if no runnable
+// request is found. For non-VIEW_BASED reports, the config ID is added to the
+// running set upon dequeue.
+func (q *ReportQueue) Dequeue() *reportGen.ReportRequest {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	req := findAndRemove(q.queue, func(req *reportGen.ReportRequest) bool {
+		if req.ReportSnapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
+			return true
+		}
+		return !q.runningConfigs.Contains(req.ReportSnapshot.GetReportConfigurationId())
+	})
+	if req == nil {
+		return nil
+	}
+	if req.ReportSnapshot.GetReportStatus().GetReportRequestType() != storage.ReportStatus_VIEW_BASED {
+		q.runningConfigs.Add(req.ReportSnapshot.GetReportConfigurationId())
+	}
+	return req
+}
+
+// Remove removes a queued (not yet running) request by report snapshot ID.
+// Returns the removed request, or nil if not found.
+func (q *ReportQueue) Remove(reportID string) *reportGen.ReportRequest {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	return findAndRemove(q.queue, func(req *reportGen.ReportRequest) bool {
+		return req.ReportSnapshot.GetReportId() == reportID
+	})
+}
+
+// MarkReportDoneForConfig removes a config ID from the running set, allowing
+// another report for the same config to be dequeued.
+func (q *ReportQueue) MarkReportDoneForConfig(configID string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.runningConfigs.Remove(configID)
+}
+
+// AddCancelFunc stores a cancel function for a running report, keyed by report ID.
+func (q *ReportQueue) AddCancelFunc(reportID string, cancel context.CancelCauseFunc) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.jobIDToCancelFunc[reportID] = cancel
+}
+
+// RemoveCancelFunc removes the cancel function for the given report ID.
+func (q *ReportQueue) RemoveCancelFunc(reportID string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	delete(q.jobIDToCancelFunc, reportID)
+}
+
+// TryCancel calls the cancel function for the given report ID with
+// ErrUserCancelled as the cause. Returns true if a cancel function was found
+// and invoked.
+func (q *ReportQueue) TryCancel(reportID string) bool {
+	cancel := concurrency.WithLock1(&q.mu, func() context.CancelCauseFunc {
+		return q.jobIDToCancelFunc[reportID]
+	})
+	if cancel == nil {
+		return false
+	}
+	cancel(reportGen.ErrUserCancelled)
+	return true
+}
+
+// Len returns the number of items in the queue.
+func (q *ReportQueue) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queue.Len()
+}
+
+// findAndRemove walks the queue front-to-back and removes the first element
+// matching the predicate. Returns the removed request, or nil if none matched.
+func findAndRemove(queue *list.List, pred func(req *reportGen.ReportRequest) bool) *reportGen.ReportRequest {
+	cur := queue.Front()
+	for cur != nil {
+		req, ok := cur.Value.(*reportGen.ReportRequest)
+		if ok && pred(req) {
+			return queue.Remove(cur).(*reportGen.ReportRequest)
+		}
+		cur = cur.Next()
+	}
+	return nil
+}

--- a/central/reports/scheduler/v2/reportqueue/report_queue.go
+++ b/central/reports/scheduler/v2/reportqueue/report_queue.go
@@ -1,12 +1,12 @@
 package reportqueue
 
 import (
-	"container/list"
 	"context"
 
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/queue"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -17,7 +17,7 @@ import (
 // to support user-initiated cancellation.
 type ReportQueue struct {
 	mu                sync.Mutex
-	queue             *list.List
+	queue             *queue.Queue[*reportGen.ReportRequest]
 	runningConfigs    set.StringSet
 	jobIDToCancelFunc map[string]context.CancelCauseFunc
 }
@@ -25,17 +25,16 @@ type ReportQueue struct {
 // New creates a new empty ReportQueue.
 func New() *ReportQueue {
 	return &ReportQueue{
-		queue:             list.New(),
+		queue:             queue.NewQueue[*reportGen.ReportRequest](),
 		runningConfigs:    set.NewStringSet(),
 		jobIDToCancelFunc: make(map[string]context.CancelCauseFunc),
 	}
 }
 
 // Enqueue adds a report request to the back of the queue.
+// The underlying queue is internally synchronized, so no additional locking is needed.
 func (q *ReportQueue) Enqueue(req *reportGen.ReportRequest) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.queue.PushBack(req)
+	q.queue.Push(req)
 }
 
 // Dequeue removes and returns the first runnable report request from the queue.
@@ -47,13 +46,13 @@ func (q *ReportQueue) Dequeue() *reportGen.ReportRequest {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	req := findAndRemove(q.queue, func(req *reportGen.ReportRequest) bool {
+	req, ok := q.queue.PullWithPred(func(req *reportGen.ReportRequest) bool {
 		if req.ReportSnapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
 			return true
 		}
 		return !q.runningConfigs.Contains(req.ReportSnapshot.GetReportConfigurationId())
 	})
-	if req == nil {
+	if !ok {
 		return nil
 	}
 	if req.ReportSnapshot.GetReportStatus().GetReportRequestType() != storage.ReportStatus_VIEW_BASED {
@@ -64,13 +63,12 @@ func (q *ReportQueue) Dequeue() *reportGen.ReportRequest {
 
 // Remove removes a queued (not yet running) request by report snapshot ID.
 // Returns the removed request, or nil if not found.
+// The underlying queue is internally synchronized, so no additional locking is needed.
 func (q *ReportQueue) Remove(reportID string) *reportGen.ReportRequest {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	return findAndRemove(q.queue, func(req *reportGen.ReportRequest) bool {
+	req, _ := q.queue.PullWithPred(func(req *reportGen.ReportRequest) bool {
 		return req.ReportSnapshot.GetReportId() == reportID
 	})
+	return req
 }
 
 // MarkReportDoneForConfig removes a config ID from the running set, allowing
@@ -110,22 +108,7 @@ func (q *ReportQueue) TryCancel(reportID string) bool {
 }
 
 // Len returns the number of items in the queue.
+// The underlying queue is internally synchronized, so no additional locking is needed.
 func (q *ReportQueue) Len() int {
-	q.mu.Lock()
-	defer q.mu.Unlock()
 	return q.queue.Len()
-}
-
-// findAndRemove walks the queue front-to-back and removes the first element
-// matching the predicate. Returns the removed request, or nil if none matched.
-func findAndRemove(queue *list.List, pred func(req *reportGen.ReportRequest) bool) *reportGen.ReportRequest {
-	cur := queue.Front()
-	for cur != nil {
-		req, ok := cur.Value.(*reportGen.ReportRequest)
-		if ok && pred(req) {
-			return queue.Remove(cur).(*reportGen.ReportRequest)
-		}
-		cur = cur.Next()
-	}
-	return nil
 }

--- a/central/reports/scheduler/v2/reportqueue/report_queue_test.go
+++ b/central/reports/scheduler/v2/reportqueue/report_queue_test.go
@@ -1,0 +1,182 @@
+package reportqueue
+
+import (
+	"context"
+	"testing"
+
+	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeRequest(reportID, configID string, requestType storage.ReportStatus_RunMethod) *reportGen.ReportRequest {
+	return &reportGen.ReportRequest{
+		ReportSnapshot: &storage.ReportSnapshot{
+			ReportId:              reportID,
+			ReportConfigurationId: configID,
+			ReportStatus: &storage.ReportStatus{
+				ReportRequestType: requestType,
+			},
+		},
+	}
+}
+
+func TestEnqueueDequeueFIFO(t *testing.T) {
+	q := New()
+
+	req1 := makeRequest("r1", "c1", storage.ReportStatus_ON_DEMAND)
+	req2 := makeRequest("r2", "c2", storage.ReportStatus_ON_DEMAND)
+	req3 := makeRequest("r3", "c3", storage.ReportStatus_SCHEDULED)
+
+	q.Enqueue(req1)
+	q.Enqueue(req2)
+	q.Enqueue(req3)
+	assert.Equal(t, 3, q.Len())
+
+	got := q.Dequeue()
+	assert.Equal(t, "r1", got.ReportSnapshot.GetReportId())
+	got = q.Dequeue()
+	assert.Equal(t, "r2", got.ReportSnapshot.GetReportId())
+	got = q.Dequeue()
+	assert.Equal(t, "r3", got.ReportSnapshot.GetReportId())
+
+	assert.Nil(t, q.Dequeue())
+	assert.Equal(t, 0, q.Len())
+}
+
+func TestDequeueSkipsRunningConfig(t *testing.T) {
+	q := New()
+
+	req1 := makeRequest("r1", "c1", storage.ReportStatus_ON_DEMAND)
+	req2 := makeRequest("r2", "c1", storage.ReportStatus_ON_DEMAND)
+	req3 := makeRequest("r3", "c2", storage.ReportStatus_ON_DEMAND)
+
+	q.Enqueue(req1)
+	q.Enqueue(req2)
+	q.Enqueue(req3)
+
+	// Dequeue r1 → c1 is now in runningConfigs
+	got := q.Dequeue()
+	assert.Equal(t, "r1", got.ReportSnapshot.GetReportId())
+
+	// r2 is for c1 (running), should be skipped; r3 (c2) is returned
+	got = q.Dequeue()
+	assert.Equal(t, "r3", got.ReportSnapshot.GetReportId())
+
+	// r2 still blocked
+	assert.Nil(t, q.Dequeue())
+	assert.Equal(t, 1, q.Len())
+}
+
+func TestDequeueViewBasedAlwaysRunnable(t *testing.T) {
+	q := New()
+
+	req1 := makeRequest("r1", "c1", storage.ReportStatus_ON_DEMAND)
+	reqView := makeRequest("r-view", "", storage.ReportStatus_VIEW_BASED)
+
+	q.Enqueue(req1)
+	q.Enqueue(reqView)
+
+	// Dequeue r1 → c1 in runningConfigs
+	got := q.Dequeue()
+	assert.Equal(t, "r1", got.ReportSnapshot.GetReportId())
+
+	// VIEW_BASED always passes regardless of runningConfigs
+	got = q.Dequeue()
+	require.NotNil(t, got)
+	assert.Equal(t, "r-view", got.ReportSnapshot.GetReportId())
+}
+
+func TestMarkReportDoneForConfigUnblocks(t *testing.T) {
+	q := New()
+
+	req1 := makeRequest("r1", "c1", storage.ReportStatus_ON_DEMAND)
+	req2 := makeRequest("r2", "c1", storage.ReportStatus_SCHEDULED)
+
+	q.Enqueue(req1)
+	q.Enqueue(req2)
+
+	got := q.Dequeue()
+	assert.Equal(t, "r1", got.ReportSnapshot.GetReportId())
+
+	// r2 blocked because c1 is running
+	assert.Nil(t, q.Dequeue())
+
+	q.MarkReportDoneForConfig("c1")
+
+	// Now r2 should be dequeued
+	got = q.Dequeue()
+	require.NotNil(t, got)
+	assert.Equal(t, "r2", got.ReportSnapshot.GetReportId())
+}
+
+func TestRemoveFromQueue(t *testing.T) {
+	q := New()
+
+	req1 := makeRequest("r1", "c1", storage.ReportStatus_ON_DEMAND)
+	req2 := makeRequest("r2", "c2", storage.ReportStatus_ON_DEMAND)
+
+	q.Enqueue(req1)
+	q.Enqueue(req2)
+
+	removed := q.Remove("r1")
+	require.NotNil(t, removed)
+	assert.Equal(t, "r1", removed.ReportSnapshot.GetReportId())
+	assert.Equal(t, 1, q.Len())
+
+	// Removing non-existent returns nil
+	assert.Nil(t, q.Remove("nonexistent"))
+	assert.Equal(t, 1, q.Len())
+}
+
+func TestAddCancelFuncAndTryCancel(t *testing.T) {
+	q := New()
+
+	var capturedCause error
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	q.AddCancelFunc("r1", cancel)
+
+	cancelled := q.TryCancel("r1")
+	assert.True(t, cancelled)
+
+	capturedCause = context.Cause(ctx)
+	assert.ErrorIs(t, capturedCause, reportGen.ErrUserCancelled)
+}
+
+func TestTryCancelReturnsFalseForUnknown(t *testing.T) {
+	q := New()
+	assert.False(t, q.TryCancel("nonexistent"))
+}
+
+func TestRemoveCancelFunc(t *testing.T) {
+	q := New()
+
+	_, cancel := context.WithCancelCause(context.Background())
+
+	q.AddCancelFunc("r1", cancel)
+	q.RemoveCancelFunc("r1")
+
+	// After removal, TryCancel should return false
+	assert.False(t, q.TryCancel("r1"))
+}
+
+func TestViewBasedNotAddedToRunningConfigs(t *testing.T) {
+	q := New()
+
+	reqView1 := makeRequest("r-view-1", "", storage.ReportStatus_VIEW_BASED)
+	reqView2 := makeRequest("r-view-2", "", storage.ReportStatus_VIEW_BASED)
+
+	q.Enqueue(reqView1)
+	q.Enqueue(reqView2)
+
+	got := q.Dequeue()
+	assert.Equal(t, "r-view-1", got.ReportSnapshot.GetReportId())
+
+	// Second VIEW_BASED should also dequeue without being blocked
+	got = q.Dequeue()
+	require.NotNil(t, got)
+	assert.Equal(t, "r-view-2", got.ReportSnapshot.GetReportId())
+}

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"container/list"
 	"context"
 	"sync/atomic"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/stackrox/rox/central/reports/common"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
+	"github.com/stackrox/rox/central/reports/scheduler/v2/reportqueue"
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	"github.com/stackrox/rox/central/reports/validation"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
@@ -21,13 +21,13 @@ import (
 	"github.com/stackrox/rox/pkg/dblock"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv/schedule"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"golang.org/x/sync/semaphore"
 	"gopkg.in/robfig/cron.v2"
@@ -39,6 +39,14 @@ var (
 	scheduledCtx = sac.WithAllAccess(context.Background())
 )
 
+// queueGeneratorBinding pairs a report job queue with the generator that processes
+// jobs from that queue. E.g., image CVE report job queue <-> image CVE report
+// generator, node CVE report job queue <-> node CVE report generator.
+type queueGeneratorBinding struct {
+	queue     *reportqueue.ReportQueue
+	generator reportGen.ReportGenerator
+}
+
 type scheduler struct {
 	// Used to map reportConfigs to their cron jobs. This is only used for scheduled reports, On-demand reports are directly added to reportsQueue
 	reportConfigToEntryIDs map[string]cron.EntryID
@@ -47,21 +55,20 @@ type scheduler struct {
 	reportSnapshotStore   reportSnapshotDS.DataStore
 	collectionDatastore   collectionDS.DataStore
 	notifierDatastore     notifierDS.DataStore
-	reportGenerator       reportGen.ReportGenerator
 	validator             *validation.Validator
 
-	reportRequestsQueue *list.List
+	// Ordered list of queue-generator bindings. The main loop round-robins through
+	// these when selecting the next report to run.
+	queues       []queueGeneratorBinding
+	nextQueueIdx int
+	// Maps report type to its queue for routing submissions.
+	queueByType map[storage.ReportSnapshot_ReportType]*reportqueue.ReportQueue
 
-	// Use to signal the scheduler to find and run a new report if a routine is available
-	// This signal is triggered when a new request is added to reportsQueue. It is also triggered when a report completes
-	// execution to inform the scheduler that a routine is free. The signal is reset when there is no report to run.
+	// Signals the scheduler to find and run a new report. Triggered when a new
+	// request is enqueued or when a report completes. Reset when no runnable report
+	// is found across any queue.
 	readyForReports concurrency.Signal
-	// Stores config IDs for which a report is currently running. Used to make sure only one report per config runs at a time.
-	runningReportConfigs set.StringSet
-	// Stores cancel functions for running reports, keyed by report ID.
-	// Used to cancel in-flight database queries and blob store writes when a user cancels a PREPARING report.
-	runningReportCancels map[string]context.CancelCauseFunc
-	Schema               *graphql.Schema
+	Schema          *graphql.Schema
 
 	/* Concurrency and synchronization related fields */
 	// isStarted will make sure only one scheduling routine runs for an instance of scheduler
@@ -69,13 +76,10 @@ type scheduler struct {
 	// isStopped will prevent scheduler from being re-started once it is stopped
 	isStopped atomic.Bool
 
-	/* Concurrency and synchronization related fields */
 	stopper concurrency.Stopper
 
 	// Use to synchronize access to reportConfigToEntryIDs map
 	cronJobsLock sync.Mutex
-	// Use to synchronize access to reportsQueue, runningReportConfigs, and runningReportCancels
-	schedulerLock sync.Mutex
 	// Use to lock any database tables if needed to prevent race conditions
 	dbLock sync.Mutex
 	// NOTE: Lock only one mutex at a time. Do not lock another mutex when one is already held.
@@ -89,7 +93,8 @@ type scheduler struct {
 // New instantiates a new cron scheduler and supports adding and removing report requests
 func New(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore reportSnapshotDS.DataStore,
 	collectionDatastore collectionDS.DataStore, notifierDatastore notifierDS.DataStore,
-	reportGenerator reportGen.ReportGenerator, validator *validation.Validator) Scheduler {
+	imageReportGenerator reportGen.ReportGenerator, nodeReportGenerator reportGen.ReportGenerator,
+	validator *validation.Validator) Scheduler {
 
 	cronScheduler := cron.New()
 	cronScheduler.Start()
@@ -98,25 +103,39 @@ func New(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore rep
 		panic(err)
 	}
 	return newSchedulerImpl(reportConfigDatastore, reportSnapshotStore, collectionDatastore, notifierDatastore,
-		reportGenerator, validator, cronScheduler, ourSchema)
+		imageReportGenerator, nodeReportGenerator, validator, cronScheduler, ourSchema)
 }
 
 func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnapshotStore reportSnapshotDS.DataStore,
 	collectionDatastore collectionDS.DataStore, notifierDatastore notifierDS.DataStore,
-	reportGenerator reportGen.ReportGenerator, validator *validation.Validator, cronScheduler *cron.Cron,
+	imageReportGenerator reportGen.ReportGenerator, nodeReportGenerator reportGen.ReportGenerator,
+	validator *validation.Validator, cronScheduler *cron.Cron,
 	schema *graphql.Schema) *scheduler {
+
+	imageQueue := reportqueue.New()
+	queues := []queueGeneratorBinding{
+		{queue: imageQueue, generator: imageReportGenerator},
+	}
+	queueByType := map[storage.ReportSnapshot_ReportType]*reportqueue.ReportQueue{
+		storage.ReportSnapshot_VULNERABILITY: imageQueue,
+	}
+
+	if features.NodeVulnerabilityReports.Enabled() {
+		nodeQueue := reportqueue.New()
+		queues = append(queues, queueGeneratorBinding{queue: nodeQueue, generator: nodeReportGenerator})
+		queueByType[storage.ReportSnapshot_NODE_VULNERABILITY] = nodeQueue
+	}
+
 	s := &scheduler{
 		reportConfigToEntryIDs: make(map[string]cron.EntryID),
 		reportConfigDatastore:  reportConfigDatastore,
 		reportSnapshotStore:    reportSnapshotStore,
 		collectionDatastore:    collectionDatastore,
 		notifierDatastore:      notifierDatastore,
-		reportGenerator:        reportGenerator,
 		validator:              validator,
-		reportRequestsQueue:    list.New(),
+		queues:                 queues,
+		queueByType:            queueByType,
 		readyForReports:        concurrency.NewSignal(),
-		runningReportConfigs:   set.NewStringSet(),
-		runningReportCancels:   make(map[string]context.CancelCauseFunc),
 		Schema:                 schema,
 		stopper:                concurrency.NewStopper(),
 		cron:                   cronScheduler,
@@ -186,8 +205,8 @@ func (s *scheduler) runReports() {
 		case <-s.stopper.Flow().StopRequested():
 			return
 		case <-s.readyForReports.Done():
-			reportRequest := s.selectNextRunnableReport()
-			if reportRequest == nil {
+			req, q, gen := s.selectNextJobRoundRobin()
+			if req == nil {
 				s.readyForReports.Reset()
 				continue
 			}
@@ -195,72 +214,37 @@ func (s *scheduler) runReports() {
 				log.Errorf("Error acquiring semaphore to run new report: %v", err)
 				continue
 			}
-			log.Infof("Executing report '%s' at %v", reportRequest.ReportSnapshot.GetName(), time.Now().Format(time.RFC822))
-			go s.runSingleReport(reportRequest)
+			log.Infof("Executing report '%s' at %v", req.ReportSnapshot.GetName(), time.Now().Format(time.RFC822))
+			go s.runSingleReport(q, gen, req)
 		}
 	}
 }
 
-func (s *scheduler) selectNextRunnableReport() *reportGen.ReportRequest {
-	s.schedulerLock.Lock()
-	defer s.schedulerLock.Unlock()
-
-	request := findAndRemoveFromQueue(s.reportRequestsQueue, func(req *reportGen.ReportRequest) bool {
-		if req.ReportSnapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
-			return true
+func (s *scheduler) selectNextJobRoundRobin() (*reportGen.ReportRequest, *reportqueue.ReportQueue, reportGen.ReportGenerator) {
+	n := len(s.queues)
+	for i := range n {
+		idx := (s.nextQueueIdx + i) % n
+		qb := s.queues[idx]
+		if req := qb.queue.Dequeue(); req != nil {
+			s.nextQueueIdx = (idx + 1) % n
+			return req, qb.queue, qb.generator
 		}
-		return !s.runningReportConfigs.Contains(req.ReportSnapshot.GetReportConfigurationId())
-	})
-	if request == nil {
-		return nil
 	}
-	if request.ReportSnapshot.GetVulnReportFilters() != nil {
-		s.runningReportConfigs.Add(request.ReportSnapshot.GetReportConfigurationId())
-	}
-	return request
+	return nil, nil, nil
 }
 
-func (s *scheduler) runSingleReport(req *reportGen.ReportRequest) {
+func (s *scheduler) runSingleReport(q *reportqueue.ReportQueue, gen reportGen.ReportGenerator, req *reportGen.ReportRequest) {
 	defer s.readyForReports.Signal()
 	defer s.concurrencySema.Release(1)
-	defer s.removeFromRunningReportConfigs(req.ReportSnapshot.GetReportConfigurationId())
+	defer q.MarkReportDoneForConfig(req.ReportSnapshot.GetReportConfigurationId())
 
 	reportID := req.ReportSnapshot.GetReportId()
 	ctx, cancel := context.WithCancelCause(context.Background())
-	s.addRunningReportCancel(reportID, cancel)
+	q.AddCancelFunc(reportID, cancel)
 	defer cancel(nil)
-	defer s.removeRunningReportCancel(reportID)
+	defer q.RemoveCancelFunc(reportID)
 
-	s.reportGenerator.ProcessReportRequest(ctx, req)
-}
-
-func (s *scheduler) removeFromRunningReportConfigs(configID string) {
-	s.schedulerLock.Lock()
-	defer s.schedulerLock.Unlock()
-	s.runningReportConfigs.Remove(configID)
-}
-
-func (s *scheduler) addRunningReportCancel(reportID string, cancel context.CancelCauseFunc) {
-	s.schedulerLock.Lock()
-	defer s.schedulerLock.Unlock()
-	s.runningReportCancels[reportID] = cancel
-}
-
-func (s *scheduler) removeRunningReportCancel(reportID string) {
-	s.schedulerLock.Lock()
-	defer s.schedulerLock.Unlock()
-	delete(s.runningReportCancels, reportID)
-}
-
-func (s *scheduler) tryCancelRunningReport(reportID string) bool {
-	cancel := concurrency.WithLock1(&s.schedulerLock, func() context.CancelCauseFunc {
-		return s.runningReportCancels[reportID]
-	})
-	if cancel == nil {
-		return false
-	}
-	cancel(reportGen.ErrUserCancelled)
-	return true
+	gen.ProcessReportRequest(ctx, req)
 }
 
 // UpsertReportSchedule adds/updates the schedule at which reports for the given report config are executed.
@@ -305,31 +289,29 @@ func (s *scheduler) RemoveReportSchedule(reportConfigID string) {
 // being prepared, its context is cancelled, which propagates cancellation to in-flight database
 // queries and blob store writes.
 func (s *scheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
-	req := s.tryRemoveFromRequestQueue(reportID)
-	if req != nil {
-		req.ReportSnapshot.ReportStatus.ErrorMsg = reportGen.ErrUserCancelled.Error()
-		req.ReportSnapshot.ReportStatus.CompletedAt = protocompat.TimestampNow()
-		req.ReportSnapshot.ReportStatus.RunState = storage.ReportStatus_FAILURE
-		if err := s.reportSnapshotStore.UpdateReportSnapshot(ctx, req.ReportSnapshot); err != nil {
-			return false, errors.Wrapf(err, "Error updating report snapshot to FAILURE for report ID '%s'", reportID)
+	for _, qb := range s.queues {
+		req := qb.queue.Remove(reportID)
+		if req != nil {
+			req.ReportSnapshot.ReportStatus.ErrorMsg = reportGen.ErrUserCancelled.Error()
+			req.ReportSnapshot.ReportStatus.CompletedAt = protocompat.TimestampNow()
+			req.ReportSnapshot.ReportStatus.RunState = storage.ReportStatus_FAILURE
+			if err := s.reportSnapshotStore.UpdateReportSnapshot(ctx, req.ReportSnapshot); err != nil {
+				return false, errors.Wrapf(err, "Error updating report snapshot to FAILURE for report ID '%s'", reportID)
+			}
+			return true, nil
 		}
-		return true, nil
 	}
-	return s.tryCancelRunningReport(reportID), nil
-}
-
-// Returns the removed ReportRequest if found, nil otherwise
-func (s *scheduler) tryRemoveFromRequestQueue(reportID string) *reportGen.ReportRequest {
-	s.schedulerLock.Lock()
-	defer s.schedulerLock.Unlock()
-
-	return findAndRemoveFromQueue(s.reportRequestsQueue, func(req *reportGen.ReportRequest) bool {
-		return req.ReportSnapshot.GetReportId() == reportID
-	})
+	for _, qb := range s.queues {
+		if qb.queue.TryCancel(reportID) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (s *scheduler) CanSubmitReportRequest(user *storage.SlimUser, reportConfig *storage.ReportConfiguration) (bool, error) {
-	return s.doesUserHavePendingReport(reportConfig.GetId(), user.GetId())
+	return s.doesUserHavePendingReport(reportConfig.GetId(), user.GetId(),
+		storage.ReportSnapshot_ReportType(reportConfig.GetType()))
 }
 
 // SubmitReportRequest submits a report execution request. The report request can be either for an on demand report or a scheduled report.
@@ -341,6 +323,11 @@ func (s *scheduler) SubmitReportRequest(ctx context.Context, request *reportGen.
 		return "", err
 	}
 
+	q := s.queueForSnapshot(request.ReportSnapshot)
+	if q == nil {
+		return "", errors.New("node vulnerability reports are not enabled")
+	}
+
 	request.ReportSnapshot.ReportStatus.RunState = storage.ReportStatus_WAITING
 	request.ReportSnapshot.ReportStatus.QueuedAt = protocompat.TimestampNow()
 	request.ReportSnapshot.ReportId, err = s.validateAndPersistSnapshot(ctx, request.ReportSnapshot, reSubmission)
@@ -348,16 +335,14 @@ func (s *scheduler) SubmitReportRequest(ctx context.Context, request *reportGen.
 		return "", err
 	}
 
-	s.appendToReportsQueue(request)
+	q.Enqueue(request)
+	s.readyForReports.Signal()
 
 	return request.ReportSnapshot.GetReportId(), nil
 }
 
-func (s *scheduler) appendToReportsQueue(req *reportGen.ReportRequest) {
-	s.schedulerLock.Lock()
-	defer s.schedulerLock.Unlock()
-	s.reportRequestsQueue.PushBack(req)
-	s.readyForReports.Signal()
+func (s *scheduler) queueForSnapshot(snap *storage.ReportSnapshot) *reportqueue.ReportQueue {
+	return s.queueByType[snap.GetType()]
 }
 
 func (s *scheduler) reportClosure(reportConfig *storage.ReportConfiguration) func() {
@@ -441,8 +426,12 @@ func (s *scheduler) queuePendingReports() {
 }
 
 func (s *scheduler) queueScheduledReports() {
+	reportTypes := []string{storage.ReportConfiguration_VULNERABILITY.String()}
+	if features.NodeVulnerabilityReports.Enabled() {
+		reportTypes = append(reportTypes, storage.ReportConfiguration_NODE_VULNERABILITY.String())
+	}
 	query := search.NewQueryBuilder().
-		AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).
+		AddExactMatches(search.ReportType, reportTypes...).
 		ProtoQuery()
 	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
 	if err != nil {
@@ -468,8 +457,12 @@ func (s *scheduler) recoverMissedSchedules() {
 		return
 	}
 
+	reportTypes := []string{storage.ReportConfiguration_VULNERABILITY.String()}
+	if features.NodeVulnerabilityReports.Enabled() {
+		reportTypes = append(reportTypes, storage.ReportConfiguration_NODE_VULNERABILITY.String())
+	}
 	query := search.NewQueryBuilder().
-		AddExactMatches(search.ReportType, storage.ReportConfiguration_VULNERABILITY.String()).
+		AddExactMatches(search.ReportType, reportTypes...).
 		ProtoQuery()
 	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
 	if err != nil {
@@ -575,28 +568,6 @@ func findPreviousFireTime(cronSchedule cron.Schedule, now time.Time) time.Time {
 	return previousFire
 }
 
-/* Utility Functions */
-
-// findAndRemoveFromQueue will find the first element that matches the given predicate and returns ReportRequest from that element
-// Elements with values that are not of type *reportGen.ReportRequest will be skipped.
-// Note: This function does not lock the queue, so any locks to prevent race conditions must be taken by the caller.
-func findAndRemoveFromQueue(reportRequestsQueue *list.List, pred func(req *reportGen.ReportRequest) bool) *reportGen.ReportRequest {
-	var toRemove *list.Element
-	cur := reportRequestsQueue.Front()
-	for cur != nil {
-		req, ok := cur.Value.(*reportGen.ReportRequest)
-		if ok && pred(req) {
-			toRemove = cur
-			break
-		}
-		cur = cur.Next()
-	}
-	if toRemove == nil {
-		return nil
-	}
-	return reportRequestsQueue.Remove(toRemove).(*reportGen.ReportRequest)
-}
-
 // Validate report snapshot and store it to db if validation succeeds.
 // Will return report_id if successful.
 // Validation will check if the user requesting the report doesn't already have a pending report for the same config
@@ -605,8 +576,11 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 	defer s.dbLock.Unlock()
 	var err error
 	if !reSubmission {
-		if snapshot.GetVulnReportFilters() != nil && snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_ON_DEMAND {
-			userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId())
+		requestType := snapshot.GetReportStatus().GetReportRequestType()
+		reportType := snapshot.GetType()
+
+		if requestType == storage.ReportStatus_ON_DEMAND {
+			userHasAnotherReport, err := s.doesUserHavePendingReport(snapshot.GetReportConfigurationId(), snapshot.GetRequester().GetId(), reportType)
 			if err != nil {
 				return "", err
 			}
@@ -616,9 +590,8 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 			}
 		}
 
-		// if user has an existing view based report job then dont queue a new one
-		if snapshot.GetViewBasedVulnReportFilters() != nil {
-			userHasAnotherReport, err := s.doesUserHaveViewBasedPendingReport(snapshot.GetRequester().GetId())
+		if requestType == storage.ReportStatus_VIEW_BASED {
+			userHasAnotherReport, err := s.doesUserHaveViewBasedPendingReport(snapshot.GetRequester().GetId(), reportType)
 			if err != nil {
 				return "", err
 			}
@@ -627,11 +600,11 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 			}
 		}
 
-		// View-based reports are authorized at the gRPC layer with only Image+Deployment
-		// view permissions (no WorkflowAdministration write required). The snapshot datastore
-		// requires WorkflowAdministration write, so we elevate to a privileged context here.
+		// View-based reports are authorized at the gRPC layer with only view permissions
+		// (no WorkflowAdministration write required). The snapshot datastore requires
+		// WorkflowAdministration write, so we elevate to a privileged context here.
 		persistCtx := ctx
-		if snapshot.GetViewBasedVulnReportFilters() != nil {
+		if requestType == storage.ReportStatus_VIEW_BASED {
 			persistCtx = sac.WithAllAccess(ctx)
 		}
 		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(persistCtx, snapshot)
@@ -645,27 +618,26 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 	return snapshot.GetReportId(), nil
 }
 
-func (s *scheduler) doesUserHaveViewBasedPendingReport(userID string) (bool, error) {
+func (s *scheduler) doesUserHaveViewBasedPendingReport(userID string, reportType storage.ReportSnapshot_ReportType) (bool, error) {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String(), storage.ReportStatus_PREPARING.String()).
 		AddExactMatches(search.ReportRequestType, storage.ReportStatus_VIEW_BASED.String()).
 		AddExactMatches(search.UserID, userID).
+		AddExactMatches(search.ReportType, reportType.String()).
 		ProtoQuery()
 	runningReports, err := s.reportSnapshotStore.Count(scheduledCtx, query)
 	if err != nil {
 		return false, err
 	}
-	if runningReports > 0 {
-		return true, nil
-	}
-	return false, nil
+	return runningReports > 0, nil
 }
 
-func (s *scheduler) doesUserHavePendingReport(configID string, userID string) (bool, error) {
+func (s *scheduler) doesUserHavePendingReport(configID string, userID string, reportType storage.ReportSnapshot_ReportType) (bool, error) {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportConfigID, configID).
 		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String(), storage.ReportStatus_PREPARING.String()).
 		AddExactMatches(search.ReportRequestType, storage.ReportStatus_ON_DEMAND.String()).
+		AddExactMatches(search.ReportType, reportType.String()).
 		ProtoQuery()
 	runningReports, err := s.reportSnapshotStore.SearchReportSnapshots(scheduledCtx, query)
 	if err != nil {

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -120,7 +120,7 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		storage.ReportSnapshot_VULNERABILITY: imageQueue,
 	}
 
-	if features.NodeVulnerabilityReports.Enabled() {
+	if features.NodeVulnerabilityReports.Enabled() && nodeReportGenerator != nil {
 		nodeQueue := reportqueue.New()
 		queues = append(queues, queueGeneratorBinding{queue: nodeQueue, generator: nodeReportGenerator})
 		queueByType[storage.ReportSnapshot_NODE_VULNERABILITY] = nodeQueue
@@ -134,6 +134,7 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		notifierDatastore:      notifierDatastore,
 		validator:              validator,
 		queues:                 queues,
+		nextQueueIdx:           0,
 		queueByType:            queueByType,
 		readyForReports:        concurrency.NewSignal(),
 		Schema:                 schema,

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -154,7 +154,7 @@ func TestQueueScheduledReportsSkipsEmptyResourceScope(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(mockReportConfigDS, nil, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(mockReportConfigDS, nil, nil, nil, nil, nil, nil, cronScheduler, nil)
 	s.queueScheduledReports()
 
 	// Only the two valid configs should have been scheduled
@@ -165,54 +165,6 @@ func TestQueueScheduledReportsSkipsEmptyResourceScope(t *testing.T) {
 	assert.NotContains(t, s.reportConfigToEntryIDs, "config-nil-scope")
 }
 
-func TestCancelRunningReportCancelsContext(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockReportGen := reportGenMocks.NewMockReportGenerator(ctrl)
-
-	cronScheduler := cron.New()
-	cronScheduler.Start()
-	defer cronScheduler.Stop()
-
-	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, cronScheduler, nil)
-
-	started := make(chan struct{})
-	done := make(chan struct{})
-	var capturedCtx context.Context
-
-	mockReportGen.EXPECT().ProcessReportRequest(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, req *reportGen.ReportRequest) {
-			capturedCtx = ctx
-			close(started)
-			<-done
-		},
-	)
-
-	req := &reportGen.ReportRequest{
-		ReportSnapshot: &storage.ReportSnapshot{
-			ReportId:              "test-report-id",
-			ReportConfigurationId: "test-config-id",
-			ReportStatus: &storage.ReportStatus{
-				RunState: storage.ReportStatus_WAITING,
-			},
-		},
-	}
-
-	// Acquire the semaphore since runSingleReport releases it
-	err := s.concurrencySema.Acquire(context.Background(), 1)
-	assert.NoError(t, err)
-
-	go s.runSingleReport(req)
-	<-started
-
-	cancelled := s.tryCancelRunningReport("test-report-id")
-	assert.True(t, cancelled)
-
-	assert.Error(t, capturedCtx.Err())
-	assert.ErrorIs(t, context.Cause(capturedCtx), reportGen.ErrUserCancelled)
-
-	close(done)
-}
-
 func TestCancelReportRequestCancelsRunningReport(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockReportGen := reportGenMocks.NewMockReportGenerator(ctrl)
@@ -221,7 +173,8 @@ func TestCancelReportRequestCancelsRunningReport(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, cronScheduler, nil)
+	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, nil, cronScheduler, nil)
+	imageQueue := s.queues[0].queue
 
 	started := make(chan struct{})
 	done := make(chan struct{})
@@ -249,7 +202,7 @@ func TestCancelReportRequestCancelsRunningReport(t *testing.T) {
 	err := s.concurrencySema.Acquire(context.Background(), 1)
 	assert.NoError(t, err)
 
-	go s.runSingleReport(req)
+	go s.runSingleReport(imageQueue, mockReportGen, req)
 	<-started
 
 	// Report is not in queue (it's running), so CancelReportRequest should cancel the running context
@@ -268,7 +221,7 @@ func TestCancelReportRequestReturnsFalseForUnknownReport(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, nil, cronScheduler, nil)
 
 	cancelled, err := s.CancelReportRequest(context.Background(), "nonexistent-id")
 	assert.NoError(t, err)
@@ -337,10 +290,10 @@ func TestQueuePendingReports(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, nil, cronScheduler, nil)
 	s.queuePendingReports()
 
-	assert.Equal(t, 2, s.reportRequestsQueue.Len())
+	assert.Equal(t, 2, s.queues[0].queue.Len())
 }
 
 func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {
@@ -351,7 +304,8 @@ func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {
 	cronScheduler.Start()
 	defer cronScheduler.Stop()
 
-	s := newSchedulerImpl(nil, mockSnapshotStore, nil, nil, nil, nil, cronScheduler, nil)
+	s := newSchedulerImpl(nil, mockSnapshotStore, nil, nil, nil, nil, nil, cronScheduler, nil)
+	imageQueue := s.queues[0].queue
 
 	req := &reportGen.ReportRequest{
 		ReportSnapshot: &storage.ReportSnapshot{
@@ -363,7 +317,7 @@ func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {
 			},
 		},
 	}
-	s.reportRequestsQueue.PushBack(req)
+	imageQueue.Enqueue(req)
 
 	mockSnapshotStore.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, snap *storage.ReportSnapshot) error {
@@ -376,5 +330,5 @@ func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {
 	cancelled, err := s.CancelReportRequest(context.Background(), "waiting-report-id")
 	assert.NoError(t, err)
 	assert.True(t, cancelled)
-	assert.Equal(t, 0, s.reportRequestsQueue.Len())
+	assert.Equal(t, 0, imageQueue.Len())
 }

--- a/central/reports/scheduler/v2/singleton.go
+++ b/central/reports/scheduler/v2/singleton.go
@@ -24,6 +24,7 @@ func initialize() {
 		collectionDatastore,
 		notifierDS.Singleton(),
 		reportGen.Singleton(),
+		nil,
 		validation.Singleton(),
 	)
 }

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -173,6 +173,31 @@ func (q *Queue[T]) Push(item T) {
 	}
 }
 
+// PullWithPred removes and returns the first element for which pred returns
+// true, scanning front-to-back. Returns the removed item and true, or the nil
+// value of T and false if no element matched.
+func (q *Queue[T]) PullWithPred(pred func(T) bool) (T, bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	for e := q.queue.Front(); e != nil; e = e.Next() {
+		item := e.Value.(T)
+		if pred(item) {
+			q.queue.Remove(e)
+			if q.queue.Len() == 0 {
+				q.notEmptySignal.Reset()
+			}
+			if q.counterMetric != nil {
+				q.counterMetric.WithLabelValues(metrics.Remove.String()).Inc()
+			}
+			return item, true
+		}
+	}
+
+	var nilT T
+	return nilT, false
+}
+
 // Len returns the number of elements in the queue.
 func (q *Queue[T]) Len() int {
 	q.mutex.Lock()

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -41,6 +41,39 @@ func TestQueue(t *testing.T) {
 	assert.Nil(t, q.PullBlocking(context.Background()))
 }
 
+func TestPullWithPred(t *testing.T) {
+	q := NewQueue[int]()
+	q.Push(1)
+	q.Push(2)
+	q.Push(3)
+	q.Push(4)
+
+	item, ok := q.PullWithPred(func(v int) bool { return v%2 == 0 })
+	assert.True(t, ok)
+	assert.Equal(t, 2, item)
+	assert.Equal(t, 3, q.Len())
+
+	item, ok = q.PullWithPred(func(v int) bool { return v > 3 })
+	assert.True(t, ok)
+	assert.Equal(t, 4, item)
+	assert.Equal(t, 2, q.Len())
+
+	_, ok = q.PullWithPred(func(v int) bool { return v > 100 })
+	assert.False(t, ok)
+	assert.Equal(t, 2, q.Len())
+
+	// Remaining items are 1, 3
+	assert.Equal(t, 1, q.Pull())
+	assert.Equal(t, 3, q.Pull())
+	assert.Equal(t, 0, q.Len())
+}
+
+func TestPullWithPredEmptyQueue(t *testing.T) {
+	q := NewQueue[int]()
+	_, ok := q.PullWithPred(func(v int) bool { return true })
+	assert.False(t, ok)
+}
+
 func TestQueueSeq(t *testing.T) {
 	t.Run("Basic Iteration", func(t *testing.T) {
 		q := NewQueue[int]()


### PR DESCRIPTION
## Description

Refactor the report scheduler to support multiple report job queues, enabling node CVE reports alongside image CVE reports.

**Design:**
- Extract queue operations into a reusable `ReportQueue` type (`reportqueue` package) with its own mutex, running-config tracking, and cancel function management.
- Single scheduler instance holds a slice of queue-generator bindings. Each binding pairs a `ReportQueue` with its `ReportGenerator` (e.g., image CVE queue + image report generator, node CVE queue + node report generator).
- Shared concurrency semaphore caps total concurrent report workers across all queues.
- Round-robin job selection (`nextQueueIdx`) ensures fairness between queues.
- Single shared `readyForReports` signal avoids stale-channel and starvation issues that per-queue signals would introduce.
- Node queue creation is gated behind the `NodeVulnerabilityReports` feature flag.
- `doesUserHaveViewBasedPendingReport` and `doesUserHavePendingReport` now filter by `ReportType` so pending image reports do not block node report submissions (and vice versa).
- `validateAndPersistSnapshot` uses `ReportRequestType` checks instead of filter-nil checks, which works for both image and node reports.

**Follow-up:** The next PR will implement and wire the node report generator into the scheduler via the `nodeReportGenerator` parameter (currently `nil`).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added unit tests for the new `ReportQueue` type and updated existing scheduler tests for the new constructor and queue API.
- Manually tested by running image CVE reports and verifying they execute correctly with the refactored scheduler.