### PR TITLE
ROX-36432: add node scan_time diagnostic logging

### DIFF
--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -102,7 +102,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
 	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node))
 
-	const iterations = 2000
+	const iterations = 500
 	const freshWriters = 4
 	const metaWriters = 4
 	var wg sync.WaitGroup
@@ -134,7 +134,7 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 	var regressions atomic.Int64
 	stop := make(chan struct{})
 	var pollWG sync.WaitGroup
-	for range 4 {
+	for range 2 {
 		pollWG.Go(func() {
 			lastSeen := baseTime
 			for {
@@ -152,6 +152,8 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 						lastSeen = st
 					}
 				}
+				// Yield between reads so the pollers don't hammer the DB in a tight busy-loop.
+				time.Sleep(time.Millisecond)
 			}
 		})
 	}

--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -35,6 +34,7 @@ import (
 	pkgSearch "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -106,6 +106,9 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 	const freshWriters = 4
 	const metaWriters = 4
 	var wg sync.WaitGroup
+	// A writer that fails leaves the intended workload incomplete, so a zero regression count would be
+	// meaningless. Track upsert failures and assert none happened.
+	var upsertFailures atomic.Int64
 
 	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
 	for w := range freshWriters {
@@ -114,7 +117,9 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 				fresh := node.CloneVT()
 				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
 				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
-				_ = suite.datastore.UpsertNode(allowAllCtx, fresh)
+				if err := suite.datastore.UpsertNode(allowAllCtx, fresh); err != nil {
+					upsertFailures.Add(1)
+				}
 			}
 		})
 	}
@@ -126,7 +131,9 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 				metaOnly := node.CloneVT()
 				metaOnly.Scan = nil
 				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
-				_ = suite.datastore.UpsertNode(allowAllCtx, metaOnly)
+				if err := suite.datastore.UpsertNode(allowAllCtx, metaOnly); err != nil {
+					upsertFailures.Add(1)
+				}
 			}
 		})
 	}
@@ -162,6 +169,9 @@ func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutex
 	close(stop)
 	pollWG.Wait()
 
