### PR TITLE
ROX-35131: Adapt from image to node report steps and views

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -6,8 +6,6 @@ import {
     HelperText,
     HelperTextItem,
 } from '@patternfly/react-core';
-import { getIn } from 'formik';
-import type { FormikProps } from 'formik';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
@@ -25,28 +23,29 @@ import {
     getSearchFilterFromSearchString,
 } from 'utils/searchUtils';
 
-export type FiltersQueryConfiguration = {
-    vulnReportFilters: {
-        query: string;
-    };
-};
-
-export type FiltersQueryProps<T extends FiltersQueryConfiguration = FiltersQueryConfiguration> = {
+// Because filter property name differs for different report types,
+// renderer is responsible to provide values from formik object.
+export type FiltersQueryProps = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
-    formik: FormikProps<T>;
+    error: string | undefined;
+    query: string;
     searchFilterConfig: CompoundSearchFilterConfig;
+    setQueryValue: (value: string, shouldValidate?: boolean) => void;
+    touched: boolean | undefined;
 };
 
-function FiltersQuery<T extends FiltersQueryConfiguration = FiltersQueryConfiguration>({
+function FiltersQuery({
     attributesSeparateFromConfig,
-    formik,
+    error,
+    query,
     searchFilterConfig,
-}: FiltersQueryProps<T>): ReactElement {
-    const searchFilter = getSearchFilterFromSearchString(formik.values.vulnReportFilters.query);
+    setQueryValue,
+    touched,
+}: FiltersQueryProps): ReactElement {
+    const searchFilter = getSearchFilterFromSearchString(query);
 
     function onFilterChange(searchFilterChanged: SearchFilter) {
-        formik.setFieldValue(
-            'vulnReportFilters.query',
+        setQueryValue(
             getRequestQueryStringForSearchFilter(applyRegexSearchModifiers(searchFilterChanged))
         );
     }
@@ -81,13 +80,11 @@ function FiltersQuery<T extends FiltersQueryConfiguration = FiltersQueryConfigur
                         searchFilter={searchFilter}
                     />
                 ) : (
-                    getIn(formik.touched, 'vulnReportFilters.query') &&
-                    getIn(formik.errors, 'vulnReportFilters.query') && (
+                    touched &&
+                    error && (
                         <FormHelperText>
                             <HelperText>
-                                <HelperTextItem variant="error">
-                                    {getIn(formik.errors, 'vulnReportFilters.query')}
-                                </HelperTextItem>
+                                <HelperTextItem variant="error">{error}</HelperTextItem>
                             </HelperText>
                         </FormHelperText>
                     )

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityFiltersView.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { DescriptionList, Flex, FlexItem, Title } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import { getSearchFilterFromSearchString } from 'utils/searchUtils';
+
+import type { NodeVulnerabilityReportFiltersConfiguration } from 'services/ReportsService.types';
+
+export type NodeVulnerabilityFiltersViewProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: NodeVulnerabilityReportFiltersConfiguration;
+};
+
+function NodeVulnerabilityFiltersView({
+    attributesSeparateFromConfig,
+    headingLevel,
+    horizontalTermWidthModifier,
+    searchFilterConfig,
+    values,
+}: NodeVulnerabilityFiltersViewProps): ReactElement {
+    // Render separate attributes (more likely to be specified) preceding config.
+    const attributesFromConfig = searchFilterConfig.flatMap(({ attributes }) => attributes);
+    const attributes = [...attributesSeparateFromConfig, ...attributesFromConfig];
+
+    const { nodeVulnReportFilters } = values;
+    const { query } = nodeVulnReportFilters;
+    const searchFilter = getSearchFilterFromSearchString(query);
+
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+            <FlexItem>
+                <Title headingLevel={headingLevel}>Filters</Title>
+            </FlexItem>
+            <FlexItem>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
+                    <CompoundSearchFilterDescriptionListGroups
+                        attributes={attributes}
+                        searchFilter={searchFilter}
+                    />
+                </DescriptionList>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default NodeVulnerabilityFiltersView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityReportView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityReportView.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from 'react';
+import { Flex } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import DeliveryView from 'Components/Reports/View/DeliveryView';
+import DetailsView from 'Components/Reports/View/DetailsView';
+import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+
+import NodeVulnerabilityFiltersView from './NodeVulnerabilityFiltersView';
+import NodeVulnerabilityResourcesView from './NodeVulnerabilityResourcesView';
+
+export type NodeVulnerabilityReportViewProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: NodeVulnerabilityReportConfiguration;
+};
+
+function NodeVulnerabilityReportView({
+    attributesSeparateFromConfig,
+    headingLevel,
+    horizontalTermWidthModifier,
+    searchFilterConfig,
+    values,
+}: NodeVulnerabilityReportViewProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+            <DetailsView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+            <NodeVulnerabilityResourcesView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+            <NodeVulnerabilityFiltersView
+                attributesSeparateFromConfig={attributesSeparateFromConfig}
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                searchFilterConfig={searchFilterConfig}
+                values={values}
+            />
+            <DeliveryView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+        </Flex>
+    );
+}
+
+export default NodeVulnerabilityReportView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityResourcesView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityResourcesView.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from 'react';
+import { DescriptionList, Flex, FlexItem, Title } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import EntityScopeDescriptionListGroups from 'Components/EntityScope/EntityScopeDescriptionListGroups';
+
+import type { NodeVulnerabilityReportResourcesConfiguration } from 'services/ReportsService.types';
+
+export type NodeVulnerabilityResourcesViewProps = {
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    values: NodeVulnerabilityReportResourcesConfiguration;
+};
+
+function NodeVulnerabilityResourcesView({
+    headingLevel,
+    horizontalTermWidthModifier,
+    values,
+}: NodeVulnerabilityResourcesViewProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+            <FlexItem>
+                <Title headingLevel={headingLevel}>Resources</Title>
+            </FlexItem>
+            <FlexItem>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
+                    {'entityScope' in values.resourceScope && (
+                        <EntityScopeDescriptionListGroups
+                            entityScope={values.resourceScope.entityScope}
+                        />
+                    )}
+                </DescriptionList>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default NodeVulnerabilityResourcesView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step2/NodeVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step2/NodeVulnerabilityResourcesStep.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { Flex, Form, PageSection, Radio, Title } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import EntityScopeCompoundSearchFilter from 'Components/EntityScope/EntityScopeCompoundSearchFilter';
+import {
+    getEntityScopeRulesFromSearchFilterForCluster,
+    getSearchFilterFromEntityScopeRulesForCluster,
+} from 'Components/EntityScope/utils';
+import { searchFilterConfigForCluster } from 'Components/EntityScope/searchFilterConfig';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import type {
+    EntityScope,
+    NodeVulnerabilityReportResourcesConfiguration,
+} from 'services/ReportsService.types';
+
+export type NodeVulnerabilityResourcesStepProps<
+    T extends NodeVulnerabilityReportResourcesConfiguration =
+        NodeVulnerabilityReportResourcesConfiguration,
+> = {
+    formik: FormikProps<T>;
+};
+
+function NodeVulnerabilityResourcesStep<
+    T extends NodeVulnerabilityReportResourcesConfiguration =
+        NodeVulnerabilityReportResourcesConfiguration,
+>({ formik }: NodeVulnerabilityResourcesStepProps<T>): ReactElement {
+    const [entityScopeSelected, setEntityScopeSelected] = useState<EntityScope>(
+        'entityScope' in formik.values.resourceScope
+            ? formik.values.resourceScope.entityScope
+            : { rules: [] }
+    );
+
+    function onChangeToEntityScope() {
+        // Set resourceScope to remove any other (future) scope property.
+        formik.setFieldValue('resourceScope', { entityScope: entityScopeSelected });
+    }
+
+    function setEntityScope(entityScope: EntityScope) {
+        setEntityScopeSelected(entityScope);
+        formik.setFieldValue('resourceScope.entityScope', entityScope);
+    }
+
+    return (
+        <PageSection>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <Title headingLevel="h2">Resources</Title>
+                <Form isWidthLimited>
+                    <FormLabelGroup
+                        label="Scope method"
+                        isRequired
+                        fieldId="resourceScope"
+                        touched={formik.touched}
+                        errors={formik.errors}
+                    >
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsLg' }}
+                        >
+                            <Radio
+                                id="entityScope"
+                                isChecked
+                                label="Custom scope"
+                                name="entityScope"
+                                onChange={onChangeToEntityScope}
+                                body={
+                                    <EntityScopeCompoundSearchFilter
+                                        entityScope={
+                                            'entityScope' in formik.values.resourceScope
+                                                ? formik.values.resourceScope.entityScope
+                                                : null
+                                        }
+                                        getEntityScopeRulesFromSearchFilter={
+                                            getEntityScopeRulesFromSearchFilterForCluster
+                                        }
+                                        getSearchFilterFromEntityScopeRules={
+                                            getSearchFilterFromEntityScopeRulesForCluster
+                                        }
+                                        searchFilterConfig={searchFilterConfigForCluster}
+                                        setEntityScope={setEntityScope}
+                                    />
+                                }
+                            />
+                        </Flex>
+                    </FormLabelGroup>
+                </Form>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default NodeVulnerabilityResourcesStep;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
@@ -10,28 +10,26 @@ import type {
 
 import FiltersQuery from 'Components/Reports/Step/FiltersQuery';
 
-import type { ImageVulnerabilityFiltersConfigurationForEntity } from '../../imageVulnerabilityReports.types';
+import type { NodeVulnerabilityReportFiltersConfiguration } from 'services/ReportsService.types';
 
-import ImageVulnerabilityFiltersSince from './ImageVulnerabilityFiltersSince';
-
-export type ImageVulnerabilityFiltersStepProps<
-    T extends ImageVulnerabilityFiltersConfigurationForEntity =
-        ImageVulnerabilityFiltersConfigurationForEntity,
+export type NodeVulnerabilityFiltersStepProps<
+    T extends NodeVulnerabilityReportFiltersConfiguration =
+        NodeVulnerabilityReportFiltersConfiguration,
 > = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };
 
-function ImageVulnerabilityFiltersStep<
-    T extends ImageVulnerabilityFiltersConfigurationForEntity =
-        ImageVulnerabilityFiltersConfigurationForEntity,
+function NodeVulnerabilityFiltersStep<
+    T extends NodeVulnerabilityReportFiltersConfiguration =
+        NodeVulnerabilityReportFiltersConfiguration,
 >({
     attributesSeparateFromConfig,
     formik,
     searchFilterConfig,
-}: ImageVulnerabilityFiltersStepProps<T>): ReactElement {
-    const queryPath = 'vulnReportFilters.query';
+}: NodeVulnerabilityFiltersStepProps<T>): ReactElement {
+    const queryPath = 'nodeVulnReportFilters.query';
 
     function setQueryValue(value: string, shouldValidate?: boolean) {
         formik.setFieldValue(queryPath, value, shouldValidate);
@@ -43,11 +41,10 @@ function ImageVulnerabilityFiltersStep<
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
                 <Form isHorizontal isWidthLimited>
-                    <ImageVulnerabilityFiltersSince formik={formik} />
                     <FiltersQuery
                         attributesSeparateFromConfig={attributesSeparateFromConfig}
                         error={getIn(formik.errors, queryPath)}
-                        query={formik.values.vulnReportFilters.query}
+                        query={formik.values.nodeVulnReportFilters.query}
                         searchFilterConfig={searchFilterConfig}
                         setQueryValue={setQueryValue}
                         touched={getIn(formik.touched, queryPath)}
@@ -58,4 +55,4 @@ function ImageVulnerabilityFiltersStep<
     );
 }
 
-export default ImageVulnerabilityFiltersStep;
+export default NodeVulnerabilityFiltersStep;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step5/NodeVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step5/NodeVulnerabilityReviewStep.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react';
+import { Alert, Flex, PageSection, Title } from '@patternfly/react-core';
+
+import type {
+    CompoundSearchFilterConfig,
+    SelectSearchFilterAttribute,
+} from 'Components/CompoundSearchFilter/types';
+import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import NodeVulnerabilityReportView from '../../View/NodeVulnerabilityReportView';
+
+export type NodeVulnerabilityReviewStepProps = {
+    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
+    error: Error | null;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: NodeVulnerabilityReportConfiguration;
+};
+
+function NodeVulnerabilityReviewStep({
+    attributesSeparateFromConfig,
+    error,
+    searchFilterConfig,
+    values,
+}: NodeVulnerabilityReviewStepProps): ReactElement {
+    return (
+        <PageSection>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <Title headingLevel="h2">Review</Title>
+                {error && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="Error saving report configuration"
+                        component="p"
+                    >
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
+                <NodeVulnerabilityReportView
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
+                    headingLevel="h3"
+                    horizontalTermWidthModifier={{ default: '24ch' }}
+                    searchFilterConfig={searchFilterConfig}
+                    values={values}
+                />
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default NodeVulnerabilityReviewStep;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/View/VirtualMachineVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/View/VirtualMachineVulnerabilityFiltersView.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { DescriptionList, Flex, FlexItem, Title } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import { getSearchFilterFromSearchString } from 'utils/searchUtils';
+
+import type { VirtualMachineVulnerabilityReportFiltersConfiguration } from 'services/ReportsService.types';
+
+export type VirtualMachineVulnerabilityFiltersViewProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: VirtualMachineVulnerabilityReportFiltersConfiguration;
+};
+
+function VirtualMachineVulnerabilityFiltersView({
+    attributesSeparateFromConfig,
+    headingLevel,
+    horizontalTermWidthModifier,
+    searchFilterConfig,
+    values,
+}: VirtualMachineVulnerabilityFiltersViewProps): ReactElement {
+    // Render separate attributes (more likely to be specified) preceding config.
+    const attributesFromConfig = searchFilterConfig.flatMap(({ attributes }) => attributes);
+    const attributes = [...attributesSeparateFromConfig, ...attributesFromConfig];
+
+    const { virtualMachineVulnReportFilters } = values;
+    const { query } = virtualMachineVulnReportFilters;
+    const searchFilter = getSearchFilterFromSearchString(query);
+
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+            <FlexItem>
+                <Title headingLevel={headingLevel}>Filters</Title>
+            </FlexItem>
+            <FlexItem>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
+                    <CompoundSearchFilterDescriptionListGroups
+                        attributes={attributes}
+                        searchFilter={searchFilter}
+                    />
+                </DescriptionList>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default VirtualMachineVulnerabilityFiltersView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/View/VirtualMachineVulnerabilityReportView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/View/VirtualMachineVulnerabilityReportView.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from 'react';
+import { Flex } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import DeliveryView from 'Components/Reports/View/DeliveryView';
+import DetailsView from 'Components/Reports/View/DetailsView';
+import type { VirtualMachineVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+
+import VirtualMachineVulnerabilityFiltersView from './VirtualMachineVulnerabilityFiltersView';
+import VirtualMachineVulnerabilityResourcesView from './VirtualMachineVulnerabilityResourcesView';
+
+export type VirtualMachineVulnerabilityReportViewProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: VirtualMachineVulnerabilityReportConfiguration;
+};
+
+function VirtualMachineVulnerabilityReportView({
+    attributesSeparateFromConfig,
+    headingLevel,
+    horizontalTermWidthModifier,
+    searchFilterConfig,
+    values,
+}: VirtualMachineVulnerabilityReportViewProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+            <DetailsView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+            <VirtualMachineVulnerabilityResourcesView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+            <VirtualMachineVulnerabilityFiltersView
+                attributesSeparateFromConfig={attributesSeparateFromConfig}
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                searchFilterConfig={searchFilterConfig}
+                values={values}
+            />
+            <DeliveryView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+        </Flex>
+    );
+}
+
+export default VirtualMachineVulnerabilityReportView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/View/VirtualMachineVulnerabilityResourcesView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/View/VirtualMachineVulnerabilityResourcesView.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from 'react';
+import { DescriptionList, Flex, FlexItem, Title } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import EntityScopeDescriptionListGroups from 'Components/EntityScope/EntityScopeDescriptionListGroups';
+
+import type { VirtualMachineVulnerabilityReportResourcesConfiguration } from 'services/ReportsService.types';
+
+export type VirtualMachineVulnerabilityResourcesViewProps = {
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    values: VirtualMachineVulnerabilityReportResourcesConfiguration;
+};
+
+function VirtualMachineVulnerabilityResourcesView({
+    headingLevel,
+    horizontalTermWidthModifier,
+    values,
+}: VirtualMachineVulnerabilityResourcesViewProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+            <FlexItem>
+                <Title headingLevel={headingLevel}>Resources</Title>
+            </FlexItem>
+            <FlexItem>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
+                    {'entityScope' in values.resourceScope && (
+                        <EntityScopeDescriptionListGroups
+                            entityScope={values.resourceScope.entityScope}
+                        />
+                    )}
+                </DescriptionList>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default VirtualMachineVulnerabilityResourcesView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/Wizard/Step2/VirtualMachineVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/Wizard/Step2/VirtualMachineVulnerabilityResourcesStep.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { Flex, Form, PageSection, Radio, Title } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import EntityScopeCompoundSearchFilter from 'Components/EntityScope/EntityScopeCompoundSearchFilter';
+import {
+    getEntityScopeRulesFromSearchFilterForClusterNamespace,
+    getSearchFilterFromEntityScopeRulesForClusterNamespace,
+} from 'Components/EntityScope/utils';
+import { searchFilterConfigForClusterNamespace } from 'Components/EntityScope/searchFilterConfig';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import type {
+    EntityScope,
+    VirtualMachineVulnerabilityReportResourcesConfiguration,
+} from 'services/ReportsService.types';
+
+export type VirtualMachineVulnerabilityResourcesStepProps<
+    T extends VirtualMachineVulnerabilityReportResourcesConfiguration =
+        VirtualMachineVulnerabilityReportResourcesConfiguration,
+> = {
+    formik: FormikProps<T>;
+};
+
+function VirtualMachineVulnerabilityResourcesStep<
+    T extends VirtualMachineVulnerabilityReportResourcesConfiguration =
+        VirtualMachineVulnerabilityReportResourcesConfiguration,
+>({ formik }: VirtualMachineVulnerabilityResourcesStepProps<T>): ReactElement {
+    const [entityScopeSelected, setEntityScopeSelected] = useState<EntityScope>(
+        'entityScope' in formik.values.resourceScope
+            ? formik.values.resourceScope.entityScope
+            : { rules: [] }
+    );
+
+    function onChangeToEntityScope() {
+        // Set resourceScope to remove any other (future) scope property.
+        formik.setFieldValue('resourceScope', { entityScope: entityScopeSelected });
+    }
+
+    function setEntityScope(entityScope: EntityScope) {
+        setEntityScopeSelected(entityScope);
+        formik.setFieldValue('resourceScope.entityScope', entityScope);
+    }
+
+    return (
+        <PageSection>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <Title headingLevel="h2">Resources</Title>
+                <Form isWidthLimited>
+                    <FormLabelGroup
+                        label="Scope method"
+                        isRequired
+                        fieldId="resourceScope"
+                        touched={formik.touched}
+                        errors={formik.errors}
+                    >
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsLg' }}
+                        >
+                            <Radio
+                                id="entityScope"
+                                isChecked
+                                label="Custom scope"
+                                name="entityScope"
+                                onChange={onChangeToEntityScope}
+                                body={
+                                    <EntityScopeCompoundSearchFilter
+                                        entityScope={
+                                            'entityScope' in formik.values.resourceScope
+                                                ? formik.values.resourceScope.entityScope
+                                                : null
+                                        }
+                                        getEntityScopeRulesFromSearchFilter={
+                                            getEntityScopeRulesFromSearchFilterForClusterNamespace
+                                        }
+                                        getSearchFilterFromEntityScopeRules={
+                                            getSearchFilterFromEntityScopeRulesForClusterNamespace
+                                        }
+                                        searchFilterConfig={searchFilterConfigForClusterNamespace}
+                                        setEntityScope={setEntityScope}
+                                    />
+                                }
+                            />
+                        </Flex>
+                    </FormLabelGroup>
+                </Form>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default VirtualMachineVulnerabilityResourcesStep;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/Wizard/Step3/VirtualMachineVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/Wizard/Step3/VirtualMachineVulnerabilityFiltersStep.tsx
@@ -10,28 +10,26 @@ import type {
 
 import FiltersQuery from 'Components/Reports/Step/FiltersQuery';
 
-import type { ImageVulnerabilityFiltersConfigurationForEntity } from '../../imageVulnerabilityReports.types';
+import type { VirtualMachineVulnerabilityReportFiltersConfiguration } from 'services/ReportsService.types';
 
-import ImageVulnerabilityFiltersSince from './ImageVulnerabilityFiltersSince';
-
-export type ImageVulnerabilityFiltersStepProps<
-    T extends ImageVulnerabilityFiltersConfigurationForEntity =
-        ImageVulnerabilityFiltersConfigurationForEntity,
+export type VirtualMachineVulnerabilityFiltersStepProps<
+    T extends VirtualMachineVulnerabilityReportFiltersConfiguration =
+        VirtualMachineVulnerabilityReportFiltersConfiguration,
 > = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };
 
-function ImageVulnerabilityFiltersStep<
-    T extends ImageVulnerabilityFiltersConfigurationForEntity =
-        ImageVulnerabilityFiltersConfigurationForEntity,
+function VirtualMachineVulnerabilityFiltersStep<
+    T extends VirtualMachineVulnerabilityReportFiltersConfiguration =
+        VirtualMachineVulnerabilityReportFiltersConfiguration,
 >({
     attributesSeparateFromConfig,
     formik,
     searchFilterConfig,
-}: ImageVulnerabilityFiltersStepProps<T>): ReactElement {
-    const queryPath = 'vulnReportFilters.query';
+}: VirtualMachineVulnerabilityFiltersStepProps<T>): ReactElement {
+    const queryPath = 'virtualMachineVulnReportFilters.query';
 
     function setQueryValue(value: string, shouldValidate?: boolean) {
         formik.setFieldValue(queryPath, value, shouldValidate);
@@ -43,11 +41,10 @@ function ImageVulnerabilityFiltersStep<
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
                 <Form isHorizontal isWidthLimited>
-                    <ImageVulnerabilityFiltersSince formik={formik} />
                     <FiltersQuery
                         attributesSeparateFromConfig={attributesSeparateFromConfig}
                         error={getIn(formik.errors, queryPath)}
-                        query={formik.values.vulnReportFilters.query}
+                        query={formik.values.virtualMachineVulnReportFilters.query}
                         searchFilterConfig={searchFilterConfig}
                         setQueryValue={setQueryValue}
                         touched={getIn(formik.touched, queryPath)}
@@ -58,4 +55,4 @@ function ImageVulnerabilityFiltersStep<
     );
 }
 
-export default ImageVulnerabilityFiltersStep;
+export default VirtualMachineVulnerabilityFiltersStep;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/Wizard/Step5/VirtualMachineVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/VirtualMachineVulnerabilityReports/Configurations/Wizard/Step5/VirtualMachineVulnerabilityReviewStep.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react';
+import { Alert, Flex, PageSection, Title } from '@patternfly/react-core';
+
+import type {
+    CompoundSearchFilterConfig,
+    SelectSearchFilterAttribute,
+} from 'Components/CompoundSearchFilter/types';
+import type { VirtualMachineVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import VirtualMachineVulnerabilityReportView from '../../View/VirtualMachineVulnerabilityReportView';
+
+export type VirtualMachineVulnerabilityReviewStepProps = {
+    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
+    error: Error | null;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: VirtualMachineVulnerabilityReportConfiguration;
+};
+
+function VirtualMachineVulnerabilityReviewStep({
+    attributesSeparateFromConfig,
+    error,
+    searchFilterConfig,
+    values,
+}: VirtualMachineVulnerabilityReviewStepProps): ReactElement {
+    return (
+        <PageSection>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <Title headingLevel="h2">Review</Title>
+                {error && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="Error saving report configuration"
+                        component="p"
+                    >
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
+                <VirtualMachineVulnerabilityReportView
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
+                    headingLevel="h3"
+                    horizontalTermWidthModifier={{ default: '24ch' }}
+                    searchFilterConfig={searchFilterConfig}
+                    values={values}
+                />
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default VirtualMachineVulnerabilityReviewStep;

--- a/ui/apps/platform/src/services/ReportsService.types.ts
+++ b/ui/apps/platform/src/services/ReportsService.types.ts
@@ -13,21 +13,59 @@ export type ReportConfigurationBase = {
     schedule: ReportSchedule | null;
 };
 
-export type NodeVulnerabilityReportFilters = {
-    allVuln: boolean;
-    query: string;
-};
-
 // Not exactly 1:1 with the proto, which uses a oneOf that technically allows mismatched
 // type/filters (e.g. node type with image filters). Backend confirmed that can't happen, so
 // we pin `type` to its matching filters to simplify the typing.
 export type NodeVulnerabilityReportConfiguration = {
     type: 'NODE_VULNERABILITY';
+} & ReportConfigurationBase &
+    NodeVulnerabilityReportFiltersConfiguration &
+    NodeVulnerabilityReportResourcesConfiguration;
+
+// Types of views and steps with only properties that they need to know:
+export type NodeVulnerabilityReportFiltersConfiguration = {
     nodeVulnReportFilters: NodeVulnerabilityReportFilters;
-    resourceScope: {
-        entityScope: EntityScope;
-    };
-} & ReportConfigurationBase;
+};
+
+export type NodeVulnerabilityReportResourcesConfiguration = {
+    resourceScope: NodeVulnerabilityReportResourceScope;
+};
+
+// Types of properties:
+export type NodeVulnerabilityReportFilters = {
+    allVuln: boolean;
+    query: string;
+};
+
+export type NodeVulnerabilityReportResourceScope = {
+    entityScope: EntityScope; // Cluster
+};
+
+// Draft of future configuration type.
+export type VirtualMachineVulnerabilityReportConfiguration = {
+    type: 'VIRTUAL_MACHINE_VULNERABILITY';
+} & ReportConfigurationBase &
+    VirtualMachineVulnerabilityReportFiltersConfiguration &
+    VirtualMachineVulnerabilityReportResourcesConfiguration;
+
+// Types of views and steps with only properties that they need to know:
+export type VirtualMachineVulnerabilityReportFiltersConfiguration = {
+    virtualMachineVulnReportFilters: VirtualMachineVulnerabilityReportFilters;
+};
+
+export type VirtualMachineVulnerabilityReportResourcesConfiguration = {
+    resourceScope: VirtualMachineVulnerabilityReportResourceScope;
+};
+
+// Types of properties:
+export type VirtualMachineVulnerabilityReportFilters = {
+    allVuln: boolean;
+    query: string;
+};
+
+export type VirtualMachineVulnerabilityReportResourceScope = {
+    entityScope: EntityScope; // Cluster and Namespace
+};
 
 // TODO temporary alias to limit changed files that might be superseded later anyway
 export type ReportConfiguration = ImageVulnerabilityReportConfiguration;
@@ -195,7 +233,7 @@ export type ViewBasedReportSnapshot = Snapshot & {
     areaOfConcern: string;
 };
 
-// TODO temporary disjunction until snamshot has type property.
+// TODO temporary disjunction until snapshot has type property.
 type VulnerabilityReportFilters =
     | NodeVulnerabilityReportFilters
     | ImageVulnerabilityReportFiltersForCollection


### PR DESCRIPTION
## Description

TL;DR Follow up contributions by **Brad** and **Charmik**

### Objective

Follow pattern of image vulnerability reports for node vulnerability reports.

**Bonus**: Add corresponding files for (future) virtual machine vulnerability reports.

### Review question

What is pro and con to apply example from **filters** view and step to **resources** view and step:

* **Filters** has props for search filter configuration specific to report type

    * `attributesSeparateFromConfig`
    * `searchFilterConfig`

* **Resources** imports functions for entity scope configuration specific to report type

    * `getEntityScopeRulesFromSearchFilterForWhatever`
    * `getSearchFilterFromEntityScopeRulesForWhatever`
    * `searchFilterConfigForWhatever`

### Analysis

1. **Details** is reusable from src/Components/Reports folder

2. **Resources** has subset of options

    * `resourceScope.entityScope` only (pending collection modernization)
    * `getEntityScopeRules` and `getSearchFilter` functions via props instead of via import
        * Entity cluster for **node** vulnerabilities
        * Entities cluster and namespace for **virtual machine** vulnerabilities

3. **Filters** has subset of options

    * Omit interface element for time filter, because data does not exist.
    * Adapt view and step files.
        Main reaon to adapt instead of generalize is that **Resources** and **Filters** overlap for **image** vulnerability reports because of `imageTypes` property.

4. **Delivery** is reusable from src/Components/Reports folder

5. **Review** and `NodesVulnerabilityReportView` has similar props as for image vulnerability reports.

### Analysis of formik in FiltersQuery

* One side of coin: Generic `FiltersQuery` element has had `formik` as a prop, because it uses:

    * `formik.values.vulnReportFilters.query`
    * `formik.setFieldValue` for `'vulnReportFilters.query'`
    * `formik.touched` for `'vulnReportFilters.query'`
    * `formik.errors` for `'vulnReportFilters.query'`

* Other side of coin: Report configurations have different property name:

    * `vulnReportFilters`
    * `nodeVulnReportFilters`

The good news is that TypeScript reports the type mismatch as an error.

THe bad news is that even if I knew how to write a conditional type, it would couple a component that is responsible for `query` string to report configurations.

### Solution

Add View and Wizard folders with files and subfolders that correspond to item in **Analysis**.

* One side of coin: Although node report configurations do **not** have coupling between resources and filters (as image does) I decided for consistency to use the entire property path from report configuration for `values` instead of properties like `resourceScope` or `nodeVulnReportFilters` to preclude need for future refactoring if they ever become coupled.

* Other side of coin: In addition to property types, I wrote type that limit access **only** to properties that components need to know.

### Solution for formik in FiltersQuery

1. Replace `formik` prop in component with separation props:

    * `query: string` 
    * `setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void`
    * `touched: boolean | undefined`
    * `error: string | undefined`

2. Replace with corresponding values in renderers, for example:

    * `query={formik.values.nodeVulnReportFilters.query}` 
    * `setQueryValue={setQueryFilters}`
    * `touched={formik.touched?.nodeVulnReportFilters?.query}`
    * `error={formik.errors?.nodeVulnReportFilters?.query}`

### Residue

Next step is wizard:

1. Provide single source of truth in searchFilterConfig.ts file for**Results** and **Reports**

2. Factor out validation schema to files in same folder as corresponding wizard step.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
