### PR TITLE
experiment: Spread VMScraper arrivals only with jitter

### DIFF
--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -223,6 +223,22 @@ var PullTrackedVMs = prometheus.NewGauge(
 	},
 )
 
+// PullForwardInterarrivalSeconds is the Sensor-level gap between consecutive
+// successful forwards to Central (across all VMs). A burst of near-zero gaps
+// means many reports left Sensor in a short window. The first forward after
+// Sensor start does not observe a sample.
+var PullForwardInterarrivalSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_forward_interarrival_seconds",
+		Help: "Seconds between consecutive successful VM index-report forwards " +
+			"from this Sensor to Central. Healthy jitter produces spread gaps; " +
+			"a burst of near-zero gaps signals a clump hitting Central at once.",
+		Buckets: prometheus.ExponentialBuckets(0.01, 2, 18), // 10ms to ~22min
+	},
+)
+
 func init() {
 	prometheus.MustRegister(
 		IndexReportsSent,
@@ -240,5 +256,6 @@ func init() {
 		PullRequestsTotal,
 		PullTicksTotal,
 		PullTrackedVMs,
+		PullForwardInterarrivalSeconds,
 	)
 }

--- a/sensor/common/virtualmachine/vmscraper/schedule.go
+++ b/sensor/common/virtualmachine/vmscraper/schedule.go
@@ -10,6 +10,16 @@ const (
 	maxReconcile   = 5 * time.Minute
 	// defaultTickInterval is the scraper scheduler step. Independent of retry-backoff.
 	defaultTickInterval = 10 * time.Second
+
+	// catchUpBound caps the first-wave spread window so a Sensor restart
+	// does not take forever to reach every VM at long poll intervals.
+	catchUpBound = 20 * time.Minute
+
+	// defaultSpreadFraction is the fraction of pollInterval used as a
+	// one-sided random band when returning to cadence: next = now +
+	// poll + U(0, fraction*poll). Prevents VMs from re-aligning on
+	// the same wall-clock minute after each successful scrape.
+	defaultSpreadFraction = 2.0 / 3
 )
 
 func backoffCap(pollInterval time.Duration) time.Duration {
@@ -27,4 +37,31 @@ func nextBackoff(current, pollInterval, initial time.Duration) time.Duration {
 		return min(initial, limit)
 	}
 	return min(current*2, limit)
+}
+
+// catchUpWindow is how long the first wave of never-scraped VMs is spread
+// over: min(catchUpBound, pollInterval/3).
+func catchUpWindow(pollInterval time.Duration) time.Duration {
+	if pollInterval <= 0 {
+		return 0
+	}
+	return min(catchUpBound, pollInterval/3)
+}
+
+// steadySpreadWidth returns the post-poll random band width:
+// spreadFraction × pollInterval.
+func steadySpreadWidth(pollInterval time.Duration) time.Duration {
+	if pollInterval <= 0 {
+		return 0
+	}
+	return time.Duration(float64(pollInterval) * defaultSpreadFraction)
+}
+
+// randOffset draws a delay in [0, width] from a unit sample in [0, 1].
+func randOffset(width time.Duration, unit float64) time.Duration {
+	if width <= 0 {
+		return 0
+	}
+	unit = max(0, min(1, unit))
+	return time.Duration(float64(width) * unit)
 }

--- a/sensor/common/virtualmachine/vmscraper/schedule_test.go
+++ b/sensor/common/virtualmachine/vmscraper/schedule_test.go
@@ -64,3 +64,25 @@ func TestReconcilePeriod(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, reconcilePeriod(time.Hour))
 	assert.Equal(t, time.Minute, reconcilePeriod(time.Minute))
 }
