### PR TITLE
ROX-36389: ensure scan stats are recomputed on rescan

### DIFF
--- a/pkg/images/enricher/enricher_v2_impl_test.go
+++ b/pkg/images/enricher/enricher_v2_impl_test.go
@@ -508,6 +508,51 @@ func TestCVESuppressionV2(t *testing.T) {
 	assert.Equal(t, storage.VulnerabilityState_DEFERRED, img.GetScan().GetComponents()[0].GetVulns()[0].GetState())
 }
 
+// TestEnrichImageV2_ScanStatsRecomputedOnNewScan reproduces the exact object flow used
+// by the image reprocessor (central/reprocessor/reprocessor.go): an ImageV2 fetched
+// from the datastore (so ScanStats is already populated from its previous scan) is
+// passed into EnrichImage, which finds a genuinely new scan. ScanStats must be
+// recomputed to match the new scan (ROX-36389).
+func TestEnrichImageV2_ScanStatsRecomputedOnNewScan(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.FlattenImageData, true)
+	ctrl := gomock.NewController(t)
+
+	fsr := newFakeRegistryScanner(opts{})
+	registrySet := registryMocks.NewMockSet(ctrl)
+	registrySet.EXPECT().IsEmpty().Return(false).AnyTimes()
+	registrySet.EXPECT().GetAllUnique().Return([]types.ImageRegistry{fsr}).AnyTimes()
+
+	scannerSet := scannerMocks.NewMockSet(ctrl)
+	scannerSet.EXPECT().IsEmpty().Return(false).AnyTimes()
+	scannerSet.EXPECT().GetAll().Return([]scannertypes.ImageScannerWithDataSource{fsr}).AnyTimes()
+
+	set := mocks.NewMockSet(ctrl)
+	set.EXPECT().RegistrySet().Return(registrySet).AnyTimes()
+	set.EXPECT().ScannerSet().Return(scannerSet).AnyTimes()
+
+	mockReporter := reporterMocks.NewMockReporter(ctrl)
+	mockReporter.EXPECT().UpdateIntegrationHealthAsync(gomock.Any()).AnyTimes()
+
+	enricherImpl := newEnricherV2(set, mockReporter)
+
+	img := &storage.ImageV2{
+		Id:        utils.NewImageV2ID(&storage.ImageName{Registry: "reg", FullName: "reg"}, "sha"),
+		Digest:    "sha",
+		Name:      &storage.ImageName{Registry: "reg", FullName: "reg"},
+		ScanStats: &storage.ImageV2_ScanStats{CveCount: 99},
+	}
+
+	results, err := enricherImpl.EnrichImage(emptyCtx, EnrichmentContext{}, img)
+	require.NoError(t, err)
+	assert.True(t, results.ImageUpdated)
+
+	// The fake scanner always returns a scan with exactly 1 CVE.
+	require.Len(t, img.GetScan().GetComponents(), 1)
+	require.Len(t, img.GetScan().GetComponents()[0].GetVulns(), 1)
+
+	assert.Equal(t, int32(1), img.GetScanStats().GetCveCount())
+}
+
 func TestZeroIntegrationsV2(t *testing.T) {
 	testutils.MustUpdateFeature(t, features.FlattenImageData, true)
 	ctrl := gomock.NewController(t)

--- a/pkg/images/utils/test/utils_test.go
+++ b/pkg/images/utils/test/utils_test.go
@@ -606,6 +606,38 @@ func TestFillScanStatsV2(t *testing.T) {
 	}
 }
 
+// TestFilterSuppressedCVEsNoCloneV2 confirms that filtering out suppressed CVEs also
+// updates ScanStats to match (ROX-36389).
+func TestFilterSuppressedCVEsNoCloneV2(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.FlattenImageData, true)
+
+	image := &storage.ImageV2{
+		Id:     utils.NewImageV2ID(&storage.ImageName{Registry: "reg", FullName: "reg"}, "sha"),
+		Digest: "sha",
+		Name:   &storage.ImageName{Registry: "reg", FullName: "reg"},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{
+					Vulns: []*storage.EmbeddedVulnerability{
+						{Cve: "cve-1", Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY},
+						{Cve: "cve-2", Severity: storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY, State: storage.VulnerabilityState_DEFERRED},
+					},
+				},
+			},
+		},
+		// ScanStats reflects the unfiltered scan, as it would for an image already
+		// fetched from the datastore before filtering.
+		ScanStats: &storage.ImageV2_ScanStats{CveCount: 2},
+	}
+
+	utils.FilterSuppressedCVEsNoCloneV2(image)
+
+	if assert.Len(t, image.GetScan().GetComponents()[0].GetVulns(), 1) {
+		assert.Equal(t, "cve-1", image.GetScan().GetComponents()[0].GetVulns()[0].GetCve())
+	}
+	assert.Equal(t, int32(1), image.GetScanStats().GetCveCount())
+}
+
 func TestStripDatasourceNoClone(t *testing.T) {
 	original := &storage.ImageScan{
 		Components: []*storage.EmbeddedImageScanComponent{

--- a/pkg/images/utils/utils.go
+++ b/pkg/images/utils/utils.go
@@ -397,9 +397,6 @@ func FillScanStatsV2(i *storage.ImageV2) {
 	if i.GetScan() == nil {
 		return
 	}
-	if i.GetScanStats() != nil {
-		return
-	}
 	i.ScanStats = &storage.ImageV2_ScanStats{}
 	i.GetScanStats().ComponentCount = int32(len(i.GetScan().GetComponents()))
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -169,15 +169,13 @@ function WorkloadCvesOverviewPage() {
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
     // If the user is viewing observed CVEs, we need to scope the query based on
-    // the selected vulnerability state, and exclude images/deployments with 0 CVEs
-    // (see ROX-36389). If the user is viewing _without_ CVEs, we need to scope the
-    // query to only show images/deployments with 0 CVEs.
+    // the selected vulnerability state. If the user is viewing _without_ CVEs, we
+    // need to scope the query to only show images/deployments with 0 CVEs.
     const workloadCvesScopedSearchFilter = isViewingWithCves
         ? {
               ...baseSearchFilter,
               ...querySearchFilter,
               'Vulnerability State': [currentVulnerabilityState],
-              'Image CVE Count': ['>0'],
           }
         : {
               ...baseSearchFilter,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -169,13 +169,15 @@ function WorkloadCvesOverviewPage() {
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
     // If the user is viewing observed CVEs, we need to scope the query based on
-    // the selected vulnerability state. If the user is viewing _without_ CVEs, we
-    // need to scope the query to only show images/deployments with 0 CVEs.
+    // the selected vulnerability state, and exclude images/deployments with 0 CVEs
+    // (see ROX-36389). If the user is viewing _without_ CVEs, we need to scope the
+    // query to only show images/deployments with 0 CVEs.
     const workloadCvesScopedSearchFilter = isViewingWithCves
         ? {
               ...baseSearchFilter,
               ...querySearchFilter,
               'Vulnerability State': [currentVulnerabilityState],
+              'Image CVE Count': ['>0'],
           }
         : {
               ...baseSearchFilter,


### PR DESCRIPTION
## Description

Follow up to #22399 - fixes bug where scan stats were not recomputed, resulting in stale CVE counts.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
Additional unit tests cover this case and guard against regressions. 
