### PR TITLE
ROX-35685: add Sensor-side FetchRepo2CPE cache to scannerdefinitions.Handler

### DIFF
--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -1,16 +1,21 @@
 package scannerdefinitions
 
 import (
+	"context"
 	"crypto/x509"
 	"io"
 	"net/http"
 	"net/url"
 	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralclient"
@@ -18,6 +23,22 @@ import (
 )
 
 const scannerDefsPath = "/api/extensions/scannerdefinitions"
+
+const (
+	// repo2CPEFileParam matches sensorMappingsFile in compliance/node/index/indexer.go.
+	repo2CPEFileParam = "repo2cpe"
+
+	// repo2CPERefreshInterval is the steady-state cadence other repo2cpe consumers use.
+	repo2CPERefreshInterval = 4 * time.Hour
+	// repo2CPERetryInterval is short so a cold cache reaches its first success quickly.
+	repo2CPERetryInterval = time.Minute
+	repo2CPEFetchTimeout  = 30 * time.Second
+
+	etagHeader            = "ETag"
+	ifNoneMatchHeader     = "If-None-Match"
+	lastModifiedHeader    = "Last-Modified"
+	ifModifiedSinceHeader = "If-Modified-Since"
+)
 
 var (
 	headersToProxy = set.NewFrozenStringSet("If-Modified-Since", "Accept-Encoding")
@@ -29,6 +50,22 @@ var (
 type Handler struct {
 	centralClient    *http.Client
 	centralReachable atomic.Bool
+
+	refreshOnce sync.Once
+	cacheMu     sync.Mutex
+	cache       repo2CPECache
+}
+
+// repo2CPECache is Sensor's in-process copy of Central's repo-to-CPE mapping,
+// independent of ServeHTTP's per-request proxying, plus enough state to issue
+// a conditional GET and to tell "never fetched" apart from "stale".
+type repo2CPECache struct {
+	mapping      []byte
+	hash         string
+	etag         string
+	lastModified string
+	lastAttempt  time.Time
+	lastSuccess  time.Time
 }
 
 // NewDefinitionsHandler creates a new scanner definitions handler.
@@ -48,6 +85,7 @@ func (h *Handler) Notify(e common.SensorComponentEvent) {
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		h.centralReachable.Store(true)
+		h.startRepo2CPERefresh()
 	case common.SensorComponentEventOfflineMode:
 		h.centralReachable.Store(false)
 	}
@@ -101,5 +139,153 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		httputil.WriteGRPCStyleErrorf(writer, codes.Internal, "failed write response: %v", err)
 		return
+	}
+}
+
+// FetchRepo2CPE returns Sensor's cached repo-to-CPE mapping for in-process
+// callers such as vmscraper, starting the background refresh loop on first
+// call. ok is false only if Central has never been fetched successfully; a
+// copy served while central is unreachable is still ok, just possibly stale.
+func (h *Handler) FetchRepo2CPE(_ context.Context) (mapping []byte, hash string, ok bool) {
+	h.startRepo2CPERefresh()
+
+	return concurrency.WithLock3(&h.cacheMu, func() ([]byte, string, bool) {
+		if h.cache.lastSuccess.IsZero() {
+			return nil, "", false
+		}
+		if !h.centralReachable.Load() {
+			log.Info("Serving stale repo-to-CPE mapping: central is unreachable")
+		}
+		return h.cache.mapping, h.cache.hash, true
+	})
+}
+
+// startRepo2CPERefresh launches the background refresh loop exactly once,
+// however many times Notify or FetchRepo2CPE end up triggering it.
+func (h *Handler) startRepo2CPERefresh() {
+	h.refreshOnce.Do(func() {
+		go h.refreshRepo2CPELoop()
+	})
+}
+
+// refreshRepo2CPELoop refetches after repo2CPERefreshInterval on success, or
+// after repo2CPERetryInterval on failure or while offline, so a cold cache
+// doesn't wait hours for its first successful fetch.
+func (h *Handler) refreshRepo2CPELoop() {
+	for {
+		delay := repo2CPERetryInterval
+		if h.centralReachable.Load() {
+			ctx, cancel := context.WithTimeout(context.Background(), repo2CPEFetchTimeout)
+			ok := h.attemptRepo2CPERefresh(ctx)
+			cancel()
+			if ok {
+				delay = repo2CPERefreshInterval
+			}
+		}
+		time.Sleep(delay)
+	}
+}
+
+// attemptRepo2CPERefresh issues one conditional GET for the repo-to-CPE
+// mapping and updates the cache on success or "unchanged". It reports
+// whether the attempt succeeded, so the caller can pick the next delay.
+func (h *Handler) attemptRepo2CPERefresh(ctx context.Context) bool {
+	etag, lastModified := concurrency.WithLock2(&h.cacheMu, func() (string, string) {
+		return h.cache.etag, h.cache.lastModified
+	})
+
+	req, err := h.newRepo2CPERequest(ctx, etag, lastModified)
+	if err != nil {
+		log.Warnf("Failed to build repo-to-CPE mapping request: %v", err)
+		h.recordRepo2CPEAttempt(false)
+		return false
+	}
+
+	resp, err := h.centralClient.Do(req)
+	if err != nil {
+		log.Warnf("Failed to fetch repo-to-CPE mapping from central: %v", err)
+		h.recordRepo2CPEAttempt(false)
+		return false
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		h.recordRepo2CPEUnchanged(resp)
+		return true
+	case http.StatusOK:
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Warnf("Failed to read repo-to-CPE mapping response: %v", err)
+			h.recordRepo2CPEAttempt(false)
+			return false
+		}
+		h.recordRepo2CPESuccess(body, resp)
+		return true
+	default:
+		log.Warnf("Unexpected status %d fetching repo-to-CPE mapping from central", resp.StatusCode)
+		h.recordRepo2CPEAttempt(false)
+		return false
+	}
+}
+
+func (h *Handler) newRepo2CPERequest(ctx context.Context, etag, lastModified string) (*http.Request, error) {
+	centralURL := url.URL{
+		Path:     scannerDefsPath,
+		RawQuery: "file=" + repo2CPEFileParam,
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, centralURL.String(), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating request")
+	}
+	if etag != "" {
+		req.Header.Set(ifNoneMatchHeader, etag)
+	}
+	if lastModified != "" {
+		req.Header.Set(ifModifiedSinceHeader, lastModified)
+	}
+	return req, nil
+}
+
+func (h *Handler) recordRepo2CPEAttempt(success bool) {
+	concurrency.WithLock(&h.cacheMu, func() {
+		h.cache.lastAttempt = time.Now()
+		if success {
+			h.cache.lastSuccess = h.cache.lastAttempt
+		}
+	})
+}
+
+func (h *Handler) recordRepo2CPEUnchanged(resp *http.Response) {
+	concurrency.WithLock(&h.cacheMu, func() {
+		h.cache.lastAttempt = time.Now()
+		h.cache.lastSuccess = h.cache.lastAttempt
+		h.updateRepo2CPEValidatorsLocked(resp)
+	})
+}
+
+// recordRepo2CPESuccess keeps the existing cached bytes when the new content
+// hashes the same as what's cached, treating a same-hash 200 like a 304.
+func (h *Handler) recordRepo2CPESuccess(body []byte, resp *http.Response) {
+	hash := repositorytocpe.HashMapping(body)
+	concurrency.WithLock(&h.cacheMu, func() {
+		h.cache.lastAttempt = time.Now()
+		h.cache.lastSuccess = h.cache.lastAttempt
+		if hash != h.cache.hash {
+			h.cache.mapping = body
+			h.cache.hash = hash
+		}
+		h.updateRepo2CPEValidatorsLocked(resp)
+	})
+}
+
+// updateRepo2CPEValidatorsLocked refreshes the cached conditional-GET
+// validators from resp. Callers must hold h.cacheMu.
+func (h *Handler) updateRepo2CPEValidatorsLocked(resp *http.Response) {
+	if etag := resp.Header.Get(etagHeader); etag != "" {
+		h.cache.etag = etag
+	}
+	if lm := resp.Header.Get(lastModifiedHeader); lm != "" {
+		h.cache.lastModified = lm
 	}
 }

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralclient"
 	"google.golang.org/grpc/codes"
