### PR TITLE
ROX-36232: fix flaky Test_NodePortPermutation timeout

### DIFF
--- a/sensor/tests/resource/service/service_test.go
+++ b/sensor/tests/resource/service/service_test.go
@@ -209,9 +209,11 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutation() {
 		setDynamicFieldsInSlice(c.orderedResources, c.portConfig, serviceNodePortFmt, getPort(s.T()), c.selector, setNodePort, setPortConfigNode)
 		s.testContext.RunTest(s.T(), helper.WithResources(c.orderedResources), helper.WithTestCase(func(t *testing.T, testC *helper.TestContext, _ map[string]k8s.Object) {
 			// Test context already takes care of creating and destroying resources
-			testC.LastDeploymentState(t, nginxDeploymentName,
-				assertLastDeploymentHasPortExposure(c.portConfig), "'PortConfig' for Node Port service test not found")
-			testC.LastViolationState(t, nginxDeploymentName,
+			testC.LastDeploymentStateWithTimeout(t, nginxDeploymentName,
+				assertLastDeploymentHasPortExposure(c.portConfig),
+				"'PortConfig' for Node Port service test not found",
+				10*time.Second)
+			testC.LastViolationStateWithTimeout(t, nginxDeploymentName,
 				assertAlertTriggered(
 					&storage.Alert{
 						Policy: &storage.Policy{
@@ -220,7 +222,8 @@ func (s *DeploymentExposureSuite) Test_NodePortPermutation() {
 						State: storage.ViolationState_ACTIVE,
 					},
 				),
-				fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName))
+				fmt.Sprintf("Alert '%s' should be triggered", servicePolicyName),
+				10*time.Second)
 			testC.GetFakeCentral().ClearReceivedBuffer()
 		}), helper.WithRetryCallback(func(err error, obj k8s.Object) error {
 			// Only checking services


### PR DESCRIPTION
## Description

The test calls `LastDeploymentState` which polls every 500ms for up to 3s (`defaultWaitTimeout`) waiting for the nginx deployment to show NodePort exposure. The poll window starts after Kubernetes confirms resources are created, but sensor still needs to:
1. Detect the NodePort service event
2. Match it to the nginx deployment (resolver)
3. Enrich the deployment with the NodePort port config
4. Send the updated deployment message to fake central

On a **loaded Kind cluster** — this CI run hit the test after ~9 minutes of prior test execution — step 2–4 takes just over 3s. The detector had already processed the deployment fast (image scan cache hits visible in logs at t+5s from test start) but the service enrichment arrived after the 3s window closed.

From the actual failure log:
```
helper.go:671: timeout reached waiting for state: ('PortConfig' for Node Port service test not found):
PortConfig 'container_port:80  protocol:"TCP"  exposure:NODE  exposure_infos:{...  node_port:30003}' not found
```

The expected PortConfig was not yet present in any polled deployment message — the deployment had been received (initial CREATE) but the NodePort-enriched UPDATE had not arrived within 3s.

**Fix:** Use `LastDeploymentStateWithTimeout` and `LastViolationStateWithTimeout` with 10s instead of the 3s default. The majority of runs succeed well within 3s; 10s gives enough headroom for loaded CI runners without significantly slowing the test.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

Analyzed the GitHub Actions CI log for build [31179497078](https://github.com/stackrox/stackrox/actions/runs/31179497078) (the triggering failure). The log confirms the timing gap between deployment CREATE and NodePort-enriched UPDATE. The 10s timeout aligns with the pattern seen in `Test_NodePortPermutationWithPod` (which uses identical timeout mechanics and passed in the same run at 43s total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)