### PR TITLE
ROX-36420: Node report configuration deletion

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/NodeConfigurationsList.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/NodeConfigurationsList.tsx
@@ -3,6 +3,7 @@ import { Link, generatePath } from 'react-router-dom-v5-compat';
 import {
     Button,
     Content,
+    DropdownItem,
     Flex,
     FlexItem,
     PageSection,
@@ -15,10 +16,12 @@ import {
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import HelpIconTh from 'Components/HelpIconTh';
+import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import PageTitle from 'Components/PageTitle';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import usePermissions from 'hooks/usePermissions';
 import useRestQuery from 'hooks/useRestQuery';
+import useTableSelection from 'hooks/useTableSelection';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
@@ -27,10 +30,14 @@ import {
     vulnerabilityNodeConfigurationsReportsPath,
 } from 'routePaths';
 import {
+    deleteNodeReportConfiguration,
     fetchNodeReportConfigurations,
     fetchNodeReportConfigurationsCount,
 } from 'services/NodeReportsService';
 import { getTableUIState } from 'utils/getTableUIState';
+
+import DeleteReportsModal from '../../components/DeleteReportsModal';
+import useDeleteModal from '../../../VulnerablityReporting/hooks/useDeleteModal';
 
 const CreateReportsButton = () => {
     return (
@@ -49,8 +56,14 @@ const sortOptions = {
 
 function NodeConfigurationsList() {
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
+    const hasDeleteAccessForReport = hasReadWriteAccess('WorkflowAdministration');
     const hasWriteAccessForReport =
         hasReadWriteAccess('WorkflowAdministration') && hasReadAccess('Integration');
+
+    // single source of truth for which optional columns actually render, should prevent drift if
+    // any permissions change above
+    const hasSelectColumn = hasDeleteAccessForReport;
+    const hasActionsColumn = hasDeleteAccessForReport || hasWriteAccessForReport;
 
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { sortOption, getSortParams } = useURLSort(sortOptions);
@@ -74,13 +87,16 @@ function NodeConfigurationsList() {
         data: reportConfigurations,
         isLoading: isListLoading,
         error: listError,
+        refetch: refetchList,
     } = useRestQuery(fetchReportConfigurationsCallback);
 
     const fetchReportConfigurationsCountCallback = useCallback(
         () => fetchNodeReportConfigurationsCount(searchFilter),
         [searchFilter]
     );
-    const { data: countData } = useRestQuery(fetchReportConfigurationsCountCallback);
+    const { data: countData, refetch: refetchCount } = useRestQuery(
+        fetchReportConfigurationsCountCallback
+    );
 
     // table should still load even if countData is not available
     const totalReports = countData?.count ?? 0;
@@ -92,7 +108,39 @@ function NodeConfigurationsList() {
         searchFilter,
     });
 
-    const colSpan = hasWriteAccessForReport ? 5 : 4;
+    const {
+        selected,
+        numSelected,
+        allRowsSelected,
+        hasSelections,
+        onSelect,
+        onSelectAll,
+        onClearAll: onClearAllSelected,
+        getSelectedIds,
+    } = useTableSelection(reportConfigurations ?? []);
+
+    const {
+        openDeleteModal,
+        isDeleteModalOpen,
+        closeDeleteModal,
+        isDeleting,
+        onDelete,
+        deleteResults,
+        reportIdsToDelete,
+    } = useDeleteModal({
+        deleteFunction: deleteNodeReportConfiguration,
+        onCompleted: () => {
+            onClearAllSelected();
+            refetchList();
+            refetchCount();
+        },
+    });
+
+    function onConfirmDeleteSelection() {
+        openDeleteModal(getSelectedIds());
+    }
+
+    const colSpan = 4 + (hasSelectColumn ? 1 : 0) + (hasActionsColumn ? 1 : 0);
 
     function onClearFilters() {
         setSearchValue('');
@@ -135,6 +183,15 @@ function NodeConfigurationsList() {
                                 onClear={onClearFilters}
                             />
                         </ToolbarItem>
+                        {hasDeleteAccessForReport && (
+                            <ToolbarItem>
+                                <MenuDropdown toggleText="Bulk actions" isDisabled={!hasSelections}>
+                                    <DropdownItem key="delete" onClick={onConfirmDeleteSelection}>
+                                        Delete ({numSelected})
+                                    </DropdownItem>
+                                </MenuDropdown>
+                            </ToolbarItem>
+                        )}
                         <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
                             <Pagination
                                 itemCount={totalReports}
@@ -150,6 +207,14 @@ function NodeConfigurationsList() {
                 <Table>
                     <Thead noWrap>
                         <Tr>
+                            {hasSelectColumn && (
+                                <Th
+                                    select={{
+                                        onSelect: onSelectAll,
+                                        isSelected: allRowsSelected,
+                                    }}
+                                />
+                            )}
                             <Th sort={getSortParams(reportNameSearchKey)}>Report</Th>
                             <HelpIconTh
                                 popoverContent={
@@ -163,7 +228,7 @@ function NodeConfigurationsList() {
                             </HelpIconTh>
                             <Th>Description</Th>
                             <Th>My last job status</Th>
-                            {hasWriteAccessForReport && <Th screenReaderText="Row actions" />}
+                            {hasActionsColumn && <Th screenReaderText="Row actions" />}
                         </Tr>
                     </Thead>
                     <TbodyUnified
@@ -179,7 +244,7 @@ function NodeConfigurationsList() {
                         }}
                         filteredEmptyProps={{ onClearFilters }}
                         renderer={({ data }) =>
-                            data.map((report) => {
+                            data.map((report, rowIndex) => {
                                 const reportURL = generatePath(
                                     vulnerabilityNodeConfigurationsReportsDetailsPath,
                                     {
@@ -190,6 +255,15 @@ function NodeConfigurationsList() {
                                 return (
                                     <Tbody key={report.id}>
                                         <Tr>
+                                            {hasSelectColumn && (
+                                                <Td
+                                                    select={{
+                                                        rowIndex,
+                                                        onSelect,
+                                                        isSelected: selected[rowIndex],
+                                                    }}
+                                                />
+                                            )}
                                             <Td dataLabel="Report">
                                                 <Link to={reportURL}>{report.name}</Link>
                                             </Td>
@@ -198,16 +272,18 @@ function NodeConfigurationsList() {
                                                 {report.description || '-'}
                                             </Td>
                                             <Td dataLabel="My last job status">ROX-36102</Td>
-                                            {hasWriteAccessForReport && (
+                                            {hasActionsColumn && (
                                                 <Td isActionCell>
                                                     <ActionsColumn
                                                         items={[
                                                             {
-                                                                title: 'Row actions',
-                                                                isDisabled: true,
+                                                                title: 'Delete report',
+                                                                onClick: (event) => {
+                                                                    event.preventDefault();
+                                                                    openDeleteModal([report.id]);
+                                                                },
                                                             },
                                                         ]}
-                                                        isDisabled
                                                     />
                                                 </Td>
                                             )}
@@ -219,6 +295,15 @@ function NodeConfigurationsList() {
                     />
                 </Table>
             </PageSection>
+            <DeleteReportsModal
+                isOpen={isDeleteModalOpen}
+                onClose={closeDeleteModal}
+                isDeleting={isDeleting}
+                onDelete={onDelete}
+                reportIdsToDelete={reportIdsToDelete}
+                deleteResults={deleteResults}
+                reportConfigurations={reportConfigurations ?? null}
+            />
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/components/DeleteReportsModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/components/DeleteReportsModal.tsx
@@ -1,0 +1,114 @@
+import {
+    Alert,
+    AlertGroup,
+    Button,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Title,
+} from '@patternfly/react-core';
+import pluralize from 'pluralize';
+
+import type { ReportConfigurationBase } from 'services/ReportsService.types';
+
+import {
+    isErrorDeleteResult,
+    isSuccessDeleteResult,
+} from '../../VulnerablityReporting/hooks/useDeleteModal';
+import type { DeleteResult } from '../../VulnerablityReporting/hooks/useDeleteModal';
+
+export type DeleteReportsModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    isDeleting: boolean;
+    onDelete: () => void;
+    reportIdsToDelete: string[];
+    deleteResults: DeleteResult[] | null;
+    reportConfigurations: ReportConfigurationBase[] | null;
+};
+
+function DeleteReportsModal({
+    isOpen,
+    onClose,
+    isDeleting,
+    onDelete,
+    reportIdsToDelete,
+    deleteResults,
+    reportConfigurations,
+}: DeleteReportsModalProps) {
+    const numSuccessfulDeletions = deleteResults?.filter(isSuccessDeleteResult).length ?? 0;
+    const title = `Permanently delete ${reportIdsToDelete.length} report ${pluralize(
+        'configuration',
+        reportIdsToDelete.length
+    )}?`;
+
+    return (
+        <Modal
+            aria-labelledby="delete-reports-modal-title"
+            variant="small"
+            isOpen={isOpen}
+            onClose={onClose}
+        >
+            <ModalHeader>
+                <Title id="delete-reports-modal-title" headingLevel="h2">
+                    {title}
+                </Title>
+            </ModalHeader>
+            <ModalBody>
+                <AlertGroup>
+                    {numSuccessfulDeletions > 0 && (
+                        <Alert
+                            component="p"
+                            isInline
+                            title={`Successfully deleted ${numSuccessfulDeletions} report ${pluralize(
+                                'configuration',
+                                numSuccessfulDeletions
+                            )}`}
+                            variant="success"
+                        />
+                    )}
+                    {deleteResults?.filter(isErrorDeleteResult).map((deleteResult) => {
+                        const reportConfiguration = reportConfigurations?.find(
+                            (configuration) => configuration.id === deleteResult.id
+                        );
+                        if (!reportConfiguration) {
+                            return null;
+                        }
+                        return (
+                            <Alert
+                                component="p"
+                                isInline
+                                key={deleteResult.id}
+                                title={`Failed to delete "${reportConfiguration.name}"`}
+                                variant="danger"
+                            >
+                                {deleteResult.error}
+                            </Alert>
+                        );
+                    })}
+                </AlertGroup>
+                <p>
+                    The selected report {pluralize('configuration', reportIdsToDelete.length)} and
+                    any attached downloadable reports will be permanently deleted. The action cannot
+                    be undone.
+                </p>
+            </ModalBody>
+            <ModalFooter>
+                <Button
+                    variant="danger"
+                    isLoading={isDeleting}
+                    isDisabled={isDeleting}
+                    onClick={onDelete}
+                >
+                    Delete
+                </Button>
+                <Button variant="link" onClick={onClose} isDisabled={isDeleting}>
+                    Cancel
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+}
+
+export default DeleteReportsModal;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -28,6 +28,7 @@ import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import usePermissions from 'hooks/usePermissions';
 import useToasts from 'hooks/patternfly/useToasts';
 import type { Toast } from 'hooks/patternfly/useToasts';
+import { deleteReportConfiguration } from 'services/ReportsService';
 import type { ReportConfiguration } from 'services/ReportsService.types';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
@@ -79,6 +80,7 @@ function ViewVulnReportPage() {
         onDelete,
         deleteResults,
     } = useDeleteModal({
+        deleteFunction: deleteReportConfiguration,
         onCompleted: () => {
             navigate(vulnerabilityConfigurationsReportsPath);
         },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -31,7 +31,6 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
 
-import DeleteModal from 'Components/PatternFly/DeleteModal';
 import PageTitle from 'Components/PageTitle';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate/EmptyStateTemplate';
 import CollectionsFormModal from 'Containers/Collections/CollectionsFormModal';
@@ -39,22 +38,19 @@ import useToasts from 'hooks/patternfly/useToasts';
 import type { Toast } from 'hooks/patternfly/useToasts';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import useTableSelection from 'hooks/useTableSelection';
-import pluralize from 'pluralize';
 import HelpIconTh from 'Components/HelpIconTh';
 import JobStatusPopoverContent from 'Components/ReportJob/JobStatusPopoverContent';
 import MyLastJobStatus from 'Components/ReportJob/MyLastJobStatus';
 import useAuthStatus from 'hooks/useAuthStatus';
-import { reportDownloadURL } from 'services/ReportsService';
+import { deleteReportConfiguration, reportDownloadURL } from 'services/ReportsService';
 import type { ImageVulnerabilityReportConfiguration } from 'services/ReportsService.types';
 
+import useDeleteModal from '../hooks/useDeleteModal';
+import DeleteReportsModal from '../../Reports/components/DeleteReportsModal';
 import type { ImageVulnerabilityResourceScope } from '../../Reports/ImageVulnerabilityReports/imageVulnerabilityReports.types';
 import useFetchReports from '../api/useFetchReports';
 import useRunReport from '../api/useRunReport';
 import { useWatchLastSnapshotForReports } from '../api/useWatchLastSnapshotForReports';
-import useDeleteModal, {
-    isErrorDeleteResult,
-    isSuccessDeleteResult,
-} from '../hooks/useDeleteModal';
 import { vulnerabilityConfigurationReportDetailsPath } from '../pathsForVulnerabilityReporting';
 
 // resourceScope: {} after roll back to previous version that does not support a newer resource scope.
@@ -151,6 +147,7 @@ function ConfigReportsTab() {
         deleteResults,
         reportIdsToDelete,
     } = useDeleteModal({
+        deleteFunction: deleteReportConfiguration,
         onCompleted: () => {
             onClearAllSelected();
             fetchReports();
@@ -169,8 +166,6 @@ function ConfigReportsTab() {
         const selectedIds = getSelectedIds();
         openDeleteModal(selectedIds);
     }
-
-    const numSuccessfulDeletions = deleteResults?.filter(isSuccessDeleteResult).length || 0;
 
     return (
         <>
@@ -525,54 +520,15 @@ function ConfigReportsTab() {
                     </Table>
                 )}
             </PageSection>
-            <DeleteModal
-                title={`Permanently delete (${reportIdsToDelete.length}) ${pluralize(
-                    'report',
-                    reportIdsToDelete.length
-                )}?`}
+            <DeleteReportsModal
                 isOpen={isDeleteModalOpen}
                 onClose={closeDeleteModal}
                 isDeleting={isDeleting}
                 onDelete={onDelete}
-            >
-                <AlertGroup>
-                    {numSuccessfulDeletions > 0 && (
-                        <Alert
-                            isInline
-                            variant="success"
-                            title={`Successfully deleted ${numSuccessfulDeletions} ${pluralize(
-                                'report',
-                                numSuccessfulDeletions
-                            )}`}
-                            component="p"
-                            className="pf-v6-u-mb-sm"
-                        />
-                    )}
-                    {deleteResults?.filter(isErrorDeleteResult).map((deleteResult) => {
-                        const report = reportConfigurations?.find(
-                            (reportConfig) => reportConfig.id === deleteResult.id
-                        );
-                        if (!report) {
-                            return null;
-                        }
-                        return (
-                            <Alert
-                                isInline
-                                variant="danger"
-                                title={`Failed to delete "${report.name}"`}
-                                component="p"
-                                className="pf-v6-u-mb-sm"
-                            >
-                                {deleteResult.error}
-                            </Alert>
-                        );
-                    })}
-                </AlertGroup>
-                <p>
-                    The selected report(s) and any attached downloadable reports will be permanently
-                    deleted. The action cannot be undone.
-                </p>
-            </DeleteModal>
+                reportIdsToDelete={reportIdsToDelete}
+                deleteResults={deleteResults}
+                reportConfigurations={reportConfigurations}
+            />
             {collectionModalId && (
                 <CollectionsFormModal
                     hasWriteAccessForCollections={false}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteModal.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import useModal from 'hooks/useModal';
-import { deleteReportConfiguration } from 'services/ReportsService';
 import type { Empty } from 'services/types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -17,9 +16,10 @@ type ErrorDeleteResult = {
     error: string;
 };
 
-type DeleteResult = SuccessDeleteResult | ErrorDeleteResult;
+export type DeleteResult = SuccessDeleteResult | ErrorDeleteResult;
 
 export type UseDeleteModalProps = {
+    deleteFunction: (id: string) => Promise<Empty>;
     onCompleted: () => void;
 };
 
@@ -43,7 +43,10 @@ export function isErrorDeleteResult(deleteResult: DeleteResult): deleteResult is
     return deleteResult.success === false;
 }
 
-function useDeleteModal({ onCompleted }: UseDeleteModalProps): UseDeleteModalResult {
+function useDeleteModal({
+    deleteFunction,
+    onCompleted,
+}: UseDeleteModalProps): UseDeleteModalResult {
     const { isModalOpen: isDeleteModalOpen, openModal, closeModal } = useModal();
     const [reportIdsToDelete, setReportIdsToDelete] = useState<string[]>([]);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -66,7 +69,7 @@ function useDeleteModal({ onCompleted }: UseDeleteModalProps): UseDeleteModalRes
     // potential errors.
     async function onSafeDelete(id: string): Promise<DeleteResult> {
         try {
-            const result = await deleteReportConfiguration(id);
+            const result = await deleteFunction(id);
             return { success: true, id, result };
         } catch (error) {
             return {

--- a/ui/apps/platform/src/services/NodeReportsService.ts
+++ b/ui/apps/platform/src/services/NodeReportsService.ts
@@ -89,12 +89,10 @@ export function fetchNodeReportConfiguration(
 }
 
 // DeleteNodeReportConfiguration
-export function deleteNodeReportConfiguration(reportId: string): CancellableRequest<Empty> {
-    return makeCancellableAxiosRequest((signal) =>
-        axios
-            .delete<Empty>(`/v2/reports/node/configurations/${reportId}`, { signal })
-            .then((response) => response.data)
-    );
+export function deleteNodeReportConfiguration(reportId: string): Promise<Empty> {
+    return axios
+        .delete<Empty>(`/v2/reports/node/configurations/${reportId}`)
+        .then((response) => response.data);
 }
 
 // Configuration-based jobs


### PR DESCRIPTION
## Description

Adds delete support for node vulnerability report configurations (bulk and per-row)

- Column visibility and `colSpan` are both derived from the same `hasSelectColumn`/`hasActionsColumn` booleans (themselves derived from permissions), rather than each recomputing permission checks independently. So if the underlying permissions change, both update together automatically and can't drift out of sync with each other.
- New shared `DeleteReportsModal` component, extracted from `ConfigReportsTab.tsx`. Built on the current, non deprecated PatternFly `Modal`, rather than the `@patternfly/react-core/deprecated` `Modal` that the older shared `Components/PatternFly/DeleteModal` wrapper still uses.
- `useDeleteModal` stays as is. Considered rebuilding it with `useRestMutation`, but think that would be a better follow up task.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

#### List page with correct permissions shows "Bulk actions" and table selections
<img width="1875" height="719" alt="Screenshot 2026-08-24 at 10 09 27 AM" src="https://github.com/user-attachments/assets/04e05d93-fcc1-4608-936c-1a32cb0578e4" />

---

#### Modal open
<img width="935" height="408" alt="Screenshot 2026-08-24 at 10 10 08 AM" src="https://github.com/user-attachments/assets/33a0bdab-46c1-4005-85f5-a2275cccf7b6" />

---

#### Failed deletion shows error message for each configuration
<img width="935" height="787" alt="Screenshot 2026-08-24 at 10 10 00 AM" src="https://github.com/user-attachments/assets/922c7c8f-aed2-4deb-b152-4acb82ca72db" />
