### PR TITLE
ROX-36240: fix flaky Severity sort test in violations E2E

### DIFF
--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -214,7 +214,7 @@ describe('Violations', () => {
     it('should sort the Severity column', () => {
         // Freeze clock so the 5s poll in ViolationsTablePage doesn't race
         // with waiting for violations responses.
-        cy.clock();
+        cy.clock(Date.now(), ['setInterval']);
 
         interactAndWaitForViolationsResponses(() => {
             visitViolations();

--- a/ui/apps/platform/cypress/integration/violations/violations.test.js
+++ b/ui/apps/platform/cypress/integration/violations/violations.test.js
@@ -212,6 +212,10 @@ describe('Violations', () => {
     });
 
     it('should sort the Severity column', () => {
+        // Freeze clock so the 5s poll in ViolationsTablePage doesn't race
+        // with waiting for violations responses.
+        cy.clock();
+
         interactAndWaitForViolationsResponses(() => {
             visitViolations();
         });


### PR DESCRIPTION
## Description

The `should sort the Severity column` test in `violations.test.js` has been flaking in nightly runs since Aug 10, 2026 (3 failures in 11 days across all three GKE nightly variants).

**Root cause:** `ViolationsTablePage` polls the server every 5 seconds via `useInterval`. When the test reaches the sort-column click at ~T=4s, the poll fires at T=5s and its response — sorted by Violation Time, not Severity — is intercepted by `interactAndWaitForViolationsResponses` before the sort-click response arrives. The assertion then runs on time-sorted data and fails.

**Why it started Aug 10:** Two file access violation UI changes (ROX-35545, ROX-35546) merged Aug 4–5 added slightly more content to the violations page, pushing the test elapsed time into the window where the 5s poll races with the sort interaction. The race condition existed since polling was introduced in 2021, but the timing was benign until the page got heavier.

**Fix:** Add `cy.clock()` at the start of the test to freeze `setInterval`. This prevents the poll from firing during the test without affecting any other behavior.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Test-only change (single `cy.clock()` call). Validation via CI nightly runs — the fix eliminates the poll entirely during the test, making the race mechanically impossible.
