### PR TITLE
chore(ui): Clean up Tailwind classes under Clusters/

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -913,7 +913,6 @@ module.exports = [
             'src/Components/visuals/**', // deprecated
             'src/Components/workflow/**', // deprecated
 
-            'src/Containers/Clusters/**', // fix errors, and then delete; also in tailwind.config.js file
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/ConfigManagement/**',
             'src/Containers/Images/**', // deprecated

--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -1,8 +1,15 @@
 import type { ReactElement } from 'react';
-import { Alert, Button, Content, Flex, FlexItem, Switch, Title } from '@patternfly/react-core';
+import {
+    Alert,
+    Button,
+    Content,
+    Flex,
+    FlexItem,
+    Spinner,
+    Switch,
+    Title,
+} from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
-import { CheckCircle } from 'react-feather';
-import { ClipLoader } from 'react-spinners';
 
 import type { ClusterManagerType } from 'types/cluster.proto';
 import useAnalytics, { LEGACY_CLUSTER_DOWNLOAD_YAML } from 'hooks/useAnalytics';
@@ -110,29 +117,23 @@ function ClusterDeployment({
                     </Flex>
                 </Flex>
             )}
-            {(!editing || !clusterCheckedIn) && (
-                <div className="flex flex-col text-primary-500 p-4">
-                    {clusterCheckedIn ? (
-                        <div className="flex text-success-600 bg-success-200 border border-solid border-success-400 p-4 items-center">
-                            <div className="flex-1 text-center">
-                                <CheckCircle />
-                            </div>
-                            <div className="flex-3 pl-2">
-                                Success! The cluster has been recognized.
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="flex text-primary-600 bg-primary-200 border border-solid border-primary-400 p-4 items-center">
-                            <div className="text-center px-4">
-                                <ClipLoader color="currentColor" loading size={20} />
-                            </div>
-                            <div className="flex-3 pl-2">
-                                Waiting for the cluster to check in successfully...
-                            </div>
-                        </div>
-                    )}
-                </div>
-            )}
+            {(!editing || !clusterCheckedIn) &&
+                (clusterCheckedIn ? (
+                    <Alert
+                        variant="success"
+                        isInline
+                        title="Success! The cluster has been recognized."
+                        component="p"
+                    />
+                ) : (
+                    <Alert
+                        variant="info"
+                        isInline
+                        title="Waiting for the cluster to check in successfully..."
+                        component="p"
+                        customIcon={<Spinner size="md" />}
+                    />
+                ))}
         </Flex>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -355,7 +355,7 @@ function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
                 />
             </PageSection>
             <Dialog
-                className="w-1/3"
+                className="pf-v6-u-w-50"
                 isOpen={showDialog}
                 text={`Deleting a cluster configuration doesn't remove security services running in the cluster. To remove them, run the "delete-sensor.sh" script from the sensor installation bundle. Are you sure you want to delete ${checkedClusterIds.length} cluster(s)?`}
                 onConfirm={makeDeleteRequest}

--- a/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/AdmissionControl/AdmissionControlStatus.tsx
@@ -25,7 +25,7 @@ function AdmissionControlStatus({ healthStatus }: AdmissionControlStatusProps): 
     const { Icon, fgColor } = isDelayed
         ? delayedAdmissionControlStatusStyle
         : healthStatusStyles[admissionControlHealthStatus];
-    const icon = <Icon className="inline h-4 w-4" />;
+    const icon = <Icon />;
 
     const healthLabelElement = (
         <HealthLabelWithDelayed

--- a/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/ClusterStatus.tsx
@@ -14,7 +14,7 @@ function ClusterStatus({ healthStatus }: ClusterStatusProps): ReactElement {
     const { overallHealthStatus = 'UNAVAILABLE' } = healthStatus ?? {};
 
     const { Icon, fgColor } = healthStatusStyles[overallHealthStatus];
-    const icon = <Icon className="h-4 w-4" />;
+    const icon = <Icon />;
 
     return (
         <HealthStatus icon={icon} iconColor={fgColor}>

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatus.tsx
@@ -26,7 +26,7 @@ function CollectorStatus({ healthStatus }: CollectorStatusProps): ReactElement {
     const { Icon, fgColor } = isDelayed
         ? delayedCollectorStatusStyle
         : healthStatusStyles[collectorHealthStatus];
-    const icon = <Icon className="inline h-4 w-4" />;
+    const icon = <Icon />;
 
     const statusElement = (
         <HealthLabelWithDelayed

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorStatusTotals.tsx
@@ -28,7 +28,7 @@ function CollectorStatusTotals({ collectorHealthInfo }: CollectorStatusTotalsPro
                     <th className={thClassName} scope="row">
                         Collector version:
                     </th>
-                    <td className={`${tdClassName} break-all`} data-testid="version">
+                    <td className={`${tdClassName} pf-v6-u-text-break-word`} data-testid="version">
                         {version || notAvailable}
                     </td>
                 </tr>
@@ -63,7 +63,7 @@ function CollectorStatusTotals({ collectorHealthInfo }: CollectorStatusTotalsPro
                                 {statusErrors.map((err) => (
                                     <li key={err}>
                                         <span
-                                            className={`${healthStatusStylesLegacy.UNHEALTHY.fgColor} break-all`}
+                                            className={`${healthStatusStylesLegacy.UNHEALTHY.fgColor} pf-v6-u-text-break-word`}
                                         >
                                             {err}
                                         </span>

--- a/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Collector/CollectorUnavailableStatus.tsx
@@ -24,7 +24,7 @@ function CollectorUnavailableStatus({
 
     return isList ? (
         <Tooltip content={reasonUnavailable}>
-            <div className="inline">
+            <div className="pf-v6-u-display-inline">
                 <HealthStatus icon={icon} iconColor={fgColor} isList={isList}>
                     {statusElement}
                 </HealthStatus>

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -36,13 +36,13 @@ function CredentialExpiration({
     // Adapt health status categories to certificate expiration.
     const healthStatus = getCredentialExpirationStatus(certExpiryStatus, currentDatetime);
     const { Icon, fgColor } = healthStatusStylesLegacy[healthStatus];
-    const icon = <Icon className="h-4 w-4" />;
+    const icon = <Icon />;
 
     // Order arguments according to date-fns@2 convention:
     // If sensorCertExpiry > currentDateTime: in X units
     // If sensorCertExpiry <= currentDateTime: X units ago
     const distanceElement = (
-        <span className="whitespace-nowrap">
+        <span className="pf-v6-u-text-nowrap">
             {getDistanceStrictAsPhrase(sensorCertExpiry, currentDatetime)}
         </span>
     );
@@ -68,7 +68,7 @@ function CredentialExpiration({
         expirationElement = (
             <div data-testid={testId}>
                 {distanceElement}{' '}
-                <span className="whitespace-nowrap">{`on ${
+                <span className="pf-v6-u-text-nowrap">{`on ${
                     diffInDays > 0 && diffInDays < 7
                         ? getDayOfWeek(sensorCertExpiry)
                         : getDate(sensorCertExpiry)
@@ -88,7 +88,7 @@ function CredentialExpiration({
                 <div>
                     {expirationElement}
                     {version && (
-                        <div className="flex flex-row items-end leading-tight">
+                        <div>
                             <ExternalLink>
                                 <a
                                     href={getVersionedDocs(

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthLabelWithDelayed.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthLabelWithDelayed.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import capitalize from 'lodash/capitalize';
 
 import { healthStatusLabels } from '../cluster.constants';
 import type { ClusterHealthItem, ClusterHealthItemStatus } from '../clusterTypes';
@@ -26,12 +27,12 @@ function HealthLabelWithDelayed({
     const healthLabelText = isList
         ? clusterHealthItem
         : healthStatusLabels[clusterHealthItemStatus];
-    const healthLabelElement = <span className="capitalize">{healthLabelText}</span>;
+    const healthLabelElement = <span>{capitalize(healthLabelText)}</span>;
     if (isDelayed) {
         return (
             <div data-testid={testId} className={`${isList ? 'inline' : ''}`}>
                 {healthLabelElement}
-                <span className="whitespace-nowrap">{` ${delayedText}`}</span>
+                <span className="pf-v6-u-text-nowrap">{` ${delayedText}`}</span>
             </div>
         );
     }

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthStatus.tsx
@@ -25,8 +25,14 @@ function HealthStatus({
 }: HealthStatusProps): ReactElement {
     return (
         // flex-row assumes a child element wraps multiple grandchildren
-        <div className={`leading-normal ${isList ? 'inline' : 'flex flex-row items-start'}`}>
-            <span className={`align-middle flex-shrink-0 mr-2 ${iconColor}`}>{icon}</span>
+        <div
+            className={
+                isList
+                    ? 'pf-v6-u-display-inline'
+                    : 'pf-v6-u-display-flex pf-v6-u-align-items-flex-start'
+            }
+        >
+            <span className={`pf-v6-u-flex-shrink-0 pf-v6-u-mr-sm ${iconColor}`}>{icon}</span>
             {children}
         </div>
     );

--- a/ui/apps/platform/src/Containers/Clusters/Components/HealthStatusNotApplicable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HealthStatusNotApplicable.tsx
@@ -7,7 +7,7 @@ function HealthStatusNotApplicable({
     isList = false,
 }: HealthStatusNotApplicableProps): ReactElement {
     return (
-        <div className={`${isList ? 'inline' : ''} leading-normal`} data-testid={testId}>
+        <div className={isList ? 'pf-v6-u-display-inline' : ''} data-testid={testId}>
             <span className="pf-v6-u-text-nowrap">Not applicable</span>
         </div>
     );

--- a/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/HelmIndicator.tsx
@@ -6,8 +6,8 @@ import HelmLogo from 'images/helm.svg?react';
 function HelmIndicator(): ReactElement {
     return (
         <Tooltip content="This cluster is managed by Helm.">
-            <span className="w-5 h-5 inline-block pf-v6-u-flex-shrink-0">
-                <HelmLogo className="w-5 h-5" />
+            <span className="pf-v6-u-display-inline-block pf-v6-u-flex-shrink-0">
+                <HelmLogo />
             </span>
         </Tooltip>
     );

--- a/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/OperatorIndicator.tsx
@@ -6,9 +6,9 @@ import operatorLogo from 'images/operator-logo.png';
 function OperatorIndicator(): ReactElement {
     return (
         <Tooltip content="This cluster is managed by a Kubernetes Operator.">
-            <span className="w-5 h-5 inline-block pf-v6-u-flex-shrink-0">
+            <span className="pf-v6-u-display-inline-block pf-v6-u-flex-shrink-0">
                 <img
-                    className="w-5 h-5"
+                    style={{ width: '20px', height: '20px' }}
                     src={operatorLogo}
                     alt="Managed by a Kubernetes Operator"
                 />

--- a/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/Scanner/ScannerStatus.tsx
@@ -22,7 +22,7 @@ const ScannerStatus = ({ healthStatus }: ScannerStatusProps) => {
     const { Icon, fgColor } = isDelayed
         ? delayedScannerStatusStyle
         : healthStatusStyles[scannerHealthStatus];
-    const icon = <Icon className="inline h-4 w-4" />;
+    const icon = <Icon />;
 
     const healthLabelElement = (
         <HealthLabelWithDelayed

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorStatus.tsx
@@ -21,7 +21,7 @@ function SensorStatus({ healthStatus }: SensorStatusProps): ReactElement {
 
     const isDelayed = !!(lastContact && isDelayedSensorHealthStatus(sensorHealthStatus));
     const { Icon, fgColor } = healthStatusStyles[sensorHealthStatus];
-    const icon = <Icon className="inline h-4 w-4" />;
+    const icon = <Icon />;
 
     const statusElement = (
         <HealthLabelWithDelayed

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -106,16 +106,8 @@ export const centralEnvDefault = {
     kernelSupportAvailable: false,
 };
 
-type MinusCircleRotate45Props = {
-    className: string;
-};
-
-const MinusCircleRotate45 = ({ className }: MinusCircleRotate45Props) => (
-    <MinusCircleIcon className={`${className} transform rotate-45`} />
-);
-
 const styleUninitializedLegacy = {
-    Icon: MinusCircleRotate45,
+    Icon: MinusCircleIcon,
     fgColor: '',
 };
 


### PR DESCRIPTION
## Description

Removes Tailwind classes and last instance of `react-feather` under the Clusters/ directory.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Icon sizing change is almost imperceptible if not a no-op.

Before:
<img width="1454" height="1084" alt="image" src="https://github.com/user-attachments/assets/7606ddef-8b8e-411b-8046-2cc4f30d28d0" />
<img width="1454" height="1084" alt="image" src="https://github.com/user-attachments/assets/2674d89b-8185-4a71-8d50-9584c032ac52" />


Before:
<img width="1454" height="1084" alt="image" src="https://github.com/user-attachments/assets/d5636447-694f-44a2-adba-1eebfeff5091" />

After:
<img width="1454" height="1084" alt="image" src="https://github.com/user-attachments/assets/25197a78-1d35-4d86-bae6-b10f5df6e68b" />
