### PR TITLE
ROX-33929: drop SortMany and unshare PLOP insert timeouts

### DIFF
--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -2735,7 +2735,7 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUID() {
 	}
 }
 
-func (suite *PLOPDataStoreTestSuite) addTooMany(plops []*storage.ProcessListeningOnPortFromSensor) {
+func (suite *PLOPDataStoreTestSuite) addTooMany(plops []*storage.ProcessListeningOnPortFromSensor) error {
 	batchSize := 30000
 
 	for plopBatch := range slices.Chunk(plops, batchSize) {
@@ -2744,8 +2744,11 @@ func (suite *PLOPDataStoreTestSuite) addTooMany(plops []*storage.ProcessListenin
 		ctx, cancel := context.WithTimeout(suite.hasWriteCtx, 5*time.Minute)
 		err := suite.datastore.AddProcessListeningOnPort(ctx, fixtureconsts.Cluster1, plopBatch...)
 		cancel()
-		suite.Require().NoError(err)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func (suite *PLOPDataStoreTestSuite) RemovePLOPsWithoutPodUIDScale(nport int, nprocess int, npod int) {
@@ -2761,7 +2764,7 @@ func (suite *PLOPDataStoreTestSuite) RemovePLOPsWithoutPodUIDScale(nport int, np
 	}
 
 	// Add the PLOPs
-	suite.addTooMany(plopObjects)
+	suite.Require().NoError(suite.addTooMany(plopObjects))
 
 	plopCount, err := suite.store.Count(suite.hasReadCtx, search.EmptyQuery())
 	suite.Equal(plopCount, 2*nport*nprocess*npod)
@@ -2820,7 +2823,7 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUIDScaleRaceCondit
 			}
 
 			// Add the open PLOPs
-			suite.addTooMany(plopObjects)
+			suite.NoError(suite.addTooMany(plopObjects))
 
 			// Close the PLOPs
 			// This is so that UpsertMany will trigger deletes
@@ -2829,7 +2832,7 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUIDScaleRaceCondit
 			}
 
 			// Add the closed PLOPs
-			suite.addTooMany(plopObjects)
+			suite.NoError(suite.addTooMany(plopObjects))
 		}
 	}()
 

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -2738,15 +2738,13 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUID() {
 func (suite *PLOPDataStoreTestSuite) addTooMany(plops []*storage.ProcessListeningOnPortFromSensor) {
 	batchSize := 30000
 
-	// Use an explicit context timeout so that ContextWithTimeoutIfNotExists
-	// in the Postgres pool layer sees an existing deadline and skips the
-	// 60-second default per-query timeout, which is too short in some cases.
-	ctx, cancel := context.WithTimeout(suite.hasWriteCtx, 5*time.Minute)
-	defer cancel()
-
 	for plopBatch := range slices.Chunk(plops, batchSize) {
+		// Per-batch deadline so ContextWithTimeoutIfNotExists skips the
+		// 60-second default without sharing one budget across all batches.
+		ctx, cancel := context.WithTimeout(suite.hasWriteCtx, 5*time.Minute)
 		err := suite.datastore.AddProcessListeningOnPort(ctx, fixtureconsts.Cluster1, plopBatch...)
-		suite.NoError(err)
+		cancel()
+		suite.Require().NoError(err)
 	}
 }
 
@@ -2873,24 +2871,4 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUIDScaleRaceCondit
 	// that number.
 	suite.GreaterOrEqual(plopsWithoutPodUids, totalPrunedCount/2)
 	suite.LessOrEqual(plopsWithoutPodUids, totalPrunedCount)
-}
-
-func (suite *PLOPDataStoreTestSuite) TestSortMany() {
-	nport := 50
-	nprocess := 50
-	npod := 50
-
-	plops := makeRandomPlops(nport, nprocess, npod, fixtureconsts.Deployment1)
-	suite.addTooMany(plops)
-
-	suite.addDeployments()
-
-	startTime := time.Now()
-	newPlops, err := suite.datastore.GetProcessListeningOnPort(
-		suite.hasWriteCtx, fixtureconsts.Deployment1)
-	suite.NoError(err)
-	duration := time.Since(startTime)
-
-	fmt.Printf("Fetching %d plops took %s\n", len(newPlops), duration)
-
 }


### PR DESCRIPTION
I will try to fix some of the flakes before the code-freeze. Here is one attempt at that.

## Description

`go-postgres` has been failing while inserting a large set of processes-listening-on-port (PLOP) rows. The CI ticket is ROX-33929. The log is always the same: `context deadline exceeded` (then a pile of `retry context is done`) inside `GetByQuery` while adding endpoints, not while sorting them.

Two things were probably wrong.

The subtest named `SortMany` inserted 250k random endpoints (50 ports × 50 processes × 50 pods × TCP/UDP), then timed a GET. It never checked sort order. Sort order is already covered by the store-level sort suite. Removing SortMany deletes the load test that was filing the ticket. The remaining 27k/125k prune-scale tests still exercise the same insert helper.

That helper is what actually timed out. It wrapped every 30k-row batch in one 5-minute context so the postgres pool would skip its 60-second default. One deadline is shared across all batches. Each batch spends some of that budget, and later batches fail even when a single batch would have finished in time. After the first error, `NoError` let the loop continue, which is why CI pastes four or five identical `retry context is done` lines after the first timeout.

Each 30k batch now gets its own 5-minute deadline, and the first error stops the test. The 125k prune-scale test uses this helper, so it gets the same change.

Local reproduction: A quiet local postgres cannot hit the 5-minute CI wall: 250k inserts finished in about 6 seconds here. The shared-budget failure was reproduced by shrinking that deadline to 2 seconds, which is under the ~6s total and above a single-batch duration. That is the same shape as CI, just scaled down.

Shared 2-second deadline (old helper). First five batches succeed while remaining time falls from 1.69s to 158ms. Batch six and every batch after it fail; `NoError` keeps going:

```
batch len=30000 took 313ms remaining=1.687s err=<nil>
batch len=30000 took 325ms remaining=1.362s err=<nil>
batch len=30000 took 368ms remaining=994ms err=<nil>
batch len=30000 took 394ms remaining=600ms err=<nil>
batch len=30000 took 442ms remaining=158ms err=<nil>
batch len=30000 took 230ms remaining=-72ms err=retry context is done: context deadline exceeded
batch len=30000 took 55ms remaining=-127ms err=retry context is done: context deadline exceeded
batch len=30000 took 36ms remaining=-163ms err=retry context is done: context deadline exceeded
batch len=10000 took 8ms remaining=-171ms err=retry context is done: context deadline exceeded
FAIL
```

Same 2-second budget, one deadline per batch (this PR). Every batch still had more than a second left. All 250k rows inserted:

```
batch len=30000 took 320ms remaining=1.680s err=<nil>
batch len=30000 took 503ms remaining=1.497s err=<nil>
batch len=30000 took 366ms remaining=1.634s err=<nil>
batch len=30000 took 400ms remaining=1.600s err=<nil>
batch len=30000 took 467ms remaining=1.533s err=<nil>
batch len=30000 took 508ms remaining=1.492s err=<nil>
batch len=30000 took 564ms remaining=1.436s err=<nil>
batch len=30000 took 535ms remaining=1.465s err=<nil>
batch len=10000 took 378ms remaining=1.622s err=<nil>
TOTAL n=250000 took 4.041s
PASS
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- Local:
    - Reproduced the shared-deadline failure on local Postgres 15 by inserting 250k PLOP rows with a 2-second budget around the whole insert (scaled from CI's 5 minutes; local total is ~6s). Five batches committed, then the remaining budget went negative and every later batch failed with `retry context is done: context deadline exceeded`.
    - Reran the same 250k insert with a 2-second deadline per batch. All nine batches succeeded; remaining time stayed between 1.4s and 1.7s. Total 4.0s.

GitHub Actions `Unit Tests` cancels any in-progress run on the same PR branch, so overlapping `go-postgres` jobs are not possible. After the first green run on this head (`5bf2651`), a local loop reran only the `go-postgres (GOTAGS="", 15)` job on [run 33062406209](https://github.com/stackrox/stackrox/actions/runs/33062406209) and waited for each attempt to finish before starting the next. The loop was stopped after 13 consecutive successes. Attempt 14 was already in flight and will finish on GitHub.

Results: 13 of 13 completed attempts green. Zero failures.

1. ✅ [Attempt 1](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98484275807): original PR run, success
2. ✅ [Attempt 2](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98505542807): success
3. ✅ [Attempt 3](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98510377548): success
4. ✅ [Attempt 4](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98515255513): success
5. ✅ [Attempt 5](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98520388336): success
6. ✅ [Attempt 6](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98526004503): success
7. ✅ [Attempt 7](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98531235829): success
8. ✅ [Attempt 8](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98537061186): success
9. ✅ [Attempt 9](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98543238747): success
10. ✅ [Attempt 10](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98549576754): success
11. ✅ [Attempt 11](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98555802411): success
12. ✅ [Attempt 12](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98562171149): success
13. ✅ [Attempt 13](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98568634034): success
14. ⏳ [Attempt 14](https://github.com/stackrox/stackrox/actions/runs/33062406209/job/98575050246): in progress when the loop was stopped

AI-Assisted: cursor, test change and local timeout reproduction, user reviewed approach
