### PR TITLE
ROX-35756: replace GetReport generation+epoch with a per-scan token

### DIFF
--- a/compliance/virtualmachines/roxagent/README.md
+++ b/compliance/virtualmachines/roxagent/README.md
@@ -9,7 +9,7 @@ The sources live under `compliance/` because the agent reuses the Scanner V4 nod
 ## What it does
 
 1. Fetches the repository-to-CPE mapping file (required before the first scan).
-2. Scans the VM for installed packages and caches the index report with a generation counter.
+2. Scans the VM for installed packages and caches the index report with a content-hash token.
 3. Listens on a VSOCK port with mandatory mTLS.
 4. On each Sensor connection, handles a framed `VMServiceRequest` / `VMServiceResponse` (for example `get_report`).
 5. Periodically rescans and atomically swaps the cached report.
@@ -40,8 +40,8 @@ sudo ./roxagent serve --port 818 --host-path / --rescan-interval 4h
 
    The default `--repo-cpe-url` is `https://security.access.redhat.com/data/metrics/repository-to-cpe.json`, so the VM needs outbound HTTPS to that host (or a proxy that can reach it). On isolated networks, host a copy of `repository-to-cpe.json` somewhere the VM can reach and point `--repo-cpe-url` at that URL.
 2. **Initial scan:** Indexes `--host-path`, stores the report and discovered VM facts in an in-memory cache, then starts the VSOCK server and the rescan loop.
-3. **Serving reports:** Sensor connects and the agent serves the cached report. If Sensor already has the current generation, the agent omits the payload.
-4. **Rescan:** On `--rescan-interval`, re-indexes the rpm/dnf database and swaps the cache, bumping the generation.
+3. **Serving reports:** Sensor connects and the agent serves the cached report. If Sensor already has the current content-hash token, the agent omits the payload. Sensor can still force a full report by sending an empty token (first request, NACK retry, or the 4h refresh).
+4. **Rescan:** On `--rescan-interval`, re-indexes the rpm/dnf database and swaps the cache. The token stays the same when the report and facts are unchanged.
 
 ### TLS (mandatory)
 

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol.go
@@ -11,6 +11,7 @@ import (
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -21,12 +22,12 @@ const maxRequestSize = 1 << 20 // 1 MiB
 // reportSnapshot is an immutable point-in-time view of the cached report state.
 type reportSnapshot struct {
 	report      *v4.IndexReport
-	generation  uint32
+	token       string
 	generatedAt time.Time
 	facts       map[string]string
 }
 
-// ReportCache holds the cached scan report with its generation counter.
+// ReportCache holds the cached scan report with its per-scan token.
 // Invariant: exactly one goroutine (the rescan loop) calls SetReport; multiple
 // HandleConn goroutines read via snap.Load(). This single-writer/multi-reader
 // pattern is safe with atomic.Pointer without CAS.
@@ -35,21 +36,17 @@ type ReportCache struct {
 }
 
 // SetReport atomically publishes a new report with updated facts in a single
-// store, incrementing the generation counter. Readers never observe a partial
-// (new report, stale facts) state.
+// store, minting a fresh token. Readers never observe a partial (new report,
+// stale facts) state.
 //
 // r and facts are defensively copied so that a caller mutating its own copy
 // after this call (or reusing the same facts map across scans) can never
 // mutate the published, supposedly-immutable snapshot out from under
 // concurrent readers.
 func (c *ReportCache) SetReport(r *v4.IndexReport, facts map[string]string) {
-	var counter uint32
-	if old := c.snap.Load(); old != nil {
-		counter = old.generation
-	}
 	c.snap.Store(&reportSnapshot{
 		report:      cloneIndexReport(r),
-		generation:  counter + 1,
+		token:       uuid.NewV4().String(),
 		generatedAt: time.Now(),
 		facts:       cloneFacts(facts),
 	})
@@ -78,32 +75,11 @@ func cloneFacts(in map[string]string) map[string]string {
 type Handler struct {
 	cache        *ReportCache
 	agentVersion string
-	// epoch is seeded once per process lifetime and never persisted to VM
-	// disk. It lets Sensor (and this handler itself, via GetReportRequest's
-	// known_epoch) distinguish "this agent restarted" from "this agent's
-	// generation counter coincidentally reset to a value Sensor already has
-	// cached" without changing report_generation's own sequential,
-	// human-readable semantics.
-	epoch uint32
 }
 
 // NewHandler creates a protocol handler.
 func NewHandler(cache *ReportCache, agentVersion string) *Handler {
-	return &Handler{cache: cache, agentVersion: agentVersion, epoch: newEpoch()}
-}
-
-// newEpoch derives a process-lifetime epoch value. Time-derived rather than
-// cryptographically random: epoch only needs to differ across restarts with
-// overwhelming probability, not resist an adversary. Seconds (not
-// nanoseconds) since the Unix epoch, so the value only wraps every ~136
-// years instead of every ~4.3 seconds when truncated to uint32. 0 is
-// reserved to mean "agent predates this field" (see ResponseMeta.epoch doc),
-// so it's excluded.
-func newEpoch() uint32 {
-	if e := uint32(time.Now().Unix()); e != 0 {
-		return e
-	}
-	return 1
+	return &Handler{cache: cache, agentVersion: agentVersion}
 }
 
 // HandleConn reads a framed request from conn, processes it, writes a framed response, and closes conn.
@@ -160,32 +136,20 @@ func (h *Handler) handleGetReport(req *pb.GetReportRequest) *pb.VMServiceRespons
 		return h.errorResponseFromSnap(snap, pb.ErrorCode_ERROR_CODE_NOT_READY, "initial scan in progress, try again later")
 	}
 
-	// Strict equality (not >=) so that after an agent restart — when the generation
-	// counter resets to 1 — a sensor still holding a higher generation from the
-	// previous instance will receive the full report instead of a false "unchanged".
-	//
-	// known_epoch guards against the opposite false positive: a restarted agent
-	// whose reset generation coincidentally re-matches last_known_generation.
-	// 0 means Sensor doesn't know our epoch yet (first-ever request for this VM,
-	// or a Sensor build that predates the field), so fall back to generation-only
-	// comparison exactly as before this field existed.
-	generationMatches := req.GetLastKnownGeneration() == snap.generation
-	knownEpoch := req.GetKnownEpoch()
-	epochMatches := knownEpoch == 0 || knownEpoch == h.epoch
-	if generationMatches && epochMatches {
-		log.Infof("GetReport: unchanged (generation=%d, last_known_generation=%d)", snap.generation, req.GetLastKnownGeneration())
+	// Empty last_known_token means Sensor has no cached token (first request
+	// or a forced refresh) and must receive the full report. A matching
+	// token is unchanged; any other value is a new scan (or a restarted
+	// agent), so the full report is served in this round trip.
+	if lastKnown := req.GetLastKnownToken(); lastKnown != "" && lastKnown == snap.token {
+		log.Infof("GetReport: unchanged (token=%s)", snap.token)
 		resp := h.newResponseFromSnap(snap)
 		resp.Result = &pb.VMServiceResponse_GetReport{
 			GetReport: &pb.GetReportResponse{Unchanged: true},
 		}
 		return resp
 	}
-	if generationMatches && !epochMatches {
-		log.Infof("GetReport: generation matches (%d) but epoch changed (known=%d, current=%d) — agent restarted, serving full report in this round trip",
-			snap.generation, knownEpoch, h.epoch)
-	}
 
-	log.Infof("GetReport: serving report (generation=%d, packages=%d)", snap.generation, len(snap.report.GetContents().GetPackages()))
+	log.Infof("GetReport: serving report (token=%s, packages=%d)", snap.token, len(snap.report.GetContents().GetPackages()))
 	resp := h.newResponseFromSnap(snap)
 	resp.Result = &pb.VMServiceResponse_GetReport{
 		GetReport: &pb.GetReportResponse{IndexReport: snap.report},
@@ -195,17 +159,16 @@ func (h *Handler) handleGetReport(req *pb.GetReportRequest) *pb.VMServiceRespons
 
 func (h *Handler) newResponseFromSnap(snap *reportSnapshot) *pb.VMServiceResponse {
 	var facts map[string]string
-	var gen uint32
+	var token string
 	if snap != nil {
 		facts = cloneFacts(snap.facts)
-		gen = snap.generation
+		token = snap.token
 	}
 	meta := &pb.ResponseMeta{
 		AgentVersion:     h.agentVersion,
-		ReportGeneration: gen,
+		ReportToken:      token,
 		SupportedMethods: []string{"get_report"},
 		Facts:            facts,
-		Epoch:            h.epoch,
 	}
 	if snap != nil && !snap.generatedAt.IsZero() {
 		meta.ReportGeneratedAt = timestamppb.New(snap.generatedAt)

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"slices"
 	"sync/atomic"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
-	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/pkg/vsockframing"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -27,7 +28,7 @@ type reportSnapshot struct {
 	facts       map[string]string
 }
 
-// ReportCache holds the cached scan report with its per-scan token.
+// ReportCache holds the cached scan report with its content-hash token.
 // Invariant: exactly one goroutine (the rescan loop) calls SetReport; multiple
 // HandleConn goroutines read via snap.Load(). This single-writer/multi-reader
 // pattern is safe with atomic.Pointer without CAS.
@@ -35,21 +36,41 @@ type ReportCache struct {
 	snap atomic.Pointer[reportSnapshot]
 }
 
-// SetReport atomically publishes a new report with updated facts in a single
-// store, minting a fresh token. Readers never observe a partial (new report,
-// stale facts) state.
+// SetReport atomically publishes a new report and facts. The token is an
+// XXH64 of that content, so identical rescans stay unchanged for Sensor.
 //
 // r and facts are defensively copied so that a caller mutating its own copy
 // after this call (or reusing the same facts map across scans) can never
 // mutate the published, supposedly-immutable snapshot out from under
 // concurrent readers.
 func (c *ReportCache) SetReport(r *v4.IndexReport, facts map[string]string) {
+	cloned := cloneIndexReport(r)
+	clonedFacts := cloneFacts(facts)
 	c.snap.Store(&reportSnapshot{
-		report:      cloneIndexReport(r),
-		token:       uuid.NewV4().String(),
+		report:      cloned,
+		token:       reportToken(cloned, clonedFacts),
 		generatedAt: time.Now(),
-		facts:       cloneFacts(facts),
+		facts:       clonedFacts,
 	})
+}
+
+// reportToken is XXH64 of the IndexReport and facts, as 16 lowercase hex
+// digits. Deterministic marshal keeps identical content stable across rescans.
+func reportToken(r *v4.IndexReport, facts map[string]string) string {
+	h := xxhash.New()
+	if r != nil {
+		b, err := proto.MarshalOptions{Deterministic: true}.Marshal(r)
+		if err == nil {
+			_, _ = h.Write(b)
+		}
+	}
+	for _, k := range slices.Sorted(maps.Keys(facts)) {
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(facts[k]))
+		_, _ = h.Write([]byte{0})
+	}
+	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 // cloneIndexReport returns a deep copy of r, or nil if r is nil.
@@ -136,10 +157,9 @@ func (h *Handler) handleGetReport(req *pb.GetReportRequest) *pb.VMServiceRespons
 		return h.errorResponseFromSnap(snap, pb.ErrorCode_ERROR_CODE_NOT_READY, "initial scan in progress, try again later")
 	}
 
-	// Empty last_known_token means Sensor has no cached token (first request
-	// or a forced refresh) and must receive the full report. A matching
-	// token is unchanged; any other value is a new scan (or a restarted
-	// agent), so the full report is served in this round trip.
+	// Empty last_known_token forces a full report (first request or Sensor
+	// refresh). A matching token is identical content; any other value
+	// means the published report or facts changed.
 	if lastKnown := req.GetLastKnownToken(); lastKnown != "" && lastKnown == snap.token {
 		log.Infof("GetReport: unchanged (token=%s)", snap.token)
 		resp := h.newResponseFromSnap(snap)

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
@@ -77,7 +77,7 @@ func TestHandleRequest_GetReport_Unchanged(t *testing.T) {
 }
 
 // TestHandleRequest_GetReport_TokenMismatch covers a Sensor-cached token
-// that does not match the agent's current scan, including after restart.
+// that does not match the agent's current content.
 func TestHandleRequest_GetReport_TokenMismatch(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "post-restart-hash"}, nil)
@@ -93,9 +93,10 @@ func TestHandleRequest_GetReport_TokenMismatch(t *testing.T) {
 	assert.NotEqual(t, "stale-token", resp.GetMeta().GetReportToken())
 }
 
-// TestHandleRequest_GetReport_NewScanMintsNewToken covers a rescan: the
-// token changes even if content is identical, so Sensor still gets a full report.
-func TestHandleRequest_GetReport_NewScanMintsNewToken(t *testing.T) {
+// TestHandleRequest_GetReport_IdenticalRescanUnchanged covers a rescan
+// whose report and facts did not change: the token is stable, so Sensor
+// gets unchanged unless it sends an empty last_known_token.
+func TestHandleRequest_GetReport_IdenticalRescanUnchanged(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "same-hash"}, nil)
 
@@ -108,10 +109,39 @@ func TestHandleRequest_GetReport_NewScanMintsNewToken(t *testing.T) {
 	resp := sendAndReceive(t, handler, getReportRequest("req-after-rescan", token))
 
 	assert.NotNil(t, resp.GetGetReport())
+	assert.True(t, resp.GetGetReport().GetUnchanged())
+	assert.Nil(t, resp.GetGetReport().GetIndexReport())
+	assert.Equal(t, token, resp.GetMeta().GetReportToken())
+}
+
+// TestHandleRequest_GetReport_ContentChangeServesReport covers a rescan
+// whose content changed: the token changes and the full report is served.
+func TestHandleRequest_GetReport_ContentChangeServesReport(t *testing.T) {
+	cache := &ReportCache{}
+	cache.SetReport(&v4.IndexReport{HashId: "before"}, nil)
+
+	handler := NewHandler(cache, "test-1.0.0")
+	first := sendAndReceive(t, handler, getReportRequest("req-before", ""))
+	token := first.GetMeta().GetReportToken()
+	require.NotEmpty(t, token)
+
+	cache.SetReport(&v4.IndexReport{HashId: "after"}, nil)
+	resp := sendAndReceive(t, handler, getReportRequest("req-after", token))
+
+	assert.NotNil(t, resp.GetGetReport())
 	assert.False(t, resp.GetGetReport().GetUnchanged())
-	assert.Equal(t, "same-hash", resp.GetGetReport().GetIndexReport().GetHashId())
+	assert.Equal(t, "after", resp.GetGetReport().GetIndexReport().GetHashId())
 	assert.NotEmpty(t, resp.GetMeta().GetReportToken())
 	assert.NotEqual(t, token, resp.GetMeta().GetReportToken())
+}
+
+func TestReportToken(t *testing.T) {
+	report := &v4.IndexReport{HashId: "a"}
+	assert.Equal(t, reportToken(report, nil), reportToken(&v4.IndexReport{HashId: "a"}, map[string]string{}))
+	assert.NotEqual(t, reportToken(report, nil), reportToken(&v4.IndexReport{HashId: "b"}, nil))
+	assert.NotEqual(t, reportToken(report, nil), reportToken(report, map[string]string{"os": "rhel"}))
+	assert.Equal(t, reportToken(nil, nil), reportToken(nil, map[string]string{}))
+	assert.Len(t, reportToken(report, nil), 16)
 }
 
 func TestHandleRequest_NotReady(t *testing.T) {

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
@@ -30,15 +30,20 @@ func sendAndReceive(t *testing.T, handler *Handler, req *pb.VMServiceRequest) *p
 	return &resp
 }
 
+func getReportRequest(requestID, lastKnownToken string) *pb.VMServiceRequest {
+	return &pb.VMServiceRequest{
+		Meta:   &pb.RequestMeta{RequestId: requestID},
+		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{LastKnownToken: lastKnownToken}},
+	}
+}
+
 func TestHandleRequest_GetReport(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
 
 	handler := NewHandler(cache, "test-1.0.0")
-	req := &pb.VMServiceRequest{
-		Meta:   &pb.RequestMeta{RequestId: "req-1", Capabilities: []string{"report_v1"}},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{LastKnownGeneration: 0}},
-	}
+	req := getReportRequest("req-1", "")
+	req.Meta.Capabilities = []string{"report_v1"}
 
 	resp := sendAndReceive(t, handler, req)
 
@@ -49,10 +54,9 @@ func TestHandleRequest_GetReport(t *testing.T) {
 	meta := resp.GetMeta()
 	require.NotNil(t, meta)
 	assert.Equal(t, "test-1.0.0", meta.GetAgentVersion())
-	assert.Equal(t, uint32(1), meta.GetReportGeneration())
+	assert.NotEmpty(t, meta.GetReportToken())
 	assert.NotNil(t, meta.GetReportGeneratedAt())
 	assert.Contains(t, meta.GetSupportedMethods(), "get_report")
-	assert.NotZero(t, meta.GetEpoch(), "epoch should be seeded on handler creation")
 }
 
 func TestHandleRequest_GetReport_Unchanged(t *testing.T) {
@@ -60,121 +64,54 @@ func TestHandleRequest_GetReport_Unchanged(t *testing.T) {
 	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
 
 	handler := NewHandler(cache, "test-1.0.0")
-	req := &pb.VMServiceRequest{
-		Meta:   &pb.RequestMeta{RequestId: "req-2"},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{LastKnownGeneration: 1}},
-	}
+	first := sendAndReceive(t, handler, getReportRequest("req-learn-token", ""))
+	token := first.GetMeta().GetReportToken()
+	require.NotEmpty(t, token)
 
-	resp := sendAndReceive(t, handler, req)
+	resp := sendAndReceive(t, handler, getReportRequest("req-2", token))
 
 	assert.NotNil(t, resp.GetGetReport())
 	assert.True(t, resp.GetGetReport().GetUnchanged())
 	assert.Nil(t, resp.GetGetReport().GetIndexReport())
+	assert.Equal(t, token, resp.GetMeta().GetReportToken())
 }
 
-func TestHandleRequest_GetReport_UnchangedWhenKnownEpochMatches(t *testing.T) {
-	cache := &ReportCache{}
-	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
-
-	handler := NewHandler(cache, "test-1.0.0")
-	// Learn the handler's epoch from a first exchange (known_epoch=0, so
-	// Sensor has no cached epoch yet — falls back to generation-only).
-	firstResp := sendAndReceive(t, handler, &pb.VMServiceRequest{
-		Meta:   &pb.RequestMeta{RequestId: "req-learn-epoch"},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{LastKnownGeneration: 0}},
-	})
-	epoch := firstResp.GetMeta().GetEpoch()
-	require.NotZero(t, epoch)
-
-	req := &pb.VMServiceRequest{
-		Meta: &pb.RequestMeta{RequestId: "req-epoch-match"},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
-			LastKnownGeneration: 1,
-			KnownEpoch:          epoch,
-		}},
-	}
-
-	resp := sendAndReceive(t, handler, req)
-
-	assert.NotNil(t, resp.GetGetReport())
-	assert.True(t, resp.GetGetReport().GetUnchanged(), "matching generation and epoch should report unchanged")
-	assert.Nil(t, resp.GetGetReport().GetIndexReport())
-}
-
-// TestHandleRequest_GetReport_ServesFullReportOnKnownEpochMismatch covers
-// the case report_generation alone cannot distinguish: report_generation
-// resets to 1 on every roxagent restart, so a restarted agent can
-// coincidentally match a generation Sensor already has cached for a
-// previous instance. known_epoch lets the agent detect this itself, in a
-// single round trip, by comparing Sensor's last-seen epoch against its own
-// current one.
-func TestHandleRequest_GetReport_ServesFullReportOnKnownEpochMismatch(t *testing.T) {
+// TestHandleRequest_GetReport_TokenMismatch covers a Sensor-cached token
+// that does not match the agent's current scan, including after restart.
+func TestHandleRequest_GetReport_TokenMismatch(t *testing.T) {
 	cache := &ReportCache{}
 	cache.SetReport(&v4.IndexReport{HashId: "post-restart-hash"}, nil)
 
 	handler := NewHandler(cache, "test-1.0.0")
-	req := &pb.VMServiceRequest{
-		Meta: &pb.RequestMeta{RequestId: "req-epoch-mismatch"},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
-			// Generation matches (both are 1), but Sensor's cached epoch is
-			// from a previous agent process instance.
-			LastKnownGeneration: 1,
-			KnownEpoch:          12345,
-		}},
-	}
-
-	resp := sendAndReceive(t, handler, req)
+	resp := sendAndReceive(t, handler, getReportRequest("req-mismatch", "stale-token"))
 
 	assert.NotNil(t, resp.GetGetReport())
