### PR TITLE
ROX-36253: Node CVE report CSV and email formatting

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/consts.go
+++ b/central/reports/scheduler/v2/reportgenerator/consts.go
@@ -8,4 +8,15 @@ const (
 		"Please review the vulnerable software packages/components from the impacted images and update them to a version containing the fix, if one is available.\n"
 
 	defaultNoVulnsEmailBodyTemplate = "{{.BrandedPrefix}} for Kubernetes has found no workload CVEs in the images matched by the following report configuration parameters.\n"
+
+	// NodeDefaultEmailSubjectTemplate is the default email subject for node CVE reports.
+	NodeDefaultEmailSubjectTemplate = "{{.BrandedProductNameShort}} Node CVE Report for {{.ReportConfigName}}"
+
+	// NodeDefaultEmailBodyTemplate is the default email body for node CVE reports.
+	NodeDefaultEmailBodyTemplate = "{{.BrandedPrefix}} for Kubernetes has identified node CVEs in the nodes matched by the following report configuration parameters. " +
+		"The attached vulnerability report lists those node CVEs and associated details to help with remediation. " +
+		"Please review the vulnerable software packages/components from the impacted nodes and update them to a version containing the fix, if one is available.\n"
+
+	// NodeDefaultNoVulnsEmailBodyTemplate is the default email body when no node CVEs are found.
+	NodeDefaultNoVulnsEmailBodyTemplate = "{{.BrandedPrefix}} for Kubernetes has found no node CVEs in the nodes matched by the following report configuration parameters.\n"
 )

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -39,7 +39,9 @@ var (
 	}
 )
 
