### PR TITLE
ROX-36540: Skip VM events and IndexReports Central cannot consume

### DIFF
--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -64,7 +64,12 @@ type pipelineImpl struct {
 
 func (p *pipelineImpl) OnFinish(string) {}
 
+// Capabilities omits VirtualMachinesSupported when ROX_VIRTUAL_MACHINES is
+// off so Sensor treats this Central like a pre-VM build.
 func (p *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
+	if !features.VirtualMachines.Enabled() {
+		return nil
+	}
 	return []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported}
 }
 

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -2,6 +2,7 @@ package virtualmachineindex
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -158,8 +159,25 @@ func (suite *PipelineTestSuite) TestRun_UpdateScanError() {
 }
 
 func (suite *PipelineTestSuite) TestCapabilities() {
-	capabilities := suite.pipeline.Capabilities()
-	suite.Contains(capabilities, centralsensor.CentralCapability(centralsensor.VirtualMachinesSupported))
+	cases := map[string]struct {
+		enabled bool
+		want    []centralsensor.CentralCapability
+	}{
+		"flag on advertises VirtualMachinesSupported": {
+			enabled: true,
+			want:    []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported},
+		},
+		"flag off advertises nothing": {
+			enabled: false,
+			want:    nil,
+		},
+	}
+	for name, tc := range cases {
+		suite.Run(name, func() {
+			suite.T().Setenv(features.VirtualMachines.EnvVar(), strconv.FormatBool(tc.enabled))
+			suite.Equal(tc.want, suite.pipeline.Capabilities())
+		})
+	}
 }
 
 func (suite *PipelineTestSuite) TestOnFinish() {

--- a/central/sensor/service/pipeline/virtualmachines/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline.go
@@ -66,6 +66,10 @@ func (p *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 }
 
 func (p *pipelineImpl) Reconcile(ctx context.Context, clusterID string, storeMap *reconciliation.StoreMap) error {
+	if !features.VirtualMachines.Enabled() {
+		// An empty Sensor snapshot would otherwise delete every VM row for the cluster.
+		return nil
+	}
 	if features.VirtualMachinesEnhancedDataModel.Enabled() {
 		return p.reconcileV2(ctx, clusterID, storeMap)
 	}
@@ -106,6 +110,11 @@ func (p *pipelineImpl) reconcileV2(ctx context.Context, clusterID string, storeM
 
 func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
 	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.VirtualMachine)
+
+	if !features.VirtualMachines.Enabled() {
+		// Returning nil avoids Sensor retries; the rows stay untouched.
+		return nil
+	}
 
 	event := msg.GetEvent()
 	virtualMachine := event.GetVirtualMachine()

--- a/central/sensor/service/pipeline/virtualmachines/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline.go
@@ -52,7 +52,12 @@ type pipelineImpl struct {
 
 func (p *pipelineImpl) OnFinish(_ string) {}
 
+// Capabilities omits VirtualMachinesSupported when ROX_VIRTUAL_MACHINES is
+// off so Sensor treats this Central like a pre-VM build.
 func (p *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
+	if !features.VirtualMachines.Enabled() {
+		return nil
+	}
 	return []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported}
 }
 

--- a/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
@@ -1,6 +1,7 @@
 package virtualmachines
 
 import (
+	"strconv"
 	"testing"
 
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
@@ -24,11 +25,25 @@ import (
 
 func TestCapabilities(t *testing.T) {
 	pipeline := &pipelineImpl{}
-	assert.ElementsMatch(
-		t,
-		[]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported},
-		pipeline.Capabilities(),
-	)
+	cases := map[string]struct {
+		enabled bool
+		want    []centralsensor.CentralCapability
+	}{
+		"flag on advertises VirtualMachinesSupported": {
+			enabled: true,
+			want:    []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported},
+		},
+		"flag off advertises nothing": {
+			enabled: false,
+			want:    nil,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.VirtualMachines.EnvVar(), strconv.FormatBool(tc.enabled))
+			assert.Equal(t, tc.want, pipeline.Capabilities())
+		})
+	}
 }
 
 func TestMatch(t *testing.T) {

--- a/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
@@ -300,6 +300,62 @@ func TestPipelineReconcile(t *testing.T) {
 	}
 }
 
