### PR TITLE
ROX-35987: Add CVE origin to generated reports

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/csv"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/stringutils"
@@ -34,8 +35,31 @@ var (
 		"Reference",
 		"Advisory Name",
 		"Advisory Link",
+		"CVE Origin",
+	}
+
+	// originDisplayNames maps VulnOrigin enum values to human-readable names for the
+	// CSV report. This must be kept in sync with the equivalent UI map.
+	originDisplayNames = map[storage.VulnOrigin]string{
+		storage.VulnOrigin_VULN_ORIGIN_ALPINE:  "Alpine Linux",
+		storage.VulnOrigin_VULN_ORIGIN_AMAZON:  "Amazon Linux",
+		storage.VulnOrigin_VULN_ORIGIN_DEBIAN:  "Debian",
+		storage.VulnOrigin_VULN_ORIGIN_ORACLE:  "Oracle Linux",
+		storage.VulnOrigin_VULN_ORIGIN_OSV:     "OSV.dev",
+		storage.VulnOrigin_VULN_ORIGIN_PHOTON:  "Photon OS",
+		storage.VulnOrigin_VULN_ORIGIN_RED_HAT: "Red Hat",
+		storage.VulnOrigin_VULN_ORIGIN_SUSE:    "SUSE",
+		storage.VulnOrigin_VULN_ORIGIN_UBUNTU:  "Ubuntu",
+		storage.VulnOrigin_VULN_ORIGIN_OTHER:   "Other",
 	}
 )
+
+func originDisplayName(origin storage.VulnOrigin) string {
+	if name, ok := originDisplayNames[origin]; ok {
+		return name
+	}
+	return origin.String()
+}
 
 // GenerateCSV takes in the results of vuln report query, converts to CSV and returns zipped data
 func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*bytes.Buffer, error) {
@@ -84,6 +108,7 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*byt
 			r.Link,
 			r.GetAdvisoryName(),
 			r.GetAdvisoryLink(),
+			originDisplayName(r.GetOrigin()),
 		)
 		csvWriter.AddValue(row)
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -558,6 +558,7 @@ func getSelectsWatchedImages() []*v1.QuerySelect {
 		search.NewQuerySelect(search.CisaKev).Proto(),
 		search.NewQuerySelect(search.AdvisoryName).Proto(),
 		search.NewQuerySelect(search.AdvisoryLink).Proto(),
+		search.NewQuerySelect(search.CVEOrigin).Proto(),
 	}
 	return ret
 }
@@ -582,6 +583,7 @@ func getSelectsDeployedImages() []*v1.QuerySelect {
 		search.NewQuerySelect(search.CisaKev).Proto(),
 		search.NewQuerySelect(search.AdvisoryName).Proto(),
 		search.NewQuerySelect(search.AdvisoryLink).Proto(),
+		search.NewQuerySelect(search.CVEOrigin).Proto(),
 	}
 	return ret
 }

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -49,6 +49,7 @@ type ImageCVEQueryResponse struct {
 	DiscoveredAtImage *time.Time                     `db:"first_image_occurrence_timestamp"`
 	AdvisoryName      *string                        `db:"advisory_name"`
 	AdvisoryLink      *string                        `db:"advisory_link"`
+	Origin            *storage.VulnOrigin            `db:"cve_origin"`
 
 	Link string
 }
@@ -135,6 +136,13 @@ func (res *ImageCVEQueryResponse) GetCVSS() float64 {
 		return 0.0
 	}
 	return *res.CVSS
+}
+
+func (res *ImageCVEQueryResponse) GetOrigin() storage.VulnOrigin {
+	if res.Origin == nil {
+		return storage.VulnOrigin_VULN_ORIGIN_OTHER
+	}
+	return *res.Origin
 }
 
 func (res *ImageCVEQueryResponse) GetNVDCVSS() float64 {


### PR DESCRIPTION
## Description

Adds the CVE Origin field to generated reports

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Change is minor to existing report gen.

### How I validated my change

CI + Manual tests

- Generated a report via collection, via advanced filters, and view based filters and confirmed the CVE Origin field is added, populated, and enum translated into friendly text.

<img width="288" height="175" alt="image" src="https://github.com/user-attachments/assets/894de333-9650-4b35-b3b4-07ef3e13230a" />

<img width="289" height="167" alt="image" src="https://github.com/user-attachments/assets/7b1bd9d3-e59a-48f9-864d-cd0da98dab49" />

<img width="267" height="165" alt="image" src="https://github.com/user-attachments/assets/8ddae777-62e3-4a8d-a6d9-f5fad213343d" />

---

**Stack**

- https://github.com/stackrox/stackrox/pull/22428 <-- this PR
- https://github.com/stackrox/stackrox/pull/22412
- https://github.com/stackrox/stackrox/pull/22335

