### PR TITLE
ROX-36498: Add CVE Origin filter to UI

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -62,7 +62,7 @@ export const KnownExploit: CompoundSearchFilterAttribute = {
 // the single image page, single deployment page, and image vulnerability reports, which
 // append it to their own configs.
 export const Origin: CompoundSearchFilterAttribute = {
-    displayName: 'CVE origin',
+    displayName: 'Origin',
     filterChipLabel: 'CVE origin',
     searchTerm: 'CVE Origin',
     inputType: 'select',

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageCVE.ts
@@ -1,5 +1,7 @@
 // If you're adding a new attribute, make sure to add it to "imageCVEAttributes" as well
 
+import { originDisplayNames } from 'Containers/Vulnerabilities/utils/vulnerabilityUtils';
+
 import type { CompoundSearchFilterAttribute } from '../types';
 import { EPSSProbability } from './epssProbability';
 
@@ -50,6 +52,27 @@ export const KnownExploit: CompoundSearchFilterAttribute = {
         ],
     },
     featureFlagDependency: ['ROX_SCANNER_V4', 'ROX_CISA_KEV'],
+};
+
+// The filter value is the VulnOrigin enum name (e.g. VULN_ORIGIN_RED_HAT), which the
+// backend enum search matches by case-insensitive prefix. The human-readable label
+// would not match, so value must be the enum key, not the display name.
+//
+// Intentionally NOT part of imageCVEAttributes: the CVE origin filter is only shown on
+// the single image page, single deployment page, and image vulnerability reports, which
+// append it to their own configs.
+export const Origin: CompoundSearchFilterAttribute = {
+    displayName: 'CVE origin',
+    filterChipLabel: 'CVE origin',
+    searchTerm: 'CVE Origin',
+    inputType: 'select',
+    inputProps: {
+        options: Object.entries(originDisplayNames).map(([value, label]) => ({
+            value,
+            label: label ?? value,
+        })),
+    },
+    featureFlagDependency: ['ROX_SCANNER_V4'],
 };
 
 export const imageCVEAttributes = [CVSS, DiscoveredTime, EPSSProbability, KnownExploit, Name];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -9,6 +9,7 @@ import {
 
 import type { ViewBasedReportSnapshot } from 'services/ReportsService.types';
 import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
+import { Origin } from 'Components/CompoundSearchFilter/attributes/imageCVE';
 import { getSearchFilterFromSearchString } from 'utils/searchUtils';
 import {
     attributesSeparateFromConfigForImageVulnerabilityReport,
@@ -33,6 +34,10 @@ function ViewBasedReportJobDetails({ reportSnapshot }: ViewBasedReportJobDetails
     const attributes = [
         ...attributesSeparateFromConfigForImageVulnerabilityReport,
         ...attributesFromConfig,
+        // Origin is not part of the shared workload/view-based config (that config also drives
+        // the overview page filter input, which is out of scope). Append it here so a view-based
+        // report created from the image/deployment single pages displays the CVE origin filter.
+        Origin,
     ];
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -40,6 +40,7 @@ import {
     getVulnStateScopedQueryString,
     parseQuerySearchFilter,
 } from '../../utils/searchUtils';
+import { Origin } from 'Components/CompoundSearchFilter/attributes/imageCVE';
 import {
     imageCVESearchFilterConfig,
     imageComponentSearchFilterConfig,
@@ -195,10 +196,13 @@ function DeploymentPageVulnerabilities({
         // imageCVESearchFilterConfig,
         {
             ...imageCVESearchFilterConfig,
-            attributes: imageCVESearchFilterConfig.attributes.filter(
-                ({ searchTerm }) =>
-                    searchTerm !== 'EPSS Probability' || isEpssProbabilityColumnEnabled
-            ),
+            attributes: [
+                ...imageCVESearchFilterConfig.attributes.filter(
+                    ({ searchTerm }) =>
+                        searchTerm !== 'EPSS Probability' || isEpssProbabilityColumnEnabled
+                ),
+                Origin, // CVE origin filter is scoped to the single deployment page
+            ],
         },
         imageSearchFilterConfig,
         imageComponentSearchFilterConfig,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -64,6 +64,7 @@ import type { ExceptionRequestModalProps } from '../../components/ExceptionReque
 import CompletedExceptionRequestModal from '../../components/ExceptionRequestModal/CompletedExceptionRequestModal';
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { Origin } from 'Components/CompoundSearchFilter/attributes/imageCVE';
 import {
     imageCVESearchFilterConfig,
     imageComponentSearchFilterConfig,
@@ -256,10 +257,13 @@ function ImagePageVulnerabilities({
         // imageCVESearchFilterConfig,
         {
             ...imageCVESearchFilterConfig,
-            attributes: imageCVESearchFilterConfig.attributes.filter(
-                ({ searchTerm }) =>
-                    searchTerm !== 'EPSS Probability' || isEpssProbabilityColumnEnabled
-            ),
+            attributes: [
+                ...imageCVESearchFilterConfig.attributes.filter(
+                    ({ searchTerm }) =>
+                        searchTerm !== 'EPSS Probability' || isEpssProbabilityColumnEnabled
+                ),
+                Origin, // CVE origin filter is scoped to the single image page
+            ],
         },
         imageComponentSearchFilterConfig,
     ];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -29,7 +29,7 @@ import {
     Name,
 } from 'Components/CompoundSearchFilter/attributes/deployment';
 import { imageAttributes } from 'Components/CompoundSearchFilter/attributes/image';
-import { imageCVEAttributes } from 'Components/CompoundSearchFilter/attributes/imageCVE';
+import { Origin, imageCVEAttributes } from 'Components/CompoundSearchFilter/attributes/imageCVE';
 import { imageComponentAttributes } from 'Components/CompoundSearchFilter/attributes/imageComponent';
 import {
     Annotation as namespaceAnnotation,
@@ -261,9 +261,12 @@ export const attributeForSeverityInBackendAndViewBasedReport: SelectSearchFilter
 export const searchFilterConfigForImageVulnerabilityReport = [
     {
         ...imageCVESearchFilterConfig,
-        attributes: imageCVESearchFilterConfig.attributes.filter(
-            ({ searchTerm }) => searchTerm !== 'CVE Created Time'
-        ),
+        attributes: [
+            ...imageCVESearchFilterConfig.attributes.filter(
+                ({ searchTerm }) => searchTerm !== 'CVE Created Time'
+            ),
+            Origin, // CVE origin filter is scoped to reports (plus single image/deployment pages)
+        ],
     },
     imageSearchFilterConfig,
     imageComponentSearchFilterConfig,

--- a/ui/apps/platform/src/types/searchOptions.ts
+++ b/ui/apps/platform/src/types/searchOptions.ts
@@ -37,6 +37,7 @@ export const searchFieldLabels = [
     'CVE Published On',
     'CVE Fix Available Timestamp',
     'CVE Created Time',
+    'CVE Origin',
     'CVE Snoozed',
     'CVE Snooze Expiry',
     'CVSS',


### PR DESCRIPTION
## Description

Builds on https://github.com/stackrox/stackrox/pull/22464 by adding the ability to filter results by CVE Origin.



## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added - following existing conventions for these fields/files.

### How I validated my change

CI + Manual (note: images below show CVE Origin in the filter slugs, this is now just 'Origin' - screenshots were not recaptured)

Confirmed on image singles and deployment pages the CVE origin filter shows up, and when an origin is selected the results are updated accordingly at the aggregate level as well as individual components level.  Also confirmed the filter does not show on other pages.

<img width="452" height="343" alt="image" src="https://github.com/user-attachments/assets/975eab6a-79c3-4dfa-a431-c7008c827121" />

<img width="507" height="519" alt="image" src="https://github.com/user-attachments/assets/1784e8ec-3912-4c98-90a5-21717293aed9" />

No origins filtered:

<img width="1471" height="746" alt="image" src="https://github.com/user-attachments/assets/69584915-73d7-4ae9-853f-a8825b9672c8" />

Filtered by Red Hat origin: 

<img width="1479" height="648" alt="image" src="https://github.com/user-attachments/assets/bea328e6-f4ad-4a96-802c-7f7a3de9f20a" />

Generated reports via configuration as well as view based, confirmed generated reports contain only the data for the origins selected.

<img width="1247" height="642" alt="image" src="https://github.com/user-attachments/assets/9f5f4026-2540-4148-b1bf-da03c244f9dc" />

View based report parameters shows origins selected at the time of export

<img width="653" height="572" alt="image" src="https://github.com/user-attachments/assets/0bdc04a1-3743-4e26-9291-78e3bdc1b045" />

May need to keep an eye on the size of this list, may grow too big for the screen eventually.

<img width="619" height="738" alt="image" src="https://github.com/user-attachments/assets/780c079a-0531-42ed-909d-29495a0253a8" />

Report with only RH data

<img width="590" height="412" alt="image" src="https://github.com/user-attachments/assets/dc1cb9f6-778d-4448-b562-9e6ce4dc7c87" />

Also confirmed that when no origins are selected ALL origins are included in the results.