### PR TITLE
ROX-35953: Direct nagivate to dynamic plugin status page

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -107,6 +107,17 @@ export function visitConsoleMainDashboard(staticResponseMap) {
 }
 
 /**
+ * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
+ */
+export function visitConsoleDynamicPluginsStatusPage(staticResponseMap) {
+    visitConsole(
+        '/k8s/cluster/operator.openshift.io~v1~Console/cluster/console-plugins',
+        routeMatcherMapForConsole,
+        staticResponseMap
+    );
+}
+
+/**
  * Visit main dashboard to test conditional rendering for user role permissions specified as response or fixture.
  * Conditional rendering for permissions might make a subset of requests.
  *

--- a/ui/apps/platform/cypress/integration-ocp/smoke.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/smoke.test.ts
@@ -1,4 +1,4 @@
-import { visitFromConsoleLeftNavExpandable } from '../helpers/nav';
+import { visitConsoleDynamicPluginsStatusPage } from '../helpers/main';
 import { withOcpAuth } from '../helpers/ocpAuth';
 
 describe('Basic tests of the OCP plugin', () => {
@@ -30,7 +30,7 @@ describe('Basic tests of the OCP plugin', () => {
         });
 
         it('should display plugin information in cluster settings', () => {
-            visitFromConsoleLeftNavExpandable('Administration', 'Dynamic Plugins');
+            visitConsoleDynamicPluginsStatusPage();
 
             cy.get('td[data-label="name"]:contains("advanced-cluster-security")')
                 .parent()


### PR DESCRIPTION
## Description

On the latest version of OCP (`ocp-dev-preview/candidate`), a test navigates to the Dynamic Plugin status page via the left hand menu. Although this link is always available, it takes >30 seconds to appear on the page, for reasons that I am not aware of. Instead of increasing the timeout, we will simply direct navigate to the page instead. The important assertion in the test is not the navigation path, but verifying that the plugin is installed and appears on the list.


Will backport to 4.11 (low urgency), but not to 4.10 since the latter version will not install on this version of OCP.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1781" height="818" alt="image" src="https://github.com/user-attachments/assets/3ddee59d-29b0-477e-8cdc-f7e3fe187dc7" />