-func formatEmailSubject(subjectTemplate string, snapshot *storage.ReportSnapshot) (string, error) {
+// FormatEmailSubject formats an email subject line from the given Go template
+// and report snapshot.
+func FormatEmailSubject(subjectTemplate string, snapshot *storage.ReportSnapshot) (string, error) {
 	configName := snapshot.GetName()
 	if len(configName) > maxConfigNameLenInSubject {
 		configName = fmt.Sprintf("%s...", configName[0:maxConfigNameLenInSubject])
@@ -65,7 +67,8 @@ func formatEmailSubject(subjectTemplate string, snapshot *storage.ReportSnapshot
 	return templates.ExecuteToString(tmpl, data)
 }
 
-func formatEmailBody(emailTemplate string) (string, error) {
+// FormatEmailBody formats an email body from the given Go template.
+func FormatEmailBody(emailTemplate string) (string, error) {
 	data := &reportEmailBodyFormat{
 		BrandedPrefix: branding.GetCombinedProductAndShortName(),
 	}
@@ -77,7 +80,8 @@ func formatEmailBody(emailTemplate string) (string, error) {
 	return templates.ExecuteToString(tmpl, data)
 }
 
-func addReportConfigDetails(emailBody, configDetailsHTML string) string {
+// AddReportConfigDetails appends report configuration details HTML to the email body.
+func AddReportConfigDetails(emailBody, configDetailsHTML string) string {
 	var writer strings.Builder
 	writer.WriteString(emailBody)
 	writer.WriteString("<br><br>")
@@ -141,6 +145,35 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 
 	writer.WriteString("</div>")
 
+	return writer.String(), nil
+}
+
+// FormatNodeReportConfigDetails formats node report configuration details as HTML
+// for inclusion in the notification email.
+func FormatNodeReportConfigDetails(snapshot *storage.ReportSnapshot, numNodeCVEs int) (string, error) {
+	filters := snapshot.GetNodeVulnReportFilters()
+	if filters == nil {
+		return "", errors.New("report snapshot is missing node vulnerability report filters")
+	}
+
+	var writer strings.Builder
+	writer.WriteString("<div>")
+
+	formatSingleDetail(&writer, "Config name", snapshot.GetName())
+	formatSingleDetail(&writer, "Number of CVEs found", fmt.Sprintf("%d", numNodeCVEs))
+
+	if query := filters.GetQuery(); query != "" {
+		formatSingleDetail(&writer, "Filter", query)
+	}
+
+	if entityScope := snapshot.GetResourceScope().GetEntityScope(); entityScope != nil {
+		scopeParts := formatEntityScope(entityScope)
+		if len(scopeParts) > 0 {
+			formatSingleDetail(&writer, "Report scope", scopeParts...)
+		}
+	}
+
+	writer.WriteString("</div>")
 	return writer.String(), nil
 }
 

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -188,6 +188,101 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 	return cases
 }
 
+func (s *EmailFormatterTestSuite) TestFormatNodeReportConfigDetails() {
+	for _, tc := range s.nodeConfigDetailsTestCases() {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			configHTML, err := FormatNodeReportConfigDetails(tc.snapshot, 25)
+			s.Require().NoError(err)
+			expectedHTML := strings.ReplaceAll(tc.expectedHTML, "\n", "")
+			expectedHTML = strings.ReplaceAll(expectedHTML, "\t", "")
+			s.Require().Equal(expectedHTML, configHTML)
+		})
+	}
+}
+
+func (s *EmailFormatterTestSuite) TestFormatNodeReportConfigDetails_NilFilters() {
+	snap := &storage.ReportSnapshot{
+		Name: "Node Report",
+	}
+	_, err := FormatNodeReportConfigDetails(snap, 0)
+	s.Require().Error(err)
+}
+
+func (s *EmailFormatterTestSuite) nodeConfigDetailsTestCases() []configDetailsTestCase {
+	return []configDetailsTestCase{
+		{
+			desc: "Node report with entity scope and filter query",
+			snapshot: &storage.ReportSnapshot{
+				Name: "Node Team Report",
+				Filter: &storage.ReportSnapshot_NodeVulnReportFilters{
+					NodeVulnReportFilters: &storage.NodeVulnerabilityReportFilters{
+						Query: "CVSS > 7",
+					},
+				},
+				ResourceScope: &storage.ResourceScope{
+					ScopeReference: &storage.ResourceScope_EntityScope{
+						EntityScope: &storage.EntityScope{
+							Rules: []*storage.EntityScopeRule{
+								{
+									Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+									Field:  storage.EntityField_FIELD_NAME,
+									Values: []*storage.RuleValue{
+										{Value: "prod-us"},
+										{Value: "prod-eu"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHTML: `<div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Config name: </span>
+							<span>Node Team Report</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Number of CVEs found: </span>
+							<span>25</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Filter: </span>
+							<span>CVSS > 7</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Report scope: </span>
+							<span>Cluster Name: prod-us, prod-eu</span>
+						</div>
+					</div>`,
+		},
+		{
+			desc: "Node report without filter query or entity scope",
+			snapshot: &storage.ReportSnapshot{
+				Name: "Simple Node Report",
+				Filter: &storage.ReportSnapshot_NodeVulnReportFilters{
+					NodeVulnReportFilters: &storage.NodeVulnerabilityReportFilters{},
+				},
+			},
+			expectedHTML: `<div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Config name: </span>
+							<span>Simple Node Report</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Number of CVEs found: </span>
+							<span>25</span>
+						</div>
+					</div>`,
+		},
+	}
+}
+
 func (s *EmailFormatterTestSuite) entityScopeTestCases() []configDetailsTestCase {
 	return []configDetailsTestCase{
 		{

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
@@ -47,16 +47,11 @@ func generateCSV(cveResponses []*NodeCVEQueryResponse, configName string) (*byte
 		csvWriter.AddValue(row)
 	}
 
-	var buf bytes.Buffer
-	if err := csvWriter.WriteBytes(&buf); err != nil {
-		return nil, errors.Wrap(err, "error creating csv report")
-	}
-
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
 	truncatedName := configName
-	if len(configName) > 80 {
-		truncatedName = configName[0:80] + "..."
+	if runes := []rune(configName); len(runes) > 80 {
+		truncatedName = string(runes[:80]) + "..."
 	}
 
 	now := time.Now()
@@ -70,7 +65,7 @@ func generateCSV(cveResponses []*NodeCVEQueryResponse, configName string) (*byte
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create the zip file for report config '%s'", configName)
 	}
-	if _, err = zipFile.Write(buf.Bytes()); err != nil {
+	if err = csvWriter.WriteCSV(zipFile); err != nil {
 		return nil, errors.Wrapf(err, "unable to write the zip file for report config '%s'", configName)
 	}
 	if err = zipWriter.Close(); err != nil {

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
@@ -23,6 +23,7 @@ var csvHeader = []string{
 	"CVE Fixed In",
 	"Severity",
 	"CVSS",
+	"First System Occurrence",
 	"Reference",
 }
 
@@ -40,6 +41,7 @@ func generateCSV(cveResponses []*NodeCVEQueryResponse, configName string) (*byte
 			r.GetFixedByVersion(),
 			strings.ToTitle(stringutils.GetUpTo(r.GetSeverity().String(), "_")),
 			strconv.FormatFloat(r.GetCVSS(), 'f', 2, 64),
+			r.GetFirstOccurrence(),
 			r.Link,
 		}
 		csvWriter.AddValue(row)

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
@@ -1,0 +1,78 @@
+package node
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/csv"
+	"github.com/stackrox/rox/pkg/stringutils"
+)
+
+var csvHeader = []string{
+	"Cluster",
+	"Node",
+	"Component",
+	"Component Version",
+	"CVE",
+	"Fixable",
+	"CVE Fixed In",
+	"Severity",
+	"CVSS",
+	"Reference",
+}
+
+func generateCSV(cveResponses []*NodeCVEQueryResponse, configName string) (*bytes.Buffer, error) {
+	csvWriter := csv.NewGenericWriter(csvHeader, true)
+
+	for _, r := range cveResponses {
+		row := csv.Value{
+			r.GetCluster(),
+			r.GetNode(),
+			r.GetComponent(),
+			r.GetComponentVersion(),
+			r.GetCVE(),
+			strconv.FormatBool(r.GetFixable()),
+			r.GetFixedByVersion(),
+			strings.ToTitle(stringutils.GetUpTo(r.GetSeverity().String(), "_")),
+			strconv.FormatFloat(r.GetCVSS(), 'f', 2, 64),
+			r.Link,
+		}
+		csvWriter.AddValue(row)
+	}
+
+	var buf bytes.Buffer
+	if err := csvWriter.WriteBytes(&buf); err != nil {
+		return nil, errors.Wrap(err, "error creating csv report")
+	}
+
+	var zipBuf bytes.Buffer
+	zipWriter := zip.NewWriter(&zipBuf)
+	truncatedName := configName
+	if len(configName) > 80 {
+		truncatedName = configName[0:80] + "..."
+	}
+
+	now := time.Now()
+	reportName := fmt.Sprintf("RHACS_Node_Vulnerability_Report_%s_%s.csv", truncatedName, now.Format("02_January_2006"))
+	header := &zip.FileHeader{
+		Name:     reportName,
+		Method:   zip.Deflate,
+		Modified: now,
+	}
+	zipFile, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to create the zip file for report config '%s'", configName)
+	}
+	if _, err = zipFile.Write(buf.Bytes()); err != nil {
+		return nil, errors.Wrapf(err, "unable to write the zip file for report config '%s'", configName)
+	}
+	if err = zipWriter.Close(); err != nil {
+		return nil, errors.Wrapf(err, "unable to close the zip file for report config %s", configName)
+	}
+	return &zipBuf, nil
+}

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
@@ -42,7 +42,7 @@ func generateCSV(cveResponses []*NodeCVEQueryResponse, configName string) (*byte
 			strings.ToTitle(stringutils.GetUpTo(r.GetSeverity().String(), "_")),
 			strconv.FormatFloat(r.GetCVSS(), 'f', 2, 64),
 			r.GetFirstOccurrence(),
-			r.Link,
+			r.GetLink(),
 		}
 		csvWriter.AddValue(row)
 	}

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
@@ -82,7 +82,7 @@ func TestGenerateCSV_WithResponses(t *testing.T) {
 
 func TestGenerateCSV_LongConfigNameIsTruncated(t *testing.T) {
 	longName := ""
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		longName += "a"
 	}
 	buf, err := generateCSV(nil, longName)

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
@@ -1,0 +1,141 @@
+package node
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/csv"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCSV_EmptyResponses(t *testing.T) {
+	buf, err := generateCSV(nil, "test-report")
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+	assert.Contains(t, reader.File[0].Name, "RHACS_Node_Vulnerability_Report_")
+	assert.Contains(t, reader.File[0].Name, "test-report")
+}
+
+func TestGenerateCSV_WithResponses(t *testing.T) {
+	cluster := "prod-us"
+	node := "node-1"
+	component := "openssl"
+	componentVersion := "1.1.1"
+	cve := "CVE-2021-1234"
+	fixable := true
+	fixedBy := "1.1.2"
+	severity := storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
+	cvss := 9.8
+
+	responses := []*NodeCVEQueryResponse{
+		{
+			Cluster:          &cluster,
+			Node:             &node,
+			Component:        &component,
+			ComponentVersion: &componentVersion,
+			CVE:              &cve,
+			Fixable:          &fixable,
+			FixedByVersion:   &fixedBy,
+			Severity:         &severity,
+			CVSS:             &cvss,
+			Link:             "https://nvd.nist.gov/vuln/detail/CVE-2021-1234",
+		},
+	}
+
+	buf, err := generateCSV(responses, "test-report")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+
+	rc, err := reader.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	csvReader := csv.NewReader(rc)
+	records, err := csvReader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + 1 data row
+	require.Len(t, records, 2)
+	assert.Equal(t, csvHeader, records[0])
+	assert.Equal(t, "prod-us", records[1][0])
+	assert.Equal(t, "node-1", records[1][1])
+	assert.Equal(t, "openssl", records[1][2])
+	assert.Equal(t, "1.1.1", records[1][3])
+	assert.Equal(t, "CVE-2021-1234", records[1][4])
+	assert.Equal(t, "true", records[1][5])
+	assert.Equal(t, "1.1.2", records[1][6])
+	assert.Equal(t, "CRITICAL", records[1][7])
+	assert.Equal(t, "9.80", records[1][8])
+	assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2021-1234", records[1][9])
+}
+
+func TestGenerateCSV_LongConfigNameIsTruncated(t *testing.T) {
+	longName := ""
+	for i := 0; i < 100; i++ {
+		longName += "a"
+	}
+	buf, err := generateCSV(nil, longName)
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+	assert.Contains(t, reader.File[0].Name, "...")
+	assert.LessOrEqual(t, len(reader.File[0].Name), 200)
+}
+
+func TestGenerateCSV_ZipEntryHasModifiedTimestamp(t *testing.T) {
+	before := time.Now().Add(-time.Minute)
+	buf, err := generateCSV(nil, "test")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+	assert.False(t, reader.File[0].Modified.IsZero(), "ZIP entry Modified timestamp should not be zero")
+	assert.True(t, reader.File[0].Modified.After(before), "ZIP entry Modified timestamp should be recent")
+}
+
+func TestGenerateCSV_NilFieldsProduceDefaults(t *testing.T) {
+	responses := []*NodeCVEQueryResponse{
+		{},
+	}
+
+	buf, err := generateCSV(responses, "defaults-test")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	rc, err := reader.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	csvReader := csv.NewReader(rc)
+	records, err := csvReader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	row := records[1]
+	assert.Equal(t, "", row[0])        // Cluster
+	assert.Equal(t, "", row[1])        // Node
+	assert.Equal(t, "", row[2])        // Component
+	assert.Equal(t, "", row[3])        // ComponentVersion
+	assert.Equal(t, "", row[4])        // CVE
+	assert.Equal(t, "false", row[5])   // Fixable
+	assert.Equal(t, "", row[6])        // FixedBy
+	assert.Equal(t, "UNKNOWN", row[7]) // Severity
+	assert.Equal(t, "0.00", row[8])    // CVSS
+	assert.Equal(t, "", row[9])        // Link
+}

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
@@ -35,6 +35,8 @@ func TestGenerateCSV_WithResponses(t *testing.T) {
 	severity := storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY
 	cvss := 9.8
 
+	firstOccurrence := time.Date(2021, 6, 15, 0, 0, 0, 0, time.UTC)
+
 	responses := []*NodeCVEQueryResponse{
 		{
 			Cluster:          &cluster,
@@ -46,6 +48,7 @@ func TestGenerateCSV_WithResponses(t *testing.T) {
 			FixedByVersion:   &fixedBy,
 			Severity:         &severity,
 			CVSS:             &cvss,
+			FirstOccurrence:  &firstOccurrence,
 			Link:             "https://nvd.nist.gov/vuln/detail/CVE-2021-1234",
 		},
 	}
@@ -77,7 +80,8 @@ func TestGenerateCSV_WithResponses(t *testing.T) {
 	assert.Equal(t, "1.1.2", records[1][6])
 	assert.Equal(t, "CRITICAL", records[1][7])
 	assert.Equal(t, "9.80", records[1][8])
-	assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2021-1234", records[1][9])
+	assert.Equal(t, "June 15, 2021", records[1][9])
+	assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2021-1234", records[1][10])
 }
 
 func TestGenerateCSV_LongConfigNameIsTruncated(t *testing.T) {
@@ -128,14 +132,15 @@ func TestGenerateCSV_NilFieldsProduceDefaults(t *testing.T) {
 	require.Len(t, records, 2)
 
 	row := records[1]
-	assert.Equal(t, "", row[0])        // Cluster
-	assert.Equal(t, "", row[1])        // Node
-	assert.Equal(t, "", row[2])        // Component
-	assert.Equal(t, "", row[3])        // ComponentVersion
-	assert.Equal(t, "", row[4])        // CVE
-	assert.Equal(t, "false", row[5])   // Fixable
-	assert.Equal(t, "", row[6])        // FixedBy
-	assert.Equal(t, "UNKNOWN", row[7]) // Severity
-	assert.Equal(t, "0.00", row[8])    // CVSS
-	assert.Equal(t, "", row[9])        // Link
+	assert.Equal(t, "", row[0])              // Cluster
+	assert.Equal(t, "", row[1])              // Node
+	assert.Equal(t, "", row[2])              // Component
+	assert.Equal(t, "", row[3])              // ComponentVersion
+	assert.Equal(t, "", row[4])              // CVE
+	assert.Equal(t, "false", row[5])         // Fixable
+	assert.Equal(t, "", row[6])              // FixedBy
+	assert.Equal(t, "UNKNOWN", row[7])       // Severity
+	assert.Equal(t, "0.00", row[8])          // CVSS
+	assert.Equal(t, "Not Available", row[9]) // First System Occurrence
+	assert.Equal(t, "", row[10])             // Link
 }

--- a/central/reports/scheduler/v2/reportgenerator/node/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/types.go
@@ -1,0 +1,91 @@
+package node
+
+import (
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// NodeCVEQueryResponse contains the fields of a node CVE report query response.
+type NodeCVEQueryResponse struct {
+	Cluster          *string                        `db:"cluster"`
+	Node             *string                        `db:"node"`
+	Component        *string                        `db:"component"`
+	ComponentVersion *string                        `db:"component_version"`
+	CVEID            *string                        `db:"cve_id"`
+	CVE              *string                        `db:"cve"`
+	Fixable          *bool                          `db:"fixable"`
+	FixedByVersion   *string                        `db:"fixed_by"`
+	Severity         *storage.VulnerabilitySeverity `db:"severity"`
+	CVSS             *float64                       `db:"cvss"`
+
+	Link string
+}
+
+func (r *NodeCVEQueryResponse) GetCluster() string {
+	if r.Cluster == nil {
+		return ""
+	}
+	return *r.Cluster
+}
+
+func (r *NodeCVEQueryResponse) GetNode() string {
+	if r.Node == nil {
+		return ""
+	}
+	return *r.Node
+}
+
+func (r *NodeCVEQueryResponse) GetComponent() string {
+	if r.Component == nil {
+		return ""
+	}
+	return *r.Component
+}
+
+func (r *NodeCVEQueryResponse) GetComponentVersion() string {
+	if r.ComponentVersion == nil {
+		return ""
+	}
+	return *r.ComponentVersion
+}
+
+func (r *NodeCVEQueryResponse) GetCVEID() string {
+	if r.CVEID == nil {
+		return ""
+	}
+	return *r.CVEID
+}
+
+func (r *NodeCVEQueryResponse) GetCVE() string {
+	if r.CVE == nil {
+		return ""
+	}
+	return *r.CVE
+}
+
+func (r *NodeCVEQueryResponse) GetFixable() bool {
+	if r.Fixable == nil {
+		return false
+	}
+	return *r.Fixable
+}
+
+func (r *NodeCVEQueryResponse) GetFixedByVersion() string {
+	if r.FixedByVersion == nil {
+		return ""
+	}
+	return *r.FixedByVersion
+}
+
+func (r *NodeCVEQueryResponse) GetSeverity() storage.VulnerabilitySeverity {
+	if r.Severity == nil {
+		return storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	}
+	return *r.Severity
+}
+
+func (r *NodeCVEQueryResponse) GetCVSS() float64 {
+	if r.CVSS == nil {
+		return 0.0
+	}
+	return *r.CVSS
+}

--- a/central/reports/scheduler/v2/reportgenerator/node/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/types.go
@@ -99,3 +99,7 @@ func (r *NodeCVEQueryResponse) GetFirstOccurrence() string {
 	}
 	return r.FirstOccurrence.Format("January 02, 2006")
 }
+
+func (r *NodeCVEQueryResponse) GetLink() string {
+	return r.Link
+}

--- a/central/reports/scheduler/v2/reportgenerator/node/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/types.go
@@ -1,6 +1,8 @@
 package node
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -16,6 +18,7 @@ type NodeCVEQueryResponse struct {
 	FixedByVersion   *string                        `db:"fixed_by"`
 	Severity         *storage.VulnerabilitySeverity `db:"severity"`
 	CVSS             *float64                       `db:"cvss"`
+	FirstOccurrence  *time.Time                     `db:"cve_created_time"`
 
 	Link string
 }
@@ -88,4 +91,11 @@ func (r *NodeCVEQueryResponse) GetCVSS() float64 {
 		return 0.0
 	}
 	return *r.CVSS
+}
+
+func (r *NodeCVEQueryResponse) GetFirstOccurrence() string {
+	if r.FirstOccurrence == nil {
+		return "Not Available"
+	}
+	return r.FirstOccurrence.Format("January 02, 2006")
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -184,7 +184,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 		}
 
 	case storage.ReportStatus_EMAIL:
-		defaultEmailSubject, err := formatEmailSubject(defaultEmailSubjectTemplate, req.ReportSnapshot)
+		defaultEmailSubject, err := FormatEmailSubject(defaultEmailSubjectTemplate, req.ReportSnapshot)
 		if err != nil {
 			return errors.Wrap(err, "Error generating email subject")
 		}
@@ -197,7 +197,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 			templateStr = defaultNoVulnsEmailBodyTemplate
 		}
 
-		defaultEmailBody, err := formatEmailBody(templateStr)
+		defaultEmailBody, err := FormatEmailBody(templateStr)
 		if err != nil {
 			return errors.Wrap(err, "Error generating email body")
 		}
@@ -226,7 +226,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 			if customSubject != "" {
 				emailSubject = customSubject
 			}
-			emailBodyWithConfigDetails := addReportConfigDetails(emailBody, configDetailsHTML)
+			emailBodyWithConfigDetails := AddReportConfigDetails(emailBody, configDetailsHTML)
 			reportName := req.ReportSnapshot.GetName()
 			err := rg.retryableSendReportResults(reportNotifier, notifierSnap.GetEmailConfig().GetMailingLists(),
 				zippedCSVData, emailSubject, emailBodyWithConfigDetails, reportName)


### PR DESCRIPTION
## Description

Add CSV generation, response types, and email formatting for node CVE reports. These are building blocks used by the node report generator in the next PR in the stack.

- `NodeCVEQueryResponse` type with accessor methods for flattened node CVE query results
- CSV generator producing zipped `RHACS_Node_Vulnerability_Report_` files with columns: Cluster, Node, Component, Version, CVE, Fixable, Fixed By, Severity, CVSS, Link
- Node email template constants (subject/body) and `FormatNodeReportConfigDetails` for node-specific email content

Gated by `NodeVulnerabilityReports` feature flag.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Unit tests. Manual E2E tests will be run when API changes are merged.