### PR TITLE
ROX-36389: ensure vulnerability state observed in console plugin

### DIFF
--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1263,8 +1263,9 @@ func standardizeImages(images ...*storage.Image) {
 	}
 }
 
-// TestImageCVECountFiltering confirms the filter added in ROX-36389 doesn't drop
-// any CVEs from the Workload CVEs CVE tab.
+// TestImageCVECountFiltering verifies that "Image CVE Count > 0" doesn't drop any
+// CVEs from ImageCVEView results when the underlying data is healthy (see ROX-36389
+// for background on this field, including a case where it isn't).
 func (s *ImageCVEViewTestSuite) TestImageCVECountFiltering() {
 	if !features.FlattenImageData.Enabled() {
 		s.T().Skip("Image CVE Count only maps to images_v2.ScanStats.CveCount when FlattenImageData is enabled")

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1311,7 +1311,7 @@ func (s *ImageCVEViewTestSuite) TestImageCVECountFiltering() {
 		for _, r := range results {
 			ids = append(ids, r.GetCVE())
 		}
-		sort.Strings(ids)
+		slices.Sort(ids)
 		return ids
 	}
 

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -1263,6 +1263,62 @@ func standardizeImages(images ...*storage.Image) {
 	}
 }
 
+// TestImageCVECountFiltering confirms the filter added in ROX-36389 doesn't drop
+// any CVEs from the Workload CVEs CVE tab.
+func (s *ImageCVEViewTestSuite) TestImageCVECountFiltering() {
+	if !features.FlattenImageData.Enabled() {
+		s.T().Skip("Image CVE Count only maps to images_v2.ScanStats.CveCount when FlattenImageData is enabled")
+	}
+
+	ctx := s.suiteCtx
+
+	imageV2Store := imageV2DS.GetTestPostgresDataStore(s.T(), s.testDB.DB)
+	zeroCveImage := &storage.ImageV2{
+		Id:     imageUtils.NewImageV2ID(&storage.ImageName{Registry: "reg-zero", FullName: "reg-zero"}, "sha-zero"),
+		Digest: "sha-zero",
+		Name:   &storage.ImageName{Registry: "reg-zero", FullName: "reg-zero"},
+		Scan: &storage.ImageScan{
+			OperatingSystem: "zero-os",
+			Components:      []*storage.EmbeddedImageScanComponent{},
+		},
+	}
+	s.Require().NoError(imageV2Store.UpsertImage(ctx, zeroCveImage))
+	actualZeroCve, found, err := imageV2Store.GetImage(ctx, zeroCveImage.GetId())
+	s.Require().NoError(err)
+	s.Require().True(found)
+	s.Require().Equal(int32(0), actualZeroCve.GetScanStats().GetCveCount())
+
+	noFilterQuery := search.EmptyQuery()
+	filteredQuery := search.NewQueryBuilder().AddStrings(search.ImageCVECount, ">0").ProtoQuery()
+
+	noFilterCount, err := s.cveView.Count(ctx, noFilterQuery)
+	s.Require().NoError(err)
+	filteredCount, err := s.cveView.Count(ctx, filteredQuery)
+	s.Require().NoError(err)
+
+	s.T().Logf("ImageCVEView.Count() with no filter: %d; with 'Image CVE Count > 0': %d", noFilterCount, filteredCount)
+
+	s.Equal(noFilterCount, filteredCount,
+		"expected 'Image CVE Count > 0' to be a no-op on the CVE count")
+
+	noFilterResults, err := s.cveView.Get(ctx, noFilterQuery, views.ReadOptions{})
+	s.Require().NoError(err)
+	filteredResults, err := s.cveView.Get(ctx, filteredQuery, views.ReadOptions{})
+	s.Require().NoError(err)
+
+	getCVESet := func(results []CveCore) []string {
+		ids := make([]string, 0, len(results))
+		for _, r := range results {
+			ids = append(ids, r.GetCVE())
+		}
+		sort.Strings(ids)
+		return ids
+	}
+
+	s.Equal(getCVESet(noFilterResults), getCVESet(filteredResults),
+		"expected the exact same set of CVEs to be returned with and without the 'Image CVE Count > 0' filter")
+}
+
 func TestImageCVEUnknownSeverity(t *testing.T) {
 	ctx := sac.WithAllAccess(context.Background())
 	testDB := pgtest.ForT(t)

--- a/central/views/images/view_test.go
+++ b/central/views/images/view_test.go
@@ -506,8 +506,8 @@ func (s *ImageViewTestSuite) TestGetImagesCore() {
 	}
 }
 
-// TestImageCVECountFiltering covers the filter added in ROX-36389 to exclude
-// zero-CVE images from the Workload CVEs Image tab.
+// TestImageCVECountFiltering verifies that "Image CVE Count > 0" excludes zero-CVE
+// images from ImageView results (see ROX-36389 for background on this field).
 func (s *ImageViewTestSuite) TestImageCVECountFiltering() {
 	ctx := sac.WithAllAccess(context.Background())
 

--- a/central/views/images/view_test.go
+++ b/central/views/images/view_test.go
@@ -85,6 +85,8 @@ type ImageViewTestSuite struct {
 	testImagesMap   map[string]*storage.Image
 	testImagesV2Map map[string]*storage.ImageV2
 	scopeToImageIDs map[string]set.StringSet
+	// zeroCveImageID is used by TestImageCVECountFiltering.
+	zeroCveImageID string
 }
 
 func (s *ImageViewTestSuite) SetupSuite() {
@@ -113,6 +115,15 @@ func (s *ImageViewTestSuite) SetupSuite() {
 			s.Require().True(found)
 			s.testImagesV2Map[actual.GetId()] = image
 		}
+
+		// For TestImageCVECountFiltering.
+		zeroCveImageV2 := utils.ConvertToV2(zeroCveTestImage())
+		s.Require().NoError(imageStore.UpsertImage(ctx, zeroCveImageV2))
+		actualZeroCve, found, err := imageStore.GetImage(ctx, zeroCveImageV2.GetId())
+		s.Require().NoError(err)
+		s.Require().True(found)
+		s.zeroCveImageID = actualZeroCve.GetId()
+		s.testImagesV2Map[s.zeroCveImageID] = zeroCveImageV2
 
 		s.imagesView = NewImageView(s.testDB.DB)
 
@@ -166,6 +177,15 @@ func (s *ImageViewTestSuite) SetupSuite() {
 			s.Require().True(found)
 			s.testImagesMap[actual.GetId()] = actual
 		}
+
+		// For TestImageCVECountFiltering.
+		zeroCveImage := zeroCveTestImage()
+		s.Require().NoError(imageStore.UpsertImage(ctx, zeroCveImage))
+		actualZeroCve, found, err := imageStore.GetImage(ctx, zeroCveImage.GetId())
+		s.Require().NoError(err)
+		s.Require().True(found)
+		s.zeroCveImageID = actualZeroCve.GetId()
+		s.testImagesMap[s.zeroCveImageID] = actualZeroCve
 
 		s.imagesView = NewImageView(s.testDB.DB)
 
@@ -484,6 +504,24 @@ func (s *ImageViewTestSuite) TestGetImagesCore() {
 			}
 		})
 	}