@@ -214,14 +214,14 @@ func (h *Handler) attemptRepo2CPERefresh(ctx context.Context) bool {
 		h.recordRepo2CPEUnchanged(resp)
 		return true
 	case http.StatusOK:
-		body, err := io.ReadAll(io.LimitReader(resp.Body, repositorytocpe.MaxMappingBytes+1))
+		body, err := io.ReadAll(io.LimitReader(resp.Body, cpemapping.MaxMappingBytes+1))
 		if err != nil {
 			log.Warnf("Failed to read repo-to-CPE mapping response: %v", err)
 			h.recordRepo2CPEAttempt(false)
 			return false
 		}
-		if len(body) > repositorytocpe.MaxMappingBytes {
-			log.Warnf("Repo-to-CPE mapping response exceeds %d bytes, rejecting", repositorytocpe.MaxMappingBytes)
+		if len(body) > cpemapping.MaxMappingBytes {
+			log.Warnf("Repo-to-CPE mapping response exceeds %d bytes, rejecting", cpemapping.MaxMappingBytes)
 			h.recordRepo2CPEAttempt(false)
 			return false
 		}
@@ -272,7 +272,7 @@ func (h *Handler) recordRepo2CPEUnchanged(resp *http.Response) {
 // recordRepo2CPESuccess keeps the existing cached bytes when the new content
 // hashes the same as what's cached, treating a same-hash 200 like a 304.
 func (h *Handler) recordRepo2CPESuccess(body []byte, resp *http.Response) {
-	hash := repositorytocpe.HashMapping(body)
+	hash := cpemapping.HashMapping(body)
 	concurrency.WithLock(&h.cacheMu, func() {
 		h.cache.lastAttempt = time.Now()
 		h.cache.lastSuccess = h.cache.lastAttempt

--- a/sensor/common/scannerdefinitions/http_handler.go
+++ b/sensor/common/scannerdefinitions/http_handler.go
@@ -214,9 +214,14 @@ func (h *Handler) attemptRepo2CPERefresh(ctx context.Context) bool {
 		h.recordRepo2CPEUnchanged(resp)
 		return true
 	case http.StatusOK:
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, repositorytocpe.MaxMappingBytes+1))
 		if err != nil {
 			log.Warnf("Failed to read repo-to-CPE mapping response: %v", err)
+			h.recordRepo2CPEAttempt(false)
+			return false
+		}
+		if len(body) > repositorytocpe.MaxMappingBytes {
+			log.Warnf("Repo-to-CPE mapping response exceeds %d bytes, rejecting", repositorytocpe.MaxMappingBytes)
 			h.recordRepo2CPEAttempt(false)
 			return false
 		}

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -218,6 +218,15 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 			wantMapping: mappingV1,
 			wantHash:    hashV1,
 		},
+		"an oversized response leaves the cache untouched": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(bytes.Repeat([]byte("a"), repositorytocpe.MaxMappingBytes+1))
+			},
+			wantOK:      false,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
 	}
 
 	for name, tt := range tests {

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/pkg/httputil"
-	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -153,8 +153,8 @@ func newTestCentralClient(t *testing.T, handler http.HandlerFunc) *http.Client {
 func TestAttemptRepo2CPERefresh(t *testing.T) {
 	const mappingV1 = `{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`
 	const mappingV2 = `{"data":{"bar":{"cpes":["cpe:/o:bar"]}}}`
-	hashV1 := repositorytocpe.HashMapping([]byte(mappingV1))
-	hashV2 := repositorytocpe.HashMapping([]byte(mappingV2))
+	hashV1 := cpemapping.HashMapping([]byte(mappingV1))
+	hashV2 := cpemapping.HashMapping([]byte(mappingV2))
 
 	tests := map[string]struct {
 		seedCache     repo2CPECache
@@ -221,7 +221,7 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 		"an oversized response leaves the cache untouched": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
 			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write(bytes.Repeat([]byte("a"), repositorytocpe.MaxMappingBytes+1))
+				_, _ = w.Write(bytes.Repeat([]byte("a"), cpemapping.MaxMappingBytes+1))
 			},
 			wantOK:      false,
 			wantMapping: mappingV1,
@@ -262,7 +262,7 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 // keeps serving the last good mapping and a later success can recover.
 func TestAttemptRepo2CPERefresh_RetryRecoversWithoutLosingCache(t *testing.T) {
 	const mapping = `{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`
-	hash := repositorytocpe.HashMapping([]byte(mapping))
+	hash := cpemapping.HashMapping([]byte(mapping))
 
 	var fail atomic.Bool
 	h := &Handler{centralClient: newTestCentralClient(t, func(w http.ResponseWriter, _ *http.Request) {
@@ -287,7 +287,7 @@ func TestAttemptRepo2CPERefresh_RetryRecoversWithoutLosingCache(t *testing.T) {
 
 func TestFetchRepo2CPE(t *testing.T) {
 	mapping := []byte(`{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`)
-	hash := repositorytocpe.HashMapping(mapping)
+	hash := cpemapping.HashMapping(mapping)
 
 	t.Run("never fetched returns ok=false", func(t *testing.T) {
 		h := &Handler{centralClient: &http.Client{}}

--- a/sensor/common/scannerdefinitions/http_handler_test.go
+++ b/sensor/common/scannerdefinitions/http_handler_test.go
@@ -2,14 +2,20 @@ package scannerdefinitions
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServeHTTP_Responses(t *testing.T) {
@@ -120,4 +126,180 @@ func TestServeHTTP_Responses(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newTestCentralClient spins up a real httptest.Server and returns a client
+// whose transport rewrites relative URLs to point at it, mirroring how the
+// production Central transport fills in scheme/host for requests built with
+// only a path (see newRepo2CPERequest).
+func newTestCentralClient(t *testing.T, handler http.HandlerFunc) *http.Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	base, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := server.Client()
+	client.Transport = httputil.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		req = req.Clone(req.Context())
+		req.URL.Scheme = base.Scheme
+		req.URL.Host = base.Host
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	return client
+}
+
+func TestAttemptRepo2CPERefresh(t *testing.T) {
+	const mappingV1 = `{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`
+	const mappingV2 = `{"data":{"bar":{"cpes":["cpe:/o:bar"]}}}`
+	hashV1 := repositorytocpe.HashMapping([]byte(mappingV1))
+	hashV2 := repositorytocpe.HashMapping([]byte(mappingV2))
+
+	tests := map[string]struct {
+		seedCache     repo2CPECache
+		serverHandler http.HandlerFunc
+		networkErr    bool
+		wantOK        bool
+		wantMapping   string
+		wantHash      string
+	}{
+		"first fetch succeeds and populates an empty cache": {
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, repo2CPEFileParam, r.URL.Query().Get("file"))
+				w.Header().Set(etagHeader, `"v1"`)
+				_, _ = w.Write([]byte(mappingV1))
+			},
+			wantOK:      true,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"304 with matching validators keeps the cached mapping": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, etag: `"v1"`},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, `"v1"`, r.Header.Get(ifNoneMatchHeader))
+				w.WriteHeader(http.StatusNotModified)
+			},
+			wantOK:      true,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"200 with a same-hash body is treated as unchanged": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(mappingV1))
+			},
+			wantOK:      true,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"200 with a different hash replaces the cached mapping": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(mappingV2))
+			},
+			wantOK:      true,
+			wantMapping: mappingV2,
+			wantHash:    hashV2,
+		},
+		"an unexpected status leaves the cache untouched": {
+			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantOK:      false,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+		"a network error leaves the cache untouched": {
+			seedCache:   repo2CPECache{mapping: []byte(mappingV1), hash: hashV1},
+			networkErr:  true,
+			wantOK:      false,
+			wantMapping: mappingV1,
+			wantHash:    hashV1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := &Handler{cache: tt.seedCache}
+			if tt.networkErr {
+				h.centralClient = &http.Client{
+					Transport: httputil.RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+						return nil, errors.New("connection refused")
+					}),
+				}
+			} else {
+				h.centralClient = newTestCentralClient(t, tt.serverHandler)
+			}
+
+			ok := h.attemptRepo2CPERefresh(context.Background())
+
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantMapping, string(h.cache.mapping))
+			assert.Equal(t, tt.wantHash, h.cache.hash)
+			assert.False(t, h.cache.lastAttempt.IsZero(), "lastAttempt should be recorded regardless of outcome")
+			if tt.wantOK {
+				assert.False(t, h.cache.lastSuccess.IsZero())
+			} else {
+				assert.True(t, h.cache.lastSuccess.IsZero())
+			}
+		})
+	}
+}
+
+// TestAttemptRepo2CPERefresh_RetryRecoversWithoutLosingCache calls the
+// refresh helper directly (no timers/sleeps) to verify a failed attempt
+// keeps serving the last good mapping and a later success can recover.
+func TestAttemptRepo2CPERefresh_RetryRecoversWithoutLosingCache(t *testing.T) {
+	const mapping = `{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`
+	hash := repositorytocpe.HashMapping([]byte(mapping))
+
+	var fail atomic.Bool
+	h := &Handler{centralClient: newTestCentralClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(mapping))
+	})}
+
+	require.True(t, h.attemptRepo2CPERefresh(context.Background()))
+	assert.Equal(t, hash, h.cache.hash)
+
+	fail.Store(true)
+	require.False(t, h.attemptRepo2CPERefresh(context.Background()))
+	assert.Equal(t, hash, h.cache.hash, "a failed refresh must not drop the last good mapping")
+
+	fail.Store(false)
+	require.True(t, h.attemptRepo2CPERefresh(context.Background()))
+	assert.Equal(t, hash, h.cache.hash)
+}
+
+func TestFetchRepo2CPE(t *testing.T) {
+	mapping := []byte(`{"data":{"foo":{"cpes":["cpe:/o:foo"]}}}`)
+	hash := repositorytocpe.HashMapping(mapping)
+
+	t.Run("never fetched returns ok=false", func(t *testing.T) {
+		h := &Handler{centralClient: &http.Client{}}
+		h.centralReachable.Store(false)
+
+		gotMapping, gotHash, ok := h.FetchRepo2CPE(context.Background())
+
+		assert.False(t, ok)
+		assert.Nil(t, gotMapping)
+		assert.Empty(t, gotHash)
+	})
+
+	t.Run("offline serves the last cached mapping with ok=true", func(t *testing.T) {
+		h := &Handler{centralClient: &http.Client{}}
+		h.cache = repo2CPECache{mapping: mapping, hash: hash, lastSuccess: time.Now()}
+		h.centralReachable.Store(false)
+
+		gotMapping, gotHash, ok := h.FetchRepo2CPE(context.Background())
+
+		assert.True(t, ok)
+		assert.Equal(t, mapping, gotMapping)
+		assert.Equal(t, hash, gotHash)
+	})
 }

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -93,6 +93,10 @@ type Sensor struct {
 	reconcile  atomic.Bool
 
 	clusterID clusterIDPeekSetter
+
+	// scannerDefsHandler is kept regardless of whether the HTTP route is
+	// registered, so VM-only clusters can inject it into vmscraper.
+	scannerDefsHandler *scannerdefinitions.Handler
 }
 
 // NewSensor initializes a Sensor, including reading configurations from the environment.