-	assert.False(t, resp.GetGetReport().GetUnchanged(), "epoch mismatch must serve the full report despite matching generation")
+	assert.False(t, resp.GetGetReport().GetUnchanged())
 	require.NotNil(t, resp.GetGetReport().GetIndexReport())
 	assert.Equal(t, "post-restart-hash", resp.GetGetReport().GetIndexReport().GetHashId())
-	assert.NotEqual(t, uint32(12345), resp.GetMeta().GetEpoch(), "response should carry the agent's real current epoch")
+	assert.NotEmpty(t, resp.GetMeta().GetReportToken())
+	assert.NotEqual(t, "stale-token", resp.GetMeta().GetReportToken())
 }
 
-// TestHandleRequest_GetReport_UnchangedWhenKnownEpochZero pins down backward
-// compatibility: known_epoch=0 means Sensor has no epoch to compare (first
-// request for this VM, or a Sensor build that predates the field), so the
-// agent must fall back to generation-only comparison exactly as before this
-// field existed.
-func TestHandleRequest_GetReport_UnchangedWhenKnownEpochZero(t *testing.T) {
+// TestHandleRequest_GetReport_NewScanMintsNewToken covers a rescan: the
+// token changes even if content is identical, so Sensor still gets a full report.
+func TestHandleRequest_GetReport_NewScanMintsNewToken(t *testing.T) {
 	cache := &ReportCache{}
-	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil)
+	cache.SetReport(&v4.IndexReport{HashId: "same-hash"}, nil)
 
 	handler := NewHandler(cache, "test-1.0.0")
-	req := &pb.VMServiceRequest{
-		Meta: &pb.RequestMeta{RequestId: "req-epoch-zero"},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
-			LastKnownGeneration: 1,
-			KnownEpoch:          0,
-		}},
-	}
+	first := sendAndReceive(t, handler, getReportRequest("req-first-scan", ""))
+	token := first.GetMeta().GetReportToken()
+	require.NotEmpty(t, token)
 
-	resp := sendAndReceive(t, handler, req)
+	cache.SetReport(&v4.IndexReport{HashId: "same-hash"}, nil)
+	resp := sendAndReceive(t, handler, getReportRequest("req-after-rescan", token))
 
 	assert.NotNil(t, resp.GetGetReport())