+}
+
+// TestImageCVECountFiltering covers the filter added in ROX-36389 to exclude
+// zero-CVE images from the Workload CVEs Image tab.
+func (s *ImageViewTestSuite) TestImageCVECountFiltering() {
+	ctx := sac.WithAllAccess(context.Background())
+
+	query := search.NewQueryBuilder().AddStrings(search.ImageCVECount, ">0").ProtoQuery()
+	cores, err := s.imagesView.Get(ctx, query)
+	s.Require().NoError(err)
+
+	ids := make([]string, 0, len(cores))
+	for _, c := range cores {
+		ids = append(ids, c.GetImageID())
+	}
+
+	s.NotContains(ids, s.zeroCveImageID, "expected the 0-CVE image to be excluded by 'Image CVE Count > 0'")
+	s.NotEmpty(ids, "expected images with CVEs to still be returned")
 }
 
 func (s *ImageViewTestSuite) compileExpected(filter *filterImpl, less lessFunc, hasVulnFilters, hasSortBySeverityCounts bool) []ImageCore {
@@ -813,4 +851,21 @@ func testImages() []*storage.Image {
 		},
 	}
 	return []*storage.Image{img1, img2, img3, img4}
+}
+
+func zeroCveTestImage() *storage.Image {
+	return &storage.Image{
+		Id: "sha5",
+		Name: &storage.ImageName{
+			Registry: "reg5",
+			Remote:   "img5",
+			Tag:      "tag5",
+			FullName: "reg5/img5:tag5",
+		},
+		RiskScore: 1,
+		Scan: &storage.ImageScan{
+			OperatingSystem: "os5",
+			Components:      []*storage.EmbeddedImageScanComponent{},
+		},
+	}
 }

