### PR TITLE
ROX-32849: Map discovered VM data in Sensor

### DIFF
--- a/central/convert/internaltostorage/virtual_machine_v2_test.go
+++ b/central/convert/internaltostorage/virtual_machine_v2_test.go
@@ -49,6 +49,34 @@ func TestVirtualMachineV2(t *testing.T) {
 			},
 		},
 		{
+			name: "copies agent facts and keeps informer GuestOs column",
+			input: &virtualMachineV1.VirtualMachine{
+				Id:        "VM-ID-3",
+				Namespace: "ns",
+				Name:      "vm-agent-facts",
+				ClusterId: uuid.NewTestUUID(3).String(),
+				Facts: map[string]string{
+					pkgVM.GuestOSKey:         "Red Hat Enterprise Linux",
+					pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
+					pkgVM.AgentVersionKey:    "4.10.0",
+				},
+				State: virtualMachineV1.VirtualMachine_RUNNING,
+			},
+			expected: &storage.VirtualMachineV2{
+				Id:        "VM-ID-3",
+				Namespace: "ns",
+				Name:      "vm-agent-facts",
+				ClusterId: uuid.NewTestUUID(3).String(),
+				Facts: map[string]string{
+					pkgVM.GuestOSKey:         "Red Hat Enterprise Linux",
+					pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
+					pkgVM.AgentVersionKey:    "4.10.0",
+				},
+				GuestOs: "Red Hat Enterprise Linux",
+				State:   storage.VirtualMachineV2_RUNNING,
+			},
+		},
+		{
 			name: "virtual machine without guestOS fact",
 			input: &virtualMachineV1.VirtualMachine{
 				Id:        "VM-ID-2",

--- a/pkg/virtualmachine/facts.go
+++ b/pkg/virtualmachine/facts.go
@@ -10,7 +10,20 @@ const (
 	NodeNameKey    = "nodeName"
 	BootOrderKey   = "bootOrder"
 	CDRomDisksKey  = "cdRomDisks"
+	// DetectedGuestOSKey is the guest OS reported by roxagent, kept separate
+	// from GuestOSKey so KubeVirt informer data is not overwritten.
+	DetectedGuestOSKey = "detectedGuestOS"
+	// ActivationStatusKey is whether the guest OS is activated.
+	ActivationStatusKey = "activationStatus"
+	// DNFMetadataStatusKey is whether DNF metadata is available on the guest.
+	DNFMetadataStatusKey = "dnfMetadataStatus"
 	// UnknownGuestOS is the user-facing default value for GuestOSKey when the
 	// guest OS has not been reported by the virtual machine instance.
 	UnknownGuestOS = "unknown"
+	// User-facing values for roxagent-derived facts. Unspecified proto enum
+	// values are omitted rather than stored as raw proto names.
+	ActivationStatusActive       = "active"
+	ActivationStatusInactive     = "inactive"
+	DNFMetadataStatusAvailable   = "available"
+	DNFMetadataStatusUnavailable = "unavailable"
 )

--- a/pkg/virtualmachine/facts.go
+++ b/pkg/virtualmachine/facts.go
@@ -13,6 +13,8 @@ const (
 	// DetectedGuestOSKey is the guest OS reported by roxagent, kept separate
 	// from GuestOSKey so KubeVirt informer data is not overwritten.
 	DetectedGuestOSKey = "detectedGuestOS"
+	// AgentVersionKey is the roxagent version from ResponseMeta.AgentVersion.
+	AgentVersionKey = "agentVersion"
 	// ActivationStatusKey is whether the guest OS is activated.
 	ActivationStatusKey = "activationStatus"
 	// DNFMetadataStatusKey is whether DNF metadata is available on the guest.

--- a/sensor/common/virtualmachine/facts.go
+++ b/sensor/common/virtualmachine/facts.go
@@ -93,6 +93,20 @@ func AgentFactsFromResponseFacts(facts map[string]string) map[string]string {
 	return out
 }
 
+// AgentFactsFromResponse merges ResponseMeta.facts with AgentVersion. Version
+// is a sibling proto field, not a fact key, so it is attached here.
+func AgentFactsFromResponse(facts map[string]string, agentVersion string) map[string]string {
+	out := AgentFactsFromResponseFacts(facts)
+	if agentVersion == "" {
+		return out
+	}
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out[pkgVM.AgentVersionKey] = agentVersion
+	return out
+}
+
 // State is RUNNING when the VM instance is up, otherwise STOPPED.
 func State(vm *Info) v1.VirtualMachine_State {
 	if vm == nil {

--- a/sensor/common/virtualmachine/facts.go
+++ b/sensor/common/virtualmachine/facts.go
@@ -8,6 +8,16 @@ import (
 	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 )
 
+const rhelGuestOS = "Red Hat Enterprise Linux"
+
+// ResponseMeta.facts keys written by roxagent (proto enum String() values).
+const (
+	responseDetectedOSKey        = "detected_os"
+	responseOSVersionKey         = "os_version"
+	responseActivationStatusKey  = "activation_status"
+	responseDNFMetadataStatusKey = "dnf_metadata_status"
+)
+
 // Facts builds the VM facts map sent to Central.
 func Facts(vm *Info) map[string]string {
 	if vm == nil {
@@ -38,7 +48,49 @@ func Facts(vm *Info) map[string]string {
 	if len(vm.CDRomDisks) > 0 {
 		facts[pkgVM.CDRomDisksKey] = strings.Join(vm.CDRomDisks, ", ")
 	}
+	// GuestOSKey is informer-owned; roxagent reports DetectedGuestOSKey instead.
+	for k, v := range vm.AgentFacts {
+		if k == pkgVM.GuestOSKey {
+			continue
+		}
+		facts[k] = v
+	}
 	return facts
+}
+
+// AgentFactsFromResponseFacts maps roxagent ResponseMeta.facts to user-facing
+// fact keys. Unrecognized or unspecified enum strings are omitted so Sensor
+// does not surface raw proto names in the UI.
+func AgentFactsFromResponseFacts(facts map[string]string) map[string]string {
+	if len(facts) == 0 {
+		return nil
+	}
+
+	out := map[string]string{}
+	switch facts[responseDetectedOSKey] {
+	case v1.DetectedOS_RHEL.String():
+		guestOS := rhelGuestOS
+		if osVersion := facts[responseOSVersionKey]; osVersion != "" {
+			guestOS += " " + osVersion
+		}
+		out[pkgVM.DetectedGuestOSKey] = guestOS
+	}
+	switch facts[responseActivationStatusKey] {
+	case v1.ActivationStatus_ACTIVE.String():
+		out[pkgVM.ActivationStatusKey] = pkgVM.ActivationStatusActive
+	case v1.ActivationStatus_INACTIVE.String():
+		out[pkgVM.ActivationStatusKey] = pkgVM.ActivationStatusInactive
+	}
+	switch facts[responseDNFMetadataStatusKey] {
+	case v1.DnfMetadataStatus_AVAILABLE.String():
+		out[pkgVM.DNFMetadataStatusKey] = pkgVM.DNFMetadataStatusAvailable
+	case v1.DnfMetadataStatus_UNAVAILABLE.String():
+		out[pkgVM.DNFMetadataStatusKey] = pkgVM.DNFMetadataStatusUnavailable
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // State is RUNNING when the VM instance is up, otherwise STOPPED.

--- a/sensor/common/virtualmachine/facts_test.go
+++ b/sensor/common/virtualmachine/facts_test.go
@@ -65,15 +65,6 @@ func TestFacts(t *testing.T) {
 				pkgVM.DetectedGuestOSKey:  "Red Hat Enterprise Linux 9.2",
 			},
 		},
-		"nil AgentFacts does not affect result": {
-			input: &Info{
-				GuestOS:    "Fedora",
-				AgentFacts: nil,
-			},
-			expected: map[string]string{
-				pkgVM.GuestOSKey: "Fedora",
-			},
-		},
 		"AgentFacts do not overwrite informer guestOS": {
 			input: &Info{
 				GuestOS: "from-informer",
@@ -101,14 +92,6 @@ func TestAgentFactsFromResponseFacts(t *testing.T) {
 		input    map[string]string
 		expected map[string]string
 	}{
-		"nil map returns nil": {
-			input:    nil,
-			expected: nil,
-		},
-		"empty map returns nil": {
-			input:    map[string]string{},
-			expected: nil,
-		},
 		"RHEL with version and statuses": {
 			input: map[string]string{
 				"detected_os":         v1.DetectedOS_RHEL.String(),
@@ -122,14 +105,6 @@ func TestAgentFactsFromResponseFacts(t *testing.T) {
 				pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusUnavailable,
 			},
 		},
-		"RHEL without version": {
-			input: map[string]string{
-				"detected_os": v1.DetectedOS_RHEL.String(),
-			},
-			expected: map[string]string{
-				pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux",
-			},
-		},
 		"unspecified enums are omitted": {
 			input: map[string]string{
 				"detected_os":         v1.DetectedOS_UNKNOWN.String(),
@@ -137,16 +112,6 @@ func TestAgentFactsFromResponseFacts(t *testing.T) {
 				"dnf_metadata_status": v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED.String(),
 			},
 			expected: nil,
-		},
-		"active and available": {
-			input: map[string]string{
-				"activation_status":   v1.ActivationStatus_ACTIVE.String(),
-				"dnf_metadata_status": v1.DnfMetadataStatus_AVAILABLE.String(),
-			},
-			expected: map[string]string{
-				pkgVM.ActivationStatusKey:  pkgVM.ActivationStatusActive,
-				pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusAvailable,
-			},
 		},
 	}
 

--- a/sensor/common/virtualmachine/facts_test.go
+++ b/sensor/common/virtualmachine/facts_test.go
@@ -122,6 +122,50 @@ func TestAgentFactsFromResponseFacts(t *testing.T) {
 	}
 }
 
+func TestAgentFactsFromResponse(t *testing.T) {
+	cases := map[string]struct {
+		facts        map[string]string
+		agentVersion string
+		expected     map[string]string
+	}{
+		"attaches agent version to mapped facts": {
+			facts: map[string]string{
+				"detected_os":       v1.DetectedOS_RHEL.String(),
+				"os_version":        "9.2",
+				"activation_status": v1.ActivationStatus_ACTIVE.String(),
+			},
+			agentVersion: "4.10.0",
+			expected: map[string]string{
+				pkgVM.DetectedGuestOSKey:  "Red Hat Enterprise Linux 9.2",
+				pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+				pkgVM.AgentVersionKey:     "4.10.0",
+			},
+		},
+		"version only when facts do not map": {
+			facts:        map[string]string{"detected_os": v1.DetectedOS_UNKNOWN.String()},
+			agentVersion: "4.10.0",
+			expected:     map[string]string{pkgVM.AgentVersionKey: "4.10.0"},
+		},
+		"omits empty agent version": {
+			facts: map[string]string{
+				"activation_status": v1.ActivationStatus_ACTIVE.String(),
+			},
+			expected: map[string]string{
+				pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+			},
+		},
+		"empty facts and empty version": {
+			expected: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, AgentFactsFromResponse(tc.facts, tc.agentVersion))
+		})
+	}
+}
+
 func TestState(t *testing.T) {
 	cases := map[string]struct {
 		input    *Info

--- a/sensor/common/virtualmachine/facts_test.go
+++ b/sensor/common/virtualmachine/facts_test.go
@@ -51,11 +51,108 @@ func TestFacts(t *testing.T) {
 				pkgVM.CDRomDisksKey:  "cdrom0",
 			},
 		},
+		"AgentFacts are merged into result": {
+			input: &Info{
+				GuestOS: "RHEL 9",
+				AgentFacts: map[string]string{
+					pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+					pkgVM.DetectedGuestOSKey:  "Red Hat Enterprise Linux 9.2",
+				},
+			},
+			expected: map[string]string{
+				pkgVM.GuestOSKey:          "RHEL 9",
+				pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+				pkgVM.DetectedGuestOSKey:  "Red Hat Enterprise Linux 9.2",
+			},
+		},
+		"nil AgentFacts does not affect result": {
+			input: &Info{
+				GuestOS:    "Fedora",
+				AgentFacts: nil,
+			},
+			expected: map[string]string{
+				pkgVM.GuestOSKey: "Fedora",
+			},
+		},
+		"AgentFacts do not overwrite informer guestOS": {
+			input: &Info{
+				GuestOS: "from-informer",
+				AgentFacts: map[string]string{
+					pkgVM.GuestOSKey:          "from-agent",
+					pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+				},
+			},
+			expected: map[string]string{
+				pkgVM.GuestOSKey:          "from-informer",
+				pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, Facts(tc.input))
+		})
+	}
+}
+
+func TestAgentFactsFromResponseFacts(t *testing.T) {
+	cases := map[string]struct {
+		input    map[string]string
+		expected map[string]string
+	}{
+		"nil map returns nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty map returns nil": {
+			input:    map[string]string{},
+			expected: nil,
+		},
+		"RHEL with version and statuses": {
+			input: map[string]string{
+				"detected_os":         v1.DetectedOS_RHEL.String(),
+				"os_version":          "9.2",
+				"activation_status":   v1.ActivationStatus_INACTIVE.String(),
+				"dnf_metadata_status": v1.DnfMetadataStatus_UNAVAILABLE.String(),
+			},
+			expected: map[string]string{
+				pkgVM.DetectedGuestOSKey:   "Red Hat Enterprise Linux 9.2",
+				pkgVM.ActivationStatusKey:  pkgVM.ActivationStatusInactive,
+				pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusUnavailable,
+			},
+		},
+		"RHEL without version": {
+			input: map[string]string{
+				"detected_os": v1.DetectedOS_RHEL.String(),
+			},
+			expected: map[string]string{
+				pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux",
+			},
+		},
+		"unspecified enums are omitted": {
+			input: map[string]string{
+				"detected_os":         v1.DetectedOS_UNKNOWN.String(),
+				"activation_status":   v1.ActivationStatus_ACTIVATION_UNSPECIFIED.String(),
+				"dnf_metadata_status": v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED.String(),
+			},
+			expected: nil,
+		},
+		"active and available": {
+			input: map[string]string{
+				"activation_status":   v1.ActivationStatus_ACTIVE.String(),
+				"dnf_metadata_status": v1.DnfMetadataStatus_AVAILABLE.String(),
+			},
+			expected: map[string]string{
+				pkgVM.ActivationStatusKey:  pkgVM.ActivationStatusActive,
+				pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusAvailable,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, AgentFactsFromResponseFacts(tc.input))
 		})
 	}
 }
@@ -132,12 +229,13 @@ func TestSensorEvent(t *testing.T) {
 
 	t.Run("running VM with VSOCK CID", func(t *testing.T) {
 		event := SensorEvent(central.ResourceAction_UPDATE_RESOURCE, "cluster-1", &Info{
-			ID:        "vm-1",
-			Name:      "rhel9",
-			Namespace: "ns",
-			Running:   true,
-			VSOCKCID:  new(uint32(7)),
-			GuestOS:   "Red Hat Enterprise Linux 9",
+			ID:         "vm-1",
+			Name:       "rhel9",
+			Namespace:  "ns",
+			Running:    true,
+			VSOCKCID:   new(uint32(7)),
+			GuestOS:    "Red Hat Enterprise Linux 9",
+			AgentFacts: map[string]string{pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive},
 		})
 		assert.Equal(t, "vm-1", event.GetId())
 		assert.Equal(t, central.ResourceAction_UPDATE_RESOURCE, event.GetAction())
@@ -147,7 +245,8 @@ func TestSensorEvent(t *testing.T) {
 		assert.True(t, vm.GetVsockCidSet())
 		assert.Equal(t, v1.VirtualMachine_RUNNING, vm.GetState())
 		assert.Equal(t, map[string]string{
-			pkgVM.GuestOSKey: "Red Hat Enterprise Linux 9",
+			pkgVM.GuestOSKey:          "Red Hat Enterprise Linux 9",
+			pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
 		}, vm.GetFacts())
 	})
 

--- a/sensor/common/virtualmachine/virtualmachineinfo.go
+++ b/sensor/common/virtualmachine/virtualmachineinfo.go
@@ -1,5 +1,7 @@
 package virtualmachine
 
+import "maps"
+
 type VMID string
 
 // Info information about a VirtualMachine
@@ -22,6 +24,8 @@ type Info struct {
 	BootOrder []string
 	// CDRomDisks lists disk names with CD-ROM devices.
 	CDRomDisks []string
+	// AgentFacts are roxagent-derived facts merged into the VM facts map.
+	AgentFacts map[string]string
 }
 
 // Key returns the identifier ("namespace/name") used to correlate this VM
@@ -60,6 +64,9 @@ func (v *Info) Copy() *Info {
 	}
 	if len(v.CDRomDisks) > 0 {
 		ret.CDRomDisks = append([]string(nil), v.CDRomDisks...)
+	}
+	if v.AgentFacts != nil {
+		ret.AgentFacts = maps.Clone(v.AgentFacts)
 	}
 	return ret
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -501,7 +501,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	}
 
 	if result.Unchanged {
-		s.forwardAgentFactsIfChanged(ctx, vm, result.Meta.GetFacts())
+		s.forwardAgentFactsIfChanged(ctx, vm, result.Meta)
 		next := s.scheduleAfterAttempt(key, vm.ID, scrapeOK)
 		log.Infof("VMScraper: scrape %q ok outcome=unchanged next=%s", key, next)
 		log.Debugf("VMScraper: unchanged report from roxagent on %q (token=%s)", key, snap.lastToken)
@@ -524,7 +524,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 	logAndRecordDiscoveredFacts(key, result.Meta.GetFacts())
-	s.persistAgentFacts(vm, result.Meta.GetFacts())
+	s.persistAgentFacts(vm, result.Meta)
 
 	// Mapping sync has its own deadline, so forward uses the scrape parent.
 	if err := s.forwardReport(ctx, vm, result.IndexReport); err != nil {
@@ -969,8 +969,8 @@ func (s *VMScraper) tryEnqueueVMUpdate(vm *virtualmachine.Info) {
 	}
 }
 
-func (s *VMScraper) persistAgentFacts(vm *virtualmachine.Info, facts map[string]string) {
-	mapped, ok := snapshotAgentFacts(facts)
+func (s *VMScraper) persistAgentFacts(vm *virtualmachine.Info, meta *pb.ResponseMeta) {
+	mapped, ok := snapshotAgentFacts(meta)
 	if !ok {
 		return
 	}
@@ -980,25 +980,25 @@ func (s *VMScraper) persistAgentFacts(vm *virtualmachine.Info, facts map[string]
 	s.store.AddOrUpdate(vm.Copy())
 }
 
-// snapshotAgentFacts maps ResponseMeta.facts. ok is false when nothing maps,
-// so stored values stay as they are.
-func snapshotAgentFacts(facts map[string]string) (mapped map[string]string, ok bool) {
-	if len(facts) == 0 {
+// snapshotAgentFacts maps ResponseMeta onto AgentFacts. ok is false when
+// nothing maps, so stored values stay as they are.
+func snapshotAgentFacts(meta *pb.ResponseMeta) (mapped map[string]string, ok bool) {
+	if meta == nil {
 		return nil, false
 	}
-	mapped = virtualmachine.AgentFactsFromResponseFacts(facts)
+	mapped = virtualmachine.AgentFactsFromResponse(meta.GetFacts(), meta.GetAgentVersion())
 	return mapped, len(mapped) > 0
 }
 
 // forwardAgentFactsIfChanged emits a VM update when roxagent facts changed
 // even if the index report is unchanged. The store is updated only after
 // enqueue succeeds so a failed send is retried on the next unchanged scrape.
-func (s *VMScraper) forwardAgentFactsIfChanged(ctx context.Context, vm *virtualmachine.Info, facts map[string]string) {
-	mapped, ok := snapshotAgentFacts(facts)
+func (s *VMScraper) forwardAgentFactsIfChanged(ctx context.Context, vm *virtualmachine.Info, meta *pb.ResponseMeta) {
+	mapped, ok := snapshotAgentFacts(meta)
 	if !ok {
 		return
 	}
-	logAndRecordDiscoveredFacts(vm.Key(), facts)
+	logAndRecordDiscoveredFacts(vm.Key(), meta.GetFacts())
 	var prevFacts map[string]string
 	if prev := s.store.Get(vm.ID); prev != nil {
 		prevFacts = prev.AgentFacts

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -64,6 +65,7 @@ func clampPollInterval(interval time.Duration) time.Duration {
 type RunningVMStore interface {
 	ListRunning() []*virtualmachine.Info
 	Get(id virtualmachine.VMID) *virtualmachine.Info
+	AddOrUpdate(vm *virtualmachine.Info) *virtualmachine.Info
 }
 
 // VMDialer connects to a VM's VSOCK port.
@@ -83,6 +85,10 @@ type Repo2CPEFetcher interface {
 	FetchRepo2CPE(ctx context.Context) (mapping []byte, hash string, ok bool)
 }
 
+type clusterIDGetter interface {
+	GetNoWait() string
+}
+
 // closeCoder is satisfied by transport errors carrying a structured close
 // code. Declared locally so VMScraper doesn't need to import a concrete
 // dialer's error type to recognize one.
@@ -97,6 +103,7 @@ type VMScraper struct {
 	dialer                VMDialer
 	client                ProtocolClient
 	repo2CPEFetcher       Repo2CPEFetcher
+	clusterID             clusterIDGetter
 	toCentral             chan *message.ExpiringMessage
 	centralReady          concurrency.Signal
 	interval              time.Duration
@@ -138,13 +145,14 @@ var _ common.SensorComponent = (*VMScraper)(nil)
 
 // New creates a VMScraper with production defaults. A nil repo2CPEFetcher leaves
 // maybeSyncRepoCPEMapping a no-op, so pull still works if the repo-to-CPE cache was not built.
-func New(store RunningVMStore, dialer VMDialer, client ProtocolClient, repo2CPEFetcher Repo2CPEFetcher) *VMScraper {
+func New(store RunningVMStore, dialer VMDialer, client ProtocolClient, repo2CPEFetcher Repo2CPEFetcher, clusterID clusterIDGetter) *VMScraper {
 	interval := clampPollInterval(env.VirtualMachinesScraperPollInterval.DurationSetting())
 	return &VMScraper{
 		store:                 store,
 		dialer:                dialer,
 		client:                client,
 		repo2CPEFetcher:       repo2CPEFetcher,
+		clusterID:             clusterID,
 		toCentral:             make(chan *message.ExpiringMessage, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting()),
 		centralReady:          concurrency.NewSignal(),
 		interval:              interval,
@@ -493,6 +501,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	}
 
 	if result.Unchanged {
+		s.forwardAgentFactsIfChanged(ctx, vm, result.Meta.GetFacts())
 		next := s.scheduleAfterAttempt(key, vm.ID, scrapeOK)
 		log.Infof("VMScraper: scrape %q ok outcome=unchanged next=%s", key, next)
 		log.Debugf("VMScraper: unchanged report from roxagent on %q (token=%s)", key, snap.lastToken)
@@ -515,6 +524,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 	logAndRecordDiscoveredFacts(key, result.Meta.GetFacts())
+	s.persistAgentFacts(vm, result.Meta.GetFacts())
 
 	// Mapping sync has its own deadline, so forward uses the scrape parent.
 	if err := s.forwardReport(ctx, vm, result.IndexReport); err != nil {
@@ -537,6 +547,7 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 		log.Infof("VMScraper: scrape %q failed %s next=%s", key, kind, next)
 		return false
 	}
+	s.tryEnqueueVMUpdate(vm)
 
 	newToken := result.Meta.GetReportToken()
 	s.commitVMState(key, vm.ID, newToken, result.Meta.GetAgentVersion())
@@ -866,6 +877,14 @@ func (s *VMScraper) commitVMState(key string, vmID virtualmachine.VMID, newToken
 }
 
 func (s *VMScraper) forwardReport(ctx context.Context, vm *virtualmachine.Info, report *v4.IndexReport) error {
+	if err := s.enqueueToCentral(ctx, newIndexReportMessage(vm, report)); err != nil {
+		return err
+	}
+	metrics.IndexReportsSent.With(metrics.StatusSuccessLabels).Inc()
+	return nil
+}
+
+func (s *VMScraper) enqueueToCentral(ctx context.Context, msg *message.ExpiringMessage) error {
 	if !centralcaps.Has(centralsensor.VirtualMachinesSupported) {
 		return errox.NotImplemented.CausedBy(errCapabilityNotSupported)
 	}
@@ -874,11 +893,9 @@ func (s *VMScraper) forwardReport(ctx context.Context, vm *virtualmachine.Info, 
 		return errox.ResourceExhausted.CausedBy(errCentralNotReachable)
 	}
 
-	msg := newIndexReportMessage(vm, report)
 	select {
 	case <-ctx.Done():
 	case s.toCentral <- msg:
-		metrics.IndexReportsSent.With(metrics.StatusSuccessLabels).Inc()
 		return nil
 	default:
 		metrics.IndexReportEnqueueBlockedTotal.Inc()
@@ -886,9 +903,8 @@ func (s *VMScraper) forwardReport(ctx context.Context, vm *virtualmachine.Info, 
 
 	select {
 	case <-ctx.Done():
-		return fmt.Errorf("waiting to forward index report: %w", ctx.Err())
+		return fmt.Errorf("waiting to forward: %w", ctx.Err())
 	case s.toCentral <- msg:
-		metrics.IndexReportsSent.With(metrics.StatusSuccessLabels).Inc()
 		return nil
 	}
 }
@@ -917,4 +933,95 @@ func newIndexReportMessage(vm *virtualmachine.Info, report *v4.IndexReport) *mes
 			},
 		},
 	})
+}
+
+func (s *VMScraper) clusterIDString() string {
+	if s.clusterID == nil {
+		return ""
+	}
+	return s.clusterID.GetNoWait()
+}
+
+func (s *VMScraper) vmUpdateMessage(vm *virtualmachine.Info) *message.ExpiringMessage {
+	event := virtualmachine.SensorEvent(central.ResourceAction_UPDATE_RESOURCE, s.clusterIDString(), vm)
+	if event == nil {
+		return nil
+	}
+	return message.New(&central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{Event: event},
+	})
+}
+
+// tryEnqueueVMUpdate best-effort enqueues a facts UPDATE after a successful
+// index forward. It must not block: forwardReport already waited on toCentral,
+// and a second blocking send would stall the scrape if the buffer is full.
+func (s *VMScraper) tryEnqueueVMUpdate(vm *virtualmachine.Info) {
+	if vm == nil || vm.AgentFacts == nil {
+		return
+	}
+	msg := s.vmUpdateMessage(vm)
+	if msg == nil {
+		return
+	}
+	select {
+	case s.toCentral <- msg:
+	default:
+	}
+}
+
+func (s *VMScraper) persistAgentFacts(vm *virtualmachine.Info, facts map[string]string) {
+	mapped, ok := snapshotAgentFacts(facts)
+	if !ok {
+		return
+	}
+	vm.AgentFacts = mapped
+	// AddOrUpdate stores the pointer it is given. Copy so the scraper's vm
+	// is not the store's live object when a later forward copies it unlocked.
+	s.store.AddOrUpdate(vm.Copy())
+}
+
+// snapshotAgentFacts maps ResponseMeta.facts. ok is false when the response
+// carried no facts, so stored values stay as they are. An empty mapped map
+// means every reported value was unspecified or unsupported.
+func snapshotAgentFacts(facts map[string]string) (mapped map[string]string, ok bool) {
+	if len(facts) == 0 {
+		return nil, false
+	}
+	mapped = virtualmachine.AgentFactsFromResponseFacts(facts)
+	if mapped == nil {
+		mapped = map[string]string{}
+	}
+	return mapped, true
+}
+
+// forwardAgentFactsIfChanged emits a VM update when roxagent facts changed
+// even if the index report is unchanged. The store is updated only after
+// enqueue succeeds so a failed send is retried on the next unchanged scrape.
+func (s *VMScraper) forwardAgentFactsIfChanged(ctx context.Context, vm *virtualmachine.Info, facts map[string]string) {
+	mapped, ok := snapshotAgentFacts(facts)
+	if !ok {
+		return
+	}
+	logAndRecordDiscoveredFacts(vm.Key(), facts)
+	var prevFacts map[string]string
+	if prev := s.store.Get(vm.ID); prev != nil {
+		prevFacts = prev.AgentFacts
+	}
+	if len(mapped) == 0 && len(prevFacts) == 0 {
+		return
+	}
+	if maps.Equal(prevFacts, mapped) {
+		return
+	}
+	toSend := vm.Copy()
+	toSend.AgentFacts = mapped
+	msg := s.vmUpdateMessage(toSend)
+	if msg == nil {
+		return
+	}
+	if err := s.enqueueToCentral(ctx, msg); err != nil {
+		log.Debugf("VMScraper: agent facts for %q not forwarded; will retry: %v", vm.Key(), err)
+		return
+	}
+	s.store.AddOrUpdate(toSend)
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -980,18 +980,14 @@ func (s *VMScraper) persistAgentFacts(vm *virtualmachine.Info, facts map[string]
 	s.store.AddOrUpdate(vm.Copy())
 }
 
-// snapshotAgentFacts maps ResponseMeta.facts. ok is false when the response
-// carried no facts, so stored values stay as they are. An empty mapped map
-// means every reported value was unspecified or unsupported.
+// snapshotAgentFacts maps ResponseMeta.facts. ok is false when nothing maps,
+// so stored values stay as they are.
 func snapshotAgentFacts(facts map[string]string) (mapped map[string]string, ok bool) {
 	if len(facts) == 0 {
 		return nil, false
 	}
 	mapped = virtualmachine.AgentFactsFromResponseFacts(facts)
-	if mapped == nil {
-		mapped = map[string]string{}
-	}
-	return mapped, true
+	return mapped, len(mapped) > 0
 }
 
 // forwardAgentFactsIfChanged emits a VM update when roxagent facts changed
@@ -1006,9 +1002,6 @@ func (s *VMScraper) forwardAgentFactsIfChanged(ctx context.Context, vm *virtualm
 	var prevFacts map[string]string
 	if prev := s.store.Get(vm.ID); prev != nil {
 		prevFacts = prev.AgentFacts
-	}
-	if len(mapped) == 0 && len(prevFacts) == 0 {
-		return
 	}
 	if maps.Equal(prevFacts, mapped) {
 		return

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -524,7 +524,9 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 	metrics.PullReportBytes.Observe(float64(reportSize))
 	metrics.PullReportPackages.Observe(float64(len(result.IndexReport.GetContents().GetPackages())))
 	logAndRecordDiscoveredFacts(key, result.Meta.GetFacts())
-	s.persistAgentFacts(vm, result.Meta)
+	if mapped, ok := snapshotAgentFacts(result.Meta); ok {
+		vm.AgentFacts = mapped
+	}
 
 	// Mapping sync has its own deadline, so forward uses the scrape parent.
 	if err := s.forwardReport(ctx, vm, result.IndexReport); err != nil {
@@ -547,7 +549,11 @@ func (s *VMScraper) scrapeVM(ctx context.Context, vm *virtualmachine.Info) bool 
 		log.Infof("VMScraper: scrape %q failed %s next=%s", key, kind, next)
 		return false
 	}
-	s.tryEnqueueVMUpdate(vm)
+	// Persist facts only after the UPDATE is queued so a dropped send
+	// retries on the next unchanged poll instead of looking like a no-op.
+	if s.tryEnqueueVMUpdate(vm) {
+		s.persistAgentFacts(vm, result.Meta)
+	}
 
 	newToken := result.Meta.GetReportToken()
 	s.commitVMState(key, vm.ID, newToken, result.Meta.GetAgentVersion())
@@ -953,19 +959,22 @@ func (s *VMScraper) vmUpdateMessage(vm *virtualmachine.Info) *message.ExpiringMe
 }
 
 // tryEnqueueVMUpdate best-effort enqueues a facts UPDATE after a successful
-// index forward. It must not block: forwardReport already waited on toCentral,
-// and a second blocking send would stall the scrape if the buffer is full.
-func (s *VMScraper) tryEnqueueVMUpdate(vm *virtualmachine.Info) {
+// index forward. It must not block: a second wait on toCentral would stall
+// the scrape if the buffer is full.
+func (s *VMScraper) tryEnqueueVMUpdate(vm *virtualmachine.Info) bool {
 	if vm == nil || vm.AgentFacts == nil {
-		return
+		return false
 	}
 	msg := s.vmUpdateMessage(vm)
 	if msg == nil {
-		return
+		return false
 	}
 	select {
 	case s.toCentral <- msg:
+		return true
 	default:
+		log.Debugf("VMScraper: agent facts for %q not forwarded; will retry", vm.Key())
+		return false
 	}
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -66,6 +66,7 @@ type RunningVMStore interface {
 	ListRunning() []*virtualmachine.Info
 	Get(id virtualmachine.VMID) *virtualmachine.Info
 	AddOrUpdate(vm *virtualmachine.Info) *virtualmachine.Info
+	SetAgentFacts(id virtualmachine.VMID, facts map[string]string)
 }
 
 // VMDialer connects to a VM's VSOCK port.
@@ -965,6 +966,9 @@ func (s *VMScraper) tryEnqueueVMUpdate(vm *virtualmachine.Info) bool {
 	if vm == nil || vm.AgentFacts == nil {
 		return false
 	}
+	if s.storedAgentFactsEqual(vm.ID, vm.AgentFacts) {
+		return false
+	}
 	msg := s.vmUpdateMessage(vm)
 	if msg == nil {
 		return false
@@ -984,13 +988,20 @@ func (s *VMScraper) persistAgentFacts(vm *virtualmachine.Info, meta *pb.Response
 		return
 	}
 	vm.AgentFacts = mapped
-	// AddOrUpdate stores the pointer it is given. Copy so the scraper's vm
-	// is not the store's live object when a later forward copies it unlocked.
-	s.store.AddOrUpdate(vm.Copy())
+	s.store.SetAgentFacts(vm.ID, mapped)
 }
 
-// snapshotAgentFacts maps ResponseMeta onto AgentFacts. ok is false when
-// nothing maps, so stored values stay as they are.
+func (s *VMScraper) storedAgentFactsEqual(id virtualmachine.VMID, mapped map[string]string) bool {
+	var prev map[string]string
+	if stored := s.store.Get(id); stored != nil {
+		prev = stored.AgentFacts
+	}
+	return maps.Equal(prev, mapped)
+}
+
+// snapshotAgentFacts maps ResponseMeta onto AgentFacts. A non-empty result
+// replaces the last scrape as a whole; unspecified keys are omitted. ok is
+// false when nothing maps, so last-known values stay.
 func snapshotAgentFacts(meta *pb.ResponseMeta) (mapped map[string]string, ok bool) {
 	if meta == nil {
 		return nil, false
@@ -1008,11 +1019,7 @@ func (s *VMScraper) forwardAgentFactsIfChanged(ctx context.Context, vm *virtualm
 		return
 	}
 	logAndRecordDiscoveredFacts(vm.Key(), meta.GetFacts())
-	var prevFacts map[string]string
-	if prev := s.store.Get(vm.ID); prev != nil {
-		prevFacts = prev.AgentFacts
-	}
-	if maps.Equal(prevFacts, mapped) {
+	if s.storedAgentFactsEqual(vm.ID, mapped) {
 		return
 	}
 	toSend := vm.Copy()
@@ -1025,5 +1032,5 @@ func (s *VMScraper) forwardAgentFactsIfChanged(ctx context.Context, vm *virtualm
 		log.Debugf("VMScraper: agent facts for %q not forwarded; will retry: %v", vm.Key(), err)
 		return
 	}
-	s.store.AddOrUpdate(toSend)
+	s.store.SetAgentFacts(vm.ID, mapped)
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -278,7 +278,8 @@ func makeReport(token string) *vsockclient.GetReportResult {
 			State: "IndexFinished",
 		},
 		Meta: &pb.ResponseMeta{
-			ReportToken: token,
+			ReportToken:  token,
+			AgentVersion: "roxagent-test",
 			Facts: map[string]string{
 				"detected_os":         "RHEL",
 				"activation_status":   "ACTIVE",
@@ -332,11 +333,11 @@ func TestVMScraper_PollsRunningVMs(t *testing.T) {
 	assert.Equal(t, 2, forwardedCount(s))
 	assert.Len(t, client.calls, 2)
 	assert.Equal(t, discoveredBefore+2, testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE")))
-	expectedFacts := virtualmachine.AgentFactsFromResponseFacts(map[string]string{
+	expectedFacts := virtualmachine.AgentFactsFromResponse(map[string]string{
 		"detected_os":         "RHEL",
 		"activation_status":   "ACTIVE",
 		"dnf_metadata_status": "AVAILABLE",
-	})
+	}, "roxagent-test")
 	assert.Equal(t, expectedFacts, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
 	assert.Equal(t, expectedFacts, store.Get(virtualmachine.VMID("ns2/vm-b")).AgentFacts)
 }
@@ -346,21 +347,24 @@ func TestPersistAgentFactsDoesNotAliasStorePointer(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{vm.Copy()}}
 	s := &VMScraper{store: store}
 
-	s.persistAgentFacts(vm, map[string]string{
-		"detected_os":         "RHEL",
-		"activation_status":   "ACTIVE",
-		"dnf_metadata_status": "AVAILABLE",
+	s.persistAgentFacts(vm, &pb.ResponseMeta{
+		AgentVersion: "roxagent-test",
+		Facts: map[string]string{
+			"detected_os":         "RHEL",
+			"activation_status":   "ACTIVE",
+			"dnf_metadata_status": "AVAILABLE",
+		},
 	})
 	vm.GuestOS = "mutated-after-persist"
 
 	stored := store.Get(vm.ID)
 	require.NotNil(t, stored)
 	assert.NotEqual(t, "mutated-after-persist", stored.GuestOS)
-	assert.Equal(t, virtualmachine.AgentFactsFromResponseFacts(map[string]string{
+	assert.Equal(t, virtualmachine.AgentFactsFromResponse(map[string]string{
 		"detected_os":         "RHEL",
 		"activation_status":   "ACTIVE",
 		"dnf_metadata_status": "AVAILABLE",
-	}), stored.AgentFacts)
+	}, "roxagent-test"), stored.AgentFacts)
 }
 
 // TestVMScraper_SkipsWhenCentralLacksCapability covers a store already
@@ -477,6 +481,43 @@ func TestVMScraper_ForwardsChangedAgentFactsOnUnchangedReport(t *testing.T) {
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
 	assert.Empty(t, drainToCentral(s), "should not emit a VM update when agent facts are unchanged")
+}
+
+func TestVMScraper_ForwardsAgentVersionChangeOnUnchangedReport(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+
+	sameFacts := map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	}
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{{
+		Unchanged: true,
+		Meta: &pb.ResponseMeta{
+			ReportToken:  "1",
+			AgentVersion: "roxagent-upgraded",
+			Facts:        sameFacts,
+		},
+	}}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	expected := virtualmachine.AgentFactsFromResponse(sameFacts, "roxagent-upgraded")
+	updates := drainVMUpdates(s)
+	require.Len(t, updates, 1)
+	assert.Equal(t, expected[pkgVM.AgentVersionKey], updates[0].GetFacts()[pkgVM.AgentVersionKey])
+	assert.Equal(t, expected, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
 }
 
 func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
@@ -33,7 +34,10 @@ import (
 
 // --- Mocks ---
 
+// mockStore is used by concurrent scrape workers (persistAgentFacts calls
+// AddOrUpdate), so mu guards vms and listRunningCalls.
 type mockStore struct {
+	mu               sync.Mutex
 	vms              []*virtualmachine.Info
 	listRunningCalls int
 }
@@ -42,23 +46,47 @@ type mockStore struct {
 // with Running set, so tests exercise reconcile pruning rather than the
 // scrapeKey nil-VM guard when a VM stops running.
 func (m *mockStore) ListRunning() []*virtualmachine.Info {
-	m.listRunningCalls++
-	var out []*virtualmachine.Info
-	for _, vm := range m.vms {
-		if vm.Running {
-			out = append(out, vm)
+	return concurrency.WithLock1(&m.mu, func() []*virtualmachine.Info {
+		m.listRunningCalls++
+		var out []*virtualmachine.Info
+		for _, vm := range m.vms {
+			if vm.Running {
+				out = append(out, vm)
+			}
 		}
-	}
-	return out
+		return out
+	})
 }
 
 func (m *mockStore) Get(id virtualmachine.VMID) *virtualmachine.Info {
-	for _, vm := range m.vms {
-		if vm.ID == id {
+	return concurrency.WithLock1(&m.mu, func() *virtualmachine.Info {
+		for _, vm := range m.vms {
+			if vm.ID == id {
+				return vm.Copy()
+			}
+		}
+		return nil
+	})
+}
+
+func (m *mockStore) AddOrUpdate(vm *virtualmachine.Info) *virtualmachine.Info {
+	if vm == nil {
+		return nil
+	}
+	return concurrency.WithLock1(&m.mu, func() *virtualmachine.Info {
+		for i, existing := range m.vms {
+			if existing.ID != vm.ID {
+				continue
+			}
+			if vm.AgentFacts == nil {
+				vm.AgentFacts = existing.AgentFacts
+			}
+			m.vms[i] = vm
 			return vm
 		}
-	}
-	return nil
+		m.vms = append(m.vms, vm)
+		return vm
+	})
 }
 
 type mockDialer struct {
@@ -274,6 +302,16 @@ func metaWithMapping(hash string, path pb.RepoCPEMappingUpdatePath) *pb.Response
 	}
 }
 
+func unchangedResultWithFacts(facts map[string]string) *vsockclient.GetReportResult {
+	return &vsockclient.GetReportResult{
+		Unchanged: true,
+		Meta: &pb.ResponseMeta{
+			ReportToken: "1",
+			Facts:       facts,
+		},
+	}
+}
+
 // --- Tests ---
 
 func TestVMScraper_PollsRunningVMs(t *testing.T) {
@@ -294,6 +332,35 @@ func TestVMScraper_PollsRunningVMs(t *testing.T) {
 	assert.Equal(t, 2, forwardedCount(s))
 	assert.Len(t, client.calls, 2)
 	assert.Equal(t, discoveredBefore+2, testutil.ToFloat64(metrics.VMDiscoveredData.WithLabelValues("RHEL", "ACTIVE", "AVAILABLE")))
+	expectedFacts := virtualmachine.AgentFactsFromResponseFacts(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	})
+	assert.Equal(t, expectedFacts, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
+	assert.Equal(t, expectedFacts, store.Get(virtualmachine.VMID("ns2/vm-b")).AgentFacts)
+}
+
+func TestPersistAgentFactsDoesNotAliasStorePointer(t *testing.T) {
+	vm := makeVM("ns1", "vm-a", 100)
+	store := &mockStore{vms: []*virtualmachine.Info{vm.Copy()}}
+	s := &VMScraper{store: store}
+
+	s.persistAgentFacts(vm, map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	})
+	vm.GuestOS = "mutated-after-persist"
+
+	stored := store.Get(vm.ID)
+	require.NotNil(t, stored)
+	assert.NotEqual(t, "mutated-after-persist", stored.GuestOS)
+	assert.Equal(t, virtualmachine.AgentFactsFromResponseFacts(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	}), stored.AgentFacts)
 }
 
 // TestVMScraper_SkipsWhenCentralLacksCapability covers a store already
@@ -367,6 +434,139 @@ func TestVMScraper_SkipsUnchangedToken(t *testing.T) {
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
 	assert.Zero(t, forwardedCount(s), "should not forward unchanged report")
+}
+
+func TestVMScraper_ForwardsChangedAgentFactsOnUnchangedReport(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "INACTIVE",
+		"dnf_metadata_status": "UNAVAILABLE",
+	})}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	expected := virtualmachine.AgentFactsFromResponseFacts(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "INACTIVE",
+		"dnf_metadata_status": "UNAVAILABLE",
+	})
+	updates := drainVMUpdates(s)
+	require.Len(t, updates, 1, "unchanged report should not be forwarded")
+	assert.Equal(t, expected[pkgVM.ActivationStatusKey], updates[0].GetFacts()[pkgVM.ActivationStatusKey])
+	assert.Equal(t, expected, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
+}
+
+func TestVMScraper_DoesNotResendUnchangedAgentFacts(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	})}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+	assert.Empty(t, drainToCentral(s), "should not emit a VM update when agent facts are unchanged")
+}
+
+func TestVMScraper_RetriesAgentFactsAfterSendFailure(t *testing.T) {
+	vmID := virtualmachine.VMID("ns1/vm-a")
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+	initialFacts := virtualmachine.AgentFactsFromResponseFacts(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	})
+	assert.Equal(t, initialFacts, store.Get(vmID).AgentFacts)
+
+	changedFacts := map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "INACTIVE",
+		"dnf_metadata_status": "UNAVAILABLE",
+	}
+	s.centralReady.Reset()
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(changedFacts)}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	assert.Empty(t, drainToCentral(s), "failed metadata send should not count as forwarded")
+	assert.Equal(t, initialFacts, store.Get(vmID).AgentFacts)
+
+	s.centralReady.Signal()
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(changedFacts)}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	expected := virtualmachine.AgentFactsFromResponseFacts(changedFacts)
+	updates := drainVMUpdates(s)
+	require.Len(t, updates, 1, "retry should be metadata-only")
+	assert.Equal(t, expected[pkgVM.ActivationStatusKey], updates[0].GetFacts()[pkgVM.ActivationStatusKey])
+	assert.Equal(t, expected, store.Get(vmID).AgentFacts)
+}
+
+func TestVMScraper_ClearsAgentFactsWhenResponseValuesUnspecified(t *testing.T) {
+	vmID := virtualmachine.VMID("ns1/vm-a")
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+	require.NotEmpty(t, store.Get(vmID).AgentFacts)
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(map[string]string{
+		"detected_os":         pb.DetectedOS_UNKNOWN.String(),
+		"activation_status":   pb.ActivationStatus_ACTIVATION_UNSPECIFIED.String(),
+		"dnf_metadata_status": pb.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED.String(),
+	})}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	updates := drainVMUpdates(s)
+	require.Len(t, updates, 1, "clearing facts should be metadata-only")
+	assert.Empty(t, store.Get(vmID).AgentFacts)
 }
 
 func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {
@@ -553,8 +753,11 @@ func TestVMScraper_NACK(t *testing.T) {
 			require.Equal(t, 1, forwardedCount(s))
 
 			// Flip Running only after the first poll, so the VM is scraped normally
-			// once before the ACK/NACK under test is delivered.
-			vmA.Running = tc.vmRunning
+			// once before the ACK/NACK under test is delivered. persistAgentFacts
+			// stores a copy, so mutate the store's current object rather than vmA.
+			concurrency.WithLock(&store.mu, func() {
+				store.vms[0].Running = tc.vmRunning
+			})
 
 			acksBefore := testutil.ToFloat64(metrics.IndexReportAcksReceived.WithLabelValues(tc.ackAction.String()))
 			err := s.ProcessMessage(context.Background(), &central.MsgToSensor{
@@ -1085,17 +1288,41 @@ func TestIsAbnormalClose(t *testing.T) {
 	}
 }
 
-func forwardedCount(s *VMScraper) int {
-	n := 0
+func drainToCentral(s *VMScraper) []*message.ExpiringMessage {
+	var out []*message.ExpiringMessage
 	for {
 		select {
-		case <-s.toCentral:
-			n++
+		case msg := <-s.toCentral:
+			out = append(out, msg)
 		default:
-			return n
+			return out
 		}
 	}
 }
+
+func forwardedCount(s *VMScraper) int {
+	n := 0
+	for _, msg := range drainToCentral(s) {
+		if msg.GetEvent().GetVirtualMachineIndexReport() != nil {
+			n++
+		}
+	}
+	return n
+}
+
+func drainVMUpdates(s *VMScraper) []*pb.VirtualMachine {
+	var out []*pb.VirtualMachine
+	for _, msg := range drainToCentral(s) {
+		if vm := msg.GetEvent().GetVirtualMachine(); vm != nil {
+			out = append(out, vm)
+		}
+	}
+	return out
+}
+
+type staticClusterID string
+
+func (c staticClusterID) GetNoWait() string { return string(c) }
 
 func newTestScraper(t *testing.T, store RunningVMStore, dialer VMDialer, client ProtocolClient) (*VMScraper, *testClock) {
 	t.Helper()
@@ -1108,6 +1335,7 @@ func newTestScraper(t *testing.T, store RunningVMStore, dialer VMDialer, client 
 		store:                 store,
 		dialer:                dialer,
 		client:                client,
+		clusterID:             staticClusterID("test-cluster"),
 		toCentral:             make(chan *message.ExpiringMessage, 256),
 		centralReady:          concurrency.NewSignal(),
 		interval:              interval,

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -520,6 +520,48 @@ func TestVMScraper_ForwardsAgentVersionChangeOnUnchangedReport(t *testing.T) {
 	assert.Equal(t, expected, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
 }
 
+func TestVMScraper_RetriesAgentFactsAfterIndexEnqueueFillsBuffer(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.toCentral = make(chan *message.ExpiringMessage, 1)
+
+	s.pollOnce(context.Background())
+	msgs := drainToCentral(s)
+	require.Len(t, msgs, 1)
+	assert.NotNil(t, msgs[0].GetEvent().GetVirtualMachineIndexReport())
+	assert.Nil(t, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
+
+	sameFacts := map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	}
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{{
+		Unchanged: true,
+		Meta: &pb.ResponseMeta{
+			ReportToken:  "1",
+			AgentVersion: "roxagent-test",
+			Facts:        sameFacts,
+		},
+	}}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	expected := virtualmachine.AgentFactsFromResponse(sameFacts, "roxagent-test")
+	updates := drainVMUpdates(s)
+	require.Len(t, updates, 1)
+	assert.Equal(t, expected[pkgVM.ActivationStatusKey], updates[0].GetFacts()[pkgVM.ActivationStatusKey])
+	assert.Equal(t, expected, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
+}
+
 func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {
 	store := &mockStore{vms: []*virtualmachine.Info{
 		makeVM("ns1", "vm-a", 100),
@@ -704,7 +746,7 @@ func TestVMScraper_NACK(t *testing.T) {
 			require.Equal(t, 1, forwardedCount(s))
 
 			// Flip Running only after the first poll, so the VM is scraped normally
-			// once before the ACK/NACK under test is delivered. persistAgentFacts
+			// once before the ACK/NACK under test is delivered. The scraper
 			// stores a copy, so mutate the store's current object rather than vmA.
 			concurrency.WithLock(&store.mu, func() {
 				store.vms[0].Running = tc.vmRunning

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -467,106 +467,16 @@ func TestVMScraper_ForwardsChangedAgentFactsOnUnchangedReport(t *testing.T) {
 	require.Len(t, updates, 1, "unchanged report should not be forwarded")
 	assert.Equal(t, expected[pkgVM.ActivationStatusKey], updates[0].GetFacts()[pkgVM.ActivationStatusKey])
 	assert.Equal(t, expected, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
-}
-
-func TestVMScraper_DoesNotResendUnchangedAgentFacts(t *testing.T) {
-	store := &mockStore{vms: []*virtualmachine.Info{
-		makeVM("ns1", "vm-a", 100),
-	}}
-	dialer := &mockDialer{}
-	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
-	}
-
-	s, clock := newTestScraper(t, store, dialer, client)
-	s.pollOnce(context.Background())
-	require.Equal(t, 1, forwardedCount(s))
 
 	client.reset()
 	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(map[string]string{
 		"detected_os":         "RHEL",
-		"activation_status":   "ACTIVE",
-		"dnf_metadata_status": "AVAILABLE",
+		"activation_status":   "INACTIVE",
+		"dnf_metadata_status": "UNAVAILABLE",
 	})}
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
 	assert.Empty(t, drainToCentral(s), "should not emit a VM update when agent facts are unchanged")
-}
-
-func TestVMScraper_RetriesAgentFactsAfterSendFailure(t *testing.T) {
-	vmID := virtualmachine.VMID("ns1/vm-a")
-	store := &mockStore{vms: []*virtualmachine.Info{
-		makeVM("ns1", "vm-a", 100),
-	}}
-	dialer := &mockDialer{}
-	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
-	}
-
-	s, clock := newTestScraper(t, store, dialer, client)
-	s.pollOnce(context.Background())
-	require.Equal(t, 1, forwardedCount(s))
-	initialFacts := virtualmachine.AgentFactsFromResponseFacts(map[string]string{
-		"detected_os":         "RHEL",
-		"activation_status":   "ACTIVE",
-		"dnf_metadata_status": "AVAILABLE",
-	})
-	assert.Equal(t, initialFacts, store.Get(vmID).AgentFacts)
-
-	changedFacts := map[string]string{
-		"detected_os":         "RHEL",
-		"activation_status":   "INACTIVE",
-		"dnf_metadata_status": "UNAVAILABLE",
-	}
-	s.centralReady.Reset()
-	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(changedFacts)}
-	clock.Advance(s.interval)
-	s.pollOnce(context.Background())
-
-	assert.Empty(t, drainToCentral(s), "failed metadata send should not count as forwarded")
-	assert.Equal(t, initialFacts, store.Get(vmID).AgentFacts)
-
-	s.centralReady.Signal()
-	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(changedFacts)}
-	clock.Advance(s.interval)
-	s.pollOnce(context.Background())
-
-	expected := virtualmachine.AgentFactsFromResponseFacts(changedFacts)
-	updates := drainVMUpdates(s)
-	require.Len(t, updates, 1, "retry should be metadata-only")
-	assert.Equal(t, expected[pkgVM.ActivationStatusKey], updates[0].GetFacts()[pkgVM.ActivationStatusKey])
-	assert.Equal(t, expected, store.Get(vmID).AgentFacts)
-}
-
-func TestVMScraper_ClearsAgentFactsWhenResponseValuesUnspecified(t *testing.T) {
-	vmID := virtualmachine.VMID("ns1/vm-a")
-	store := &mockStore{vms: []*virtualmachine.Info{
-		makeVM("ns1", "vm-a", 100),
-	}}
-	dialer := &mockDialer{}
-	client := &mockProtocolClient{
-		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
-	}
-
-	s, clock := newTestScraper(t, store, dialer, client)
-	s.pollOnce(context.Background())
-	require.Equal(t, 1, forwardedCount(s))
-	require.NotEmpty(t, store.Get(vmID).AgentFacts)
-
-	client.reset()
-	client.resultQueue = []*vsockclient.GetReportResult{unchangedResultWithFacts(map[string]string{
-		"detected_os":         pb.DetectedOS_UNKNOWN.String(),
-		"activation_status":   pb.ActivationStatus_ACTIVATION_UNSPECIFIED.String(),
-		"dnf_metadata_status": pb.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED.String(),
-	})}
-	clock.Advance(s.interval)
-	s.pollOnce(context.Background())
-
-	updates := drainVMUpdates(s)
-	require.Len(t, updates, 1, "clearing facts should be metadata-only")
-	assert.Empty(t, store.Get(vmID).AgentFacts)
 }
 
 func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -35,7 +36,7 @@ import (
 // --- Mocks ---
 
 // mockStore is used by concurrent scrape workers (persistAgentFacts calls
-// AddOrUpdate), so mu guards vms and listRunningCalls.
+// SetAgentFacts), so mu guards vms and listRunningCalls.
 type mockStore struct {
 	mu               sync.Mutex
 	vms              []*virtualmachine.Info
@@ -86,6 +87,18 @@ func (m *mockStore) AddOrUpdate(vm *virtualmachine.Info) *virtualmachine.Info {
 		}
 		m.vms = append(m.vms, vm)
 		return vm
+	})
+}
+
+func (m *mockStore) SetAgentFacts(id virtualmachine.VMID, facts map[string]string) {
+	concurrency.WithLock(&m.mu, func() {
+		for _, vm := range m.vms {
+			if vm.ID != id {
+				continue
+			}
+			vm.AgentFacts = maps.Clone(facts)
+			return
+		}
 	})
 }
 
@@ -367,6 +380,36 @@ func TestPersistAgentFactsDoesNotAliasStorePointer(t *testing.T) {
 	}, "roxagent-test"), stored.AgentFacts)
 }
 
+func TestPersistAgentFactsDoesNotClobberInstanceFields(t *testing.T) {
+	stored := makeVM("ns1", "vm-a", 100)
+	stored.GuestOS = "from-informer"
+	stored.Description = "from-informer"
+	store := &mockStore{vms: []*virtualmachine.Info{stored}}
+	s := &VMScraper{store: store}
+
+	stale := stored.Copy()
+	stale.GuestOS = "stale-scrape-copy"
+	stale.Description = "stale-scrape-copy"
+	s.persistAgentFacts(stale, &pb.ResponseMeta{
+		AgentVersion: "roxagent-test",
+		Facts: map[string]string{
+			"detected_os":         "RHEL",
+			"activation_status":   "ACTIVE",
+			"dnf_metadata_status": "AVAILABLE",
+		},
+	})
+
+	got := store.Get(stored.ID)
+	require.NotNil(t, got)
+	assert.Equal(t, "from-informer", got.GuestOS)
+	assert.Equal(t, "from-informer", got.Description)
+	assert.Equal(t, virtualmachine.AgentFactsFromResponse(map[string]string{
+		"detected_os":         "RHEL",
+		"activation_status":   "ACTIVE",
+		"dnf_metadata_status": "AVAILABLE",
+	}, "roxagent-test"), got.AgentFacts)
+}
+
 // TestVMScraper_SkipsWhenCentralLacksCapability covers a store already
 // populated (for example after reconnecting to an older Central) so the
 // scraper must not dial or forward.
@@ -560,6 +603,31 @@ func TestVMScraper_RetriesAgentFactsAfterIndexEnqueueFillsBuffer(t *testing.T) {
 	require.Len(t, updates, 1)
 	assert.Equal(t, expected[pkgVM.ActivationStatusKey], updates[0].GetFacts()[pkgVM.ActivationStatusKey])
 	assert.Equal(t, expected, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
+}
+
+func TestVMScraper_SkipsFactsUpdateWhenUnchangedOnNewIndex(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+	require.NotNil(t, store.Get(virtualmachine.VMID("ns1/vm-a")).AgentFacts)
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{makeReport("2")}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	msgs := drainToCentral(s)
+	require.Len(t, msgs, 1)
+	assert.NotNil(t, msgs[0].GetEvent().GetVirtualMachineIndexReport())
+	assert.Nil(t, msgs[0].GetEvent().GetVirtualMachine())
 }
 
 func TestVMScraper_RemainsScheduledAcrossUnchangedPolls(t *testing.T) {

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/utils.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/utils.go
@@ -21,3 +21,16 @@ func getVirtualMachineOwnerReference(owners []metav1.OwnerReference) (*metav1.Ow
 func createEvent(action central.ResourceAction, clusterID string, vm *sensorVirtualMachine.Info) *central.SensorEvent {
 	return sensorVirtualMachine.SensorEvent(action, clusterID, vm)
 }
+
+// attachStoredAgentFacts copies scrape-owned facts onto vm. Informer UPDATEs are
+// built from the VMI and would otherwise replace Central's facts map without them.
+func attachStoredAgentFacts(store virtualMachineStore, vm *sensorVirtualMachine.Info) {
+	if vm == nil {
+		return
+	}
+	stored := store.Get(vm.ID)
+	if stored == nil || len(stored.AgentFacts) == 0 {
+		return
+	}
+	vm.AgentFacts = stored.AgentFacts
+}

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances.go
@@ -110,6 +110,8 @@ func (d *VirtualMachineInstanceDispatcher) ProcessEvent(
 		return nil
 	}
 
+	attachStoredAgentFacts(d.store, vm)
+
 	// Send an Update event for the VirtualMachine that handles this instance
 	return component.NewEvent(createEvent(central.ResourceAction_UPDATE_RESOURCE, d.clusterID, vm))
 }

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances_test.go
@@ -104,6 +104,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 							Running:   false,
 						}),
 					).Times(1),
+					s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(nil),
 				)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
@@ -136,6 +137,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 							Running:   false,
 						}),
 					).Times(1),
+					s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(nil),
 				)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
@@ -160,6 +162,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 				gomock.InOrder(
 					s.store.EXPECT().Has(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(true),
 					s.store.EXPECT().ClearState(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1),
+					s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(nil),
 				)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
@@ -173,6 +176,45 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
 						Facts:     getFactsForTest(s.T(), pkgVM.UnknownGuestOS),
+					},
+				},
+			}),
+		},
+		"remove event keeps stored agent facts": {
+			action: central.ResourceAction_REMOVE_RESOURCE,
+			obj:    toUnstructured(newVirtualMachineInstance(vmiUID, vmiName, vmiNamespace, ownerUID, nil, v1.Scheduled)),
+			expectFn: func() {
+				gomock.InOrder(
+					s.store.EXPECT().Has(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(true),
+					s.store.EXPECT().ClearState(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1),
+					s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(&vmInfo.Info{
+						ID: ownerUID,
+						AgentFacts: map[string]string{
+							pkgVM.DetectedGuestOSKey:   "Red Hat Enterprise Linux 9.8",
+							pkgVM.ActivationStatusKey:  pkgVM.ActivationStatusActive,
+							pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusAvailable,
+							pkgVM.AgentVersionKey:      "development",
+						},
+					}),
+				)
+			},
+			expectedMsg: component.NewEvent(&central.SensorEvent{
+				Id:     ownerUID,
+				Action: central.ResourceAction_UPDATE_RESOURCE,
+				Resource: &central.SensorEvent_VirtualMachine{
+					VirtualMachine: &virtualMachineV1.VirtualMachine{
+						Id:        ownerUID,
+						Name:      vmiName,
+						Namespace: vmiNamespace,
+						ClusterId: clusterID,
+						State:     virtualMachineV1.VirtualMachine_STOPPED,
+						Facts: map[string]string{
+							pkgVM.GuestOSKey:           pkgVM.UnknownGuestOS,
+							pkgVM.DetectedGuestOSKey:   "Red Hat Enterprise Linux 9.8",
+							pkgVM.ActivationStatusKey:  pkgVM.ActivationStatusActive,
+							pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusAvailable,
+							pkgVM.AgentVersionKey:      "development",
+						},
 					},
 				},
 			}),
@@ -352,6 +394,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 							Running:   true,
 						}),
 					).Times(1),
+					s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(ownerUID))).Times(1).Return(nil),
 				)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"maps"
+
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -45,6 +47,9 @@ func (s *VirtualMachineStore) AddOrUpdate(vm *virtualmachine.Info) *virtualmachi
 		vm.IPAddresses = copyStringSlice(oldVM.IPAddresses)
 		vm.ActivePods = copyStringSlice(oldVM.ActivePods)
 		vm.NodeName = oldVM.NodeName
+		if vm.AgentFacts == nil {
+			vm.AgentFacts = oldVM.AgentFacts
+		}
 	}
 	s.addOrUpdateNoLock(vm)
 	return vm
@@ -131,6 +136,7 @@ func (s *VirtualMachineStore) addOrUpdateNoLock(vm *virtualmachine.Info) {
 	// Upsert the VirtualMachineInfo
 	vmIDsByNamespace := s.getOrCreateNamespaceSet(vm.Namespace)
 	vmIDsByNamespace.Add(vm.ID)
+	vm.AgentFacts = maps.Clone(vm.AgentFacts)
 	s.virtualMachines[vm.ID] = vm
 }
 
@@ -160,6 +166,9 @@ func (s *VirtualMachineStore) updateStatusOrCreateNoLock(updateInfo *virtualmach
 	prev.Description = updateInfo.Description
 	prev.BootOrder = copyStringSlice(updateInfo.BootOrder)
 	prev.CDRomDisks = copyStringSlice(updateInfo.CDRomDisks)
+	if updateInfo.AgentFacts != nil {
+		prev.AgentFacts = maps.Clone(updateInfo.AgentFacts)
+	}
 }
 
 // copyVSOCKCID returns a new pointer so later changes to the caller's value

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
@@ -55,6 +55,18 @@ func (s *VirtualMachineStore) AddOrUpdate(vm *virtualmachine.Info) *virtualmachi
 	return vm
 }
 
+// SetAgentFacts replaces scrape-owned facts on an existing VM. A missing ID
+// is ignored so persist cannot recreate a VM the informer already removed.
+func (s *VirtualMachineStore) SetAgentFacts(id virtualmachine.VMID, facts map[string]string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	vm, ok := s.virtualMachines[id]
+	if !ok {
+		return
+	}
+	vm.AgentFacts = maps.Clone(facts)
+}
+
 // UpdateStateOrCreate updates the VirtualMachine state
 // If the VirtualMachine is not present we create a new VirtualMachine
 func (s *VirtualMachineStore) UpdateStateOrCreate(vm *virtualmachine.Info) {

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store_test.go
@@ -723,114 +723,24 @@ func (s *storeSuite) Test_RuntimeUpdatesShouldPreserveAgentFacts() {
 	}
 
 	s.Run("AddOrUpdate preserves when nil", func() {
-		original := &virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			AgentFacts: agentFacts,
-		}
-		update := &virtualmachine.Info{
-			ID:          vmID,
-			Name:        vmName,
-			Namespace:   vmNamespace,
-			Description: "updated description",
-		}
-
-		s.store.AddOrUpdate(original)
-		s.store.AddOrUpdate(update)
-
-		actual := s.store.Get(vmID)
-		s.Require().NotNil(actual)
-		assert.Equal(s.T(), agentFacts, actual.AgentFacts)
-	})
-
-	s.Run("AddOrUpdate overrides when provided", func() {
-		originalFacts := map[string]string{"original": "value"}
-		updatedFacts := map[string]string{
-			pkgVM.ActivationStatusKey: pkgVM.ActivationStatusInactive,
-		}
-
-		s.store = NewVirtualMachineStore()
 		s.store.AddOrUpdate(&virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			AgentFacts: originalFacts,
+			ID: vmID, Name: vmName, Namespace: vmNamespace, AgentFacts: agentFacts,
 		})
 		s.store.AddOrUpdate(&virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			AgentFacts: updatedFacts,
+			ID: vmID, Name: vmName, Namespace: vmNamespace, Description: "updated",
 		})
-
-		actual := s.store.Get(vmID)
-		s.Require().NotNil(actual)
-		assert.Equal(s.T(), updatedFacts, actual.AgentFacts)
+		assert.Equal(s.T(), agentFacts, s.store.Get(vmID).AgentFacts)
 	})
 
 	s.Run("UpdateStateOrCreate preserves when nil", func() {
 		s.store = NewVirtualMachineStore()
 		s.store.AddOrUpdate(&virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			AgentFacts: agentFacts,
+			ID: vmID, Name: vmName, Namespace: vmNamespace, AgentFacts: agentFacts,
 		})
 		s.store.UpdateStateOrCreate(&virtualmachine.Info{
-			ID:        vmID,
-			Name:      vmName,
-			Namespace: vmNamespace,
-			Running:   true,
-			VSOCKCID:  new(uint32(1)),
-			GuestOS:   "Red Hat Enterprise Linux 9",
+			ID: vmID, Name: vmName, Namespace: vmNamespace, Running: true, VSOCKCID: new(uint32(1)),
 		})
-
-		actual := s.store.Get(vmID)
-		s.Require().NotNil(actual)
-		assert.Equal(s.T(), agentFacts, actual.AgentFacts)
-	})
-
-	s.Run("UpdateStateOrCreate overrides when provided", func() {
-		originalFacts := map[string]string{"original": "value"}
-		updatedFacts := map[string]string{
-			pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusAvailable,
-		}
-
-		s.store = NewVirtualMachineStore()
-		s.store.AddOrUpdate(&virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			AgentFacts: originalFacts,
-		})
-		s.store.UpdateStateOrCreate(&virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			Running:    true,
-			AgentFacts: updatedFacts,
-		})
-
-		actual := s.store.Get(vmID)
-		s.Require().NotNil(actual)
-		assert.Equal(s.T(), updatedFacts, actual.AgentFacts)
-	})
-
-	s.Run("AddOrUpdate clones incoming AgentFacts", func() {
-		facts := map[string]string{pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive}
-		s.store = NewVirtualMachineStore()
-		s.store.AddOrUpdate(&virtualmachine.Info{
-			ID:         vmID,
-			Name:       vmName,
-			Namespace:  vmNamespace,
-			AgentFacts: facts,
-		})
-		facts[pkgVM.ActivationStatusKey] = "mutated"
-
-		actual := s.store.Get(vmID)
-		s.Require().NotNil(actual)
-		assert.Equal(s.T(), pkgVM.ActivationStatusActive, actual.AgentFacts[pkgVM.ActivationStatusKey])
+		assert.Equal(s.T(), agentFacts, s.store.Get(vmID).AgentFacts)
 	})
 }
 

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"testing"
 
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -714,6 +715,123 @@ func (s *storeSuite) Test_UpdateStateOrCreateShouldRefreshRuntimeFields() {
 	} else {
 		assert.Equal(s.T(), *update.VSOCKCID, *actual.VSOCKCID)
 	}
+}
+
+func (s *storeSuite) Test_RuntimeUpdatesShouldPreserveAgentFacts() {
+	agentFacts := map[string]string{
+		pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive,
+	}
+
+	s.Run("AddOrUpdate preserves when nil", func() {
+		original := &virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			AgentFacts: agentFacts,
+		}
+		update := &virtualmachine.Info{
+			ID:          vmID,
+			Name:        vmName,
+			Namespace:   vmNamespace,
+			Description: "updated description",
+		}
+
+		s.store.AddOrUpdate(original)
+		s.store.AddOrUpdate(update)
+
+		actual := s.store.Get(vmID)
+		s.Require().NotNil(actual)
+		assert.Equal(s.T(), agentFacts, actual.AgentFacts)
+	})
+
+	s.Run("AddOrUpdate overrides when provided", func() {
+		originalFacts := map[string]string{"original": "value"}
+		updatedFacts := map[string]string{
+			pkgVM.ActivationStatusKey: pkgVM.ActivationStatusInactive,
+		}
+
+		s.store = NewVirtualMachineStore()
+		s.store.AddOrUpdate(&virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			AgentFacts: originalFacts,
+		})
+		s.store.AddOrUpdate(&virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			AgentFacts: updatedFacts,
+		})
+
+		actual := s.store.Get(vmID)
+		s.Require().NotNil(actual)
+		assert.Equal(s.T(), updatedFacts, actual.AgentFacts)
+	})
+
+	s.Run("UpdateStateOrCreate preserves when nil", func() {
+		s.store = NewVirtualMachineStore()
+		s.store.AddOrUpdate(&virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			AgentFacts: agentFacts,
+		})
+		s.store.UpdateStateOrCreate(&virtualmachine.Info{
+			ID:        vmID,
+			Name:      vmName,
+			Namespace: vmNamespace,
+			Running:   true,
+			VSOCKCID:  new(uint32(1)),
+			GuestOS:   "Red Hat Enterprise Linux 9",
+		})
+
+		actual := s.store.Get(vmID)
+		s.Require().NotNil(actual)
+		assert.Equal(s.T(), agentFacts, actual.AgentFacts)
+	})
+
+	s.Run("UpdateStateOrCreate overrides when provided", func() {
+		originalFacts := map[string]string{"original": "value"}
+		updatedFacts := map[string]string{
+			pkgVM.DNFMetadataStatusKey: pkgVM.DNFMetadataStatusAvailable,
+		}
+
+		s.store = NewVirtualMachineStore()
+		s.store.AddOrUpdate(&virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			AgentFacts: originalFacts,
+		})
+		s.store.UpdateStateOrCreate(&virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			Running:    true,
+			AgentFacts: updatedFacts,
+		})
+
+		actual := s.store.Get(vmID)
+		s.Require().NotNil(actual)
+		assert.Equal(s.T(), updatedFacts, actual.AgentFacts)
+	})
+
+	s.Run("AddOrUpdate clones incoming AgentFacts", func() {
+		facts := map[string]string{pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive}
+		s.store = NewVirtualMachineStore()
+		s.store.AddOrUpdate(&virtualmachine.Info{
+			ID:         vmID,
+			Name:       vmName,
+			Namespace:  vmNamespace,
+			AgentFacts: facts,
+		})
+		facts[pkgVM.ActivationStatusKey] = "mutated"
+
+		actual := s.store.Get(vmID)
+		s.Require().NotNil(actual)
+		assert.Equal(s.T(), pkgVM.ActivationStatusActive, actual.AgentFacts[pkgVM.ActivationStatusKey])
+	})
 }
 
 func (s *storeSuite) Test_RemoveVirtualMachine() {

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store_test.go
@@ -744,6 +744,29 @@ func (s *storeSuite) Test_RuntimeUpdatesShouldPreserveAgentFacts() {
 	})
 }
 
