### PR TITLE
fix(sensor): preserve VM scrape NACK against late commit

### DIFF
--- a/sensor/common/virtualmachine/ACK_MODEL.md
+++ b/sensor/common/virtualmachine/ACK_MODEL.md
@@ -41,4 +41,4 @@ Using only the vsock CID is unsafe because a CID can be reused by a different VM
 
 The pair is not a per-report unique ID: multiple in-flight reports from the same VM with the same CID are still not fully distinguishable, so a stale ACK can match the latest entry instead of the one it was actually for.
 
-A NACK that changes `lastToken` or backoff before `commitVMState` runs is not overwritten by that commit.
+A NACK that changes `lastToken` or backoff before `commitVMState` runs is not overwritten by that commit. If `lastToken` is already empty and backoff is already at the cap, `nextBackoff` is a no-op, so that NACK is invisible to the commit.

--- a/sensor/common/virtualmachine/ACK_MODEL.md
+++ b/sensor/common/virtualmachine/ACK_MODEL.md
@@ -41,4 +41,4 @@ Using only the vsock CID is unsafe because a CID can be reused by a different VM
 
 The pair is not a per-report unique ID: multiple in-flight reports from the same VM with the same CID are still not fully distinguishable, so a stale ACK can match the latest entry instead of the one it was actually for.
 
-A NACK can also lose a race with the post-forward commit of `lastToken`, in which case the next poll may still see an "unchanged" delta.
+A NACK that changes `lastToken` or backoff before `commitVMState` runs is not overwritten by that commit.

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -231,11 +231,8 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 	return nil
 }
 
-// handleNACK clears the cached token and applies the shared backoff so
-// the next tick resends a full report without tight-looping on persistent NACKs.
-//
-// Race with commitVMState after forward is accepted: a fast NACK may be
-// overwritten by a late success commit.
+// handleNACK clears lastToken and applies retry backoff so the next tick
+// resends a full report without tight-looping on persistent NACKs.
 func (s *VMScraper) handleNACK(resourceID string) {
 	key := s.findKeyByVMID(vmIDFromResourceID(resourceID))
 	if key == "" {
@@ -557,9 +554,8 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	}
 
 	newToken := result.Meta.GetReportToken()
-	s.commitVMState(key, vm.ID, newToken, result.Meta.GetAgentVersion())
+	next := s.commitVMState(key, vm.ID, snap.lastToken, snap.backoff, newToken, result.Meta.GetAgentVersion())
 	s.observeForwardInterarrival()
-	next := s.scheduleAfterAttempt(key, vm.ID, scrapeOK)
 
 	log.Infof("VMScraper: scrape %q ok outcome=forwarded next=%s", key, next)
 	totalElapsed := s.now().Sub(totalStart)
@@ -860,26 +856,28 @@ func (s *VMScraper) snapshotVMState(key string) vmStateSnapshot {
 	})
 }
 
