### PR TITLE
ROX-36127: switch vulnerability pipeline to production

### DIFF
--- a/.github/workflows/scanner-updater-bundle.yaml
+++ b/.github/workflows/scanner-updater-bundle.yaml
@@ -3,9 +3,6 @@ name: Scanner updater bundle
 # and assembles vulnerabilities.zip for each bundle stream defined in
 # VULNERABILITY_BUNDLE_VERSION. Missing or empty sources are skipped with a
 # Slack notification; if no sources are valid the job fails.
-# TODO(ROX-36127): production cutover — update storage.bucket in
-# source-config.yaml to definitions.stackrox.io and remove the schedule from
-# scanner-versioned-definitions-update.yaml.
 
 on:
   schedule:
@@ -73,8 +70,7 @@ jobs:
     - name: Authenticate with GCS
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3

--- a/.github/workflows/scanner-updater-export.yaml
+++ b/.github/workflows/scanner-updater-export.yaml
@@ -56,8 +56,7 @@ jobs:
     - name: Authenticate with GCS
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
@@ -151,10 +150,15 @@ jobs:
         scanner/bin/updater export --manual-url "$MANUAL_URL" bundles
 
     - name: Authenticate with GCS for upload
+      if: ${{ !inputs.skip_freshness_check }}
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER
-        # for non-PR runs (select via inputs.skip_freshness_check or a dedicated input).
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
+
+    - name: Authenticate with GCS for upload (PR)
+      if: ${{ inputs.skip_freshness_check }}
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
+      with:
         credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
 
     - name: Set up Cloud SDK

--- a/.github/workflows/scanner-updater-schedule.yaml
+++ b/.github/workflows/scanner-updater-schedule.yaml
@@ -1,8 +1,4 @@
 name: Scanner updater schedule
-# This workflow writes to the test bucket while under validation.
-# Once the bundler workflow is ready and the full pipeline is verified,
-# update storage.bucket in source-config.yaml to definitions.stackrox.io
-# and remove the schedule from scanner-versioned-definitions-update.yaml.
 
 on:
   schedule:
@@ -39,8 +35,7 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # ratchet:google-github-actions/auth@v3
       with:
-        # TODO(ROX-36127): production cutover — use GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER.
-        credentials_json: ${{ secrets.GOOGLE_SA_CIRCLECI_SCANNER }}
+        credentials_json: ${{ secrets.GOOGLE_SA_STACKROX_HUB_VULN_DUMP_UPLOADER }}
 
     - name: Set up Cloud SDK
       if: github.event_name != 'pull_request'
@@ -82,7 +77,7 @@ jobs:
       run: |
         set -euo pipefail
         sc=./.github/workflows/scripts/scanner-updater-config.sh
-        bucket=$("$sc" bucket)
+        bucket="scanner-v4-test"
         prefix=$("$sc" prefix)
         matrix="{\"include\":[{\"source\":\"manual\",\"ref\":\"${PR_SHA}\",\"object\":\"gs://${bucket}/${prefix}/pr-${PR_NUMBER}/sources/manual.json.zst\"}]}"
         printf '{"has_due":true,"has_errors":false,"errors":[],"matrix":%s}\n' "$matrix" > matrix-result.json

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -1,8 +1,6 @@
 name: Scanner versioned vulnerabilities update
 
 on:
-  schedule:
-  - cron: "30 */4 * * *"
   pull_request:
     types:
     - opened

--- a/scanner/updater/ci/source-config.yaml
+++ b/scanner/updater/ci/source-config.yaml
@@ -12,8 +12,8 @@
 # as the pipeline evolves.
 
 storage:
-  bucket: scanner-v4-test
-  prefix: vulnerability-bundles
+  bucket: definitions.stackrox.io
+  prefix: v4/vulnerability-bundles
 
 bundles:
   dev:


### PR DESCRIPTION
## Description

Switch the per-source vulnerability pipeline from the test bucket (`scanner-v4-test`) to production (`definitions.stackrox.io`). This retires the old monolithic workflow's automatic schedule and makes the new per-source scheduler + bundler pipeline the production data path.

Two atomic changes:

1. `source-config.yaml`: switch `storage.bucket` to `definitions.stackrox.io` and fix `prefix` to `v4/vulnerability-bundles` (matches the path Central and the offline bundle script construct).
2. `scanner-versioned-definitions-update.yaml`: remove the `schedule:` cron trigger. `workflow_dispatch` is preserved for manual rollback.

After merge, manually dispatch the scheduler and bundler to populate production before the next cron cycle.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Pre-conditions verified before opening:

- All 39 source objects (13 sources x 3 streams) exist in the test bucket with fresh data and non-zero sizes.
- Test-bucket ZIPs contain exactly 13 entries each and are >200MB.
- The `workflow_dispatch` trigger is preserved in the old workflow for rollback.

Post-merge validation includes: manual scheduler dispatch, bundler run, HTTP 200 verification on production URLs, and end-to-end import check in a live deployment.