-	assert.True(t, resp.GetGetReport().GetUnchanged(), "known_epoch=0 should fall back to generation-only comparison")
-	assert.Nil(t, resp.GetGetReport().GetIndexReport())
-}
-
-func TestHandleRequest_GetReport_GenerationRegression(t *testing.T) {
-	cache := &ReportCache{}
-	cache.SetReport(&v4.IndexReport{HashId: "post-restart-hash"}, nil)
-
-	handler := NewHandler(cache, "test-1.0.0")
-	req := &pb.VMServiceRequest{
-		Meta: &pb.RequestMeta{RequestId: "req-regression"},
-		Method: &pb.VMServiceRequest_GetReport{GetReport: &pb.GetReportRequest{
-			LastKnownGeneration: 5,
-		}},
-	}
-
-	resp := sendAndReceive(t, handler, req)
-
-	assert.NotNil(t, resp.GetGetReport())
-	assert.False(t, resp.GetGetReport().GetUnchanged(), "agent restarted (gen=1 < requested=5), must serve full report")
-	assert.Equal(t, "post-restart-hash", resp.GetGetReport().GetIndexReport().GetHashId())
-	assert.Equal(t, uint32(1), resp.GetMeta().GetReportGeneration())
+	assert.False(t, resp.GetGetReport().GetUnchanged())
+	assert.Equal(t, "same-hash", resp.GetGetReport().GetIndexReport().GetHashId())
+	assert.NotEmpty(t, resp.GetMeta().GetReportToken())
+	assert.NotEqual(t, token, resp.GetMeta().GetReportToken())
 }
 
 func TestHandleRequest_NotReady(t *testing.T) {

--- a/generated/internalapi/virtualmachine/v1/vm_service.pb.go
+++ b/generated/internalapi/virtualmachine/v1/vm_service.pb.go
@@ -419,9 +419,8 @@ type ResponseMeta struct {
 	AgentVersion string `protobuf:"bytes,1,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
 	// When the cached scan report was produced by the scanner.
 	ReportGeneratedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=report_generated_at,json=reportGeneratedAt,proto3" json:"report_generated_at,omitempty"`
-	// Opaque per-scan identifier minted when the cached report is published.
-	// Changes on every scan regardless of content, so Sensor always receives
-	// a full report at least once per rescan interval.
+	// XXH64 of the cached IndexReport and facts. Identical content keeps the
+	// same token; Sensor still forces a full report with an empty last_known_token.
 	ReportToken string `protobuf:"bytes,3,opt,name=report_token,json=reportToken,proto3" json:"report_token,omitempty"`
 	// Methods this agent accepts (e.g. ["get_report"]). Doubles as capability
 	// discovery — no separate handshake needed. See ADR-0006 §2.
@@ -565,10 +564,10 @@ func (x *GetReportRequest) GetLastKnownToken() string {
 
 type GetReportResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Full scan report; set when the token changed or last_known_token is empty.
+	// Full scan report; set when the content hash changed or last_known_token is empty.
 	IndexReport *v4.IndexReport `protobuf:"bytes,1,opt,name=index_report,json=indexReport,proto3" json:"index_report,omitempty"`
 	// True when the agent's token matches last_known_token; index_report is nil.
-	// Sensor may still force a refresh after 4 h.
+	// Sensor may still force a refresh after 4 h with an empty last_known_token.
 	Unchanged     bool `protobuf:"varint,2,opt,name=unchanged,proto3" json:"unchanged,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/generated/internalapi/virtualmachine/v1/vm_service.pb.go
+++ b/generated/internalapi/virtualmachine/v1/vm_service.pb.go
@@ -419,28 +419,21 @@ type ResponseMeta struct {
 	AgentVersion string `protobuf:"bytes,1,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
 	// When the cached scan report was produced by the scanner.
 	ReportGeneratedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=report_generated_at,json=reportGeneratedAt,proto3" json:"report_generated_at,omitempty"`
-	// Monotonic counter incremented on each rescan; resets to 1 on agent restart.
-	// Sensor uses this for deduplication (see ADR-0006 §2, "Generation counter").
-	ReportGeneration uint32 `protobuf:"varint,3,opt,name=report_generation,json=reportGeneration,proto3" json:"report_generation,omitempty"`
+	// Opaque per-scan identifier minted when the cached report is published.
+	// Changes on every scan regardless of content, so Sensor always receives
+	// a full report at least once per rescan interval.
+	ReportToken string `protobuf:"bytes,3,opt,name=report_token,json=reportToken,proto3" json:"report_token,omitempty"`
 	// Methods this agent accepts (e.g. ["get_report"]). Doubles as capability
 	// discovery — no separate handshake needed. See ADR-0006 §2.
 	SupportedMethods []string `protobuf:"bytes,4,rep,name=supported_methods,json=supportedMethods,proto3" json:"supported_methods,omitempty"`
 	// VM metadata from the scan (detected_os, os_version, activation_status, etc.).
 	// Future: may also carry roxagent operational metrics.
 	Facts map[string]string `protobuf:"bytes,5,rep,name=facts,proto3" json:"facts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Opaque value seeded once per agent process lifetime (random/time-derived),
-	// held in memory only, never persisted to VM disk. Changes on every agent
-	// restart, unlike report_generation which resets to 1. Sensor should treat
-	// an epoch mismatch as "changed" regardless of report_generation, to avoid
-	// false-negative dedup when a restarted agent's reset generation coincides
-	// with Sensor's cached value for that VM. Zero means the agent predates this
-	// field; Sensor falls back to generation-only comparison in that case.
-	Epoch uint32 `protobuf:"varint,6,opt,name=epoch,proto3" json:"epoch,omitempty"`
 	// XXH64 hex of active mapping; empty string means none. optional so absence
 	// means an older agent that does not report mapping metadata.
-	RepoCpeMappingHash *string `protobuf:"bytes,7,opt,name=repo_cpe_mapping_hash,json=repoCpeMappingHash,proto3,oneof" json:"repo_cpe_mapping_hash,omitempty"`
+	RepoCpeMappingHash *string `protobuf:"bytes,6,opt,name=repo_cpe_mapping_hash,json=repoCpeMappingHash,proto3,oneof" json:"repo_cpe_mapping_hash,omitempty"`
 	// SENSOR or URL only; UNSPECIFIED means Sensor must not sync.
-	RepoCpeMappingUpdatePath *RepoCPEMappingUpdatePath `protobuf:"varint,8,opt,name=repo_cpe_mapping_update_path,json=repoCpeMappingUpdatePath,proto3,enum=virtualmachine.v1.RepoCPEMappingUpdatePath,oneof" json:"repo_cpe_mapping_update_path,omitempty"`
+	RepoCpeMappingUpdatePath *RepoCPEMappingUpdatePath `protobuf:"varint,7,opt,name=repo_cpe_mapping_update_path,json=repoCpeMappingUpdatePath,proto3,enum=virtualmachine.v1.RepoCPEMappingUpdatePath,oneof" json:"repo_cpe_mapping_update_path,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -489,11 +482,11 @@ func (x *ResponseMeta) GetReportGeneratedAt() *timestamppb.Timestamp {
 	return nil
 }
 
-func (x *ResponseMeta) GetReportGeneration() uint32 {
+func (x *ResponseMeta) GetReportToken() string {
 	if x != nil {
-		return x.ReportGeneration
+		return x.ReportToken
 	}
-	return 0
+	return ""
 }
 
 func (x *ResponseMeta) GetSupportedMethods() []string {
@@ -508,13 +501,6 @@ func (x *ResponseMeta) GetFacts() map[string]string {
 		return x.Facts
 	}
 	return nil
-}
-
-func (x *ResponseMeta) GetEpoch() uint32 {
-	if x != nil {
-		return x.Epoch
-	}
-	return 0
 }
 
 func (x *ResponseMeta) GetRepoCpeMappingHash() string {
@@ -533,20 +519,11 @@ func (x *ResponseMeta) GetRepoCpeMappingUpdatePath() RepoCPEMappingUpdatePath {
 
 type GetReportRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Generation last observed by Sensor for this VM (see ResponseMeta.report_generation).
-	// Use 0 when no prior generation is known, which forces a full report. See
-	// ADR-0006 §2, "Generation counter", for how the agent uses this value.
-	LastKnownGeneration uint32 `protobuf:"varint,1,opt,name=last_known_generation,json=lastKnownGeneration,proto3" json:"last_known_generation,omitempty"`
-	// Epoch last observed by Sensor for this VM (see ResponseMeta.epoch). 0 means
-	// unknown (first-ever request for this VM, or a Sensor build that predates
-	// this field) -- the agent should ignore epoch and fall back to
-	// generation-only comparison, exactly as if this field did not exist. This
-	// lets the agent detect a restart-coincidence false match (last_known_generation
-	// happens to equal the post-restart generation) and serve the full report in
-	// the same round trip, instead of Sensor needing a second, forced request.
-	KnownEpoch    uint32 `protobuf:"varint,2,opt,name=known_epoch,json=knownEpoch,proto3" json:"known_epoch,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Token last observed by Sensor for this VM (see ResponseMeta.report_token).
+	// Empty when none is known, which forces a full report.
+	LastKnownToken string `protobuf:"bytes,1,opt,name=last_known_token,json=lastKnownToken,proto3" json:"last_known_token,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetReportRequest) Reset() {
@@ -579,26 +556,19 @@ func (*GetReportRequest) Descriptor() ([]byte, []int) {
 	return file_internalapi_virtualmachine_v1_vm_service_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *GetReportRequest) GetLastKnownGeneration() uint32 {
+func (x *GetReportRequest) GetLastKnownToken() string {
 	if x != nil {
-		return x.LastKnownGeneration
+		return x.LastKnownToken
 	}
-	return 0
-}
-
-func (x *GetReportRequest) GetKnownEpoch() uint32 {
-	if x != nil {
-		return x.KnownEpoch
-	}
-	return 0
+	return ""
 }
 
 type GetReportResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Full scan report; set when generation changed or forced (generation 0).
+	// Full scan report; set when the token changed or last_known_token is empty.
 	IndexReport *v4.IndexReport `protobuf:"bytes,1,opt,name=index_report,json=indexReport,proto3" json:"index_report,omitempty"`
-	// True when agent's generation matches last_known_generation; index_report
-	// is nil in this case. Sensor may still force a refresh after 4 h (ADR-0006 §2).
+	// True when the agent's token matches last_known_token; index_report is nil.
+	// Sensor may still force a refresh after 4 h.
 	Unchanged     bool `protobuf:"varint,2,opt,name=unchanged,proto3" json:"unchanged,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -825,26 +795,23 @@ const file_internalapi_virtualmachine_v1_vm_service_proto_rawDesc = "" +
 	"\n" +
 	"FactsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd0\x04\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb0\x04\n" +
 	"\fResponseMeta\x12#\n" +
 	"\ragent_version\x18\x01 \x01(\tR\fagentVersion\x12J\n" +
-	"\x13report_generated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x11reportGeneratedAt\x12+\n" +
-	"\x11report_generation\x18\x03 \x01(\rR\x10reportGeneration\x12+\n" +
+	"\x13report_generated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x11reportGeneratedAt\x12!\n" +
+	"\freport_token\x18\x03 \x01(\tR\vreportToken\x12+\n" +
 	"\x11supported_methods\x18\x04 \x03(\tR\x10supportedMethods\x12@\n" +
-	"\x05facts\x18\x05 \x03(\v2*.virtualmachine.v1.ResponseMeta.FactsEntryR\x05facts\x12\x14\n" +
-	"\x05epoch\x18\x06 \x01(\rR\x05epoch\x126\n" +
-	"\x15repo_cpe_mapping_hash\x18\a \x01(\tH\x00R\x12repoCpeMappingHash\x88\x01\x01\x12p\n" +
-	"\x1crepo_cpe_mapping_update_path\x18\b \x01(\x0e2+.virtualmachine.v1.RepoCPEMappingUpdatePathH\x01R\x18repoCpeMappingUpdatePath\x88\x01\x01\x1a8\n" +
+	"\x05facts\x18\x05 \x03(\v2*.virtualmachine.v1.ResponseMeta.FactsEntryR\x05facts\x126\n" +
+	"\x15repo_cpe_mapping_hash\x18\x06 \x01(\tH\x00R\x12repoCpeMappingHash\x88\x01\x01\x12p\n" +
+	"\x1crepo_cpe_mapping_update_path\x18\a \x01(\x0e2+.virtualmachine.v1.RepoCPEMappingUpdatePathH\x01R\x18repoCpeMappingUpdatePath\x88\x01\x01\x1a8\n" +
 	"\n" +
 	"FactsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x18\n" +
 	"\x16_repo_cpe_mapping_hashB\x1f\n" +
-	"\x1d_repo_cpe_mapping_update_path\"g\n" +
-	"\x10GetReportRequest\x122\n" +
-	"\x15last_known_generation\x18\x01 \x01(\rR\x13lastKnownGeneration\x12\x1f\n" +
-	"\vknown_epoch\x18\x02 \x01(\rR\n" +
-	"knownEpoch\"m\n" +
+	"\x1d_repo_cpe_mapping_update_path\"<\n" +
+	"\x10GetReportRequest\x12(\n" +
+	"\x10last_known_token\x18\x01 \x01(\tR\x0elastKnownToken\"m\n" +
 	"\x11GetReportResponse\x12:\n" +
 	"\findex_report\x18\x01 \x01(\v2\x17.scanner.v4.IndexReportR\vindexReport\x12\x1c\n" +
 	"\tunchanged\x18\x02 \x01(\bR\tunchanged\"5\n" +

--- a/generated/internalapi/virtualmachine/v1/vm_service_vtproto.pb.go
+++ b/generated/internalapi/virtualmachine/v1/vm_service_vtproto.pb.go
@@ -148,8 +148,7 @@ func (m *ResponseMeta) CloneVT() *ResponseMeta {
 	r := new(ResponseMeta)
 	r.AgentVersion = m.AgentVersion
 	r.ReportGeneratedAt = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.ReportGeneratedAt).CloneVT())
-	r.ReportGeneration = m.ReportGeneration
-	r.Epoch = m.Epoch
+	r.ReportToken = m.ReportToken
 	if rhs := m.SupportedMethods; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -186,8 +185,7 @@ func (m *GetReportRequest) CloneVT() *GetReportRequest {
 		return (*GetReportRequest)(nil)
 	}
 	r := new(GetReportRequest)
-	r.LastKnownGeneration = m.LastKnownGeneration
-	r.KnownEpoch = m.KnownEpoch
+	r.LastKnownToken = m.LastKnownToken
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -525,7 +523,7 @@ func (this *ResponseMeta) EqualVT(that *ResponseMeta) bool {
 	if !(*timestamppb1.Timestamp)(this.ReportGeneratedAt).EqualVT((*timestamppb1.Timestamp)(that.ReportGeneratedAt)) {
 		return false
 	}
-	if this.ReportGeneration != that.ReportGeneration {
+	if this.ReportToken != that.ReportToken {
 		return false
 	}
 	if len(this.SupportedMethods) != len(that.SupportedMethods) {
@@ -549,9 +547,6 @@ func (this *ResponseMeta) EqualVT(that *ResponseMeta) bool {
 			return false
 		}
 	}
-	if this.Epoch != that.Epoch {
-		return false
-	}
 	if p, q := this.RepoCpeMappingHash, that.RepoCpeMappingHash; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
 		return false
 	}
@@ -574,10 +569,7 @@ func (this *GetReportRequest) EqualVT(that *GetReportRequest) bool {
 	} else if this == nil || that == nil {
 		return false
 	}
-	if this.LastKnownGeneration != that.LastKnownGeneration {
-		return false
-	}
-	if this.KnownEpoch != that.KnownEpoch {
+	if this.LastKnownToken != that.LastKnownToken {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1008,19 +1000,14 @@ func (m *ResponseMeta) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.RepoCpeMappingUpdatePath != nil {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.RepoCpeMappingUpdatePath))
 		i--
-		dAtA[i] = 0x40
+		dAtA[i] = 0x38
 	}
 	if m.RepoCpeMappingHash != nil {
 		i -= len(*m.RepoCpeMappingHash)
 		copy(dAtA[i:], *m.RepoCpeMappingHash)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.RepoCpeMappingHash)))
 		i--
-		dAtA[i] = 0x3a
-	}
-	if m.Epoch != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Epoch))
-		i--
-		dAtA[i] = 0x30
+		dAtA[i] = 0x32
 	}
 	if len(m.Facts) > 0 {
 		for k := range m.Facts {
@@ -1050,10 +1037,12 @@ func (m *ResponseMeta) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			dAtA[i] = 0x22
 		}
 	}
-	if m.ReportGeneration != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ReportGeneration))
+	if len(m.ReportToken) > 0 {
+		i -= len(m.ReportToken)
+		copy(dAtA[i:], m.ReportToken)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ReportToken)))
 		i--
-		dAtA[i] = 0x18
+		dAtA[i] = 0x1a
 	}
 	if m.ReportGeneratedAt != nil {
 		size, err := (*timestamppb1.Timestamp)(m.ReportGeneratedAt).MarshalToSizedBufferVT(dAtA[:i])
@@ -1105,15 +1094,12 @@ func (m *GetReportRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.KnownEpoch != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.KnownEpoch))
+	if len(m.LastKnownToken) > 0 {
+		i -= len(m.LastKnownToken)
+		copy(dAtA[i:], m.LastKnownToken)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.LastKnownToken)))
 		i--
-		dAtA[i] = 0x10
-	}
-	if m.LastKnownGeneration != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.LastKnownGeneration))
-		i--
-		dAtA[i] = 0x8
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -1476,8 +1462,9 @@ func (m *ResponseMeta) SizeVT() (n int) {
 		l = (*timestamppb1.Timestamp)(m.ReportGeneratedAt).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	if m.ReportGeneration != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.ReportGeneration))
+	l = len(m.ReportToken)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if len(m.SupportedMethods) > 0 {
 		for _, s := range m.SupportedMethods {
@@ -1492,9 +1479,6 @@ func (m *ResponseMeta) SizeVT() (n int) {
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
-	}
-	if m.Epoch != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.Epoch))
 	}
 	if m.RepoCpeMappingHash != nil {
 		l = len(*m.RepoCpeMappingHash)
@@ -1513,11 +1497,9 @@ func (m *GetReportRequest) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
-	if m.LastKnownGeneration != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.LastKnownGeneration))
-	}
-	if m.KnownEpoch != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.KnownEpoch))
+	l = len(m.LastKnownToken)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2317,10 +2299,10 @@ func (m *ResponseMeta) UnmarshalVT(dAtA []byte) error {
 			}
 			iNdEx = postIndex
 		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ReportGeneration", wireType)
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReportToken", wireType)
 			}
-			m.ReportGeneration = 0
+			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -2330,11 +2312,24 @@ func (m *ResponseMeta) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ReportGeneration |= uint32(b&0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ReportToken = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SupportedMethods", wireType)
@@ -2495,25 +2490,6 @@ func (m *ResponseMeta) UnmarshalVT(dAtA []byte) error {
 			m.Facts[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 6:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Epoch", wireType)
-			}
-			m.Epoch = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.Epoch |= uint32(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingHash", wireType)
 			}
@@ -2546,7 +2522,7 @@ func (m *ResponseMeta) UnmarshalVT(dAtA []byte) error {
 			s := string(dAtA[iNdEx:postIndex])
 			m.RepoCpeMappingHash = &s
 			iNdEx = postIndex
-		case 8:
+		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingUpdatePath", wireType)
 			}
@@ -2618,10 +2594,10 @@ func (m *GetReportRequest) UnmarshalVT(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field LastKnownGeneration", wireType)
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastKnownToken", wireType)
 			}
-			m.LastKnownGeneration = 0
+			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -2631,30 +2607,24 @@ func (m *GetReportRequest) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.LastKnownGeneration |= uint32(b&0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field KnownEpoch", wireType)
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
 			}
-			m.KnownEpoch = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.KnownEpoch |= uint32(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
 			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.LastKnownToken = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -3916,10 +3886,10 @@ func (m *ResponseMeta) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			iNdEx = postIndex
 		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ReportGeneration", wireType)
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReportToken", wireType)
 			}
-			m.ReportGeneration = 0
+			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -3929,11 +3899,28 @@ func (m *ResponseMeta) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ReportGeneration |= uint32(b&0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ReportToken = stringValue
+			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SupportedMethods", wireType)
@@ -4106,25 +4093,6 @@ func (m *ResponseMeta) UnmarshalVTUnsafe(dAtA []byte) error {
 			m.Facts[mapkey] = mapvalue
 			iNdEx = postIndex
 		case 6:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Epoch", wireType)
-			}
-			m.Epoch = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.Epoch |= uint32(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingHash", wireType)
 			}
@@ -4161,7 +4129,7 @@ func (m *ResponseMeta) UnmarshalVTUnsafe(dAtA []byte) error {
 			s := stringValue
 			m.RepoCpeMappingHash = &s
 			iNdEx = postIndex
-		case 8:
+		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field RepoCpeMappingUpdatePath", wireType)
 			}
@@ -4233,10 +4201,10 @@ func (m *GetReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field LastKnownGeneration", wireType)
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastKnownToken", wireType)
 			}
-			m.LastKnownGeneration = 0
+			var stringLen uint64
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -4246,30 +4214,28 @@ func (m *GetReportRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.LastKnownGeneration |= uint32(b&0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field KnownEpoch", wireType)
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
 			}
-			m.KnownEpoch = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.KnownEpoch |= uint32(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
 			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.LastKnownToken = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/internalapi/virtualmachine/v1/vm_service.proto
+++ b/proto/internalapi/virtualmachine/v1/vm_service.proto
@@ -51,9 +51,8 @@ message ResponseMeta {
   string agent_version = 1;
   // When the cached scan report was produced by the scanner.
   google.protobuf.Timestamp report_generated_at = 2;
-  // Opaque per-scan identifier minted when the cached report is published.
-  // Changes on every scan regardless of content, so Sensor always receives
-  // a full report at least once per rescan interval.
+  // XXH64 of the cached IndexReport and facts. Identical content keeps the
+  // same token; Sensor still forces a full report with an empty last_known_token.
   string report_token = 3;
   // Methods this agent accepts (e.g. ["get_report"]). Doubles as capability
   // discovery — no separate handshake needed. See ADR-0006 §2.
@@ -77,10 +76,10 @@ message GetReportRequest {
 }
 
 message GetReportResponse {
-  // Full scan report; set when the token changed or last_known_token is empty.
+  // Full scan report; set when the content hash changed or last_known_token is empty.
   scanner.v4.IndexReport index_report = 1;
   // True when the agent's token matches last_known_token; index_report is nil.
-  // Sensor may still force a refresh after 4 h.
+  // Sensor may still force a refresh after 4 h with an empty last_known_token.
   bool unchanged = 2;
 }
 

--- a/proto/internalapi/virtualmachine/v1/vm_service.proto
+++ b/proto/internalapi/virtualmachine/v1/vm_service.proto
@@ -9,7 +9,7 @@ option go_package = "./internalapi/virtualmachine/v1;v1";
 
 // Protocol for pull-mode VM scanning over VSOCK between Sensor and roxagent.
 // See ADR-0006 §2 (Protocol) for the full design, exchange examples, and
-// generation-based deduplication semantics.
+// token-based deduplication semantics.
 
 // --- Envelope ---
 
@@ -51,52 +51,36 @@ message ResponseMeta {
   string agent_version = 1;
   // When the cached scan report was produced by the scanner.
   google.protobuf.Timestamp report_generated_at = 2;
-  // Monotonic counter incremented on each rescan; resets to 1 on agent restart.
-  // Sensor uses this for deduplication (see ADR-0006 §2, "Generation counter").
-  uint32 report_generation = 3;
+  // Opaque per-scan identifier minted when the cached report is published.
+  // Changes on every scan regardless of content, so Sensor always receives
+  // a full report at least once per rescan interval.
+  string report_token = 3;
   // Methods this agent accepts (e.g. ["get_report"]). Doubles as capability
   // discovery — no separate handshake needed. See ADR-0006 §2.
   repeated string supported_methods = 4;
   // VM metadata from the scan (detected_os, os_version, activation_status, etc.).
   // Future: may also carry roxagent operational metrics.
   map<string, string> facts = 5;
-  // Opaque value seeded once per agent process lifetime (random/time-derived),
-  // held in memory only, never persisted to VM disk. Changes on every agent
-  // restart, unlike report_generation which resets to 1. Sensor should treat
-  // an epoch mismatch as "changed" regardless of report_generation, to avoid
-  // false-negative dedup when a restarted agent's reset generation coincides
-  // with Sensor's cached value for that VM. Zero means the agent predates this
-  // field; Sensor falls back to generation-only comparison in that case.
-  uint32 epoch = 6;
   // XXH64 hex of active mapping; empty string means none. optional so absence
   // means an older agent that does not report mapping metadata.
-  optional string repo_cpe_mapping_hash = 7;
+  optional string repo_cpe_mapping_hash = 6;
   // SENSOR or URL only; UNSPECIFIED means Sensor must not sync.
-  optional RepoCPEMappingUpdatePath repo_cpe_mapping_update_path = 8;
+  optional RepoCPEMappingUpdatePath repo_cpe_mapping_update_path = 7;
 }
 
 // --- Methods ---
 
 message GetReportRequest {
-  // Generation last observed by Sensor for this VM (see ResponseMeta.report_generation).
-  // Use 0 when no prior generation is known, which forces a full report. See
-  // ADR-0006 §2, "Generation counter", for how the agent uses this value.
-  uint32 last_known_generation = 1;
-  // Epoch last observed by Sensor for this VM (see ResponseMeta.epoch). 0 means
-  // unknown (first-ever request for this VM, or a Sensor build that predates
-  // this field) -- the agent should ignore epoch and fall back to
-  // generation-only comparison, exactly as if this field did not exist. This
-  // lets the agent detect a restart-coincidence false match (last_known_generation
-  // happens to equal the post-restart generation) and serve the full report in
-  // the same round trip, instead of Sensor needing a second, forced request.
-  uint32 known_epoch = 2;
+  // Token last observed by Sensor for this VM (see ResponseMeta.report_token).
+  // Empty when none is known, which forces a full report.
+  string last_known_token = 1;
 }
 
 message GetReportResponse {
-  // Full scan report; set when generation changed or forced (generation 0).
+  // Full scan report; set when the token changed or last_known_token is empty.
   scanner.v4.IndexReport index_report = 1;
-  // True when agent's generation matches last_known_generation; index_report
-  // is nil in this case. Sensor may still force a refresh after 4 h (ADR-0006 §2).
+  // True when the agent's token matches last_known_token; index_report is nil.
+  // Sensor may still force a refresh after 4 h.
   bool unchanged = 2;
 }
 

--- a/sensor/common/virtualmachine/ACK_MODEL.md
+++ b/sensor/common/virtualmachine/ACK_MODEL.md
@@ -4,7 +4,7 @@ VM index reports flow directly from Sensor to Central; Compliance is not involve
 
 `VMScraper` pulls reports from each running VM's roxagent over VSOCK and forwards successful reports to Central through `vmIndex.Handler`, which wraps the Scanner V4 payload as a `v1.IndexReport`.
 
-A successful forward already returns the VM to poll cadence. Central's ACK is counted (`IndexReportAcksReceived`) and otherwise ignored. A NACK clears cached `report_generation` and applies the shared retry backoff so the next attempt pulls a full report. There is no payload cache and no ACK timeout.
+A successful forward already returns the VM to poll cadence. Central's ACK is counted (`IndexReportAcksReceived`) and otherwise ignored. A NACK clears cached `report_token` and applies the shared retry backoff so the next attempt pulls a full report. There is no payload cache and no ACK timeout.
 
 A short tick (`ROX_VIRTUAL_MACHINES_SCRAPER_TICK_INTERVAL`, default 10s) walks the per-VM schedule. Each VM is due at its own `nextAttemptAt`. Success and permanent failures reschedule at `pollInterval + U(0, W)`, where `pollInterval` is `ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL` (default 4h) and `W` is `ROX_VIRTUAL_MACHINES_SCRAPER_STEADY_SPREAD_FRACTION` times that interval (default 2/3).
 
@@ -30,7 +30,7 @@ sequenceDiagram
     alt ACK
         Note over Sc: recorded; schedule unchanged
     else NACK
-        Sc->>Sc: clear cached generation; apply retry backoff
+        Sc->>Sc: clear cached token; apply retry backoff
         Note over Sc,A: next due attempt requests a full report
     end
 ```
@@ -43,4 +43,4 @@ Using only the vsock CID is unsafe because a CID can be reused by a different VM
 
 The pair is not a per-report unique ID: multiple in-flight reports from the same VM with the same CID are still not fully distinguishable, so a stale ACK can match the latest entry instead of the one it was actually for.
 
-A NACK can also lose a race with the post-`Send` commit of `lastGeneration`, in which case the next poll may still see an "unchanged" delta.
+A NACK can also lose a race with the post-`Send` commit of `lastToken`, in which case the next poll may still see an "unchanged" delta.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -67,7 +67,7 @@ type IndexReportSender interface {
 
 // ProtocolClient performs the request/response protocol over a stream.
 type ProtocolClient interface {
-	GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error)
+	GetReport(ctx context.Context, stream io.ReadWriteCloser, lastKnownToken string) (*vsockclient.GetReportResult, error)
 }
 
 // VMScraper polls running VMs and pulls their scan reports via VSOCK.
@@ -100,8 +100,7 @@ type VMScraper struct {
 }
 
 type vmState struct {
-	lastGeneration  uint32
-	lastEpoch       uint32
+	lastToken       string
 	lastForwardedAt time.Time
 	nextAttemptAt   time.Time
 	backoff         time.Duration
@@ -183,11 +182,11 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 	return nil
 }
 
-// handleNACK clears the cached generation and applies the shared backoff so
+// handleNACK clears the cached token and applies the shared backoff so
 // the next tick resends a full report without tight-looping on persistent NACKs.
 //
-// Race with commitVMState after Send is accepted (same class as today's
-// lastGeneration race): a fast NACK may be overwritten by a late success commit.
+// Race with commitVMState after Send is accepted: a fast NACK may be
+// overwritten by a late success commit.
 func (s *VMScraper) handleNACK(resourceID string) {
 	key := s.findKeyByVMID(vmIDFromResourceID(resourceID))
 	if key == "" {
@@ -201,14 +200,14 @@ func (s *VMScraper) handleNACK(resourceID string) {
 		if !exists {
 			return false
 		}
-		state.lastGeneration = 0
+		state.lastToken = ""
 		state.backoff = nextBackoff(state.backoff, s.interval, s.initialBackoff)
 		state.nextAttemptAt = s.now().Add(state.backoff)
 		backoff = state.backoff
 		return true
 	})
 	if ok {
-		log.Infof("VMScraper: NACK for %q; cleared generation, next attempt in %s", key, backoff)
+		log.Infof("VMScraper: NACK for %q; cleared token, next attempt in %s", key, backoff)
 	}
 }
 
@@ -415,14 +414,14 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	// The mandatory refresh is a deterministic, time-based decision Sensor
 	// can make before dialing at all, so request the full report on this
 	// round trip instead of asking "anything newer?" and dialing again.
-	ifNewerThan, knownEpoch := snap.lastGeneration, snap.lastEpoch
+	lastKnownToken := snap.lastToken
 	mandatoryRefreshDue := s.now().Sub(snap.lastForwardedAt) > s.mandatoryRefreshAfter
 	if mandatoryRefreshDue {
-		ifNewerThan, knownEpoch = 0, 0
+		lastKnownToken = ""
 	}
 
 	log.Debugf("VMScraper: dialing roxagent on %q with TLS", key)
-	result, outcome := s.dialAndGetReport(vmCtx, vm, key, port, ifNewerThan, knownEpoch)
+	result, outcome := s.dialAndGetReport(vmCtx, vm, key, port, lastKnownToken)
 	if outcome != scrapeOK {
 		next := s.scheduleAfterAttempt(key, outcome)
 		kind := "retryable"
@@ -436,7 +435,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	if result.Unchanged {
 		next := s.scheduleAfterAttempt(key, scrapeOK)
 		log.Infof("VMScraper: scrape %q ok outcome=unchanged next=%s", key, next)
-		log.Debugf("VMScraper: unchanged report from roxagent on %q (generation=%d)", key, snap.lastGeneration)
+		log.Debugf("VMScraper: unchanged report from roxagent on %q (token=%s)", key, snap.lastToken)
 		metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusUnchanged).Inc()
 		return true
 	}
@@ -467,15 +466,15 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 		return false
 	}
 
-	newGen := result.Meta.GetReportGeneration()
-	s.commitVMState(key, newGen, result.Meta.GetEpoch())
+	newToken := result.Meta.GetReportToken()
+	s.commitVMState(key, newToken)
 	s.observeForwardInterarrival()
 	next := s.scheduleAfterAttempt(key, scrapeOK)
 
 	log.Infof("VMScraper: scrape %q ok outcome=forwarded next=%s", key, next)
 	totalElapsed := s.now().Sub(totalStart)
-	log.Debugf("VMScraper: successfully pulled report for %q: generation=%d, packages=%d, size=%d bytes, total=%s",
-		key, newGen, len(result.IndexReport.GetContents().GetPackages()), reportSize,
+	log.Debugf("VMScraper: successfully pulled report for %q: token=%s, packages=%d, size=%d bytes, total=%s",
+		key, newToken, len(result.IndexReport.GetContents().GetPackages()), reportSize,
 		totalElapsed.Truncate(time.Millisecond))
 	metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusSuccess).Inc()
 	metrics.PullTotalDurationSeconds.Observe(totalElapsed.Seconds())
@@ -532,7 +531,7 @@ func (s *VMScraper) scheduleAfterAttempt(key string, outcome scrapeOutcome) time
 
 // dialAndGetReport dials the VM and issues a single GetReport request,
 // recording dial/read latency metrics and classifying failures.
-func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Info, key string, port, ifNewerThan, knownEpoch uint32) (*vsockclient.GetReportResult, scrapeOutcome) {
+func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, lastKnownToken string) (*vsockclient.GetReportResult, scrapeOutcome) {
 	dialStart := s.now()
 	stream, err := s.dialer.Dial(ctx, vm.Namespace, vm.Name, port, true)
 	metrics.PullDialDurationSeconds.Observe(s.now().Sub(dialStart).Seconds())
@@ -553,7 +552,7 @@ func (s *VMScraper) dialAndGetReport(ctx context.Context, vm *virtualmachine.Inf
 	defer func() { _ = stream.Close() }()
 
 	readStart := s.now()
-	result, err := s.client.GetReport(ctx, stream, ifNewerThan, knownEpoch)
+	result, err := s.client.GetReport(ctx, stream, lastKnownToken)
 	metrics.PullReadDurationSeconds.Observe(s.now().Sub(readStart).Seconds())
 	if err != nil {
 		return nil, s.handleGetReportError(ctx, key, err)
@@ -604,8 +603,7 @@ func (s *VMScraper) handleGetReportError(ctx context.Context, key string, err er
 }
 
 type vmStateSnapshot struct {
-	lastGeneration  uint32
-	lastEpoch       uint32
+	lastToken       string
 	lastForwardedAt time.Time
 	backoff         time.Duration
 }
@@ -620,15 +618,14 @@ func (s *VMScraper) snapshotVMState(key string) vmStateSnapshot {
 			return vmStateSnapshot{}
 		}
 		return vmStateSnapshot{
-			lastGeneration:  st.lastGeneration,
-			lastEpoch:       st.lastEpoch,
+			lastToken:       st.lastToken,
 			lastForwardedAt: st.lastForwardedAt,
 			backoff:         st.backoff,
 		}
 	})
 }
 
-// commitVMState records the generation/epoch from a just-sent report as key's cached scrape state.
+// commitVMState records the token from a just-sent report as key's cached scrape state.
 //
 // Race: If a NACK arrives from Central faster than this function completes, for example, due to:
 //   - a scheduling delay on the caller's goroutine between Send returning and this function
@@ -636,17 +633,16 @@ func (s *VMScraper) snapshotVMState(key string) vmStateSnapshot {
 //   - contention on `s.mu` itself, from other concurrent scrapes or NACKs delaying this
 //     function's lock acquisition,
 //
-// then the NACK will overwrite lastGeneration / backoff / nextAttemptAt, and then this code
-// will set generation (and a later scheduleAfterAttempt(scrapeOK) will reset backoff schedule).
-// This race is accepted for v1 (same class as the historical lastGeneration-only race).
-func (s *VMScraper) commitVMState(key string, newGen, newEpoch uint32) {
+// then the NACK will overwrite lastToken / backoff / nextAttemptAt, and then this code
+// will set the token (and a later scheduleAfterAttempt(scrapeOK) will reset backoff schedule).
+// This race is accepted for v1.
+func (s *VMScraper) commitVMState(key string, newToken string) {
 	concurrency.WithLock(&s.mu, func() {
 		state, ok := s.vmState[key]
 		if !ok {
 			return
 		}
-		state.lastGeneration = newGen
-		state.lastEpoch = newEpoch
+		state.lastToken = newToken
 		state.lastForwardedAt = s.now()
 	})
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -95,14 +95,13 @@ type mockProtocolClient struct {
 }
 
 type protocolCall struct {
-	ifNewerThan uint32
-	knownEpoch  uint32
+	lastKnownToken string
 }
 
-func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*vsockclient.GetReportResult, error) {
+func (m *mockProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, lastKnownToken string) (*vsockclient.GetReportResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, protocolCall{ifNewerThan: ifNewerThan, knownEpoch: knownEpoch})
+	m.calls = append(m.calls, protocolCall{lastKnownToken: lastKnownToken})
 	idx := m.callIdx
 	m.callIdx++
 	if idx < len(m.errQueue) && m.errQueue[idx] != nil {
@@ -171,13 +170,13 @@ func (c *testClock) Advance(d time.Duration) {
 	c.t = c.t.Add(d)
 }
 
-func makeReport(gen uint32) *vsockclient.GetReportResult {
+func makeReport(token string) *vsockclient.GetReportResult {
 	return &vsockclient.GetReportResult{
 		IndexReport: &v4.IndexReport{
 			State: "IndexFinished",
 		},
 		Meta: &pb.ResponseMeta{
-			ReportGeneration: gen,
+			ReportToken: token,
 			Facts: map[string]string{
 				"detected_os":         "RHEL",
 				"activation_status":   "ACTIVE",
@@ -190,26 +189,7 @@ func makeReport(gen uint32) *vsockclient.GetReportResult {
 func unchangedResult() *vsockclient.GetReportResult {
 	return &vsockclient.GetReportResult{
 		Unchanged: true,
-		Meta:      &pb.ResponseMeta{ReportGeneration: 1},
-	}
-}
-
-func makeReportWithEpoch(gen, epoch uint32) *vsockclient.GetReportResult {
-	return &vsockclient.GetReportResult{
-		IndexReport: &v4.IndexReport{
-			State: "IndexFinished",
-		},
-		Meta: &pb.ResponseMeta{
-			ReportGeneration: gen,
-			Epoch:            epoch,
-		},
-	}
-}
-
-func unchangedResultWithEpoch(gen, epoch uint32) *vsockclient.GetReportResult {
-	return &vsockclient.GetReportResult{
-		Unchanged: true,
-		Meta:      &pb.ResponseMeta{ReportGeneration: gen, Epoch: epoch},
+		Meta:      &pb.ResponseMeta{ReportToken: "1"},
 	}
 }
 
@@ -223,7 +203,7 @@ func TestVMScraper_PollsRunningVMs(t *testing.T) {
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1), makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1"), makeReport("1")},
 		errQueue:    []error{nil, nil},
 	}
 
@@ -236,14 +216,14 @@ func TestVMScraper_PollsRunningVMs(t *testing.T) {
 	assert.Equal(t, discoveredBefore+2, testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE")))
 }
 
-func TestVMScraper_SkipsUnchangedGeneration(t *testing.T) {
+func TestVMScraper_SkipsUnchangedToken(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),
 	}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
@@ -266,7 +246,7 @@ func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
@@ -290,7 +270,7 @@ func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
@@ -302,143 +282,113 @@ func TestVMScraper_ForwardsAfter4Hours(t *testing.T) {
 	clock.Advance(s.mandatoryRefreshAfter + time.Second)
 
 	// The mandatory refresh is known before dialing, so a single call
-	// requesting the full report (ifNewerThan=0) is enough.
+	// requesting the full report (empty last_known_token) is enough.
 	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport("1")}
 	s.pollOnce(context.Background())
 
 	require.Len(t, client.calls, 1, "mandatory refresh should resolve in a single round trip")
-	assert.Equal(t, uint32(0), client.calls[0].ifNewerThan, "mandatory refresh forces the full report on the only call")
-	assert.Equal(t, uint32(0), client.calls[0].knownEpoch, "mandatory refresh forces the full report on the only call")
+	assert.Empty(t, client.calls[0].lastKnownToken, "mandatory refresh forces the full report on the only call")
 	assert.Len(t, sender.sent, 2, "should forward after 4h even if unchanged")
 }
 
-// TestVMScraper_ForwardsOnEpochChangeInSingleDial covers a current agent that
-// resolves restart-coincidence in one response (full report, new epoch).
-func TestVMScraper_ForwardsOnEpochChangeInSingleDial(t *testing.T) {
+// TestVMScraper_SendsLastKnownTokenOnRequest verifies Sensor sends its
+// last-cached token on every request so a matching scan reports unchanged.
+func TestVMScraper_SendsLastKnownTokenOnRequest(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),
 	}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReportWithEpoch(5, 100)},
-	}
-
-	s, clock := newTestScraper(store, sender, dialer, client)
-	s.pollOnce(context.Background())
-	require.Len(t, sender.sent, 1)
-
-	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReportWithEpoch(5, 200)}
-	clock.Advance(s.interval)
-	s.pollOnce(context.Background())
-
-	require.Len(t, client.calls, 1, "current agent serves the full report in one dial")
-	assert.Equal(t, uint32(5), client.calls[0].ifNewerThan)
-	assert.Equal(t, uint32(100), client.calls[0].knownEpoch)
-	assert.Len(t, sender.sent, 2)
-}
-
-// TestVMScraper_SendsKnownEpochOnRequest verifies Sensor sends its
-// last-cached epoch on every request, letting a current roxagent resolve a
-// restart-coincidence false match in a single round trip.
-func TestVMScraper_SendsKnownEpochOnRequest(t *testing.T) {
-	store := &mockStore{vms: []*virtualmachine.Info{
-		makeVM("ns1", "vm-a", 100),
-	}}
-	sender := &mockSender{}
-	dialer := &mockDialer{}
-	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReportWithEpoch(1, 100)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("tok-100")},
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
 	s.pollOnce(context.Background())
 
 	require.Len(t, client.calls, 1)
-	assert.Equal(t, uint32(0), client.calls[0].knownEpoch, "first-ever request for a VM has no cached epoch")
+	assert.Empty(t, client.calls[0].lastKnownToken, "first-ever request for a VM has no cached token")
 
 	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithEpoch(1, 100)}
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResult()}
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
 
-	require.Len(t, client.calls, 1, "matching epoch and generation should resolve in a single round trip")
-	assert.Equal(t, uint32(100), client.calls[0].knownEpoch, "subsequent requests send the cached epoch")
+	require.Len(t, client.calls, 1, "matching token should resolve in a single round trip")
+	assert.Equal(t, "tok-100", client.calls[0].lastKnownToken, "subsequent requests send the cached token")
 }
 
-func TestVMScraper_ForwardsOnGenerationChange(t *testing.T) {
+func TestVMScraper_ForwardsOnTokenChange(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),
 	}}
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
 	s.pollOnce(context.Background())
 	require.Len(t, sender.sent, 1)
 
-	// New generation
+	// New token
 	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport("2")}
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
-	assert.Len(t, sender.sent, 2, "should forward on generation change")
+	assert.Len(t, sender.sent, 2, "should forward on token change")
 }
 
 // TestVMScraper_NACK reproduces a scenario where Central NACKs a report
 // (e.g. Scanner was still starting up). Without resetting the cached
-// generation, the next poll would see roxagent report "unchanged"
-// (report_generation didn't change) and skip resending, stranding the VM
-// until mandatoryRefreshAfter (4h) instead of retrying on the next poll
-// interval. It also verifies that a NACK is a no-op when it doesn't resolve
-// to a currently-running, known VM (unrelated VM ID, malformed resource ID,
-// or a VM that stopped running), and that an ACK never touches the cached
-// generation.
+// token, the next poll would see roxagent report "unchanged" and skip
+// resending, stranding the VM until mandatoryRefreshAfter (4h) instead of
+// retrying on the next poll interval. It also verifies that a NACK is a
+// no-op when it doesn't resolve to a currently-running, known VM (unrelated
+// VM ID, malformed resource ID, or a VM that stopped running), and that an
+// ACK never touches the cached token.
 func TestVMScraper_NACK(t *testing.T) {
 	cases := map[string]struct {
-		ackAction                  central.SensorACK_Action
-		nackResourceID             string
-		vmRunning                  bool
-		pollResultAfterNack        *vsockclient.GetReportResult
-		advanceAfterAck            time.Duration
-		wantCalls                  int
-		wantIfNewerThanOnRetryPoll uint32
-		wantTotalSent              int
+		ackAction                     central.SensorACK_Action
+		nackResourceID                string
+		vmRunning                     bool
+		pollResultAfterNack           *vsockclient.GetReportResult
+		advanceAfterAck               time.Duration
+		wantCalls                     int
+		wantLastKnownTokenOnRetryPoll string
+		wantTotalSent                 int
 	}{
-		"resets generation and resends after backoff when NACK matches the running VM": {
-			ackAction:                  central.SensorACK_NACK,
-			nackResourceID:             "vm-a-id:100",
-			vmRunning:                  true,
-			pollResultAfterNack:        makeReport(1),
-			advanceAfterAck:            initialBackoff,
-			wantCalls:                  1,
-			wantIfNewerThanOnRetryPoll: 0,
-			wantTotalSent:              2,
+		"resets token and resends after backoff when NACK matches the running VM": {
+			ackAction:                     central.SensorACK_NACK,
+			nackResourceID:                "vm-a-id:100",
+			vmRunning:                     true,
+			pollResultAfterNack:           makeReport("1"),
+			advanceAfterAck:               initialBackoff,
+			wantCalls:                     1,
+			wantLastKnownTokenOnRetryPoll: "",
+			wantTotalSent:                 2,
 		},
 		"is a no-op when NACK references an unrelated VM ID": {
-			ackAction:                  central.SensorACK_NACK,
-			nackResourceID:             "unknown-vm-id:999",
-			vmRunning:                  true,
-			pollResultAfterNack:        unchangedResult(),
-			advanceAfterAck:            5 * time.Minute,
-			wantCalls:                  1,
-			wantIfNewerThanOnRetryPoll: 1,
-			wantTotalSent:              1,
+			ackAction:                     central.SensorACK_NACK,
+			nackResourceID:                "unknown-vm-id:999",
+			vmRunning:                     true,
+			pollResultAfterNack:           unchangedResult(),
+			advanceAfterAck:               5 * time.Minute,
+			wantCalls:                     1,
+			wantLastKnownTokenOnRetryPoll: "1",
+			wantTotalSent:                 1,
 		},
 		"is a no-op when the resource ID has no vsockCID suffix": {
-			ackAction:                  central.SensorACK_NACK,
-			nackResourceID:             "vm-a-id-with-no-colon",
-			vmRunning:                  true,
-			pollResultAfterNack:        unchangedResult(),
-			advanceAfterAck:            5 * time.Minute,
-			wantCalls:                  1,
-			wantIfNewerThanOnRetryPoll: 1,
-			wantTotalSent:              1,
+			ackAction:                     central.SensorACK_NACK,
+			nackResourceID:                "vm-a-id-with-no-colon",
+			vmRunning:                     true,
+			pollResultAfterNack:           unchangedResult(),
+			advanceAfterAck:               5 * time.Minute,
+			wantCalls:                     1,
+			wantLastKnownTokenOnRetryPoll: "1",
+			wantTotalSent:                 1,
 		},
 		"is a no-op when the NACKed VM is no longer running": {
 			ackAction:           central.SensorACK_NACK,
@@ -450,14 +400,14 @@ func TestVMScraper_NACK(t *testing.T) {
 			wantTotalSent:       1,
 		},
 		"is a no-op for an ACK": {
-			ackAction:                  central.SensorACK_ACK,
-			nackResourceID:             "vm-a-id:100",
-			vmRunning:                  true,
-			pollResultAfterNack:        unchangedResult(),
-			advanceAfterAck:            5 * time.Minute,
-			wantCalls:                  1,
-			wantIfNewerThanOnRetryPoll: 1,
-			wantTotalSent:              1,
+			ackAction:                     central.SensorACK_ACK,
+			nackResourceID:                "vm-a-id:100",
+			vmRunning:                     true,
+			pollResultAfterNack:           unchangedResult(),
+			advanceAfterAck:               5 * time.Minute,
+			wantCalls:                     1,
+			wantLastKnownTokenOnRetryPoll: "1",
+			wantTotalSent:                 1,
 		},
 	}
 
@@ -469,7 +419,7 @@ func TestVMScraper_NACK(t *testing.T) {
 			sender := &mockSender{}
 			dialer := &mockDialer{}
 			client := &mockProtocolClient{
-				resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+				resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 			}
 
 			s, clock := newTestScraper(store, sender, dialer, client)
@@ -500,8 +450,8 @@ func TestVMScraper_NACK(t *testing.T) {
 
 			require.Len(t, client.calls, tc.wantCalls)
 			if tc.wantCalls > 0 {
-				assert.Equal(t, tc.wantIfNewerThanOnRetryPoll, client.calls[0].ifNewerThan,
-					"generation the scraper requests on the poll following the NACK")
+				assert.Equal(t, tc.wantLastKnownTokenOnRetryPoll, client.calls[0].lastKnownToken,
+					"token the scraper requests on the poll following the NACK")
 			}
 			assert.Len(t, sender.sent, tc.wantTotalSent, "total reports handed to the sender across both polls")
 		})
@@ -536,11 +486,11 @@ func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 		vmA := makeVM("ns1", "vm-a", 100)
 		vmA.ID = "vm-a-id"
 		store := &mockStore{vms: []*virtualmachine.Info{vmA}}
-		client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport(1)}}
+		client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport("1")}}
 		s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
 
 		s.pollOnce(t.Context())
-		require.Equal(t, uint32(1), cachedGeneration(t, s, "ns1/vm-a"))
+		require.Equal(t, "1", cachedToken(t, s, "ns1/vm-a"))
 
 		gate := &gateSender{
 			blockAt: 1,
@@ -548,7 +498,7 @@ func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 		}
 		s.sender = gate
 		client.reset()
-		client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
+		client.resultQueue = []*vsockclient.GetReportResult{makeReport("2")}
 		clock.Advance(s.interval)
 
 		done := make(chan struct{})
@@ -570,12 +520,12 @@ func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
 				},
 			},
 		}))