+
+func TestCatchUpWindow(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 20*time.Minute, catchUpWindow(time.Hour))
+	assert.Equal(t, 100*time.Second, catchUpWindow(5*time.Minute))
+	assert.Equal(t, time.Duration(0), catchUpWindow(0))
+}
+
+func TestSteadySpreadWidth(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 40*time.Minute, steadySpreadWidth(time.Hour))
+	assert.Equal(t, time.Duration(0), steadySpreadWidth(0))
+}
+
+func TestRandOffset(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, time.Duration(0), randOffset(0, 0.5))
+	assert.Equal(t, 20*time.Minute, randOffset(40*time.Minute, 0.5))
+	assert.Equal(t, time.Duration(0), randOffset(40*time.Minute, 0))
+	assert.Equal(t, 40*time.Minute, randOffset(40*time.Minute, 1))
+	assert.Equal(t, time.Duration(0), randOffset(40*time.Minute, -1))
+}

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -91,10 +91,11 @@ type VMScraper struct {
 	// tests inject a fixed source for determinism.
 	randFloat64 func() float64
 
-	mu            sync.Mutex
-	vmState       map[string]*vmState
-	lastReconcile time.Time
-	inFlight      set.StringSet
+	mu              sync.Mutex
+	vmState         map[string]*vmState
+	lastReconcile   time.Time
+	inFlight        set.StringSet
+	lastForwardTime time.Time // Sensor-level; for forward interarrival metric
 }
 
 type vmState struct {
@@ -439,6 +440,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 
 	newGen := result.Meta.GetReportGeneration()
 	s.commitVMState(key, newGen, result.Meta.GetEpoch())
+	s.observeForwardInterarrival()
 	next := s.scheduleAfterAttempt(key, scrapeOK)
 
 	log.Infof("VMScraper: scrape %q ok outcome=forwarded next=%s", key, next)
@@ -605,6 +607,18 @@ func (s *VMScraper) commitVMState(key string, newGen, newEpoch uint32) {
 		state.lastGeneration = newGen
 		state.lastEpoch = newEpoch
 		state.lastForwardedAt = s.now()
+	})
+}
+
+// observeForwardInterarrival records the Sensor-level gap between successful
+// forwards. The first forward after start does not observe a sample.
+func (s *VMScraper) observeForwardInterarrival() {
+	concurrency.WithLock(&s.mu, func() {
+		now := s.now()
+		if !s.lastForwardTime.IsZero() {
+			metrics.PullForwardInterarrivalSeconds.Observe(now.Sub(s.lastForwardTime).Seconds())
+		}
+		s.lastForwardTime = now
 	})
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/rand"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -86,6 +87,9 @@ type VMScraper struct {
 	stopper               concurrency.Stopper
 	started               atomic.Bool
 	now                   func() time.Time
+	// randFloat64 returns a unit sample in [0, 1] for schedule jitter;
+	// tests inject a fixed source for determinism.
+	randFloat64 func() float64
 
 	mu            sync.Mutex
 	vmState       map[string]*vmState
@@ -123,9 +127,10 @@ func New(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client
 		// so operators get advance notice before reports start actually
 		// being rejected at that limit.
 		warnMaxBytes: env.VirtualMachinesPullMaxResponseSizeKB.IntegerSetting() * 1024 / 2,
-		vmState:      make(map[string]*vmState),
-		inFlight:     set.NewStringSet(),
-		now:          time.Now,
+		vmState:     make(map[string]*vmState),
+		inFlight:    set.NewStringSet(),
+		now:         time.Now,
+		randFloat64: rand.Float64,
 	}
 }
 
