### PR TITLE
fix(ui): Expands sensor compat cell when sensor not initialized

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTable.tsx
@@ -167,23 +167,16 @@ function ClustersTable({
                                             </Td>
                                             <Td
                                                 dataLabel={sensorColumnLabel}
-                                                compoundExpand={
-                                                    clusterInfo?.status?.sensorVersionCompatibility
-                                                        ? {
-                                                              isExpanded: isCellExpanded(
-                                                                  clusterId,
-                                                                  EXPANDABLE_COLUMN.SENSOR
-                                                              ),
-                                                              onToggle: () =>
-                                                                  toggle(
-                                                                      clusterId,
-                                                                      EXPANDABLE_COLUMN.SENSOR
-                                                                  ),
-                                                              rowIndex,
-                                                              columnIndex: 4,
-                                                          }
-                                                        : undefined
-                                                }
+                                                compoundExpand={{
+                                                    isExpanded: isCellExpanded(
+                                                        clusterId,
+                                                        EXPANDABLE_COLUMN.SENSOR
+                                                    ),
+                                                    onToggle: () =>
+                                                        toggle(clusterId, EXPANDABLE_COLUMN.SENSOR),
+                                                    rowIndex,
+                                                    columnIndex: 4,
+                                                }}
                                             >
                                                 <SensorCompatibility
                                                     compatibility={

--- a/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilityPanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/SensorCompatibilityPanel.tsx
@@ -135,7 +135,7 @@ function SensorCompatibilityPanel({
             <SensorCompatibilitySubPanel
                 header="Sensor version"
                 bodyItems={{
-                    version: ['Version', sensorVersion],
+                    version: ['Version', sensorVersion ?? 'Unknown'],
                     range: [
                         'Version range',
                         shouldShowSensorVersionRangeChart(compatibility, compatibleVersions) ? (


### PR DESCRIPTION
## Description

Allows the "Sensor compatibility status" row to expand when the sensor has not been initialized on the cluster. This results in the same UI as if the sensor was initialized, but simply did not have version information. The info communicated to the useris the same in both cases (all we can know) and makes this UI more consistent.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1123" height="724" alt="image" src="https://github.com/user-attachments/assets/091d1955-2af1-43d7-8190-2da7c3087176" />