@@ -235,16 +239,23 @@ func (s *Sensor) Start() {
 		s.AddNotifiable(wrapNotifiable(koCacheSource, "Kernel object cache"))
 	}
 
-	// Enable endpoint to retrieve vulnerability definitions if local image scanning or Node Indexing is enabled.
-	// Node Indexing requires access to the repo to cpe mapping file hosted by central.
-	if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() {
-		route, err := s.newScannerDefinitionsRoute(s.centralEndpoint, centralCertificates)
+	// Construct the scanner definitions handler if local image scanning, Node Indexing, or VM
+	// scanning is enabled: all three need access to the repo-to-CPE mapping file hosted by
+	// central, whether through the HTTP route below or, for VM scanning, via FetchRepo2CPE.
+	if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() || features.VirtualMachines.Enabled() {
+		handler, err := scannerdefinitions.NewDefinitionsHandler(s.centralEndpoint, centralCertificates)
 		if err != nil {
-			utils.Should(errors.Wrap(err, "Failed to create scanner definition route"))
-		}
-		customRoutes = append(customRoutes, *route)
+			utils.Should(errors.Wrap(err, "Failed to create scanner definitions handler"))
+		} else {
+			s.scannerDefsHandler = handler
+			s.AddNotifiable(handler)
 
-		s.AddNotifiable(scannerclient.ResetNotifiable())
+			// The HTTP route itself is only needed by Scanner/Collector/node-index callers.
+			if env.LocalImageScanningEnabled.BooleanSetting() || features.NodeIndexEnabled.Enabled() {
+				customRoutes = append(customRoutes, s.newScannerDefinitionsRoute(handler))
+				s.AddNotifiable(scannerclient.ResetNotifiable())
+			}
+		}
 	}
 
 	// Enable proxy endpoint for forwarding requests to Central on OpenShift.
