### PR TITLE
fix: delete administration events on integration deletion ROX-29789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-34804: The machine access configuration for `config-controller` now validates the audience (`aud` claim) of the service account token. The expected audience is `central.stackrox.io`. When users have added their own role bindings to this machine access configuration, the audience check is not enforced by default to keep backwards compatibility. It is recommended to set the expected audience to `central.stackrox.io` after ensuring that all exchange tokens are being created with this audience claim.
 
 - ROX-34535: Fixes an issue where if ScannerV2 is disabled or unavailable on initial startup the central deployment leaks GRPC connections until the scanner becomes available.
+- ROX-29789: Deleting an image integration now also removes associated administration events so stale errors no longer remain on the system health dashboard.
 - ROX-36509: Improved Central memory efficiency by optimizing process filter data structures in high-cardinality scenarios. The `ROX_PROCESS_FILTER_FAN_OUT_LEVELS` environment variable now accepts values up to 255; higher values are automatically clamped with a warning.
 
 ## [4.11.0]

--- a/central/administration/events/datastore/datastore.go
+++ b/central/administration/events/datastore/datastore.go
@@ -26,6 +26,10 @@ type DataStore interface {
 	CountEvents(ctx context.Context, query *v1.Query) (int, error)
 	GetEvent(ctx context.Context, id string) (*storage.AdministrationEvent, error)
 	ListEvents(ctx context.Context, query *v1.Query) ([]*storage.AdministrationEvent, error)
+	// DeleteEventsForResource deletes events associated with the given resource ID,
+	// including events still held in the write buffer. An empty resourceID is a no-op
+	// and returns nil without deleting anything.
+	DeleteEventsForResource(ctx context.Context, resourceID string) error
 }
 
 func newDataStore(storage store.Store, writer writer.Writer) DataStore {

--- a/central/administration/events/datastore/datastore_impl.go
+++ b/central/administration/events/datastore/datastore_impl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
 )
 
 var (
@@ -70,6 +71,36 @@ func (ds *datastoreImpl) Flush(ctx context.Context) error {
 	err := ds.writer.Flush(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to flush administration events")
+	}
+	return nil
+}
+
+func (ds *datastoreImpl) DeleteEventsForResource(ctx context.Context, resourceID string) error {
+	if resourceID == "" {
+		return nil
+	}
+	if err := sac.VerifyAuthzOK(eventSAC.WriteAllowed(ctx)); err != nil {
+		return err
+	}
+
+	// Drop matching buffered events first so a later Flush cannot reinsert them.
+	ds.writer.DropForResource(resourceID)
+
+	var ids []string
+	err := ds.store.GetByQueryFn(ctx, search.EmptyQuery(), func(event *storage.AdministrationEvent) error {
+		if event.GetResource().GetId() == resourceID {
+			ids = append(ids, event.GetId())
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list administration events for resource %q", resourceID)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	if err := ds.store.DeleteMany(ctx, ids); err != nil {
+		return errors.Wrapf(err, "failed to delete administration events for resource %q", resourceID)
 	}
 	return nil
 }

--- a/central/administration/events/datastore/datastore_impl_postgres_test.go
+++ b/central/administration/events/datastore/datastore_impl_postgres_test.go
@@ -167,6 +167,73 @@ func (s *datastorePostgresTestSuite) TestGetEvent() {
 	s.assertEventsEqual(administrationEvent, event)
 }
 
+func (s *datastorePostgresTestSuite) TestDeleteEventsForResource() {
+	s.NoError(s.datastore.DeleteEventsForResource(s.writeCtx, ""))
+
+	keep := fixtures.GetAdministrationEvent()
+	keep.ResourceID = "keep-id"
+	remove := fixtures.GetAdministrationEvent()
+	remove.ResourceID = "remove-id"
+	remove.Message = "other message"
+
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, keep))
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, remove))
+	s.Require().NoError(s.datastore.Flush(s.writeCtx))
+
+	s.Require().NoError(s.datastore.DeleteEventsForResource(s.writeCtx, "remove-id"))
+
+	_, err := s.datastore.GetEvent(s.readCtx, events.GenerateEventID(remove))
+	s.ErrorIs(err, errox.NotFound)
+
+	got, err := s.datastore.GetEvent(s.readCtx, events.GenerateEventID(keep))
+	s.NoError(err)
+	s.assertEventsEqual(keep, got)
+}
+
+func (s *datastorePostgresTestSuite) TestDeleteEventsForResource_DropsBufferedEvents() {
+	keep := fixtures.GetAdministrationEvent()
+	keep.ResourceID = "keep-id"
+	remove := fixtures.GetAdministrationEvent()
+	remove.ResourceID = "remove-id"
+	remove.Message = "other message"
+
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, keep))
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, remove))
+
+	s.Require().NoError(s.datastore.DeleteEventsForResource(s.writeCtx, "remove-id"))
+	s.Require().NoError(s.datastore.Flush(s.writeCtx))
+
+	_, err := s.datastore.GetEvent(s.readCtx, events.GenerateEventID(remove))
+	s.ErrorIs(err, errox.NotFound)
+
+	got, err := s.datastore.GetEvent(s.readCtx, events.GenerateEventID(keep))
+	s.NoError(err)
+	s.assertEventsEqual(keep, got)
+}
+
+func (s *datastorePostgresTestSuite) TestDeleteEventsForResource_DropsPersistedAndBufferedEvents() {
+	remove := fixtures.GetAdministrationEvent()
+	remove.ResourceID = "remove-id"
+	keep := fixtures.GetAdministrationEvent()
+	keep.ResourceID = "keep-id"
+
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, remove))
+	s.Require().NoError(s.datastore.Flush(s.writeCtx))
+
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, remove))
+	s.Require().NoError(s.datastore.AddEvent(s.writeCtx, keep))
+
+	s.Require().NoError(s.datastore.DeleteEventsForResource(s.writeCtx, "remove-id"))
+	s.Require().NoError(s.datastore.Flush(s.writeCtx))
+
+	_, err := s.datastore.GetEvent(s.readCtx, events.GenerateEventID(remove))
+	s.ErrorIs(err, errox.NotFound)
+
+	got, err := s.datastore.GetEvent(s.readCtx, events.GenerateEventID(keep))
+	s.NoError(err)
+	s.assertEventsEqual(keep, got)
+}
+
 func (s *datastorePostgresTestSuite) TestCountEvents() {
 	count, err := s.datastore.CountEvents(s.readCtx, &v1.Query{})
 	s.NoError(err)

--- a/central/administration/events/datastore/internal/writer/mocks/writer.go
+++ b/central/administration/events/datastore/internal/writer/mocks/writer.go
@@ -41,6 +41,18 @@ func (m *MockWriter) EXPECT() *MockWriterMockRecorder {
 	return m.recorder
 }
 
+// DropForResource mocks base method.
+func (m *MockWriter) DropForResource(resourceID string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DropForResource", resourceID)
+}
+
+// DropForResource indicates an expected call of DropForResource.
+func (mr *MockWriterMockRecorder) DropForResource(resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropForResource", reflect.TypeOf((*MockWriter)(nil).DropForResource), resourceID)
+}
+
 // Flush mocks base method.
 func (m *MockWriter) Flush(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/central/administration/events/datastore/internal/writer/writer.go
+++ b/central/administration/events/datastore/internal/writer/writer.go
@@ -26,6 +26,9 @@ import (
 type Writer interface {
 	Upsert(ctx context.Context, obj *events.AdministrationEvent) error
 	Flush(ctx context.Context) error
+	// DropForResource removes buffered events for the given resource ID so a
+	// later Flush cannot persist them after the resource has been deleted.
+	DropForResource(resourceID string)
 }
 
 // New returns a new writer instance.

--- a/central/administration/events/datastore/internal/writer/writer_impl.go
+++ b/central/administration/events/datastore/internal/writer/writer_impl.go
@@ -122,6 +122,19 @@ func (c *writerImpl) Flush(ctx context.Context) error {
 	return c.flushNoLock(ctx)
 }
 
+func (c *writerImpl) DropForResource(resourceID string) {
+	if resourceID == "" {
+		return
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	for id, event := range c.buffer {
+		if event.GetResource().GetId() == resourceID {
+			delete(c.buffer, id)
+		}
+	}
+}
+
 // Modifies `updated` with the values of the base event and returns the merged event.
 func mergeEvents(updated *storage.AdministrationEvent, base *storage.AdministrationEvent) *storage.AdministrationEvent {
 	if base == nil {

--- a/central/administration/events/datastore/mocks/datastore.go
+++ b/central/administration/events/datastore/mocks/datastore.go
@@ -72,6 +72,20 @@ func (mr *MockDataStoreMockRecorder) CountEvents(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountEvents", reflect.TypeOf((*MockDataStore)(nil).CountEvents), ctx, query)
 }
 
+// DeleteEventsForResource mocks base method.
+func (m *MockDataStore) DeleteEventsForResource(ctx context.Context, resourceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEventsForResource", ctx, resourceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEventsForResource indicates an expected call of DeleteEventsForResource.
+func (mr *MockDataStoreMockRecorder) DeleteEventsForResource(ctx, resourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEventsForResource", reflect.TypeOf((*MockDataStore)(nil).DeleteEventsForResource), ctx, resourceID)
+}
+
 // Flush mocks base method.
 func (m *MockDataStore) Flush(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/central/imageintegration/datastore/datastore.go
+++ b/central/imageintegration/datastore/datastore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	adminEventsDS "github.com/stackrox/rox/central/administration/events/datastore"
 	"github.com/stackrox/rox/central/imageintegration/store"
 	pgStore "github.com/stackrox/rox/central/imageintegration/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -33,23 +34,20 @@ type DataStore interface {
 }
 
 // New returns an instance of DataStore.
-func New(imageIntegrationStorage store.Store) DataStore {
-	ds := &datastoreImpl{
-		storage: imageIntegrationStorage,
+func New(imageIntegrationStorage store.Store, adminEvents adminEventsDS.DataStore) DataStore {
+	return &datastoreImpl{
+		storage:     imageIntegrationStorage,
+		adminEvents: adminEvents,
 	}
-	return ds
 }
 
 // NewForTestOnly returns an instance of DataStore only for tests.
-func NewForTestOnly(imageIntegrationStorage store.Store) DataStore {
-	ds := &datastoreImpl{
-		storage: imageIntegrationStorage,
-	}
-	return ds
+func NewForTestOnly(imageIntegrationStorage store.Store, adminEvents adminEventsDS.DataStore) DataStore {
+	return New(imageIntegrationStorage, adminEvents)
 }
 
 // GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
-func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
+func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) DataStore {
 	store := pgStore.New(pool)
-	return New(store)
+	return New(store, adminEventsDS.GetTestPostgresDataStore(t, pool))
 }

--- a/central/imageintegration/datastore/datastore_impl.go
+++ b/central/imageintegration/datastore/datastore_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	adminEventsDS "github.com/stackrox/rox/central/administration/events/datastore"
 	"github.com/stackrox/rox/central/imageintegration/store"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -21,7 +22,8 @@ var (
 )
 
 type datastoreImpl struct {
-	storage store.Store
+	storage     store.Store
+	adminEvents adminEventsDS.DataStore
 }
 
 func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
@@ -109,7 +111,20 @@ func (ds *datastoreImpl) RemoveImageIntegration(ctx context.Context, id string) 
 	} else if !ok {
 		return sac.ErrResourceAccessDenied
 	}
-	return ds.storage.Delete(ctx, id)
+	if err := ds.storage.Delete(ctx, id); err != nil {
+		return err
+	}
+
+	adminCtx := sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration),
+		),
+	)
+	if err := ds.adminEvents.DeleteEventsForResource(adminCtx, id); err != nil {
+		log.Errorf("Failed to delete administration events for image integration %s: %v", id, err)
+	}
+	return nil
 }
 
 // SearchImageIntegrations

--- a/central/imageintegration/datastore/datastore_impl_test.go
+++ b/central/imageintegration/datastore/datastore_impl_test.go
@@ -6,10 +6,14 @@ import (
 	"context"
 	"testing"
 
+	adminEventsDS "github.com/stackrox/rox/central/administration/events/datastore"
 	"github.com/stackrox/rox/central/imageintegration/store"
 	postgresStore "github.com/stackrox/rox/central/imageintegration/store/postgres"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	adminEvents "github.com/stackrox/rox/pkg/administration/events"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -35,8 +39,10 @@ type ImageIntegrationDataStoreTestSuite struct {
 	hasNoneCtx  context.Context
 	hasReadCtx  context.Context
 	hasWriteCtx context.Context
+	adminCtx    context.Context
 
-	datastore DataStore
+	datastore   DataStore
+	adminEvents adminEventsDS.DataStore
 
 	testDB *pgtest.TestPostgres
 	store  store.Store
@@ -52,14 +58,19 @@ func (suite *ImageIntegrationDataStoreTestSuite) SetupTest() {
 		sac.AllowFixedScopes(
 			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.Integration)))
+	suite.adminCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Administration)))
 
 	suite.testDB = pgtest.ForT(suite.T())
 	suite.NotNil(suite.testDB)
 
 	suite.store = postgresStore.New(suite.testDB.DB)
 
+	suite.adminEvents = adminEventsDS.GetTestPostgresDataStore(suite.T(), suite.testDB.DB)
 	// test formattedSearcher
-	suite.datastore = NewForTestOnly(suite.store)
+	suite.datastore = NewForTestOnly(suite.store, suite.adminEvents)
 }
 
 func (suite *ImageIntegrationDataStoreTestSuite) TestIntegrationsPersistence() {
@@ -279,6 +290,53 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestAllowsRemove() {
 	suite.NoError(err, "expected no error trying to write with permissions")
 }
 
+func (suite *ImageIntegrationDataStoreTestSuite) TestRemoveImageIntegrationClearsEvents() {
+	integration := suite.storeIntegration("events cleanup")
+
+	keepEvent := &storage.AdministrationEvent{
+		Id: uuid.NewV4().String(),
+		Resource: &storage.AdministrationEvent_Resource{
+			Id: uuid.NewV4().String(),
+		},
+	}
+	event := &storage.AdministrationEvent{
+		Id: uuid.NewV4().String(),
+		Resource: &storage.AdministrationEvent_Resource{
+			Id: integration.GetId(),
+		},
+	}
+	err := adminEventsDS.UpsertTestEvents(suite.adminCtx, suite.T(), suite.adminEvents, keepEvent, event)
+	suite.NoError(err)
+
+	err = suite.datastore.RemoveImageIntegration(suite.hasWriteCtx, integration.GetId())
+	suite.NoError(err)
+
+	_, exists, err := suite.datastore.GetImageIntegration(suite.hasWriteCtx, integration.GetId())
+	suite.NoError(err)
+	suite.False(exists)
+
+	_, err = suite.adminEvents.GetEvent(suite.adminCtx, event.GetId())
+	suite.ErrorIs(err, errox.NotFound)
+
+	gotKeep, err := suite.adminEvents.GetEvent(suite.adminCtx, keepEvent.GetId())
+	suite.NoError(err)
+	suite.Equal(keepEvent.GetId(), gotKeep.GetId())
+}
+
+func (suite *ImageIntegrationDataStoreTestSuite) TestRemoveImageIntegrationClearsBufferedEvents() {
+	integration := suite.storeIntegration("buffered events cleanup")
+
+	event := fixtures.GetAdministrationEvent()
+	event.ResourceID = integration.GetId()
+	suite.Require().NoError(suite.adminEvents.AddEvent(suite.adminCtx, event))
+
+	suite.Require().NoError(suite.datastore.RemoveImageIntegration(suite.hasWriteCtx, integration.GetId()))
+	suite.Require().NoError(suite.adminEvents.Flush(suite.adminCtx))
+
+	_, err := suite.adminEvents.GetEvent(suite.adminCtx, adminEvents.GenerateEventID(event))
+	suite.ErrorIs(err, errox.NotFound)
+}
+
 func (suite *ImageIntegrationDataStoreTestSuite) TestSearch() {
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 	_, err := suite.datastore.Search(ctx, nil)
@@ -308,7 +366,7 @@ func (suite *ImageIntegrationDataStoreTestSuite) TestDataStoreSearch() {
 	}
 
 	// Create a new datastore since the one in suite uses mocks
-	ds := New(suite.store)
+	ds := New(suite.store, suite.adminEvents)
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 	_, err := ds.AddImageIntegration(ctx, ii)

--- a/central/imageintegration/datastore/singleton.go
+++ b/central/imageintegration/datastore/singleton.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	adminEventsDS "github.com/stackrox/rox/central/administration/events/datastore"
 	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/imageintegration/store"
 	pgStore "github.com/stackrox/rox/central/imageintegration/store/postgres"
@@ -218,7 +219,7 @@ func initialize() {
 	storage := pgStore.New(globaldb.GetPostgres())
 
 	initializeIntegrations(storage)
-	dataStore = New(storage)
+	dataStore = New(storage, adminEventsDS.Singleton())
 }
 
 // Singleton provides the interface for non-service external interaction.


### PR DESCRIPTION
## Description

When an image integration is deleted, associated administration events were left in the database and still appeared on the system health dashboard.

This change adds resource-scoped deletion for administration events and calls it from image-integration removal so related events (including buffered ones) are cleaned up with the integration. Unrelated events are left untouched.

Resolves ROX-29789.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added/updated unit tests covering deletion of administration events for a specific resource when an image integration is removed.
- Verified unrelated administration events for other resources are preserved.
- Confirmed buffered (not yet flushed) events for the deleted resource are dropped so a later flush cannot recreate them.
- Ran the relevant datastore unit tests locally for administration events and image integration removal.