### PR TITLE
ROX-26663: Inform Dele Scan Waiter When Cannot Acquire Semaphore

### DIFF
--- a/central/image/service/service_impl.go
+++ b/central/image/service/service_impl.go
@@ -857,6 +857,7 @@ func (s *serviceImpl) EnrichLocalImageInternal(ctx context.Context, request *v1.
 			logging.Err(err),
 			logging.String("request_id", request.GetRequestId()),
 		)
+		s.informScanWaiter(request.GetRequestId(), nil, err)
 		return nil, err
 	}
 	defer func() {
@@ -1011,6 +1012,7 @@ func (s *serviceImpl) enrichLocalImageV2Internal(ctx context.Context, request *v
 			logging.Err(err),
 			logging.String("request_id", request.GetRequestId()),
 		)
+		s.informScanWaiterV2(request.GetRequestId(), nil, err)
 		return nil, err
 	}
 	defer func() {

--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -75,6 +75,10 @@ const (
 	// deleScanDefaultRetryDelay the time to wait between retries.
 	deleScanDefaultRetryDelay = 5 * time.Second
 
+	// deleScanDefaultScanTimeout the per-call timeout for scan API requests. This prevents a single
+	// hung call from consuming the entire test timeout, allowing the retry mechanism to function.
+	deleScanDefaultScanTimeout = 3 * time.Minute
+
 	// deleScanArtifactsDir the base directory to store test artifacts on failure.
 	deleScanArtifactsDir = "dele-scan"
 )
@@ -135,6 +139,10 @@ var (
 		// - http: non-successful response (status=504 body="<html>...<title>504 Gateway Time-out</title>...")
 		"non-successful response (status=502",
 		"non-successful response (status=504",
+
+		// Central's internal scan semaphore may reject enrichment requests when under load,
+		// retry when this happens.
+		"acquiring scan semaphore",
 	}
 )
 