-// commitVMState records the token from a just-sent report as key's cached scrape state.
-//
-// Race: If a NACK arrives from Central faster than this function completes, for example, due to:
-//   - a scheduling delay on the caller's goroutine between forward returning and this function
-//     acquiring `s.mu` (a GC pause, CPU throttling, or GOMAXPROCS contention),
-//   - contention on `s.mu` itself, from other concurrent scrapes or NACKs delaying this
-//     function's lock acquisition,
-//
-// then the NACK will overwrite lastToken / backoff / nextAttemptAt, and then this code
-// will set the token (and a later scheduleAfterAttempt(scrapeOK) will reset backoff schedule).
-// This race is accepted for v1.
-func (s *VMScraper) commitVMState(key string, vmID virtualmachine.VMID, newToken string, agentVersion string) {
-	concurrency.WithLock(&s.mu, func() {
+// commitVMState records the just-sent report's token and agent version and
+// applies poll-cadence scheduling in the same lock, so a concurrent NACK
+// that changed lastToken or backoff is not overwritten.
+func (s *VMScraper) commitVMState(key string, vmID virtualmachine.VMID, expectedToken string, expectedBackoff time.Duration, newToken string, agentVersion string) time.Duration {
+	return concurrency.WithLock1(&s.mu, func() time.Duration {
 		state, ok := s.vmState[key]
 		if !ok || state.vmID != vmID {
-			return
+			return 0
 		}
+		if state.lastToken != expectedToken || state.backoff != expectedBackoff {
+			return max(0, state.nextAttemptAt.Sub(s.now()))
+		}
+		now := s.now()
 		state.lastToken = newToken
-		state.lastForwardedAt = s.now()
+		state.lastForwardedAt = now
 		state.lastAgentVersion = agentVersion
+		state.backoff = 0
+		offset := randOffset(steadySpreadWidth(s.interval, s.spreadFraction), s.randFloat64())
+		metrics.PullScheduleOffsetSeconds.Observe(offset.Seconds())
+		delay := s.interval + offset
+		state.nextAttemptAt = now.Add(delay)
+		return delay
 	})
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -848,52 +848,66 @@ func TestVMScraper_NACK(t *testing.T) {
 	}
 }
 
-// TestVMScraper_InFlightSendCanOverwriteNACKReset exercises a known race involving
-// an unusually slow execution of `commitVMState` and a quick NACK from Central.
-func TestVMScraper_InFlightSendCanOverwriteNACKReset(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		vmA := makeVM("ns1", "vm-a", 100)
-		vmA.ID = "vm-a-id"
-		store := &mockStore{vms: []*virtualmachine.Info{vmA}}
-		client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport("1")}}
-		s, clock := newTestScraper(t, store, &mockDialer{}, client)
+// TestVMScraper_InFlightSendDoesNotOverwriteNACKReset covers NACK while
+// forwardReport is blocked: commit must not restore lastToken or clear NACK backoff.
+func TestVMScraper_InFlightSendDoesNotOverwriteNACKReset(t *testing.T) {
+	cases := map[string]struct {
+		priorPoll bool
+		sendToken string
+	}{
+		"after a prior successful commit": {priorPoll: true, sendToken: "2"},
+		"when lastToken is already empty": {priorPoll: false, sendToken: "1"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				vmA := makeVM("ns1", "vm-a", 100)
+				vmA.ID = "vm-a-id"
+				store := &mockStore{vms: []*virtualmachine.Info{vmA}}
+				client := &mockProtocolClient{resultQueue: []*vsockclient.GetReportResult{makeReport("1")}}
+				s, clock := newTestScraper(t, store, &mockDialer{}, client)
 
-		s.pollOnce(t.Context())
-		require.Equal(t, "1", cachedToken(t, s, "ns1/vm-a"))
-		require.Equal(t, 1, forwardedCount(s))
+				if tc.priorPoll {
+					s.pollOnce(t.Context())
+					require.Equal(t, "1", cachedToken(t, s, "ns1/vm-a"))
+					clock.Advance(s.interval)
+				}
 
-		s.toCentral = make(chan *message.ExpiringMessage)
-		client.reset()
-		client.resultQueue = []*vsockclient.GetReportResult{makeReport("2")}
-		clock.Advance(s.interval)
+				s.toCentral = make(chan *message.ExpiringMessage)
+				client.reset()
+				client.resultQueue = []*vsockclient.GetReportResult{makeReport(tc.sendToken)}
 
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			s.pollOnce(t.Context())
-		}()
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					s.pollOnce(t.Context())
+				}()
 
-		// Block until the scrape goroutine is durably blocked in forwardReport,
-		// i.e. the report is on toCentral but not yet committed.
-		synctest.Wait()
+				// Block until the scrape goroutine is durably blocked in forwardReport,
+				// i.e. the report is on toCentral but not yet committed.
+				synctest.Wait()
 
-		require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
-			Msg: &central.MsgToSensor_SensorAck{
-				SensorAck: &central.SensorACK{
-					MessageType: central.SensorACK_VM_INDEX_REPORT,
-					Action:      central.SensorACK_NACK,
-					ResourceId:  "vm-a-id:100",
-				},
-			},
-		}))
-		assert.Empty(t, cachedToken(t, s, "ns1/vm-a"),
-			"NACK applies immediately while the send it targets is still in flight")
+				require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
+					Msg: &central.MsgToSensor_SensorAck{
+						SensorAck: &central.SensorACK{
+							MessageType: central.SensorACK_VM_INDEX_REPORT,
+							Action:      central.SensorACK_NACK,
+							ResourceId:  "vm-a-id:100",
+						},
+					},
+				}))
+				assert.Empty(t, cachedToken(t, s, "ns1/vm-a"),
+					"NACK applies immediately while the send it targets is still in flight")
 
-		<-s.toCentral
-		<-done
-		assert.Equal(t, "2", cachedToken(t, s, "ns1/vm-a"),
-			"the in-flight send's commit runs after the NACK reset and overwrites it unconditionally")
-	})
+				<-s.toCentral
+				<-done
+				assert.Empty(t, cachedToken(t, s, "ns1/vm-a"),
+					"the in-flight send must not restore lastToken after a NACK")
+				assert.Equal(t, initialBackoff, cachedBackoff(t, s, "ns1/vm-a"),
+					"success scheduling must not clear the NACK backoff")
+			})
+		})
+	}
 }
 
 func TestVMScraper_HandlesDialAndProtocolFailures(t *testing.T) {


### PR DESCRIPTION
## Description

After Sensor forwards a VM index report, it records `lastToken` and returns that VM to poll cadence (default 4h). Central may NACK the report, for example while Scanner is still starting. `ProcessMessage` then clears `lastToken` and applies a short backoff so the next GetReport is a full pull, not an "unchanged" delta.

`Send` and `ProcessMessage` run on different goroutines. If the NACK arrives while `Send` is still in flight, the scrape goroutine used to write `lastToken` back and wipe backoff. The next poll asked with that token, the agent replied unchanged, and Central did not see the report again until the 4h mandatory refresh.

`commitVMState` now records the new token and applies poll-cadence scheduling only if `lastToken` and backoff still match the values snapped at scrape start. A NACK always clears the token and calls `nextBackoff`, so that scrape leaves the retry state alone.

When `lastToken` is already empty and backoff is already at the cap, `nextBackoff` is a no-op and the commit cannot see the NACK. That leftover is documented in `ACK_MODEL.md`. A per-NACK revision counter was considered and dropped. Resource IDs remain `vmID:vsockCID` and are not per-report, so a stale NACK can still match the latest scrape.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI

No cluster run. The race is exercised with synctest: Send is blocked until the NACK is applied, then the scrape is allowed to commit.

AI-Assisted: cursor, generated the CAS and tests, user chose lastToken-plus-backoff over a revision counter
