### PR TITLE
chore(triage): delegate CI triage to the investigator subagent

### DIFF
--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,1 +1,12 @@
-Analyze this CI failure and find a root cause and permanent solution:
+Investigate this StackRox CI failure by launching the `stackrox-ci-failure-investigator`
+subagent (via the Agent tool). Pass it the input below — a Prow build ID or URL, a failing
+job name, a ROX-XXXXX ticket, or pasted logs — and have it download and read the CI
+artifacts (Prow step logs plus the collected k8s service logs, pod descriptions, events, and
+node capacity) before forming a hypothesis.
+
+Do not guess at a cause or attribute the failure to flakiness or a version being behind until
+the artifacts rule everything else out. Follow the causal chain to its origin — a failed
+check is usually a downstream symptom. Do not write code until the root cause is confirmed
+with the user.
+
+$ARGUMENTS


### PR DESCRIPTION
## Description

The `/triage` command in `.claude/commands/triage.md` was a single-line prompt
("Analyze this CI failure...") that fetched no artifacts and did not route to the
existing `stackrox-ci-failure-investigator` subagent. In practice that invites
guessing at a cause instead of reading the CI artifacts.

This change makes `/triage` delegate to the `stackrox-ci-failure-investigator`
subagent and instructs it to download and read the Prow/GCS artifacts (step logs,
collected k8s service logs, pod descriptions, events, node capacity) before forming
a hypothesis, and to confirm the root cause before writing code.

No product code is affected — this only touches a local Claude Code slash command.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] no tests changed

### How I validated my change

- Markdown-only change to a local Claude Code slash command; no product code or tests are affected, so automated testing is skipped per the template's allowance for markdown-only changes.
- Verified the command now instructs delegation to the existing `stackrox-ci-failure-investigator` agent (`.claude/agents/stackrox-ci-failure-investigator.md`).
