### PR TITLE
ROX-36250: add conversion layer for node report API

### DIFF
--- a/central/reports/service/v2/convert.go
+++ b/central/reports/service/v2/convert.go
@@ -589,6 +589,10 @@ func (s *serviceImpl) convertProtoReportSnapshotstoV2(snapshots []*storage.Repor
 				return nil, err
 			}
 		}
+		parentDir := snapshot.GetReportConfigurationId()
+		if snapshot.GetViewBasedVulnReportFilters() != nil {
+			parentDir = "view-based-report"
+		}
 		snapshotv2 := &apiV2.ReportSnapshot{
 			ReportStatus:       s.convertPrototoV2Reportstatus(snapshot.GetReportStatus()),
 			ReportConfigId:     snapshot.GetReportConfigurationId(),
@@ -603,7 +607,7 @@ func (s *serviceImpl) convertProtoReportSnapshotstoV2(snapshots []*storage.Repor
 			},
 			Schedule:            ConvertProtoScheduleToV2(snapshot.GetSchedule()),
 			ResourceScope:       resourceScope,
-			IsDownloadAvailable: blobNames.Contains(common.GetReportBlobPath(snapshot.GetReportConfigurationId(), snapshot.GetReportId())),
+			IsDownloadAvailable: blobNames.Contains(common.GetReportBlobPath(parentDir, snapshot.GetReportId())),
 		}
 
 		switch snapshot.GetType() {

--- a/central/reports/service/v2/convert.go
+++ b/central/reports/service/v2/convert.go
@@ -56,7 +56,7 @@ func (s *serviceImpl) convertV2ReportConfigurationToProto(config *apiV2.ReportCo
 		Name:          config.GetName(),
 		Description:   config.GetDescription(),
 		Type:          storage.ReportConfiguration_ReportType(config.GetType()),
-		Schedule:      s.convertV2ScheduleToProto(config.GetSchedule()),
+		Schedule:      ConvertV2ScheduleToProto(config.GetSchedule()),
 		ResourceScope: s.convertV2ResourceScopeToProto(config.GetResourceScope()),
 		Creator:       creator,
 		Version:       2,
@@ -223,7 +223,8 @@ func (s *serviceImpl) convertV2NotifierConfigToProto(notifier *apiV2.NotifierCon
 }
 
 // convertV2ScheduleToProto converts v2.ReportSchedule to storage.Schedule. Does not validate v2.ReportSchedule
-func (s *serviceImpl) convertV2ScheduleToProto(schedule *apiV2.ReportSchedule) *storage.Schedule {
+// ConvertV2ScheduleToProto converts v2.ReportSchedule to storage.Schedule
+func ConvertV2ScheduleToProto(schedule *apiV2.ReportSchedule) *storage.Schedule {
 	if schedule == nil {
 		return nil
 	}
@@ -266,7 +267,7 @@ func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.Report
 		Name:          config.GetName(),
 		Description:   config.GetDescription(),
 		Type:          apiV2.ReportConfiguration_ReportType(config.GetType()),
-		Schedule:      s.convertProtoScheduleToV2(config.GetSchedule()),
+		Schedule:      ConvertProtoScheduleToV2(config.GetSchedule()),
 		ResourceScope: resourceScope,
 	}
 
@@ -461,8 +462,8 @@ func (s *serviceImpl) convertProtoNotifierConfigToV2(notifierConfig *storage.Not
 	}, nil
 }
 
-// convertProtoScheduleToV2 converts storage.Schedule to v2.ReportSchedule. Does not validate storage.Schedule
-func (s *serviceImpl) convertProtoScheduleToV2(schedule *storage.Schedule) *apiV2.ReportSchedule {
+// ConvertProtoScheduleToV2 converts storage.Schedule to v2.ReportSchedule
+func ConvertProtoScheduleToV2(schedule *storage.Schedule) *apiV2.ReportSchedule {
 	if schedule == nil {
 		return nil
 	}
@@ -592,17 +593,30 @@ func (s *serviceImpl) convertProtoReportSnapshotstoV2(snapshots []*storage.Repor
 			ReportJobId:        snapshot.GetReportId(),
 			Name:               snapshot.GetName(),
 			Description:        snapshot.GetDescription(),
+			Type:               apiV2.ReportSnapshot_ReportType(snapshot.GetType()),
 			CollectionSnapshot: s.convertProtoReportCollectiontoV2(snapshot.GetCollection()),
 			User: &apiV2.SlimUser{
 				Id:   snapshot.GetRequester().GetId(),
 				Name: snapshot.GetRequester().GetName(),
 			},
-			Schedule: s.convertProtoScheduleToV2(snapshot.GetSchedule()),
-			Filter: &apiV2.ReportSnapshot_VulnReportFilters{
-				VulnReportFilters: s.convertProtoVulnReportFiltersToV2(snapshot.GetVulnReportFilters()),
-			},
+			Schedule:            ConvertProtoScheduleToV2(snapshot.GetSchedule()),
 			ResourceScope:       resourceScope,
 			IsDownloadAvailable: blobNames.Contains(common.GetReportBlobPath(snapshot.GetReportConfigurationId(), snapshot.GetReportId())),
+		}
+
+		switch snapshot.GetType() {
+		case storage.ReportSnapshot_VULNERABILITY:
+			snapshotv2.Filter = &apiV2.ReportSnapshot_VulnReportFilters{
+				VulnReportFilters: s.convertProtoVulnReportFiltersToV2(snapshot.GetVulnReportFilters()),
+			}
+		case storage.ReportSnapshot_NODE_VULNERABILITY:
+			snapshotv2.Filter = &apiV2.ReportSnapshot_NodeVulnReportFilters{
+				NodeVulnReportFilters: convertProtoNodeReportFiltersToV2(snapshot.GetNodeVulnReportFilters()),
+			}
+		default:
+			snapshotv2.Filter = &apiV2.ReportSnapshot_VulnReportFilters{
+				VulnReportFilters: s.convertProtoVulnReportFiltersToV2(snapshot.GetVulnReportFilters()),
+			}
 		}
 		for _, notifier := range snapshot.GetNotifiers() {
 			converted := s.convertProtoNotifierSnapshotToV2(notifier)
@@ -620,7 +634,7 @@ func (s *serviceImpl) getExistingBlobNames(snapshots []*storage.ReportSnapshot) 
 	blobNames := make([]string, 0)
 	for _, snap := range snapshots {
 		status := snap.GetReportStatus()
-		if status.GetReportNotificationMethod() == storage.ReportStatus_DOWNLOAD {
+		if status != nil && status.GetReportNotificationMethod() == storage.ReportStatus_DOWNLOAD {
 			if status.GetRunState() == storage.ReportStatus_GENERATED ||
 				status.GetRunState() == storage.ReportStatus_DELIVERED {
 				parentDir := snap.GetReportConfigurationId()
@@ -639,4 +653,24 @@ func (s *serviceImpl) getExistingBlobNames(snapshots []*storage.ReportSnapshot) 
 	}
 
 	return search.ResultsToIDSet(results), nil
+}
+
+// convertProtoNodeReportFiltersToV2 converts storage.NodeVulnerabilityReportFilters to apiV2.NodeVulnerabilityReportFilters
+func convertProtoNodeReportFiltersToV2(filters *storage.NodeVulnerabilityReportFilters) *apiV2.NodeVulnerabilityReportFilters {
+	if filters == nil {
+		return nil
+	}
+
+	ret := &apiV2.NodeVulnerabilityReportFilters{
+		Query: filters.GetQuery(),
+	}
+
+	switch filters.GetCvesSince().(type) {
+	case *storage.NodeVulnerabilityReportFilters_AllVuln:
+		ret.CvesSince = &apiV2.NodeVulnerabilityReportFilters_AllVuln{
+			AllVuln: filters.GetAllVuln(),
+		}
+	}
+
+	return ret
 }

--- a/central/reports/service/v2/convert.go
+++ b/central/reports/service/v2/convert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/reports/common"
 	apiV2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
@@ -69,7 +70,7 @@ func (s *serviceImpl) convertV2ReportConfigurationToProto(config *apiV2.ReportCo
 	}
 
 	for _, notifier := range config.GetNotifiers() {
-		ret.Notifiers = append(ret.Notifiers, s.convertV2NotifierConfigToProto(notifier))
+		ret.Notifiers = append(ret.Notifiers, ConvertV2NotifierConfigToProto(notifier))
 	}
 
 	return ret
@@ -199,7 +200,8 @@ func v2MatchTypeToStorage(m apiV2.MatchType) storage.MatchType {
 	}
 }
 
-func (s *serviceImpl) convertV2NotifierConfigToProto(notifier *apiV2.NotifierConfiguration) *storage.NotifierConfiguration {
+// ConvertV2NotifierConfigToProto converts apiV2.NotifierConfiguration to storage.NotifierConfiguration.
+func ConvertV2NotifierConfigToProto(notifier *apiV2.NotifierConfiguration) *storage.NotifierConfiguration {
 	if notifier == nil {
 		return nil
 	}
@@ -222,8 +224,7 @@ func (s *serviceImpl) convertV2NotifierConfigToProto(notifier *apiV2.NotifierCon
 	return ret
 }
 
-// convertV2ScheduleToProto converts v2.ReportSchedule to storage.Schedule. Does not validate v2.ReportSchedule
-// ConvertV2ScheduleToProto converts v2.ReportSchedule to storage.Schedule
+// ConvertV2ScheduleToProto converts v2.ReportSchedule to storage.Schedule. Does not validate v2.ReportSchedule.
 func ConvertV2ScheduleToProto(schedule *apiV2.ReportSchedule) *storage.Schedule {
 	if schedule == nil {
 		return nil
@@ -286,11 +287,13 @@ func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.Report
 	}
 
 	for _, notifier := range config.GetNotifiers() {
-		converted, err := s.convertProtoNotifierConfigToV2(notifier)
+		converted, err := ConvertProtoNotifierConfigToV2(s.notifierDatastore, notifier)
 		if err != nil {
 			return nil, err
 		}
-		ret.Notifiers = append(ret.Notifiers, converted)
+		if converted != nil {
+			ret.Notifiers = append(ret.Notifiers, converted)
+		}
 	}
 
 	return ret, nil
@@ -431,8 +434,8 @@ func storageMatchTypeToV2(m storage.MatchType) apiV2.MatchType {
 	}
 }
 
-// convertProtoNotifierConfigToV2 converts storage.NotifierConfiguration to apiV2.NotifierConfiguration
-func (s *serviceImpl) convertProtoNotifierConfigToV2(notifierConfig *storage.NotifierConfiguration) (*apiV2.NotifierConfiguration, error) {
+// ConvertProtoNotifierConfigToV2 converts storage.NotifierConfiguration to apiV2.NotifierConfiguration.
+func ConvertProtoNotifierConfigToV2(ds notifierDS.DataStore, notifierConfig *storage.NotifierConfiguration) (*apiV2.NotifierConfiguration, error) {
 	if notifierConfig == nil {
 		return nil, nil
 	}
@@ -441,7 +444,7 @@ func (s *serviceImpl) convertProtoNotifierConfigToV2(notifierConfig *storage.Not
 		return nil, nil
 	}
 
-	notifier, found, err := s.notifierDatastore.GetNotifier(allAccessCtx, notifierConfig.GetId())
+	notifier, found, err := ds.GetNotifier(allAccessCtx, notifierConfig.GetId())
 	if err != nil {
 		return nil, err
 	}
@@ -511,8 +514,8 @@ func (s *serviceImpl) convertProtoReportCollectiontoV2(collection *storage.Colle
 	}
 }
 
-// convertProtoNotifierSnapshotToV2 converts notifiersnapshot proto to v2
-func (s *serviceImpl) convertProtoNotifierSnapshotToV2(notifierSnapshot *storage.NotifierSnapshot) *apiV2.NotifierConfiguration {
+// ConvertProtoNotifierSnapshotToV2 converts storage.NotifierSnapshot to apiV2.NotifierConfiguration.
+func ConvertProtoNotifierSnapshotToV2(notifierSnapshot *storage.NotifierSnapshot) *apiV2.NotifierConfiguration {
 	if notifierSnapshot == nil {
 		return nil
 	}
@@ -608,24 +611,12 @@ func (s *serviceImpl) convertProtoReportSnapshotstoV2(snapshots []*storage.Repor
 			Schedule:            ConvertProtoScheduleToV2(snapshot.GetSchedule()),
 			ResourceScope:       resourceScope,
 			IsDownloadAvailable: blobNames.Contains(common.GetReportBlobPath(parentDir, snapshot.GetReportId())),
-		}
-
-		switch snapshot.GetType() {
-		case storage.ReportSnapshot_VULNERABILITY:
-			snapshotv2.Filter = &apiV2.ReportSnapshot_VulnReportFilters{
+			Filter: &apiV2.ReportSnapshot_VulnReportFilters{
 				VulnReportFilters: s.convertProtoVulnReportFiltersToV2(snapshot.GetVulnReportFilters()),
-			}
-		case storage.ReportSnapshot_NODE_VULNERABILITY:
-			snapshotv2.Filter = &apiV2.ReportSnapshot_NodeVulnReportFilters{
-				NodeVulnReportFilters: convertProtoNodeReportFiltersToV2(snapshot.GetNodeVulnReportFilters()),
-			}
-		default:
-			snapshotv2.Filter = &apiV2.ReportSnapshot_VulnReportFilters{
-				VulnReportFilters: s.convertProtoVulnReportFiltersToV2(snapshot.GetVulnReportFilters()),
-			}
+			},
 		}
 		for _, notifier := range snapshot.GetNotifiers() {
-			converted := s.convertProtoNotifierSnapshotToV2(notifier)
+			converted := ConvertProtoNotifierSnapshotToV2(notifier)
 			if converted != nil {
 				snapshotv2.Notifiers = append(snapshotv2.Notifiers, converted)
 			}
@@ -659,24 +650,4 @@ func (s *serviceImpl) getExistingBlobNames(snapshots []*storage.ReportSnapshot) 
 	}
 
 	return search.ResultsToIDSet(results), nil
-}
-
-// convertProtoNodeReportFiltersToV2 converts storage.NodeVulnerabilityReportFilters to apiV2.NodeVulnerabilityReportFilters
-func convertProtoNodeReportFiltersToV2(filters *storage.NodeVulnerabilityReportFilters) *apiV2.NodeVulnerabilityReportFilters {
-	if filters == nil {
-		return nil
-	}
-
-	ret := &apiV2.NodeVulnerabilityReportFilters{
-		Query: filters.GetQuery(),
-	}
-
-	switch filters.GetCvesSince().(type) {
-	case *storage.NodeVulnerabilityReportFilters_AllVuln:
-		ret.CvesSince = &apiV2.NodeVulnerabilityReportFilters_AllVuln{
-			AllVuln: filters.GetAllVuln(),
-		}
-	}
-
-	return ret
 }

--- a/central/reports/service/v2/convert.go
+++ b/central/reports/service/v2/convert.go
@@ -517,7 +517,9 @@ func (s *serviceImpl) convertProtoNotifierSnapshotToV2(notifierSnapshot *storage
 		return nil
 	}
 	if notifierSnapshot.GetEmailConfig() == nil {
-		return &apiV2.NotifierConfiguration{}
+		return &apiV2.NotifierConfiguration{
+			NotifierName: notifierSnapshot.GetNotifierName(),
+		}
 	}
 
 	return &apiV2.NotifierConfiguration{

--- a/central/reports/service/v2/convert_test.go
+++ b/central/reports/service/v2/convert_test.go
@@ -750,7 +750,7 @@ func TestConvertProtoNotifierSnapshotToV2(t *testing.T) {
 		}
 		result := service.convertProtoNotifierSnapshotToV2(snapshot)
 		assert.NotNil(t, result)
-		assert.Empty(t, result.GetNotifierName())
+		assert.Equal(t, "test-notifier", result.GetNotifierName())
 	})
 
 	t.Run("snapshot with email config", func(t *testing.T) {

--- a/central/reports/service/v2/convert_test.go
+++ b/central/reports/service/v2/convert_test.go
@@ -729,18 +729,8 @@ func TestEnumConversions(t *testing.T) {
 }
 
 func TestConvertProtoNotifierSnapshotToV2(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	collectionDS := collectionDSMocks.NewMockDataStore(ctrl)
-	notifierDS := notifierDSMocks.NewMockDataStore(ctrl)
-	service := &serviceImpl{
-		collectionDatastore: collectionDS,
-		notifierDatastore:   notifierDS,
-	}
-
 	t.Run("nil snapshot", func(t *testing.T) {
-		result := service.convertProtoNotifierSnapshotToV2(nil)
+		result := ConvertProtoNotifierSnapshotToV2(nil)
 		assert.Nil(t, result)
 	})
 
@@ -748,7 +738,7 @@ func TestConvertProtoNotifierSnapshotToV2(t *testing.T) {
 		snapshot := &storage.NotifierSnapshot{
 			NotifierName: "test-notifier",
 		}
-		result := service.convertProtoNotifierSnapshotToV2(snapshot)
+		result := ConvertProtoNotifierSnapshotToV2(snapshot)
 		assert.NotNil(t, result)
 		assert.Equal(t, "test-notifier", result.GetNotifierName())
 	})
@@ -765,7 +755,7 @@ func TestConvertProtoNotifierSnapshotToV2(t *testing.T) {
 				},
 			},
 		}
-		result := service.convertProtoNotifierSnapshotToV2(snapshot)
+		result := ConvertProtoNotifierSnapshotToV2(snapshot)
 		assert.NotNil(t, result)
 		assert.Equal(t, "test-notifier", result.GetNotifierName())
 		assert.Equal(t, "notifier-1", result.GetEmailConfig().GetNotifierId())

--- a/central/reports/service/v2/convert_test.go
+++ b/central/reports/service/v2/convert_test.go
@@ -479,7 +479,7 @@ func (s *typeConversionTestSuite) TestConvertProtoScheduleToV2() {
 
 	for _, c := range cases {
 		s.T().Run(c.testname, func(t *testing.T) {
-			converted := s.service.convertProtoScheduleToV2(c.schedule)
+			converted := ConvertProtoScheduleToV2(c.schedule)
 			protoassert.Equal(t, c.result, converted)
 		})
 	}
@@ -515,7 +515,7 @@ func (s *typeConversionTestSuite) TestConvertSchedulePreservesTime() {
 				Hour:         c.hour,
 				Minute:       c.minute,
 			}
-			converted := s.service.convertV2ScheduleToProto(v2Schedule)
+			converted := ConvertV2ScheduleToProto(v2Schedule)
 			assert.Equal(t, c.hour, converted.GetHour())
 			assert.Equal(t, c.minute, converted.GetMinute())
 			assert.Equal(t, storage.Schedule_DAILY, converted.GetIntervalType())
@@ -527,7 +527,7 @@ func (s *typeConversionTestSuite) TestConvertSchedulePreservesTime() {
 				Hour:         c.hour,
 				Minute:       c.minute,
 			}
-			converted := s.service.convertProtoScheduleToV2(storageSchedule)
+			converted := ConvertProtoScheduleToV2(storageSchedule)
 			assert.Equal(t, c.hour, converted.GetHour())
 			assert.Equal(t, c.minute, converted.GetMinute())
 			assert.Equal(t, apiV2.ReportSchedule_DAILY, converted.GetIntervalType())
@@ -542,8 +542,8 @@ func (s *typeConversionTestSuite) TestConvertSchedulePreservesTime() {
 					DaysOfWeek: &apiV2.ReportSchedule_DaysOfWeek{Days: []int32{1}},
 				},
 			}
-			storage := s.service.convertV2ScheduleToProto(v2Schedule)
-			roundTripped := s.service.convertProtoScheduleToV2(storage)
+			storage := ConvertV2ScheduleToProto(v2Schedule)
+			roundTripped := ConvertProtoScheduleToV2(storage)
 			assert.Equal(t, c.hour, roundTripped.GetHour())
 			assert.Equal(t, c.minute, roundTripped.GetMinute())
 		})
@@ -580,7 +580,7 @@ func (s *typeConversionTestSuite) TestConvertV2ScheduleToProto() {
 
 	for _, c := range cases {
 		s.T().Run(c.testname, func(t *testing.T) {
-			converted := s.service.convertV2ScheduleToProto(c.schedule)
+			converted := ConvertV2ScheduleToProto(c.schedule)
 			protoassert.Equal(t, c.result, converted)
 		})
 	}
@@ -646,4 +646,131 @@ func newScheduleV2(minute int32, hour int32, weekdays []int32, daysOfMonth []int
 		}
 	}
 	return &sched
+}
+
+func TestEnumConversions(t *testing.T) {
+	t.Run("v2EntityTypeToStorage", func(t *testing.T) {
+		tests := map[string]struct {
+			input    apiV2.ScopeEntity
+			expected storage.EntityType
+		}{
+			"deployment": {apiV2.ScopeEntity_SCOPE_ENTITY_DEPLOYMENT, storage.EntityType_ENTITY_TYPE_DEPLOYMENT},
+			"namespace":  {apiV2.ScopeEntity_SCOPE_ENTITY_NAMESPACE, storage.EntityType_ENTITY_TYPE_NAMESPACE},
+			"cluster":    {apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER, storage.EntityType_ENTITY_TYPE_CLUSTER},
+			"unset":      {apiV2.ScopeEntity_SCOPE_ENTITY_UNSET, storage.EntityType_ENTITY_TYPE_UNSET},
+			"unknown":    {apiV2.ScopeEntity(999), storage.EntityType_ENTITY_TYPE_UNSET},
+		}
+		for name, tc := range tests {
+			t.Run(name, func(t *testing.T) {
+				result := v2EntityTypeToStorage(tc.input)
+				assert.Equal(t, tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("v2EntityFieldToStorage", func(t *testing.T) {
+		tests := map[string]struct {
+			input    apiV2.ScopeField
+			expected storage.EntityField
+		}{
+			"id":         {apiV2.ScopeField_FIELD_ID, storage.EntityField_FIELD_ID},
+			"name":       {apiV2.ScopeField_FIELD_NAME, storage.EntityField_FIELD_NAME},
+			"label":      {apiV2.ScopeField_FIELD_LABEL, storage.EntityField_FIELD_LABEL},
+			"annotation": {apiV2.ScopeField_FIELD_ANNOTATION, storage.EntityField_FIELD_ANNOTATION},
+			"unset":      {apiV2.ScopeField_FIELD_UNSET, storage.EntityField_FIELD_UNSET},
+			"unknown":    {apiV2.ScopeField(999), storage.EntityField_FIELD_UNSET},
+		}
+		for name, tc := range tests {
+			t.Run(name, func(t *testing.T) {
+				result := v2EntityFieldToStorage(tc.input)
+				assert.Equal(t, tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("storageEntityTypeToV2", func(t *testing.T) {
+		tests := map[string]struct {
+			input    storage.EntityType
+			expected apiV2.ScopeEntity
+		}{
+			"deployment": {storage.EntityType_ENTITY_TYPE_DEPLOYMENT, apiV2.ScopeEntity_SCOPE_ENTITY_DEPLOYMENT},
+			"namespace":  {storage.EntityType_ENTITY_TYPE_NAMESPACE, apiV2.ScopeEntity_SCOPE_ENTITY_NAMESPACE},
+			"cluster":    {storage.EntityType_ENTITY_TYPE_CLUSTER, apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER},
+			"unset":      {storage.EntityType_ENTITY_TYPE_UNSET, apiV2.ScopeEntity_SCOPE_ENTITY_UNSET},
+			"unknown":    {storage.EntityType(999), apiV2.ScopeEntity_SCOPE_ENTITY_UNSET},
+		}
+		for name, tc := range tests {
+			t.Run(name, func(t *testing.T) {
+				result := storageEntityTypeToV2(tc.input)
+				assert.Equal(t, tc.expected, result)
+			})
+		}
+	})
+
+	t.Run("storageEntityFieldToV2", func(t *testing.T) {
+		tests := map[string]struct {
+			input    storage.EntityField
+			expected apiV2.ScopeField
+		}{
+			"id":         {storage.EntityField_FIELD_ID, apiV2.ScopeField_FIELD_ID},
+			"name":       {storage.EntityField_FIELD_NAME, apiV2.ScopeField_FIELD_NAME},
+			"label":      {storage.EntityField_FIELD_LABEL, apiV2.ScopeField_FIELD_LABEL},
+			"annotation": {storage.EntityField_FIELD_ANNOTATION, apiV2.ScopeField_FIELD_ANNOTATION},
+			"unset":      {storage.EntityField_FIELD_UNSET, apiV2.ScopeField_FIELD_UNSET},
+			"unknown":    {storage.EntityField(999), apiV2.ScopeField_FIELD_UNSET},
+		}
+		for name, tc := range tests {
+			t.Run(name, func(t *testing.T) {
+				result := storageEntityFieldToV2(tc.input)
+				assert.Equal(t, tc.expected, result)
+			})
+		}
+	})
+}
+
+func TestConvertProtoNotifierSnapshotToV2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	collectionDS := collectionDSMocks.NewMockDataStore(ctrl)
+	notifierDS := notifierDSMocks.NewMockDataStore(ctrl)
+	service := &serviceImpl{
+		collectionDatastore: collectionDS,
+		notifierDatastore:   notifierDS,
+	}
+
+	t.Run("nil snapshot", func(t *testing.T) {
+		result := service.convertProtoNotifierSnapshotToV2(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("snapshot without email config", func(t *testing.T) {
+		snapshot := &storage.NotifierSnapshot{
+			NotifierName: "test-notifier",
+		}
+		result := service.convertProtoNotifierSnapshotToV2(snapshot)
+		assert.NotNil(t, result)
+		assert.Empty(t, result.GetNotifierName())
+	})
+
+	t.Run("snapshot with email config", func(t *testing.T) {
+		snapshot := &storage.NotifierSnapshot{
+			NotifierName: "test-notifier",
+			NotifierConfig: &storage.NotifierSnapshot_EmailConfig{
+				EmailConfig: &storage.EmailNotifierConfiguration{
+					NotifierId:    "notifier-1",
+					MailingLists:  []string{"user@example.com"},
+					CustomSubject: "Test Subject",
+					CustomBody:    "Test Body",
+				},
+			},
+		}
+		result := service.convertProtoNotifierSnapshotToV2(snapshot)
+		assert.NotNil(t, result)
+		assert.Equal(t, "test-notifier", result.GetNotifierName())
+		assert.Equal(t, "notifier-1", result.GetEmailConfig().GetNotifierId())
+		assert.Equal(t, []string{"user@example.com"}, result.GetEmailConfig().GetMailingLists())
+		assert.Equal(t, "Test Subject", result.GetEmailConfig().GetCustomSubject())
+		assert.Equal(t, "Test Body", result.GetEmailConfig().GetCustomBody())
+	})
 }

--- a/central/reports/service/v2/node/convert.go
+++ b/central/reports/service/v2/node/convert.go
@@ -14,20 +14,6 @@ import (
 )
 
 var (
-	v2IntervalTypeToStorage = map[apiV2.ReportSchedule_IntervalType]storage.Schedule_IntervalType{
-		apiV2.ReportSchedule_UNSET:   storage.Schedule_UNSET,
-		apiV2.ReportSchedule_WEEKLY:  storage.Schedule_WEEKLY,
-		apiV2.ReportSchedule_MONTHLY: storage.Schedule_MONTHLY,
-		apiV2.ReportSchedule_DAILY:   storage.Schedule_DAILY,
-	}
-
-	storageIntervalTypeToV2 = map[storage.Schedule_IntervalType]apiV2.ReportSchedule_IntervalType{
-		storage.Schedule_UNSET:   apiV2.ReportSchedule_UNSET,
-		storage.Schedule_DAILY:   apiV2.ReportSchedule_DAILY,
-		storage.Schedule_WEEKLY:  apiV2.ReportSchedule_WEEKLY,
-		storage.Schedule_MONTHLY: apiV2.ReportSchedule_MONTHLY,
-	}
-
 	storageRunStateToV2 = map[storage.ReportStatus_RunState]apiV2.ReportStatus_RunState{
 		storage.ReportStatus_WAITING:   apiV2.ReportStatus_WAITING,
 		storage.ReportStatus_PREPARING: apiV2.ReportStatus_PREPARING,
@@ -36,7 +22,7 @@ var (
 		storage.ReportStatus_FAILURE:   apiV2.ReportStatus_FAILURE,
 	}
 
-	// Use this context only to populate notifier, collection names and IsDownloadAvailable fields in converted responses
+	// Use this context only to populate notifier names and IsDownloadAvailable fields in converted responses
 	allAccessCtx = sac.WithAllAccess(context.Background())
 )
 
@@ -65,18 +51,18 @@ func (s *serviceImpl) convertV2ReportConfigurationToProto(config *apiV2.ReportCo
 
 	if config.GetNodeVulnReportFilters() != nil {
 		ret.Filter = &storage.ReportConfiguration_NodeVulnReportFilters{
-			NodeVulnReportFilters: s.convertV2NodeReportFiltersToProto(config.GetNodeVulnReportFilters(), accessScopeRules),
+			NodeVulnReportFilters: convertV2NodeReportFiltersToProto(config.GetNodeVulnReportFilters(), accessScopeRules),
 		}
 	}
 
 	for _, notifier := range config.GetNotifiers() {
-		ret.Notifiers = append(ret.Notifiers, s.convertV2NotifierConfigToProto(notifier))
+		ret.Notifiers = append(ret.Notifiers, v2.ConvertV2NotifierConfigToProto(notifier))
 	}
 
 	return ret, nil
 }
 
-func (s *serviceImpl) convertV2NodeReportFiltersToProto(filters *apiV2.NodeVulnerabilityReportFilters,
+func convertV2NodeReportFiltersToProto(filters *apiV2.NodeVulnerabilityReportFilters,
 	accessScopeRules []*storage.SimpleAccessScope_Rules) *storage.NodeVulnerabilityReportFilters {
 	if filters == nil {
 		return nil
@@ -168,29 +154,6 @@ func v2MatchTypeToStorage(m apiV2.MatchType) storage.MatchType {
 	}
 }
 
-func (s *serviceImpl) convertV2NotifierConfigToProto(notifier *apiV2.NotifierConfiguration) *storage.NotifierConfiguration {
-	if notifier == nil {
-		return nil
-	}
-
-	ret := &storage.NotifierConfiguration{
-		Ref: &storage.NotifierConfiguration_Id{
-			Id: notifier.GetEmailConfig().GetNotifierId(),
-		},
-	}
-
-	if emailConfig := notifier.GetEmailConfig(); emailConfig != nil {
-		ret.NotifierConfig = &storage.NotifierConfiguration_EmailConfig{
-			EmailConfig: &storage.EmailNotifierConfiguration{
-				MailingLists:  emailConfig.GetMailingLists(),
-				CustomSubject: emailConfig.GetCustomSubject(),
-				CustomBody:    emailConfig.GetCustomBody(),
-			},
-		}
-	}
-	return ret
-}
-
 // Proto to V2 conversions
 
 func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.ReportConfiguration) (*apiV2.ReportConfiguration, error) {
@@ -198,10 +161,7 @@ func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.Report
 		return nil, nil
 	}
 
-	resourceScope, err := s.convertProtoResourceScopeToV2(config.GetResourceScope())
-	if err != nil {
-		return nil, err
-	}
+	resourceScope := convertProtoResourceScopeToV2(config.GetResourceScope())
 
 	ret := &apiV2.ReportConfiguration{
 		Id:            config.GetId(),
@@ -214,22 +174,24 @@ func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.Report
 
 	if config.GetNodeVulnReportFilters() != nil {
 		ret.Filter = &apiV2.ReportConfiguration_NodeVulnReportFilters{
-			NodeVulnReportFilters: s.convertProtoNodeReportFiltersToV2(config.GetNodeVulnReportFilters()),
+			NodeVulnReportFilters: convertProtoNodeReportFiltersToV2(config.GetNodeVulnReportFilters()),
 		}
 	}
 
 	for _, notifier := range config.GetNotifiers() {
-		converted, err := s.convertProtoNotifierConfigToV2(notifier)
+		converted, err := v2.ConvertProtoNotifierConfigToV2(s.notifierDatastore, notifier)
 		if err != nil {
 			return nil, err
 		}
-		ret.Notifiers = append(ret.Notifiers, converted)
+		if converted != nil {
+			ret.Notifiers = append(ret.Notifiers, converted)
+		}
 	}
 
 	return ret, nil
 }
 
-func (s *serviceImpl) convertProtoNodeReportFiltersToV2(filters *storage.NodeVulnerabilityReportFilters) *apiV2.NodeVulnerabilityReportFilters {
+func convertProtoNodeReportFiltersToV2(filters *storage.NodeVulnerabilityReportFilters) *apiV2.NodeVulnerabilityReportFilters {
 	if filters == nil {
 		return nil
 	}
@@ -248,16 +210,16 @@ func (s *serviceImpl) convertProtoNodeReportFiltersToV2(filters *storage.NodeVul
 	return ret
 }
 
-func (s *serviceImpl) convertProtoResourceScopeToV2(scope *storage.ResourceScope) (*apiV2.ResourceScope, error) {
+func convertProtoResourceScopeToV2(scope *storage.ResourceScope) *apiV2.ResourceScope {
 	if scope == nil {
-		return nil, nil
+		return nil
 	}
 
 	ret := &apiV2.ResourceScope{}
 	if ref, ok := scope.GetScopeReference().(*storage.ResourceScope_EntityScope); ok {
 		ret.ScopeReference = &apiV2.ResourceScope_EntityScope{EntityScope: convertStorageEntityScopeToV2(ref.EntityScope)}
 	}
-	return ret, nil
+	return ret
 }
 
 func convertStorageEntityScopeToV2(es *storage.EntityScope) *apiV2.EntityScope {
@@ -312,38 +274,17 @@ func storageMatchTypeToV2(m storage.MatchType) apiV2.MatchType {
 	}
 }
 
-func (s *serviceImpl) convertProtoNotifierConfigToV2(notifierConfig *storage.NotifierConfiguration) (*apiV2.NotifierConfiguration, error) {
-	if notifierConfig == nil {
-		return nil, nil
+// reportBlobParentDir returns the blob directory for a snapshot. View-based
+// report blobs are stored under "view-based-report", not under a report config ID.
+func reportBlobParentDir(snapshot *storage.ReportSnapshot) string {
+	if snapshot.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
+		return "view-based-report"
 	}
-
-	if notifierConfig.GetEmailConfig() == nil {
-		return nil, nil
-	}
-
-	notifier, found, err := s.notifierDatastore.GetNotifier(allAccessCtx, notifierConfig.GetId())
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, errors.Errorf("Notifier with ID %s no longer exists", notifierConfig.GetId())
-	}
-
-	return &apiV2.NotifierConfiguration{
-		NotifierName: notifier.GetName(),
-		NotifierConfig: &apiV2.NotifierConfiguration_EmailConfig{
-			EmailConfig: &apiV2.EmailNotifierConfiguration{
-				NotifierId:    notifierConfig.GetId(),
-				MailingLists:  notifierConfig.GetEmailConfig().GetMailingLists(),
-				CustomSubject: notifierConfig.GetEmailConfig().GetCustomSubject(),
-				CustomBody:    notifierConfig.GetEmailConfig().GetCustomBody(),
-			},
-		},
-	}, nil
+	return snapshot.GetReportConfigurationId()
 }
 
-func isDownloadAvailable(blobNames set.FrozenStringSet, configID, reportID string) bool {
-	return blobNames.Contains(common.GetReportBlobPath(configID, reportID))
+func isDownloadAvailable(blobNames set.FrozenStringSet, snapshot *storage.ReportSnapshot) bool {
+	return blobNames.Contains(common.GetReportBlobPath(reportBlobParentDir(snapshot), snapshot.GetReportId()))
 }
 
 func (s *serviceImpl) convertProtoReportSnapshotToV2(snapshot *storage.ReportSnapshot, blobNames set.FrozenStringSet) (*apiV2.ReportSnapshot, error) {
@@ -351,10 +292,7 @@ func (s *serviceImpl) convertProtoReportSnapshotToV2(snapshot *storage.ReportSna
 		return nil, nil
 	}
 
-	resourceScope, err := s.convertProtoResourceScopeToV2(snapshot.GetResourceScope())
-	if err != nil {
-		return nil, err
-	}
+	resourceScope := convertProtoResourceScopeToV2(snapshot.GetResourceScope())
 
 	ret := &apiV2.ReportSnapshot{
 		ReportStatus:   convertPrototoV2Reportstatus(snapshot.GetReportStatus()),
@@ -362,6 +300,7 @@ func (s *serviceImpl) convertProtoReportSnapshotToV2(snapshot *storage.ReportSna
 		ReportJobId:    snapshot.GetReportId(),
 		Name:           snapshot.GetName(),
 		Description:    snapshot.GetDescription(),
+		AreaOfConcern:  snapshot.GetAreaOfConcern(),
 		Type:           apiV2.ReportSnapshot_NODE_VULNERABILITY,
 		User: &apiV2.SlimUser{
 			Id:   snapshot.GetRequester().GetId(),
@@ -369,46 +308,23 @@ func (s *serviceImpl) convertProtoReportSnapshotToV2(snapshot *storage.ReportSna
 		},
 		Schedule:            v2.ConvertProtoScheduleToV2(snapshot.GetSchedule()),
 		ResourceScope:       resourceScope,
-		IsDownloadAvailable: isDownloadAvailable(blobNames, snapshot.GetReportConfigurationId(), snapshot.GetReportId()),
+		IsDownloadAvailable: isDownloadAvailable(blobNames, snapshot),
 	}
 
 	if snapshot.GetNodeVulnReportFilters() != nil {
 		ret.Filter = &apiV2.ReportSnapshot_NodeVulnReportFilters{
-			NodeVulnReportFilters: s.convertProtoNodeReportFiltersToV2(snapshot.GetNodeVulnReportFilters()),
+			NodeVulnReportFilters: convertProtoNodeReportFiltersToV2(snapshot.GetNodeVulnReportFilters()),
 		}
 	}
 
 	for _, notifier := range snapshot.GetNotifiers() {
-		converted := s.convertProtoNotifierSnapshotToV2(notifier)
+		converted := v2.ConvertProtoNotifierSnapshotToV2(notifier)
 		if converted != nil {
 			ret.Notifiers = append(ret.Notifiers, converted)
 		}
 	}
 
 	return ret, nil
-}
-
-func (s *serviceImpl) convertProtoNotifierSnapshotToV2(notifierSnapshot *storage.NotifierSnapshot) *apiV2.NotifierConfiguration {
-	if notifierSnapshot == nil {
-		return nil
-	}
-	if notifierSnapshot.GetEmailConfig() == nil {
-		return &apiV2.NotifierConfiguration{
-			NotifierName: notifierSnapshot.GetNotifierName(),
-		}
-	}
-
-	return &apiV2.NotifierConfiguration{
-		NotifierName: notifierSnapshot.GetNotifierName(),
-		NotifierConfig: &apiV2.NotifierConfiguration_EmailConfig{
-			EmailConfig: &apiV2.EmailNotifierConfiguration{
-				NotifierId:    notifierSnapshot.GetEmailConfig().GetNotifierId(),
-				MailingLists:  notifierSnapshot.GetEmailConfig().GetMailingLists(),
-				CustomSubject: notifierSnapshot.GetEmailConfig().GetCustomSubject(),
-				CustomBody:    notifierSnapshot.GetEmailConfig().GetCustomBody(),
-			},
-		},
-	}
 }
 
 func convertPrototoV2Reportstatus(status *storage.ReportStatus) *apiV2.ReportStatus {
@@ -418,6 +334,7 @@ func convertPrototoV2Reportstatus(status *storage.ReportStatus) *apiV2.ReportSta
 
 	ret := &apiV2.ReportStatus{
 		ReportNotificationMethod: apiV2.NotificationMethod(status.GetReportNotificationMethod()),
+		ReportRequestType:        apiV2.ReportStatus_ReportMethod(status.GetReportRequestType()),
 		RunState:                 storageRunStateToV2[status.GetRunState()],
 		ErrorMsg:                 status.GetErrorMsg(),
 		CompletedAt:              status.GetCompletedAt(),
@@ -426,7 +343,7 @@ func convertPrototoV2Reportstatus(status *storage.ReportStatus) *apiV2.ReportSta
 	return ret
 }
 
-func (s *serviceImpl) getExistingBlobNames(ctx context.Context, snapshots []*storage.ReportSnapshot) (set.FrozenStringSet, error) {
+func (s *serviceImpl) getExistingBlobNames(snapshots []*storage.ReportSnapshot) (set.FrozenStringSet, error) {
 	if len(snapshots) == 0 {
 		return set.NewFrozenStringSet(), nil
 	}
@@ -437,11 +354,7 @@ func (s *serviceImpl) getExistingBlobNames(ctx context.Context, snapshots []*sto
 		if status.GetReportNotificationMethod() == storage.ReportStatus_DOWNLOAD {
 			if status.GetRunState() == storage.ReportStatus_GENERATED ||
 				status.GetRunState() == storage.ReportStatus_DELIVERED {
-				parentDir := snapshot.GetReportConfigurationId()
-				if snapshot.GetViewBasedVulnReportFilters() != nil {
-					parentDir = "view-based-report"
-				}
-				blobNames = append(blobNames, common.GetReportBlobPath(parentDir, snapshot.GetReportId()))
+				blobNames = append(blobNames, common.GetReportBlobPath(reportBlobParentDir(snapshot), snapshot.GetReportId()))
 			}
 		}
 	}
@@ -451,7 +364,7 @@ func (s *serviceImpl) getExistingBlobNames(ctx context.Context, snapshots []*sto
 	}
 
 	query := search.NewQueryBuilder().AddExactMatches(search.BlobName, blobNames...).ProtoQuery()
-	results, err := s.blobStore.Search(ctx, query)
+	results, err := s.blobStore.Search(allAccessCtx, query)
 	if err != nil {
 		return set.NewFrozenStringSet(), errors.Wrap(err, "failed to search for report blobs")
 	}

--- a/central/reports/service/v2/node/convert.go
+++ b/central/reports/service/v2/node/convert.go
@@ -1,0 +1,448 @@
+package node
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/reports/common"
+	v2 "github.com/stackrox/rox/central/reports/service/v2"
+	apiV2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+var (
+	v2IntervalTypeToStorage = map[apiV2.ReportSchedule_IntervalType]storage.Schedule_IntervalType{
+		apiV2.ReportSchedule_UNSET:   storage.Schedule_UNSET,
+		apiV2.ReportSchedule_WEEKLY:  storage.Schedule_WEEKLY,
+		apiV2.ReportSchedule_MONTHLY: storage.Schedule_MONTHLY,
+		apiV2.ReportSchedule_DAILY:   storage.Schedule_DAILY,
+	}
+
+	storageIntervalTypeToV2 = map[storage.Schedule_IntervalType]apiV2.ReportSchedule_IntervalType{
+		storage.Schedule_UNSET:   apiV2.ReportSchedule_UNSET,
+		storage.Schedule_DAILY:   apiV2.ReportSchedule_DAILY,
+		storage.Schedule_WEEKLY:  apiV2.ReportSchedule_WEEKLY,
+		storage.Schedule_MONTHLY: apiV2.ReportSchedule_MONTHLY,
+	}
+
+	storageRunStateToV2 = map[storage.ReportStatus_RunState]apiV2.ReportStatus_RunState{
+		storage.ReportStatus_WAITING:   apiV2.ReportStatus_WAITING,
+		storage.ReportStatus_PREPARING: apiV2.ReportStatus_PREPARING,
+		storage.ReportStatus_GENERATED: apiV2.ReportStatus_GENERATED,
+		storage.ReportStatus_DELIVERED: apiV2.ReportStatus_DELIVERED,
+		storage.ReportStatus_FAILURE:   apiV2.ReportStatus_FAILURE,
+	}
+)
+
+// convertV2ReportConfigurationToProto converts v2.ReportConfiguration to storage.ReportConfiguration for node reports
+func (s *serviceImpl) convertV2ReportConfigurationToProto(config *apiV2.ReportConfiguration, creator *storage.SlimUser,
+	accessScopeRules []*storage.SimpleAccessScope_Rules) (*storage.ReportConfiguration, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	resourceScope, err := s.convertV2ResourceScopeToProto(config.GetResourceScope())
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &storage.ReportConfiguration{
+		Id:            config.GetId(),
+		Name:          config.GetName(),
+		Description:   config.GetDescription(),
+		Type:          storage.ReportConfiguration_NODE_VULNERABILITY,
+		Schedule:      v2.ConvertV2ScheduleToProto(config.GetSchedule()),
+		ResourceScope: resourceScope,
+		Creator:       creator,
+		Version:       2,
+	}
+
+	if config.GetNodeVulnReportFilters() != nil {
+		ret.Filter = &storage.ReportConfiguration_NodeVulnReportFilters{
+			NodeVulnReportFilters: s.convertV2NodeReportFiltersToProto(config.GetNodeVulnReportFilters(), accessScopeRules),
+		}
+	}
+
+	for _, notifier := range config.GetNotifiers() {
+		ret.Notifiers = append(ret.Notifiers, s.convertV2NotifierConfigToProto(notifier))
+	}
+
+	return ret, nil
+}
+
+func (s *serviceImpl) convertV2NodeReportFiltersToProto(filters *apiV2.NodeVulnerabilityReportFilters,
+	accessScopeRules []*storage.SimpleAccessScope_Rules) *storage.NodeVulnerabilityReportFilters {
+	if filters == nil {
+		return nil
+	}
+
+	ret := &storage.NodeVulnerabilityReportFilters{
+		AccessScopeRules: accessScopeRules,
+		Query:            filters.GetQuery(),
+	}
+
+	switch filters.GetCvesSince().(type) {
+	case *apiV2.NodeVulnerabilityReportFilters_AllVuln:
+		ret.CvesSince = &storage.NodeVulnerabilityReportFilters_AllVuln{
+			AllVuln: filters.GetAllVuln(),
+		}
+	}
+
+	return ret
+}
+
+func (s *serviceImpl) convertV2ResourceScopeToProto(scope *apiV2.ResourceScope) (*storage.ResourceScope, error) {
+	if scope == nil {
+		return nil, nil
+	}
+
+	ret := &storage.ResourceScope{}
+	switch ref := scope.GetScopeReference().(type) {
+	case *apiV2.ResourceScope_CollectionScope:
+		if ref.CollectionScope == nil {
+			return nil, errors.New("collection scope reference is nil")
+		}
+		ret.ScopeReference = &storage.ResourceScope_CollectionId{
+			CollectionId: ref.CollectionScope.GetCollectionId(),
+		}
+	case *apiV2.ResourceScope_EntityScope:
+		ret.ScopeReference = &storage.ResourceScope_EntityScope{
+			EntityScope: convertV2EntityScopeToStorage(ref.EntityScope),
+		}
+	case nil:
+		return nil, errors.New("resource scope reference is required")
+	default:
+		return nil, errors.Errorf("unsupported resource scope type: %T", ref)
+	}
+	return ret, nil
+}
+
+func convertV2EntityScopeToStorage(es *apiV2.EntityScope) *storage.EntityScope {
+	if es == nil {
+		return nil
+	}
+	rules := make([]*storage.EntityScopeRule, 0, len(es.GetRules()))
+	for _, rule := range es.GetRules() {
+		sr := &storage.EntityScopeRule{
+			Entity: v2EntityTypeToStorage(rule.GetEntity()),
+			Field:  v2EntityFieldToStorage(rule.GetField()),
+		}
+		for _, rv := range rule.GetValues() {
+			sr.Values = append(sr.Values, &storage.RuleValue{
+				Value:     rv.GetValue(),
+				MatchType: v2MatchTypeToStorage(rv.GetMatchType()),
+			})
+		}
+		rules = append(rules, sr)
+	}
+	return &storage.EntityScope{Rules: rules}
+}
+
+func v2EntityTypeToStorage(e apiV2.ScopeEntity) storage.EntityType {
+	switch e {
+	case apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER:
+		return storage.EntityType_ENTITY_TYPE_CLUSTER
+	default:
+		return storage.EntityType_ENTITY_TYPE_UNSET
+	}
+}
+
+func v2EntityFieldToStorage(f apiV2.ScopeField) storage.EntityField {
+	switch f {
+	case apiV2.ScopeField_FIELD_ID:
+		return storage.EntityField_FIELD_ID
+	case apiV2.ScopeField_FIELD_NAME:
+		return storage.EntityField_FIELD_NAME
+	case apiV2.ScopeField_FIELD_LABEL:
+		return storage.EntityField_FIELD_LABEL
+	default:
+		return storage.EntityField_FIELD_UNSET
+	}
+}
+
+func v2MatchTypeToStorage(m apiV2.MatchType) storage.MatchType {
+	switch m {
+	case apiV2.MatchType_REGEX:
+		return storage.MatchType_REGEX
+	default:
+		return storage.MatchType_EXACT
+	}
+}
+
+func (s *serviceImpl) convertV2NotifierConfigToProto(config *apiV2.NotifierConfiguration) *storage.NotifierConfiguration {
+	if config == nil {
+		return nil
+	}
+
+	ret := &storage.NotifierConfiguration{}
+
+	if emailConfig := config.GetEmailConfig(); emailConfig != nil {
+		ret.NotifierConfig = &storage.NotifierConfiguration_EmailConfig{
+			EmailConfig: &storage.EmailNotifierConfiguration{
+				NotifierId:    emailConfig.GetNotifierId(),
+				MailingLists:  emailConfig.GetMailingLists(),
+				CustomSubject: emailConfig.GetCustomSubject(),
+				CustomBody:    emailConfig.GetCustomBody(),
+			},
+		}
+	}
+
+	return ret
+}
+
+// Proto to V2 conversions
+
+func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.ReportConfiguration) (*apiV2.ReportConfiguration, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	resourceScope, err := s.convertProtoResourceScopeToV2(config.GetResourceScope())
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &apiV2.ReportConfiguration{
+		Id:            config.GetId(),
+		Name:          config.GetName(),
+		Description:   config.GetDescription(),
+		Type:          apiV2.ReportConfiguration_NODE_VULNERABILITY,
+		Schedule:      v2.ConvertProtoScheduleToV2(config.GetSchedule()),
+		ResourceScope: resourceScope,
+	}
+
+	if config.GetNodeVulnReportFilters() != nil {
+		ret.Filter = &apiV2.ReportConfiguration_NodeVulnReportFilters{
+			NodeVulnReportFilters: s.convertProtoNodeReportFiltersToV2(config.GetNodeVulnReportFilters()),
+		}
+	}
+
+	for _, notifier := range config.GetNotifiers() {
+		converted, err := s.convertProtoNotifierConfigToV2(notifier)
+		if err != nil {
+			return nil, err
+		}
+		ret.Notifiers = append(ret.Notifiers, converted)
+	}
+
+	return ret, nil
+}
+
+func (s *serviceImpl) convertProtoNodeReportFiltersToV2(filters *storage.NodeVulnerabilityReportFilters) *apiV2.NodeVulnerabilityReportFilters {
+	if filters == nil {
+		return nil
+	}
+
+	ret := &apiV2.NodeVulnerabilityReportFilters{
+		Query: filters.GetQuery(),
+	}
+
+	switch filters.GetCvesSince().(type) {
+	case *storage.NodeVulnerabilityReportFilters_AllVuln:
+		ret.CvesSince = &apiV2.NodeVulnerabilityReportFilters_AllVuln{
+			AllVuln: filters.GetAllVuln(),
+		}
+	}
+
+	return ret
+}
+
+func (s *serviceImpl) convertProtoResourceScopeToV2(scope *storage.ResourceScope) (*apiV2.ResourceScope, error) {
+	if scope == nil {
+		return nil, nil
+	}
+
+	ret := &apiV2.ResourceScope{}
+	if ref, ok := scope.GetScopeReference().(*storage.ResourceScope_EntityScope); ok {
+		ret.ScopeReference = &apiV2.ResourceScope_EntityScope{EntityScope: convertStorageEntityScopeToV2(ref.EntityScope)}
+	}
+	return ret, nil
+}
+
+func convertStorageEntityScopeToV2(es *storage.EntityScope) *apiV2.EntityScope {
+	if es == nil {
+		return nil
+	}
+	rules := make([]*apiV2.EntityScopeRule, 0, len(es.GetRules()))
+	for _, rule := range es.GetRules() {
+		sr := &apiV2.EntityScopeRule{
+			Entity: storageEntityTypeToV2(rule.GetEntity()),
+			Field:  storageEntityFieldToV2(rule.GetField()),
+		}
+		for _, rv := range rule.GetValues() {
+			sr.Values = append(sr.Values, &apiV2.RuleValue{
+				Value:     rv.GetValue(),
+				MatchType: storageMatchTypeToV2(rv.GetMatchType()),
+			})
+		}
+		rules = append(rules, sr)
+	}
+	return &apiV2.EntityScope{Rules: rules}
+}
+
+func storageEntityTypeToV2(e storage.EntityType) apiV2.ScopeEntity {
+	switch e {
+	case storage.EntityType_ENTITY_TYPE_CLUSTER:
+		return apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER
+	default:
+		return apiV2.ScopeEntity_SCOPE_ENTITY_UNSET
+	}
+}
+
+func storageEntityFieldToV2(f storage.EntityField) apiV2.ScopeField {
+	switch f {
+	case storage.EntityField_FIELD_ID:
+		return apiV2.ScopeField_FIELD_ID
+	case storage.EntityField_FIELD_NAME:
+		return apiV2.ScopeField_FIELD_NAME
+	case storage.EntityField_FIELD_LABEL:
+		return apiV2.ScopeField_FIELD_LABEL
+	default:
+		return apiV2.ScopeField_FIELD_UNSET
+	}
+}
+
+func storageMatchTypeToV2(m storage.MatchType) apiV2.MatchType {
+	switch m {
+	case storage.MatchType_REGEX:
+		return apiV2.MatchType_REGEX
+	default:
+		return apiV2.MatchType_EXACT
+	}
+}
+
+func (s *serviceImpl) convertProtoNotifierConfigToV2(config *storage.NotifierConfiguration) (*apiV2.NotifierConfiguration, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	ret := &apiV2.NotifierConfiguration{}
+
+	if emailConfig := config.GetEmailConfig(); emailConfig != nil {
+		ret.NotifierConfig = &apiV2.NotifierConfiguration_EmailConfig{
+			EmailConfig: &apiV2.EmailNotifierConfiguration{
+				NotifierId:    emailConfig.GetNotifierId(),
+				MailingLists:  emailConfig.GetMailingLists(),
+				CustomSubject: emailConfig.GetCustomSubject(),
+				CustomBody:    emailConfig.GetCustomBody(),
+			},
+		}
+	}
+
+	return ret, nil
+}
+
+func isDownloadAvailable(blobNames set.FrozenStringSet, configID, reportID string) bool {
+	return blobNames.Contains(common.GetReportBlobPath(configID, reportID))
+}
+
+func (s *serviceImpl) convertProtoReportSnapshotToV2(snapshot *storage.ReportSnapshot, blobNames set.FrozenStringSet) (*apiV2.ReportSnapshot, error) {
+	if snapshot == nil {
+		return nil, nil
+	}
+
+	resourceScope, err := s.convertProtoResourceScopeToV2(snapshot.GetResourceScope())
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &apiV2.ReportSnapshot{
+		ReportStatus:   convertPrototoV2Reportstatus(snapshot.GetReportStatus()),
+		ReportConfigId: snapshot.GetReportConfigurationId(),
+		ReportJobId:    snapshot.GetReportId(),
+		Name:           snapshot.GetName(),
+		Description:    snapshot.GetDescription(),
+		Type:           apiV2.ReportSnapshot_NODE_VULNERABILITY,
+		User: &apiV2.SlimUser{
+			Id:   snapshot.GetRequester().GetId(),
+			Name: snapshot.GetRequester().GetName(),
+		},
+		Schedule:            v2.ConvertProtoScheduleToV2(snapshot.GetSchedule()),
+		ResourceScope:       resourceScope,
+		IsDownloadAvailable: isDownloadAvailable(blobNames, snapshot.GetReportConfigurationId(), snapshot.GetReportId()),
+	}
+
+	if snapshot.GetNodeVulnReportFilters() != nil {
+		ret.Filter = &apiV2.ReportSnapshot_NodeVulnReportFilters{
+			NodeVulnReportFilters: s.convertProtoNodeReportFiltersToV2(snapshot.GetNodeVulnReportFilters()),
+		}
+	}
+
+	for _, notifier := range snapshot.GetNotifiers() {
+		converted := s.convertProtoNotifierSnapshotToV2(notifier)
+		if converted != nil {
+			ret.Notifiers = append(ret.Notifiers, converted)
+		}
+	}
+
+	return ret, nil
+}
+
+func (s *serviceImpl) convertProtoNotifierSnapshotToV2(notifier *storage.NotifierSnapshot) *apiV2.NotifierConfiguration {
+	if notifier == nil {
+		return nil
+	}
+
+	ret := &apiV2.NotifierConfiguration{
+		NotifierName: notifier.GetNotifierName(),
+	}
+
+	if emailConfig := notifier.GetEmailConfig(); emailConfig != nil {
+		ret.NotifierConfig = &apiV2.NotifierConfiguration_EmailConfig{
+			EmailConfig: &apiV2.EmailNotifierConfiguration{
+				NotifierId:    emailConfig.GetNotifierId(),
+				MailingLists:  emailConfig.GetMailingLists(),
+				CustomSubject: emailConfig.GetCustomSubject(),
+				CustomBody:    emailConfig.GetCustomBody(),
+			},
+		}
+	}
+
+	return ret
+}
+
+func convertPrototoV2Reportstatus(status *storage.ReportStatus) *apiV2.ReportStatus {
+	if status == nil {
+		return nil
+	}
+
+	ret := &apiV2.ReportStatus{
+		ReportNotificationMethod: apiV2.NotificationMethod(status.GetReportNotificationMethod()),
+		RunState:                 storageRunStateToV2[status.GetRunState()],
+		ErrorMsg:                 status.GetErrorMsg(),
+		CompletedAt:              status.GetCompletedAt(),
+	}
+
+	return ret
+}
+
+func (s *serviceImpl) getExistingBlobNames(ctx context.Context, snapshots []*storage.ReportSnapshot) (set.FrozenStringSet, error) {
+	if len(snapshots) == 0 {
+		return set.NewFrozenStringSet(), nil
+	}
+
+	blobNames := make([]string, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		status := snapshot.GetReportStatus()
+		if status.GetReportNotificationMethod() == storage.ReportStatus_DOWNLOAD {
+			if status.GetRunState() == storage.ReportStatus_GENERATED ||
+				status.GetRunState() == storage.ReportStatus_DELIVERED {
+				blobNames = append(blobNames, common.GetReportBlobPath(snapshot.GetReportConfigurationId(), snapshot.GetReportId()))
+			}
+		}
+	}
+
+	if len(blobNames) == 0 {
+		return set.NewFrozenStringSet(), nil
+	}
+
+	query := search.NewQueryBuilder().AddExactMatches(search.BlobName, blobNames...).ProtoQuery()
+	results, err := s.blobStore.Search(ctx, query)
+	if err != nil {
+		return set.NewFrozenStringSet(), errors.Wrap(err, "failed to search for report blobs")
+	}
+
+	return search.ResultsToIDSet(results).Freeze(), nil
+}

--- a/central/reports/service/v2/node/convert.go
+++ b/central/reports/service/v2/node/convert.go
@@ -8,6 +8,7 @@ import (
 	v2 "github.com/stackrox/rox/central/reports/service/v2"
 	apiV2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 )
@@ -34,6 +35,9 @@ var (
 		storage.ReportStatus_DELIVERED: apiV2.ReportStatus_DELIVERED,
 		storage.ReportStatus_FAILURE:   apiV2.ReportStatus_FAILURE,
 	}
+
+	// Use this context only to populate notifier, collection names and IsDownloadAvailable fields in converted responses
+	allAccessCtx = sac.WithAllAccess(context.Background())
 )
 
 // convertV2ReportConfigurationToProto converts v2.ReportConfiguration to storage.ReportConfiguration for node reports
@@ -100,13 +104,6 @@ func (s *serviceImpl) convertV2ResourceScopeToProto(scope *apiV2.ResourceScope) 
 
 	ret := &storage.ResourceScope{}
 	switch ref := scope.GetScopeReference().(type) {
-	case *apiV2.ResourceScope_CollectionScope:
-		if ref.CollectionScope == nil {
-			return nil, errors.New("collection scope reference is nil")
-		}
-		ret.ScopeReference = &storage.ResourceScope_CollectionId{
-			CollectionId: ref.CollectionScope.GetCollectionId(),
-		}
 	case *apiV2.ResourceScope_EntityScope:
 		ret.ScopeReference = &storage.ResourceScope_EntityScope{
 			EntityScope: convertV2EntityScopeToStorage(ref.EntityScope),
@@ -171,24 +168,26 @@ func v2MatchTypeToStorage(m apiV2.MatchType) storage.MatchType {
 	}
 }
 
-func (s *serviceImpl) convertV2NotifierConfigToProto(config *apiV2.NotifierConfiguration) *storage.NotifierConfiguration {
-	if config == nil {
+func (s *serviceImpl) convertV2NotifierConfigToProto(notifier *apiV2.NotifierConfiguration) *storage.NotifierConfiguration {
+	if notifier == nil {
 		return nil
 	}
 
-	ret := &storage.NotifierConfiguration{}
+	ret := &storage.NotifierConfiguration{
+		Ref: &storage.NotifierConfiguration_Id{
+			Id: notifier.GetEmailConfig().GetNotifierId(),
+		},
+	}
 
-	if emailConfig := config.GetEmailConfig(); emailConfig != nil {
+	if emailConfig := notifier.GetEmailConfig(); emailConfig != nil {
 		ret.NotifierConfig = &storage.NotifierConfiguration_EmailConfig{
 			EmailConfig: &storage.EmailNotifierConfiguration{
-				NotifierId:    emailConfig.GetNotifierId(),
 				MailingLists:  emailConfig.GetMailingLists(),
 				CustomSubject: emailConfig.GetCustomSubject(),
 				CustomBody:    emailConfig.GetCustomBody(),
 			},
 		}
 	}
-
 	return ret
 }
 
@@ -313,25 +312,34 @@ func storageMatchTypeToV2(m storage.MatchType) apiV2.MatchType {
 	}
 }
 
-func (s *serviceImpl) convertProtoNotifierConfigToV2(config *storage.NotifierConfiguration) (*apiV2.NotifierConfiguration, error) {
-	if config == nil {
+func (s *serviceImpl) convertProtoNotifierConfigToV2(notifierConfig *storage.NotifierConfiguration) (*apiV2.NotifierConfiguration, error) {
+	if notifierConfig == nil {
 		return nil, nil
 	}
 
-	ret := &apiV2.NotifierConfiguration{}
-
-	if emailConfig := config.GetEmailConfig(); emailConfig != nil {
-		ret.NotifierConfig = &apiV2.NotifierConfiguration_EmailConfig{
-			EmailConfig: &apiV2.EmailNotifierConfiguration{
-				NotifierId:    emailConfig.GetNotifierId(),
-				MailingLists:  emailConfig.GetMailingLists(),
-				CustomSubject: emailConfig.GetCustomSubject(),
-				CustomBody:    emailConfig.GetCustomBody(),
-			},
-		}
+	if notifierConfig.GetEmailConfig() == nil {
+		return nil, nil
 	}
 
-	return ret, nil
+	notifier, found, err := s.notifierDatastore.GetNotifier(allAccessCtx, notifierConfig.GetId())
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.Errorf("Notifier with ID %s no longer exists", notifierConfig.GetId())
+	}
+
+	return &apiV2.NotifierConfiguration{
+		NotifierName: notifier.GetName(),
+		NotifierConfig: &apiV2.NotifierConfiguration_EmailConfig{
+			EmailConfig: &apiV2.EmailNotifierConfiguration{
+				NotifierId:    notifierConfig.GetId(),
+				MailingLists:  notifierConfig.GetEmailConfig().GetMailingLists(),
+				CustomSubject: notifierConfig.GetEmailConfig().GetCustomSubject(),
+				CustomBody:    notifierConfig.GetEmailConfig().GetCustomBody(),
+			},
+		},
+	}, nil
 }
 
 func isDownloadAvailable(blobNames set.FrozenStringSet, configID, reportID string) bool {
@@ -380,27 +388,27 @@ func (s *serviceImpl) convertProtoReportSnapshotToV2(snapshot *storage.ReportSna
 	return ret, nil
 }
 
-func (s *serviceImpl) convertProtoNotifierSnapshotToV2(notifier *storage.NotifierSnapshot) *apiV2.NotifierConfiguration {
-	if notifier == nil {
+func (s *serviceImpl) convertProtoNotifierSnapshotToV2(notifierSnapshot *storage.NotifierSnapshot) *apiV2.NotifierConfiguration {
+	if notifierSnapshot == nil {
 		return nil
 	}
-
-	ret := &apiV2.NotifierConfiguration{
-		NotifierName: notifier.GetNotifierName(),
-	}
-
-	if emailConfig := notifier.GetEmailConfig(); emailConfig != nil {
-		ret.NotifierConfig = &apiV2.NotifierConfiguration_EmailConfig{
-			EmailConfig: &apiV2.EmailNotifierConfiguration{
-				NotifierId:    emailConfig.GetNotifierId(),
-				MailingLists:  emailConfig.GetMailingLists(),
-				CustomSubject: emailConfig.GetCustomSubject(),
-				CustomBody:    emailConfig.GetCustomBody(),
-			},
+	if notifierSnapshot.GetEmailConfig() == nil {
+		return &apiV2.NotifierConfiguration{
+			NotifierName: notifierSnapshot.GetNotifierName(),
 		}
 	}
 
-	return ret
+	return &apiV2.NotifierConfiguration{
+		NotifierName: notifierSnapshot.GetNotifierName(),
+		NotifierConfig: &apiV2.NotifierConfiguration_EmailConfig{
+			EmailConfig: &apiV2.EmailNotifierConfiguration{
+				NotifierId:    notifierSnapshot.GetEmailConfig().GetNotifierId(),
+				MailingLists:  notifierSnapshot.GetEmailConfig().GetMailingLists(),
+				CustomSubject: notifierSnapshot.GetEmailConfig().GetCustomSubject(),
+				CustomBody:    notifierSnapshot.GetEmailConfig().GetCustomBody(),
+			},
+		},
+	}
 }
 
 func convertPrototoV2Reportstatus(status *storage.ReportStatus) *apiV2.ReportStatus {
@@ -429,7 +437,11 @@ func (s *serviceImpl) getExistingBlobNames(ctx context.Context, snapshots []*sto
 		if status.GetReportNotificationMethod() == storage.ReportStatus_DOWNLOAD {
 			if status.GetRunState() == storage.ReportStatus_GENERATED ||
 				status.GetRunState() == storage.ReportStatus_DELIVERED {
-				blobNames = append(blobNames, common.GetReportBlobPath(snapshot.GetReportConfigurationId(), snapshot.GetReportId()))
+				parentDir := snapshot.GetReportConfigurationId()
+				if snapshot.GetViewBasedVulnReportFilters() != nil {
+					parentDir = "view-based-report"
+				}
+				blobNames = append(blobNames, common.GetReportBlobPath(parentDir, snapshot.GetReportId()))
 			}
 		}
 	}

--- a/central/reports/service/v2/node/convert_test.go
+++ b/central/reports/service/v2/node/convert_test.go
@@ -138,8 +138,15 @@ func (s *ConversionTestSuite) TestNotifierConversions() {
 
 	protoNotifier := s.service.convertV2NotifierConfigToProto(v2Notifier)
 	assert.NotNil(s.T(), protoNotifier)
-	assert.Equal(s.T(), "notifier-123", protoNotifier.GetEmailConfig().GetNotifierId())
+	assert.Equal(s.T(), "notifier-123", protoNotifier.GetId())
 	assert.Equal(s.T(), "Custom Subject", protoNotifier.GetEmailConfig().GetCustomSubject())
+
+	// Mock GetNotifier for the conversion back
+	notifierDataStore := s.service.notifierDatastore.(*notifierDSMocks.MockDataStore)
+	notifierDataStore.EXPECT().GetNotifier(gomock.Any(), "notifier-123").Return(&storage.Notifier{
+		Id:   "notifier-123",
+		Name: "Test Notifier",
+	}, true, nil).Times(1)
 
 	v2NotifierBack, err := s.service.convertProtoNotifierConfigToV2(protoNotifier)
 	assert.NoError(s.T(), err)
@@ -324,6 +331,13 @@ func (s *ConversionTestSuite) TestReportConfigurationRoundTrip() {
 	assert.Equal(s.T(), v2Config.GetName(), protoConfig.GetName())
 	assert.Equal(s.T(), storage.ReportConfiguration_NODE_VULNERABILITY, protoConfig.GetType())
 	protoassert.Equal(s.T(), creator, protoConfig.GetCreator())
+
+	// Mock GetNotifier for the conversion back
+	notifierDataStore := s.service.notifierDatastore.(*notifierDSMocks.MockDataStore)
+	notifierDataStore.EXPECT().GetNotifier(gomock.Any(), "email-1").Return(&storage.Notifier{
+		Id:   "email-1",
+		Name: "Email Notifier",
+	}, true, nil).Times(1)
 
 	v2ConfigBack, err := s.service.convertProtoReportConfigurationToV2(protoConfig)
 	assert.NoError(s.T(), err)
@@ -540,6 +554,9 @@ func (s *ConversionTestSuite) TestProtoReportConfigurationToV2() {
 		},
 		Notifiers: []*storage.NotifierConfiguration{
 			{
+				Ref: &storage.NotifierConfiguration_Id{
+					Id: "notifier-1",
+				},
 				NotifierConfig: &storage.NotifierConfiguration_EmailConfig{
 					EmailConfig: &storage.EmailNotifierConfiguration{
 						NotifierId:   "notifier-1",
@@ -549,6 +566,13 @@ func (s *ConversionTestSuite) TestProtoReportConfigurationToV2() {
 			},
 		},
 	}
+
+	// Mock GetNotifier for the conversion
+	notifierDataStore := s.service.notifierDatastore.(*notifierDSMocks.MockDataStore)
+	notifierDataStore.EXPECT().GetNotifier(gomock.Any(), "notifier-1").Return(&storage.Notifier{
+		Id:   "notifier-1",
+		Name: "Notifier 1",
+	}, true, nil).Times(1)
 
 	v2Config, err := s.service.convertProtoReportConfigurationToV2(protoConfig)
 	assert.NoError(s.T(), err)

--- a/central/reports/service/v2/node/convert_test.go
+++ b/central/reports/service/v2/node/convert_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"context"
 	"testing"
 
 	blobDSMocks "github.com/stackrox/rox/central/blob/datastore/mocks"
@@ -31,12 +30,10 @@ type ConversionTestSuite struct {
 	suite.Suite
 	mockCtrl *gomock.Controller
 	service  *serviceImpl
-	ctx      context.Context
 }
 
 func (s *ConversionTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
-	s.ctx = context.Background()
 	reportConfigDataStore := reportConfigDSMocks.NewMockDataStore(s.mockCtrl)
 	reportSnapshotDataStore := reportSnapshotDSMocks.NewMockDataStore(s.mockCtrl)
 	collectionDataStore := collectionDSMocks.NewMockDataStore(s.mockCtrl)
@@ -136,7 +133,7 @@ func (s *ConversionTestSuite) TestNotifierConversions() {
 		},
 	}
 
-	protoNotifier := s.service.convertV2NotifierConfigToProto(v2Notifier)
+	protoNotifier := v2.ConvertV2NotifierConfigToProto(v2Notifier)
 	assert.NotNil(s.T(), protoNotifier)
 	assert.Equal(s.T(), "notifier-123", protoNotifier.GetId())
 	assert.Equal(s.T(), "Custom Subject", protoNotifier.GetEmailConfig().GetCustomSubject())
@@ -148,7 +145,7 @@ func (s *ConversionTestSuite) TestNotifierConversions() {
 		Name: "Test Notifier",
 	}, true, nil).Times(1)
 
-	v2NotifierBack, err := s.service.convertProtoNotifierConfigToV2(protoNotifier)
+	v2NotifierBack, err := v2.ConvertProtoNotifierConfigToV2(s.service.notifierDatastore, protoNotifier)
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), v2NotifierBack)
 	assert.Equal(s.T(), "Test Notifier", v2NotifierBack.GetNotifierName())
@@ -158,6 +155,7 @@ func (s *ConversionTestSuite) TestNotifierConversions() {
 
 func (s *ConversionTestSuite) TestNotifierSnapshotConversion() {
 	protoSnapshot := &storage.NotifierSnapshot{
+		NotifierName: "Email Notifier",
 		NotifierConfig: &storage.NotifierSnapshot_EmailConfig{
 			EmailConfig: &storage.EmailNotifierConfiguration{
 				NotifierId:    "notifier-456",
@@ -168,8 +166,9 @@ func (s *ConversionTestSuite) TestNotifierSnapshotConversion() {
 		},
 	}
 
-	v2Config := s.service.convertProtoNotifierSnapshotToV2(protoSnapshot)
+	v2Config := v2.ConvertProtoNotifierSnapshotToV2(protoSnapshot)
 	assert.NotNil(s.T(), v2Config)
+	assert.Equal(s.T(), "Email Notifier", v2Config.GetNotifierName())
 	assert.Equal(s.T(), "notifier-456", v2Config.GetEmailConfig().GetNotifierId())
 	assert.Equal(s.T(), "Snapshot Subject", v2Config.GetEmailConfig().GetCustomSubject())
 	assert.Equal(s.T(), []string{"alerts@example.com"}, v2Config.GetEmailConfig().GetMailingLists())
@@ -220,18 +219,41 @@ func (s *ConversionTestSuite) TestEntityScopeConversions() {
 }
 
 func (s *ConversionTestSuite) TestReportStatusConversion() {
-	protoStatus := &storage.ReportStatus{
-		RunState:                 storage.ReportStatus_GENERATED,
-		ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
-		ErrorMsg:                 "test error",
-		CompletedAt:              nil,
+	testCases := map[string]struct {
+		requestType storage.ReportStatus_RunMethod
+		want        apiV2.ReportStatus_ReportMethod
+	}{
+		"on-demand": {
+			requestType: storage.ReportStatus_ON_DEMAND,
+			want:        apiV2.ReportStatus_ON_DEMAND,
+		},
+		"scheduled": {
+			requestType: storage.ReportStatus_SCHEDULED,
+			want:        apiV2.ReportStatus_SCHEDULED,
+		},
+		"view-based": {
+			requestType: storage.ReportStatus_VIEW_BASED,
+			want:        apiV2.ReportStatus_ReportMethod(storage.ReportStatus_VIEW_BASED),
+		},
 	}
 
-	v2Status := convertPrototoV2Reportstatus(protoStatus)
-	assert.NotNil(s.T(), v2Status)
-	assert.Equal(s.T(), apiV2.ReportStatus_GENERATED, v2Status.GetRunState())
-	assert.Equal(s.T(), apiV2.NotificationMethod_DOWNLOAD, v2Status.GetReportNotificationMethod())
-	assert.Equal(s.T(), "test error", v2Status.GetErrorMsg())
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			protoStatus := &storage.ReportStatus{
+				RunState:                 storage.ReportStatus_GENERATED,
+				ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+				ReportRequestType:        tc.requestType,
+				ErrorMsg:                 "test error",
+			}
+
+			v2Status := convertPrototoV2Reportstatus(protoStatus)
+			assert.NotNil(s.T(), v2Status)
+			assert.Equal(s.T(), apiV2.ReportStatus_GENERATED, v2Status.GetRunState())
+			assert.Equal(s.T(), apiV2.NotificationMethod_DOWNLOAD, v2Status.GetReportNotificationMethod())
+			assert.Equal(s.T(), "test error", v2Status.GetErrorMsg())
+			assert.Equal(s.T(), tc.want, v2Status.GetReportRequestType())
+		})
+	}
 }
 
 func (s *ConversionTestSuite) TestNodeFiltersConversion() {
@@ -248,13 +270,13 @@ func (s *ConversionTestSuite) TestNodeFiltersConversion() {
 		},
 	}
 
-	protoFilters := s.service.convertV2NodeReportFiltersToProto(v2Filters, accessScopeRules)
+	protoFilters := convertV2NodeReportFiltersToProto(v2Filters, accessScopeRules)
 	assert.NotNil(s.T(), protoFilters)
 	assert.Equal(s.T(), "Cluster:prod", protoFilters.GetQuery())
 	assert.True(s.T(), protoFilters.GetAllVuln())
 	protoassert.SlicesEqual(s.T(), accessScopeRules, protoFilters.GetAccessScopeRules())
 
-	v2FiltersBack := s.service.convertProtoNodeReportFiltersToV2(protoFilters)
+	v2FiltersBack := convertProtoNodeReportFiltersToV2(protoFilters)
 	assert.NotNil(s.T(), v2FiltersBack)
 	assert.Equal(s.T(), v2Filters.GetQuery(), v2FiltersBack.GetQuery())
 	assert.True(s.T(), v2FiltersBack.GetAllVuln())
@@ -353,16 +375,16 @@ func (s *ConversionTestSuite) TestReportConfigurationRoundTrip() {
 func (s *ConversionTestSuite) TestNilConversions() {
 	assert.Nil(s.T(), v2.ConvertV2ScheduleToProto(nil))
 	assert.Nil(s.T(), v2.ConvertProtoScheduleToV2(nil))
-	assert.Nil(s.T(), s.service.convertV2NotifierConfigToProto(nil))
+	assert.Nil(s.T(), v2.ConvertV2NotifierConfigToProto(nil))
 
-	result, err := s.service.convertProtoNotifierConfigToV2(nil)
+	result, err := v2.ConvertProtoNotifierConfigToV2(s.service.notifierDatastore, nil)
 	assert.NoError(s.T(), err)
 	assert.Nil(s.T(), result)
 
-	assert.Nil(s.T(), s.service.convertProtoNotifierSnapshotToV2(nil))
+	assert.Nil(s.T(), v2.ConvertProtoNotifierSnapshotToV2(nil))
 	assert.Nil(s.T(), convertPrototoV2Reportstatus(nil))
-	assert.Nil(s.T(), s.service.convertV2NodeReportFiltersToProto(nil, nil))
-	assert.Nil(s.T(), s.service.convertProtoNodeReportFiltersToV2(nil))
+	assert.Nil(s.T(), convertV2NodeReportFiltersToProto(nil, nil))
+	assert.Nil(s.T(), convertProtoNodeReportFiltersToV2(nil))
 }
 
 func (s *ConversionTestSuite) TestEntityTypeEdgeCases() {
@@ -376,7 +398,7 @@ func (s *ConversionTestSuite) TestEntityTypeEdgeCases() {
 	assert.Equal(s.T(), apiV2.MatchType_EXACT, storageMatchTypeToV2(storage.MatchType_EXACT))
 }
 
-func (s *ConversionTestSuite) TestReportSnapshotWithDownloadAvailable() {
+func (s *ConversionTestSuite) TestConvertProtoReportSnapshotToV2() {
 	configID := "test-config"
 	reportID := "test-report"
 
@@ -384,6 +406,8 @@ func (s *ConversionTestSuite) TestReportSnapshotWithDownloadAvailable() {
 		ReportConfigurationId: configID,
 		ReportId:              reportID,
 		Name:                  "Test Report",
+		Description:           "Test description",
+		AreaOfConcern:         "User Workloads",
 		Type:                  storage.ReportSnapshot_NODE_VULNERABILITY,
 		Requester: &storage.SlimUser{
 			Id:   "user-1",
@@ -414,18 +438,78 @@ func (s *ConversionTestSuite) TestReportSnapshotWithDownloadAvailable() {
 	assert.Equal(s.T(), reportID, result.GetReportJobId())
 	assert.Equal(s.T(), configID, result.GetReportConfigId())
 	assert.Equal(s.T(), "Test Report", result.GetName())
+	assert.Equal(s.T(), "Test description", result.GetDescription())
+	assert.Equal(s.T(), "User Workloads", result.GetAreaOfConcern())
+	assert.False(s.T(), result.GetIsDownloadAvailable())
 }
 
-func (s *ConversionTestSuite) TestIntervalTypeConversions() {
-	assert.Equal(s.T(), storage.Schedule_UNSET, v2IntervalTypeToStorage[apiV2.ReportSchedule_UNSET])
-	assert.Equal(s.T(), storage.Schedule_DAILY, v2IntervalTypeToStorage[apiV2.ReportSchedule_DAILY])
-	assert.Equal(s.T(), storage.Schedule_WEEKLY, v2IntervalTypeToStorage[apiV2.ReportSchedule_WEEKLY])
-	assert.Equal(s.T(), storage.Schedule_MONTHLY, v2IntervalTypeToStorage[apiV2.ReportSchedule_MONTHLY])
+func (s *ConversionTestSuite) TestReportSnapshotDownloadAvailable() {
+	configID := "test-config"
+	reportID := "test-report"
 
-	assert.Equal(s.T(), apiV2.ReportSchedule_UNSET, storageIntervalTypeToV2[storage.Schedule_UNSET])
-	assert.Equal(s.T(), apiV2.ReportSchedule_DAILY, storageIntervalTypeToV2[storage.Schedule_DAILY])
-	assert.Equal(s.T(), apiV2.ReportSchedule_WEEKLY, storageIntervalTypeToV2[storage.Schedule_WEEKLY])
-	assert.Equal(s.T(), apiV2.ReportSchedule_MONTHLY, storageIntervalTypeToV2[storage.Schedule_MONTHLY])
+	testCases := map[string]struct {
+		snapshot  *storage.ReportSnapshot
+		blobNames set.FrozenStringSet
+		available bool
+	}{
+		"config-based with matching blob": {
+			snapshot: &storage.ReportSnapshot{
+				ReportConfigurationId: configID,
+				ReportId:              reportID,
+				ReportStatus: &storage.ReportStatus{
+					RunState:                 storage.ReportStatus_GENERATED,
+					ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+				},
+			},
+			blobNames: set.NewFrozenStringSet(common.GetReportBlobPath(configID, reportID)),
+			available: true,
+		},
+		"view-based with matching blob": {
+			snapshot: &storage.ReportSnapshot{
+				ReportId: reportID,
+				ReportStatus: &storage.ReportStatus{
+					RunState:                 storage.ReportStatus_GENERATED,
+					ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+					ReportRequestType:        storage.ReportStatus_VIEW_BASED,
+				},
+			},
+			blobNames: set.NewFrozenStringSet(common.GetReportBlobPath("view-based-report", reportID)),
+			available: true,
+		},
+		"view-based without blob": {
+			snapshot: &storage.ReportSnapshot{
+				ReportId: reportID,
+				ReportStatus: &storage.ReportStatus{
+					RunState:                 storage.ReportStatus_GENERATED,
+					ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+					ReportRequestType:        storage.ReportStatus_VIEW_BASED,
+				},
+			},
+			blobNames: set.NewFrozenStringSet(),
+			available: false,
+		},
+		"view-based does not match config-id blob path": {
+			snapshot: &storage.ReportSnapshot{
+				ReportConfigurationId: configID,
+				ReportId:              reportID,
+				ReportStatus: &storage.ReportStatus{
+					RunState:                 storage.ReportStatus_GENERATED,
+					ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+					ReportRequestType:        storage.ReportStatus_VIEW_BASED,
+				},
+			},
+			blobNames: set.NewFrozenStringSet(common.GetReportBlobPath(configID, reportID)),
+			available: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			result, err := s.service.convertProtoReportSnapshotToV2(tc.snapshot, tc.blobNames)
+			assert.NoError(s.T(), err)
+			assert.Equal(s.T(), tc.available, result.GetIsDownloadAvailable())
+		})
+	}
 }
 
 func (s *ConversionTestSuite) TestRunStateConversions() {
@@ -460,8 +544,7 @@ func (s *ConversionTestSuite) TestResourceScopeConversions() {
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), protoScope)
 
-	v2ScopeBack, err := s.service.convertProtoResourceScopeToV2(protoScope)
-	assert.NoError(s.T(), err)
+	v2ScopeBack := convertProtoResourceScopeToV2(protoScope)
 	assert.NotNil(s.T(), v2ScopeBack)
 	assert.NotNil(s.T(), v2ScopeBack.GetEntityScope())
 	assert.Len(s.T(), v2ScopeBack.GetEntityScope().GetRules(), 1)
@@ -472,8 +555,7 @@ func (s *ConversionTestSuite) TestEmptyResourceScope() {
 	assert.NoError(s.T(), err)
 	assert.Nil(s.T(), result)
 
-	v2Result, err := s.service.convertProtoResourceScopeToV2(nil)
-	assert.NoError(s.T(), err)
+	v2Result := convertProtoResourceScopeToV2(nil)
 	assert.Nil(s.T(), v2Result)
 }
 
@@ -587,6 +669,24 @@ func (s *ConversionTestSuite) TestProtoReportConfigurationToV2() {
 	assert.Equal(s.T(), "Notifier 1", v2Config.GetNotifiers()[0].GetNotifierName())
 }
 
+func (s *ConversionTestSuite) TestProtoReportConfigurationToV2_SkipsNotifierWithoutEmail() {
+	protoConfig := &storage.ReportConfiguration{
+		Id:   "config-proto",
+		Name: "Proto Config",
+		Type: storage.ReportConfiguration_NODE_VULNERABILITY,
+		Notifiers: []*storage.NotifierConfiguration{
+			{
+				Ref: &storage.NotifierConfiguration_Id{Id: "notifier-1"},
+			},
+		},
+	}
+
+	v2Config, err := s.service.convertProtoReportConfigurationToV2(protoConfig)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), v2Config)
+	assert.Empty(s.T(), v2Config.GetNotifiers())
+}
+
 func (s *ConversionTestSuite) TestGetExistingBlobNames_NotDownloadMethod() {
 	snapshot := &storage.ReportSnapshot{
 		ReportConfigurationId: "config-1",
@@ -597,7 +697,7 @@ func (s *ConversionTestSuite) TestGetExistingBlobNames_NotDownloadMethod() {
 		},
 	}
 
-	result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+	result, err := s.service.getExistingBlobNames([]*storage.ReportSnapshot{snapshot})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 0, result.Cardinality())
 }
@@ -623,7 +723,7 @@ func (s *ConversionTestSuite) TestGetExistingBlobNames_WrongRunState() {
 				},
 			}
 
-			result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+			result, err := s.service.getExistingBlobNames([]*storage.ReportSnapshot{snapshot})
 			assert.NoError(s.T(), err)
 			assert.Equal(s.T(), 0, result.Cardinality())
 		})
@@ -643,7 +743,7 @@ func (s *ConversionTestSuite) TestGetExistingBlobNames_BlobSearchError() {
 	blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
 	blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, assert.AnError).Times(1)
 
-	result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+	result, err := s.service.getExistingBlobNames([]*storage.ReportSnapshot{snapshot})
 	assert.Error(s.T(), err)
 	assert.Equal(s.T(), 0, result.Cardinality())
 }
@@ -661,7 +761,7 @@ func (s *ConversionTestSuite) TestGetExistingBlobNames_NoBlobFound() {
 	blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
 	blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{}, nil).Times(1)
 
-	result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+	result, err := s.service.getExistingBlobNames([]*storage.ReportSnapshot{snapshot})
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), 0, result.Cardinality())
 }
@@ -687,13 +787,74 @@ func (s *ConversionTestSuite) TestGetExistingBlobNames_BlobFound() {
 			}
 
 			blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
-			blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
+			blobStore.EXPECT().Search(allAccessCtx, gomock.Any()).Return([]search.Result{
 				{ID: common.GetReportBlobPath("config-1", "report-1")},
 			}, nil).Times(1)
 
-			result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+			result, err := s.service.getExistingBlobNames([]*storage.ReportSnapshot{snapshot})
 			assert.NoError(s.T(), err)
 			assert.True(s.T(), result.Contains(common.GetReportBlobPath("config-1", "report-1")))
+		})
+	}
+}
+
+func (s *ConversionTestSuite) TestGetExistingBlobNames_ViewBased() {
+	snapshot := &storage.ReportSnapshot{
+		ReportId: "report-1",
+		ReportStatus: &storage.ReportStatus{
+			RunState:                 storage.ReportStatus_GENERATED,
+			ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+			ReportRequestType:        storage.ReportStatus_VIEW_BASED,
+		},
+	}
+
+	blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
+	blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
+		{ID: common.GetReportBlobPath("view-based-report", "report-1")},
+	}, nil).Times(1)
+
+	result, err := s.service.getExistingBlobNames([]*storage.ReportSnapshot{snapshot})
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), result.Contains(common.GetReportBlobPath("view-based-report", "report-1")))
+}
+
+func (s *ConversionTestSuite) TestReportBlobParentDir() {
+	testCases := map[string]struct {
+		snapshot *storage.ReportSnapshot
+		want     string
+	}{
+		"config-based on-demand": {
+			snapshot: &storage.ReportSnapshot{
+				ReportConfigurationId: "config-1",
+				ReportStatus: &storage.ReportStatus{
+					ReportRequestType: storage.ReportStatus_ON_DEMAND,
+				},
+			},
+			want: "config-1",
+		},
+		"config-based scheduled": {
+			snapshot: &storage.ReportSnapshot{
+				ReportConfigurationId: "config-1",
+				ReportStatus: &storage.ReportStatus{
+					ReportRequestType: storage.ReportStatus_SCHEDULED,
+				},
+			},
+			want: "config-1",
+		},
+		"view-based uses shared blob directory": {
+			snapshot: &storage.ReportSnapshot{
+				ReportConfigurationId: "config-1",
+				ReportStatus: &storage.ReportStatus{
+					ReportRequestType: storage.ReportStatus_VIEW_BASED,
+				},
+			},
+			want: "view-based-report",
+		},
+	}
+
+	for name, tc := range testCases {
+		s.Run(name, func() {
+			assert.Equal(s.T(), tc.want, reportBlobParentDir(tc.snapshot))
 		})
 	}
 }

--- a/central/reports/service/v2/node/convert_test.go
+++ b/central/reports/service/v2/node/convert_test.go
@@ -151,6 +151,7 @@ func (s *ConversionTestSuite) TestNotifierConversions() {
 	v2NotifierBack, err := s.service.convertProtoNotifierConfigToV2(protoNotifier)
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), v2NotifierBack)
+	assert.Equal(s.T(), "Test Notifier", v2NotifierBack.GetNotifierName())
 	assert.Equal(s.T(), v2Notifier.GetEmailConfig().GetNotifierId(), v2NotifierBack.GetEmailConfig().GetNotifierId())
 	assert.Equal(s.T(), v2Notifier.GetEmailConfig().GetMailingLists(), v2NotifierBack.GetEmailConfig().GetMailingLists())
 }
@@ -345,6 +346,8 @@ func (s *ConversionTestSuite) TestReportConfigurationRoundTrip() {
 	assert.Equal(s.T(), v2Config.GetId(), v2ConfigBack.GetId())
 	assert.Equal(s.T(), v2Config.GetName(), v2ConfigBack.GetName())
 	assert.Equal(s.T(), apiV2.ReportConfiguration_NODE_VULNERABILITY, v2ConfigBack.GetType())
+	assert.Len(s.T(), v2ConfigBack.GetNotifiers(), 1)
+	assert.Equal(s.T(), "Email Notifier", v2ConfigBack.GetNotifiers()[0].GetNotifierName())
 }
 
 func (s *ConversionTestSuite) TestNilConversions() {
@@ -581,6 +584,7 @@ func (s *ConversionTestSuite) TestProtoReportConfigurationToV2() {
 	assert.Equal(s.T(), "Proto Config", v2Config.GetName())
 	assert.Equal(s.T(), apiV2.ReportConfiguration_NODE_VULNERABILITY, v2Config.GetType())
 	assert.Len(s.T(), v2Config.GetNotifiers(), 1)
+	assert.Equal(s.T(), "Notifier 1", v2Config.GetNotifiers()[0].GetNotifierName())
 }
 
 func (s *ConversionTestSuite) TestGetExistingBlobNames_NotDownloadMethod() {

--- a/central/reports/service/v2/node/convert_test.go
+++ b/central/reports/service/v2/node/convert_test.go
@@ -1,0 +1,671 @@
+package node
+
+import (
+	"context"
+	"testing"
+
+	blobDSMocks "github.com/stackrox/rox/central/blob/datastore/mocks"
+	notifierDSMocks "github.com/stackrox/rox/central/notifier/datastore/mocks"
+	"github.com/stackrox/rox/central/reports/common"
+	reportConfigDSMocks "github.com/stackrox/rox/central/reports/config/datastore/mocks"
+	schedulerMocks "github.com/stackrox/rox/central/reports/scheduler/v2/mocks"
+	v2 "github.com/stackrox/rox/central/reports/service/v2"
+	reportSnapshotDSMocks "github.com/stackrox/rox/central/reports/snapshot/datastore/mocks"
+	"github.com/stackrox/rox/central/reports/validation"
+	collectionDSMocks "github.com/stackrox/rox/central/resourcecollection/datastore/mocks"
+	apiV2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestConversions(t *testing.T) {
+	suite.Run(t, new(ConversionTestSuite))
+}
+
+type ConversionTestSuite struct {
+	suite.Suite
+	mockCtrl *gomock.Controller
+	service  *serviceImpl
+	ctx      context.Context
+}
+
+func (s *ConversionTestSuite) SetupTest() {
+	s.mockCtrl = gomock.NewController(s.T())
+	s.ctx = context.Background()
+	reportConfigDataStore := reportConfigDSMocks.NewMockDataStore(s.mockCtrl)
+	reportSnapshotDataStore := reportSnapshotDSMocks.NewMockDataStore(s.mockCtrl)
+	collectionDataStore := collectionDSMocks.NewMockDataStore(s.mockCtrl)
+	notifierDataStore := notifierDSMocks.NewMockDataStore(s.mockCtrl)
+	blobStore := blobDSMocks.NewMockDatastore(s.mockCtrl)
+	scheduler := schedulerMocks.NewMockScheduler(s.mockCtrl)
+	validator := validation.New(reportConfigDataStore, reportSnapshotDataStore, collectionDataStore, notifierDataStore)
+
+	s.service = &serviceImpl{
+		reportConfigStore:   reportConfigDataStore,
+		snapshotDatastore:   reportSnapshotDataStore,
+		collectionDatastore: collectionDataStore,
+		notifierDatastore:   notifierDataStore,
+		scheduler:           scheduler,
+		blobStore:           blobStore,
+		validator:           validator,
+	}
+}
+
+func (s *ConversionTestSuite) TearDownTest() {
+	s.mockCtrl.Finish()
+}
+
+func (s *ConversionTestSuite) TestScheduleConversions() {
+	testCases := []struct {
+		name       string
+		v2Schedule *apiV2.ReportSchedule
+	}{
+		{
+			name: "Daily schedule",
+			v2Schedule: &apiV2.ReportSchedule{
+				IntervalType: apiV2.ReportSchedule_DAILY,
+				Hour:         14,
+				Minute:       30,
+			},
+		},
+		{
+			name: "Weekly schedule",
+			v2Schedule: &apiV2.ReportSchedule{
+				IntervalType: apiV2.ReportSchedule_WEEKLY,
+				Hour:         9,
+				Minute:       0,
+				Interval: &apiV2.ReportSchedule_DaysOfWeek_{
+					DaysOfWeek: &apiV2.ReportSchedule_DaysOfWeek{
+						Days: []int32{1, 3, 5},
+					},
+				},
+			},
+		},
+		{
+			name: "Monthly schedule",
+			v2Schedule: &apiV2.ReportSchedule{
+				IntervalType: apiV2.ReportSchedule_MONTHLY,
+				Hour:         10,
+				Minute:       15,
+				Interval: &apiV2.ReportSchedule_DaysOfMonth_{
+					DaysOfMonth: &apiV2.ReportSchedule_DaysOfMonth{
+						Days: []int32{1, 15},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			protoSchedule := v2.ConvertV2ScheduleToProto(tc.v2Schedule)
+			assert.NotNil(s.T(), protoSchedule)
+			assert.Equal(s.T(), tc.v2Schedule.GetHour(), protoSchedule.GetHour())
+			assert.Equal(s.T(), tc.v2Schedule.GetMinute(), protoSchedule.GetMinute())
+
+			v2Schedule := v2.ConvertProtoScheduleToV2(protoSchedule)
+			assert.NotNil(s.T(), v2Schedule)
+			assert.Equal(s.T(), tc.v2Schedule.GetIntervalType(), v2Schedule.GetIntervalType())
+			assert.Equal(s.T(), tc.v2Schedule.GetHour(), v2Schedule.GetHour())
+			assert.Equal(s.T(), tc.v2Schedule.GetMinute(), v2Schedule.GetMinute())
+
+			if tc.v2Schedule.GetDaysOfWeek() != nil {
+				assert.Equal(s.T(), tc.v2Schedule.GetDaysOfWeek().GetDays(), v2Schedule.GetDaysOfWeek().GetDays())
+			}
+			if tc.v2Schedule.GetDaysOfMonth() != nil {
+				assert.Equal(s.T(), tc.v2Schedule.GetDaysOfMonth().GetDays(), v2Schedule.GetDaysOfMonth().GetDays())
+			}
+		})
+	}
+}
+
+func (s *ConversionTestSuite) TestNotifierConversions() {
+	v2Notifier := &apiV2.NotifierConfiguration{
+		NotifierConfig: &apiV2.NotifierConfiguration_EmailConfig{
+			EmailConfig: &apiV2.EmailNotifierConfiguration{
+				NotifierId:    "notifier-123",
+				MailingLists:  []string{"test@example.com", "team@example.com"},
+				CustomSubject: "Custom Subject",
+				CustomBody:    "Custom Body",
+			},
+		},
+	}
+
+	protoNotifier := s.service.convertV2NotifierConfigToProto(v2Notifier)
+	assert.NotNil(s.T(), protoNotifier)
+	assert.Equal(s.T(), "notifier-123", protoNotifier.GetEmailConfig().GetNotifierId())
+	assert.Equal(s.T(), "Custom Subject", protoNotifier.GetEmailConfig().GetCustomSubject())
+
+	v2NotifierBack, err := s.service.convertProtoNotifierConfigToV2(protoNotifier)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), v2NotifierBack)
+	assert.Equal(s.T(), v2Notifier.GetEmailConfig().GetNotifierId(), v2NotifierBack.GetEmailConfig().GetNotifierId())
+	assert.Equal(s.T(), v2Notifier.GetEmailConfig().GetMailingLists(), v2NotifierBack.GetEmailConfig().GetMailingLists())
+}
+
+func (s *ConversionTestSuite) TestNotifierSnapshotConversion() {
+	protoSnapshot := &storage.NotifierSnapshot{
+		NotifierConfig: &storage.NotifierSnapshot_EmailConfig{
+			EmailConfig: &storage.EmailNotifierConfiguration{
+				NotifierId:    "notifier-456",
+				MailingLists:  []string{"alerts@example.com"},
+				CustomSubject: "Snapshot Subject",
+				CustomBody:    "Snapshot Body",
+			},
+		},
+	}
+
+	v2Config := s.service.convertProtoNotifierSnapshotToV2(protoSnapshot)
+	assert.NotNil(s.T(), v2Config)
+	assert.Equal(s.T(), "notifier-456", v2Config.GetEmailConfig().GetNotifierId())
+	assert.Equal(s.T(), "Snapshot Subject", v2Config.GetEmailConfig().GetCustomSubject())
+	assert.Equal(s.T(), []string{"alerts@example.com"}, v2Config.GetEmailConfig().GetMailingLists())
+}
+
+func (s *ConversionTestSuite) TestEntityScopeConversions() {
+	testCases := []struct {
+		name       string
+		entityType apiV2.ScopeEntity
+		field      apiV2.ScopeField
+		matchType  apiV2.MatchType
+	}{
+		{
+			name:       "Cluster ID exact match",
+			entityType: apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER,
+			field:      apiV2.ScopeField_FIELD_ID,
+			matchType:  apiV2.MatchType_EXACT,
+		},
+		{
+			name:       "Cluster name regex match",
+			entityType: apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER,
+			field:      apiV2.ScopeField_FIELD_NAME,
+			matchType:  apiV2.MatchType_REGEX,
+		},
+		{
+			name:       "Cluster label exact match",
+			entityType: apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER,
+			field:      apiV2.ScopeField_FIELD_LABEL,
+			matchType:  apiV2.MatchType_EXACT,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			storageType := v2EntityTypeToStorage(tc.entityType)
+			v2Type := storageEntityTypeToV2(storageType)
+			assert.Equal(s.T(), tc.entityType, v2Type)
+
+			storageField := v2EntityFieldToStorage(tc.field)
+			v2Field := storageEntityFieldToV2(storageField)
+			assert.Equal(s.T(), tc.field, v2Field)
+
+			storageMatch := v2MatchTypeToStorage(tc.matchType)
+			v2Match := storageMatchTypeToV2(storageMatch)
+			assert.Equal(s.T(), tc.matchType, v2Match)
+		})
+	}
+}
+
+func (s *ConversionTestSuite) TestReportStatusConversion() {
+	protoStatus := &storage.ReportStatus{
+		RunState:                 storage.ReportStatus_GENERATED,
+		ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+		ErrorMsg:                 "test error",
+		CompletedAt:              nil,
+	}
+
+	v2Status := convertPrototoV2Reportstatus(protoStatus)
+	assert.NotNil(s.T(), v2Status)
+	assert.Equal(s.T(), apiV2.ReportStatus_GENERATED, v2Status.GetRunState())
+	assert.Equal(s.T(), apiV2.NotificationMethod_DOWNLOAD, v2Status.GetReportNotificationMethod())
+	assert.Equal(s.T(), "test error", v2Status.GetErrorMsg())
+}
+
+func (s *ConversionTestSuite) TestNodeFiltersConversion() {
+	v2Filters := &apiV2.NodeVulnerabilityReportFilters{
+		Query: "Cluster:prod",
+		CvesSince: &apiV2.NodeVulnerabilityReportFilters_AllVuln{
+			AllVuln: true,
+		},
+	}
+
+	accessScopeRules := []*storage.SimpleAccessScope_Rules{
+		{
+			IncludedClusters: []string{"cluster-1"},
+		},
+	}
+
+	protoFilters := s.service.convertV2NodeReportFiltersToProto(v2Filters, accessScopeRules)
+	assert.NotNil(s.T(), protoFilters)
+	assert.Equal(s.T(), "Cluster:prod", protoFilters.GetQuery())
+	assert.True(s.T(), protoFilters.GetAllVuln())
+	protoassert.SlicesEqual(s.T(), accessScopeRules, protoFilters.GetAccessScopeRules())
+
+	v2FiltersBack := s.service.convertProtoNodeReportFiltersToV2(protoFilters)
+	assert.NotNil(s.T(), v2FiltersBack)
+	assert.Equal(s.T(), v2Filters.GetQuery(), v2FiltersBack.GetQuery())
+	assert.True(s.T(), v2FiltersBack.GetAllVuln())
+}
+
+func (s *ConversionTestSuite) TestReportConfigurationRoundTrip() {
+	creator := &storage.SlimUser{
+		Id:   "user-123",
+		Name: "Test User",
+	}
+
+	accessScopeRules := []*storage.SimpleAccessScope_Rules{
+		{
+			IncludedClusters: []string{"cluster-1", "cluster-2"},
+		},
+	}
+
+	v2Config := &apiV2.ReportConfiguration{
+		Id:          "config-123",
+		Name:        "Node Report",
+		Description: "Test node vulnerability report",
+		Type:        apiV2.ReportConfiguration_NODE_VULNERABILITY,
+		ResourceScope: &apiV2.ResourceScope{
+			ScopeReference: &apiV2.ResourceScope_EntityScope{
+				EntityScope: &apiV2.EntityScope{
+					Rules: []*apiV2.EntityScopeRule{
+						{
+							Entity: apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER,
+							Field:  apiV2.ScopeField_FIELD_ID,
+							Values: []*apiV2.RuleValue{
+								{
+									Value:     "cluster-1",
+									MatchType: apiV2.MatchType_EXACT,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Filter: &apiV2.ReportConfiguration_NodeVulnReportFilters{
+			NodeVulnReportFilters: &apiV2.NodeVulnerabilityReportFilters{
+				Query: "Cluster:prod",
+				CvesSince: &apiV2.NodeVulnerabilityReportFilters_AllVuln{
+					AllVuln: true,
+				},
+			},
+		},
+		Schedule: &apiV2.ReportSchedule{
+			IntervalType: apiV2.ReportSchedule_WEEKLY,
+			Hour:         9,
+			Minute:       0,
+			Interval: &apiV2.ReportSchedule_DaysOfWeek_{
+				DaysOfWeek: &apiV2.ReportSchedule_DaysOfWeek{
+					Days: []int32{1, 3, 5},
+				},
+			},
+		},
+		Notifiers: []*apiV2.NotifierConfiguration{
+			{
+				NotifierConfig: &apiV2.NotifierConfiguration_EmailConfig{
+					EmailConfig: &apiV2.EmailNotifierConfiguration{
+						NotifierId:   "email-1",
+						MailingLists: []string{"team@example.com"},
+					},
+				},
+			},
+		},
+	}
+
+	protoConfig, err := s.service.convertV2ReportConfigurationToProto(v2Config, creator, accessScopeRules)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), protoConfig)
+	assert.Equal(s.T(), v2Config.GetId(), protoConfig.GetId())
+	assert.Equal(s.T(), v2Config.GetName(), protoConfig.GetName())
+	assert.Equal(s.T(), storage.ReportConfiguration_NODE_VULNERABILITY, protoConfig.GetType())
+	protoassert.Equal(s.T(), creator, protoConfig.GetCreator())
+
+	v2ConfigBack, err := s.service.convertProtoReportConfigurationToV2(protoConfig)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), v2ConfigBack)
+	assert.Equal(s.T(), v2Config.GetId(), v2ConfigBack.GetId())
+	assert.Equal(s.T(), v2Config.GetName(), v2ConfigBack.GetName())
+	assert.Equal(s.T(), apiV2.ReportConfiguration_NODE_VULNERABILITY, v2ConfigBack.GetType())
+}
+
+func (s *ConversionTestSuite) TestNilConversions() {
+	assert.Nil(s.T(), v2.ConvertV2ScheduleToProto(nil))
+	assert.Nil(s.T(), v2.ConvertProtoScheduleToV2(nil))
+	assert.Nil(s.T(), s.service.convertV2NotifierConfigToProto(nil))
+
+	result, err := s.service.convertProtoNotifierConfigToV2(nil)
+	assert.NoError(s.T(), err)
+	assert.Nil(s.T(), result)
+
+	assert.Nil(s.T(), s.service.convertProtoNotifierSnapshotToV2(nil))
+	assert.Nil(s.T(), convertPrototoV2Reportstatus(nil))
+	assert.Nil(s.T(), s.service.convertV2NodeReportFiltersToProto(nil, nil))
+	assert.Nil(s.T(), s.service.convertProtoNodeReportFiltersToV2(nil))
+}
+
+func (s *ConversionTestSuite) TestEntityTypeEdgeCases() {
+	assert.Equal(s.T(), storage.EntityType_ENTITY_TYPE_UNSET, v2EntityTypeToStorage(apiV2.ScopeEntity_SCOPE_ENTITY_UNSET))
+	assert.Equal(s.T(), apiV2.ScopeEntity_SCOPE_ENTITY_UNSET, storageEntityTypeToV2(storage.EntityType_ENTITY_TYPE_UNSET))
+
+	assert.Equal(s.T(), storage.EntityField_FIELD_UNSET, v2EntityFieldToStorage(apiV2.ScopeField_FIELD_UNSET))
+	assert.Equal(s.T(), apiV2.ScopeField_FIELD_UNSET, storageEntityFieldToV2(storage.EntityField_FIELD_UNSET))
+
+	assert.Equal(s.T(), storage.MatchType_EXACT, v2MatchTypeToStorage(apiV2.MatchType_EXACT))
+	assert.Equal(s.T(), apiV2.MatchType_EXACT, storageMatchTypeToV2(storage.MatchType_EXACT))
+}
+
+func (s *ConversionTestSuite) TestReportSnapshotWithDownloadAvailable() {
+	configID := "test-config"
+	reportID := "test-report"
+
+	snapshot := &storage.ReportSnapshot{
+		ReportConfigurationId: configID,
+		ReportId:              reportID,
+		Name:                  "Test Report",
+		Type:                  storage.ReportSnapshot_NODE_VULNERABILITY,
+		Requester: &storage.SlimUser{
+			Id:   "user-1",
+			Name: "Test User",
+		},
+		ReportStatus: &storage.ReportStatus{
+			RunState:                 storage.ReportStatus_GENERATED,
+			ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+		},
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_EntityScope{
+				EntityScope: &storage.EntityScope{},
+			},
+		},
+		Filter: &storage.ReportSnapshot_NodeVulnReportFilters{
+			NodeVulnReportFilters: &storage.NodeVulnerabilityReportFilters{
+				Query: "test",
+			},
+		},
+	}
+
+	blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
+	blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	result, err := s.service.convertProtoReportSnapshotToV2(snapshot, set.NewFrozenStringSet())
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), result)
+	assert.Equal(s.T(), reportID, result.GetReportJobId())
+	assert.Equal(s.T(), configID, result.GetReportConfigId())
+	assert.Equal(s.T(), "Test Report", result.GetName())
+}
+
+func (s *ConversionTestSuite) TestIntervalTypeConversions() {
+	assert.Equal(s.T(), storage.Schedule_UNSET, v2IntervalTypeToStorage[apiV2.ReportSchedule_UNSET])
+	assert.Equal(s.T(), storage.Schedule_DAILY, v2IntervalTypeToStorage[apiV2.ReportSchedule_DAILY])
+	assert.Equal(s.T(), storage.Schedule_WEEKLY, v2IntervalTypeToStorage[apiV2.ReportSchedule_WEEKLY])
+	assert.Equal(s.T(), storage.Schedule_MONTHLY, v2IntervalTypeToStorage[apiV2.ReportSchedule_MONTHLY])
+
+	assert.Equal(s.T(), apiV2.ReportSchedule_UNSET, storageIntervalTypeToV2[storage.Schedule_UNSET])
+	assert.Equal(s.T(), apiV2.ReportSchedule_DAILY, storageIntervalTypeToV2[storage.Schedule_DAILY])
+	assert.Equal(s.T(), apiV2.ReportSchedule_WEEKLY, storageIntervalTypeToV2[storage.Schedule_WEEKLY])
+	assert.Equal(s.T(), apiV2.ReportSchedule_MONTHLY, storageIntervalTypeToV2[storage.Schedule_MONTHLY])
+}
+
+func (s *ConversionTestSuite) TestRunStateConversions() {
+	assert.Equal(s.T(), apiV2.ReportStatus_WAITING, storageRunStateToV2[storage.ReportStatus_WAITING])
+	assert.Equal(s.T(), apiV2.ReportStatus_PREPARING, storageRunStateToV2[storage.ReportStatus_PREPARING])
+	assert.Equal(s.T(), apiV2.ReportStatus_GENERATED, storageRunStateToV2[storage.ReportStatus_GENERATED])
+	assert.Equal(s.T(), apiV2.ReportStatus_DELIVERED, storageRunStateToV2[storage.ReportStatus_DELIVERED])
+	assert.Equal(s.T(), apiV2.ReportStatus_FAILURE, storageRunStateToV2[storage.ReportStatus_FAILURE])
+}
+
+func (s *ConversionTestSuite) TestResourceScopeConversions() {
+	v2Scope := &apiV2.ResourceScope{
+		ScopeReference: &apiV2.ResourceScope_EntityScope{
+			EntityScope: &apiV2.EntityScope{
+				Rules: []*apiV2.EntityScopeRule{
+					{
+						Entity: apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER,
+						Field:  apiV2.ScopeField_FIELD_NAME,
+						Values: []*apiV2.RuleValue{
+							{
+								Value:     "prod-cluster",
+								MatchType: apiV2.MatchType_REGEX,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	protoScope, err := s.service.convertV2ResourceScopeToProto(v2Scope)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), protoScope)
+
+	v2ScopeBack, err := s.service.convertProtoResourceScopeToV2(protoScope)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), v2ScopeBack)
+	assert.NotNil(s.T(), v2ScopeBack.GetEntityScope())
+	assert.Len(s.T(), v2ScopeBack.GetEntityScope().GetRules(), 1)
+}
+
+func (s *ConversionTestSuite) TestEmptyResourceScope() {
+	result, err := s.service.convertV2ResourceScopeToProto(nil)
+	assert.NoError(s.T(), err)
+	assert.Nil(s.T(), result)
+
+	v2Result, err := s.service.convertProtoResourceScopeToV2(nil)
+	assert.NoError(s.T(), err)
+	assert.Nil(s.T(), v2Result)
+}
+
+func (s *ConversionTestSuite) TestReportConfigurationWithoutNotifiers() {
+	creator := &storage.SlimUser{
+		Id:   "user-123",
+		Name: "Test User",
+	}
+
+	v2Config := &apiV2.ReportConfiguration{
+		Id:          "config-no-notifiers",
+		Name:        "Node Report No Notifiers",
+		Description: "Test without notifiers",
+		Type:        apiV2.ReportConfiguration_NODE_VULNERABILITY,
+		ResourceScope: &apiV2.ResourceScope{
+			ScopeReference: &apiV2.ResourceScope_EntityScope{
+				EntityScope: &apiV2.EntityScope{
+					Rules: []*apiV2.EntityScopeRule{
+						{
+							Entity: apiV2.ScopeEntity_SCOPE_ENTITY_CLUSTER,
+							Field:  apiV2.ScopeField_FIELD_ID,
+							Values: []*apiV2.RuleValue{
+								{
+									Value:     "cluster-1",
+									MatchType: apiV2.MatchType_EXACT,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Filter: &apiV2.ReportConfiguration_NodeVulnReportFilters{
+			NodeVulnReportFilters: &apiV2.NodeVulnerabilityReportFilters{
+				Query: "Cluster:prod",
+				CvesSince: &apiV2.NodeVulnerabilityReportFilters_AllVuln{
+					AllVuln: true,
+				},
+			},
+		},
+		Notifiers: nil,
+	}
+
+	protoConfig, err := s.service.convertV2ReportConfigurationToProto(v2Config, creator, nil)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), protoConfig)
+	assert.Empty(s.T(), protoConfig.GetNotifiers())
+}
+
+func (s *ConversionTestSuite) TestProtoReportConfigurationToV2() {
+	protoConfig := &storage.ReportConfiguration{
+		Id:          "config-proto",
+		Name:        "Proto Config",
+		Description: "Test proto to v2",
+		Type:        storage.ReportConfiguration_NODE_VULNERABILITY,
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_EntityScope{
+				EntityScope: &storage.EntityScope{
+					Rules: []*storage.EntityScopeRule{
+						{
+							Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+							Field:  storage.EntityField_FIELD_ID,
+							Values: []*storage.RuleValue{
+								{
+									Value:     "cluster-1",
+									MatchType: storage.MatchType_EXACT,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Filter: &storage.ReportConfiguration_NodeVulnReportFilters{
+			NodeVulnReportFilters: &storage.NodeVulnerabilityReportFilters{
+				Query: "test query",
+				CvesSince: &storage.NodeVulnerabilityReportFilters_AllVuln{
+					AllVuln: true,
+				},
+			},
+		},
+		Notifiers: []*storage.NotifierConfiguration{
+			{
+				NotifierConfig: &storage.NotifierConfiguration_EmailConfig{
+					EmailConfig: &storage.EmailNotifierConfiguration{
+						NotifierId:   "notifier-1",
+						MailingLists: []string{"team@example.com"},
+					},
+				},
+			},
+		},
+	}
+
+	v2Config, err := s.service.convertProtoReportConfigurationToV2(protoConfig)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), v2Config)
+	assert.Equal(s.T(), "config-proto", v2Config.GetId())
+	assert.Equal(s.T(), "Proto Config", v2Config.GetName())
+	assert.Equal(s.T(), apiV2.ReportConfiguration_NODE_VULNERABILITY, v2Config.GetType())
+	assert.Len(s.T(), v2Config.GetNotifiers(), 1)
+}
+
+func (s *ConversionTestSuite) TestGetExistingBlobNames_NotDownloadMethod() {
+	snapshot := &storage.ReportSnapshot{
+		ReportConfigurationId: "config-1",
+		ReportId:              "report-1",
+		ReportStatus: &storage.ReportStatus{
+			RunState:                 storage.ReportStatus_GENERATED,
+			ReportNotificationMethod: storage.ReportStatus_EMAIL,
+		},
+	}
+
+	result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, result.Cardinality())
+}
+
+func (s *ConversionTestSuite) TestGetExistingBlobNames_WrongRunState() {
+	testCases := []struct {
+		name     string
+		runState storage.ReportStatus_RunState
+	}{
+		{"Waiting", storage.ReportStatus_WAITING},
+		{"Preparing", storage.ReportStatus_PREPARING},
+		{"Failure", storage.ReportStatus_FAILURE},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			snapshot := &storage.ReportSnapshot{
+				ReportConfigurationId: "config-1",
+				ReportId:              "report-1",
+				ReportStatus: &storage.ReportStatus{
+					RunState:                 tc.runState,
+					ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+				},
+			}
+
+			result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+			assert.NoError(s.T(), err)
+			assert.Equal(s.T(), 0, result.Cardinality())
+		})
+	}
+}
+
+func (s *ConversionTestSuite) TestGetExistingBlobNames_BlobSearchError() {
+	snapshot := &storage.ReportSnapshot{
+		ReportConfigurationId: "config-1",
+		ReportId:              "report-1",
+		ReportStatus: &storage.ReportStatus{
+			RunState:                 storage.ReportStatus_GENERATED,
+			ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+		},
+	}
+
+	blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
+	blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, assert.AnError).Times(1)
+
+	result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+	assert.Error(s.T(), err)
+	assert.Equal(s.T(), 0, result.Cardinality())
+}
+
+func (s *ConversionTestSuite) TestGetExistingBlobNames_NoBlobFound() {
+	snapshot := &storage.ReportSnapshot{
+		ReportConfigurationId: "config-1",
+		ReportId:              "report-1",
+		ReportStatus: &storage.ReportStatus{
+			RunState:                 storage.ReportStatus_GENERATED,
+			ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+		},
+	}
+
+	blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
+	blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{}, nil).Times(1)
+
+	result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 0, result.Cardinality())
+}
+
+func (s *ConversionTestSuite) TestGetExistingBlobNames_BlobFound() {
+	testCases := []struct {
+		name     string
+		runState storage.ReportStatus_RunState
+	}{
+		{"Generated state", storage.ReportStatus_GENERATED},
+		{"Delivered state", storage.ReportStatus_DELIVERED},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			snapshot := &storage.ReportSnapshot{
+				ReportConfigurationId: "config-1",
+				ReportId:              "report-1",
+				ReportStatus: &storage.ReportStatus{
+					RunState:                 tc.runState,
+					ReportNotificationMethod: storage.ReportStatus_DOWNLOAD,
+				},
+			}
+
+			blobStore := s.service.blobStore.(*blobDSMocks.MockDatastore)
+			blobStore.EXPECT().Search(gomock.Any(), gomock.Any()).Return([]search.Result{
+				{ID: common.GetReportBlobPath("config-1", "report-1")},
+			}, nil).Times(1)
+
+			result, err := s.service.getExistingBlobNames(s.ctx, []*storage.ReportSnapshot{snapshot})
+			assert.NoError(s.T(), err)
+			assert.True(s.T(), result.Contains(common.GetReportBlobPath("config-1", "report-1")))
+		})
+	}
+}

--- a/central/reports/service/v2/node/service_impl.go
+++ b/central/reports/service/v2/node/service_impl.go
@@ -1,0 +1,21 @@
+package node
+
+import (
+	blobDS "github.com/stackrox/rox/central/blob/datastore"
+	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
+	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
+	schedulerV2 "github.com/stackrox/rox/central/reports/scheduler/v2"
+	snapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
+	"github.com/stackrox/rox/central/reports/validation"
+	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+)
+
+type serviceImpl struct {
+	reportConfigStore   reportConfigDS.DataStore
+	snapshotDatastore   snapshotDS.DataStore
+	collectionDatastore collectionDS.DataStore
+	notifierDatastore   notifierDS.DataStore
+	scheduler           schedulerV2.Scheduler
+	blobStore           blobDS.Datastore
+	validator           *validation.Validator
+}

--- a/central/reports/service/v2/node/service_impl.go
+++ b/central/reports/service/v2/node/service_impl.go
@@ -8,9 +8,11 @@ import (
 	snapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	"github.com/stackrox/rox/central/reports/validation"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	apiV2 "github.com/stackrox/rox/generated/api/v2"
 )
 
 type serviceImpl struct {
+	apiV2.UnimplementedNodeReportServiceServer
 	reportConfigStore   reportConfigDS.DataStore
 	snapshotDatastore   snapshotDS.DataStore
 	collectionDatastore collectionDS.DataStore


### PR DESCRIPTION
This commit implements bidirectional conversion between protobuf storage
models and API request/response models for node vulnerability reports.

Node-specific conversions:
- NodeReportFormData ↔ storage.ReportConfiguration
- NodeVulnerabilityReportFilters ↔ API filter models
- ReportSnapshot ↔ NodeReportResponse with metadata
- Schedule configuration conversions

Key features:
- Populate NotifierName field for better API responses
- Handle node-specific filter validation and transformation
- Convert between storage enums and API constants
- Proper nil handling for optional fields

Refactoring:
- Export v2ScheduleToStorage and storageScheduleToV2Schedule functions
- Make schedule converters reusable across image and node reports
- Update tests to reflect exported function names

The conversion layer ensures type safety and proper validation at the API
boundary while maintaining backward compatibility with existing image report
conversions.

Testing:
- Comprehensive unit tests for all conversion paths
- Test edge cases like nil values and empty collections
- Validate round-trip conversions

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
