### PR TITLE
ROX-36559: Update frontend files for CISA KEV as search field

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -27,10 +27,10 @@ export const CVSS: CompoundSearchFilterAttribute = {
 export const KnownExploit: CompoundSearchFilterAttribute = {
     displayName: 'Known exploit',
     filterChipLabel: 'Known exploit',
-    searchTerm: 'CISA KEV', // and 'Known Ransonware Campaign' as category2
+    searchTerm: 'CISA KEV', // and 'Known Ransomware Campaign' as category2
     inputType: 'select-exclusive-double',
     inputProps: {
-        category2: 'Known Ransonware Campaign',
+        category2: 'Known Ransomware Campaign',
         options: [
             {
                 label: 'Has a known exploit',
@@ -39,7 +39,7 @@ export const KnownExploit: CompoundSearchFilterAttribute = {
             },
             {
                 label: 'Used in ransomware campaigns',
-                category: 'Known Ransonware Campaign',
+                category: 'Known Ransomware Campaign',
                 value: 'true',
             },
             {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -27,14 +27,14 @@ export const CVSS: CompoundSearchFilterAttribute = {
 export const KnownExploit: CompoundSearchFilterAttribute = {
     displayName: 'Known exploit',
     filterChipLabel: 'Known exploit',
-    searchTerm: 'Known Exploit', // and 'Known Ransonware Campaign' as category2
+    searchTerm: 'CISA KEV', // and 'Known Ransonware Campaign' as category2
     inputType: 'select-exclusive-double',
     inputProps: {
         category2: 'Known Ransonware Campaign',
         options: [
             {
                 label: 'Has a known exploit',
-                category: 'Known Exploit',
+                category: 'CISA KEV',
                 value: 'true',
             },
             {
@@ -44,7 +44,7 @@ export const KnownExploit: CompoundSearchFilterAttribute = {
             },
             {
                 label: 'No known exploit',
-                category: 'Known Exploit',
+                category: 'CISA KEV',
                 value: 'false',
             },
         ],

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -62,12 +62,12 @@ export type SelectExclusiveDoubleSearchFilterAttribute = {
 } & BaseSearchFilterAttribute;
 
 export type SelectExclusiveDoubleSearchFilterInputProps = {
-    category2: string;
+    category2: SearchFieldLabel;
     options: NonEmptyArray<SelectExclusiveDoubleSearchFilterOption>;
 };
 
 export type SelectExclusiveDoubleSearchFilterOption = {
-    category: string;
+    category: SearchFieldLabel;
 } & SelectSearchFilterOption;
 
 export type CompoundSearchFilterAttribute =

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -35,7 +35,7 @@ export type EPSS = {
 export type Exploit = {
     // This must always be set to true.
     // This field solely exists for search purposes.
-    // exists: boolean; // search:"Known Exploit,store"
+    // exists: boolean; // search:"CISA KEV,store"
     knownRansomwareCampaignUse: boolean; // search:"Known Ransomware Campaign,store"
 };
 

--- a/ui/apps/platform/src/types/searchOptions.ts
+++ b/ui/apps/platform/src/types/searchOptions.ts
@@ -46,8 +46,8 @@ export const searchFieldLabels = [
     'CVE Orphaned',
     'CVE Orphaned Time',
     'EPSS Probability',
-    'Known Exploit', // frontend only pending backend implementation see obsolete #16887
-    'Known Ransomware Campaign', // frontend only pending backend implementation see obsolete #16887
+    'CISA KEV',
+    'Known Ransomware Campaign',
     'Advisory Name',
     'Advisory Link',
     //


### PR DESCRIPTION
## Description

Corresponds to backend changes in #22103

See also backend changes for `'Known Ransomware Campaign'` in #22455

Replace `'Known Exploit'` from draft contributions by **Ross** with `'CISA KEV'` as implemented.

### Analysis

Find in Files **Known Exploit** in ui/apps/platform/src folder
* ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
* ui/apps/platform/src/types/cve.proto.ts
* ui/apps/platform/src/types/searchOptions.ts

### Solution

Replace search field, but keep **Known exploit** and **Has a known exploit** as visible text.

Bravo TypeScript for reporting partial change as an error for `searchTerm` property!

### Residue

Done in additional commit to this branch.

See presence of errors with type and then absence of error with correct label.

Improve type checking in types.ts file in CompoundSearchFilter folder:
* Replace `category: string;` with `category: SearchFieldLabel;`
* Replace `category2: string;` with `category2: SearchFieldLabel;`

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.

Bug bash will verify end-to-end.
