### PR TITLE
ROX-36136: fix bundler here-string shell compat

### DIFF
--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -57,6 +57,9 @@ jobs:
     concurrency:
       group: scanner-updater-bundle-${{ matrix.stream }}
       cancel-in-progress: false
+    defaults:
+      run:
+        shell: bash
     env:
       STREAM: ${{ matrix.stream }}
       SOURCE_CONFIG: scanner/updater/ci/source-config.yaml
@@ -132,7 +135,7 @@ jobs:
     - name: Download sources
       if: steps.check-changes.outputs.changed == 'true'
       run: |
-        set -euo pipefail
+        set -euxo pipefail
 
         sc=./.github/workflows/scripts/scanner-updater-config.sh
         mkdir -p bundles
@@ -146,7 +149,7 @@ jobs:
             for attempt in 1 2 3; do
                 meta=$(gcloud storage objects describe "$object" --format=json)
                 gen=$(jq -r '.generation' <<< "$meta")
-                timestamp=$(jq -re '.metadata["refresh-completed-at"]' <<< "$meta")
+                timestamp=$(jq -re '.custom_fields["refresh-completed-at"]' <<< "$meta")
 
                 if gcloud storage cp "$object" "$dest" --if-generation-match="$gen"; then
                     touch -d "$timestamp" "$dest"


### PR DESCRIPTION
## Description

The bundler workflow's download step uses `<<<` (here-strings) to pipe JSON metadata to jq. The container's default shell (`sh`) does not support this syntax, causing the step to fail immediately with exit code 1 and no output.

Replaces `<<<` with `echo ... | jq ...` which is POSIX-compatible.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

Triggering `workflow_dispatch` on the bundle workflow from this branch to verify the download step completes: https://github.com/stackrox/stackrox/actions/runs/32917177118