### PR TITLE
ROX-35135: Vulnerability reports landing page

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/reports/reportsOverviewNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/reports/reportsOverviewNav.test.ts
@@ -23,7 +23,7 @@ describe('Vulnerability Reports Overview Navigation', () => {
     });
 
     it('navigates to the node vulnerability reports page', () => {
-        interceptAndOverridePermissions({ Node: 'READ_ACCESS' });
+        interceptAndOverridePermissions({ Cluster: 'READ_ACCESS', Node: 'READ_ACCESS' });
         interceptAndOverrideFeatureFlags({ ROX_NODE_VULNERABILITY_REPORTS: true });
 
         visit(vulnerabilityReportsOverviewPath);

--- a/ui/apps/platform/cypress/integration/vulnerabilities/reports/reportsOverviewNav.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/reports/reportsOverviewNav.test.ts
@@ -1,0 +1,34 @@
+import withAuth from '../../../helpers/basicAuth';
+import {
+    interceptAndOverrideFeatureFlags,
+    interceptAndOverridePermissions,
+} from '../../../helpers/request';
+import { visit } from '../../../helpers/visit';
+import pf6 from '../../../selectors/pf6';
+
+const vulnerabilityReportsOverviewPath = '/main/vulnerabilities/reports';
+const vulnerabilityImageReportsPath = '/main/vulnerabilities/reports/images';
+const vulnerabilityNodeReportsPath = '/main/vulnerabilities/reports/nodes';
+
+describe('Vulnerability Reports Overview Navigation', () => {
+    withAuth();
+
+    it('navigates to the image vulnerability reports page', () => {
+        interceptAndOverridePermissions({ Deployment: 'READ_ACCESS', Image: 'READ_ACCESS' });
+
+        visit(vulnerabilityReportsOverviewPath);
+
+        cy.get(`${pf6.card}:contains("Image vulnerability reports") button`).click();
+        cy.location('pathname').should('include', vulnerabilityImageReportsPath);
+    });
+
+    it('navigates to the node vulnerability reports page', () => {
+        interceptAndOverridePermissions({ Node: 'READ_ACCESS' });
+        interceptAndOverrideFeatureFlags({ ROX_NODE_VULNERABILITY_REPORTS: true });
+
+        visit(vulnerabilityReportsOverviewPath);
+
+        cy.get(`${pf6.card}:contains("Node vulnerability reports") button`).click();
+        cy.location('pathname').should('include', vulnerabilityNodeReportsPath);
+    });
+});

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -54,6 +54,7 @@ import {
     vulnerabilitiesWorkloadCvesPath,
     vulnerabilityImageReportsPath,
     vulnerabilityNodeReportsPath,
+    vulnerabilityReportsPath,
 } from 'routePaths';
 import type { RouteKey } from 'routePaths';
 
@@ -292,18 +293,24 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
         component: makeVulnMgmtUserWorkloadView('images-without-cves'),
         path: vulnerabilitiesImagesWithoutCvesPath,
     },
-    'vulnerabilities/node-reports': {
+    'vulnerabilities/reports': {
+        component: asyncComponent(
+            () => import('Containers/Vulnerabilities/Reports/VulnerabilityReportsPage')
+        ),
+        path: vulnerabilityReportsPath,
+    },
+    'vulnerabilities/reports/images': {
+        component: asyncComponent(
+            () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
+        ),
+        path: vulnerabilityImageReportsPath,
+    },
+    'vulnerabilities/reports/nodes': {
         component: asyncComponent(
             () =>
                 import('Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsPage')
         ),
         path: vulnerabilityNodeReportsPath,
-    },
-    'vulnerabilities/reports': {
-        component: asyncComponent(
-            () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
-        ),
-        path: vulnerabilityImageReportsPath,
     },
     'vulnerability-management': {
         component: asyncComponent(() => import('Containers/VulnMgmt/WorkflowLayout')),

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -46,7 +46,7 @@ import {
     vulnerabilitiesUserWorkloadsPath,
     vulnerabilitiesViewPath,
     vulnerabilitiesVirtualMachineCvesPath,
-    vulnerabilityImageReportsPath,
+    vulnerabilityReportsPath,
 } from 'routePaths';
 
 import NavigationContent from './NavigationContent';
@@ -98,9 +98,8 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
         {
             type: 'link',
             content: 'Reports',
-            // TODO: point to the vulnerability reports overview page once it exists.
-            path: vulnerabilityImageReportsPath,
-            routeKey: 'vulnerabilities/reports',
+            path: vulnerabilityReportsPath,
+            routeKey: ['vulnerabilities/reports/images', 'vulnerabilities/reports/nodes'],
         },
         {
             type: 'separator',

--- a/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/utils.ts
@@ -17,7 +17,7 @@ export type LinkDescription = {
     type: 'link';
     content: string | TitleCallback | ReactElement;
     path: string;
-    routeKey: RouteKey;
+    routeKey: RouteKey | RouteKey[];
     description?: string;
     isActive?: IsActiveCallback; // for example, exact match
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VulnerabilityReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VulnerabilityReportsPage.tsx
@@ -1,0 +1,83 @@
+import { useNavigate } from 'react-router-dom-v5-compat';
+import {
+    Card,
+    CardBody,
+    CardHeader,
+    CardTitle,
+    Flex,
+    FlexItem,
+    Gallery,
+    GalleryItem,
+    PageSection,
+    Title,
+} from '@patternfly/react-core';
+
+import PageTitle from 'Components/PageTitle';
+import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
+import { vulnerabilityImageReportsPath, vulnerabilityNodeReportsPath } from 'routePaths';
+
+function VulnerabilityReportsPage() {
+    const navigate = useNavigate();
+    const isRouteEnabled = useIsRouteEnabled();
+    const isImageReportsEnabled = isRouteEnabled('vulnerabilities/reports/images');
+    const isNodeReportsEnabled = isRouteEnabled('vulnerabilities/reports/nodes');
+
+    return (
+        <>
+            <PageTitle title="Vulnerability reports" />
+            <PageSection>
+                <Flex direction={{ default: 'column' }}>
+                    <Title headingLevel="h1">Vulnerability reports</Title>
+                    <FlexItem>
+                        Configure scheduled vulnerability reports and view-based exports by report
+                        type.
+                    </FlexItem>
+                </Flex>
+            </PageSection>
+            <PageSection>
+                <Gallery hasGutter>
+                    {isImageReportsEnabled && (
+                        <GalleryItem>
+                            <Card isClickable isFullHeight>
+                                <CardHeader
+                                    selectableActions={{
+                                        onClickAction: () =>
+                                            navigate(vulnerabilityImageReportsPath),
+                                        selectableActionAriaLabel:
+                                            'View Image vulnerability reports',
+                                    }}
+                                >
+                                    <CardTitle>Image vulnerability reports</CardTitle>
+                                </CardHeader>
+                                <CardBody>
+                                    CVE reports scoped to workload images, platform components, all
+                                    deployed images, and inactive images across your clusters.
+                                </CardBody>
+                            </Card>
+                        </GalleryItem>
+                    )}
+                    {isNodeReportsEnabled && (
+                        <GalleryItem>
+                            <Card isClickable isFullHeight>
+                                <CardHeader
+                                    selectableActions={{
+                                        onClickAction: () => navigate(vulnerabilityNodeReportsPath),
+                                        selectableActionAriaLabel:
+                                            'View Node vulnerability reports',
+                                    }}
+                                >
+                                    <CardTitle>Node vulnerability reports</CardTitle>
+                                </CardHeader>
+                                <CardBody>
+                                    OS and runtime CVEs across nodes in selected clusters.
+                                </CardBody>
+                            </Card>
+                        </GalleryItem>
+                    )}
+                </Gallery>
+            </PageSection>
+        </>
+    );
+}
+
+export default VulnerabilityReportsPage;

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -199,8 +199,9 @@ export type RouteKey =
     | 'violations'
     | 'vulnerabilities/exception-management'
     | 'vulnerabilities/node-cves'
-    | 'vulnerabilities/node-reports'
     | 'vulnerabilities/reports'
+    | 'vulnerabilities/reports/images'
+    | 'vulnerabilities/reports/nodes'
     | 'vulnerabilities/user-workloads'
     | 'vulnerabilities/platform'
     | 'vulnerabilities/all-images'
@@ -372,16 +373,21 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
     'vulnerabilities/node-cves': {
         resourceAccessRequirements: everyResource(['Cluster', 'Node']),
     },
-    'vulnerabilities/node-reports': {
-        featureFlagRequirements: allEnabled(['ROX_NODE_VULNERABILITY_REPORTS']),
-        resourceAccessRequirements: everyResource(['Node']),
-    },
     'vulnerabilities/platform-cves': {
         featureFlagRequirements: allEnabled(['ROX_LEGACY_SCANNER']),
         resourceAccessRequirements: everyResource(['Cluster']),
     },
+    // This is a lightweight page with cards that link to the individually gated report types
+    // below. NavigationSidebar decides link visibility by checking the sub-route keys directly
     'vulnerabilities/reports': {
+        resourceAccessRequirements: everyResource([]),
+    },
+    'vulnerabilities/reports/images': {
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),
+    },
+    'vulnerabilities/reports/nodes': {
+        featureFlagRequirements: allEnabled(['ROX_NODE_VULNERABILITY_REPORTS']),
+        resourceAccessRequirements: everyResource(['Cluster', 'Node']),
     },
     'vulnerabilities/user-workloads': {
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),
@@ -425,9 +431,15 @@ type RoutePredicates = {
 };
 
 export function isRouteEnabled(
-    { hasReadAccess, isFeatureFlagEnabled }: RoutePredicates,
-    routeKey: RouteKey
-) {
+    routePredicates: RoutePredicates,
+    routeKey: RouteKey | RouteKey[]
+): boolean {
+    // An array is enabled if any one of the route keys is enabled.
+    if (Array.isArray(routeKey)) {
+        return routeKey.some((key) => isRouteEnabled(routePredicates, key));
+    }
+
+    const { hasReadAccess, isFeatureFlagEnabled } = routePredicates;
     const { featureFlagRequirements, resourceAccessRequirements } = routeRequirementsMap[routeKey];
 
     const areFeatureFlagRequirementsMet = featureFlagRequirements
@@ -495,6 +507,7 @@ const vulnerabilitiesPathToLabelMap: Record<string, string> = {
     [vulnerabilitiesPlatformCvesPath]: 'Platform CVEs',
     [vulnerabilitiesNodeCvesPath]: 'Node CVEs',
     [vulnerabilityReportsPath]: 'Reports',
+    [vulnerabilityImageReportsPath]: 'Image reports',
     [exceptionManagementPath]: 'Exception Management',
 };
 


### PR DESCRIPTION
## Description

Adds a vulnerability reports overview ("landing") page

- Splits the single `vulnerabilities/reports` route into three: the overview (`vulnerabilities/reports`, ungated), `vulnerabilities/reports/images`, and `vulnerabilities/reports/nodes`. Each report type keeps the permissions/feature-flag requirements it already had.
- New `VulnerabilityReportsPage` renders two cards (Image / Node vulnerability reports) linking to each sub-route. Each card only renders if `useIsRouteEnabled` reports that type as reachable, so a user only sees cards for report types they can actually use.
- Generalized `isRouteEnabled` (and `LinkDescription.routeKey`) to accept an array of route keys with OR semantics. The sidebar "Reports" link uses this to show if *either* report type is reachable, correctly accounting for both permissions and feature flags per type.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests



### How I validated my change

- Manually tested by toggling permissions and the `ROX_NODE_VULNERABILITY_REPORTS` flag, checking sidebar visibility, overview cards, and direct sub-route navigation for:
  - Both report types available
  - Image access only
  - Node access only
  - Neither
  - Node access only but the flag off

<img width="1515" height="931" alt="Screenshot 2026-08-23 at 11 08 03 AM" src="https://github.com/user-attachments/assets/2f540618-b822-496b-93d0-144f2b761706" />
