### PR TITLE
ROX-36493: Move validation schema to same folder as wizard step

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/validationSchemaDelivery.ts
+++ b/ui/apps/platform/src/Components/Reports/Step/validationSchemaDelivery.ts
@@ -1,0 +1,54 @@
+import * as yup from 'yup';
+
+import type { Schedule } from 'types/schedule.proto';
+
+import type { DeliveryType } from '../reports.types';
+
+export const validationSchemaDelivery: yup.ObjectSchema<DeliveryType> = yup.object().shape({
+    notifiers: yup
+        .array()
+        .of(
+            yup.object().shape({
+                emailConfig: yup.object().shape({
+                    notifierId: yup.string().required('Email notifier is required'),
+                    mailingLists: yup
+                        .array()
+                        .of(yup.string().required())
+                        .min(1, 'At least one distribution list email is required')
+                        .required(),
+                    customSubject: yup.string().defined(),
+                    customBody: yup.string().defined(),
+                }),
+                notifierName: yup.string().defined(),
+            })
+        )
+        .defined(),
+    schedule: yup
+        .object()
+        .nullable()
+        .defined()
+        .test('schedule-days-required', 'At least one day must be selected', function test(value) {
+            if (value == null) {
+                return true;
+            }
+            // Schedule is a union type that .shape() can't express.
+            // Cast so property access is type-checked.
+            const schedule = value as Schedule;
+            if (schedule.intervalType === 'UNSET' || schedule.intervalType === 'DAILY') {
+                return true;
+            }
+            if ('daysOfWeek' in schedule && schedule.daysOfWeek.days.length === 0) {
+                return this.createError({
+                    path: 'schedule.daysOfWeek.days',
+                    message: 'At least one day must be selected',
+                });
+            }
+            if ('daysOfMonth' in schedule && schedule.daysOfMonth.days.length === 0) {
+                return this.createError({
+                    path: 'schedule.daysOfMonth.days',
+                    message: 'At least one day must be selected',
+                });
+            }
+            return true;
+        }) as unknown as yup.Schema<Schedule | null>,
+});

--- a/ui/apps/platform/src/Components/Reports/Step/validationSchemaDetails.ts
+++ b/ui/apps/platform/src/Components/Reports/Step/validationSchemaDetails.ts
@@ -1,0 +1,8 @@
+import * as yup from 'yup';
+
+import type { DetailsType } from 'Components/Reports/reports.types'; // TODO ./
+
+export const validationSchemaDetails: yup.ObjectSchema<DetailsType> = yup.object().shape({
+    name: yup.string().trim().required('Report name is required'),
+    description: yup.string().ensure(),
+});

--- a/ui/apps/platform/src/Components/Reports/Step/validationSchemaDetails.ts
+++ b/ui/apps/platform/src/Components/Reports/Step/validationSchemaDetails.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-import type { DetailsType } from 'Components/Reports/reports.types'; // TODO ./
+import type { DetailsType } from '../reports.types';
 
 export const validationSchemaDetails: yup.ObjectSchema<DetailsType> = yup.object().shape({
     name: yup.string().trim().required('Report name is required'),


### PR DESCRIPTION
## Description

### Objective

Follow pattern in image snd node vulnerability reports.

### Problem

Because imageVulnerabilityReportValidationSchemas.ts file includes generic and type-specific schemas, it is not clear which is which for new report types to eitherreuse or adapt.

### Solution

Use schema variable names as file names. Thank you **Brad** for solid naming convention.

https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts

Move schema to same folder from which wizard imports step file.

1. Generic steps

    Reusable for node vulnerability report wizard.

    * src/Components/Reports/Step/DeliveryStep.tsx
        validationSchemaDelivery.ts

    * src/Components/Reports/Step/DeliveryStep.tsx
        validationSchemaDetails.ts

2. Specific steps

    Wait until after Brad adds VulnerabilityReports folder.

    * src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
        validationSchemaResources.ts

    * src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
        validationSchemaFilters

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the functionality is gated by a feature flag]
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