-		assert.Equal(t, uint32(0), cachedGeneration(t, s, "ns1/vm-a"),
+		assert.Empty(t, cachedToken(t, s, "ns1/vm-a"),
 			"NACK applies immediately while the send it targets is still in flight")
 
 		close(gate.release)
 		<-done
-		assert.Equal(t, uint32(2), cachedGeneration(t, s, "ns1/vm-a"),
+		assert.Equal(t, "2", cachedToken(t, s, "ns1/vm-a"),
 			"the in-flight send's commit runs after the NACK reset and overwrites it unconditionally")
 	})
 }
@@ -596,7 +546,7 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 	}{
 		"should still send for vm-b when vm-a hits a protocol error": {
 			dialer:      &mockDialer{},
-			resultQueue: []*vsockclient.GetReportResult{nil, makeReport(1)},
+			resultQueue: []*vsockclient.GetReportResult{nil, makeReport("1")},
 			errQueue:    []error{errors.New("connection refused"), nil},
 			wantCalls:   2,
 			wantSent:    1,
@@ -605,7 +555,7 @@ func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {
 			dialer: &mockDialer{
 				errQueue: []error{errors.New("dial failed"), nil},
 			},
-			resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+			resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 			wantCalls:   1,
 			wantSent:    1,
 		},
@@ -659,7 +609,7 @@ func TestVMScraper_GetReportTimeoutClassified(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, outcome := s.dialAndGetReport(ctx, vm, "ns1/vm-a", 1, 0, 0)
+	_, outcome := s.dialAndGetReport(ctx, vm, "ns1/vm-a", 1, "")
 
 	assert.Equal(t, scrapeNonRetryable, outcome,
 		"parent cancellation must not schedule a retry on the short tick")
@@ -681,7 +631,7 @@ func TestVMScraper_GetReportDeadlineExceededClassified(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
 	<-ctx.Done()
-	_, outcome := s.dialAndGetReport(ctx, vm, "ns1/vm-a", 1, 0, 0)
+	_, outcome := s.dialAndGetReport(ctx, vm, "ns1/vm-a", 1, "")
 
 	assert.Equal(t, scrapeRetryable, outcome, "a per-VM deadline is retried on the short tick")
 }
@@ -698,7 +648,7 @@ func TestVMScraper_GetReportBusyClassified(t *testing.T) {
 	busyBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy))
 	readErrBefore := testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusReadError))
 