@@ -318,19 +329,14 @@ func (s *Sensor) Start() {
 }
 
 // newScannerDefinitionsRoute returns a custom route that serves scanner
-// definitions retrieved from Central.
-func (s *Sensor) newScannerDefinitionsRoute(centralEndpoint string, centralCertificates []*x509.Certificate) (*routes.CustomRoute, error) {
-	handler, err := scannerdefinitions.NewDefinitionsHandler(centralEndpoint, centralCertificates)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating scanner definitions handler")
-	}
-	s.AddNotifiable(handler)
+// definitions retrieved from Central via handler.
+func (s *Sensor) newScannerDefinitionsRoute(handler *scannerdefinitions.Handler) routes.CustomRoute {
 	// We rely on central to handle content encoding negotiation.
-	return &routes.CustomRoute{
+	return routes.CustomRoute{
 		Route:         scannerDefinitionsRoute,
 		Authorizer:    or.Or(idcheck.ScannerOnly(), idcheck.ScannerV4IndexerOnly(), idcheck.CollectorOnly()),
 		ServerHandler: handler,
-	}, nil
+	}
 }
 
 func (s *Sensor) registerSoftRestartHandler() {


### PR DESCRIPTION
ROX-35685: add Sensor-side FetchRepo2CPE cache to scannerdefinitions.Handler

Extends scannerdefinitions.Handler with an in-process, self-refreshing cache
of the repo-to-CPE mapping, exposed via FetchRepo2CPE for a later task's
vmscraper consumer. It reuses the existing Central client and reachability
flag rather than a new component; ServeHTTP's live-proxy behavior is
unchanged. The background refresh loop starts once (sync.Once, triggered by
Notify or FetchRepo2CPE), retries quickly on failure so a cold cache doesn't
wait 4 hours for its first fetch, and pauses while central is unreachable
instead of failing against a client it knows can't be reached.

Also widens sensor.go's scannerdefinitions.Handler construction gate to
include features.VirtualMachines.Enabled(), and stores the handler on
Sensor.scannerDefsHandler regardless of whether the HTTP route is
registered, so a VM-only cluster still gets a Handler instance for a later
task to inject into vmscraper.

Partially generated with AI assistance (Cursor).

Co-authored-by: Cursor <cursoragent@cursor.com>

ROX-35685: bound the repo-to-CPE mapping fetch response body

FetchRepo2CPE read Central's response with a plain io.ReadAll, the only
mapping-ingestion path in this feature without a size cap; every other
path enforces repositorytocpe.MaxMappingBytes (5 MiB). Wrap the read in
io.LimitReader(..., MaxMappingBytes+1) and reject anything over the cap
before it reaches the cache.

Found via CodeRabbit's automated review on the original, unsplit PR (#22097).

Co-authored-by: Cursor <cursoragent@cursor.com>

ROX-35685: import mapping helpers from pkg/virtualmachine/cpemapping

Point Sensor's FetchRepo2CPE size cap and hash at the package the
squash of #22140 actually landed.

Restack after merging https://github.com/stackrox/stackrox/pull/22140.

Partially generated by AI.

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
