### PR TITLE
fix(ci): Reduce false `Image_Availability` failures

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -583,21 +583,37 @@ poll_for_system_test_images() {
 
     local tag
     local image
+    local success="true"
     while read -r image tag
     do
         while ! check_rhacs_eng_image_exists "$image" "$tag"
         do
             info "$image does not exist"
             if (( $(date '+%s') - start_time > time_limit )); then
-                check_build_workflows "$(get_commit_sha)"
-                die "ERROR: Timed out waiting for images after ${time_limit} seconds"
+                success="false"
+                break 2
             fi
             sleep 60
         done
     done < "$image_list"
 
-    info "All images exist."
-    touch "${STATE_IMAGES_AVAILABLE}"
+    local images_available=("Image_Availability" "Were the required images built successfully by GitHub Actions?")
+    if [[ "$success" == "true" ]]; then
+        save_junit_success "${images_available[@]}"
+        info "All images exist."
+        touch "${STATE_IMAGES_AVAILABLE}"
+    else
+        local commit_sha="$(get_commit_sha)"
+        local build_details="Build results are unknown"
+        local build_results
+        if build_results="$(check-workflow-run --workflow=build.yaml --head-SHA="${commit_sha}")"; then
+            build_details="GitHub Actions workflow status for build.yaml:
+$build_results"
+        fi
+        info "${build_details}"
+        save_junit_failure "${images_available[@]}" "${build_details}"
+        die "ERROR: Timed out waiting for images after ${time_limit} seconds"
+    fi
 }
 
 # Image prefetch is broken into two sets:
@@ -1078,18 +1094,6 @@ check_rhacs_eng_image_exists() {
     check=$(curl --location -sS "${extra_args[@]}" "$url")
     echo "$check"
     [[ "$(jq -r '.tags | first | .name' <<<"$check")" == "$tag" ]]
-}
-
-check_build_workflows() {
-    local commit_sha="$1"
-
-    {
-        echo
-        info "GitHub Actions workflow status for build.yaml:"
-        check-workflow-run \
-            --workflow=build.yaml \
-            --head-SHA="${commit_sha}"
-    } | tee "${STATE_BUILD_RESULTS}" || true
 }
 
 check_scanner_version() {

--- a/scripts/ci/test_state.sh
+++ b/scripts/ci/test_state.sh
@@ -3,7 +3,6 @@
 # State files used to track test progress across script invocations.
 
 export STATE_IMAGES_AVAILABLE="${SHARED_DIR:-/tmp}/stackrox_ci_state_images_available"
-export STATE_BUILD_RESULTS="${SHARED_DIR:-/tmp}/stackrox_ci_state_build_results"
 export STATE_DEPLOYED="${SHARED_DIR:-/tmp}/stackrox_ci_state_deployed"
 
 # For the upgrade test

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1864,24 +1864,12 @@ db_backup_and_restore_test() {
 handle_e2e_progress_failures() {
     info "Checking for progress events"
 
-    local images_available=("Image_Availability" "Were the required images built successfully by GitHub Actions?")
     local stackrox_deployed=("Stackrox_Deployment" "Was Stackrox deployed to the cluster?")
 
     local check_deployment=false
 
     if [[ -f "${STATE_IMAGES_AVAILABLE}" ]]; then
-        save_junit_success "${images_available[@]}"
         check_deployment=true
-    else
-        local build_results="build results are unknown"
-        if [[ -f "${STATE_BUILD_RESULTS}" ]]; then
-            build_results="$(cat "${STATE_BUILD_RESULTS}")"
-        fi
-        read -r -d '' build_details <<- _EO_DETAILS_ || true
-Check the build workflow runs on GitHub:
-${build_results}
-_EO_DETAILS_
-        save_junit_failure "${images_available[@]}" "${build_details}"
     fi
 
     case "$CI_JOB_NAME" in


### PR DESCRIPTION
## Description

This should reduce the number of times tickets like https://redhat.atlassian.net/browse/ROX-34808 get opened or bumped with new comments.

I frequently see this combo ([example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21056/pull-ci-stackrox-stackrox-master-gke-ui-e2e-tests/2090745414016831488)):
<img width="672" height="256" alt="image" src="https://github.com/user-attachments/assets/6338f6ce-7941-4f84-947c-d59d63f2597b" />

The cluster creation failed and `Image_Availability: Were the required images built successfully by GitHub Actions?` is reported.

This was a bug in the old logic. `handle_e2e_progress_failures()` wrongly assumed that if `$STATE_IMAGES_AVAILABLE` file is not available, the images are absent, but this is not the case when the cluster creation failed. If the cluster creation failed, the execution does not even get to `poll_for_system_test_images()` and so we don't know whether images are available or not.

I moved JUnit creation into `poll_for_system_test_images()` and that pulled a bit of spaghetti with it but hopefully for good, there's one less file passed around (`$STATE_BUILD_RESULTS`).
Ultimately, [I think](https://github.com/stackrox/stackrox/pull/21056#discussion_r3752318002) we can get rid of `check-workflow-run`, but that's for another time.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

- Got GKE failure in prow and saw no JUnit for `Image_Availability` created - https://github.com/stackrox/stackrox/pull/22407#issuecomment-5373176278
- Got successful runs in prow and GHA (https://github.com/stackrox/stackrox/pull/22407#issuecomment-5378461866) and saw positive `Image_Availability` created JUnit created.

Did not get a failing run in GHA but I hope it'll be as expected.