### PR TITLE
ROX-36554: wait for deployment teardown to sync 

### DIFF
--- a/tests/excluded_scopes_test.go
+++ b/tests/excluded_scopes_test.go
@@ -20,7 +20,7 @@ func TestExcludedScopes(t *testing.T) {
 	deploymentName := fmt.Sprintf("test-excluded-scopes-%d", rand.Intn(10000))
 
 	setupDeploymentInNamespace(t, "quay.io/rhacs-eng/qa-multi-arch-nginx:latest", deploymentName, "default")
-	defer teardownDeploymentWithoutCheck(t, deploymentName, "default")
+	defer teardownDeployment(t, deploymentName, "default")
 	waitForDeploymentInCentral(t, deploymentName)
 
 	verifyNoAlertForExcludedScopes(t, deploymentName)


### PR DESCRIPTION
## Description

Avoids graphql count flake/inconsistency.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI is enough.
