### PR TITLE
fix(ui): apply UI_CUSTOM_PROXIES in dev server proxy config

### DIFF
--- a/ui/apps/platform/src/setupProxy.js
+++ b/ui/apps/platform/src/setupProxy.js
@@ -46,7 +46,11 @@ export function viteProxy() {
 
     const proxy = proxyWithTarget(process.env.UI_START_TARGET || 'https://localhost:8000');
 
+    // Custom proxies come first so their (often more specific, possibly regex)
+    // paths take precedence over the generic catch-alls below. Vite matches proxy
+    // contexts in insertion order, and treats keys beginning with `^` as RegExp.
     return {
+        ...customProxies,
         '/v1': proxy,
         '/v2': proxy,
         '/api': proxy,


### PR DESCRIPTION
## Description

This was accidentally lost in the migration to Vite, and hasn't been needed again until now.

I noticed a need for this again in two separate features, where the Google Chrome overrides were unable to handle an endpoint that matches a directory in the overrides in addition to sub-endpoints/sub-directories off of this top level override.

For example, APIs of
`v1/clusters`
`v1/clsuters/<cluster-id>`
cannot both be mocked simultaneously with Google Chrome overrides.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Test locally with dev server, e.g.:
```
UI_CUSTOM_PROXIES='/v2/ai-integrations,http://localhost:3030,^/v1/deploymentswithrisk/[^/]+/ai-summary,http://localhost:3030' UI_START_TARGET=https://staging.demo.stackrox.com/ npm run start
```
