### PR TITLE
ROX-36566: Make filterChipLabel consistent for CVSS search field

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/nodeCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/nodeCVE.ts
@@ -18,7 +18,7 @@ export const DiscoveredTime: CompoundSearchFilterAttribute = {
 
 export const CVSS: CompoundSearchFilterAttribute = {
     displayName: 'CVSS',
-    filterChipLabel: 'CVE CVSS',
+    filterChipLabel: 'CVSS',
     searchTerm: 'CVSS',
     inputType: 'condition-number',
 };

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/platformCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/platformCVE.ts
@@ -18,7 +18,7 @@ export const DiscoveredTime: CompoundSearchFilterAttribute = {
 
 export const CVSS: CompoundSearchFilterAttribute = {
     displayName: 'CVSS',
-    filterChipLabel: 'CVE CVSS',
+    filterChipLabel: 'CVSS',
     searchTerm: 'CVSS',
     inputType: 'condition-number',
 };


### PR DESCRIPTION
## Description

### Problem

During homework to factor out search filter config as single source of truth for **Results** and **Reports** routes, especially in  node vulnerability reports, I found:

* imageCVE.ts file has `filterChipLabel: 'CVSS'`
* nodeCVE and platformCVE.ts files have: `filterChipLabel: 'CVE CVSS'`

### Analysis

No search results in cypress folder.

### Solution

Be consistent. Confirmed the change in **acs-ux** channel.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