@@ -289,13 +294,21 @@ func (s *VMScraper) reconcile() {
 	liveKeys := set.NewStringSet()
 	concurrency.WithLock(&s.mu, func() {
 		now := s.now()
+		catchUp := catchUpWindow(s.interval)
 		for _, vm := range vms {
 			key := vm.Key()
 			liveKeys.Add(key)
 			st, ok := s.vmState[key]
 			if !ok {
-				st = &vmState{nextAttemptAt: now, vmID: vm.ID}
+				// Spread first-wave inserts (new guests, Sensor restart)
+				// over the catch-up window so they don't all fire on
+				// the same tick.
+				st = &vmState{
+					nextAttemptAt: now.Add(randOffset(catchUp, s.randFloat64())),
+					vmID:          vm.ID,
+				}
 				s.vmState[key] = st
+				continue
 			}
 			st.vmID = vm.ID
 		}
@@ -461,10 +474,13 @@ func (s *VMScraper) scheduleAfterAttempt(key string, outcome scrapeOutcome) time
 			st.nextAttemptAt = now.Add(st.backoff)
 			return st.backoff
 		case scrapeOK, scrapeNonRetryable:
-			// Both return to the normal poll cadence without growing backoff.
+			// Return to cadence with a random post-poll offset so VMs
+			// don't re-align on the same wall-clock minute.
 			st.backoff = 0
-			st.nextAttemptAt = now.Add(s.interval)
-			return s.interval
+			offset := randOffset(steadySpreadWidth(s.interval), s.randFloat64())
+			delay := s.interval + offset
+			st.nextAttemptAt = now.Add(delay)
+			return delay
 		default:
 			return 0
 		}

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -765,9 +765,10 @@ func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDia
 		// Half of the 16MiB default pull response-size ceiling — same
 		// derivation New() uses from env.VirtualMachinesPullMaxResponseSizeKB.
 		warnMaxBytes: 8 << 20,
-		vmState:      make(map[string]*vmState),
-		inFlight:     set.NewStringSet(),
-		now:          clock.Now,
+		vmState:     make(map[string]*vmState),
+		inFlight:    set.NewStringSet(),
+		now:         clock.Now,
+		randFloat64: func() float64 { return 0 }, // deterministic: no jitter
 	}, clock
 }
 

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,4 +112,21 @@ func TestVMScraper_NACKDoesNotUseSteadyBand(t *testing.T) {
 	s.handleNACK(string(vm.ID) + ":1")
 	assert.Equal(t, initialBackoff, cachedNextAttemptAt(t, s, "ns1/vm-a").Sub(start),
 		"NACK must use backoff, not interval+offset")
+}
+
+func TestVMScraper_ForwardInterarrivalObservesAfterFirst(t *testing.T) {
+	s, _ := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	before := histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds)
+	s.observeForwardInterarrival()
+	assert.Equal(t, before, histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds),
+		"first forward does not observe a gap")
+	s.observeForwardInterarrival()
+	assert.Equal(t, before+1, histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds))
+}
+
+func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, h.(prometheus.Metric).Write(&m))
+	return m.GetHistogram().GetSampleCount()
 }

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -1,0 +1,112 @@
+package vmscraper
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
+	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sequencedRand returns successive values from seq, cycling the last value.
+// Not goroutine-safe; only use with concurrency=1 (the newTestScraper default).
+func sequencedRand(seq ...float64) func() float64 {
+	i := 0
+	return func() float64 {
+		v := seq[i]
+		if i < len(seq)-1 {
+			i++
+		}
+		return v
+	}
+}
+
+func TestVMScraper_ReconcileSpreadsCatchUpWindow(t *testing.T) {
+	const numVMs = 10
+	vms := make([]*virtualmachine.Info, numVMs)
+	for i := range vms {
+		vms[i] = makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i))
+	}
+	store := &mockStore{vms: vms}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	s.interval = time.Hour
+	// Evenly spaced draws: 0/9, 1/9, ..., 9/9
+	units := make([]float64, numVMs)
+	for i := range units {
+		units[i] = float64(i) / float64(numVMs-1)
+	}
+	s.randFloat64 = sequencedRand(units...)
+
+	s.reconcile()
+
+	catchUp := catchUpWindow(s.interval)
+	now := clock.Now()
+	var earliest, latest time.Time
+	concurrency.WithLock(&s.mu, func() {
+		require.Len(t, s.vmState, numVMs)
+		for _, st := range s.vmState {
+			assert.False(t, st.nextAttemptAt.Before(now))
+			assert.False(t, st.nextAttemptAt.After(now.Add(catchUp)))
+			if earliest.IsZero() || st.nextAttemptAt.Before(earliest) {
+				earliest = st.nextAttemptAt
+			}
+			if latest.IsZero() || st.nextAttemptAt.After(latest) {
+				latest = st.nextAttemptAt
+			}
+		}
+	})
+	assert.Greater(t, latest.Sub(earliest), time.Duration(0),
+		"mass insert must not schedule every VM at exactly now")
+	assert.GreaterOrEqual(t, latest.Sub(earliest), catchUp/2,
+		"draws should span at least half the catch-up window")
+}
+
+func TestVMScraper_CadenceRescheduleUsesSteadyBand(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "vm-a", 1)}}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	})
+	// First draw (reconcile): 0 → due now. Second draw (cadence): 0.5.
+	s.randFloat64 = sequencedRand(0, 0.5)
+
+	start := clock.Now()
+	s.pollOnce(context.Background())
+
+	steadyWidth := steadySpreadWidth(s.interval)
+	want := start.Add(s.interval + steadyWidth/2)
+	assert.Equal(t, want, cachedNextAttemptAt(t, s, "ns/vm-a"),
+		"cadence reschedule should use interval + random offset in steady band")
+}
+
+func TestVMScraper_RetryDoesNotUseSteadyBand(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
+	client := &mockProtocolClient{errQueue: []error{vsockclient.ErrNotReady}}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+	// Reconcile draw: 0 → due now. Cadence draw if reached: 1 → full width.
+	s.randFloat64 = sequencedRand(0, 1)
+
+	start := clock.Now()
+	s.pollOnce(context.Background())
+	assert.Equal(t, initialBackoff, cachedNextAttemptAt(t, s, "ns1/vm-a").Sub(start),
+		"retryable path must use backoff, not interval+offset")
+}
+
+func TestVMScraper_NACKDoesNotUseSteadyBand(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	store := &mockStore{vms: []*virtualmachine.Info{vm}}
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+	})
+	s.randFloat64 = sequencedRand(0, 1)
+	s.pollOnce(context.Background())
+
+	start := clock.Now()
+	s.handleNACK(string(vm.ID) + ":1")
+	assert.Equal(t, initialBackoff, cachedNextAttemptAt(t, s, "ns1/vm-a").Sub(start),
+		"NACK must use backoff, not interval+offset")
+}


