### PR TITLE
ROX-36465: prevent kubectl NotFound errors from corrupting logs

### DIFF
--- a/scripts/ci/collect-service-logs.sh
+++ b/scripts/ci/collect-service-logs.sh
@@ -83,7 +83,15 @@ main() {
         local item_count=0
 
         for item in $(kubectl -n "${namespace}" get "${object}" -o jsonpath='{.items}' | jq -r '.[] | select(.metadata.deletionTimestamp | not) | .metadata.name'); do
-            kubectl get "${object}" "${item}" -n "${namespace}" -o json > "${log_dir}/${object}/${item}_object.json" 2>&1
+            if ! kubectl get "${object}" "${item}" -n "${namespace}" -o json > "${log_dir}/${object}/${item}_object.json" 2>/dev/null; then
+                # The object may have been deleted/replaced between listing it above and
+                # fetching it here. Don't let the stderr text (e.g. "Error from server
+                # (NotFound)") get merged into what is meant to be a JSON file, and don't
+                # leave a partial/empty file behind for downstream jq consumers to choke on.
+                info "Cannot get ${object}/${item} in ${namespace} (likely deleted mid-collection): skipping"
+                rm -f "${log_dir}/${object}/${item}_object.json"
+                continue
+            fi
             {
               kubectl describe "${object}" "${item}" -n "${namespace}" 2>&1
               echo


### PR DESCRIPTION
## Description

"Error from server (NotFound)" could be written to a file that is meant to be json, which fails to parse later on. This checks whether the kubectl command succeeds, and otherwise logs an warning and removes the invalid file. 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI is enough.