+func TestPipelineRun_FeatureDisabledDoesNotWrite(t *testing.T) {
+	t.Setenv(features.VirtualMachines.EnvVar(), "false")
+	testClusterID := fixtureconsts.Cluster1
+	upsertTestVM := &virtualMachineV1.VirtualMachine{
+		Id:        uuid.NewTestUUID(1).String(),
+		Namespace: "test-namespace",
+		Name:      "test-virtual-machine",
+		ClusterId: testClusterID,
+	}
+	msgs := map[string]*central.MsgFromSensor{
+		"create": getVirtualMachineAdditionMessage(upsertTestVM),
+		"remove": getVirtualMachineRemovalMessage("removed_vm_id"),
+	}
+	models := map[string]bool{
+		"v1": false,
+		"v2": true,
+	}
+	for model, enhanced := range models {
+		t.Run(model, func(t *testing.T) {
+			t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), strconv.FormatBool(enhanced))
+			for name, msg := range msgs {
+				t.Run(name, func(t *testing.T) {
+					mockCtrl := gomock.NewController(t)
+					pipeline := newPipeline(
+						clusterDSMocks.NewMockDataStore(mockCtrl),
+						virtualMachineDSMocks.NewMockDataStore(mockCtrl),
+						virtualMachineV2DSMocks.NewMockDataStore(mockCtrl),
+					)
+					assert.NoError(t, pipeline.Run(t.Context(), testClusterID, msg, nil))
+				})
+			}
+		})
+	}
+}
+
+func TestPipelineReconcile_FeatureDisabledDoesNotDelete(t *testing.T) {
+	t.Setenv(features.VirtualMachines.EnvVar(), "false")
+	testClusterID := fixtureconsts.Cluster1
+	cases := map[string]bool{
+		"v1": false,
+		"v2": true,
+	}
+	for name, enhanced := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), strconv.FormatBool(enhanced))
+			mockCtrl := gomock.NewController(t)
+			pipeline := newPipeline(
+				nil,
+				virtualMachineDSMocks.NewMockDataStore(mockCtrl),
+				virtualMachineV2DSMocks.NewMockDataStore(mockCtrl),
+			)
+			assert.NoError(t, pipeline.Reconcile(t.Context(), testClusterID, reconciliation.NewStoreMap()))
+		})
+	}
+}
+
 func TestPipelineRunV2(t *testing.T) {
 	t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
 	testClusterID := fixtureconsts.Cluster1

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -34,9 +34,13 @@ var (
 	errStartMoreThanOnce = errors.New("unable to start the VM scraper more than once")
 )
 
-// minPollInterval clamps ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL to avoid
-// accidental high-churn vsock polling.
-const minPollInterval = time.Minute
+const (
+	// minPollInterval clamps ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL to avoid
+	// accidental high-churn vsock polling.
+	minPollInterval = time.Minute
+
+	sendNotImplementedLogLimiter = "vm-scraper-send-not-implemented"
+)
 
 func getVsockPort() uint32 {
 	return uint32(env.VirtualMachinesVsockPort.IntegerSetting())
@@ -89,7 +93,10 @@ type VMScraper struct {
 	warnMaxBytes          int
 	stopper               concurrency.Stopper
 	started               atomic.Bool
-	now                   func() time.Time
+	// loggedSkip is set after the first skip log for a missing-capability stretch
+	// so a 10s ticker does not repeat it until the capability returns.
+	loggedSkip atomic.Bool
+	now        func() time.Time
 	// randFloat64 returns a unit sample in [0, 1] for schedule offsets; tests inject a fixed source.
 	randFloat64          func() float64
 	lastSpreadWarnNumVMs int
@@ -257,9 +264,12 @@ func (s *VMScraper) run() {
 
 func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	if !centralcaps.Has(centralsensor.VirtualMachinesSupported) {
-		log.Debugf("VMScraper: skipping pull; Central does not advertise VirtualMachinesSupported")
+		if s.loggedSkip.CompareAndSwap(false, true) {
+			log.Infof("VMScraper: skipping pulling index reports from VMs; Central does not advertise VirtualMachinesSupported")
+		}
 		return
 	}
+	s.loggedSkip.Store(false)
 
 	tickStart := s.now()
 	reconcile := forceReconcile
@@ -464,12 +474,14 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	logAndRecordDiscoveredFacts(key, result.Meta.GetFacts())
 
 	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
-		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
 		outcome := scrapeRetryable
 		if errors.Is(err, errox.NotImplemented) {
-			// Central cannot consume VM index reports (missing capability).
+			logging.GetRateLimitedLogger().WarnL(sendNotImplementedLogLimiter,
+				"VMScraper: Central cannot consume VM index reports: %v", err)
 			outcome = scrapeNonRetryable
+		} else {
+			log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		}
 		// Send failures are typically a transient Central connection issue, so
 		// retry on the short backoff rather than waiting a full poll interval.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
@@ -254,6 +256,11 @@ func (s *VMScraper) run() {
 }
 
 func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
+	if !centralcaps.Has(centralsensor.VirtualMachinesSupported) {
+		log.Debugf("VMScraper: skipping pull; Central does not advertise VirtualMachinesSupported")
+		return
+	}
+
 	tickStart := s.now()
 	reconcile := forceReconcile
 	if !reconcile {
@@ -461,8 +468,17 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
 		// Send failures are typically a transient Central connection issue, so
 		// retry on the short backoff rather than waiting a full poll interval.
-		next := s.scheduleAfterAttempt(key, scrapeRetryable)
-		log.Infof("VMScraper: scrape %q failed retryable next=%s", key, next)
+		outcome := scrapeRetryable
+		if errors.Is(err, errox.NotImplemented) {
+			// Central cannot consume VM index reports (missing capability).
+			outcome = scrapeNonRetryable
+		}
+		next := s.scheduleAfterAttempt(key, outcome)
+		kind := "retryable"
+		if outcome == scrapeNonRetryable {
+			kind = "non-retryable"
+		}
+		log.Infof("VMScraper: scrape %q failed %s next=%s", key, kind, next)
 		return false
 	}
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -466,13 +466,13 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	if err := s.sender.Send(vmCtx, vm, result.IndexReport); err != nil {
 		log.Errorf("VMScraper: sending %q report to Central failed: %v", key, err)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSendError).Inc()
-		// Send failures are typically a transient Central connection issue, so
-		// retry on the short backoff rather than waiting a full poll interval.
 		outcome := scrapeRetryable
 		if errors.Is(err, errox.NotImplemented) {
 			// Central cannot consume VM index reports (missing capability).
 			outcome = scrapeNonRetryable
 		}
+		// Send failures are typically a transient Central connection issue, so
+		// retry on the short backoff rather than waiting a full poll interval.
 		next := s.scheduleAfterAttempt(key, outcome)
 		kind := "retryable"
 		if outcome == scrapeNonRetryable {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
@@ -25,6 +26,8 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // --- Mocks ---
@@ -241,6 +244,34 @@ func TestVMScraper_SkipsWhenCentralLacksCapability(t *testing.T) {
 	assert.Zero(t, dialer.callIdx.Load())
 	assert.Empty(t, sender.sent)
 	assert.Empty(t, client.calls)
+}
+
+// TestVMScraper_LogsSkipOnceWhileCapabilityMissing covers a missing-capability
+// stretch that lasts more than one tick, then a later drop after the
+// capability returns, so the skip log fires once per stretch not once per tick.
+func TestVMScraper_LogsSkipOnceWhileCapabilityMissing(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+
+	s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	})
+	centralcaps.Set(nil)
+
+	s.pollOnce(t.Context())
+	s.pollOnce(t.Context())
+	assert.Equal(t, 1, logs.FilterMessageSnippet("skipping pull").Len())
+
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported})
+	s.pollOnce(t.Context())
+
+	centralcaps.Set(nil)
+	s.pollOnce(t.Context())
+	assert.Equal(t, 2, logs.FilterMessageSnippet("skipping pull").Len())
 }
 
 func TestVMScraper_SkipsUnchangedToken(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/vsockclient"
@@ -207,13 +210,37 @@ func TestVMScraper_PollsRunningVMs(t *testing.T) {
 		errQueue:    []error{nil, nil},
 	}
 
-	s, _ := newTestScraper(store, sender, dialer, client)
+	s, _ := newTestScraper(t, store, sender, dialer, client)
 	discoveredBefore := testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE"))
 	s.pollOnce(context.Background())
 
 	assert.Len(t, sender.sent, 2)
 	assert.Len(t, client.calls, 2)
 	assert.Equal(t, discoveredBefore+2, testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE")))
+}
+
+// TestVMScraper_SkipsWhenCentralLacksCapability covers a store already
+// populated (for example after reconnecting to an older Central) so the
+// scraper must not dial or forward.
+func TestVMScraper_SkipsWhenCentralLacksCapability(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	sender := &mockSender{}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, _ := newTestScraper(t, store, sender, dialer, client)
+	centralcaps.Set(nil)
+
+	s.pollOnce(context.Background())
+
+	assert.Equal(t, 0, store.listRunningCalls, "should not reconcile when Central cannot consume reports")
+	assert.Zero(t, dialer.callIdx.Load())
+	assert.Empty(t, sender.sent)
+	assert.Empty(t, client.calls)
 }
 
 func TestVMScraper_SkipsUnchangedToken(t *testing.T) {
@@ -226,7 +253,7 @@ func TestVMScraper_SkipsUnchangedToken(t *testing.T) {
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
-	s, clock := newTestScraper(store, sender, dialer, client)
+	s, clock := newTestScraper(t, store, sender, dialer, client)
 
 	s.pollOnce(context.Background())
 	require.Len(t, sender.sent, 1)
@@ -249,7 +276,7 @@ func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
-	s, clock := newTestScraper(store, sender, dialer, client)
+	s, clock := newTestScraper(t, store, sender, dialer, client)
 
 	s.pollOnce(context.Background())
 	require.True(t, hasScheduleSlot(t, s, "ns1/vm-a"))
@@ -273,7 +300,7 @@ func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
-	s, clock := newTestScraper(store, sender, dialer, client)
+	s, clock := newTestScraper(t, store, sender, dialer, client)
 
 	s.pollOnce(context.Background())
 	require.Len(t, sender.sent, 1)
@@ -304,7 +331,7 @@ func TestVMScraper_SendsLastKnownTokenOnRequest(t *testing.T) {
 		resultQueue: []*vsockclient.GetReportResult{makeReport("tok-100")},
 	}
 
-	s, clock := newTestScraper(store, sender, dialer, client)
+	s, clock := newTestScraper(t, store, sender, dialer, client)
 	s.pollOnce(context.Background())
 
 	require.Len(t, client.calls, 1)
@@ -329,7 +356,7 @@ func TestVMScraper_ForwardsOnTokenChange(t *testing.T) {
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
-	s, clock := newTestScraper(store, sender, dialer, client)
+	s, clock := newTestScraper(t, store, sender, dialer, client)
 	s.pollOnce(context.Background())
 	require.Len(t, sender.sent, 1)
 
@@ -422,7 +449,7 @@ func TestVMScraper_NACK(t *testing.T) {
 				resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 			}
 
-			s, clock := newTestScraper(store, sender, dialer, client)
+			s, clock := newTestScraper(t, store, sender, dialer, client)
 			s.pollOnce(context.Background())
 			require.Len(t, sender.sent, 1)
 
@@ -487,7 +514,7 @@ func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 		vmA.ID = "vm-a-id"
 		store := &mockStore{vms: []*virtualmachine.Info{vmA}}
 		client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport("1")}}
-		s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+		s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, client)
 
 		s.pollOnce(t.Context())
 		require.Equal(t, "1", cachedToken(t, s, "ns1/vm-a"))
@@ -574,7 +601,7 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 				resultQueue: tc.resultQueue,
 				errQueue:    tc.errQueue,
 			}
-			s, _ := newTestScraper(&mockStore{vms: vms}, sender, tc.dialer, client)
+			s, _ := newTestScraper(t, &mockStore{vms: vms}, sender, tc.dialer, client)
 			if tc.perVMTimeout > 0 {
 				s.perVMTimeout = tc.perVMTimeout
 			}
@@ -587,7 +614,7 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 }
 
 func TestVMScraper_StartRejectsSecondCall(t *testing.T) {
-	s, _ := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
 	require.NoError(t, s.Start())
 	t.Cleanup(s.Stop)
 
@@ -602,7 +629,7 @@ func TestVMScraper_GetReportTimeoutClassified(t *testing.T) {
 	client := &mockProtocolClient{
 		errQueue: []error{errors.New("i/o timeout")},
 	}
-	s, _ := newTestScraper(&mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
+	s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
 
 	timeoutBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusTimeout))
 	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
@@ -626,7 +653,7 @@ func TestVMScraper_GetReportDeadlineExceededClassified(t *testing.T) {
 	client := &mockProtocolClient{
 		errQueue: []error{errors.New("i/o timeout")},
 	}
-	s, _ := newTestScraper(&mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
+	s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
@@ -643,7 +670,7 @@ func TestVMScraper_GetReportBusyClassified(t *testing.T) {
 	client := &mockProtocolClient{
 		errQueue: []error{vsockclient.ErrBusy},
 	}
-	s, _ := newTestScraper(&mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
+	s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, client)
 
 	busyBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy))
 	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
@@ -667,7 +694,7 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1"), makeReport("1")},
 	}
 
-	s, clock := newTestScraper(store, sender, dialer, client)
+	s, clock := newTestScraper(t, store, sender, dialer, client)
 	s.pollOnce(context.Background())
 	assert.Len(t, s.vmState, 2)
 	assert.True(t, hasScheduleSlot(t, s, "ns1/vm-a"))
@@ -704,7 +731,11 @@ func cachedToken(t *testing.T, s *VMScraper, key string) string {
 	})
 }
 
