### PR TITLE
fix: adjust central-db conn limit for central-worker

### DIFF
--- a/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
+++ b/image/templates/helm/stackrox-central/config/centraldb/postgresql.conf.default
@@ -1,6 +1,6 @@
 hba_file = '/etc/stackrox.d/config/pg_hba.conf'
 listen_addresses = '*'
-max_connections = 100
+max_connections = 120
 password_encryption = scram-sha-256
 
 ssl = on


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

#21569 Introduced the CR option to deploy `central-worker` which has a DB connection pool of 20 without adjusting any other configurations.

The `central-db` default max connection count is 100 before this PR with the intend of central using 90 and reserving 10 connection for headroom to debug / monitor etc. Following that logic we should go for 90 (central) + 20 (worker) + 10 (headroom) = 120.

Instead of adjusting on a configuration basis this PR increases the default to 120. This will have no impact if not opted in to `central-worker`. No process is using the 20 additional connection, because of that there is no DB resource overhead. When `central-worker` is enabled we have enough connection left, and they will be used leading to a slight increase in memory usage at PSQL which is expected.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