@@ -1024,7 +1032,9 @@ func (ts *DelegatedScanningSuite) scanWithRetries(ctx context.Context, service v
 	var img *storage.Image
 
 	retryFunc := func() error {
-		img, err = service.ScanImage(ctx, req)
+		callCtx, cancel := context.WithTimeout(ctx, deleScanDefaultScanTimeout)
+		defer cancel()
+		img, err = service.ScanImage(callCtx, req)
 		if err == nil {
 			return nil
 		}

--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -1311,6 +1311,7 @@ func (ts *DelegatedScanningSuite) withRetries(retryFunc func() error, statusMsg 
 	}
 
 	return retry.WithRetry(retryFunc,
+		retry.WithContext(ts.ctx),
 		retry.BetweenAttempts(betweenAttemptsFunc),
 		retry.Tries(deleScanDefaultMaxRetries),
 		retry.WithExponentialBackoff(),

--- a/tests/delegated_scanning_test.go
+++ b/tests/delegated_scanning_test.go
@@ -143,6 +143,16 @@ var (
 		// Central's internal scan semaphore may reject enrichment requests when under load,
 		// retry when this happens.
 		"acquiring scan semaphore",
+
+		// Intermittent network timeouts dialing the registry/CDN (e.g. quay.io's Akamai
+		// edge) may interrupt fetching a layer blob. These surface as a gRPC DeadlineExceeded
+		// wrapping a net dial timeout, so retry when this happens.
+		//
+		// ex:
+		// - create index: rpc error: code = DeadlineExceeded desc = getting layer request URL
+		//   and headers (digest: "sha256:..."): Get "https://cdn01.quay.io/...": dial tcp
+		//   23.192.220.151:443: i/o timeout
+		"i/o timeout",
 	}
 )
 

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -78,6 +78,7 @@ scripts/ci/lib.sh
 sensor/tests/data/policies.json
 sensor/upgrader/preflight/testdata/k8s-1.22.json.gz
 tests/common.go
+tests/delegated_scanning_test.go
 tests/e2e/lib.sh
 tests/e2e/run-scanner-v4-install.bats
 tests/performance/load/package-lock.json


### PR DESCRIPTION
## Description

Observed in [CI flake](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22335/pull-ci-stackrox-stackrox-master-ocp-4-12-nongroovy-e2e-tests/2090589340940898304):

```
=== NAME  TestDelegatedScanning
...
panic: test timed out after 30m0s
	running tests:
		TestDelegatedScanning (23m55s)
		TestDelegatedScanning/TestAdHocScans (22m13s)
		TestDelegatedScanning/TestAdHocScans/delegate_scan_via_cluster_flag (22m13s)
```

The 20 mins were spent waiting for a response that never came, exhausting the full test suite timeout. 

The delegated scanning test restarts Sensor in order to get debug logging enabled to confirm behaviors are actually happening in Sensor. When this happens a flood of requests are sent to Central consuming the semaphore.

The root cause of the failure is the enrichment request from Sensor to Central failed - it was unable to acquire Centrals scan semaphore (were already 30 enrichment requests in progress):

`Aborted desc = acquiring scan semaphore`, full error:
```
common/delegatedregistry: 2026/08/21 01:36:33.986754 delegated_registry_handler.go:156: Error: Scan failed for req "a6477d7d-a99a-4486-b29f-2ba6a90777d3" image "registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194": enriching image "registry:\"registry.access.redhat.com\" remote:\"ubi9/ubi-minimal\" tag:\"9.4-1194\" full_name:\"registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194\"" via central: rpc error: code = Aborted desc = acquiring scan semaphore: context deadline exceeded
```

When this happens the Central waiter is never informed that the request failed, causing it to wait for the full timeout (which in this case is the overall delegated scanning test timeout)

With this PR the waiter will now be informed and no longer have to wait for the full timeout to be exhausted. 

Also adds a retry for `i/o timeout`([observed in CI](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22428/pull-ci-stackrox-stackrox-master-ocp-4-22-nongroovy-e2e-tests/2092496774064246784))

### Alternatives Considered
- Having Sensor send the failure via `UpdateLocalScanStatusInternal`
  - This would put Sensor in control of retries in the future if we so choose, but adds complexity/mixed behavior to error handling in Sensor, the Central approach was preferred as it's cleaner and Central being the orchestrator of ad-hoc scans should be in control of behaviors (such as retries) or put that on the client to decide.
- Not modifying Central at all and just relying on the new pre-request timeout added to the delegated scanning test
  - This would address the flake, however would mean each retry is waiting 3 mins per request needlessly when the outcome would be known immediately. Also could argue this is a legit bug that should be addressed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI and manual tests:

- Enabled delegated scanning (`ALL`), set `ROX_MAX_PARALLEL_IMAGE_SCAN_INTERNAL` to 1, cleared cached scans in central and scanner v4, and restarted sensor to cause flood of enrich requests.
- Then compared before and after behavior via `roxctl`.

Before: 

```sh
$ time rctl image scan --retries=0 --timeout=1m --image=nginx --force --cluster=remote
...
ERROR:	image scan failed: retrieving image scan result: could not scan image: "nginx": rpc error: code = DeadlineExceeded desc = context deadline exceeded

real  1m0.149s
user  0m0.054s
sys   0m0.047s
```

After: 

```sh
$ time rctl image scan --retries=0 --timeout=1m --image=nginx --force --cluster=remote
...
ERROR:	image scan failed: retrieving image scan result: could not scan image: "nginx": rpc error: code = Aborted desc = error delegating scan to cluster "81e1d9e8-775d-4437-bceb-dc9b0b4a68ca" for image "docker.io/library/nginx:latest": rpc error: code = Aborted desc = acquiring scan semaphore: context deadline exceeded

real  0m10.126s
user  0m0.057s
sys   0m0.126s
```