-func newTestScraper(store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) (*VMScraper, *testClock) {
+func newTestScraper(t *testing.T, store RunningVMStore, sender IndexReportSender, dialer VMDialer, client ProtocolClient) (*VMScraper, *testClock) {
+	t.Helper()
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
 	clock := newTestClock()
 	interval := 5 * time.Minute
 	s := &VMScraper{
@@ -810,7 +841,7 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 	dialer := &delayDialer{delay: dialDelay}
 	client := &safeProtocolClient{token: "1"}
 
-	s, _ := newTestScraper(store, sender, dialer, client)
+	s, _ := newTestScraper(t, store, sender, dialer, client)
 	s.concurrency = concurrency
 	// This test measures real dial overlap via delayDialer's timers, so it
 	// needs the wall clock rather than the fake test clock.
@@ -835,7 +866,7 @@ func TestVMScraper_RetryableFailureSchedulesBackoff(t *testing.T) {
 	client := &mockProtocolClient{
 		errQueue: []error{vsockclient.ErrNotReady},
 	}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, client)
 
 	s.pollOnce(context.Background())
 	require.Len(t, client.calls, 1)
@@ -883,6 +914,12 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 			wantBackoff: initialBackoff,
 			wantGap:     initialBackoff,
 		},
+		"not-implemented send should not retry using backoff": {
+			client:      &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport("1")}},
+			sender:      &mockSender{err: errox.NotImplemented},
+			wantBackoff: 0,
+			wantGap:     5 * time.Minute,
+		},
 		"ErrInternal should retry using backoff": {
 			client:      &mockProtocolClient{errQueue: []error{vsockclient.ErrInternal}},
 			sender:      &mockSender{},
@@ -924,7 +961,7 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			s, clock := newTestScraper(
+			s, clock := newTestScraper(t,
 				&mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}},
 				tc.sender, &mockDialer{}, tc.client,
 			)
