### PR TITLE
chore(ci): Separate JUnit results in summary

### DIFF
--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -193,7 +193,6 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
-        folded: true
     - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()

--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -192,13 +192,13 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "fail, skip"
+        show: "fail"
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "pass"
+        show: "pass, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -187,14 +187,14 @@ jobs:
           exit 6
         fi
 
-    - name: Publish test summary
+    - name: Publish summary for failed tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
         folded: true
-    - name: Publish test summary
+    - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:

--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -193,6 +193,7 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
+        folded: true
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()

--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -192,7 +192,7 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: all
+        show: "fail, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -193,6 +193,12 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail, skip"
+    - name: Publish test summary
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: "pass"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-db-backup-restore-tests.yaml
+++ b/.github/workflows/e2e-db-backup-restore-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           exit 6
         fi
 
-    - name: Publish test summary
+    - name: Publish summary for all tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:

--- a/.github/workflows/e2e-db-backup-restore-tests.yaml
+++ b/.github/workflows/e2e-db-backup-restore-tests.yaml
@@ -153,7 +153,6 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: all
-        folded: true
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-db-backup-restore-tests.yaml
+++ b/.github/workflows/e2e-db-backup-restore-tests.yaml
@@ -153,6 +153,7 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: all
+        folded: true
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -161,6 +161,7 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
+        folded: true
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
@@ -311,6 +312,7 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
+        folded: true
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
@@ -448,6 +450,7 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
+        folded: true
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -155,14 +155,14 @@ jobs:
           exit 6
         fi
 
-    - name: Publish test summary
+    - name: Publish summary for failed tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
         folded: true
-    - name: Publish test summary
+    - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
@@ -306,14 +306,14 @@ jobs:
           exit 6
         fi
 
-    - name: Publish test summary
+    - name: Publish summary for failed tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
         folded: true
-    - name: Publish test summary
+    - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
@@ -444,14 +444,14 @@ jobs:
           exit 6
         fi
 
-    - name: Publish test summary
+    - name: Publish summary for failed tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
         folded: true
-    - name: Publish test summary
+    - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -161,7 +161,6 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
-        folded: true
     - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
@@ -312,7 +311,6 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
-        folded: true
     - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
@@ -450,7 +448,6 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
-        folded: true
     - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -160,13 +160,13 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "fail, skip"
+        show: "fail"
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "pass"
+        show: "pass, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())
@@ -310,13 +310,13 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "fail, skip"
+        show: "fail"
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "pass"
+        show: "pass, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())
@@ -447,13 +447,13 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "fail, skip"
+        show: "fail"
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "pass"
+        show: "pass, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -161,6 +161,12 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail, skip"
+    - name: Publish test summary
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: "pass"
 
     - name: Report junit failures in jira
       if: (!cancelled())
@@ -305,6 +311,12 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail, skip"
+    - name: Publish test summary
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: "pass"
 
     - name: Report junit failures in jira
       if: (!cancelled())
@@ -435,7 +447,13 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: all
+        show: "fail, skip"
+    - name: Publish test summary
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: "pass"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-gke-upgrade-tests.yaml
+++ b/.github/workflows/e2e-gke-upgrade-tests.yaml
@@ -160,7 +160,7 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: all
+        show: "fail, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())
@@ -304,7 +304,7 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: all
+        show: "fail, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -198,6 +198,12 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail, skip"
+    - name: Publish test summary
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: "pass"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -198,6 +198,7 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
+        folded: true
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -192,14 +192,14 @@ jobs:
           exit 6
         fi
 
-    - name: Publish test summary
+    - name: Publish summary for failed tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
         folded: true
-    - name: Publish test summary
+    - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -198,7 +198,6 @@ jobs:
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
         show: "fail"
-        folded: true
     - name: Publish summary for passed and skipped tests
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -197,13 +197,13 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "fail, skip"
+        show: "fail"
     - name: Publish test summary
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: "pass"
+        show: "pass, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -197,7 +197,7 @@ jobs:
       if: always()
       with:
         paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-        show: all
+        show: "fail, skip"
 
     - name: Report junit failures in jira
       if: (!cancelled())

--- a/.github/workflows/e2e-qa-tests.yaml
+++ b/.github/workflows/e2e-qa-tests.yaml
@@ -330,13 +330,13 @@ jobs:
         if: always()
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-          show: "fail, skip"
+          show: "fail"
       - name: Publish test summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
         if: always()
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-          show: "pass"
+          show: "pass, skip"
 
       - name: Report junit failures in jira
         if: (!cancelled())

--- a/.github/workflows/e2e-qa-tests.yaml
+++ b/.github/workflows/e2e-qa-tests.yaml
@@ -331,6 +331,7 @@ jobs:
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
           show: "fail"
+          folded: true
       - name: Publish test summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
         if: always()

--- a/.github/workflows/e2e-qa-tests.yaml
+++ b/.github/workflows/e2e-qa-tests.yaml
@@ -325,14 +325,14 @@ jobs:
           from post_tests import FinalPost
           FinalPost(store_qa_tests_data=True).run()
 
-      - name: Publish test summary
+      - name: Publish summary for failed tests
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
         if: always()
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
           show: "fail"
           folded: true
-      - name: Publish test summary
+      - name: Publish summary for passed and skipped tests
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
         if: always()
         with:

--- a/.github/workflows/e2e-qa-tests.yaml
+++ b/.github/workflows/e2e-qa-tests.yaml
@@ -331,6 +331,12 @@ jobs:
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
           show: "fail, skip"
+      - name: Publish test summary
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+        if: always()
+        with:
+          paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+          show: "pass"
 
       - name: Report junit failures in jira
         if: (!cancelled())

--- a/.github/workflows/e2e-qa-tests.yaml
+++ b/.github/workflows/e2e-qa-tests.yaml
@@ -331,7 +331,6 @@ jobs:
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
           show: "fail"
-          folded: true
       - name: Publish summary for passed and skipped tests
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
         if: always()

--- a/.github/workflows/e2e-qa-tests.yaml
+++ b/.github/workflows/e2e-qa-tests.yaml
@@ -330,7 +330,7 @@ jobs:
         if: always()
         with:
           paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
-          show: all
+          show: "fail, skip"
 
       - name: Report junit failures in jira
         if: (!cancelled())


### PR DESCRIPTION
## Description

See this thread: https://redhat-internal.slack.com/archives/C0321S70YK1/p1787824344751289

Refdoc: https://github.com/test-summary/action#options

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

- [x] Checked how e2e summary looks.