-	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, 0, 0)
+	_, outcome := s.dialAndGetReport(context.Background(), vm, "ns1/vm-a", 1, "")
 
 	assert.Equal(t, scrapeRetryable, outcome)
 	assert.Equal(t, busyBefore+1, testutil.ToFloat64(metrics.PullRequestsTotal.WithLabelValues(metrics.PullStatusBusy)))
@@ -714,7 +664,7 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 	sender := &mockSender{}
 	dialer := &mockDialer{}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1), makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1"), makeReport("1")},
 	}
 
 	s, clock := newTestScraper(store, sender, dialer, client)
@@ -725,7 +675,7 @@ func TestVMScraper_PrunesStaleState(t *testing.T) {
 	// Remove vm-a from running set
 	store.vms = []*virtualmachine.Info{makeVM("ns2", "vm-b", 200)}
 	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(2)}
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport("2")}
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
 
@@ -743,14 +693,14 @@ func hasScheduleSlot(t *testing.T, s *VMScraper, key string) bool {
 	})
 }
 
-// cachedGeneration reads a VM's cached generation under s.mu, so the read is
+// cachedToken reads a VM's cached token under s.mu, so the read is
 // race-safe regardless of what locking handleNACK or commitVMState use internally.
-func cachedGeneration(t *testing.T, s *VMScraper, key string) uint32 {
+func cachedToken(t *testing.T, s *VMScraper, key string) string {
 	t.Helper()
-	return concurrency.WithLock1(&s.mu, func() uint32 {
+	return concurrency.WithLock1(&s.mu, func() string {
 		st, ok := s.vmState[key]
 		require.True(t, ok, "no cached state for %q", key)
-		return st.lastGeneration
+		return st.lastToken
 	})
 }
 
@@ -820,15 +770,15 @@ func (d *delayDialer) Dial(_ context.Context, _, _ string, _ uint32, _ bool) (io
 
 type safeProtocolClient struct {
 	mu    sync.Mutex
-	gen   uint32
+	token string
 	calls int
 }
 
-func (c *safeProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, _ uint32, _ uint32) (*vsockclient.GetReportResult, error) {
+func (c *safeProtocolClient) GetReport(_ context.Context, _ io.ReadWriteCloser, _ string) (*vsockclient.GetReportResult, error) {
 	c.mu.Lock()
 	c.calls++
 	c.mu.Unlock()
-	return makeReport(c.gen), nil
+	return makeReport(c.token), nil
 }
 
 type safeSender struct {
@@ -858,7 +808,7 @@ func TestVMScraper_ConcurrentFasterThanSequential(t *testing.T) {
 	store := &mockStore{vms: vms}
 	sender := &safeSender{}
 	dialer := &delayDialer{delay: dialDelay}
-	client := &safeProtocolClient{gen: 1}
+	client := &safeProtocolClient{token: "1"}
 
 	s, _ := newTestScraper(store, sender, dialer, client)
 	s.concurrency = concurrency
@@ -893,7 +843,7 @@ func TestVMScraper_RetryableFailureSchedulesBackoff(t *testing.T) {
 
 	client.reset()
 	client.errQueue = nil
-	client.resultQueue = []*vsockclient.GetReportResult{makeReport(1)}
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport("1")}
 	s.pollOnce(context.Background())
 	assert.Len(t, client.calls, 0, "should skip while backoff has not elapsed")
 
@@ -928,7 +878,7 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 		wantGap     time.Duration
 	}{
 		"send failure should retry using backoff": {
-			client:      &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport(1)}},
+			client:      &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport("1")}},
 			sender:      &mockSender{err: errors.New("central unavailable")},
 			wantBackoff: initialBackoff,
 			wantGap:     initialBackoff,
@@ -965,7 +915,7 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 		},
 		"invalid report should not retry using backoff": {
 			client: &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{{
-				Meta: &pb.ResponseMeta{ReportGeneration: 1},
+				Meta: &pb.ResponseMeta{ReportToken: "1"},
 			}}},
 			sender:      &mockSender{},
 			wantBackoff: 0,
@@ -994,7 +944,7 @@ func TestVMScraper_SchedulesByOutcome(t *testing.T) {
 func TestVMScraper_NonForcedTickSkipsReconcileWhenNotDue(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns1", "vm-a", 100)}}
 	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1), makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1"), makeReport("1")},
 	}
 	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, client)
 

--- a/sensor/common/virtualmachine/vmscraper/spreading_test.go
+++ b/sensor/common/virtualmachine/vmscraper/spreading_test.go
@@ -47,7 +47,7 @@ func sequencedRand(seq []float64) func() float64 {
 func TestVMScraper_CadenceRescheduleUsesSteadyBand(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "vm-a", 1)}}
 	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	})
 	s.spreadFraction = 2.0 / 3
 	// First draw (reconcile insert) keeps the VM due now; second is the cadence offset.
