### PR TITLE
ROX-36528: retry network policy apply/undo calls 

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -956,7 +956,9 @@ class NetworkFlowTest extends BaseSpecification {
         expect:
         "actual policies should exist in generated response depending on delete mode"
         def modification = NetworkPolicyService.generateNetworkPolicies(deleteMode, 'Namespace:r/^qa2?$')
-        assert !(NetworkPolicyService.applyGeneratedNetworkPolicy(modification) instanceof StatusRuntimeException)
+        Helpers.withRetry(3, 2) {
+            assert !(NetworkPolicyService.applyGeneratedNetworkPolicy(modification) instanceof StatusRuntimeException)
+        }
         def appliedNetworkPolicies = getQANetworkPoliciesNamesByNamespace(true)
         log.info "${appliedNetworkPolicies}"
 
@@ -1009,10 +1011,12 @@ class NetworkFlowTest extends BaseSpecification {
         def undoRecord = NetworkPolicyService.undoGeneratedNetworkPolicy()
         assert undoRecord.originalModification == modification
 
-        assert !(
-                NetworkPolicyService.applyGeneratedNetworkPolicy(undoRecord.undoModification)
-                        instanceof StatusRuntimeException
-        )
+        Helpers.withRetry(3, 2) {
+            assert !(
+                    NetworkPolicyService.applyGeneratedNetworkPolicy(undoRecord.undoModification)
+                            instanceof StatusRuntimeException
+            )
+        }
         def undoNetworkPolicies = getQANetworkPoliciesNamesByNamespace(true)
         log.info "${undoNetworkPolicies}"
         assert undoNetworkPolicies == preExistingNetworkPolicies


### PR DESCRIPTION
## Description

Attempts to improve robustness by wrapping network policy apply/undo calls in retries to avoid grpc flakiness.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI is enough