### PR DESCRIPTION
## Description

Add random jitter to VMScraper scheduling to prevent all VMs from becoming due on the same tick after Sensor restart or cadence alignment. Previously, every VM was scheduled at `now` on first insert and at `now + pollInterval` on cadence reschedule, causing bursts that overwhelmed Central's rate limiter with NACKs.

Two jitter points, ~50 lines of production code:

1. **Catch-up spread (reconcile):** new VMs get `nextAttemptAt = now + U(0, min(20m, poll/3))` instead of `now`. Spreads the first-wave storm across minutes.
2. **Cadence spread (scheduleAfterAttempt):** successful scrapes reschedule at `now + poll + U(0, 2/3 * poll)` instead of `now + poll`. Prevents re-alignment after each cycle.

Retry and NACK paths are unchanged (short exponential backoff). The existing concurrency limit (`errgroup.SetLimit(20)`) and Central's per-sensor token-bucket rate limiter remain as backstops.

With 100 VMs spread over a 20-minute catch-up window, E[VMs per 10s tick] = 0.83, P(>3 per tick) ~1%. The rare tick with 2-3 simultaneous starts is within Central's burst capacity.

AI-assisted: opencode, implementation with user design review

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Unit tests pass with `-race`:
```
ok  github.com/stackrox/rox/sensor/common/virtualmachine/vmscraper  1.339s (race)
```

Tests cover: catch-up window spreading (10 VMs span ≥ half the window), cadence reschedule uses steady band (pinned exact offset), retry and NACK paths are unaffected by jitter.