### PR TITLE
ROX-36614: Virtual Machines Overview Sorting

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesCveTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesCveTable.tsx
@@ -85,7 +85,7 @@ function VirtualMachineCvesCveTable({
                         <Th sort={getSortParams(CVSS_SORT_FIELD)}>Top CVSS</Th>
                         <Th>Affected virtual machines</Th>
                         <Th>EPSS probability</Th>
-                        <Th sort={getSortParams(CVE_PUBLISHED_ON_SORT_FIELD)}>First discovered</Th>
+                        <Th sort={getSortParams(CVE_PUBLISHED_ON_SORT_FIELD)}>Published</Th>
                     </Tr>
                 </Thead>
                 <TbodyUnified
@@ -138,7 +138,7 @@ function VirtualMachineCvesCveTable({
                                                 virtualMachineCve.epssProbability
                                             )}
                                         </Td>
-                                        <Td dataLabel="First discovered">
+                                        <Td dataLabel="Published">
                                             <DateDistance date={virtualMachineCve.publishedOn} />
                                         </Td>
                                     </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesCveTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesCveTable.tsx
@@ -7,6 +7,7 @@ import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useRestQuery from 'hooks/useRestQuery';
+import useURLSort from 'hooks/useURLSort';
 import { listVMCVEs } from 'services/VirtualMachineService';
 import type { SearchFilter } from 'types/search';
 import { getTableUIState } from 'utils/getTableUIState';
@@ -14,9 +15,18 @@ import { getTableUIState } from 'utils/getTableUIState';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import TableEntityToolbar from '../../components/TableEntityToolbar';
 import { getVirtualMachineEntityPagePath } from '../../utils/searchUtils';
+import {
+    CVE_PUBLISHED_ON_SORT_FIELD,
+    CVE_SORT_FIELD,
+    CVSS_SORT_FIELD,
+} from '../../utils/sortFields';
 import { formatEpssProbabilityAsPercent } from '../../WorkloadCves/Tables/table.utils';
 import VirtualMachineCvesFilterToolbar from './VirtualMachineCvesFilterToolbar';
 import VirtualMachineCvesToggleGroup from './VirtualMachineCvesToggleGroup';
+
+const sortFields = [CVE_SORT_FIELD, CVSS_SORT_FIELD, CVE_PUBLISHED_ON_SORT_FIELD];
+
+const defaultSortOption = { field: CVSS_SORT_FIELD, direction: 'desc' } as const;
 
 type VirtualMachineCvesCveTableProps = {
     searchFilter: SearchFilter;
@@ -32,10 +42,15 @@ function VirtualMachineCvesCveTable({
     onClearFilters,
 }: VirtualMachineCvesCveTableProps) {
     const { page, perPage } = pagination;
+    const { sortOption, getSortParams } = useURLSort({
+        sortFields,
+        defaultSortOption,
+        onSort: () => pagination.setPage(1, 'replace'),
+    });
 
     const fetchVirtualMachineCVEs = useCallback(
-        () => listVMCVEs({ searchFilter, page, perPage }),
-        [searchFilter, page, perPage]
+        () => listVMCVEs({ searchFilter, page, perPage, sortOption }),
+        [searchFilter, page, perPage, sortOption]
     );
     const { data, isLoading, error } = useRestQuery(fetchVirtualMachineCVEs);
 
@@ -65,12 +80,12 @@ function VirtualMachineCvesCveTable({
             >
                 <Thead noWrap>
                     <Tr>
-                        <Th>CVE</Th>
+                        <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
                         <Th>Virtual machines by severity</Th>
-                        <Th>Top CVSS</Th>
+                        <Th sort={getSortParams(CVSS_SORT_FIELD)}>Top CVSS</Th>
                         <Th>Affected virtual machines</Th>
                         <Th>EPSS probability</Th>
-                        <Th>First discovered</Th>
+                        <Th sort={getSortParams(CVE_PUBLISHED_ON_SORT_FIELD)}>First discovered</Th>
                     </Tr>
                 </Thead>
                 <TbodyUnified

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesToggleGroup.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesToggleGroup.tsx
@@ -1,10 +1,12 @@
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 import useURLPagination from 'hooks/useURLPagination';
+import useURLParameter from 'hooks/useURLParameter';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { virtualMachineEntityTabValues } from '../../types';
+import type { VirtualMachineEntityTab } from '../../types';
 
 // Shared entity toggle for both overview tables, which each render their own toolbar.
 // Factored out to make sure the two tables stay in sync. State is read from the URL, not props.
@@ -14,6 +16,13 @@ function VirtualMachineCvesToggleGroup() {
         virtualMachineEntityTabValues
     );
     const { setPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
+    const [, setSortOption] = useURLParameter('sortOption', undefined);
+
+    function selectEntityTab(entityTab: VirtualMachineEntityTab) {
+        setActiveEntityTabKey(entityTab);
+        setPage(1);
+        setSortOption(undefined);
+    }
 
     return (
         <ToggleGroup aria-label="Entity type toggle items">
@@ -21,19 +30,13 @@ function VirtualMachineCvesToggleGroup() {
                 text="CVEs"
                 buttonId="CVE"
                 isSelected={activeEntityTabKey === 'CVE'}
-                onChange={() => {
-                    setActiveEntityTabKey('CVE');
-                    setPage(1);
-                }}
+                onChange={() => selectEntityTab('CVE')}
             />
             <ToggleGroupItem
                 text="Virtual Machines"
                 buttonId="VirtualMachine"
                 isSelected={activeEntityTabKey === 'VirtualMachine'}
-                onChange={() => {
-                    setActiveEntityTabKey('VirtualMachine');
-                    setPage(1);
-                }}
+                onChange={() => selectEntityTab('VirtualMachine')}
             />
         </ToggleGroup>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesVmTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesVmTable.tsx
@@ -19,12 +19,16 @@ import { getTableUIState } from 'utils/getTableUIState';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import TableEntityToolbar from '../../components/TableEntityToolbar';
 import { getVirtualMachineEntityPagePath } from '../../utils/searchUtils';
-import { VIRTUAL_MACHINE_SORT_FIELD } from '../../utils/sortFields';
+import {
+    CLUSTER_SORT_FIELD,
+    NAMESPACE_SORT_FIELD,
+    VIRTUAL_MACHINE_SORT_FIELD,
+} from '../../utils/sortFields';
 import VirtualMachineCvesFilterToolbar from './VirtualMachineCvesFilterToolbar';
 import VirtualMachineCvesToggleGroup from './VirtualMachineCvesToggleGroup';
 import VirtualMachinesCvesTableLegacy from './VirtualMachinesCvesTableLegacy';
 
-const sortFields = [VIRTUAL_MACHINE_SORT_FIELD];
+const sortFields = [VIRTUAL_MACHINE_SORT_FIELD, CLUSTER_SORT_FIELD, NAMESPACE_SORT_FIELD];
 
 const defaultSortOption = { field: VIRTUAL_MACHINE_SORT_FIELD, direction: 'asc' } as const;
 
@@ -134,8 +138,18 @@ function VirtualMachineCvesVmTableEnhanced({
                             <Th className={getVisibilityClass('cvesBySeverity')}>
                                 CVEs by severity
                             </Th>
-                            <Th className={getVisibilityClass('cluster')}>Cluster</Th>
-                            <Th className={getVisibilityClass('namespace')}>Namespace</Th>
+                            <Th
+                                className={getVisibilityClass('cluster')}
+                                sort={getSortParams(CLUSTER_SORT_FIELD)}
+                            >
+                                Cluster
+                            </Th>
+                            <Th
+                                className={getVisibilityClass('namespace')}
+                                sort={getSortParams(NAMESPACE_SORT_FIELD)}
+                            >
+                                Namespace
+                            </Th>
                             <Th className={getVisibilityClass('scannedComponents')}>
                                 Scanned components
                             </Th>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/sortFields.ts
@@ -6,8 +6,10 @@ export const CVE_SEVERITY_SORT_FIELD = 'Severity';
 export const CVE_STATUS_SORT_FIELD = 'Fixable';
 export const CVE_TYPE_SORT_FIELD = 'CVE Type';
 export const CVE_COUNT_SORT_FIELD = 'CVE Count';
+export const CVE_PUBLISHED_ON_SORT_FIELD = 'CVE Published On';
 export const OPERATING_SYSTEM_SORT_FIELD = 'Operating System';
 export const COMPONENT_SORT_FIELD = 'Component';
+export const NAMESPACE_SORT_FIELD = 'Namespace';
 
 // Cluster sort fields
 export const CLUSTER_SORT_FIELD = 'Cluster';

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -247,11 +247,13 @@ export function listVMCVEs({
     searchFilter,
     page,
     perPage,
+    sortOption,
 }: SearchQueryOptions): Promise<ListVMCVEsResponse> {
     const params = buildNestedRawQueryParams({
         page,
         perPage,
         searchFilter: applyRegexSearchModifiers(searchFilter ?? {}),
+        sortOption,
     });
     return axios
         .get<ListVMCVEsResponse>(`/v2/virtualmachines/cves?${params}`)


### PR DESCRIPTION
## Description

Adds column sorting to the virtual machine CVE overview tables (both the CVE and the Virtual Machines entity tabs) and resets the sort when switching entity tabs.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Sorted each column on both overview tabs and confirmed the request `sortOption` and the
  URL update as expected.
- Toggled between the CVE and Virtual Machines tabs and confirmed the sort resets rather
  than carrying over an invalid field.


<img width="2132" height="518" alt="Screenshot 2026-09-02 at 12 17 32 PM" src="https://github.com/user-attachments/assets/03029a60-e035-4c9f-8b4a-8cf3c4bd1601" />
<img width="2132" height="518" alt="Screenshot 2026-09-02 at 12 17 38 PM" src="https://github.com/user-attachments/assets/05ac57be-747b-40a3-861c-fbe36d76bbb6" />