+	suite.Zero(upsertFailures.Load(),
+		"every concurrent UpsertNode must succeed; a failure means the intended workload did not complete, "+
+			"which would make the regression assertion below meaningless")
 	suite.Zero(regressions.Load(),
 		"scan_time must never regress through UpsertNode, since every real caller (nodeindex and nodes "+
 			"pipelines alike) goes through the per-node-ID keyedMutex that wraps the entire read-decide-write "+

--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -85,15 +85,11 @@ func (suite *NodePostgresDataStoreTestSuite) TearDownTest() {
 // TestConcurrentUpsertNode_KeyedMutexPreventsRegression is the datastore-layer counterpart of
 // store_test.go's TestStore_ConcurrentUpsert_BypassingOuterLock. That test proves the store layer alone has
 // a check-then-act race in isUpdated(): the read-old-scan-and-decide step isn't covered by the store's own
-// keyFence lock. This test calls the same workload through UpsertNode instead, i.e. through the
-// production call path, which wraps the entire call (read, decide, and write) in a per-node-ID
-// keyedMutex (see UpsertNode in datastore_impl.go). Since every real caller in this codebase reaches the
-// store exclusively through UpsertNode, and the customer's Central runs as a single replica (confirmed
-// from their diagnostic bundle: one Deployment, replicas: 1, one Central pod), this is the path that
-// actually matters for reproducing their bug. If scan_time never regresses here even under heavy
-// concurrency, the "ccp-fc-ogob01a" symptom is not explained by an in-process concurrency race, and the
-// remaining suspects are either something specific to their exact payload/environment or a defect outside
-// what this workload exercises.
+// keyFence lock. This test drives the same workload through UpsertNode, the production call path, which
+// wraps the entire read-decide-write sequence in a per-node-ID keyedMutex (see UpsertNode in
+// datastore_impl.go). Every caller in this codebase reaches the store exclusively through UpsertNode, so
+// this path determines whether concurrent upserts can regress scan_time; the test asserts scan_time never
+// regresses even under heavy concurrency.
 func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutexPreventsRegression() {
 	allowAllCtx := sac.WithAllAccess(context.Background())
 

--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -4,8 +4,12 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	nodeCVEDS "github.com/stackrox/rox/central/cve/node/datastore"
 	nodeCVEPostgres "github.com/stackrox/rox/central/cve/node/datastore/store/postgres"
@@ -76,6 +80,91 @@ func (suite *NodePostgresDataStoreTestSuite) SetupTest() {
 func (suite *NodePostgresDataStoreTestSuite) TearDownTest() {
 	suite.mockCtrl.Finish()
 	suite.db.Close()
+}
+
+// TestConcurrentUpsertNode_KeyedMutexPreventsRegression is the datastore-layer counterpart of
+// store_test.go's TestStore_ConcurrentUpsert_BypassingOuterLock. That test proves the store layer alone has
+// a check-then-act race in isUpdated(): the read-old-scan-and-decide step isn't covered by the store's own
+// keyFence lock. This test calls the same workload through UpsertNode instead, i.e. through the
+// production call path, which wraps the entire call (read, decide, and write) in a per-node-ID
+// keyedMutex (see UpsertNode in datastore_impl.go). Since every real caller in this codebase reaches the
+// store exclusively through UpsertNode, and the customer's Central runs as a single replica (confirmed
+// from their diagnostic bundle: one Deployment, replicas: 1, one Central pod), this is the path that
+// actually matters for reproducing their bug. If scan_time never regresses here even under heavy
+// concurrency, the "ccp-fc-ogob01a" symptom is not explained by an in-process concurrency race, and the
+// remaining suspects are either something specific to their exact payload/environment or a defect outside
+// what this workload exercises.
+func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutexPreventsRegression() {
+	allowAllCtx := sac.WithAllAccess(context.Background())
+
+	node := getTestNodeForPostgres(fixtureconsts.Node1, "concurrent-node")
+	baseTime := time.Now().Add(-24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node))
+
+	const iterations = 2000
+	const freshWriters = 4
+	const metaWriters = 4
+	var wg sync.WaitGroup
+
+	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
+	for w := range freshWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				fresh := node.CloneVT()
+				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
+				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
+				_ = suite.datastore.UpsertNode(allowAllCtx, fresh)
+			}
+		})
+	}
+
+	// Simulates the nodes pipeline: frequent metadata-only churn, Scan explicitly nil.
+	for w := range metaWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				metaOnly := node.CloneVT()
+				metaOnly.Scan = nil
+				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
+				_ = suite.datastore.UpsertNode(allowAllCtx, metaOnly)
+			}
+		})
+	}
+
+	var regressions atomic.Int64
+	stop := make(chan struct{})
+	var pollWG sync.WaitGroup
+	for range 4 {
+		pollWG.Go(func() {
+			lastSeen := baseTime
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				current, exists, err := suite.datastore.GetNode(allowAllCtx, node.GetId())
+				if err == nil && exists {
+					st := current.GetScan().GetScanTime().AsTime()
+					if st.Before(lastSeen) {
+						regressions.Add(1)
+					} else {
+						lastSeen = st
+					}
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+	close(stop)
+	pollWG.Wait()
+
+	suite.Zero(regressions.Load(),
+		"scan_time must never regress through UpsertNode, since every real caller (nodeindex and nodes "+
+			"pipelines alike) goes through the per-node-ID keyedMutex that wraps the entire read-decide-write "+
+			"sequence; a non-zero count here would mean the keyedMutex itself has a bug, not just the store "+
+			"layer's already-known gap")
 }
 
 func (suite *NodePostgresDataStoreTestSuite) TestBasicOps() {

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -529,12 +529,18 @@ func (s *storeImpl) isUpdated(ctx context.Context, node *storage.Node) (bool, er
 	// We skip rewriting components and vulnerabilities if the node scan is older.
 	scanUpdated := protocompat.CompareTimestamps(oldNode.GetScan().GetScanTime(), node.GetScan().GetScanTime()) <= 0
 	if !scanUpdated {
-		log.Warnf("Rejecting incoming node scan for node %s (%s) as not newer than the stored one: "+
-			"stored scan_time=%s, incoming scan_time=%s. The incoming scan and its component/CVE data will "+
-			"be discarded and the previously stored scan will be kept.",
-			node.GetId(), node.GetName(),
-			protocompat.ConvertTimestampToString(oldNode.GetScan().GetScanTime(), time.RFC3339Nano),
-			protocompat.ConvertTimestampToString(node.GetScan().GetScanTime(), time.RFC3339Nano))
+		// Metadata-only upserts (e.g. from the informer-driven nodes pipeline) intentionally send no scan at
+		// all, relying on this method to preserve the stored one; that's expected, frequent, fleet-wide
+		// traffic and would flood the log if warned about here. Only warn when a real, incoming scan with its
+		// own scan_time was rejected as not newer than what's stored - that's the actually anomalous case.
+		if node.GetScan().GetScanTime() != nil {
+			log.Warnf("Rejecting incoming node scan for node %s (%s) in cluster %s (%s) as not newer than the "+
+				"stored one: stored scan_time=%s, incoming scan_time=%s. The incoming scan and its "+
+				"component/CVE data will be discarded and the previously stored scan will be kept.",
+				node.GetId(), node.GetName(), node.GetClusterName(), node.GetClusterId(),
+				protocompat.ConvertTimestampToString(oldNode.GetScan().GetScanTime(), time.RFC3339Nano),
+				protocompat.ConvertTimestampToString(node.GetScan().GetScanTime(), time.RFC3339Nano))
+		}
 		node.Scan = oldNode.GetScan()
 		node.RiskScore = oldNode.GetRiskScore()
 		node.SetComponents = oldNode.GetSetComponents()

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -529,6 +529,12 @@ func (s *storeImpl) isUpdated(ctx context.Context, node *storage.Node) (bool, er
 	// We skip rewriting components and vulnerabilities if the node scan is older.
 	scanUpdated := protocompat.CompareTimestamps(oldNode.GetScan().GetScanTime(), node.GetScan().GetScanTime()) <= 0
 	if !scanUpdated {
+		log.Warnf("Rejecting incoming node scan for node %s (%s) as not newer than the stored one: "+
+			"stored scan_time=%s, incoming scan_time=%s. The incoming scan and its component/CVE data will "+
+			"be discarded and the previously stored scan will be kept.",
+			node.GetId(), node.GetName(),
+			protocompat.ConvertTimestampToString(oldNode.GetScan().GetScanTime(), time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(node.GetScan().GetScanTime(), time.RFC3339Nano))
 		node.Scan = oldNode.GetScan()
 		node.RiskScore = oldNode.GetRiskScore()
 		node.SetComponents = oldNode.GetSetComponents()

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -530,9 +530,8 @@ func (s *storeImpl) isUpdated(ctx context.Context, node *storage.Node) (bool, er
 	scanUpdated := protocompat.CompareTimestamps(oldNode.GetScan().GetScanTime(), node.GetScan().GetScanTime()) <= 0
 	if !scanUpdated {
 		// Metadata-only upserts (e.g. from the informer-driven nodes pipeline) intentionally send no scan at
-		// all, relying on this method to preserve the stored one; that's expected, frequent, fleet-wide
-		// traffic and would flood the log if warned about here. Only warn when a real, incoming scan with its
-		// own scan_time was rejected as not newer than what's stored - that's the actually anomalous case.
+		// all, relying on this method to preserve the stored one; only warn when a real, incoming scan with
+		// its own scan_time was rejected as not newer than what's stored.
 		if node.GetScan().GetScanTime() != nil {
 			log.Warnf("Rejecting incoming node scan for node %s (%s) in cluster %s (%s) as not newer than the "+
 				"stored one: stored scan_time=%s, incoming scan_time=%s. The incoming scan and its "+

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -5,7 +5,6 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -183,96 +182,6 @@ func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
 	s.Equal(freshTime.Unix(), found.GetScan().GetScanTime().AsTime().Unix(),
 		"a strictly newer scan must always replace an older one when applied sequentially")
 	s.Len(found.GetScan().GetComponents(), 1)
-}
-
-// TestStore_ConcurrentUpsert_BypassingOuterLock intentionally calls the store layer directly, without the
-// per-node keyedMutex that central/node/datastore/datastore_impl.go normally wraps around every UpsertNode
-// call. isUpdated() (the read-and-decide step) runs *before* storeImpl.upsert acquires its own keyFence
-// lock, so nothing internal to this package serializes "read old scan, decide, write" as one atomic unit.
-// This test proves that gap is real: with two goroutines hammering the same node ID (one always sending a
-// monotonically fresher scan, the other sending metadata-only updates with Scan=nil that rely on the store
-// preserving the existing scan), the persisted scan_time can be observed to regress mid-run.
-//
-// This does not reproduce the customer's exact deployment (Central runs as a single replica, and in
-// production every call is routed through the outer keyedMutex in datastore_impl.go), but it documents a
-// real defense-in-depth gap: if any current or future caller ever reaches storeImpl.Upsert without going
-// through that outer lock, this exact "scan_time never advances" symptom is reproducible on demand.
-func (s *NodesStoreSuite) TestStore_ConcurrentUpsert_BypassingOuterLock() {
-	store := New(s.pool, false, concurrency.NewKeyFence())
-
-	node := &storage.Node{}
-	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
-	for _, comp := range node.GetScan().GetComponents() {
-		comp.Vulns = nil
-	}
-	baseTime := time.Now().Add(-24 * time.Hour)
-	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
-	s.NoError(store.Upsert(s.ctx, node))
-
-	const iterations = 2000
-	const freshWriters = 4
-	const metaWriters = 4
-	var wg sync.WaitGroup
-
-	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
-	// Multiple concurrent writers of this kind widen the race window further (real Central handles many
-	// clusters/nodes worth of concurrent pipeline traffic, not just one goroutine at a time).
-	for w := range freshWriters {
-		wg.Go(func() {
-			for i := range iterations {
-				fresh := node.CloneVT()
-				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
-				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
-				_ = store.Upsert(s.ctx, fresh)
-			}
-		})
-	}
-
-	// Simulates the nodes pipeline: frequent metadata-only churn, Scan explicitly nil.
-	for w := range metaWriters {
-		wg.Go(func() {
-			for i := range iterations {
-				metaOnly := node.CloneVT()
-				metaOnly.Scan = nil
-				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
-				_ = store.Upsert(s.ctx, metaOnly)
-			}
-		})
-	}
-
-	regressed := concurrency.NewSignal()
-	stop := make(chan struct{})
-	var pollWG sync.WaitGroup
-	for range 4 {
-		pollWG.Go(func() {
-			lastSeen := baseTime
-			for {
-				select {
-				case <-stop:
-					return
-				default:
-				}
-				current, exists, err := store.Get(s.ctx, node.GetId())
-				if err == nil && exists {
-					st := current.GetScan().GetScanTime().AsTime()
-					if st.Before(lastSeen) {
-						regressed.Signal()
-						return
-					}
-					lastSeen = st
-				}
-			}
-		})
-	}
-
-	wg.Wait()
-	close(stop)
-	pollWG.Wait()
-
-	s.True(regressed.IsDone(),
-		"expected scan_time to regress at least once when isUpdated()'s read-decide step races unprotected "+
-			"concurrent upserts for the same node ID; if this now passes without regressing, the store-layer "+
-			"race window may have been closed and this test's assumption should be revisited")
 }
 
 func (s *NodesStoreSuite) TestStore_OrphanedCVEs() {

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -165,12 +165,10 @@ func (s *NodesStoreSuite) TestStore_UpsertWithoutScan() {
 	protoassert.Equal(s.T(), foundNode, newNode)
 }
 
-// TestStore_FreshScanAlwaysWinsSequential is the direct, non-concurrent reproduction attempt for the
-// ccp-fc-ogob01a "scan_time never advances" symptom: upsert an old scan, then upsert a strictly newer
-// one for the same node ID, and confirm the newer one is what gets persisted. This is expected to pass;
-// it establishes the happy path is correct in isolation, which narrows the bug to something that only
-// shows up under concurrency or with specific payload shapes, not to a deterministic single-threaded
-// logic error.
+// TestStore_FreshScanAlwaysWinsSequential covers the sequential happy path of the isUpdated() freshness
+// guard: upsert an old scan, then upsert a strictly newer one for the same node ID, and confirm the newer
+// one is persisted (both scan_time and payload advance). This isolates single-threaded correctness of the
+// guard from the concurrency behavior exercised elsewhere.
 func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
 	store := New(s.pool, false, concurrency.NewKeyFence())
 
@@ -198,7 +196,7 @@ func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
 	s.Len(found.GetScan().GetComponents(), 1)
 }
 
-// TestStore_RejectionWarningFiresOnlyForRealStaleScan validates the ROX-36432 diagnostic in isUpdated():
+// TestStore_RejectionWarningFiresOnlyForRealStaleScan validates the rejection warning in isUpdated():
 // a real, non-nil incoming scan that is older than the stored one is rejected AND warned about, while a
 // metadata-only upsert (Scan == nil) - which is also "not newer" - is rejected silently (the gate).
 func (s *NodesStoreSuite) TestStore_RejectionWarningFiresOnlyForRealStaleScan() {

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -21,8 +22,21 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+const rejectionWarnSnippet = "Rejecting incoming node scan for node"
+
+func swapObservedLogger(t interface{ Cleanup(func()) }) *observer.ObservedLogs {
+	core, logs := observer.New(zap.WarnLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+	return logs
+}
 
 type NodesStoreSuite struct {
 	suite.Suite
@@ -182,6 +196,42 @@ func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
 	s.Equal(freshTime.Unix(), found.GetScan().GetScanTime().AsTime().Unix(),
 		"a strictly newer scan must always replace an older one when applied sequentially")
 	s.Len(found.GetScan().GetComponents(), 1)
+}
+
+// TestStore_RejectionWarningFiresOnlyForRealStaleScan validates the ROX-36432 diagnostic in isUpdated():
+// a real, non-nil incoming scan that is older than the stored one is rejected AND warned about, while a
+// metadata-only upsert (Scan == nil) - which is also "not newer" - is rejected silently (the gate).
+func (s *NodesStoreSuite) TestStore_RejectionWarningFiresOnlyForRealStaleScan() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+	logs := swapObservedLogger(s.T())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+	newer := time.Now()
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&newer)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	// A real, non-nil, older scan must be rejected and warned about.
+	stale := node.CloneVT()
+	older := newer.Add(-time.Hour)
+	stale.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&older)
+	s.NoError(store.Upsert(s.ctx, stale))
+
+	found, exists, err := store.Get(s.ctx, node.GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(newer.Unix(), found.GetScan().GetScanTime().AsTime().Unix(), "stale scan must be rejected")
+	require.Len(s.T(), logs.FilterMessageSnippet(rejectionWarnSnippet).All(), 1)
+
+	// A metadata-only upsert (Scan == nil) is also "not newer" but must NOT emit the warning.
+	metaOnly := found.CloneVT()
+	metaOnly.Scan = nil
+	s.NoError(store.Upsert(s.ctx, metaOnly))
+	require.Len(s.T(), logs.FilterMessageSnippet(rejectionWarnSnippet).All(), 1,
+		"metadata-only upserts must not emit the rejection warning")
 }
 
 func (s *NodesStoreSuite) TestStore_OrphanedCVEs() {

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -149,6 +150,129 @@ func (s *NodesStoreSuite) TestStore_UpsertWithoutScan() {
 	// We expect only LastUpdated to have changed.
 	foundNode.LastUpdated = newNode.GetLastUpdated()
 	protoassert.Equal(s.T(), foundNode, newNode)
+}
+
+// TestStore_FreshScanAlwaysWinsSequential is the direct, non-concurrent reproduction attempt for the
+// ccp-fc-ogob01a "scan_time never advances" symptom: upsert an old scan, then upsert a strictly newer
+// one for the same node ID, and confirm the newer one is what gets persisted. This is expected to pass;
+// it establishes the happy path is correct in isolation, which narrows the bug to something that only
+// shows up under concurrency or with specific payload shapes, not to a deterministic single-threaded
+// logic error.
+func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&oldTime)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	fresh := node.CloneVT()
+	freshTime := time.Now()
+	fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&freshTime)
+	fresh.Scan.Components = fresh.GetScan().GetComponents()[:1] // Change the payload shape too, not just the timestamp.
+	s.NoError(store.Upsert(s.ctx, fresh))
+
+	found, exists, err := store.Get(s.ctx, node.GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(freshTime.Unix(), found.GetScan().GetScanTime().AsTime().Unix(),
+		"a strictly newer scan must always replace an older one when applied sequentially")
+	s.Len(found.GetScan().GetComponents(), 1)
+}
+
+// TestStore_ConcurrentUpsert_BypassingOuterLock intentionally calls the store layer directly, without the
+// per-node keyedMutex that central/node/datastore/datastore_impl.go normally wraps around every UpsertNode
+// call. isUpdated() (the read-and-decide step) runs *before* storeImpl.upsert acquires its own keyFence
+// lock, so nothing internal to this package serializes "read old scan, decide, write" as one atomic unit.
+// This test proves that gap is real: with two goroutines hammering the same node ID (one always sending a
+// monotonically fresher scan, the other sending metadata-only updates with Scan=nil that rely on the store
+// preserving the existing scan), the persisted scan_time can be observed to regress mid-run.
+//
+// This does not reproduce the customer's exact deployment (Central runs as a single replica, and in
+// production every call is routed through the outer keyedMutex in datastore_impl.go), but it documents a
+// real defense-in-depth gap: if any current or future caller ever reaches storeImpl.Upsert without going
+// through that outer lock, this exact "scan_time never advances" symptom is reproducible on demand.
+func (s *NodesStoreSuite) TestStore_ConcurrentUpsert_BypassingOuterLock() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+	baseTime := time.Now().Add(-24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	const iterations = 2000
+	const freshWriters = 4
+	const metaWriters = 4
+	var wg sync.WaitGroup
+
+	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
+	// Multiple concurrent writers of this kind widen the race window further (real Central handles many
+	// clusters/nodes worth of concurrent pipeline traffic, not just one goroutine at a time).
+	for w := range freshWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				fresh := node.CloneVT()
+				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
+				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
+				_ = store.Upsert(s.ctx, fresh)
+			}
+		})
+	}
+
+	// Simulates the nodes pipeline: frequent metadata-only churn, Scan explicitly nil.
+	for w := range metaWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				metaOnly := node.CloneVT()
+				metaOnly.Scan = nil
+				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
+				_ = store.Upsert(s.ctx, metaOnly)
+			}
+		})
+	}
+
+	regressed := concurrency.NewSignal()
+	stop := make(chan struct{})
+	var pollWG sync.WaitGroup
+	for range 4 {
+		pollWG.Go(func() {
+			lastSeen := baseTime
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				current, exists, err := store.Get(s.ctx, node.GetId())
+				if err == nil && exists {
+					st := current.GetScan().GetScanTime().AsTime()
+					if st.Before(lastSeen) {
+						regressed.Signal()
+						return
+					}
+					lastSeen = st
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+	close(stop)
+	pollWG.Wait()
+
+	s.True(regressed.IsDone(),
+		"expected scan_time to regress at least once when isUpdated()'s read-decide step races unprotected "+
+			"concurrent upserts for the same node ID; if this now passes without regressing, the store-layer "+
+			"race window may have been closed and this test's assumption should be revisited")
 }
 
 func (s *NodesStoreSuite) TestStore_OrphanedCVEs() {

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -132,10 +132,10 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	persistedScanTime := node.GetScan().GetScanTime()
 	switch cmp := protocompat.CompareTimestamps(incomingScanTime, persistedScanTime); {
 	case cmp > 0:
-		// The store kept a scan_time older than the one we just processed. isUpdated() only rejects scans that
-		// are not strictly newer than the stored one, so a fresh scan should have been accepted - this
-		// direction means the freshly processed scan silently lost to an older persisted one, which is the
-		// ROX-36432 symptom (scan_time stuck in the past while processing continues).
+		// The store kept a scan_time older than the one we just processed. isUpdated() only rejects scans
+		// that are not strictly newer than the stored one, so a fresh scan should have been accepted here;
+		// a persisted scan older than the processed one means the fresh scan was silently dropped, which the
+		// freshness guard should never do.
 		log.Warnf("Persisted scan_time for node %s is older than the freshly processed scan_time: "+
 			"processed=%s persisted=%s. The store kept an older scan than the one just processed, which the "+
 			"freshness guard should have accepted - possible scan regression.",

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -2,6 +2,7 @@ package nodeindex
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
@@ -19,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/nodes/enricher"
+	"github.com/stackrox/rox/pkg/protocompat"
 )
 
 var (
@@ -115,11 +117,24 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	}
 	log.Infof("Scanned index report and found %d components for node %s",
 		len(node.GetScan().GetComponents()), nodeDatastore.NodeString(node))
+	incomingScanTime := node.GetScan().GetScanTime()
 
 	// Update the whole node in the database with the new and previous information.
 	err = p.riskManager.CalculateRiskAndUpsertNode(node)
 	if err != nil {
 		return errors.Wrapf(err, "failed calculating risk and upserting node %s", nodeDatastore.NodeString(node))
+	}
+
+	// The store may have rejected this scan as not newer than what's already persisted, in which case it
+	// rewrites node.Scan in place to the previously stored one before returning - see isUpdated() in
+	// central/node/datastore/store/postgres/store.go. Comparing scan times here, on the same object we just
+	// tried to upsert, tells us definitively whether the fresh scan we just processed actually landed.
+	if persistedScanTime := node.GetScan().GetScanTime(); protocompat.CompareTimestamps(incomingScanTime, persistedScanTime) != 0 {
+		log.Warnf("Persisted scan_time for node %s does not match the freshly processed scan_time: "+
+			"processed=%s persisted=%s. The store rejected this scan as not newer than the stored one.",
+			nodeDatastore.NodeString(node),
+			protocompat.ConvertTimestampToString(incomingScanTime, time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(persistedScanTime, time.RFC3339Nano))
 	}
 
 	sendComplianceAck(ctx, node, injector)

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -129,7 +129,22 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	// rewrites node.Scan in place to the previously stored one before returning - see isUpdated() in
 	// central/node/datastore/store/postgres/store.go. Comparing scan times here, on the same object we just
 	// tried to upsert, tells us definitively whether the fresh scan we just processed actually landed.
-	if persistedScanTime := node.GetScan().GetScanTime(); protocompat.CompareTimestamps(incomingScanTime, persistedScanTime) != 0 {
+	persistedScanTime := node.GetScan().GetScanTime()
+	switch cmp := protocompat.CompareTimestamps(incomingScanTime, persistedScanTime); {
+	case cmp > 0:
+		// The store kept a scan_time older than the one we just processed. isUpdated() only rejects scans that
+		// are not strictly newer than the stored one, so a fresh scan should have been accepted - this
+		// direction means the freshly processed scan silently lost to an older persisted one, which is the
+		// ROX-36432 symptom (scan_time stuck in the past while processing continues).
+		log.Warnf("Persisted scan_time for node %s is older than the freshly processed scan_time: "+
+			"processed=%s persisted=%s. The store kept an older scan than the one just processed, which the "+
+			"freshness guard should have accepted - possible scan regression.",
+			nodeDatastore.NodeString(node),
+			protocompat.ConvertTimestampToString(incomingScanTime, time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(persistedScanTime, time.RFC3339Nano))
+	case cmp < 0:
+		// The store kept a scan_time newer than the one we just processed - the expected shape of an
+		// isUpdated() rejection, where node.Scan was rewritten back to the newer stored scan.
 		log.Warnf("Persisted scan_time for node %s does not match the freshly processed scan_time: "+
 			"processed=%s persisted=%s. The store rejected this scan as not newer than the stored one.",
 			nodeDatastore.NodeString(node),

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -2,6 +2,7 @@ package nodeindex
 
 import (
 	"testing"
+	"time"
 
 	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
@@ -12,12 +13,90 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+const scanMismatchWarnSnippet = "does not match the freshly processed scan_time"
+
+func swapObservedLogger(t *testing.T) *observer.ObservedLogs {
+	core, logs := observer.New(zap.WarnLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+	return logs
+}
+
+// TestPipelineWarnsWhenPersistedScanTimeRegresses validates the ROX-36432 accept/post-upsert diagnostic:
+// after the upsert, the pipeline compares the scan_time it processed against what the store actually kept
+// (the store rewrites node.Scan in place when it rejects a scan as not-newer) and warns on a mismatch.
+func TestPipelineWarnsWhenPersistedScanTimeRegresses(t *testing.T) {
+	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+
+	processed := time.Now()
+	stored := processed.Add(-time.Hour) // what the store keeps after rejecting the fresh scan
+
+	cases := map[string]struct {
+		persistedScanTime time.Time
+		expectWarning     bool
+	}{
+		"warns when the store rejected the fresh scan": {persistedScanTime: stored, expectWarning: true},
+		"silent when the fresh scan was accepted":      {persistedScanTime: processed, expectWarning: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			logs := swapObservedLogger(t)
+			node := &storage.Node{Id: "1", Name: "node-name", ClusterId: "cluster-id"}
+
+			ctrl := gomock.NewController(t)
+			nodeDatastore := nodeDatastoreMocks.NewMockDataStore(ctrl)
+			riskManager := riskManagerMocks.NewMockManager(ctrl)
+			enricher := nodesEnricherMocks.NewMockNodeEnricher(ctrl)
+
+			gomock.InOrder(
+				nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(node, true, nil),
+				// Enrichment stamps a fresh scan_time, as the real enricher does with TimestampNow().
+				enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), nil, gomock.Any()).Times(1).
+					DoAndReturn(func(n *storage.Node, _ *storage.NodeInventory, _ *v4.IndexReport) error {
+						n.Scan = &storage.NodeScan{ScanTime: protocompat.ConvertTimeToTimestampOrNil(&processed)}
+						return nil
+					}),
+				// Upsert rewrites node.Scan in place to whatever was persisted (mimics isUpdated()).
+				riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).
+					DoAndReturn(func(n *storage.Node) error {
+						n.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&tc.persistedScanTime)
+						return nil
+					}),
+			)
+
+			p := &pipelineImpl{
+				nodeDatastore: nodeDatastore,
+				riskManager:   riskManager,
+				enricher:      enricher,
+			}
+
+			err := p.Run(t.Context(), node.GetClusterId(), createMsg(mockIndexReport), nil)
+			require.NoError(t, err)
+
+			got := logs.FilterMessageSnippet(scanMismatchWarnSnippet).All()
+			if tc.expectWarning {
+				assert.Len(t, got, 1)
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}
 
 func TestPipelineWithEmptyIndex(t *testing.T) {
 	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -25,7 +25,10 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-const scanMismatchWarnSnippet = "does not match the freshly processed scan_time"
+const (
+	scanRejectedWarnSnippet   = "rejected this scan as not newer than the stored one"
+	scanRegressionWarnSnippet = "possible scan regression"
+)
 
 func swapObservedLogger(t *testing.T) *observer.ObservedLogs {
 	core, logs := observer.New(zap.WarnLevel)
@@ -43,14 +46,27 @@ func TestPipelineWarnsWhenPersistedScanTimeRegresses(t *testing.T) {
 	t.Setenv(features.ScannerV4.EnvVar(), "true")
 
 	processed := time.Now()
-	stored := processed.Add(-time.Hour) // what the store keeps after rejecting the fresh scan
 
 	cases := map[string]struct {
+		// persistedScanTime is what the store leaves on node.Scan after the upsert returns.
 		persistedScanTime time.Time
-		expectWarning     bool
+		// expectSnippet is the warning we expect to see; empty means no warning at all.
+		expectSnippet string
 	}{
-		"warns when the store rejected the fresh scan": {persistedScanTime: stored, expectWarning: true},
-		"silent when the fresh scan was accepted":      {persistedScanTime: processed, expectWarning: false},
+		// A genuine isUpdated() rejection keeps a scan strictly newer than the one we just processed.
+		"warns (rejection) when the store kept a newer scan": {
+			persistedScanTime: processed.Add(time.Hour),
+			expectSnippet:     scanRejectedWarnSnippet,
+		},
+		// The store kept an older scan than the fresh one - a scan the freshness guard should have accepted.
+		"warns (regression) when the store kept an older scan": {
+			persistedScanTime: processed.Add(-time.Hour),
+			expectSnippet:     scanRegressionWarnSnippet,
+		},
+		"silent when the fresh scan was accepted": {
+			persistedScanTime: processed,
+			expectSnippet:     "",
+		},
 	}
 
 	for name, tc := range cases {
@@ -88,11 +104,18 @@ func TestPipelineWarnsWhenPersistedScanTimeRegresses(t *testing.T) {
 			err := p.Run(t.Context(), node.GetClusterId(), createMsg(mockIndexReport), nil)
 			require.NoError(t, err)
 
-			got := logs.FilterMessageSnippet(scanMismatchWarnSnippet).All()
-			if tc.expectWarning {
-				assert.Len(t, got, 1)
-			} else {
-				assert.Empty(t, got)
+			rejections := logs.FilterMessageSnippet(scanRejectedWarnSnippet).All()
+			regressions := logs.FilterMessageSnippet(scanRegressionWarnSnippet).All()
+			switch tc.expectSnippet {
+			case scanRejectedWarnSnippet:
+				assert.Len(t, rejections, 1)
+				assert.Empty(t, regressions)
+			case scanRegressionWarnSnippet:
+				assert.Len(t, regressions, 1)
+				assert.Empty(t, rejections)
+			default:
+				assert.Empty(t, rejections)
+				assert.Empty(t, regressions)
 			}
 		})
 	}

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -38,9 +38,9 @@ func swapObservedLogger(t *testing.T) *observer.ObservedLogs {
 	return logs
 }
 
-// TestPipelineWarnsWhenPersistedScanTimeRegresses validates the ROX-36432 accept/post-upsert diagnostic:
-// after the upsert, the pipeline compares the scan_time it processed against what the store actually kept
-// (the store rewrites node.Scan in place when it rejects a scan as not-newer) and warns on a mismatch.
+// TestPipelineWarnsWhenPersistedScanTimeRegresses validates the post-upsert diagnostic: after the upsert,
+// the pipeline compares the scan_time it processed against what the store actually kept (the store rewrites
+// node.Scan in place when it rejects a scan as not-newer) and warns on a mismatch.
 func TestPipelineWarnsWhenPersistedScanTimeRegresses(t *testing.T) {
 	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
 	t.Setenv(features.ScannerV4.EnvVar(), "true")

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -117,12 +117,15 @@ func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage
 		return nil
 	}
 
-	if errorList.Empty() && len(skippedScannerTypes) == len(scanners) {
-		// Every registered scanner was skipped as inapplicable to this payload (e.g. only a Clairify/v2
-		// integration is registered but this call carries an IndexReport, which only ScannerV4 consumes).
-		// This is NOT surfaced as an error (matching prior behavior: ToError() returns nil below), so node.Scan
-		// is left completely untouched by this call - the caller will upsert whatever scan the node already
-		// had. That upsert looks identical to a successful no-op scan refresh in logs/metrics downstream.
+	// Only warn for the v4/nodeindex path (indexReport != nil). A v4-only Central that still receives
+	// legacy v2 NodeInventory reports would otherwise log this on every such report, indefinitely - benign
+	// noise, since v2-on-a-v4-only-Central is an expected transitional state, not the bug we're hunting.
+	// When an IndexReport arrives and every registered scanner was still skipped, ScannerV4 is not
+	// registered and the node scan silently never refreshes - exactly the condition worth surfacing.
+	if indexReport != nil && errorList.Empty() && len(skippedScannerTypes) == len(scanners) {
+		// node.Scan is left completely untouched by this call (this is NOT surfaced as an error - ToError()
+		// returns nil below), so the caller will upsert whatever scan the node already had. That upsert looks
+		// identical to a successful no-op scan refresh in logs/metrics downstream.
 		log.Warnf("No applicable node scanner ran for node %s:%s (inventory=%t, indexReport=%t); registered "+
 			"scanner types were all skipped as inapplicable: %v. The node's existing scan, if any, was not "+
 			"refreshed by this call.",

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -118,10 +118,10 @@ func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage
 	}
 
 	// Only warn for the v4/nodeindex path (indexReport != nil). A v4-only Central that still receives
-	// legacy v2 NodeInventory reports would otherwise log this on every such report, indefinitely - benign
-	// noise, since v2-on-a-v4-only-Central is an expected transitional state, not the bug we're hunting.
-	// When an IndexReport arrives and every registered scanner was still skipped, ScannerV4 is not
-	// registered and the node scan silently never refreshes - exactly the condition worth surfacing.
+	// legacy v2 NodeInventory reports would otherwise log this on every such report indefinitely - benign
+	// noise, since v2-on-a-v4-only-Central is an expected transitional state. When an IndexReport arrives and
+	// every registered scanner was still skipped, ScannerV4 is not registered and the node scan silently
+	// never refreshes - the condition worth surfacing.
 	if indexReport != nil && errorList.Empty() && len(skippedScannerTypes) == len(scanners) {
 		// node.Scan is left completely untouched by this call (this is NOT surfaced as an error - ToError()
 		// returns nil below), so the caller will upsert whatever scan the node already had. That upsert looks

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -100,11 +100,13 @@ func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage
 		return errorList.ToError()
 	}
 
+	skippedScannerTypes := make([]string, 0, len(scanners))
 	for _, scanner := range scanners {
 		// Prevent unnecessary scanner calls - v4 only works on indexReports, v2/Clairify only on nodeInventory.
 		// If both, indexReport and nodeInventory, are unset, we do not skip to keep the legacy NodeScan v1 working.
 		if (scanner.GetNodeScanner().Type() == types.ScannerV4 && indexReport == nil && nodeInventory != nil) ||
 			(scanner.GetNodeScanner().Type() == types.Clairify && nodeInventory == nil && indexReport != nil) {
+			skippedScannerTypes = append(skippedScannerTypes, scanner.GetNodeScanner().Type())
 			continue
 		}
 		log.Debugf("Enriching Node with Scanner %s / %s", scanner.GetNodeScanner().Type(), scanner.GetNodeScanner().Name())
@@ -113,6 +115,18 @@ func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage
 			continue
 		}
 		return nil
+	}
+
+	if errorList.Empty() && len(skippedScannerTypes) == len(scanners) {
+		// Every registered scanner was skipped as inapplicable to this payload (e.g. only a Clairify/v2
+		// integration is registered but this call carries an IndexReport, which only ScannerV4 consumes).
+		// This is NOT surfaced as an error (matching prior behavior: ToError() returns nil below), so node.Scan
+		// is left completely untouched by this call - the caller will upsert whatever scan the node already
+		// had. That upsert looks identical to a successful no-op scan refresh in logs/metrics downstream.
+		log.Warnf("No applicable node scanner ran for node %s:%s (inventory=%t, indexReport=%t); registered "+
+			"scanner types were all skipped as inapplicable: %v. The node's existing scan, if any, was not "+
+			"refreshed by this call.",
+			node.GetClusterName(), node.GetName(), nodeInventory != nil, indexReport != nil, skippedScannerTypes)
 	}
 
 	return errorList.ToError()

--- a/pkg/nodes/enricher/enricher_impl_test.go
+++ b/pkg/nodes/enricher/enricher_impl_test.go
@@ -6,13 +6,28 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/logging"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/scanners/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/sync/semaphore"
 )
+
+const allSkippedWarnSnippet = "No applicable node scanner ran"
+
+// swapObservedLogger replaces the package-level logger with an observer-backed one at Warn level and
+// returns the observed logs plus a restore func. Lets us assert exactly which diagnostic warnings fire.
+func swapObservedLogger(t *testing.T) *observer.ObservedLogs {
+	core, logs := observer.New(zap.WarnLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+	return logs
+}
 
 var _ types.NodeScannerWithDataSource = (*fakeNodeScannerWithDataSource)(nil)
 
@@ -22,12 +37,14 @@ type fakeNodeScannerWithDataSource struct {
 
 type opts struct {
 	requestedScan bool
+	scannerType   string
 }
 
 func newFakeNodeScannerWithDataSource(opts opts) types.NodeScannerWithDataSource {
 	return &fakeNodeScannerWithDataSource{
 		nodeScanner: &fakeNodeScanner{
 			requestedScan: opts.requestedScan,
+			scannerType:   opts.scannerType,
 		},
 	}
 }
@@ -44,6 +61,7 @@ var _ types.NodeScanner = (*fakeNodeScanner)(nil)
 
 type fakeNodeScanner struct {
 	requestedScan bool
+	scannerType   string
 }
 
 func (*fakeNodeScanner) MaxConcurrentNodeScanSemaphore() *semaphore.Weighted {
@@ -96,7 +114,10 @@ func (*fakeNodeScanner) TestNodeScanner() error {
 	return nil
 }
 
-func (*fakeNodeScanner) Type() string {
+func (f *fakeNodeScanner) Type() string {
+	if f.scannerType != "" {
+		return f.scannerType
+	}
 	return "type"
 }
 
@@ -259,6 +280,61 @@ func TestZeroIntegrations(t *testing.T) {
 	assert.Error(t, err)
 	expectedErrMsg := "error scanning node cluster:node error: no node scanners are integrated"
 	assert.Equal(t, expectedErrMsg, err.Error())
+}
+
+// TestEnrichWithScan_AllScannersSkippedWarning validates the ROX-36432 diagnostic: when an IndexReport
+// arrives but every registered scanner is inapplicable (no ScannerV4 registered), we warn - and, per
+// review, only for the v4/nodeindex path (indexReport != nil), not for benign v2-on-a-v4-only-Central.
+func TestEnrichWithScan_AllScannersSkippedWarning(t *testing.T) {
+	node := &storage.Node{Id: fixtureconsts.Node1, ClusterName: "cluster", Name: "node"}
+
+	newEnricher := func(scanner types.NodeScannerWithDataSource) *enricherImpl {
+		return &enricherImpl{
+			cves: &fakeCVESuppressor{},
+			scanners: map[string]types.NodeScannerWithDataSource{
+				scanner.GetNodeScanner().Type(): scanner,
+			},
+			metrics: newMetrics(pkgMetrics.CentralSubsystem),
+		}
+	}
+
+	t.Run("warns when only v2 registered and an IndexReport arrives", func(t *testing.T) {
+		logs := swapObservedLogger(t)
+		clairify := newFakeNodeScannerWithDataSource(opts{scannerType: types.Clairify})
+		e := newEnricher(clairify)
+		testNode := node.CloneVT()
+
+		err := e.enrichWithScan(testNode, nil, &v4.IndexReport{})
+		require.NoError(t, err)
+		assert.Nil(t, testNode.GetScan(), "node scan must be left untouched when every scanner is skipped")
+		assert.Len(t, logs.FilterMessageSnippet(allSkippedWarnSnippet).All(), 1)
+	})
+
+	t.Run("does not warn on the v2 path (indexReport == nil)", func(t *testing.T) {
+		logs := swapObservedLogger(t)
+		// Only ScannerV4 registered; a v2 NodeInventory arrives - v4 is skipped, all skipped, but the gate
+		// (indexReport != nil) must suppress the warning.
+		v4Scanner := newFakeNodeScannerWithDataSource(opts{scannerType: types.ScannerV4})
+		e := newEnricher(v4Scanner)
+		testNode := node.CloneVT()
+
+		err := e.enrichWithScan(testNode, &storage.NodeInventory{}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, logs.FilterMessageSnippet(allSkippedWarnSnippet).All(),
+			"must not warn for the routine v2-on-a-v4-only-Central case")
+	})
+
+	t.Run("does not warn when a scanner actually runs", func(t *testing.T) {
+		logs := swapObservedLogger(t)
+		v4Scanner := newFakeNodeScannerWithDataSource(opts{scannerType: types.ScannerV4})
+		e := newEnricher(v4Scanner)
+		testNode := node.CloneVT()
+
+		err := e.enrichWithScan(testNode, nil, &v4.IndexReport{})
+		require.NoError(t, err)
+		assert.NotNil(t, testNode.GetScan(), "scanner should have populated the scan")
+		assert.Empty(t, logs.FilterMessageSnippet(allSkippedWarnSnippet).All())
+	})
 }
 
 func TestFillScanStatsWithPostgres(t *testing.T) {


### PR DESCRIPTION
## Description

Adds diagnostic logging around Central's node-scan enrichment and persistence so that, from a customer's logs alone, we can see why `scan.scanTime` on some nodes stops advancing while `lastUpdated` keeps moving (ROX-36432). Today that whole decision path is silent, so a node whose scan never refreshes looks identical to a healthy one.

**Logging-only — no behavior change.** This PR does **not** fix the root cause; it makes it observable. The fix is a separate follow-up (see "Root cause" below).

_Supersedes #22266 (folded in here)._

### Root cause (confirmed and reproduced)

The freeze is an **enrichment silent no-op**, not a store rejection. A Scanner V4 image-integration left with `Categories=[SCANNER]` only — an upgrade artifact from before node scanning existed, never reconciled — is missing `NODE_SCANNER`, so `isNodeIntegration` is false and v4 is removed from the node enricher even with `ROX_SCANNER_V4=true`. An incoming IndexReport then finds no applicable scanner (Clairify/v2 is skipped for index reports; v4 is absent), the enricher returns `nil` **without touching `node.Scan`**, and the node is re-upserted unchanged: `scan_time` stays frozen, `lastUpdated` advances, the component count is constant, and no error is logged. The store's freshness guard is not involved — the "incoming" scan equals the stored one, so it is accepted silently.

This was reproduced on a live cluster via the actual root cause (forcing the integration to `[SCANNER]`-only, no code hack): `scan_time` frozen across cycles, `lastUpdated` advancing, constant component count, zero warnings — the exact customer signature.

The actual fix (reconciling the default v4 integration's categories on Central startup so upgraded installs gain `NODE_SCANNER`) is out of scope here and will be a separate PR.

### Signals

1. **"No applicable node scanner ran" warning** (`pkg/nodes/enricher/enricher_impl.go`) — **this is the signal that surfaces the confirmed root cause.** Warns when an IndexReport arrives but every registered scanner is inapplicable (ScannerV4 not registered as a node scanner), which leaves `node.Scan` untouched yet looks like a successful scan downstream. Gated on `indexReport != nil` so a v4-only Central still receiving legacy v2 reports doesn't log this benign case.
2. **`isUpdated()` rejection warning** (`central/node/datastore/store/postgres/store.go`) — warns when an incoming node scan is rejected as not-newer than the stored one. Does **not** fire for the root cause above (an equal scan_time is accepted silently), but covers the adjacent failure mode of a genuinely older/rejected scan and makes the store's otherwise-silent accept/reject decision visible. Gated on a non-nil incoming `scan_time` so routine metadata-only upserts from the informer pipeline (`Scan=nil`) don't flood the logs. Includes cluster id/name.
3. **Post-upsert mismatch warning** (`central/sensor/service/pipeline/nodeindex/pipeline.go`) — after the upsert, compares the scan_time we processed against what the store actually kept (the store rewrites `node.Scan` in place on rejection). Also does not fire for the root cause (processed == persisted), but catches a store-side discard from the pipeline's vantage point without reading the store's internals.
4. **Concurrency regression test** `TestConcurrentUpsertNode_KeyedMutexPreventsRegression` exercising the real production path (`UpsertNode` → per-node `keyedMutex` wrapping the whole read-decide-write). Removed the sibling `TestStore_ConcurrentUpsert_BypassingOuterLock`, which asserted a nondeterministic race must manifest (flaky by construction) on a store-only path unreachable in production.

Note on history: the initial investigation suspected the `isUpdated()` monotonicity guard / a concurrency race. The live reproduction has since ruled that out and confirmed the enrichment no-op (Path C) as the cause. Signals 2–4 are retained because they add real observability for adjacent failure modes; signal 1 is the one that catches this bug.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added regression tests
- [x] modified existing tests

Each warning has a log-capture test (via `zaptest/observer`) asserting it fires under exactly its trigger condition and stays silent otherwise. In particular, `TestEnrichWithScan_AllScannersSkippedWarning` covers the confirmed root cause directly: with only v2/Clairify registered and an IndexReport arriving, it asserts the warning fires **and** `node.Scan` is left untouched — plus the gates (the v2-on-a-v4-only-Central case stays silent, and a scanner that actually runs stays silent). Plus the `sql_integration` store test and the keyedMutex regression test.

### How I validated my change

- `go build` and `go vet` (including `-tags sql_integration`) pass clean for all touched packages; `gofmt -l` is clean.
- All log-capture tests (enricher, nodeindex, and the `sql_integration` store test) plus the full node-datastore integration suites run and pass locally against Postgres 15.
- No behavior change beyond logging: accept/reject semantics in `isUpdated()` are untouched; `enrichWithScan()` still returns `nil` in the all-skipped case; the pipeline change is a pure post-hoc comparison/log after the existing upsert.

### Live-cluster proof

**Root cause (signal 1).** On a real OCP cluster I reproduced the freeze via the suspected root cause — forcing the Scanner V4 integration to `[SCANNER]`-only (no code hack) — and confirmed the customer signature over consecutive node-scan cycles: `scan_scantime` frozen at its old value, `lastupdated` advancing, component count constant, and no error/rejection. Important caveat: this reproduces the **condition** signal 1 fires on, **not the log line itself** — the reproduction ran on a build predating this PR, so the warning was never captured on a cluster. That the warning is actually emitted for exactly this scanner configuration rests on the unit test `TestEnrichWithScan_AllScannersSkippedWarning` and the code trace, not on observed cluster logs. (Signals 2 and 3 below, by contrast, were seen firing live.)

| capture | scan_scantime | components (N) | lastupdated |
|---|---|---|---|
| before | 2026-05-15 10:30:00 | 150 | 14:17:55.091 |
| after cycle 1 | 2026-05-15 10:30:00 (unchanged) | 150 | 14:19:50.149 |
| after cycle 2 | 2026-05-15 10:30:00 (unchanged) | 150 | 14:22:24.703 |

**Store/pipeline signals (2 and 3).** Separately validated that these two fire, paired, on a real cluster by synthetically forcing a scan rejection (a throwaway local hack that force-rejects fresh scans; not part of this PR, not committed). Over a ~40 min window, 41 paired cycles were logged across all nodes — the store logging the discarded `incoming` scan_time and the pipeline independently observing `processed != persisted`:

```
node/datastore/store/postgres: store.go: Warn: Rejecting incoming node scan for node 6a578641-… as not newer than the stored one: stored scan_time=…11:41:55.083Z, incoming scan_time=…12:14:35.536Z. The incoming scan and its component/CVE data will be discarded …
sensor/service/pipeline/nodeindex: pipeline.go: Warn: Persisted scan_time for node …-master-0 (id: 6a578641-…) does not match the freshly processed scan_time: processed=…12:14:35.536Z persisted=…11:41:55.083Z. The store rejected this scan as not newer than the stored one.
```