### PR TITLE
ROX-36136: bundler change detection and per-source timestamps

### DIFF
--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -75,13 +75,14 @@ jobs:
       run: |
         set -euo pipefail
 
-        bucket=$(yq '.storage.bucket' "$SOURCE_CONFIG")
-        prefix=$(yq '.storage.prefix' "$SOURCE_CONFIG")
+        sc=./.github/workflows/scripts/scanner-updater-config.sh
+        bucket=$("$sc" bucket)
+        prefix=$("$sc" prefix)
 
         echo "GCS_BUCKET=$bucket" >> "$GITHUB_ENV"
         echo "GCS_PREFIX=$prefix" >> "$GITHUB_ENV"
 
-        bundle_obj="gs://${bucket}/${prefix}/${STREAM}/vulnerabilities.zip"
+        bundle_obj=$("$sc" bundle-object "$STREAM")
 
         # Get the bundle's creation timestamp. If the bundle does not
         # exist or the query fails, assume changes and proceed.
@@ -109,7 +110,7 @@ jobs:
                 changed=true
                 break
             fi
-        done < <(yq ".bundles.${STREAM}[]" "$SOURCE_CONFIG")
+        done < <("$sc" sources "$STREAM")
 
         echo "changed=${changed}" >> "$GITHUB_OUTPUT"
         if [ "$changed" = "false" ]; then
@@ -158,7 +159,7 @@ jobs:
                 echo "source '${source}': OK"
                 valid_files+=("$dest")
             fi
-        done < <(yq ".bundles.${STREAM}[]" "$SOURCE_CONFIG")
+        done < <(./.github/workflows/scripts/scanner-updater-config.sh sources "$STREAM")
 
         ( IFS=','; echo "failed=${failed_sources[*]}" >> "$GITHUB_OUTPUT" )
 

--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -70,7 +70,8 @@ jobs:
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
 
-    - name: Download sources
+    - name: Check for changes
+      id: check-changes
       run: |
         set -euo pipefail
 
@@ -80,11 +81,69 @@ jobs:
         echo "GCS_BUCKET=$bucket" >> "$GITHUB_ENV"
         echo "GCS_PREFIX=$prefix" >> "$GITHUB_ENV"
 
+        bundle_obj="gs://${bucket}/${prefix}/${STREAM}/vulnerabilities.zip"
+
+        # Get the bundle's creation timestamp. If the bundle does not
+        # exist or the query fails, assume changes and proceed.
+        if ! bundle_ts=$(gcloud storage objects describe "$bundle_obj" \
+            --format="value(creation_time)" 2>/dev/null) || [ -z "$bundle_ts" ]; then
+            echo "Bundle not found or query failed; assuming changes"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+        fi
+        bundle_epoch=$(date -d "$bundle_ts" +%s)
+        echo "Bundle created: $bundle_ts (epoch: $bundle_epoch)"
+
+        # Check if any source has been updated after the bundle.
+        changed=false
+        while IFS= read -r source; do
+            object="gs://${bucket}/${prefix}/${STREAM}/sources/${source}.json.zst"
+            if GCS_OBJECT="$object" \
+               ./.github/workflows/scripts/scanner-updater-check-freshness.sh --newer-than "$bundle_epoch"
+            then
+                echo "Source '${source}' is newer than bundle"
+                changed=true
+                break
+            elif [ $? -eq 2 ]; then
+                echo "Source '${source}': check failed; assuming changes"
+                changed=true
+                break
+            fi
+        done < <(yq ".bundles.${STREAM}[]" "$SOURCE_CONFIG")
+
+        echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+        if [ "$changed" = "false" ]; then
+            echo "No sources newer than bundle; skipping"
+        fi
+
+    - name: Download sources
+      if: steps.check-changes.outputs.changed == 'true'
+      run: |
+        set -euo pipefail
+
         mkdir -p bundles
