### PR TITLE
ROX-36587: Make ReportsService consistent with NodeReportsService

### DIFF
--- a/ui/apps/platform/src/services/NodeReportsService.ts
+++ b/ui/apps/platform/src/services/NodeReportsService.ts
@@ -68,9 +68,7 @@ export function fetchNodeReportConfigurationsCount(
     return makeCancellableAxiosRequest((signal) =>
         axios
             .get<{ count: number }>(`/v2/reports/node/configuration-count?${params}`, { signal })
-            .then((response) => {
-                return response.data;
-            })
+            .then((response) => response.data)
     );
 }
 

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -169,6 +169,8 @@ export function runReportRequest(
         .then((response) => response.data);
 }
 
+// Job management
+
 // Promise because of TS2322 in ReportJobs component
 // DeleteReport
 export function deleteDownloadableReport(reportId: string): Promise<Empty> {
@@ -176,8 +178,6 @@ export function deleteDownloadableReport(reportId: string): Promise<Empty> {
         .delete<Empty>(`/v2/reports/jobs/${reportId}/delete`)
         .then((response) => response.data);
 }
-
-// Job management
 
 // View-based jobs
 

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -6,7 +6,7 @@ import {
 } from 'services/ReportsService.types';
 import type {
     ConfiguredReportSnapshot,
-    ReportConfiguration,
+    ImageVulnerabilityReportConfiguration,
     ReportHistoryResponse,
     ReportRequestViewBased,
     RunReportResponse,
@@ -15,17 +15,45 @@ import type {
 } from 'services/ReportsService.types';
 import type { ApiSortOption, SearchFilter } from 'types/search';
 import { buildNestedRawQueryParams, getPaginationParams } from 'utils/searchUtils';
-import type { ReportNotificationMethod, ReportStatus } from 'types/reportJob';
+import type { ReportNotificationMethod } from 'types/reportJob';
 import { sanitizeFilename } from 'utils/fileUtils';
 
 import axios from './instance';
+import { makeCancellableAxiosRequest } from './cancellationUtils';
+import type { CancellableRequest } from './cancellationUtils';
 import type { Empty } from './types';
 import { saveFile } from './DownloadService';
 
 // The following functions are built around the new VM Reporting Enhancements
 export const reportDownloadURL = '/api/reports/jobs/download';
 
-// @TODO: Same logic is used in fetchReportConfigurations. Maybe consider something more DRY
+// https://github.com/stackrox/stackrox/blob/master/proto/api/v2/report_service.proto
+
+// Configuration of scheduled reports
+
+// Promise because of TS2339 in ImageVulnerabilityReportWizard component
+// PostReportConfiguration
+export function createReportConfiguration(
+    configuration: ImageVulnerabilityReportConfiguration
+): Promise<ImageVulnerabilityReportConfiguration> {
+    return axios
+        .post<ImageVulnerabilityReportConfiguration>('/v2/reports/configurations', configuration)
+        .then((response) => response.data);
+}
+
+// Promise because of TS2339 in ImageVulnerabilityReportWizard component
+// UpdateReportConfiguration
+export function updateReportConfiguration(
+    reportId: string,
+    configuration: ImageVulnerabilityReportConfiguration
+): Promise<Empty> {
+    return axios
+        .put<Empty>(`/v2/reports/configurations/${reportId}`, configuration)
+        .then((response) => response.data);
+}
+
+// Promise because of @typescript-eslint/await-thenable in useFetchReports hook
+// CountReportConfigurations
 export function fetchReportConfigurationsCount({
     query,
 }: {
@@ -39,11 +67,11 @@ export function fetchReportConfigurationsCount({
     );
     return axios
         .get<{ count: number }>(`/v2/reports/configuration-count?${params}`)
-        .then((response) => {
-            return response.data;
-        });
+        .then((response) => response.data);
 }
 
+// Promise because of @typescript-eslint/await-thenable in useFetchReports hook
+// ListReportConfigurations
 export function fetchReportConfigurations({
     query,
     page,
@@ -54,7 +82,7 @@ export function fetchReportConfigurations({
     page: number;
     perPage: number;
     sortOption: ApiSortOption;
-}): Promise<ReportConfiguration[]> {
+}): Promise<ImageVulnerabilityReportConfiguration[]> {
     const params = queryString.stringify(
         {
             query,
@@ -63,35 +91,31 @@ export function fetchReportConfigurations({
         { arrayFormat: 'repeat', allowDots: true }
     );
     return axios
-        .get<{ reportConfigs: ReportConfiguration[] }>(`/v2/reports/configurations?${params}`)
-        .then((response) => {
-            return response?.data?.reportConfigs ?? [];
-        });
+        .get<{
+            reportConfigs: ImageVulnerabilityReportConfiguration[];
+        }>(`/v2/reports/configurations?${params}`)
+        .then((response) => response?.data?.reportConfigs ?? []);
 }
 
-export function fetchReportConfiguration(reportId: string): Promise<ReportConfiguration> {
+// Promise because of @typescript-eslint/await-thenable in useFetchReport hook
+// GetReportConfiguration
+export function fetchReportConfiguration(
+    reportId: string
+): Promise<ImageVulnerabilityReportConfiguration> {
     return axios
-        .get<ReportConfiguration>(`/v2/reports/configurations/${reportId}`)
-        .then((response) => {
-            return response.data;
-        });
+        .get<ImageVulnerabilityReportConfiguration>(`/v2/reports/configurations/${reportId}`)
+        .then((response) => response.data);
 }
 
-export function fetchReportStatus(id: string): Promise<ReportStatus | null> {
+// Promise because of @typescript-eslint/await-thenable in useDeleteModal hook
+// DeleteReportConfiguration
+export function deleteReportConfiguration(reportId: string): Promise<Empty> {
     return axios
-        .get<{ status: ReportStatus | null }>(`/v2/reports/jobs/${id}/status`)
-        .then((response) => {
-            return response.data?.status;
-        });
+        .delete<Empty>(`/v2/reports/configurations/${reportId}`)
+        .then((response) => response.data);
 }
 
-export function fetchReportLastRunStatus(id: string): Promise<ReportStatus | null> {
-    return axios
-        .get<{ status: ReportStatus | null }>(`/v2/reports/last-status/${id}`)
-        .then((response) => {
-            return response.data?.status;
-        });
-}
+// Configuration-based jobs
 
 export type FetchReportHistoryServiceParams = {
     id: string;
@@ -102,6 +126,8 @@ export type FetchReportHistoryServiceParams = {
     showMyHistory: boolean;
 };
 
+// Promise because of @typescript-eslint/await-thenable in useWatchLastSnapshotForReports hook
+// GetReportHistory and GetMyReportHistory
 export function fetchReportHistory({
     id,
     query,
@@ -119,73 +145,17 @@ export function fetchReportHistory({
         },
         { arrayFormat: 'repeat', allowDots: true }
     );
+    const history = showMyHistory ? 'my-history' : 'history';
     return axios
-        .get<ReportHistoryResponse>(
-            `/v2/reports/configurations/${id}/${showMyHistory ? 'my-history' : 'history'}?${params}`
-        )
+        .get<ReportHistoryResponse>(`/v2/reports/configurations/${id}/${history}?${params}`)
         .then((response) => {
             const snapshots = response.data?.reportSnapshots ?? [];
             return snapshots.filter(isConfiguredReportSnapshot);
         });
 }
 
-export type FetchViewBasedReportHistoryServiceParams = {
-    searchFilter: SearchFilter;
-    page: number;
-    perPage: number;
-    sortOption: ApiSortOption;
-    showMyHistory: boolean;
-};
-
-export function fetchViewBasedReportHistory({
-    searchFilter,
-    page,
-    perPage,
-    sortOption,
-    showMyHistory,
-}: FetchViewBasedReportHistoryServiceParams): Promise<ViewBasedReportSnapshot[]> {
-    const params = buildNestedRawQueryParams(
-        { searchFilter, page, perPage, sortOption },
-        'reportParamQuery'
-    );
-
-    const endpoint = showMyHistory
-        ? '/v2/reports/view-based/my-history'
-        : '/v2/reports/view-based/history';
-
-    return axios.get<ReportHistoryResponse>(`${endpoint}?${params}`).then((response) => {
-        const snapshots = response.data?.reportSnapshots ?? [];
-        return snapshots.filter(isViewBasedReportSnapshot);
-    });
-}
-
-export function createReportConfiguration(
-    report: ReportConfiguration
-): Promise<ReportConfiguration> {
-    return axios
-        .post<ReportConfiguration>('/v2/reports/configurations', report)
-        .then((response) => {
-            return response.data;
-        });
-}
-
-export function updateReportConfiguration(
-    reportId: string,
-    report: ReportConfiguration
-): Promise<ReportConfiguration> {
-    return axios
-        .put<ReportConfiguration>(`/v2/reports/configurations/${reportId}`, report)
-        .then((response) => {
-            return response.data;
-        });
-}
-
-export function deleteReportConfiguration(reportId: string): Promise<Empty> {
-    return axios.delete<Empty>(`/v2/reports/configurations/${reportId}`).then((response) => {
-        return response.data;
-    });
-}
-
+// Promise because of TS2339 in useRunReport hook
+// RunReport
 // @TODO: Rename this to runReport when we remove the old report code
 export function runReportRequest(
     reportConfigId: string,
@@ -196,23 +166,55 @@ export function runReportRequest(
             reportConfigId,
             reportNotificationMethod,
         })
-        .then((response) => {
-            return response.data;
-        });
+        .then((response) => response.data);
 }
 
-export function downloadReport(reportId: string) {
-    return axios.get<string>(`/v2/reports/jobs/${reportId}/download`).then((response) => {
-        return response.data;
-    });
+// Promise because of TS2322 in ReportJobs component
+// DeleteReport
+export function deleteDownloadableReport(reportId: string): Promise<Empty> {
+    return axios
+        .delete<Empty>(`/v2/reports/jobs/${reportId}/delete`)
+        .then((response) => response.data);
 }
 
-export function deleteDownloadableReport(reportId: string) {
-    return axios.delete<Empty>(`/v2/reports/jobs/${reportId}/delete`).then((response) => {
-        return response.data;
-    });
+// Job management
+
+// View-based jobs
+
+export type FetchViewBasedReportHistoryServiceParams = {
+    searchFilter: SearchFilter;
+    page: number;
+    perPage: number;
+    sortOption: ApiSortOption;
+    showMyHistory: boolean;
+};
+
+// GetViewBasedMyReportHistory and GetViewBasedReportHistory
+export function fetchViewBasedReportHistory({
+    searchFilter,
+    page,
+    perPage,
+    sortOption,
+    showMyHistory,
+}: FetchViewBasedReportHistoryServiceParams): CancellableRequest<ViewBasedReportSnapshot[]> {
+    const params = buildNestedRawQueryParams(
+        { searchFilter, page, perPage, sortOption },
+        'reportParamQuery'
+    );
+
+    const endpoint = showMyHistory
+        ? '/v2/reports/view-based/my-history'
+        : '/v2/reports/view-based/history';
+
+    return makeCancellableAxiosRequest((signal) =>
+        axios.get<ReportHistoryResponse>(`${endpoint}?${params}`, { signal }).then((response) => {
+            const snapshots = response.data?.reportSnapshots ?? [];
+            return snapshots.filter(isViewBasedReportSnapshot);
+        })
+    );
 }
 
+// PostViewBasedReport
 export function runViewBasedReport({
     query,
     areaOfConcern,
@@ -232,6 +234,8 @@ export function runViewBasedReport({
         .post<RunReportResponseViewBased>('/v2/reports/view-based/run', requestBody)
         .then((response) => response.data);
 }
+
+// Job download
 
 /**
  * Downloads a report file by job ID and saves it to the user's device with a sanitized filename


### PR DESCRIPTION
## Description

**Review**: hide space for indentation changes

**Brad**: Some occurrences of `CancellableRequest` in NodeReportsService.ts file might have erros if I imitate existing wizard code. We might discuss on Thursday or Monday.

### Objective

Follow pattern in image and node vulnerability reports.

### Changes

1. Delete obsolete service functions. Leftovers from `v1` API maybe?

2. Replace `ReportConfiguration` with `ImageVulnerabilityReportConfiguration` type.

3. Replace `report` with `configuration` ass argument name.

4. Simplify `then` clause with `(response) => response.data` when possible.

5. Move some functions to more closely follow order in proto file.

### Residue

1. Investigate `searchFilter` versus `query` as argument to use `SearchQueryOptions` type and `getListQueryParams` function.

.2 Investigate pro and con of `Promise` versus `CancellableRequest` idiom.

3. Rename `RunReportRequest` function without misleaing **Request** infix.

4. Rename functions to include **Image** infix?

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.