@@ -946,7 +983,7 @@ func TestVMScraper_NonForcedTickSkipsReconcileWhenNotDue(t *testing.T) {
 	client := &mockProtocolClient{
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1"), makeReport("1")},
 	}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, client)
 
 	s.pollOnce(context.Background())
 	require.Equal(t, 1, store.listRunningCalls, "pollOnce forces exactly one reconcile")

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -46,7 +46,7 @@ func sequencedRand(seq []float64) func() float64 {
 
 func TestVMScraper_CadenceRescheduleUsesSteadyBand(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "vm-a", 1)}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	})
 	s.spreadFraction = 2.0 / 3
@@ -69,7 +69,7 @@ func TestVMScraper_ManyCadencedSuccessesSpanSteadyBand(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(10+i)))
 	}
 	store := &mockStore{vms: vms}
-	s, clock := newTestScraper(store, &safeSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
+	s, clock := newTestScraper(t, store, &safeSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	s.spreadFraction = 2.0 / 3
@@ -116,7 +116,7 @@ func TestVMScraper_MassFirstInsertSpansNewVMIndexReportWindow(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	store := &mockStore{vms: vms}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	units := make([]float64, numVMs)
@@ -150,7 +150,7 @@ func TestVMScraper_MassFirstInsertSpansNewVMIndexReportWindow(t *testing.T) {
 
 func TestVMScraper_SingleInsertUsesNewVMIndexReportSpread(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "only", 1)}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = 20
 	s.randFloat64 = func() float64 { return 0.5 }
 
@@ -166,7 +166,7 @@ func TestVMScraper_MultiInsertUsesNewVMIndexReportSpread(t *testing.T) {
 		makeVM("ns", "a", 1),
 		makeVM("ns", "b", 2),
 	}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = 20
 	s.randFloat64 = sequencedRand([]float64{0.25, 0.75})
 
@@ -180,7 +180,7 @@ func TestVMScraper_MultiInsertUsesNewVMIndexReportSpread(t *testing.T) {
 func TestVMScraper_RetryPathDoesNotUseSteadyBand(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
 	client := &mockProtocolClient{errQueue: []error{vsockclient.ErrNotReady}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, client)
 	// Insert due now; a later unit of 1 would be full steadyWidth if cadence used RNG.
 	s.randFloat64 = sequencedRand([]float64{0, 1})
 
@@ -194,7 +194,7 @@ func TestVMScraper_RetryPathDoesNotUseSteadyBand(t *testing.T) {
 func TestVMScraper_NACKPathDoesNotUseSteadyBand(t *testing.T) {
 	vm := makeVM("ns1", "vm-a", 100)
 	store := &mockStore{vms: []*virtualmachine.Info{vm}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
+	s, clock := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
 		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	})
 	s.randFloat64 = sequencedRand([]float64{0, 1})
@@ -213,7 +213,7 @@ func TestVMScraper_DuePileIsPacedByStartBudget(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	dialer := &recordingDialer{}
-	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
+	s, _ := newTestScraper(t, &mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	s.tickInterval = defaultTickInterval
@@ -254,7 +254,7 @@ func TestVMScraper_AllDueClumpDrainsWithinIndexWindow(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	dialer := &recordingDialer{}
-	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
+	s, _ := newTestScraper(t, &mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.tickInterval = defaultTickInterval
 	s.reconcileEvery = reconcilePeriod(s.interval)
@@ -298,7 +298,7 @@ func TestVMScraper_SpreadDuePileStartsAtFleetRate(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	dialer := &recordingDialer{}
-	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
+	s, _ := newTestScraper(t, &mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.tickInterval = defaultTickInterval
 	s.reconcileEvery = reconcilePeriod(s.interval)
@@ -336,7 +336,7 @@ func TestVMScraper_StartsPerTickObservesLaunchCount(t *testing.T) {
 	for i := range numVMs {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(10+i)))
 	}
-	s, clock := newTestScraper(&mockStore{vms: vms}, &safeSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
+	s, clock := newTestScraper(t, &mockStore{vms: vms}, &safeSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.reconcileEvery = reconcilePeriod(s.interval)
 
@@ -359,7 +359,7 @@ func TestVMScraper_StartsPerTickObservesLaunchCount(t *testing.T) {
 }
 
 func TestVMScraper_StartsPerTickSkipsIdleTicks(t *testing.T) {
-	s, clock := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	s, clock := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
 	now := clock.Now()
 	concurrency.WithLock(&s.mu, func() {
 		s.lastReconcile = now
@@ -409,7 +409,7 @@ func TestVMScraper_WarnIfSpreadSaturated(t *testing.T) {
 			log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
 			t.Cleanup(func() { log = orig })
 
-			s, _ := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
 			s.tickInterval = tc.tickInterval
 			s.spreadFraction = tc.spreadFraction
 			s.warnIfSpreadSaturated(tc.numVMs)
@@ -420,7 +420,7 @@ func TestVMScraper_WarnIfSpreadSaturated(t *testing.T) {
 }
 
 func TestVMScraper_ForwardInterarrivalObservesAfterFirst(t *testing.T) {
-	s, _ := newTestScraper(&mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+	s, _ := newTestScraper(t, &mockStore{}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
 	before := histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds)
 	s.observeForwardInterarrival()
 	assert.Equal(t, before, histogramSampleCount(t, metrics.PullForwardInterarrivalSeconds),


### PR DESCRIPTION
## Description

This PR makes the handshake match what Central will actually consume.

1. Central's VM pipelines always advertised `VirtualMachinesSupported` in `CentralHello`, including when `ROX_VIRTUAL_MACHINES` was off. Sensor then sent both `VirtualMachine` events and `VirtualMachineIndexReport` events, and those land in different pipelines. The VM index pipeline checks the flag, so it ACKed the scan reports as feature-disabled and did not write them. Both VM pipelines now advertise `VirtualMachinesSupported` only when the feature flag is on, so a flag-off Central looks like a pre-VM Central to Sensor.
2. The VM resource pipeline does not check the flag, so it still wrote the `VirtualMachine` records into Central's database (`virtual_machines`, or the v2 store if the enhanced data model is on). It now skips `Run` and `Reconcile` when the flag is off: it does not write those records, and it does not delete existing rows when Sensor's snapshot is empty.
3. The pull-mode scraper never consulted Central's capabilities. After a reconnect to an older Central that does not advertise VM support, Sensor could keep dialing guests and treat `Send` `not implemented` as a transient connection error, which retries on the short backoff. `VMScraper` now returns at the start of each tick when that capability is missing, so it does not reconcile or dial. If `Send` still returns `not implemented`, the scraper uses the poll cadence instead of the short retry backoff. Ordinary send failures still retry sooner, because those are usually a transient Central connection issue.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [ ] Manually verified on a cluster

AI-Assisted: Cursor, ~70% generated, user reviewed logic and comment placement.