### PR TITLE
ROX-35970: Add CVE Origin UI

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -182,9 +182,11 @@ function DeploymentPageVulnerabilities({
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
     const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isOriginColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
     const columnConfig = overrideManagedColumns(managedColumnState.columns, {
         epssProbability: hideColumnIf(!isEpssProbabilityColumnEnabled),
+        origin: hideColumnIf(!isOriginColumnEnabled),
     });
 
     // Keep searchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4 also Advisory.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -237,6 +237,7 @@ function ImagePageVulnerabilities({
 
     const isNvdCvssColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isEpssProbabilityColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isOriginColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
     const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
@@ -244,6 +245,7 @@ function ImagePageVulnerabilities({
         cveSelection: hideColumnIf(!canSelectRows),
         nvdCvss: hideColumnIf(!isNvdCvssColumnEnabled),
         epssProbability: hideColumnIf(!isEpssProbabilityColumnEnabled),
+        origin: hideColumnIf(!isOriginColumnEnabled),
         requestDetails: hideColumnIf(vulnerabilityState === 'OBSERVED'),
         rowActions: hideColumnIf(createTableActions === undefined),
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -10,6 +10,7 @@ import type { VulnerabilityState } from 'types/cve.proto';
 import CvssFormatted from 'Components/CvssFormatted';
 
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
+import { getOriginDisplayName } from '../../utils/vulnerabilityUtils';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 import ImageNameLink from '../components/ImageNameLink';
 import {
@@ -37,6 +38,7 @@ export const deploymentComponentVulnerabilitiesFragment = gql`
             cvss
             scoreVersion
             fixedByVersion
+            origin
             advisory {
                 name
                 link
@@ -69,7 +71,7 @@ function DeploymentComponentVulnerabilitiesTable({
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
-    const colSpanForDockerfileLayer = 8 + (isAdvisoryColumnEnabled ? 1 : 0);
+    const colSpanForDockerfileLayer = 9 + (isAdvisoryColumnEnabled ? 1 : 0);
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = images.flatMap(({ imageMetadataContext, componentVulnerabilities }) =>
@@ -89,6 +91,7 @@ function DeploymentComponentVulnerabilitiesTable({
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
+                    <Th>CVE origin</Th>
                     <Th>Location</Th>
                 </Tr>
             </Thead>
@@ -101,6 +104,7 @@ function DeploymentComponentVulnerabilitiesTable({
                     cvss,
                     scoreVersion,
                     fixedByVersion,
+                    origin,
                     advisory,
                     location,
                     source,
@@ -161,6 +165,7 @@ function DeploymentComponentVulnerabilitiesTable({
                                 </Td>
                             )}
                             <Td dataLabel="Source">{source}</Td>
+                            <Td dataLabel="CVE origin">{getOriginDisplayName(origin)}</Td>
                             <Td dataLabel="Location">
                                 <ComponentLocation location={location} source={source} />
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -70,8 +70,10 @@ function DeploymentComponentVulnerabilitiesTable({
 }: DeploymentComponentVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isOriginColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
-    const colSpanForDockerfileLayer = 9 + (isAdvisoryColumnEnabled ? 1 : 0);
+    const colSpanForDockerfileLayer =
+        8 + (isAdvisoryColumnEnabled ? 1 : 0) + (isOriginColumnEnabled ? 1 : 0);
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = images.flatMap(({ imageMetadataContext, componentVulnerabilities }) =>
@@ -91,7 +93,7 @@ function DeploymentComponentVulnerabilitiesTable({
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
-                    <Th>CVE origin</Th>
+                    {isOriginColumnEnabled && <Th>CVE origin</Th>}
                     <Th>Location</Th>
                 </Tr>
             </Thead>
@@ -165,7 +167,9 @@ function DeploymentComponentVulnerabilitiesTable({
                                 </Td>
                             )}
                             <Td dataLabel="Source">{source}</Td>
-                            <Td dataLabel="CVE origin">{getOriginDisplayName(origin)}</Td>
+                            {isOriginColumnEnabled && (
+                                <Td dataLabel="CVE origin">{getOriginDisplayName(origin)}</Td>
+                            )}
                             <Td dataLabel="Location">
                                 <ComponentLocation location={location} source={source} />
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -60,12 +60,12 @@ export const defaultColumns = {
         title: 'EPSS probability',
         isShownByDefault: true,
     },
-    origin: {
-        title: 'CVE origin',
-        isShownByDefault: true,
-    },
     affectedComponents: {
         title: 'Affected components',
+        isShownByDefault: true,
+    },
+    origin: {
+        title: 'CVE origin',
         isShownByDefault: true,
     },
     firstDiscovered: {
@@ -158,15 +158,15 @@ function DeploymentVulnerabilitiesTable({
                     >
                         EPSS probability
                     </Th>
+                    <Th className={getVisibilityClass('affectedComponents')}>
+                        Affected components
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
                     <Th
                         className={getVisibilityClass('origin')}
                         info={getInfoForCveOrigin(version, 'deployment')}
                     >
                         CVE origin
-                    </Th>
-                    <Th className={getVisibilityClass('affectedComponents')}>
-                        Affected components
-                        {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('firstDiscovered')}>First discovered</Th>
                     <Th className={getVisibilityClass('publishedOn')}>Published</Th>
@@ -282,16 +282,16 @@ function DeploymentVulnerabilitiesTable({
                                         {formatEpssProbabilityAsPercent(epssProbability)}
                                     </Td>
                                     <Td
-                                        className={getVisibilityClass('origin')}
-                                        dataLabel="CVE origin"
-                                    >
-                                        {origin}
-                                    </Td>
-                                    <Td
                                         className={getVisibilityClass('affectedComponents')}
                                         dataLabel="Affected components"
                                     >
                                         {affectedComponentsText}
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('origin')}
+                                        dataLabel="CVE origin"
+                                    >
+                                        {origin}
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('firstDiscovered')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -59,6 +59,10 @@ export const defaultColumns = {
         title: 'EPSS probability',
         isShownByDefault: true,
     },
+    origin: {
+        title: 'CVE origin',
+        isShownByDefault: true,
+    },
     affectedComponents: {
         title: 'Affected components',
         isShownByDefault: true,
@@ -152,6 +156,7 @@ function DeploymentVulnerabilitiesTable({
                     >
                         EPSS probability
                     </Th>
+                    <Th className={getVisibilityClass('origin')}>CVE origin</Th>
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
@@ -175,6 +180,7 @@ function DeploymentVulnerabilitiesTable({
                             severity,
                             summary,
                             isFixable,
+                            origin,
                             images,
                             affectedComponentsText,
                             discoveredAtImage,
@@ -267,6 +273,12 @@ function DeploymentVulnerabilitiesTable({
                                         dataLabel="EPSS probability"
                                     >
                                         {formatEpssProbabilityAsPercent(epssProbability)}
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('origin')}
+                                        dataLabel="CVE origin"
+                                    >
+                                        {origin}
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('affectedComponents')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -5,6 +5,7 @@ import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternf
 import { gql } from '@apollo/client';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import useMetadata from 'hooks/useMetadata';
 import useSet from 'hooks/useSet';
 import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -27,7 +28,7 @@ import DeploymentComponentVulnerabilitiesTable, {
 } from './DeploymentComponentVulnerabilitiesTable';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
-import { infoForEpssProbability } from './infoForTh';
+import { getInfoForCveOrigin, infoForEpssProbability } from './infoForTh';
 import { formatEpssProbabilityAsPercent } from './table.utils';
 import type { FormattedDeploymentVulnerability } from './table.utils';
 
@@ -124,6 +125,7 @@ function DeploymentVulnerabilitiesTable({
     tableConfig,
 }: DeploymentVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { version } = useMetadata();
     const { urlBuilder } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
@@ -156,7 +158,12 @@ function DeploymentVulnerabilitiesTable({
                     >
                         EPSS probability
                     </Th>
-                    <Th className={getVisibilityClass('origin')}>CVE origin</Th>
+                    <Th
+                        className={getVisibilityClass('origin')}
+                        info={getInfoForCveOrigin(version, 'deployment')}
+                    >
+                        CVE origin
+                    </Th>
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -4,6 +4,8 @@ import { gql } from '@apollo/client';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useTableSort from 'hooks/useTableSort';
+import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
+import CvssFormatted from 'Components/CvssFormatted';
 
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
 import { getOriginDisplayName } from '../../utils/vulnerabilityUtils';
@@ -30,6 +32,8 @@ export const imageComponentVulnerabilitiesFragment = gql`
         inBaseImageLayer
         imageVulnerabilities(query: $query) {
             severity
+            cvss
+            scoreVersion
             fixedByVersion
             origin
             advisory {
@@ -60,7 +64,7 @@ function ImageComponentVulnerabilitiesTable({
     const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_BASE_IMAGE_DETECTION');
 
     const colSpanForDockerfileLayer =
-        5 +
+        7 +
         (isAdvisoryColumnEnabled ? 1 : 0) +
         (isOriginColumnEnabled ? 1 : 0) +
         (isLayerTypeColumnEnabled ? 1 : 0);
@@ -78,6 +82,8 @@ function ImageComponentVulnerabilitiesTable({
                 <Tr>
                     <Th sort={getSortParams('Component')}>Component</Th>
                     <Th>Version</Th>
+                    <Th>CVE severity</Th>
+                    <Th>CVSS</Th>
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
@@ -91,6 +97,9 @@ function ImageComponentVulnerabilitiesTable({
                     image,
                     name,
                     version,
+                    severity,
+                    cvss,
+                    scoreVersion,
                     fixedByVersion,
                     origin,
                     advisory,
@@ -113,6 +122,12 @@ function ImageComponentVulnerabilitiesTable({
                         <Tr>
                             <Td dataLabel="Component">{name}</Td>
                             <Td dataLabel="Version">{version}</Td>
+                            <Td dataLabel="CVE severity" modifier="nowrap">
+                                <VulnerabilitySeverityIconText severity={severity} />
+                            </Td>
+                            <Td dataLabel="CVSS" modifier="nowrap">
+                                <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
+                            </Td>
                             <Td dataLabel="CVE fixed in" modifier="nowrap">
                                 <FixedByVersion fixedByVersion={fixedByVersion} />
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -6,6 +6,7 @@ import useFeatureFlags from 'hooks/useFeatureFlags';
 import useTableSort from 'hooks/useTableSort';
 
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
+import { getOriginDisplayName } from '../../utils/vulnerabilityUtils';
 import {
     flattenImageComponentVulns,
     imageMetadataContextFragment,
@@ -30,6 +31,7 @@ export const imageComponentVulnerabilitiesFragment = gql`
         imageVulnerabilities(query: $query) {
             severity
             fixedByVersion
+            origin
             advisory {
                 name
                 link
@@ -57,7 +59,7 @@ function ImageComponentVulnerabilitiesTable({
     const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_BASE_IMAGE_DETECTION');
 
     const colSpanForDockerfileLayer =
-        5 + (isAdvisoryColumnEnabled ? 1 : 0) + (isLayerTypeColumnEnabled ? 1 : 0);
+        6 + (isAdvisoryColumnEnabled ? 1 : 0) + (isLayerTypeColumnEnabled ? 1 : 0);
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = flattenImageComponentVulns(
@@ -75,6 +77,7 @@ function ImageComponentVulnerabilitiesTable({
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
+                    <Th>CVE origin</Th>
                     {isLayerTypeColumnEnabled && <Th>Layer type</Th>}
                     <Th>Location</Th>
                 </Tr>
@@ -85,6 +88,7 @@ function ImageComponentVulnerabilitiesTable({
                     name,
                     version,
                     fixedByVersion,
+                    origin,
                     advisory,
                     location,
                     source,
@@ -114,6 +118,7 @@ function ImageComponentVulnerabilitiesTable({
                                 </Td>
                             )}
                             <Td dataLabel="Source">{source}</Td>
+                            <Td dataLabel="CVE origin">{getOriginDisplayName(origin)}</Td>
                             {isLayerTypeColumnEnabled && (
                                 <Td dataLabel="Layer type">
                                     <Label color={inBaseImageLayer ? 'blue' : 'grey'} isCompact>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -56,10 +56,14 @@ function ImageComponentVulnerabilitiesTable({
 }: ImageComponentVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isOriginColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_BASE_IMAGE_DETECTION');
 
     const colSpanForDockerfileLayer =
-        6 + (isAdvisoryColumnEnabled ? 1 : 0) + (isLayerTypeColumnEnabled ? 1 : 0);
+        5 +
+        (isAdvisoryColumnEnabled ? 1 : 0) +
+        (isOriginColumnEnabled ? 1 : 0) +
+        (isLayerTypeColumnEnabled ? 1 : 0);
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = flattenImageComponentVulns(
@@ -77,7 +81,7 @@ function ImageComponentVulnerabilitiesTable({
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
-                    <Th>CVE origin</Th>
+                    {isOriginColumnEnabled && <Th>CVE origin</Th>}
                     {isLayerTypeColumnEnabled && <Th>Layer type</Th>}
                     <Th>Location</Th>
                 </Tr>
@@ -118,7 +122,9 @@ function ImageComponentVulnerabilitiesTable({
                                 </Td>
                             )}
                             <Td dataLabel="Source">{source}</Td>
-                            <Td dataLabel="CVE origin">{getOriginDisplayName(origin)}</Td>
+                            {isOriginColumnEnabled && (
+                                <Td dataLabel="CVE origin">{getOriginDisplayName(origin)}</Td>
+                            )}
                             {isLayerTypeColumnEnabled && (
                                 <Td dataLabel="Layer type">
                                     <Label color={inBaseImageLayer ? 'blue' : 'grey'} isCompact>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -95,12 +95,12 @@ export const defaultColumns = {
         title: 'EPSS probability',
         isShownByDefault: true,
     },
-    origin: {
-        title: 'CVE origin',
-        isShownByDefault: true,
-    },
     affectedComponents: {
         title: 'Affected components',
+        isShownByDefault: true,
+    },
+    origin: {
+        title: 'CVE origin',
         isShownByDefault: true,
     },
     firstDiscovered: {
@@ -231,15 +231,15 @@ function ImageVulnerabilitiesTable({
                     >
                         EPSS probability
                     </Th>
+                    <Th className={getVisibilityClass('affectedComponents')}>
+                        Affected components
+                        {isFiltered && <DynamicColumnIcon />}
+                    </Th>
                     <Th
                         className={getVisibilityClass('origin')}
                         info={getInfoForCveOrigin(version, 'image')}
                     >
                         CVE origin
-                    </Th>
-                    <Th className={getVisibilityClass('affectedComponents')}>
-                        Affected components
-                        {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('firstDiscovered')} modifier="nowrap">
                         First discovered
@@ -398,18 +398,18 @@ function ImageVulnerabilitiesTable({
                                         {formatEpssProbabilityAsPercent(epssProbability)}
                                     </Td>
                                     <Td
-                                        className={getVisibilityClass('origin')}
-                                        dataLabel="CVE origin"
-                                    >
-                                        {aggregateOrigin}
-                                    </Td>
-                                    <Td
                                         className={getVisibilityClass('affectedComponents')}
                                         dataLabel="Affected components"
                                     >
                                         {imageComponents.length === 1
                                             ? imageComponents[0].name
                                             : `${imageComponents.length} components`}
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('origin')}
+                                        dataLabel="CVE origin"
+                                    >
+                                        {aggregateOrigin}
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('firstDiscovered')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -15,6 +15,7 @@ import type { IAction } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
+import useMetadata from 'hooks/useMetadata';
 import useSet from 'hooks/useSet';
 import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
@@ -54,7 +55,7 @@ import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
-import { infoForEpssProbability } from './infoForTh';
+import { getInfoForCveOrigin, infoForEpssProbability } from './infoForTh';
 import { formatEpssProbabilityAsPercent } from './table.utils';
 
 export const tableId = 'WorkloadCvesImageVulnerabilitiesTable';
@@ -189,6 +190,7 @@ function ImageVulnerabilitiesTable({
     tableConfig,
 }: ImageVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { version } = useMetadata();
     const { urlBuilder } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
@@ -229,7 +231,12 @@ function ImageVulnerabilitiesTable({
                     >
                         EPSS probability
                     </Th>
-                    <Th className={getVisibilityClass('origin')}>CVE origin</Th>
+                    <Th
+                        className={getVisibilityClass('origin')}
+                        info={getInfoForCveOrigin(version, 'image')}
+                    >
+                        CVE origin
+                    </Th>
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -32,6 +32,7 @@ import type { TableUIState } from 'utils/getTableUIState';
 import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
 import type { ManagedColumns } from 'hooks/useManagedColumns';
 import {
+    getAggregateOrigin,
     getIsSomeVulnerabilityFixable,
     hasKnownExploit,
     hasKnownRansomwareCampaignUse,
@@ -91,6 +92,10 @@ export const defaultColumns = {
     },
     epssProbability: {
         title: 'EPSS probability',
+        isShownByDefault: true,
+    },
+    origin: {
+        title: 'CVE origin',
         isShownByDefault: true,
     },
     affectedComponents: {
@@ -224,6 +229,7 @@ function ImageVulnerabilitiesTable({
                     >
                         EPSS probability
                     </Th>
+                    <Th className={getVisibilityClass('origin')}>CVE origin</Th>
                     <Th className={getVisibilityClass('affectedComponents')}>
                         Affected components
                         {isFiltered && <DynamicColumnIcon />}
@@ -271,6 +277,7 @@ function ImageVulnerabilitiesTable({
                             (imageComponent) => imageComponent.imageVulnerabilities
                         );
                         const isFixableInImage = getIsSomeVulnerabilityFixable(vulnerabilities);
+                        const aggregateOrigin = getAggregateOrigin(vulnerabilities);
                         const epssProbability = cveBaseInfo?.epss?.epssProbability;
 
                         const labels: ReactNode[] = [];
@@ -382,6 +389,12 @@ function ImageVulnerabilitiesTable({
                                         dataLabel="EPSS probability"
                                     >
                                         {formatEpssProbabilityAsPercent(epssProbability)}
+                                    </Td>
+                                    <Td
+                                        className={getVisibilityClass('origin')}
+                                        dataLabel="CVE origin"
+                                    >
+                                        {aggregateOrigin}
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('affectedComponents')}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
@@ -3,6 +3,7 @@ import type { ThProps } from '@patternfly/react-table';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import PopoverBodyContent from 'Components/PopoverBodyContent';
+import { getVersionedDocs } from 'utils/versioning';
 
 export const infoForEpssProbability: ThProps['info'] = {
     // ariaLabel for OutlinedQuestionCircleIcon
@@ -34,3 +35,43 @@ export const infoForEpssProbability: ThProps['info'] = {
         />
     ),
 };
+
+// The CVE origin popover links to versioned RHACS documentation, so it must be
+// built with the current version rather than defined as a static object.
+export function getInfoForCveOrigin(
+    version: string,
+    resourceType: 'image' | 'deployment'
+): ThProps['info'] {
+    return {
+        ariaLabel: 'Information about CVE origin',
+        popover: (
+            <PopoverBodyContent
+                headerContent="CVE origin"
+                bodyContent={
+                    <Flex direction={{ default: 'column' }}>
+                        <FlexItem>
+                            Where the CVE assessment comes from for components in this{' '}
+                            {resourceType}. Values are supported OS vendors, OSV.dev, Other, or
+                            Multiple when components differ.
+                        </FlexItem>
+                        <FlexItem>
+                            For more information, see{' '}
+                            <ExternalLink>
+                                <a
+                                    href={getVersionedDocs(
+                                        version,
+                                        'operating/examine-images-for-vulnerabilities#supported-operating-systems_examine-images-for-vulnerabilities'
+                                    )}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Supported operating systems (RHACS)
+                                </a>
+                            </ExternalLink>
+                        </FlexItem>
+                    </Flex>
+                }
+            />
+        ),
+    };
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -9,6 +9,7 @@ import type { SourceType } from 'types/image.proto';
 import type { ApiSortOptionSingle } from 'types/search';
 
 import {
+    getAggregateOrigin,
     getHighestVulnerabilitySeverity,
     getIsSomeVulnerabilityFixable,
 } from '../../utils/vulnerabilityUtils';
@@ -83,6 +84,7 @@ export type ComponentVulnerabilityBase = {
     imageVulnerabilities: {
         severity: string;
         fixedByVersion: string;
+        origin?: string;
         advisory?: Advisory | null;
         pendingExceptionCount: number;
     }[];
@@ -99,6 +101,7 @@ export type DeploymentComponentVulnerability = Omit<
         cvss: number;
         scoreVersion: string;
         fixedByVersion: string;
+        origin?: string;
         advisory?: Advisory | null;
         discoveredAtImage: string | null;
         publishedOn: string | null;
@@ -128,6 +131,7 @@ export type TableDataRow = {
         instruction: string;
         value: string;
     } | null;
+    origin?: string;
     pendingExceptionCount: number;
     inBaseImageLayer?: boolean;
 };
@@ -204,6 +208,7 @@ function extractCommonComponentFields(
             ? vulnerability.severity
             : 'UNKNOWN_VULNERABILITY_SEVERITY';
     const fixedByVersion = vulnerability?.fixedByVersion ?? 'N/A';
+    const origin = vulnerability?.origin;
     const advisory = vulnerability?.advisory;
     const pendingExceptionCount = vulnerability?.pendingExceptionCount ?? 0;
 
@@ -220,6 +225,7 @@ function extractCommonComponentFields(
         layer,
         severity,
         fixedByVersion,
+        origin,
         advisory,
         pendingExceptionCount,
         inBaseImageLayer,
@@ -277,6 +283,7 @@ export type FormattedDeploymentVulnerability = {
     operatingSystem: string;
     severity: VulnerabilitySeverity;
     isFixable: boolean;
+    origin: string;
     discoveredAtImage: Date | null;
     publishedOn: Date | null;
     summary: string;
@@ -310,6 +317,7 @@ export function formatVulnerabilityData(
         const allVulnerabilities = allVulnerableComponents.flatMap((c) => c.imageVulnerabilities);
         const highestVulnSeverity = getHighestVulnerabilitySeverity(allVulnerabilities);
         const isFixableInDeployment = getIsSomeVulnerabilityFixable(allVulnerabilities);
+        const origin = getAggregateOrigin(allVulnerabilities);
         const allDiscoveredDates = allVulnerableComponents
             .flatMap((c) => c.imageVulnerabilities.map((v) => v.discoveredAtImage))
             .filter((d): d is string => d !== null);
@@ -343,6 +351,7 @@ export function formatVulnerabilityData(
             operatingSystem,
             severity: highestVulnSeverity,
             isFixable: isFixableInDeployment,
+            origin,
             discoveredAtImage: oldestDiscoveredVulnDate,
             publishedOn: publishedOnDate,
             summary,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -83,6 +83,8 @@ export type ComponentVulnerabilityBase = {
     inBaseImageLayer?: boolean;
     imageVulnerabilities: {
         severity: string;
+        cvss: number;
+        scoreVersion: string;
         fixedByVersion: string;
         origin?: string;
         advisory?: Advisory | null;
@@ -123,6 +125,8 @@ export type TableDataRow = {
     fixedByVersion: string;
     advisory?: Advisory | null;
     severity: VulnerabilitySeverity;
+    cvss: number;
+    scoreVersion: string;
     version: string;
     location: string;
     source: SourceType;
@@ -162,23 +166,13 @@ export function flattenImageComponentVulns(
 export function flattenDeploymentComponentVulns(
     imageMetadataContext: ImageMetadataContext,
     componentVulnerabilities: DeploymentComponentVulnerability[]
-): (TableDataRow & {
-    cvss: number;
-    scoreVersion: string;
-})[] {
+): TableDataRow[] {
     const image = imageMetadataContext;
     const layers = imageMetadataContext.metadata?.v1?.layers ?? [];
 
     return componentVulnerabilities.map((component) => {
         const vulnerability = component.imageVulnerabilities[0];
-        const cvss = vulnerability?.cvss ?? 0;
-        const scoreVersion = vulnerability?.scoreVersion ?? 'N/A';
-
-        return {
-            ...extractCommonComponentFields(image, layers, component, vulnerability),
-            scoreVersion,
-            cvss,
-        };
+        return extractCommonComponentFields(image, layers, component, vulnerability);
     });
 }
 
@@ -207,6 +201,8 @@ function extractCommonComponentFields(
         vulnerability?.severity && isVulnerabilitySeverity(vulnerability.severity)
             ? vulnerability.severity
             : 'UNKNOWN_VULNERABILITY_SEVERITY';
+    const cvss = vulnerability?.cvss ?? 0;
+    const scoreVersion = vulnerability?.scoreVersion ?? 'N/A';
     const fixedByVersion = vulnerability?.fixedByVersion ?? 'N/A';
     const origin = vulnerability?.origin;
     const advisory = vulnerability?.advisory;
@@ -224,6 +220,8 @@ function extractCommonComponentFields(
         },
         layer,
         severity,
+        cvss,
+        scoreVersion,
         fixedByVersion,
         origin,
         advisory,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
@@ -1,9 +1,11 @@
 import type { NonEmptyArray } from 'utils/type.utils';
 import {
+    getAggregateOrigin,
     getEarliestDiscoveredAtTime,
     getHighestCvssScore,
     getHighestVulnerabilitySeverity,
     getIsSomeVulnerabilityFixable,
+    getOriginDisplayName,
 } from './vulnerabilityUtils';
 
 const CRITICAL = 'CRITICAL_VULNERABILITY_SEVERITY';
@@ -98,6 +100,57 @@ describe('vulnerability utils', () => {
                 { discoveredAtImage: '2021-01-03T00:00:00Z' },
             ];
             expect(getEarliestDiscoveredAtTime(vulnerabilities)).toEqual('2021-01-01T00:00:00Z');
+        });
+    });
+
+    describe('getOriginDisplayName', () => {
+        const testCases = [
+            { origin: 'VULN_ORIGIN_ALPINE', expected: 'Alpine Linux' },
+            { origin: 'VULN_ORIGIN_RED_HAT', expected: 'Red Hat' },
+            { origin: 'VULN_ORIGIN_UBUNTU', expected: 'Ubuntu' },
+            { origin: 'VULN_ORIGIN_OTHER', expected: 'Other' },
+        ];
+
+        testCases.forEach(({ origin, expected }) => {
+            it(`returns '${expected}' for origin: ${origin}`, () => {
+                expect(getOriginDisplayName(origin)).toEqual(expected);
+            });
+        });
+
+        it('returns the raw value for an unrecognized origin', () => {
+            expect(getOriginDisplayName('VULN_ORIGIN_FUTURE')).toEqual('VULN_ORIGIN_FUTURE');
+        });
+
+        it("returns 'Other' when the origin is null or undefined", () => {
+            expect(getOriginDisplayName(null)).toEqual('Other');
+            expect(getOriginDisplayName(undefined)).toEqual('Other');
+        });
+    });
+
+    describe('getAggregateOrigin', () => {
+        it('returns the display name when all vulnerabilities share a single origin', () => {
+            const vulnerabilities = [
+                { origin: 'VULN_ORIGIN_UBUNTU' },
+                { origin: 'VULN_ORIGIN_UBUNTU' },
+            ];
+            expect(getAggregateOrigin(vulnerabilities)).toEqual('Ubuntu');
+        });
+
+        it("returns 'Multiple' when vulnerabilities have more than one distinct origin", () => {
+            const vulnerabilities = [
+                { origin: 'VULN_ORIGIN_UBUNTU' },
+                { origin: 'VULN_ORIGIN_RED_HAT' },
+            ];
+            expect(getAggregateOrigin(vulnerabilities)).toEqual('Multiple');
+        });
+
+        it("returns 'Other' when there are no vulnerabilities", () => {
+            expect(getAggregateOrigin([])).toEqual('Other');
+        });
+
+        it("returns 'Other' when no vulnerability has an origin", () => {
+            const vulnerabilities = [{ origin: undefined }, {}];
+            expect(getAggregateOrigin(vulnerabilities)).toEqual('Other');
         });
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.test.ts
@@ -152,5 +152,12 @@ describe('vulnerability utils', () => {
             const vulnerabilities = [{ origin: undefined }, {}];
             expect(getAggregateOrigin(vulnerabilities)).toEqual('Other');
         });
+
+        it("returns 'Multiple' when a known origin is mixed with a missing origin", () => {
+            // A missing origin counts as the distinct 'Other' origin, so it aggregates to
+            // 'Multiple' rather than collapsing to the single known origin.
+            const vulnerabilities = [{ origin: 'VULN_ORIGIN_RED_HAT' }, { origin: undefined }];
+            expect(getAggregateOrigin(vulnerabilities)).toEqual('Multiple');
+        });
     });
 });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
@@ -77,7 +77,9 @@ export function getEarliestDiscoveredAtTime(
     return earliestDiscoveredAt;
 }
 
-export const originDisplayNames: Record<string, string> = {
+const OTHER_ORIGIN_DISPLAY_NAME = 'Other';
+
+export const originDisplayNames: Partial<Record<string, string>> = {
     VULN_ORIGIN_ALPINE: 'Alpine Linux',
     VULN_ORIGIN_AMAZON: 'Amazon Linux',
     VULN_ORIGIN_DEBIAN: 'Debian',
@@ -87,22 +89,25 @@ export const originDisplayNames: Record<string, string> = {
     VULN_ORIGIN_RED_HAT: 'Red Hat',
     VULN_ORIGIN_SUSE: 'SUSE',
     VULN_ORIGIN_UBUNTU: 'Ubuntu',
-    VULN_ORIGIN_OTHER: 'Other',
+    VULN_ORIGIN_OTHER: OTHER_ORIGIN_DISPLAY_NAME,
 };
 
 export function getOriginDisplayName(origin: string | null | undefined): string {
     if (!origin) {
-        return originDisplayNames.VULN_ORIGIN_OTHER;
+        return OTHER_ORIGIN_DISPLAY_NAME;
     }
     return originDisplayNames[origin] ?? origin;
 }
 
 export function getAggregateOrigin(vulnerabilities: { origin?: string }[]): string {
+    // A missing origin is treated as 'Other', which is a distinct origin, so a CVE that
+    // originates from Red Hat data in one component and has no origin in another aggregates
+    // to 'Multiple' rather than 'Red Hat'.
     const distinctOrigins = [
-        ...new Set(vulnerabilities.map(({ origin }) => origin).filter(Boolean)),
+        ...new Set(vulnerabilities.map(({ origin }) => origin || 'VULN_ORIGIN_OTHER')),
     ];
     if (distinctOrigins.length === 0) {
-        return originDisplayNames.VULN_ORIGIN_OTHER;
+        return OTHER_ORIGIN_DISPLAY_NAME;
     }
     if (distinctOrigins.length === 1) {
         return getOriginDisplayName(distinctOrigins[0]);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
@@ -77,6 +77,39 @@ export function getEarliestDiscoveredAtTime(
     return earliestDiscoveredAt;
 }
 
+export const originDisplayNames: Record<string, string> = {
+    VULN_ORIGIN_ALPINE: 'Alpine Linux',
+    VULN_ORIGIN_AMAZON: 'Amazon Linux',
+    VULN_ORIGIN_DEBIAN: 'Debian',
+    VULN_ORIGIN_ORACLE: 'Oracle Linux',
+    VULN_ORIGIN_OSV: 'OSV.dev',
+    VULN_ORIGIN_PHOTON: 'Photon OS',
+    VULN_ORIGIN_RED_HAT: 'Red Hat',
+    VULN_ORIGIN_SUSE: 'SUSE',
+    VULN_ORIGIN_UBUNTU: 'Ubuntu',
+    VULN_ORIGIN_OTHER: 'Other',
+};
+
+export function getOriginDisplayName(origin: string | null | undefined): string {
+    if (!origin) {
+        return originDisplayNames.VULN_ORIGIN_OTHER;
+    }
+    return originDisplayNames[origin] ?? origin;
+}
+
+export function getAggregateOrigin(vulnerabilities: { origin?: string }[]): string {
+    const distinctOrigins = [
+        ...new Set(vulnerabilities.map(({ origin }) => origin).filter(Boolean)),
+    ];
+    if (distinctOrigins.length === 0) {
+        return originDisplayNames.VULN_ORIGIN_OTHER;
+    }
+    if (distinctOrigins.length === 1) {
+        return getOriginDisplayName(distinctOrigins[0]);
+    }
+    return 'Multiple';
+}
+
 export function hasKnownExploit(exploit: Exploit | null | undefined): exploit is Exploit {
     return Boolean(exploit);
 }


### PR DESCRIPTION
## Description

Adds new CVE Origin field to the single image and deployment pages. The field is added to the aggregate CVE rows as well as individual component rows. 

Also adds severity and CVSS columns to the image component rows.

The origin field is conditional on Scanner V4 being enabled (similar to EPSS).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

CI + Manual testing

Image page:

<img width="2744" height="868" alt="image" src="https://github.com/user-attachments/assets/a06ffc13-8847-4a6f-8cd7-029aabccbf81" />

<img width="2724" height="1056" alt="image" src="https://github.com/user-attachments/assets/d0ea8770-d12d-4fbd-a308-b6cbadd915d1" />

Deployment Page:

<img width="2756" height="1026" alt="image" src="https://github.com/user-attachments/assets/4c96b4d6-432b-4d0d-9b7d-6d9b2a8f6783" />

Info Popover:

<img width="764" height="658" alt="image" src="https://github.com/user-attachments/assets/aaa7ea14-6f70-4adf-9e99-732a5a32a8c7" />

CVE Origin column is hidden when Scanner V4 Disabled:

<img width="2712" height="974" alt="image" src="https://github.com/user-attachments/assets/dfd4bcda-ed1c-4238-96e9-aab609d91da2" />

<img width="2736" height="950" alt="image" src="https://github.com/user-attachments/assets/9d9c7c82-bd49-4856-b618-ca56885fe7ad" />