@@ -69,7 +69,7 @@ func TestVMScraper_ManyCadencedSuccessesSpanSteadyBand(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(10+i)))
 	}
 	store := &mockStore{vms: vms}
-	s, clock := newTestScraper(store, &safeSender{}, &mockDialer{}, &safeProtocolClient{gen: 1})
+	s, clock := newTestScraper(store, &safeSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	s.spreadFraction = 2.0 / 3
@@ -116,7 +116,7 @@ func TestVMScraper_MassFirstInsertSpansNewVMIndexReportWindow(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	store := &mockStore{vms: vms}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{gen: 1})
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	units := make([]float64, numVMs)
@@ -150,7 +150,7 @@ func TestVMScraper_MassFirstInsertSpansNewVMIndexReportWindow(t *testing.T) {
 
 func TestVMScraper_SingleInsertUsesNewVMIndexReportSpread(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{makeVM("ns", "only", 1)}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{gen: 1})
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = 20
 	s.randFloat64 = func() float64 { return 0.5 }
 
@@ -166,7 +166,7 @@ func TestVMScraper_MultiInsertUsesNewVMIndexReportSpread(t *testing.T) {
 		makeVM("ns", "a", 1),
 		makeVM("ns", "b", 2),
 	}}
-	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{gen: 1})
+	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = 20
 	s.randFloat64 = sequencedRand([]float64{0.25, 0.75})
 