-        gcloud storage cp "gs://${bucket}/${prefix}/${STREAM}/sources/*.json.zst" bundles/
+        gcloud storage cp "gs://${GCS_BUCKET}/${GCS_PREFIX}/${STREAM}/sources/*.json.zst" bundles/
+
+    - name: Set source timestamps
+      if: steps.check-changes.outputs.changed == 'true'
+      run: |
+        set -euo pipefail
+
+        # The exporter writes refresh-completed-at to each source object's
+        # custom metadata. Setting file mtimes from it ensures ZIP entries
+        # carry per-source update times instead of the bundler's download time.
+        for file in bundles/*.json.zst; do
+            [ -f "$file" ] || continue
+            filename=$(basename "$file")
+            object="gs://${GCS_BUCKET}/${GCS_PREFIX}/${STREAM}/sources/${filename}"
+            gcloud storage objects describe "$object" --format=json > "bundles/${filename}.metadata.json"
+            timestamp=$(jq -re '.metadata["refresh-completed-at"]' "bundles/${filename}.metadata.json")
+            touch -d "$timestamp" "$file"
+        done
 
     - name: Validate sources
       id: download-validate
+      if: steps.check-changes.outputs.changed == 'true'
       run: |
         set -euo pipefail
 
@@ -112,6 +171,7 @@ jobs:
         echo "Validated: ${#valid_files[@]} of $(( ${#valid_files[@]} + ${#failed_sources[@]} )) source(s) OK"
 
     - name: Assemble and upload bundle
+      if: steps.check-changes.outputs.changed == 'true'
       run: |
         set -euo pipefail
 

--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -11,6 +11,12 @@ on:
   schedule:
   - cron: "47 * * * *"
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Force rebuild even if no sources are newer than the bundle"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -72,6 +78,8 @@ jobs:
 
     - name: Check for changes
       id: check-changes
+      env:
+        FORCE: ${{ inputs.force == true }}
       run: |
         set -euo pipefail
 
@@ -81,6 +89,12 @@ jobs:
 
         echo "GCS_BUCKET=$bucket" >> "$GITHUB_ENV"
         echo "GCS_PREFIX=$prefix" >> "$GITHUB_ENV"
+
+        if [[ "$FORCE" == "true" ]]; then
+            echo "Force rebuild requested"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+        fi
 
         bundle_obj=$("$sc" bundle-object "$STREAM")
 
@@ -120,25 +134,33 @@ jobs:
       run: |
         set -euo pipefail
 
+        sc=./.github/workflows/scripts/scanner-updater-config.sh
         mkdir -p bundles
-        gcloud storage cp "gs://${GCS_BUCKET}/${GCS_PREFIX}/${STREAM}/sources/*.json.zst" bundles/
 
-    - name: Set source timestamps
-      if: steps.check-changes.outputs.changed == 'true'
-      run: |
-        set -euo pipefail
+        while IFS= read -r source; do
+            object="gs://${GCS_BUCKET}/${GCS_PREFIX}/${STREAM}/sources/${source}.json.zst"
+            dest="bundles/${source}.json.zst"
 
-        # The exporter writes refresh-completed-at to each source object's
-        # custom metadata. Setting file mtimes from it ensures ZIP entries
-        # carry per-source update times instead of the bundler's download time.
-        for file in bundles/*.json.zst; do
-            [ -f "$file" ] || continue
-            filename=$(basename "$file")
-            object="gs://${GCS_BUCKET}/${GCS_PREFIX}/${STREAM}/sources/${filename}"
-            gcloud storage objects describe "$object" --format=json > "bundles/${filename}.metadata.json"
-            timestamp=$(jq -re '.metadata["refresh-completed-at"]' "bundles/${filename}.metadata.json")
-            touch -d "$timestamp" "$file"
-        done
+            # Retry if the source is overwritten between describe and cp.
+            downloaded=false
+            for attempt in 1 2 3; do
+                meta=$(gcloud storage objects describe "$object" --format=json)
+                gen=$(jq -r '.generation' <<< "$meta")
+                timestamp=$(jq -re '.metadata["refresh-completed-at"]' <<< "$meta")
+
+                if gcloud storage cp "$object" "$dest" --if-generation-match="$gen"; then
+                    touch -d "$timestamp" "$dest"
+                    downloaded=true
+                    break
+                fi
+                echo "Source '${source}': download attempt ${attempt} failed, retrying"
+            done
+
+            if [[ "$downloaded" != "true" ]]; then
+                echo "::error::${source}: download failed after 3 attempts"
+                exit 1
+            fi
+        done < <("$sc" sources "$STREAM")
 
     - name: Validate sources
       id: download-validate

--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -99,16 +99,14 @@ jobs:
         changed=false
         while IFS= read -r source; do
             object="gs://${bucket}/${prefix}/${STREAM}/sources/${source}.json.zst"
-            if GCS_OBJECT="$object" \
-               ./.github/workflows/scripts/scanner-updater-check-freshness.sh --newer-than "$bundle_epoch"
-            then
-                echo "Source '${source}' is newer than bundle"
-                changed=true
-                break
-            elif [ $? -eq 2 ]; then
+            newer=$(GCS_OBJECT="$object" \
+                ./.github/workflows/scripts/scanner-updater-check-freshness.sh --newer-than "$bundle_epoch") || {
                 echo "Source '${source}': check failed; assuming changes"
-                changed=true
-                break
+                changed=true; break
+            }
+            if [[ "$newer" == "true" ]]; then
+                echo "Source '${source}' is newer than bundle"
+                changed=true; break
             fi
         done < <("$sc" sources "$STREAM")
 

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -69,9 +69,31 @@ jobs:
         UPDATER_SOURCE: ${{ inputs.source }}
         SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
       run: |
+        config="$SOURCE_CONFIG"
+        default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
+        interval=$(yq ".updaters.\"${UPDATER_SOURCE}\".interval // \"$default_interval\"" "$config")
+
+        duration_to_seconds() {
+            local dur="${1:?}"
+            local total=0 remaining="$dur"
+            while [[ -n "$remaining" ]]; do
+                if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
+                    total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
+                elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
+                    total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
+                elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
+                    total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
+                else
+                    echo "::error::cannot parse duration: $remaining"; exit 2
+                fi
+            done
+            echo "$total"
+        }
+        interval_secs=$(duration_to_seconds "$interval")
+
         # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
         rc=0
-        ./.github/workflows/scripts/scanner-updater-check-freshness.sh || rc=$?
+        ./.github/workflows/scripts/scanner-updater-check-freshness.sh --max-age "$interval_secs" || rc=$?
         if [[ $rc -eq 0 ]]; then
             echo "result=skip" >> "$GITHUB_OUTPUT"
         elif [[ $rc -eq 1 ]]; then

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -69,27 +69,7 @@ jobs:
         UPDATER_SOURCE: ${{ inputs.source }}
         SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
       run: |
-        config="$SOURCE_CONFIG"
-        default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
-        interval=$(yq ".updaters.\"${UPDATER_SOURCE}\".interval // \"$default_interval\"" "$config")
-
-        duration_to_seconds() {
-            local dur="${1:?}"
-            local total=0 remaining="$dur"
-            while [[ -n "$remaining" ]]; do
-                if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
-                    total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
-                elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
-                    total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
-                elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
-                    total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
-                else
-                    echo "::error::cannot parse duration: $remaining"; exit 2
-                fi
-            done
-            echo "$total"
-        }
-        interval_secs=$(duration_to_seconds "$interval")
+        interval_secs=$(./.github/workflows/scripts/scanner-updater-config.sh interval-secs "$UPDATER_SOURCE")
 
         # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
         rc=0

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -71,15 +71,14 @@ jobs:
       run: |
         interval_secs=$(./.github/workflows/scripts/scanner-updater-config.sh interval-secs "$UPDATER_SOURCE")
 
-        # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
-        rc=0
-        ./.github/workflows/scripts/scanner-updater-check-freshness.sh --max-age "$interval_secs" || rc=$?
-        if [[ $rc -eq 0 ]]; then
-            echo "result=skip" >> "$GITHUB_OUTPUT"
-        elif [[ $rc -eq 1 ]]; then
-            echo "result=run" >> "$GITHUB_OUTPUT"
-        else
+        fresh=$(./.github/workflows/scripts/scanner-updater-check-freshness.sh --max-age "$interval_secs") || {
             echo "result=error" >> "$GITHUB_OUTPUT"
+            exit 0
+        }
+        if [[ "$fresh" == "true" ]]; then
+            echo "result=skip" >> "$GITHUB_OUTPUT"
+        else
+            echo "result=run" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Fail on recheck error

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -81,8 +81,9 @@ jobs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         set -euo pipefail
-        bucket=$(yq '.storage.bucket' "$SOURCE_CONFIG")
-        prefix=$(yq '.storage.prefix' "$SOURCE_CONFIG")
+        sc=./.github/workflows/scripts/scanner-updater-config.sh
+        bucket=$("$sc" bucket)
+        prefix=$("$sc" prefix)
         matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual.json.zst\"}]}"
         printf '{"has_due":true,"has_errors":false,"errors":[],"matrix":%s}\n' "$matrix" > matrix-result.json
 

--- a/.github/workflows/scripts/scanner-updater-check-freshness.sh
+++ b/.github/workflows/scripts/scanner-updater-check-freshness.sh
@@ -1,22 +1,29 @@
 #!/usr/bin/env bash
 #
-# Check whether an updater's vulnerability data is fresh.
+# Check whether a GCS object is newer than a reference point.
 #
 # Uses an unauthenticated curl against the public GCS download URL to
-# classify the object state (200/404/other), then gcloud for creation_time
-# when the object exists.
+# classify the object state (200/404/other), then gcloud for the object
+# timestamp when it exists.
+#
+# Exactly one of --newer-than or --max-age must be provided.
+#
+# --newer-than <epoch>:
+#   The object is "fresh" if its timestamp is after <epoch>.
+#
+# --max-age <seconds>:
+#   The object is "fresh" if its age is below <seconds>
+#   (equivalent to --newer-than "$(date +%s) - N").
 #
 # Exit codes:
-#   0 — object exists and is fresh (age < interval)
-#   1 — object is missing (404) or stale (age >= interval)
-#   2 — unexpected failure: caller should treat as error and notify
+#   0 — object exists and is newer than the threshold
+#   1 — object is missing (404) or not newer than the threshold
+#   2 — unexpected failure
 #
 # Inputs (environment):
-#   GCS_OBJECT       — full GCS object path (gs://bucket/path/to/data.json.zst)
-#   UPDATER_SOURCE   — updater name, used to look up interval in config
-#   SOURCE_CONFIG    — path to source-config.yaml
+#   GCS_OBJECT — full GCS object path (gs://bucket/path/to/object)
 #
-# Requires: curl, yq, gcloud.
+# Requires: curl, gcloud, date.
 
 set -euo pipefail
 
@@ -27,34 +34,34 @@ set -euo pipefail
 # from our explicit exit 1 calls.
 trap 'echo "::error::unexpected failure in check-freshness.sh at line $LINENO"; exit 2' ERR
 
+threshold=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --newer-than)
+            threshold="${2:?--newer-than requires an epoch value}"
+            shift 2
+            ;;
+        --max-age)
+            max_age="${2:?--max-age requires a value in seconds}"
+            threshold=$(( $(date +%s) - max_age ))
+            shift 2
+            ;;
+        *)
+            echo "::error::unknown argument: $1"
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$threshold" ]]; then
+    echo "::error::one of --newer-than or --max-age is required"
+    exit 2
+fi
+
 object="${GCS_OBJECT:?GCS_OBJECT is required}"
-updater="${UPDATER_SOURCE:?UPDATER_SOURCE is required}"
-config="${SOURCE_CONFIG:?SOURCE_CONFIG is required}"
 
 # Derive the download URL from the gs:// path.
 download_url="https://storage.googleapis.com/${object#gs://}"
-
-duration_to_seconds() {
-    local dur="${1:?}"
-    local total=0 remaining="$dur"
-    while [[ -n "$remaining" ]]; do
-        if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
-            total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
-        elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
-            total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
-        elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
-            total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
-        else
-            echo "::error::cannot parse duration: $remaining"; exit 2
-        fi
-    done
-    echo "$total"
-}
-
-# Read interval from config.
-default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
-interval=$(yq ".updaters.\"${updater}\".interval // \"$default_interval\"" "$config")
-interval_secs=$(duration_to_seconds "$interval")
 
 # Check object existence via unauthenticated curl.
 http_code=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -65,14 +72,12 @@ case "$http_code" in
     200)
         creation_time=$(gcloud storage objects describe "$object" \
             --format="value(creation_time)")
-        created_epoch=$(date -d "$creation_time" +%s)
-        now=$(date +%s)
-        age=$(( now - created_epoch ))
-        if (( age < interval_secs )); then
-            echo >&2 "INFO: ${object}: fresh (age=${age}s < interval=${interval_secs}s)"
+        object_epoch=$(date -d "$creation_time" +%s)
+        if (( object_epoch > threshold )); then
+            echo >&2 "INFO: ${object}: newer than threshold (${object_epoch} > ${threshold})"
             exit 0
         fi
-        echo >&2 "INFO: ${object}: stale (age=${age}s >= interval=${interval_secs}s)"
+        echo >&2 "INFO: ${object}: not newer than threshold (${object_epoch} <= ${threshold})"
         exit 1
         ;;
     404)

--- a/.github/workflows/scripts/scanner-updater-check-freshness.sh
+++ b/.github/workflows/scripts/scanner-updater-check-freshness.sh
@@ -2,9 +2,9 @@
 #
 # Check whether a GCS object is newer than a reference point.
 #
-# Uses an unauthenticated curl against the public GCS download URL to
-# classify the object state (200/404/other), then gcloud for the object
-# timestamp when it exists.
+# Uses an unauthenticated HTTP HEAD request against the public GCS
+# download URL to classify the object state (200/404/other), then
+# gcloud for the object timestamp when it exists.
 #
 # Exactly one of --newer-than or --max-age must be provided.
 #
@@ -15,10 +15,13 @@
 #   The object is "fresh" if its age is below <seconds>
 #   (equivalent to --newer-than "$(date +%s) - N").
 #
+# Output (stdout):
+#   "true"  — object exists and is newer than the threshold
+#   "false" — object is not newer, or does not exist (404)
+#
 # Exit codes:
-#   0 — object exists and is newer than the threshold
-#   1 — object is missing (404) or not newer than the threshold
-#   2 — unexpected failure
+#   0 — check completed (result is on stdout)
+#   non-zero — unexpected failure (stdout is irrelevant)
 #
 # Inputs (environment):
 #   GCS_OBJECT — full GCS object path (gs://bucket/path/to/object)
@@ -27,65 +30,68 @@
 
 set -euo pipefail
 
-# The ERR trap below forces any unexpected command failure to exit 2 instead of
-# the failing command's own exit code. Without it, set -e would exit with the
-# failing command's code (usually 1), making it indistinguishable from the
-# intentional "not fresh" exit. The trap guarantees that exit 1 can only come
-# from our explicit exit 1 calls.
-trap 'echo "::error::unexpected failure in check-freshness.sh at line $LINENO"; exit 2' ERR
+trap 'echo "::error::unexpected failure in check-freshness.sh at line $LINENO" >&2; exit 2' ERR
 
 threshold=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --newer-than)
+            if [[ -n "$threshold" ]]; then
+                echo "::error::--newer-than and --max-age are mutually exclusive" >&2
+                exit 1
+            fi
             threshold="${2:?--newer-than requires an epoch value}"
             shift 2
             ;;
         --max-age)
+            if [[ -n "$threshold" ]]; then
+                echo "::error::--newer-than and --max-age are mutually exclusive" >&2
+                exit 1
+            fi
             max_age="${2:?--max-age requires a value in seconds}"
             threshold=$(( $(date +%s) - max_age ))
             shift 2
             ;;
         *)
-            echo "::error::unknown argument: $1"
-            exit 2
+            echo "::error::unknown argument: $1" >&2
+            exit 1
             ;;
     esac
 done
 
 if [[ -z "$threshold" ]]; then
-    echo "::error::one of --newer-than or --max-age is required"
-    exit 2
+    echo "::error::one of --newer-than or --max-age is required" >&2
+    exit 1
 fi
 
 object="${GCS_OBJECT:?GCS_OBJECT is required}"
 
-# Derive the download URL from the gs:// path.
+# Derive the public download URL from the gs:// path.
 download_url="https://storage.googleapis.com/${object#gs://}"
 
-# Check object existence via unauthenticated curl.
-http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+http_code=$(curl --head --silent --show-error -o /dev/null -w "%{http_code}" \
     --connect-timeout 10 --max-time 15 \
     "$download_url")
 
 case "$http_code" in
     200)
-        creation_time=$(gcloud storage objects describe "$object" \
+        creation_time=$(timeout 30 gcloud storage objects describe "$object" \
             --format="value(creation_time)")
         object_epoch=$(date -d "$creation_time" +%s)
         if (( object_epoch > threshold )); then
             echo >&2 "INFO: ${object}: newer than threshold (${object_epoch} > ${threshold})"
-            exit 0
+            echo "true"
+        else
+            echo >&2 "INFO: ${object}: not newer than threshold (${object_epoch} <= ${threshold})"
+            echo "false"
         fi
-        echo >&2 "INFO: ${object}: not newer than threshold (${object_epoch} <= ${threshold})"
-        exit 1
         ;;
     404)
         echo >&2 "INFO: ${object}: not found"
-        exit 1
+        echo "false"
         ;;
     *)
-        echo "::error::${object}: GCS returned HTTP $http_code"
-        exit 2
+        echo "::error::${object}: GCS returned HTTP $http_code" >&2
+        exit 1
         ;;
 esac

--- a/.github/workflows/scripts/scanner-updater-config.sh
+++ b/.github/workflows/scripts/scanner-updater-config.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Query source-config.yaml for scanner updater workflows.
+#
+# Usage:
+#   scanner-updater-config.sh <command> [args...]
+#
+# Commands:
+#   bucket                      Storage bucket name.
+#   prefix                      Storage prefix path.
+#   sources <stream>            List updater sources for a stream, one per line.
+#   source-object <stream> <source>  GCS object path for a source.
+#   bundle-object <stream>      GCS object path for a bundle.
+#   interval-secs <source>      Updater refresh interval in seconds.
+#
+# Inputs (environment):
+#   SOURCE_CONFIG — path to source-config.yaml
+#
+# Requires: yq.
+
+set -euo pipefail
+
+config="${SOURCE_CONFIG:?SOURCE_CONFIG is required}"
+
+if [[ ! -f "$config" ]]; then
+    echo "::error::config file not found: $config" >&2
+    exit 1
+fi
+
+if ! yq '.' "$config" > /dev/null 2>&1; then
+    echo "::error::config file is not valid YAML: $config" >&2
+    exit 1
+fi
+
+duration_to_seconds() {
+    local dur="${1:?missing required argument 'duration'}"; shift
+    local total=0 remaining="$dur"
+    while [[ -n "$remaining" ]]; do
+        if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
+        elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
+        elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
+        else
+            echo "::error::cannot parse duration: $remaining" >&2; exit 1
+        fi
+    done
+    echo "$total"
+}
+
+command="${1:?missing required argument 'command'}"; shift
+
+case "$command" in
+    bucket)
+        yq '.storage.bucket' "$config"
+        ;;
+    prefix)
+        yq '.storage.prefix' "$config"
+        ;;
+    sources)
+        stream="${1:?missing required argument 'stream'}"; shift
+        yq ".bundles.\"${stream}\"[]" "$config"
+        ;;
+    source-object)
+        stream="${1:?missing required argument 'stream'}"; shift
+        source="${1:?missing required argument 'source'}"; shift
+        bucket=$(yq '.storage.bucket' "$config")
+        prefix=$(yq '.storage.prefix' "$config")
+        echo "gs://${bucket}/${prefix}/${stream}/sources/${source}.json.zst"
+        ;;
+    bundle-object)
+        stream="${1:?missing required argument 'stream'}"; shift
+        bucket=$(yq '.storage.bucket' "$config")
+        prefix=$(yq '.storage.prefix' "$config")
+        echo "gs://${bucket}/${prefix}/${stream}/vulnerabilities.zip"
+        ;;
+    interval-secs)
+        source="${1:?missing required argument 'source'}"; shift
+        default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
+        interval=$(yq ".updaters.\"${source}\".interval // \"$default_interval\"" "$config")
+        duration_to_seconds "$interval"
+        ;;
+    *)
+        echo "::error::unknown command: $command" >&2
+        exit 1
+        ;;
+esac

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -20,8 +20,6 @@
 
 set -euo pipefail
 
-config="${SOURCE_CONFIG:?SOURCE_CONFIG is required}"
-
 for cmd in yq jq; do
     if ! command -v "$cmd" &>/dev/null; then
         echo "::error::$cmd is required but not found"
@@ -29,42 +27,23 @@ for cmd in yq jq; do
     fi
 done
 
-# Read storage location from config.
-bucket=$(yq '.storage.bucket' "$config")
-prefix=$(yq '.storage.prefix' "$config")
+sc="$(dirname "$0")/scanner-updater-config.sh"
 
-duration_to_seconds() {
-    local dur="${1:?}"
-    local total=0 remaining="$dur"
-    while [[ -n "$remaining" ]]; do
-        if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
-            total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
-        elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
-            total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
-        elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
-            total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
-        else
-            echo "::error::cannot parse duration: $remaining"; return 1
-        fi
-    done
-    echo "$total"
-}
-
-default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
+bucket=$("$sc" bucket)
+prefix=$("$sc" prefix)
 
 # Expand stream/ref/updater triples, check freshness, emit due pairs.
 ./.github/workflows/scripts/scanner-get-released-tags.sh \
     | jq -r '.[] | "\(.version) \(.ref)"' \
     | while read -r stream ref; do
-          yq ".bundles.\"$stream\" | .[]" "$config" \
+          "$sc" sources "$stream" \
               | while read -r updater; do
                     echo "$stream $ref $updater"
                 done
       done \
     | while read -r stream ref updater; do
           object="gs://${bucket}/${prefix}/${stream}/sources/${updater}.json.zst"
-          interval=$(yq ".updaters.\"${updater}\".interval // \"$default_interval\"" "$config")
-          interval_secs=$(duration_to_seconds "$interval")
+          interval_secs=$("$sc" interval-secs "$updater")
 
           # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
           if GCS_OBJECT="$object" \

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -33,6 +33,25 @@ done
 bucket=$(yq '.storage.bucket' "$config")
 prefix=$(yq '.storage.prefix' "$config")
 
+duration_to_seconds() {
+    local dur="${1:?}"
+    local total=0 remaining="$dur"
+    while [[ -n "$remaining" ]]; do
+        if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] * 3600 )); remaining="${BASH_REMATCH[2]}"
+        elif [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] * 60 )); remaining="${BASH_REMATCH[2]}"
+        elif [[ "$remaining" =~ ^([0-9]+)s(.*)$ ]]; then
+            total=$(( total + BASH_REMATCH[1] )); remaining="${BASH_REMATCH[2]}"
+        else
+            echo "::error::cannot parse duration: $remaining"; return 1
+        fi
+    done
+    echo "$total"
+}
+
+default_interval=$(yq '.updaters.default.interval // "4h"' "$config")
+
 # Expand stream/ref/updater triples, check freshness, emit due pairs.
 ./.github/workflows/scripts/scanner-get-released-tags.sh \
     | jq -r '.[] | "\(.version) \(.ref)"' \
@@ -44,12 +63,12 @@ prefix=$(yq '.storage.prefix' "$config")
       done \
     | while read -r stream ref updater; do
           object="gs://${bucket}/${prefix}/${stream}/sources/${updater}.json.zst"
+          interval=$(yq ".updaters.\"${updater}\".interval // \"$default_interval\"" "$config")
+          interval_secs=$(duration_to_seconds "$interval")
 
           # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
           if GCS_OBJECT="$object" \
-             UPDATER_SOURCE="$updater" \
-             SOURCE_CONFIG="$config" \
-             ./.github/workflows/scripts/scanner-updater-check-freshness.sh
+             ./.github/workflows/scripts/scanner-updater-check-freshness.sh --max-age "$interval_secs"
           then
               continue
           elif [[ $? -eq 1 ]]; then

--- a/.github/workflows/scripts/scanner-updater-matrix.sh
+++ b/.github/workflows/scripts/scanner-updater-matrix.sh
@@ -45,22 +45,20 @@ prefix=$("$sc" prefix)
           object="gs://${bucket}/${prefix}/${stream}/sources/${updater}.json.zst"
           interval_secs=$("$sc" interval-secs "$updater")
 
-          # check-freshness.sh exit codes: 0=fresh, 1=stale/missing, 2=error.
-          if GCS_OBJECT="$object" \
-             ./.github/workflows/scripts/scanner-updater-check-freshness.sh --max-age "$interval_secs"
-          then
-              continue
-          elif [[ $? -eq 1 ]]; then
-              jq -n \
-                  --arg source "$updater" \
-                  --arg ref "$ref" \
-                  --arg object "$object" \
-                  '{source: $source, ref: $ref, object: $object}'
-          else
+          fresh=$(GCS_OBJECT="$object" \
+              ./.github/workflows/scripts/scanner-updater-check-freshness.sh --max-age "$interval_secs") || {
               echo "::error::${object}: freshness check failed"
               jq -n --arg msg "${object}: freshness check failed" '{error: $msg}'
               continue
+          }
+          if [[ "$fresh" == "true" ]]; then
+              continue
           fi
+          jq -n \
+              --arg source "$updater" \
+              --arg ref "$ref" \
+              --arg object "$object" \
+              '{source: $source, ref: $ref, object: $object}'
       done \
     | jq -s '{
           has_due:    (map(select(.source)) | length > 0 | tostring),


### PR DESCRIPTION
## Description

Refactor `check-freshness.sh` to accept `--max-age` and `--newer-than` parameters instead of reading config internally, moving duration parsing and interval lookup to the matrix builder. This makes the script reusable across workflows with different freshness semantics.

Add two capabilities to the bundler workflow:

**Change detection**: before downloading sources, compare each source's GCS timestamp against the bundle's. Skip the entire pipeline when nothing has changed — prevents unnecessary re-uploads that cause Scanner to re-download via `If-Modified-Since` every hour.

**Per-source timestamps**: after downloading, set file mtimes from the exporter's `refresh-completed-at` custom metadata so ZIP entries carry per-source update times instead of the bundler's download time. This is the producer-side counterpart to ROX-36137 (consumer-side: Scanner reads `zipF.Modified` instead of `zipTime`).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Validated via `workflow_dispatch` of the bundler workflow on this branch. The `check-freshness.sh` refactor preserves the same exit code semantics (0/1/2) and the matrix builder passes shellcheck.