--- a/ui/apps/platform/src/ConsolePlugin/hooks/useDefaultWorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/ConsolePlugin/hooks/useDefaultWorkloadCveViewContext.ts
@@ -21,7 +21,7 @@ export function useDefaultWorkloadCveViewContext(): WorkloadCveView {
         const querySearchFilter = parseQuerySearchFilter(searchFilter);
         return {
             baseSearchFilter: {
-                'Image CVE Count': ['>0'],
+                'Vulnerability State': ['OBSERVED'],
                 Namespace:
                     activeNamespace === ALL_NAMESPACES_KEY
                         ? querySearchFilter.Namespace

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -169,15 +169,13 @@ function WorkloadCvesOverviewPage() {
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
     // If the user is viewing observed CVEs, we need to scope the query based on
-    // the selected vulnerability state, and exclude images/deployments with 0 CVEs
-    // (see ROX-36389). If the user is viewing _without_ CVEs, we need to scope the
-    // query to only show images/deployments with 0 CVEs.
+    // the selected vulnerability state. If the user is viewing _without_ CVEs, we
+    // need to scope the query to only show images/deployments with 0 CVEs.
     const workloadCvesScopedSearchFilter = isViewingWithCves
         ? {
               ...baseSearchFilter,
               ...querySearchFilter,
               'Vulnerability State': [currentVulnerabilityState],
-              'Image CVE Count': ['>0'],
           }
         : {
               ...baseSearchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -169,13 +169,15 @@ function WorkloadCvesOverviewPage() {
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
     // If the user is viewing observed CVEs, we need to scope the query based on
-    // the selected vulnerability state. If the user is viewing _without_ CVEs, we
-    // need to scope the query to only show images/deployments with 0 CVEs.
+    // the selected vulnerability state, and exclude images/deployments with 0 CVEs
+    // (see ROX-36389). If the user is viewing _without_ CVEs, we need to scope the
+    // query to only show images/deployments with 0 CVEs.
     const workloadCvesScopedSearchFilter = isViewingWithCves
         ? {
               ...baseSearchFilter,
               ...querySearchFilter,
               'Vulnerability State': [currentVulnerabilityState],
+              'Image CVE Count': ['>0'],
           }
         : {
               ...baseSearchFilter,


### PR DESCRIPTION
## Description

A discrepancy between the Openshift Console plugin and ACS UI page identified a difference between the CVE counts in each page even when the filters were the same (see ticket screenshots as an example.)

The console plugin sets Image CVE Count >0 for this query, while the UI does not (it only sets Image CVE Count = 0 for another view). Due to issues with stale scan stats (fixed in #22422) this can over-filter vulnerability data. Removing this filter and relying on Vulnerability State: OBSERVED ensures that all appropriate entities are returned while also fixing the discrepancy between the UI and the console.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manually confirmed on a cluster demonstrating this discrepancy, verifying CVE counts match with the addition of the query field.

Additional unit tests cover this cased.