@@ -195,7 +195,7 @@ func TestVMScraper_NACKPathDoesNotUseSteadyBand(t *testing.T) {
 	vm := makeVM("ns1", "vm-a", 100)
 	store := &mockStore{vms: []*virtualmachine.Info{vm}}
 	s, clock := newTestScraper(store, &mockSender{}, &mockDialer{}, &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport(1)},
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
 	})
 	s.randFloat64 = sequencedRand([]float64{0, 1})
 	s.pollOnce(context.Background())
@@ -213,7 +213,7 @@ func TestVMScraper_DuePileIsPacedByStartBudget(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	dialer := &recordingDialer{}
-	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.interval = time.Hour
 	s.tickInterval = defaultTickInterval
@@ -254,7 +254,7 @@ func TestVMScraper_AllDueClumpDrainsWithinIndexWindow(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	dialer := &recordingDialer{}
-	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.tickInterval = defaultTickInterval
 	s.reconcileEvery = reconcilePeriod(s.interval)
@@ -298,7 +298,7 @@ func TestVMScraper_SpreadDuePileStartsAtFleetRate(t *testing.T) {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(100+i)))
 	}
 	dialer := &recordingDialer{}
-	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{gen: 1})
+	s, _ := newTestScraper(&mockStore{vms: vms}, &mockSender{}, dialer, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.tickInterval = defaultTickInterval
 	s.reconcileEvery = reconcilePeriod(s.interval)
@@ -336,7 +336,7 @@ func TestVMScraper_StartsPerTickObservesLaunchCount(t *testing.T) {
 	for i := range numVMs {
 		vms = append(vms, makeVM("ns", fmt.Sprintf("vm-%d", i), uint32(10+i)))
 	}
-	s, clock := newTestScraper(&mockStore{vms: vms}, &safeSender{}, &mockDialer{}, &safeProtocolClient{gen: 1})
+	s, clock := newTestScraper(&mockStore{vms: vms}, &safeSender{}, &mockDialer{}, &safeProtocolClient{token: "1"})
 	s.concurrency = numVMs
 	s.reconcileEvery = reconcilePeriod(s.interval)
 

--- a/sensor/common/virtualmachine/vsockclient/client.go
+++ b/sensor/common/virtualmachine/vsockclient/client.go
@@ -65,17 +65,15 @@ func NewClient(capabilities []string, maxResponseSize int) *Client {
 	return &Client{capabilities: capabilities, maxResponseSize: maxResponseSize}
 }
 
-// GetReport sends a GetReportRequest and returns the response. knownEpoch is
-// the last epoch Sensor observed for this VM (see ResponseMeta.epoch); pass 0
-// when unknown. Sending it lets the agent detect a restart-coincidence false
-// match and serve the full report in this same round trip, instead of the
-// caller needing a second, forced request.
+// GetReport sends a GetReportRequest and returns the response. lastKnownToken
+// is the last report_token Sensor observed for this VM; pass "" when unknown
+// or when forcing a full report (mandatory refresh).
 //
 // The stream must be an io.ReadWriteCloser (from MultiDialer.Dial). If ctx is
 // cancelled while a write or read is in progress, the stream is closed so the
 // blocked I/O unblocks promptly — needed on Sensor shutdown, where parent
 // cancel does not rewrite the dial-time socket deadline.
-func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNewerThan uint32, knownEpoch uint32) (*GetReportResult, error) {
+func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, lastKnownToken string) (*GetReportResult, error) {
 	stop := context.AfterFunc(ctx, func() {
 		_ = stream.Close()
 	})
@@ -88,8 +86,7 @@ func (c *Client) GetReport(ctx context.Context, stream io.ReadWriteCloser, ifNew
 		},
 		Method: &pb.VMServiceRequest_GetReport{
 			GetReport: &pb.GetReportRequest{
-				LastKnownGeneration: ifNewerThan,
-				KnownEpoch:          knownEpoch,
+				LastKnownToken: lastKnownToken,
 			},
 		},
 	}

--- a/sensor/common/virtualmachine/vsockclient/client_integration_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_integration_test.go
@@ -65,16 +65,16 @@ func newProtocolHarness(t *testing.T, opts protocolHarnessOptions) *protocolHarn
 	}
 }
 