+func (s *storeSuite) Test_SetAgentFacts() {
+	s.Run("replaces facts on an existing VM", func() {
+		s.store.AddOrUpdate(&virtualmachine.Info{
+			ID:          vmID,
+			Name:        vmName,
+			Namespace:   vmNamespace,
+			GuestOS:     "from-informer",
+			Description: "kept",
+		})
+		facts := map[string]string{pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive}
+		s.store.SetAgentFacts(vmID, facts)
+		got := s.store.Get(vmID)
+		assert.Equal(s.T(), facts, got.AgentFacts)
+		assert.Equal(s.T(), "from-informer", got.GuestOS)
+		assert.Equal(s.T(), "kept", got.Description)
+	})
+
+	s.Run("ignores a missing VM", func() {
+		s.store.SetAgentFacts(vmID, map[string]string{pkgVM.ActivationStatusKey: pkgVM.ActivationStatusActive})
+		assert.Nil(s.T(), s.store.Get(vmID))
+	})
+}
+
 func (s *storeSuite) Test_RemoveVirtualMachine() {
 	vsockCID1 := new(uint32(1))
 	cases := map[string]struct {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -212,7 +212,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 		if repo2CPE != nil {
 			repo2CPEFetcher = repo2CPE
 		}
-		vmScraper = vmscraper.New(storeProvider.VirtualMachines(), dialer, vmProtoClient, repo2CPEFetcher)
+		vmScraper = vmscraper.New(storeProvider.VirtualMachines(), dialer, vmProtoClient, repo2CPEFetcher, clusterID)
 		vmStats = vmScraper
 	}
 

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	v2 "github.com/stackrox/rox/generated/api/v2"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"github.com/stackrox/rox/tests/vmhelpers"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +69,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				require.Equal(t, v2.VirtualMachine_RUNNING, first.GetState())
 				require.NotNil(t, first.GetScan())
 				require.NotNil(t, first.GetScan().GetScanTime())
+				requireForwardedAgentFacts(t, first.GetFacts())
 			})
 
 			t.Run("CentralScanComponents", func(t *testing.T) {
@@ -105,6 +107,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, detail.GetState())
 				require.NotNil(t, detail.GetLatestScan())
 				require.NotNil(t, detail.GetLatestScan().GetScanTime())
+				requireForwardedAgentFacts(t, detail.GetFacts())
 			})
 
 			t.Run("VirtualMachineV2ListVMs", func(t *testing.T) {
@@ -263,6 +266,15 @@ func componentRowNames(comps []*v2.VMComponentRow) []string {
 		}
 	}
 	return names
+}
+
+func requireForwardedAgentFacts(t *testing.T, facts map[string]string) {
+	t.Helper()
+	require.NotEmpty(t, facts)
+	require.Regexp(t, `^Red Hat Enterprise Linux \d`, facts[pkgVM.DetectedGuestOSKey],
+		"facts.detectedGuestOS should be the versioned guest OS from roxagent")
+	require.NotEmpty(t, facts[pkgVM.AgentVersionKey],
+		"facts.agentVersion should be the roxagent version from ResponseMeta")
 }
 
 func distinctCVEIDs(cves []*v2.VMCVERow) []string {


### PR DESCRIPTION
## Description

Sensor forwards roxagent scan-prerequisite metadata on the existing `VirtualMachine.facts` map. After a successful VSOCK pull, it maps `ResponseMeta` onto user-facing keys, keeps those keys on the in-memory VM across KubeVirt informer updates, and sends a `VirtualMachine` UPDATE when they change. That UPDATE also fires when the index report itself is unchanged: activation and DNF status can change without a rescan. New reports still go out as the existing index-report SYNC.

This PR writes these fact keys:

- `detectedGuestOS` (roxagent OS; informer `guestOS` is left alone)
- `activationStatus`
- `dnfMetadataStatus`
- `agentVersion`

Unspecified proto enums are omitted. If mapping produces nothing, Sensor keeps last-known agent facts. A failed facts send is retried on the next scrape. If the VM is missing from the store, a facts-only request still uses the scrape snapshot.

Central already copies the facts map into storage and returns it on GetVM. API `guest_os` stays the informer `GuestOs` column, which scan OS stamping still uses.

The VM UI follow-up ([ROX-34863](https://redhat.atlassian.net/browse/ROX-34863)) will project `facts.detectedGuestOS` onto API `guest_os` and show that versioned string on the VM page. That work is not in this PR.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [ ] CI: Added unit and e2e test coverage
- [x] Manually on a cluster

In browser, I checked the Central API reply to URL: https://central-stackrox.apps.pr-08-31-far-stay-pain.ocp.infra.rox.systems/main/vulnerabilities/virtual-machine-cves/virtualmachines/5cc56d40-a4c1-448f-bb8b-54662f29d2a4?detailsTab=Vulnerabilities

Before:
```
TODO
``` 

After:

```
{
    "id": "5cc56d40-a4c1-448f-bb8b-54662f29d2a4",
    "name": "rhel10-1",
    "namespace": "openshift-cnv",
    "clusterId": "b5f31338-f948-43e3-a232-ac7223404767",
    "clusterName": "pr-08-31-far-stay-pain",
    "guestOs": "Red Hat Enterprise Linux",
    "state": "VM_STATE_RUNNING",
    "lastUpdated": "2026-09-04T12:07:16.879772407Z",
    "facts": {
        "activationStatus": "inactive",
        "activePods": "aeed0b31-761d-4177-953f-372b48bb87ec=pr-08-31-far-stay-pai-2dmsp-worker-c-fnlj7",
        "agentVersion": "5.0.x-174-g6b7ccc2192",
        "bootOrder": "containerdisk=1, cloudinitdisk=2",
        "detectedGuestOS": "Red Hat Enterprise Linux 10.2",
        "dnfMetadataStatus": "available",
        "guestOS": "Red Hat Enterprise Linux",
        "ipAddresses": "10.129.2.47",
        "nodeName": "pr-08-31-far-stay-pai-2dmsp-worker-c-fnlj7"
    },
    "annotations": {},
    "labels": {},
    "vsockCid": 2120452532,
    "notes": [],
    "latestScan": {
        "scanId": "01a06c50-e88a-7559-9db5-99f54f90d12d",
        "scanOs": "Red Hat Enterprise Linux",
        "scanTime": "2026-09-04T12:07:16.879772407Z",
        "topCvss": 9.1,
        "scanNotes": [
            "VM_SCAN_NOTE_OS_UNKNOWN"
        ]
    },
    "agentStatus": "AGENT_STATUS_UNKNOWN"
}
```
- `facts.detectedGuestOS` is the versioned agent string (`Red Hat Enterprise Linux 10.2`). 
- `facts.guestOS` and top-level `guestOs` stay the informer value (`Red Hat Enterprise Linux`) - Those two are different on purpose.
- Activation, DNF, and agentVersion are all present.

⚠️ The `"agentStatus": "AGENT_STATUS_UNKNOWN"` is something that we missed (added in https://github.com/stackrox/stackrox/pull/19663)  and we would need a small followup for this to set this value - sensor has the data. 

[ROX-34863]: https://redhat.atlassian.net/browse/ROX-34863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