### PR TITLE
ROX-36404: clarify roles column name and add tooltip

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
@@ -144,19 +144,7 @@ const ConfigManagementEntitySubject = ({
                         value: (
                             <span className="flex items-center">
                                 {clusterAdmin ? 'Yes' : 'No'}
-                                <Tooltip
-                                    content={
-                                        <div>
-                                            Yes only if this subject is bound to Kubernetes&apos;
-                                            built-in cluster-admin role, or an equivalent
-                                            ClusterRole with unrestricted access to everything in
-                                            the cluster. A subject can still hold other powerful
-                                            ClusterRoles (see Roles below) without this being Yes.
-                                        </div>
-                                    }
-                                    isContentLeftAligned
-                                    maxWidth="24rem"
-                                >
+                                <Tooltip content="Full, unrestricted cluster access">
                                     <span className="pf-v6-c-button pf-m-plain pf-m-smallest pf-v6-u-ml-sm">
                                         <OutlinedQuestionCircleIcon />
                                     </span>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
 import { gql } from '@apollo/client';
+import { Tooltip } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import Query from 'Components/ThrowingQuery';
 import Loader from 'Components/Loader';
@@ -138,8 +140,29 @@ const ConfigManagementEntitySubject = ({
                 const metadataKeyValuePairs = [
                     { key: 'Role type', value: type },
                     {
-                        key: 'Cluster Admin Role',
-                        value: clusterAdmin ? 'Enabled' : 'Disabled',
+                        key: 'Cluster Admin',
+                        value: (
+                            <span className="flex items-center">
+                                {clusterAdmin ? 'Yes' : 'No'}
+                                <Tooltip
+                                    content={
+                                        <div>
+                                            Yes only if this subject is bound to Kubernetes&apos;
+                                            built-in cluster-admin role, or an equivalent
+                                            ClusterRole with unrestricted access to everything in
+                                            the cluster. A subject can still hold other powerful
+                                            ClusterRoles (see Roles below) without this being Yes.
+                                        </div>
+                                    }
+                                    isContentLeftAligned
+                                    maxWidth="24rem"
+                                >
+                                    <span className="pf-v6-c-button pf-m-plain pf-m-smallest pf-v6-u-ml-sm">
+                                        <OutlinedQuestionCircleIcon />
+                                    </span>
+                                </Tooltip>
+                            </span>
+                        ),
                     },
                 ];
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
@@ -79,17 +79,17 @@ const buildTableColumns = (match, location) => {
             sortField: subjectSortFields.SUBJECT_KIND,
         },
         {
-            Header: `Cluster Admin`,
+            Header: (
+                <span className="flex items-center">
+                    Cluster Admin
+                    {clusterAdminTooltip}
+                </span>
+            ),
             headerClassName: `w-1/10 ${nonSortableHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,
             Cell: ({ original }) => {
                 const { clusterAdmin } = original;
-                return (
-                    <span className="flex items-center">
-                        {clusterAdmin ? 'Yes' : 'No'}
-                        {clusterAdminTooltip}
-                    </span>
-                );
+                return clusterAdmin ? 'Yes' : 'No';
             },
             accessor: 'clusterAdmin',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
@@ -1,5 +1,7 @@
 import { useLocation } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
+import { Tooltip } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import {
     defaultColumnClassName,
@@ -15,6 +17,25 @@ import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 import { getConfigMgmtPathForEntitiesAndId } from '../entities';
 import List from './List';
+
+const clusterAdminTooltip = (
+    <Tooltip
+        content={
+            <div>
+                Yes only if this subject is bound to Kubernetes&apos; built-in cluster-admin role,
+                or an equivalent ClusterRole with unrestricted access to everything in the cluster.
+                A subject can still hold other powerful ClusterRoles (see the Roles column) without
+                this being Yes.
+            </div>
+        }
+        isContentLeftAligned
+        maxWidth="24rem"
+    >
+        <span className="pf-v6-c-button pf-m-plain pf-m-smallest pf-v6-u-ml-sm">
+            <OutlinedQuestionCircleIcon />
+        </span>
+    </Tooltip>
+);
 
 export const defaultSubjectSort = [
     {
@@ -58,12 +79,17 @@ const buildTableColumns = (match, location) => {
             sortField: subjectSortFields.SUBJECT_KIND,
         },
         {
-            Header: `Cluster Admin Role`,
+            Header: `Cluster Admin`,
             headerClassName: `w-1/10 ${nonSortableHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,
             Cell: ({ original }) => {
                 const { clusterAdmin } = original;
-                return clusterAdmin ? 'Enabled' : 'Disabled';
+                return (
+                    <span className="flex items-center">
+                        {clusterAdmin ? 'Yes' : 'No'}
+                        {clusterAdminTooltip}
+                    </span>
+                );
             },
             accessor: 'clusterAdmin',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
@@ -19,18 +19,7 @@ import { getConfigMgmtPathForEntitiesAndId } from '../entities';
 import List from './List';
 
 const clusterAdminTooltip = (
-    <Tooltip
-        content={
-            <div>
-                Yes only if this subject is bound to Kubernetes&apos; built-in cluster-admin role,
-                or an equivalent ClusterRole with unrestricted access to everything in the cluster.
-                A subject can still hold other powerful ClusterRoles (see the Roles column) without
-                this being Yes.
-            </div>
-        }
-        isContentLeftAligned
-        maxWidth="24rem"
-    >
+    <Tooltip content="Full, unrestricted cluster access">
         <span className="pf-v6-c-button pf-m-plain pf-m-smallest pf-v6-u-ml-sm">
             <OutlinedQuestionCircleIcon />
         </span>


### PR DESCRIPTION
## Description

The Cluster Admin Roles column in the user and roles table is somewhat ambiguous. In practice, the cell is "Enabled" when the subject either has the literal cluster-admin role, or they have a set of roles that give full access to the cluster.

This PR changes the header, including a tooltip, and changes to a yes/no field value to make it clearer that the given subject is considered a cluster admin.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