-func (h *protocolHarness) getReport(t *testing.T, ifNewerThan, knownEpoch uint32) (*GetReportResult, error) {
+func (h *protocolHarness) getReport(t *testing.T, lastKnownToken string) (*GetReportResult, error) {
 	t.Helper()
-	return exchangeOnce(t, h.client, ifNewerThan, knownEpoch, h.handler.HandleConn)
+	return exchangeOnce(t, h.client, lastKnownToken, h.handler.HandleConn)
 }
 
 // exchangeOnce runs a single GetReport against responder over net.Pipe()
 // inside a synctest bubble. A stuck peer makes the exchange timeout fire on
 // the fake clock (via GetReport's AfterFunc stream close) instead of hanging
 // the package on wall time.
-func exchangeOnce(t *testing.T, client *Client, ifNewerThan, knownEpoch uint32, responder func(net.Conn)) (*GetReportResult, error) {
+func exchangeOnce(t *testing.T, client *Client, lastKnownToken string, responder func(net.Conn)) (*GetReportResult, error) {
 	t.Helper()
 
 	var result *GetReportResult
@@ -91,7 +91,7 @@ func exchangeOnce(t *testing.T, client *Client, ifNewerThan, knownEpoch uint32, 
 			responder(agentConn)
 		}()
 
-		result, err = client.GetReport(ctx, clientConn, ifNewerThan, knownEpoch)
+		result, err = client.GetReport(ctx, clientConn, lastKnownToken)
 		// Close the client end before waiting so a responder blocked in WriteFrame
 		// (or similar) is unblocked even when GetReport already returned.
 		_ = clientConn.Close()
@@ -109,11 +109,10 @@ func exchangeOnce(t *testing.T, client *Client, ifNewerThan, knownEpoch uint32, 
 func TestGetReportIntegration(t *testing.T) {
 	cases := map[string]struct {
 		// Arguments
-		seedReport   *v4.IndexReport
-		seedFacts    map[string]string
-		agentVersion string
-		ifNewerThan  uint32
-		knownEpoch   uint32
+		seedReport     *v4.IndexReport
+		seedFacts      map[string]string
+		agentVersion   string
+		lastKnownToken string
 		// Expectations
 		wantErr     error
 		checkResult func(t *testing.T, result *GetReportResult)
@@ -132,30 +131,22 @@ func TestGetReportIntegration(t *testing.T) {
 
 				require.NotNil(t, result.Meta)
 				assert.Equal(t, "roxagent-0.3.1-deadbeef", result.Meta.GetAgentVersion())
-				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.NotEmpty(t, result.Meta.GetReportToken())
 				assert.NotNil(t, result.Meta.GetReportGeneratedAt())
 				assert.Contains(t, result.Meta.GetSupportedMethods(), "get_report")
 				assert.Equal(t, "rhel", result.Meta.GetFacts()["os"])
 				assert.Equal(t, "x86_64", result.Meta.GetFacts()["arch"])
 			},
 		},
-		"should return unchanged when generation matches": {
-			seedReport:  &v4.IndexReport{HashId: "unchanged-hash"},
-			ifNewerThan: 1,
+		"should return full report when last known token does not match": {
+			seedReport:     &v4.IndexReport{HashId: "post-restart-hash"},
+			lastKnownToken: "stale-token",
 			checkResult: func(t *testing.T, result *GetReportResult) {
-				assert.True(t, result.Unchanged)
-				assert.Nil(t, result.IndexReport)
-				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
-			},
-		},
-		"should return full report when sensor generation exceeds agent after restart": {
-			seedReport:  &v4.IndexReport{HashId: "post-restart-hash"},
-			ifNewerThan: 5,
-			checkResult: func(t *testing.T, result *GetReportResult) {
-				assert.False(t, result.Unchanged, "agent restarted (gen=1 < requested=5), must serve full report")
+				assert.False(t, result.Unchanged)
 				require.NotNil(t, result.IndexReport)
 				assert.Equal(t, "post-restart-hash", result.IndexReport.GetHashId())
-				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.NotEmpty(t, result.Meta.GetReportToken())
+				assert.NotEqual(t, "stale-token", result.Meta.GetReportToken())
 				assert.NotNil(t, result.Meta.GetReportGeneratedAt())
 				assert.Contains(t, result.Meta.GetSupportedMethods(), "get_report")
 			},
@@ -170,7 +161,7 @@ func TestGetReportIntegration(t *testing.T) {
 				agentVersion: tc.agentVersion,
 			})
 
-			result, err := h.getReport(t, tc.ifNewerThan, tc.knownEpoch)
+			result, err := h.getReport(t, tc.lastKnownToken)
 
 			if tc.wantErr != nil {
 				require.Error(t, err)
@@ -185,44 +176,35 @@ func TestGetReportIntegration(t *testing.T) {
 	}
 }
 
-// TestGetReportIntegration_KnownEpochSingleRoundTrip drives a real Client
-// against a real roxagent Handler to verify the single-round-trip contract.
-// report_generation resets to 1 on every roxagent restart, so a restarted
-// agent can coincidentally match a generation Sensor already has cached.
-// known_epoch lets the agent detect that restart itself, in a single round
-// trip, by comparing Sensor's last-seen epoch against its current one.
-func TestGetReportIntegration_KnownEpochSingleRoundTrip(t *testing.T) {
+// TestGetReportIntegration_TokenRoundTrip drives a real Client against a
+// real roxagent Handler: matching token is unchanged, a different token
+// (restart or new scan) serves the full report in the same round trip.
+func TestGetReportIntegration_TokenRoundTrip(t *testing.T) {
 	h := newProtocolHarness(t, protocolHarnessOptions{
-		seedReport: &v4.IndexReport{HashId: "epoch-test-hash"},
+		seedReport: &v4.IndexReport{HashId: "token-test-hash"},
 	})
 
-	// First-ever request for this VM: Sensor has no cached epoch yet.
-	first, err := h.getReport(t, 0, 0)
+	first, err := h.getReport(t, "")
 	require.NoError(t, err)
 	require.False(t, first.Unchanged)
-	epoch := first.Meta.GetEpoch()
-	require.NotZero(t, epoch, "agent should seed a non-zero epoch")
+	token := first.Meta.GetReportToken()
+	require.NotEmpty(t, token)
 
-	t.Run("unchanged in a single round trip when known epoch matches", func(t *testing.T) {
-		result, err := h.getReport(t, 1, epoch)
+	t.Run("unchanged in a single round trip when last known token matches", func(t *testing.T) {
+		result, err := h.getReport(t, token)
 		require.NoError(t, err)
 		assert.True(t, result.Unchanged)
 		assert.Nil(t, result.IndexReport)
+		assert.Equal(t, token, result.Meta.GetReportToken())
 	})
 
-	t.Run("full report in a single round trip when known epoch mismatches despite matching generation", func(t *testing.T) {
-		result, err := h.getReport(t, 1, epoch+1)
+	t.Run("full report in a single round trip when last known token mismatches", func(t *testing.T) {
+		result, err := h.getReport(t, "other-token")
 		require.NoError(t, err)
-		assert.False(t, result.Unchanged, "epoch mismatch must be resolved in this same response, not a second dial")
+		assert.False(t, result.Unchanged)
 		require.NotNil(t, result.IndexReport)
-		assert.Equal(t, "epoch-test-hash", result.IndexReport.GetHashId())
-		assert.Equal(t, epoch, result.Meta.GetEpoch(), "response must carry the agent's current epoch")
-	})
-
-	t.Run("unchanged when known epoch is zero (backward compat: falls back to generation-only)", func(t *testing.T) {
-		result, err := h.getReport(t, 1, 0)
-		require.NoError(t, err)
-		assert.True(t, result.Unchanged)
+		assert.Equal(t, "token-test-hash", result.IndexReport.GetHashId())
+		assert.Equal(t, token, result.Meta.GetReportToken())
 	})
 }
 
@@ -262,16 +244,15 @@ func respondOnce(t testing.TB, conn net.Conn, build func(*pb.VMServiceRequest) *
 // oldAgentResponder models a plausible older roxagent that:
 //   - supports only get_report
 //   - does not advertise supported_methods
-//   - does not include facts, report_generated_at, or epoch
-//   - always returns the full report (ignores last_known_generation and known_epoch)
+//   - does not include facts, report_generated_at, or report_token
+//   - always returns the full report (ignores last_known_token)
 //   - returns UNKNOWN_METHOD for anything else
-func oldAgentResponder(t testing.TB, report *v4.IndexReport, generation uint32) func(net.Conn) {
+func oldAgentResponder(t testing.TB, report *v4.IndexReport) func(net.Conn) {
 	return func(conn net.Conn) {
 		respondOnce(t, conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
 			resp := &pb.VMServiceResponse{
 				Meta: &pb.ResponseMeta{
-					AgentVersion:     "roxagent-0.1.0",
-					ReportGeneration: generation,
+					AgentVersion: "roxagent-0.1.0",
 				},
 			}
 			if req.GetGetReport() != nil {
@@ -295,22 +276,22 @@ func oldAgentResponder(t testing.TB, report *v4.IndexReport, generation uint32) 
 //   - advertises extra supported_methods beyond get_report
 //   - still handles get_report correctly
 //   - includes richer metadata (facts, supported_methods)
-//   - supports last_known_generation (unchanged semantics)
+//   - supports last_known_token (unchanged semantics)
 //   - returns UNKNOWN_METHOD for methods it doesn't recognize
-func futureAgentResponder(t testing.TB, report *v4.IndexReport, generation uint32) func(net.Conn) {
+func futureAgentResponder(t testing.TB, report *v4.IndexReport, token string) func(net.Conn) {
 	return func(conn net.Conn) {
 		respondOnce(t, conn, func(req *pb.VMServiceRequest) *pb.VMServiceResponse {
 			resp := &pb.VMServiceResponse{
 				Meta: &pb.ResponseMeta{
 					AgentVersion:     "roxagent-2.0.0-future",
-					ReportGeneration: generation,
+					ReportToken:      token,
 					SupportedMethods: []string{"get_report", "get_config", "submit_event"},
 					Facts:            map[string]string{"os_id": "rhel", "protocol_version": "2"},
 				},
 			}
 			switch {
 			case req.GetGetReport() != nil:
-				if req.GetGetReport().GetLastKnownGeneration() == generation {
+				if req.GetGetReport().GetLastKnownToken() == token {
 					resp.Result = &pb.VMServiceResponse_GetReport{
 						GetReport: &pb.GetReportResponse{Unchanged: true},
 					}
@@ -341,7 +322,7 @@ func assertOldAgentReport(t *testing.T, result *GetReportResult) {
 	require.NotNil(t, result.IndexReport)
 	assert.Equal(t, "compat-hash", result.IndexReport.GetHashId())
 	assert.Equal(t, "roxagent-0.1.0", result.Meta.GetAgentVersion())
-	assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+	assert.Empty(t, result.Meta.GetReportToken())
 	assert.Empty(t, result.Meta.GetSupportedMethods())
 	assert.Empty(t, result.Meta.GetFacts())
 }
@@ -353,63 +334,52 @@ func TestGetReportCompatibility(t *testing.T) {
 	cases := map[string]struct {
 		// Arguments
 		makeResponderFunc func(t testing.TB) func(net.Conn)
-		ifNewerThan       uint32
-		knownEpoch        uint32
+		lastKnownToken    string
 		// Expectations
 		checkResult func(t *testing.T, result *GetReportResult)
 	}{
 		"old agent should serve get_report to current sensor": {
-			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report, 1) },
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report) },
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged)
 				assertOldAgentReport(t, result)
 			},
 		},
-		"old agent should always return full report ignoring last_known_generation": {
-			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report, 1) },
-			ifNewerThan:       1,
+		"old agent should always return full report ignoring last_known_token": {
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report) },
+			lastKnownToken:    "tok-1",
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged, "old agent does not support unchanged optimization")
 				assertOldAgentReport(t, result)
 			},
 		},
-		"old agent should tolerate non-zero known_epoch and omit epoch in response": {
-			makeResponderFunc: func(t testing.TB) func(net.Conn) { return oldAgentResponder(t, report, 1) },
-			ifNewerThan:       1,
-			knownEpoch:        42,
-			checkResult: func(t *testing.T, result *GetReportResult) {
-				assert.False(t, result.Unchanged)
-				assertOldAgentReport(t, result)
-				assert.Zero(t, result.Meta.GetEpoch(), "old agent does not populate epoch")
-			},
-		},
 		"future agent should serve get_report to current sensor": {
-			makeResponderFunc: func(t testing.TB) func(net.Conn) { return futureAgentResponder(t, report, 1) },
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return futureAgentResponder(t, report, "tok-1") },
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.False(t, result.Unchanged)
 				require.NotNil(t, result.IndexReport)
 				assert.Equal(t, "compat-hash", result.IndexReport.GetHashId())
 				assert.Equal(t, "roxagent-2.0.0-future", result.Meta.GetAgentVersion())
-				assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+				assert.Equal(t, "tok-1", result.Meta.GetReportToken())
 				assert.Equal(t, []string{"get_report", "get_config", "submit_event"}, result.Meta.GetSupportedMethods())
 				assert.Equal(t, "rhel", result.Meta.GetFacts()["os_id"])
 				assert.Equal(t, "2", result.Meta.GetFacts()["protocol_version"])
 			},
 		},
-		"future agent should return unchanged when generation matches": {
-			makeResponderFunc: func(t testing.TB) func(net.Conn) { return futureAgentResponder(t, report, 3) },
-			ifNewerThan:       3,
+		"future agent should return unchanged when last known token matches": {
+			makeResponderFunc: func(t testing.TB) func(net.Conn) { return futureAgentResponder(t, report, "tok-3") },
+			lastKnownToken:    "tok-3",
 			checkResult: func(t *testing.T, result *GetReportResult) {
 				assert.True(t, result.Unchanged)
 				assert.Nil(t, result.IndexReport)
-				assert.Equal(t, uint32(3), result.Meta.GetReportGeneration())
+				assert.Equal(t, "tok-3", result.Meta.GetReportToken())
 			},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result, err := exchangeOnce(t, client, tc.ifNewerThan, tc.knownEpoch, tc.makeResponderFunc(t))
+			result, err := exchangeOnce(t, client, tc.lastKnownToken, tc.makeResponderFunc(t))
 
 			require.NoError(t, err)
 			if tc.checkResult != nil {

--- a/sensor/common/virtualmachine/vsockclient/client_test.go
+++ b/sensor/common/virtualmachine/vsockclient/client_test.go
@@ -40,7 +40,7 @@ func TestSendGetReport_Success(t *testing.T) {
 	defer utils.IgnoreError(clientConn.Close)
 
 	go serveOnce(t, agentConn, &pb.VMServiceResponse{
-		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
+		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportToken: "tok-1"},
 		Result: &pb.VMServiceResponse_GetReport{
 			GetReport: &pb.GetReportResponse{
 				IndexReport: &v4.IndexReport{HashId: "test-hash"},
@@ -49,14 +49,14 @@ func TestSendGetReport_Success(t *testing.T) {
 	}, func(req *pb.VMServiceRequest) {
 		assert.NotEmpty(t, req.GetMeta().GetRequestId())
 		assert.Equal(t, []string{CapabilityReportV1}, req.GetMeta().GetCapabilities())
-		assert.Equal(t, uint32(0), req.GetGetReport().GetLastKnownGeneration())
+		assert.Empty(t, req.GetGetReport().GetLastKnownToken())
 	})
 
-	result, err := client.GetReport(context.Background(), clientConn, 0, 0)
+	result, err := client.GetReport(context.Background(), clientConn, "")
 	require.NoError(t, err)
 	assert.Equal(t, "test-hash", result.IndexReport.GetHashId())
 	assert.False(t, result.Unchanged)
-	assert.Equal(t, uint32(1), result.Meta.GetReportGeneration())
+	assert.Equal(t, "tok-1", result.Meta.GetReportToken())
 }
 
 func TestSendGetReport_Unchanged(t *testing.T) {
@@ -65,20 +65,19 @@ func TestSendGetReport_Unchanged(t *testing.T) {
 	defer utils.IgnoreError(clientConn.Close)
 
 	go serveOnce(t, agentConn, &pb.VMServiceResponse{
-		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 5},
+		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportToken: "tok-5"},
 		Result: &pb.VMServiceResponse_GetReport{
 			GetReport: &pb.GetReportResponse{Unchanged: true},
 		},
 	}, func(req *pb.VMServiceRequest) {
-		assert.Equal(t, uint32(5), req.GetGetReport().GetLastKnownGeneration())
-		assert.Equal(t, uint32(42), req.GetGetReport().GetKnownEpoch())
+		assert.Equal(t, "tok-5", req.GetGetReport().GetLastKnownToken())
 	})
 
-	result, err := client.GetReport(context.Background(), clientConn, 5, 42)
+	result, err := client.GetReport(context.Background(), clientConn, "tok-5")
 	require.NoError(t, err)
 	assert.Nil(t, result.IndexReport)
 	assert.True(t, result.Unchanged)
-	assert.Equal(t, uint32(5), result.Meta.GetReportGeneration())
+	assert.Equal(t, "tok-5", result.Meta.GetReportToken())
 }
 
 func TestSendGetReport_NilReportRejected(t *testing.T) {
@@ -87,13 +86,13 @@ func TestSendGetReport_NilReportRejected(t *testing.T) {
 	defer utils.IgnoreError(clientConn.Close)
 
 	go serveOnce(t, agentConn, &pb.VMServiceResponse{
-		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportGeneration: 1},
+		Meta: &pb.ResponseMeta{AgentVersion: "test-agent", ReportToken: "tok-1"},
 		Result: &pb.VMServiceResponse_GetReport{
 			GetReport: &pb.GetReportResponse{},
 		},
 	}, nil)
 
-	_, err := client.GetReport(context.Background(), clientConn, 0, 0)
+	_, err := client.GetReport(context.Background(), clientConn, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "IndexReport is nil")
 }
@@ -140,7 +139,7 @@ func TestSendGetReport_ErrorCodes(t *testing.T) {
 				},
 			}, nil)
 
-			_, err := client.GetReport(context.Background(), clientConn, 0, 0)
+			_, err := client.GetReport(context.Background(), clientConn, "")
 			require.Error(t, err)
 			assert.ErrorIs(t, err, tc.wantErr)
 			if tc.wantInMsg != "" {
@@ -171,7 +170,7 @@ func TestSendGetReport_ContextCancelUnblocks(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := client.GetReport(ctx, clientConn, 0, 0)
+		_, err := client.GetReport(ctx, clientConn, "")
 		errCh <- err
 	}()
 


### PR DESCRIPTION
## Description

GetReport used two fields to decide whether to send a full scan report or `unchanged`: `report_generation`, a uint32 that increments on every scan and resets to 1 when the agent restarts, and `epoch`/`known_epoch`, a per-process value whose only job was to catch the case where a restarted agent's counter coincidentally matches what Sensor already has.

That pair has not shipped in a release. This change replaces both with one opaque per-scan token (a UUID minted in `SetReport`). The token changes on every scan even when the report content is identical, so Sensor still gets a full report at least once per rescan interval. A restart mints a new token, so the coincidence case disappears without a second field.

A content hash would be the wrong replacement: two identical scans would hash the same, and Sensor would skip the periodic full refresh the product requires.

Wire shape:

- `ResponseMeta.report_generation` and `epoch` become `report_token`.
- `GetReportRequest.last_known_generation` and `known_epoch` become `last_known_token`. Empty means send the full report (first request, NACK retry, or the 4h mandatory refresh).
- Field numbers are consecutive: `repo_cpe_mapping_hash` is 6 and `repo_cpe_mapping_update_path` is 7.

Agent, Sensor's VSOCK client, and VMScraper compare and cache the token instead of the generation/epoch pair.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI

No manual validation beyond the automated tests.

AI-Assisted: Cursor, proto/agent/sensor/tests generated, user directed field numbering and comments.