### PR TITLE
feat(compliance): read RHCOS labels.json identity

### DIFF
--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -195,7 +195,8 @@ func (l *localNodeIndexer) IndexNode(ctx context.Context) (*v4.IndexReport, erro
 		log.Debugf("Not adding RHCOS package to index report: %v", err)
 	} else {
 		arch := extractArch(ccReport, pkgs)
-		addRHCOS(rhcosRel, arch, ccReport)
+		labels := resolveBuildLabels(l.cfg.HostPath, l.cfg.OSReleasePath)
+		addRHCOS(rhcosRel, labels, arch, ccReport)
 	}
 
 	ccReport.Success = true
@@ -391,16 +392,57 @@ func osRelease(ctx context.Context, osRelPath string) (rhcosRelease, error) {
 	return rel, nil
 }
 
-func addRHCOS(rel rhcosRelease, arch string, report *claircore.IndexReport) {
+// resolveBuildLabels reads labels.json from hostPath, falling back to
+// osReleasePath when they differ (tests and split mounts).
+func resolveBuildLabels(hostPath, osReleasePath string) buildLabels {
+	for _, p := range []string{hostPath, osReleasePath} {
+		if p == "" {
+			continue
+		}
+		lb, path, err := parseLabelsJSON(p)
+		switch {
+		case err == nil:
+			log.Debugf("Using build labels from %s (name=%q cpe=%q arch=%q)", path, lb.Name, lb.CPE, lb.Architecture)
+			return lb
+		case errors.Is(err, errLabelsNotFound):
+			continue
+		default:
+			log.Warnf("Failed to read labels.json under %q: %v", p, err)
+		}
+	}
+	return buildLabels{}
+}
+
+func addRHCOS(rel rhcosRelease, labels buildLabels, arch string, report *claircore.IndexReport) {
 	const (
 		rhcosPkgID  = "rhcos-pkg"
 		rhcosSrcID  = "rhcos-src"
 		rhcosRepoID = "rhcos-repo"
+		// legacyRHCOSName is used when labels.json is absent so existing
+		// inventories keep working until nodes expose OCI build labels.
+		legacyRHCOSName = "rhcos"
 	)
+
+	name := labels.Name
+	if name == "" {
+		name = legacyRHCOSName
+	}
+	if labels.Architecture != "" {
+		arch = labels.Architecture
+	}
+
+	repoCPE := rel.repoCPE
+	if labels.CPE != "" {
+		if wfn, err := cpe.Unbind(labels.CPE); err != nil {
+			log.Warnf("Ignoring invalid CPE from labels.json %q: %v", labels.CPE, err)
+		} else {
+			repoCPE = wfn
+		}
+	}
 
 	srcPkg := &claircore.Package{
 		ID:                rhcosSrcID,
-		Name:              "rhcos",
+		Name:              name,
 		Version:           rel.version,
 		Kind:              types.SourcePackage,
 		NormalizedVersion: rel.normVersion,
@@ -408,7 +450,7 @@ func addRHCOS(rel rhcosRelease, arch string, report *claircore.IndexReport) {
 	}
 	binPkg := &claircore.Package{
 		ID:                rhcosPkgID,
-		Name:              "rhcos",
+		Name:              name,
 		Version:           rel.version,
 		Kind:              types.BinaryPackage,
 		NormalizedVersion: rel.normVersion,
@@ -419,9 +461,9 @@ func addRHCOS(rel rhcosRelease, arch string, report *claircore.IndexReport) {
 	}
 	repo := &claircore.Repository{
 		ID:   rhcosRepoID,
-		Name: rel.repoCPE.String(),
+		Name: repoCPE.String(),
 		Key:  rhcc.RepositoryKey,
-		CPE:  rel.repoCPE,
+		CPE:  repoCPE,
 	}
 
 	if report.Packages == nil {
@@ -445,7 +487,7 @@ func addRHCOS(rel rhcosRelease, arch string, report *claircore.IndexReport) {
 		},
 	}
 
-	log.Debugf("Added RHCOS package: version=%s, cpe=%s", rel.version, rel.repoCPE.String())
+	log.Debugf("Added RHCOS package: name=%s version=%s cpe=%s", name, rel.version, repoCPE.String())
 }
 
 // extractArch attempts to determine the RHCOS architecture from the current list

--- a/compliance/node/index/indexer_test.go
+++ b/compliance/node/index/indexer_test.go
@@ -339,13 +339,13 @@ func (s *nodeIndexerSuite) TestIndexerE2ESeparateOSReleasePath() {
 
 	var hasRHCOS bool
 	for _, pkg := range report.GetContents().GetPackages() {
-		if pkg.GetName() == "rhcos" {
+		if pkg.GetName() == "openshift/ose-rhel-coreos-9" {
 			hasRHCOS = true
 			s.Equal("9.6.20260324-0", pkg.GetVersion())
 			break
 		}
 	}
-	s.True(hasRHCOS, "Expected rhcos package in report")
+	s.True(hasRHCOS, "Expected ose-rhel-coreos package from labels.json in report")
 }
 
 func (s *nodeIndexerSuite) TestIndexerE2ENoPath() {
@@ -405,7 +405,7 @@ func (s *nodeIndexerSuite) TestAddRHCOSPackageToReport() {
 		Environments: make(map[string][]*claircore.Environment),
 	}
 
-	addRHCOS(rel, "x86_64", report)
+	addRHCOS(rel, buildLabels{}, "x86_64", report)
 
 	s.Len(report.Packages, 2)
 	s.Len(report.Repositories, 1)
@@ -432,6 +432,45 @@ func (s *nodeIndexerSuite) TestAddRHCOSPackageToReport() {
 	s.Require().NotNil(repo)
 	s.Equal("rhcc-container-repository", repo.Key)
 	s.Contains(repo.Name, "cpe:")
+	s.Contains(repo.Name, "openshift")
+	s.Contains(repo.Name, "4.21")
+}
+
+func (s *nodeIndexerSuite) TestAddRHCOSPackageFromLabels() {
+	rel, err := osRelease(context.Background(), "testdata-rhcos")
+	s.Require().NoError(err)
+
+	labels, path, err := parseLabelsJSON("testdata-rhcos")
+	s.Require().NoError(err)
+	s.Contains(path, "labels.json")
+	s.Equal("openshift/ose-rhel-coreos-9", labels.Name)
+
+	report := &claircore.IndexReport{
+		Packages:     make(map[string]*claircore.Package),
+		Repositories: make(map[string]*claircore.Repository),
+		Environments: make(map[string][]*claircore.Environment),
+	}
+
+	addRHCOS(rel, labels, "", report)
+
+	var binPkg *claircore.Package
+	for _, p := range report.Packages {
+		if p.Kind == types.BinaryPackage {
+			binPkg = p
+			break
+		}
+	}
+	s.Require().NotNil(binPkg)
+	s.Equal("openshift/ose-rhel-coreos-9", binPkg.Name)
+	s.Equal("9.6.20260324-0", binPkg.Version, "version still comes from os-release")
+	s.Equal("x86_64", binPkg.Arch)
+
+	var repo *claircore.Repository
+	for _, r := range report.Repositories {
+		repo = r
+		break
+	}
+	s.Require().NotNil(repo)
 	s.Contains(repo.Name, "openshift")
 	s.Contains(repo.Name, "4.21")
 }

--- a/compliance/node/index/labels.go
+++ b/compliance/node/index/labels.go
@@ -1,0 +1,70 @@
+package index
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+var (
+	// labelsJSONPaths are known locations for RH build labels.json on a node
+	// root (or container layer). Matches Claircore RHCC detector paths with
+	// the container "root/" prefix stripped for host mounts.
+	labelsJSONPaths = []string{
+		"usr/share/buildinfo/labels.json",
+		"root/buildinfo/labels.json",
+	}
+
+	errLabelsNotFound = errors.New("labels.json not found")
+)
+
+// buildLabels holds identifying fields from labels.json.
+// See Claircore rhel/rhcc labels schema.
+type buildLabels struct {
+	Created      time.Time `json:"org.opencontainers.image.created"`
+	Architecture string    `json:"architecture"`
+	Name         string    `json:"name"`
+	CPE          string    `json:"cpe"`
+}
+
+// parseLabelsJSON reads the first available labels.json under hostPath.
+// Missing files are not an error (returns errLabelsNotFound); other I/O or
+// JSON errors are returned as-is.
+func parseLabelsJSON(hostPath string) (buildLabels, string, error) {
+	if hostPath == "" {
+		return buildLabels{}, "", errLabelsNotFound
+	}
+	var lastNotExist error
+	for _, relPath := range labelsJSONPaths {
+		path := filepath.Join(hostPath, relPath)
+		data, err := os.ReadFile(path)
+		switch {
+		case err == nil:
+			var lb buildLabels
+			if err := json.Unmarshal(data, &lb); err != nil {
+				return buildLabels{}, "", fmt.Errorf("parsing labels.json %q: %w", path, err)
+			}
+			// Some images were published with an extra layer of JSON string
+			// quoting on label values (same bug Claircore RHCC handles).
+			for _, p := range []*string{&lb.Name, &lb.Architecture, &lb.CPE} {
+				if u, err := strconv.Unquote(*p); err == nil {
+					*p = u
+				}
+			}
+			return lb, path, nil
+		case errors.Is(err, os.ErrNotExist):
+			lastNotExist = err
+			continue
+		default:
+			return buildLabels{}, "", fmt.Errorf("opening labels.json %q: %w", path, err)
+		}
+	}
+	if lastNotExist != nil {
+		return buildLabels{}, "", errLabelsNotFound
+	}
+	return buildLabels{}, "", errLabelsNotFound
+}

--- a/compliance/node/index/labels_test.go
+++ b/compliance/node/index/labels_test.go
@@ -1,0 +1,56 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLabelsJSON(t *testing.T) {
+	t.Parallel()
+
+	lb, path, err := parseLabelsJSON("testdata-rhcos")
+	require.NoError(t, err)
+	assert.Contains(t, path, filepath.Join("usr", "share", "buildinfo", "labels.json"))
+	assert.Equal(t, "openshift/ose-rhel-coreos-9", lb.Name)
+	assert.Equal(t, "x86_64", lb.Architecture)
+	assert.Equal(t, "cpe:/a:redhat:openshift:4.21::el9", lb.CPE)
+	assert.False(t, lb.Created.IsZero())
+}
+
+func TestParseLabelsJSONNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseLabelsJSON(t.TempDir())
+	require.ErrorIs(t, err, errLabelsNotFound)
+}
+
+func TestParseLabelsJSONQuotedValues(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usr", "share", "buildinfo")
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(path, "labels.json"), []byte(`{
+		"name": "\"openshift/ose-rhel-coreos-9\"",
+		"org.opencontainers.image.created": "2025-03-24T10:34:00Z",
+		"cpe": "\"cpe:/a:redhat:openshift:4.21::el9\"",
+		"architecture": "\"x86_64\""
+	}`), 0o644))
+
+	lb, _, err := parseLabelsJSON(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "openshift/ose-rhel-coreos-9", lb.Name)
+	assert.Equal(t, "x86_64", lb.Architecture)
+	assert.Equal(t, "cpe:/a:redhat:openshift:4.21::el9", lb.CPE)
+}
+
+func TestResolveBuildLabelsFallsBackToOSReleasePath(t *testing.T) {
+	t.Parallel()
+
+	lb := resolveBuildLabels("testdata", "testdata-rhcos")
+	assert.Equal(t, "openshift/ose-rhel-coreos-9", lb.Name)
+}

--- a/compliance/node/index/testdata-rhcos/usr/share/buildinfo/labels.json
+++ b/compliance/node/index/testdata-rhcos/usr/share/buildinfo/labels.json
@@ -1,0 +1,6 @@
+{
+    "name": "openshift/ose-rhel-coreos-9",
+    "org.opencontainers.image.created": "2025-03-24T10:34:00Z",
+    "cpe": "cpe:/a:redhat:openshift:4.21::el9",
+    "architecture": "x86_64"
+}


### PR DESCRIPTION
## Description

Read RHCOS host `labels.json` (same paths as Claircore RHCC) so the synthetic node package can take its **name**, **CPE**, and **arch** from build labels when present.

- Version continues to come from `os-release` (for FixedInVersion alignment).
- If `labels.json` is missing, keep the legacy package name `rhcos`.
- Searches `HostPath` then `OSReleasePath` for split-mount / test setups.

This is a first step toward matching upcoming OCI-shaped RHCOS parent affects (`openshift/ose-rhel-coreos-{N}`).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `go test ./compliance/node/index/` in a worktree based on `upstream/master`

Made with [Cursor](https://cursor.com)