### PR TITLE
ROX-36555: Drain persist goroutines before TempDir cleanup

### DIFF
--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater.go
@@ -34,6 +34,9 @@ type SensorUpdater struct {
 	// persistMu serializes cachePath writes. persistActive is the only
 	// acquirer; it takes persistMu, then mu, never the reverse.
 	persistMu sync.Mutex
+	// persistWG tracks persistAndNotify's background writes so tests can
+	// drain them before TempDir cleanup.
+	persistWG sync.WaitGroup
 }
 
 // NewSensorUpdater seeds active from cachePath, else bundledPath, else
@@ -189,14 +192,21 @@ func (u *SensorUpdater) applyLocked(content []byte, hash string) {
 // background. Path is the write barrier if the file is needed before
 // that goroutine finishes.
 func (u *SensorUpdater) persistAndNotify() {
-	go func() {
+	u.persistWG.Go(func() {
 		if _, err := u.persistActive(); err != nil {
 			log.Warnf("Persisting repo-to-CPE mapping cache to %q: %v", u.cachePath, err)
 		}
-	}()
+	})
 	if u.onChange != nil {
 		u.onChange()
 	}
+}
+
+// waitPersist blocks until every persistAndNotify goroutine has finished
+// writing cachePath. Tests register it with t.Cleanup so TempDir removal
+// cannot race AtomicWriteFile's sibling .tmp files.
+func (u *SensorUpdater) waitPersist() {
+	u.persistWG.Wait()
 }
 
 // persistActive writes a copy of the current active mapping to cachePath.

--- a/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/sensor_updater_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/virtualmachine/cpemapping"
@@ -15,13 +14,6 @@ import (
 const validMappingJSON = `{"data":{"rhel-8-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:8"]}}}`
 const otherValidMappingJSON = `{"data":{"rhel-9-server-rpms":{"cpes":["cpe:/o:redhat:enterprise_linux:9"]}}}`
 const invalidMappingJSON = `{not json`
-
-// waitTimeout/waitTick bound assert.Eventually polling for the
-// fire-and-forget cache-persistence goroutine shared by both updaters' tests.
-const (
-	waitTimeout = 2 * time.Second
-	waitTick    = 10 * time.Millisecond
-)
 
 // onChangeCounter is a test double for a MappingProvider's onChange
 // callback that records how many times it fired.
@@ -36,22 +28,28 @@ func writeFile(t *testing.T, path, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 }
 
-// waitForCacheContent polls cachePath for the persist goroutine an applied
-// Update starts in the background, so tests can drain it deterministically
-// instead of letting it race the tempdir's end-of-test cleanup.
-func waitForCacheContent(t *testing.T, cachePath, want string) {
+func newSensorUpdater(t *testing.T, cachePath, bundledPath string, onChange func()) *SensorUpdater {
 	t.Helper()
-	assert.Eventually(t, func() bool {
-		b, err := os.ReadFile(cachePath)
-		return err == nil && string(b) == want
-	}, waitTimeout, waitTick, "expected %q to be persisted to %s", want, cachePath)
+	u := NewSensorUpdater(cachePath, bundledPath, onChange)
+	t.Cleanup(u.waitPersist)
+	return u
+}
+
+// waitForCacheContent drains persistAndNotify's background write, then
+// checks cachePath, so the assertion cannot race AtomicWriteFile.
+func waitForCacheContent(t *testing.T, u *SensorUpdater, cachePath, want string) {
+	t.Helper()
+	u.waitPersist()
+	b, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	assert.Equal(t, want, string(b), "expected %q to be persisted to %s", want, cachePath)
 }
 
 func TestNewSensorUpdater_EmptyStart_NotReady(t *testing.T) {
 	dir := t.TempDir()
 	counter := &onChangeCounter{}
 
-	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), "", counter.fn)
+	u := newSensorUpdater(t, filepath.Join(dir, "cache.json"), "", counter.fn)
 
 	assert.False(t, u.Ready())
 	assert.Empty(t, u.Hash())
@@ -69,7 +67,7 @@ func TestNewSensorUpdater_BootstrapFromCache(t *testing.T) {
 	writeFile(t, cachePath, validMappingJSON)
 	counter := &onChangeCounter{}
 
-	u := NewSensorUpdater(cachePath, "", counter.fn)
+	u := newSensorUpdater(t, cachePath, "", counter.fn)
 
 	require.True(t, u.Ready())
 	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
@@ -85,7 +83,7 @@ func TestNewSensorUpdater_BootstrapFromBundled_WhenNoCache(t *testing.T) {
 	writeFile(t, bundledPath, validMappingJSON)
 	counter := &onChangeCounter{}
 
-	u := NewSensorUpdater(filepath.Join(dir, "cache.json"), bundledPath, counter.fn)
+	u := newSensorUpdater(t, filepath.Join(dir, "cache.json"), bundledPath, counter.fn)
 
 	require.True(t, u.Ready())
 	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
@@ -99,7 +97,7 @@ func TestNewSensorUpdater_CacheTakesPrecedenceOverBundled(t *testing.T) {
 	writeFile(t, cachePath, validMappingJSON)
 	writeFile(t, bundledPath, otherValidMappingJSON)
 
-	u := NewSensorUpdater(cachePath, bundledPath, func() {})
+	u := newSensorUpdater(t, cachePath, bundledPath, func() {})
 
 	b, err := u.Bytes()
 	require.NoError(t, err)
@@ -113,7 +111,7 @@ func TestNewSensorUpdater_InvalidCacheFallsBackToBundled(t *testing.T) {
 	writeFile(t, cachePath, invalidMappingJSON)
 	writeFile(t, bundledPath, validMappingJSON)
 
-	u := NewSensorUpdater(cachePath, bundledPath, func() {})
+	u := newSensorUpdater(t, cachePath, bundledPath, func() {})
 
 	require.True(t, u.Ready())
 	b, err := u.Bytes()
@@ -127,7 +125,7 @@ func TestNewSensorUpdater_InvalidCacheNoBundled_NotReady(t *testing.T) {
 	writeFile(t, cachePath, invalidMappingJSON)
 	counter := &onChangeCounter{}
 
-	u := NewSensorUpdater(cachePath, "", counter.fn)
+	u := newSensorUpdater(t, cachePath, "", counter.fn)
 
 	assert.False(t, u.Ready())
 	assert.Equal(t, 0, counter.count)
@@ -135,7 +133,7 @@ func TestNewSensorUpdater_InvalidCacheNoBundled_NotReady(t *testing.T) {
 
 func TestSensorUpdater_Update_OwnsContent(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
-	u := NewSensorUpdater(cachePath, "", func() {})
+	u := newSensorUpdater(t, cachePath, "", func() {})
 	content := []byte(validMappingJSON)
 
 	updated, err := u.Update(content)
@@ -146,12 +144,12 @@ func TestSensorUpdater_Update_OwnsContent(t *testing.T) {
 	b, err := u.Bytes()
 	require.NoError(t, err)
 	assert.Equal(t, validMappingJSON, string(b), "mutating the caller's buffer must not change the active mapping")
-	waitForCacheContent(t, cachePath, validMappingJSON)
+	waitForCacheContent(t, u, cachePath, validMappingJSON)
 }
 
 func TestSensorUpdater_Path_WritesCurrentActive(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
-	u := NewSensorUpdater(cachePath, "", func() {})
+	u := newSensorUpdater(t, cachePath, "", func() {})
 	_, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
 	_, err = u.Update([]byte(otherValidMappingJSON))
@@ -163,14 +161,14 @@ func TestSensorUpdater_Path_WritesCurrentActive(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, otherValidMappingJSON, string(onDisk),
 		"Path must persist the current active mapping, not an in-flight older write")
-	waitForCacheContent(t, cachePath, otherValidMappingJSON)
+	waitForCacheContent(t, u, cachePath, otherValidMappingJSON)
 }
 
 func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "cache.json")
 	counter := &onChangeCounter{}
-	u := NewSensorUpdater(cachePath, "", counter.fn)
+	u := newSensorUpdater(t, cachePath, "", counter.fn)
 
 	updated, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
@@ -178,15 +176,15 @@ func TestSensorUpdater_Update_AppliesWhenIdle(t *testing.T) {
 	assert.True(t, u.Ready())
 	assert.Equal(t, cpemapping.HashMapping([]byte(validMappingJSON)), u.Hash())
 	assert.Equal(t, 1, counter.count)
-	waitForCacheContent(t, cachePath, validMappingJSON)
+	waitForCacheContent(t, u, cachePath, validMappingJSON)
 }
 
 func TestSensorUpdater_Update_NoOpWhenUnchanged(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
-	u := NewSensorUpdater(cachePath, "", func() {})
+	u := newSensorUpdater(t, cachePath, "", func() {})
 	_, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
-	waitForCacheContent(t, cachePath, validMappingJSON)
+	waitForCacheContent(t, u, cachePath, validMappingJSON)
 
 	updated, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
@@ -195,11 +193,11 @@ func TestSensorUpdater_Update_NoOpWhenUnchanged(t *testing.T) {
 
 func TestSensorUpdater_Update_RejectsInvalidKeepsLastGood(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
-	u := NewSensorUpdater(cachePath, "", func() {})
+	u := newSensorUpdater(t, cachePath, "", func() {})
 	_, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
 	wantHash := u.Hash()
-	waitForCacheContent(t, cachePath, validMappingJSON)
+	waitForCacheContent(t, u, cachePath, validMappingJSON)
 
 	updated, err := u.Update([]byte(invalidMappingJSON))
 	assert.Error(t, err)
@@ -208,7 +206,7 @@ func TestSensorUpdater_Update_RejectsInvalidKeepsLastGood(t *testing.T) {
 }
 
 func TestSensorUpdater_Update_OversizeRejected(t *testing.T) {
-	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	u := newSensorUpdater(t, filepath.Join(t.TempDir(), "cache.json"), "", func() {})
 	oversized := make([]byte, cpemapping.MaxMappingBytes+1)
 
 	updated, err := u.Update(oversized)
@@ -221,7 +219,7 @@ func TestSensorUpdater_UpdateWhileBusy_DefersUntilIdle(t *testing.T) {
 	dir := t.TempDir()
 	cachePath := filepath.Join(dir, "cache.json")
 	counter := &onChangeCounter{}
-	u := NewSensorUpdater(cachePath, "", counter.fn)
+	u := newSensorUpdater(t, cachePath, "", counter.fn)
 	_, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
 	require.Equal(t, 1, counter.count)
@@ -250,11 +248,11 @@ func TestSensorUpdater_UpdateWhileBusy_DefersUntilIdle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, otherValidMappingJSON, string(b))
 	assert.Equal(t, 2, counter.count, "onChange must fire once the pending mapping is promoted")
-	waitForCacheContent(t, cachePath, otherValidMappingJSON)
+	waitForCacheContent(t, u, cachePath, otherValidMappingJSON)
 }
 
 func TestSensorUpdater_UpdateWhileBusy_SameAsPending_NoOp(t *testing.T) {
-	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	u := newSensorUpdater(t, filepath.Join(t.TempDir(), "cache.json"), "", func() {})
 	u.MarkScanBusy()
 
 	updated, err := u.Update([]byte(validMappingJSON))
@@ -271,7 +269,7 @@ func TestSensorUpdater_UpdateWhileBusy_SameAsPending_NoOp(t *testing.T) {
 // are ordered, so the newest push (matching active) must win, not the
 // earlier, now-stale pending content.
 func TestSensorUpdater_UpdateWhileBusy_RevertToActive_ClearsStalePending(t *testing.T) {
-	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	u := newSensorUpdater(t, filepath.Join(t.TempDir(), "cache.json"), "", func() {})
 	_, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
 	u.MarkScanBusy()
@@ -293,11 +291,11 @@ func TestSensorUpdater_UpdateWhileBusy_RevertToActive_ClearsStalePending(t *test
 func TestSensorUpdater_MarkScanIdleAndApplyPending_NoPending_NoOp(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "cache.json")
 	counter := &onChangeCounter{}
-	u := NewSensorUpdater(cachePath, "", counter.fn)
+	u := newSensorUpdater(t, cachePath, "", counter.fn)
 	_, err := u.Update([]byte(validMappingJSON))
 	require.NoError(t, err)
 	require.Equal(t, 1, counter.count)
-	waitForCacheContent(t, cachePath, validMappingJSON)
+	waitForCacheContent(t, u, cachePath, validMappingJSON)
 
 	u.MarkScanBusy()
 	u.MarkScanIdleAndApplyPending()
@@ -307,6 +305,6 @@ func TestSensorUpdater_MarkScanIdleAndApplyPending_NoPending_NoOp(t *testing.T) 
 }
 
 func TestSensorUpdater_UpdatePath_IsSensor(t *testing.T) {
-	u := NewSensorUpdater(filepath.Join(t.TempDir(), "cache.json"), "", func() {})
+	u := newSensorUpdater(t, filepath.Join(t.TempDir(), "cache.json"), "", func() {})
 	assert.Equal(t, pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR, u.UpdatePath())
 }


### PR DESCRIPTION
## Description

CI flakes on `TestSensorUpdater_Path_WritesCurrentActive` with:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...: directory not empty
```

`SensorUpdater.Update` applies the mapping in memory and persists the cache on a background goroutine via `AtomicWriteFile`. That write creates a sibling `.download-*.tmp` next to `cache.json`, then renames it. `t.TempDir` cleanup can run while that goroutine is still writing, so `RemoveAll` sees a new file and returns ENOTEMPTY.

Waiting until `cache.json` has the expected bytes does not drain the goroutine. A persist that has not created the temp file yet is invisible to that poll. Two back-to-back `Update` calls make this likely: both persist goroutines can still be in flight after `Path()` has already written the current mapping.

This change tracks those writes with a WaitGroup. Tests wait on it in `t.Cleanup` (before `TempDir` removal) and before asserting cache contents.

Fire-and-forget persist is unchanged for production: `Update` must not block the VSOCK handler on disk I/O, and `Path()` remains the write barrier when a caller needs the file immediately. The WaitGroup only lets tests observe that work.

On master, this failed locally within a few hundred runs:

```
go test -count=300 -timeout 3m ./compliance/virtualmachines/roxagent/vsockserver/ -run '^TestSensorUpdater_Path_WritesCurrentActive$'
```

The same command on this branch stayed green for 300 runs. `go test -race` does not catch this: it is a filesystem race, not a Go data race.

Fixes [ROX-36555](https://redhat.atlassian.net/browse/ROX-36555).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
    - First Reproduced the TempDir `ENOTEMPTY` failure on master with the 300-run loop as in the description.
    - After fixing, the same loop passed on this branch.

AI-Assisted: cursor, ~70% generated, user reviewed logic