### PR TITLE
fix(vm): vm4vm bug bash fixes

### DIFF
--- a/central/convert/v1tov2storage/vm_scan_parts.go
+++ b/central/convert/v1tov2storage/vm_scan_parts.go
@@ -126,6 +126,14 @@ func convertCVEBaseInfo(info *storage.VirtualMachineCVEInfo) *storage.CVEInfo {
 		})
 	}
 
+	var epss *storage.EPSS
+	if e := info.GetEpss(); e != nil {
+		epss = &storage.EPSS{
+			EpssProbability: e.GetEpssProbability(),
+			EpssPercentile:  e.GetEpssPercentile(),
+		}
+	}
+
 	return &storage.CVEInfo{
 		Cve:          info.GetCve(),
 		Summary:      info.GetSummary(),
@@ -135,6 +143,7 @@ func convertCVEBaseInfo(info *storage.VirtualMachineCVEInfo) *storage.CVEInfo {
 		LastModified: info.GetLastModified(),
 		CvssMetrics:  info.GetCvssMetrics(),
 		References:   refs,
+		Epss:         epss,
 	}
 }
 

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -135,8 +135,6 @@ type cveForVMResponse struct {
 	EPSSProbabilityMax     *float32   `db:"epss_probability_max"`
 	AffectedComponentCount int        `db:"component_id_count"`
 	Published              *time.Time `db:"cve_published_on_min"`
-	Advisory               string     `db:"advisory_name"`
-	AdvisoryURL            string     `db:"advisory_link"`
 }
 
 func (r *cveForVMResponse) GetCVE() string                 { return r.CVE }
@@ -146,8 +144,6 @@ func (r *cveForVMResponse) GetMaxCVSS() float32            { return r.MaxCVSS }
 func (r *cveForVMResponse) GetMaxNVDCVSS() float32         { return r.MaxNVDCVSS }
 func (r *cveForVMResponse) GetAffectedComponentCount() int { return r.AffectedComponentCount }
 func (r *cveForVMResponse) GetPublishDate() *time.Time     { return r.Published }
-func (r *cveForVMResponse) GetAdvisoryName() string        { return r.Advisory }
-func (r *cveForVMResponse) GetAdvisoryLink() string        { return r.AdvisoryURL }
 func (r *cveForVMResponse) GetEPSSProbability() float32 {
 	if r.EPSSProbabilityMax == nil {
 		return 0

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -139,15 +139,15 @@ type cveForVMResponse struct {
 	AdvisoryURL            string     `db:"advisory_link"`
 }
 
-func (r *cveForVMResponse) GetCVE() string                  { return r.CVE }
-func (r *cveForVMResponse) GetMaxSeverity() int32            { return r.MaxSeverity }
-func (r *cveForVMResponse) GetIsFixable() bool               { return r.FixableCount > 0 }
-func (r *cveForVMResponse) GetMaxCVSS() float32              { return r.MaxCVSS }
-func (r *cveForVMResponse) GetMaxNVDCVSS() float32           { return r.MaxNVDCVSS }
-func (r *cveForVMResponse) GetAffectedComponentCount() int   { return r.AffectedComponentCount }
-func (r *cveForVMResponse) GetPublishDate() *time.Time       { return r.Published }
-func (r *cveForVMResponse) GetAdvisoryName() string          { return r.Advisory }
-func (r *cveForVMResponse) GetAdvisoryLink() string          { return r.AdvisoryURL }
+func (r *cveForVMResponse) GetCVE() string                 { return r.CVE }
+func (r *cveForVMResponse) GetMaxSeverity() int32          { return r.MaxSeverity }
+func (r *cveForVMResponse) GetIsFixable() bool             { return r.FixableCount > 0 }
+func (r *cveForVMResponse) GetMaxCVSS() float32            { return r.MaxCVSS }
+func (r *cveForVMResponse) GetMaxNVDCVSS() float32         { return r.MaxNVDCVSS }
+func (r *cveForVMResponse) GetAffectedComponentCount() int { return r.AffectedComponentCount }
+func (r *cveForVMResponse) GetPublishDate() *time.Time     { return r.Published }
+func (r *cveForVMResponse) GetAdvisoryName() string        { return r.Advisory }
+func (r *cveForVMResponse) GetAdvisoryLink() string        { return r.AdvisoryURL }
 func (r *cveForVMResponse) GetEPSSProbability() float32 {
 	if r.EPSSProbabilityMax == nil {
 		return 0

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -121,6 +121,11 @@ func (r *resourceCountByFixability) GetFixable() int {
 	return r.fixable
 }
 
+type cveComponentCountResponse struct {
+	CVE            string `db:"cve"`
+	ComponentCount int    `db:"component_id_count"`
+}
+
 type cveComponentResponse struct {
 	ComponentName    string `db:"component"`
 	ComponentVersion string `db:"component_version"`

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -121,11 +121,6 @@ func (r *resourceCountByFixability) GetFixable() int {
 	return r.fixable
 }
 
-type cveComponentCountResponse struct {
-	CVE            string `db:"cve"`
-	ComponentCount int    `db:"component_id_count"`
-}
-
 type cveForVMResponse struct {
 	CVE                    string     `db:"cve"`
 	MaxSeverity            int32      `db:"severity_max"`

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -126,6 +126,35 @@ type cveComponentCountResponse struct {
 	ComponentCount int    `db:"component_id_count"`
 }
 
+type cveForVMResponse struct {
+	CVE                    string     `db:"cve"`
+	MaxSeverity            int32      `db:"severity_max"`
+	FixableCount           int        `db:"fixable_count"`
+	MaxCVSS                float32    `db:"cvss_max"`
+	MaxNVDCVSS             float32    `db:"nvd_cvss_max"`
+	EPSSProbabilityMax     *float32   `db:"epss_probability_max"`
+	AffectedComponentCount int        `db:"component_id_count"`
+	Published              *time.Time `db:"cve_published_on_min"`
+	Advisory               string     `db:"advisory_name"`
+	AdvisoryURL            string     `db:"advisory_link"`
+}
+
+func (r *cveForVMResponse) GetCVE() string                  { return r.CVE }
+func (r *cveForVMResponse) GetMaxSeverity() int32            { return r.MaxSeverity }
+func (r *cveForVMResponse) GetIsFixable() bool               { return r.FixableCount > 0 }
+func (r *cveForVMResponse) GetMaxCVSS() float32              { return r.MaxCVSS }
+func (r *cveForVMResponse) GetMaxNVDCVSS() float32           { return r.MaxNVDCVSS }
+func (r *cveForVMResponse) GetAffectedComponentCount() int   { return r.AffectedComponentCount }
+func (r *cveForVMResponse) GetPublishDate() *time.Time       { return r.Published }
+func (r *cveForVMResponse) GetAdvisoryName() string          { return r.Advisory }
+func (r *cveForVMResponse) GetAdvisoryLink() string          { return r.AdvisoryURL }
+func (r *cveForVMResponse) GetEPSSProbability() float32 {
+	if r.EPSSProbabilityMax == nil {
+		return 0
+	}
+	return *r.EPSSProbabilityMax
+}
+
 type cveComponentResponse struct {
 	ComponentName    string `db:"component"`
 	ComponentVersion string `db:"component_version"`

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -17,6 +17,7 @@ import (
 	common "github.com/stackrox/rox/central/views/common"
 	vmcve "github.com/stackrox/rox/central/views/vmcve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -305,18 +306,18 @@ func (mr *MockCveViewMockRecorder) CountAffectedVMs(ctx, q any) *gomock.Call {
 }
 
 // CountBySeverity mocks base method.
-func (m *MockCveView) CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error) {
+func (m *MockCveView) CountBySeverity(ctx context.Context, q *v1.Query, countOn search.FieldLabel) (common.ResourceCountByCVESeverity, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountBySeverity", ctx, q)
+	ret := m.ctrl.Call(m, "CountBySeverity", ctx, q, countOn)
 	ret0, _ := ret[0].(common.ResourceCountByCVESeverity)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CountBySeverity indicates an expected call of CountBySeverity.
-func (mr *MockCveViewMockRecorder) CountBySeverity(ctx, q any) *gomock.Call {
+func (mr *MockCveViewMockRecorder) CountBySeverity(ctx, q, countOn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverity", reflect.TypeOf((*MockCveView)(nil).CountBySeverity), ctx, q)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverity", reflect.TypeOf((*MockCveView)(nil).CountBySeverity), ctx, q, countOn)
 }
 
 // CountBySeverityPerVM mocks base method.
@@ -332,6 +333,21 @@ func (m *MockCveView) CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]
 func (mr *MockCveViewMockRecorder) CountBySeverityPerVM(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverityPerVM", reflect.TypeOf((*MockCveView)(nil).CountBySeverityPerVM), ctx, q)
+}
+
+// CountComponentsPerCVE mocks base method.
+func (m *MockCveView) CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountComponentsPerCVE", ctx, q)
+	ret0, _ := ret[0].(map[string]int32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountComponentsPerCVE indicates an expected call of CountComponentsPerCVE.
+func (mr *MockCveViewMockRecorder) CountComponentsPerCVE(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountComponentsPerCVE", reflect.TypeOf((*MockCveView)(nil).CountComponentsPerCVE), ctx, q)
 }
 
 // Get mocks base method.

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -425,6 +425,170 @@ func (mr *MockCveViewMockRecorder) GetVMIDs(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMIDs", reflect.TypeOf((*MockCveView)(nil).GetVMIDs), ctx, q)
 }
 
+// MockCVEForVMCore is a mock of CVEForVMCore interface.
+type MockCVEForVMCore struct {
+	ctrl     *gomock.Controller
+	recorder *MockCVEForVMCoreMockRecorder
+	isgomock struct{}
+}
+
+// MockCVEForVMCoreMockRecorder is the mock recorder for MockCVEForVMCore.
+type MockCVEForVMCoreMockRecorder struct {
+	mock *MockCVEForVMCore
+}
+
+// NewMockCVEForVMCore creates a new mock instance.
+func NewMockCVEForVMCore(ctrl *gomock.Controller) *MockCVEForVMCore {
+	mock := &MockCVEForVMCore{ctrl: ctrl}
+	mock.recorder = &MockCVEForVMCoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCVEForVMCore) EXPECT() *MockCVEForVMCoreMockRecorder {
+	return m.recorder
+}
+
+// GetAdvisoryLink mocks base method.
+func (m *MockCVEForVMCore) GetAdvisoryLink() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdvisoryLink")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAdvisoryLink indicates an expected call of GetAdvisoryLink.
+func (mr *MockCVEForVMCoreMockRecorder) GetAdvisoryLink() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvisoryLink", reflect.TypeOf((*MockCVEForVMCore)(nil).GetAdvisoryLink))
+}
+
+// GetAdvisoryName mocks base method.
+func (m *MockCVEForVMCore) GetAdvisoryName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdvisoryName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAdvisoryName indicates an expected call of GetAdvisoryName.
+func (mr *MockCVEForVMCoreMockRecorder) GetAdvisoryName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvisoryName", reflect.TypeOf((*MockCVEForVMCore)(nil).GetAdvisoryName))
+}
+
+// GetAffectedComponentCount mocks base method.
+func (m *MockCVEForVMCore) GetAffectedComponentCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAffectedComponentCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetAffectedComponentCount indicates an expected call of GetAffectedComponentCount.
+func (mr *MockCVEForVMCoreMockRecorder) GetAffectedComponentCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAffectedComponentCount", reflect.TypeOf((*MockCVEForVMCore)(nil).GetAffectedComponentCount))
+}
+
+// GetCVE mocks base method.
+func (m *MockCVEForVMCore) GetCVE() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCVE")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetCVE indicates an expected call of GetCVE.
+func (mr *MockCVEForVMCoreMockRecorder) GetCVE() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVE", reflect.TypeOf((*MockCVEForVMCore)(nil).GetCVE))
+}
+
+// GetEPSSProbability mocks base method.
+func (m *MockCVEForVMCore) GetEPSSProbability() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEPSSProbability")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetEPSSProbability indicates an expected call of GetEPSSProbability.
+func (mr *MockCVEForVMCoreMockRecorder) GetEPSSProbability() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEPSSProbability", reflect.TypeOf((*MockCVEForVMCore)(nil).GetEPSSProbability))
+}
+
+// GetIsFixable mocks base method.
+func (m *MockCVEForVMCore) GetIsFixable() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIsFixable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetIsFixable indicates an expected call of GetIsFixable.
+func (mr *MockCVEForVMCoreMockRecorder) GetIsFixable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsFixable", reflect.TypeOf((*MockCVEForVMCore)(nil).GetIsFixable))
+}
+
+// GetMaxCVSS mocks base method.
+func (m *MockCVEForVMCore) GetMaxCVSS() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxCVSS")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetMaxCVSS indicates an expected call of GetMaxCVSS.
+func (mr *MockCVEForVMCoreMockRecorder) GetMaxCVSS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxCVSS", reflect.TypeOf((*MockCVEForVMCore)(nil).GetMaxCVSS))
+}
+
+// GetMaxNVDCVSS mocks base method.
+func (m *MockCVEForVMCore) GetMaxNVDCVSS() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxNVDCVSS")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetMaxNVDCVSS indicates an expected call of GetMaxNVDCVSS.
+func (mr *MockCVEForVMCoreMockRecorder) GetMaxNVDCVSS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxNVDCVSS", reflect.TypeOf((*MockCVEForVMCore)(nil).GetMaxNVDCVSS))
+}
+
+// GetMaxSeverity mocks base method.
+func (m *MockCVEForVMCore) GetMaxSeverity() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxSeverity")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetMaxSeverity indicates an expected call of GetMaxSeverity.
+func (mr *MockCVEForVMCoreMockRecorder) GetMaxSeverity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxSeverity", reflect.TypeOf((*MockCVEForVMCore)(nil).GetMaxSeverity))
+}
+
+// GetPublishDate mocks base method.
+func (m *MockCVEForVMCore) GetPublishDate() *time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublishDate")
+	ret0, _ := ret[0].(*time.Time)
+	return ret0
+}
+
+// GetPublishDate indicates an expected call of GetPublishDate.
+func (mr *MockCVEForVMCoreMockRecorder) GetPublishDate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishDate", reflect.TypeOf((*MockCVEForVMCore)(nil).GetPublishDate))
+}
+
 // MockVMSeverityCounts is a mock of VMSeverityCounts interface.
 type MockVMSeverityCounts struct {
 	ctrl     *gomock.Controller

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -17,7 +17,7 @@ import (
 	common "github.com/stackrox/rox/central/views/common"
 	vmcve "github.com/stackrox/rox/central/views/vmcve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/search"
+	search "github.com/stackrox/rox/pkg/search"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -350,21 +350,6 @@ func (mr *MockCveViewMockRecorder) CountComponentsPerCVE(ctx, q any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountComponentsPerCVE", reflect.TypeOf((*MockCveView)(nil).CountComponentsPerCVE), ctx, q)
 }
 
-// GetCVEsForVM mocks base method.
-func (m *MockCveView) GetCVEsForVM(ctx context.Context, q *v1.Query) ([]vmcve.CVEForVMCore, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCVEsForVM", ctx, q)
-	ret0, _ := ret[0].([]vmcve.CVEForVMCore)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCVEsForVM indicates an expected call of GetCVEsForVM.
-func (mr *MockCveViewMockRecorder) GetCVEsForVM(ctx, q any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEsForVM", reflect.TypeOf((*MockCveView)(nil).GetCVEsForVM), ctx, q)
-}
-
 // Get mocks base method.
 func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, error) {
 	m.ctrl.T.Helper()
@@ -408,6 +393,21 @@ func (m *MockCveView) GetCVEComponents(ctx context.Context, q *v1.Query) ([]vmcv
 func (mr *MockCveViewMockRecorder) GetCVEComponents(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEComponents", reflect.TypeOf((*MockCveView)(nil).GetCVEComponents), ctx, q)
+}
+
+// GetCVEsForVM mocks base method.
+func (m *MockCveView) GetCVEsForVM(ctx context.Context, q *v1.Query) ([]vmcve.CVEForVMCore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCVEsForVM", ctx, q)
+	ret0, _ := ret[0].([]vmcve.CVEForVMCore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCVEsForVM indicates an expected call of GetCVEsForVM.
+func (mr *MockCveViewMockRecorder) GetCVEsForVM(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEsForVM", reflect.TypeOf((*MockCveView)(nil).GetCVEsForVM), ctx, q)
 }
 
 // GetVMIDs mocks base method.

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -335,21 +335,6 @@ func (mr *MockCveViewMockRecorder) CountBySeverityPerVM(ctx, q any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverityPerVM", reflect.TypeOf((*MockCveView)(nil).CountBySeverityPerVM), ctx, q)
 }
 
-// CountComponentsPerCVE mocks base method.
-func (m *MockCveView) CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountComponentsPerCVE", ctx, q)
-	ret0, _ := ret[0].(map[string]int32)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CountComponentsPerCVE indicates an expected call of CountComponentsPerCVE.
-func (mr *MockCveViewMockRecorder) CountComponentsPerCVE(ctx, q any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountComponentsPerCVE", reflect.TypeOf((*MockCveView)(nil).CountComponentsPerCVE), ctx, q)
-}
-
 // Get mocks base method.
 func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, error) {
 	m.ctrl.T.Helper()

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -449,34 +449,6 @@ func (m *MockCVEForVMCore) EXPECT() *MockCVEForVMCoreMockRecorder {
 	return m.recorder
 }
 
-// GetAdvisoryLink mocks base method.
-func (m *MockCVEForVMCore) GetAdvisoryLink() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAdvisoryLink")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetAdvisoryLink indicates an expected call of GetAdvisoryLink.
-func (mr *MockCVEForVMCoreMockRecorder) GetAdvisoryLink() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvisoryLink", reflect.TypeOf((*MockCVEForVMCore)(nil).GetAdvisoryLink))
-}
-
-// GetAdvisoryName mocks base method.
-func (m *MockCVEForVMCore) GetAdvisoryName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAdvisoryName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetAdvisoryName indicates an expected call of GetAdvisoryName.
-func (mr *MockCVEForVMCoreMockRecorder) GetAdvisoryName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvisoryName", reflect.TypeOf((*MockCVEForVMCore)(nil).GetAdvisoryName))
-}
-
 // GetAffectedComponentCount mocks base method.
 func (m *MockCVEForVMCore) GetAffectedComponentCount() int {
 	m.ctrl.T.Helper()

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -350,6 +350,21 @@ func (mr *MockCveViewMockRecorder) CountComponentsPerCVE(ctx, q any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountComponentsPerCVE", reflect.TypeOf((*MockCveView)(nil).CountComponentsPerCVE), ctx, q)
 }
 
+// GetCVEsForVM mocks base method.
+func (m *MockCveView) GetCVEsForVM(ctx context.Context, q *v1.Query) ([]vmcve.CVEForVMCore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCVEsForVM", ctx, q)
+	ret0, _ := ret[0].([]vmcve.CVEForVMCore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCVEsForVM indicates an expected call of GetCVEsForVM.
+func (mr *MockCveViewMockRecorder) GetCVEsForVM(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEsForVM", reflect.TypeOf((*MockCveView)(nil).GetCVEsForVM), ctx, q)
+}
+
 // Get mocks base method.
 func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, error) {
 	m.ctrl.T.Helper()

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -49,6 +49,21 @@ type CveView interface {
 	GetAffectedVMs(ctx context.Context, q *v1.Query) ([]AffectedVMCore, error)
 	CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error)
 	CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error)
+	GetCVEsForVM(ctx context.Context, q *v1.Query) ([]CVEForVMCore, error)
+}
+
+// CVEForVMCore provides per-CVE aggregation scoped to a single VM.
+type CVEForVMCore interface {
+	GetCVE() string
+	GetMaxSeverity() int32
+	GetIsFixable() bool
+	GetMaxCVSS() float32
+	GetMaxNVDCVSS() float32
+	GetEPSSProbability() float32
+	GetAffectedComponentCount() int
+	GetPublishDate() *time.Time
+	GetAdvisoryName() string
+	GetAdvisoryLink() string
 }
 
 // VMSeverityCounts provides per-VM severity counts.

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/search"
 )
 
 // CveCore is an interface to get VM CVE properties.
@@ -40,13 +41,14 @@ type CVEComponentCore interface {
 //go:generate mockgen-wrapper
 type CveView interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
-	CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error)
+	CountBySeverity(ctx context.Context, q *v1.Query, countOn search.FieldLabel) (common.ResourceCountByCVESeverity, error)
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 	GetVMIDs(ctx context.Context, q *v1.Query) ([]string, error)
 	GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error)
 	CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]VMSeverityCounts, error)
 	GetAffectedVMs(ctx context.Context, q *v1.Query) ([]AffectedVMCore, error)
 	CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error)
+	CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error)
 }
 
 // VMSeverityCounts provides per-VM severity counts.

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -62,8 +62,6 @@ type CVEForVMCore interface {
 	GetEPSSProbability() float32
 	GetAffectedComponentCount() int
 	GetPublishDate() *time.Time
-	GetAdvisoryName() string
-	GetAdvisoryLink() string
 }
 
 // VMSeverityCounts provides per-VM severity counts.

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -48,7 +48,6 @@ type CveView interface {
 	CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]VMSeverityCounts, error)
 	GetAffectedVMs(ctx context.Context, q *v1.Query) ([]AffectedVMCore, error)
 	CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error)
-	CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error)
 	GetCVEsForVM(ctx context.Context, q *v1.Query) ([]CVEForVMCore, error)
 }
 

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -35,7 +35,7 @@ func (v *vmCVECoreViewImpl) Count(ctx context.Context, q *v1.Query) (int, error)
 	return pgSearch.RunDistinctCountForSchema(queryCtx, v.db, v.schema, q, search.CVE)
 }
 
-func (v *vmCVECoreViewImpl) CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error) {
+func (v *vmCVECoreViewImpl) CountBySeverity(ctx context.Context, q *v1.Query, countOn search.FieldLabel) (common.ResourceCountByCVESeverity, error) {
 	if err := common.ValidateQuery(q); err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (v *vmCVECoreViewImpl) CountBySeverity(ctx context.Context, q *v1.Query) (c
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
-	result, err := pgSearch.RunSelectOneForSchema[resourceCountByVMCVESeverity](queryCtx, v.db, v.schema, common.WithCountBySeverityAndFixabilityQuery(q, search.VirtualMachineID))
+	result, err := pgSearch.RunSelectOneForSchema[resourceCountByVMCVESeverity](queryCtx, v.db, v.schema, common.WithCountBySeverityAndFixabilityQuery(q, countOn))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (v *vmCVECoreViewImpl) CountBySeverityPerVM(ctx context.Context, q *v1.Quer
 		return nil, err
 	}
 
-	cloned := common.WithCountBySeverityAndFixabilityQuery(q, search.VirtualMachineID)
+	cloned := common.WithCountBySeverityAndFixabilityQuery(q, search.CVE)
 	cloned.Selects = append([]*v1.QuerySelect{
 		search.NewQuerySelect(search.VirtualMachineID).Proto(),
 	}, cloned.GetSelects()...)
@@ -190,6 +190,30 @@ func (v *vmCVECoreViewImpl) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]
 		return nil, err
 	}
 	return ret, nil
+}
+
+func (v *vmCVECoreViewImpl) CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error) {
+	cloned := q.CloneVT()
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(search.CVE).Proto(),
+		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{search.CVE.String()},
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	result := make(map[string]int32)
+	err := pgSearch.RunSelectRequestForSchemaFn[cveComponentCountResponse](queryCtx, v.db, v.schema, cloned, func(r *cveComponentCountResponse) error {
+		result[r.CVE] = int32(r.ComponentCount)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func (v *vmCVECoreViewImpl) GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error) {

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -192,30 +192,6 @@ func (v *vmCVECoreViewImpl) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]
 	return ret, nil
 }
 
-func (v *vmCVECoreViewImpl) CountComponentsPerCVE(ctx context.Context, q *v1.Query) (map[string]int32, error) {
-	cloned := q.CloneVT()
-	cloned.Selects = []*v1.QuerySelect{
-		search.NewQuerySelect(search.CVE).Proto(),
-		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
-	}
-	cloned.GroupBy = &v1.QueryGroupBy{
-		Fields: []string{search.CVE.String()},
-	}
-
-	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
-	defer cancel()
-
-	result := make(map[string]int32)
-	err := pgSearch.RunSelectRequestForSchemaFn[cveComponentCountResponse](queryCtx, v.db, v.schema, cloned, func(r *cveComponentCountResponse) error {
-		result[r.CVE] = int32(r.ComponentCount)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
 func (v *vmCVECoreViewImpl) GetCVEsForVM(ctx context.Context, q *v1.Query) ([]CVEForVMCore, error) {
 	if err := common.ValidateQuery(q); err != nil {
 		return nil, err

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -216,6 +216,50 @@ func (v *vmCVECoreViewImpl) CountComponentsPerCVE(ctx context.Context, q *v1.Que
 	return result, nil
 }
 
+func (v *vmCVECoreViewImpl) GetCVEsForVM(ctx context.Context, q *v1.Query) ([]CVEForVMCore, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return nil, err
+	}
+
+	cloned := q.CloneVT()
+	cloned = common.UpdateSortAggs(cloned)
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(search.CVE).Proto(),
+		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.Fixable).AggrFunc(aggregatefunc.Count).
+			Filter("fixable_count",
+				search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.CVSS).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.NVDCVSS).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.EPSSProbablity).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+		search.NewQuerySelect(search.CVEPublishedOn).AggrFunc(aggregatefunc.Min).Proto(),
+		search.NewQuerySelect(search.AdvisoryName).Proto(),
+		search.NewQuerySelect(search.AdvisoryLink).Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{
+			search.CVE.String(),
+			search.AdvisoryName.String(),
+			search.AdvisoryLink.String(),
+		},
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	var ret []CVEForVMCore
+	err := pgSearch.RunSelectRequestForSchemaFn[cveForVMResponse](queryCtx, v.db, v.schema, cloned, func(r *cveForVMResponse) error {
+		ret = append(ret, r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (v *vmCVECoreViewImpl) GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error) {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -235,15 +235,9 @@ func (v *vmCVECoreViewImpl) GetCVEsForVM(ctx context.Context, q *v1.Query) ([]CV
 		search.NewQuerySelect(search.EPSSProbablity).AggrFunc(aggregatefunc.Max).Proto(),
 		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
 		search.NewQuerySelect(search.CVEPublishedOn).AggrFunc(aggregatefunc.Min).Proto(),
-		search.NewQuerySelect(search.AdvisoryName).Proto(),
-		search.NewQuerySelect(search.AdvisoryLink).Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
-		Fields: []string{
-			search.CVE.String(),
-			search.AdvisoryName.String(),
-			search.AdvisoryLink.String(),
-		},
+		Fields: []string{search.CVE.String()},
 	}
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -375,11 +375,11 @@ func (s *serviceImpl) ListVMCVEsByVM(ctx context.Context, request *v2.ListVMCVEs
 		if meta, ok := metadataByID[cve.GetCVE()]; ok {
 			row.Summary = meta.GetCveBaseInfo().GetSummary()
 			row.Link = meta.GetCveBaseInfo().GetLink()
-		}
-		if cve.GetAdvisoryName() != "" {
-			row.Advisory = &v2.Advisory{
-				Name: cve.GetAdvisoryName(),
-				Link: cve.GetAdvisoryLink(),
+			if adv := meta.GetAdvisory(); adv != nil && adv.GetName() != "" {
+				row.Advisory = &v2.Advisory{
+					Name: adv.GetName(),
+					Link: adv.GetLink(),
+				}
 			}
 		}
 		items = append(items, row)

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -339,26 +339,49 @@ func (s *serviceImpl) ListVMCVEsByVM(ctx context.Context, request *v2.ListVMCVEs
 
 	countQuery := searchQuery.CloneVT()
 	countQuery.Pagination = nil
-	totalCount, err := s.cveDS.Count(ctx, countQuery)
+	totalCount, err := s.cveView.Count(ctx, countQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	cves, err := s.cveDS.SearchRawVMCVEs(ctx, searchQuery)
+	cves, err := s.cveView.GetCVEsForVM(ctx, searchQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	componentCountFilter := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, request.GetVmId()).ProtoQuery()
-	componentCounts, err := s.cveView.CountComponentsPerCVE(ctx, componentCountFilter)
+	// Fetch one raw storage row per CVE for metadata not available through
+	// the view (summary, link). These are stored in the serialized blob.
+	cveIDs := make([]string, 0, len(cves))
+	for _, cve := range cves {
+		cveIDs = append(cveIDs, cve.GetCVE())
+	}
+	metadataByID, err := s.fetchCVEMetadata(ctx, request.GetVmId(), cveIDs)
 	if err != nil {
 		return nil, err
 	}
 
 	items := make([]*v2.VMCVERow, 0, len(cves))
 	for _, cve := range cves {
-		row := storagetov2.VirtualMachineCVEV2ToRow(cve)
-		row.AffectedComponentCount = componentCounts[cve.GetCveBaseInfo().GetCve()]
+		row := &v2.VMCVERow{
+			Cve:                    cve.GetCVE(),
+			Severity:               v2.VulnerabilitySeverity(cve.GetMaxSeverity()),
+			IsFixable:              cve.GetIsFixable(),
+			Cvss:                   cve.GetMaxCVSS(),
+			NvdCvss:                cve.GetMaxNVDCVSS(),
+			EpssProbability:        cve.GetEPSSProbability(),
+			AffectedComponentCount: int32(cve.GetAffectedComponentCount()),
+			PublishedOn:            protocompat.ConvertTimeToTimestampOrNil(cve.GetPublishDate()),
+		}
+		if meta, ok := metadataByID[cve.GetCVE()]; ok {
+			row.Summary = meta.GetCveBaseInfo().GetSummary()
+			row.Link = meta.GetCveBaseInfo().GetLink()
+		}
+		if cve.GetAdvisoryName() != "" {
+			row.Advisory = &v2.Advisory{
+				Name: cve.GetAdvisoryName(),
+				Link: cve.GetAdvisoryLink(),
+			}
+		}
 		items = append(items, row)
 	}
 
@@ -366,6 +389,30 @@ func (s *serviceImpl) ListVMCVEsByVM(ctx context.Context, request *v2.ListVMCVEs
 		Cves:       items,
 		TotalCount: int32(totalCount),
 	}, nil
+}
+
+// fetchCVEMetadata fetches one raw storage row per CVE for metadata fields
+// (summary, link) that aren't available through the SQL view.
+func (s *serviceImpl) fetchCVEMetadata(ctx context.Context, vmID string, cveIDs []string) (map[string]*storage.VirtualMachineCVEV2, error) {
+	if len(cveIDs) == 0 {
+		return nil, nil
+	}
+	q := search.ConjunctionQuery(
+		search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, vmID).ProtoQuery(),
+		search.NewQueryBuilder().AddExactMatches(search.CVE, cveIDs...).ProtoQuery(),
+	)
+	rows, err := s.cveDS.SearchRawVMCVEs(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*storage.VirtualMachineCVEV2, len(cveIDs))
+	for _, row := range rows {
+		cveID := row.GetCveBaseInfo().GetCve()
+		if _, exists := result[cveID]; !exists {
+			result[cveID] = row
+		}
+	}
+	return result, nil
 }
 
 // GetVMCVEComponents returns components affected by a specific CVE on a specific VM.

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -303,7 +303,7 @@ func (s *serviceImpl) GetVMVulnSummary(ctx context.Context, request *v2.GetVMVul
 		vmFilter = search.ConjunctionQuery(vmFilter, additionalQuery)
 	}
 
-	severityCounts, err := s.cveView.CountBySeverity(ctx, vmFilter)
+	severityCounts, err := s.cveView.CountBySeverity(ctx, vmFilter, search.CVE)
 	if err != nil {
 		return nil, err
 	}
@@ -349,9 +349,17 @@ func (s *serviceImpl) ListVMCVEsByVM(ctx context.Context, request *v2.ListVMCVEs
 		return nil, err
 	}
 
+	componentCountFilter := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, request.GetVmId()).ProtoQuery()
+	componentCounts, err := s.cveView.CountComponentsPerCVE(ctx, componentCountFilter)
+	if err != nil {
+		return nil, err
+	}
+
 	items := make([]*v2.VMCVERow, 0, len(cves))
 	for _, cve := range cves {
-		items = append(items, storagetov2.VirtualMachineCVEV2ToRow(cve))
+		row := storagetov2.VirtualMachineCVEV2ToRow(cve)
+		row.AffectedComponentCount = componentCounts[cve.GetCveBaseInfo().GetCve()]
+		items = append(items, row)
 	}
 
 	return &v2.ListVMCVEsByVMResponse{
@@ -486,7 +494,7 @@ func (s *serviceImpl) GetVMCVEDetail(ctx context.Context, request *v2.GetVMCVEDe
 		viewFilter = search.ConjunctionQuery(viewFilter, additionalQuery)
 	}
 
-	severityCounts, err := s.cveView.CountBySeverity(ctx, viewFilter)
+	severityCounts, err := s.cveView.CountBySeverity(ctx, viewFilter, search.VirtualMachineID)
 	if err != nil {
 		return nil, err
 	}

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -25,28 +25,28 @@ import (
 )
 
 type testCVEForVM struct {
-	cve            string
-	maxSeverity    int32
-	isFixable      bool
-	maxCVSS        float32
-	maxNVDCVSS     float32
+	cve             string
+	maxSeverity     int32
+	isFixable       bool
+	maxCVSS         float32
+	maxNVDCVSS      float32
 	epssProbability float32
-	componentCount int
-	publishDate    *time.Time
-	advisoryName   string
-	advisoryLink   string
+	componentCount  int
+	publishDate     *time.Time
+	advisoryName    string
+	advisoryLink    string
 }
 
-func (t *testCVEForVM) GetCVE() string                  { return t.cve }
-func (t *testCVEForVM) GetMaxSeverity() int32            { return t.maxSeverity }
-func (t *testCVEForVM) GetIsFixable() bool               { return t.isFixable }
-func (t *testCVEForVM) GetMaxCVSS() float32              { return t.maxCVSS }
-func (t *testCVEForVM) GetMaxNVDCVSS() float32           { return t.maxNVDCVSS }
-func (t *testCVEForVM) GetEPSSProbability() float32      { return t.epssProbability }
-func (t *testCVEForVM) GetAffectedComponentCount() int   { return t.componentCount }
-func (t *testCVEForVM) GetPublishDate() *time.Time       { return t.publishDate }
-func (t *testCVEForVM) GetAdvisoryName() string          { return t.advisoryName }
-func (t *testCVEForVM) GetAdvisoryLink() string          { return t.advisoryLink }
+func (t *testCVEForVM) GetCVE() string                 { return t.cve }
+func (t *testCVEForVM) GetMaxSeverity() int32          { return t.maxSeverity }
+func (t *testCVEForVM) GetIsFixable() bool             { return t.isFixable }
+func (t *testCVEForVM) GetMaxCVSS() float32            { return t.maxCVSS }
+func (t *testCVEForVM) GetMaxNVDCVSS() float32         { return t.maxNVDCVSS }
+func (t *testCVEForVM) GetEPSSProbability() float32    { return t.epssProbability }
+func (t *testCVEForVM) GetAffectedComponentCount() int { return t.componentCount }
+func (t *testCVEForVM) GetPublishDate() *time.Time     { return t.publishDate }
+func (t *testCVEForVM) GetAdvisoryName() string        { return t.advisoryName }
+func (t *testCVEForVM) GetAdvisoryLink() string        { return t.advisoryLink }
 
 func TestAuthz(t *testing.T) {
 	testutils.AssertAuthzWorks(t, &serviceImpl{})

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -33,8 +33,6 @@ type testCVEForVM struct {
 	epssProbability float32
 	componentCount  int
 	publishDate     *time.Time
-	advisoryName    string
-	advisoryLink    string
 }
 
 func (t *testCVEForVM) GetCVE() string                 { return t.cve }
@@ -45,8 +43,6 @@ func (t *testCVEForVM) GetMaxNVDCVSS() float32         { return t.maxNVDCVSS }
 func (t *testCVEForVM) GetEPSSProbability() float32    { return t.epssProbability }
 func (t *testCVEForVM) GetAffectedComponentCount() int { return t.componentCount }
 func (t *testCVEForVM) GetPublishDate() *time.Time     { return t.publishDate }
-func (t *testCVEForVM) GetAdvisoryName() string        { return t.advisoryName }
-func (t *testCVEForVM) GetAdvisoryLink() string        { return t.advisoryLink }
 
 func TestAuthz(t *testing.T) {
 	testutils.AssertAuthzWorks(t, &serviceImpl{})

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stackrox/rox/central/convert/storagetov2"
 	commonViews "github.com/stackrox/rox/central/views/common"
@@ -22,6 +23,30 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+type testCVEForVM struct {
+	cve            string
+	maxSeverity    int32
+	isFixable      bool
+	maxCVSS        float32
+	maxNVDCVSS     float32
+	epssProbability float32
+	componentCount int
+	publishDate    *time.Time
+	advisoryName   string
+	advisoryLink   string
+}
+
+func (t *testCVEForVM) GetCVE() string                  { return t.cve }
+func (t *testCVEForVM) GetMaxSeverity() int32            { return t.maxSeverity }
+func (t *testCVEForVM) GetIsFixable() bool               { return t.isFixable }
+func (t *testCVEForVM) GetMaxCVSS() float32              { return t.maxCVSS }
+func (t *testCVEForVM) GetMaxNVDCVSS() float32           { return t.maxNVDCVSS }
+func (t *testCVEForVM) GetEPSSProbability() float32      { return t.epssProbability }
+func (t *testCVEForVM) GetAffectedComponentCount() int   { return t.componentCount }
+func (t *testCVEForVM) GetPublishDate() *time.Time       { return t.publishDate }
+func (t *testCVEForVM) GetAdvisoryName() string          { return t.advisoryName }
+func (t *testCVEForVM) GetAdvisoryLink() string          { return t.advisoryLink }
 
 func TestAuthz(t *testing.T) {
 	testutils.AssertAuthzWorks(t, &serviceImpl{})
@@ -189,7 +214,7 @@ func TestGetVMVulnSummary(t *testing.T) {
 func TestListVMCVEsByVM(t *testing.T) {
 	ctx := context.Background()
 
-	cve1 := &storage.VirtualMachineCVEV2{
+	cve1Raw := &storage.VirtualMachineCVEV2{
 		Id:            "cve-uuid-1",
 		VmV2Id:        "vm-1",
 		VmComponentId: "comp-1",
@@ -202,6 +227,14 @@ func TestListVMCVEsByVM(t *testing.T) {
 		Severity:        storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
 		IsFixable:       true,
 		EpssProbability: 0.5,
+	}
+
+	cve1View := &testCVEForVM{
+		cve:            "CVE-2024-1234",
+		maxSeverity:    int32(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY),
+		isFixable:      true,
+		maxCVSS:        7.5,
+		componentCount: 3,
 	}
 
 	tests := map[string]struct {
@@ -231,9 +264,9 @@ func TestListVMCVEsByVM(t *testing.T) {
 				VmId: fixtureconsts.VirtualMachine1,
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
-				mockCVE.EXPECT().Count(ctx, gomock.Any()).Return(1, nil)
-				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountComponentsPerCVE(ctx, gomock.Any()).Return(map[string]int32{"CVE-2024-1234": 3}, nil)
+				mockView.EXPECT().Count(ctx, gomock.Any()).Return(1, nil)
+				mockView.EXPECT().GetCVEsForVM(ctx, gomock.Any()).Return([]vmcve.CVEForVMCore{cve1View}, nil)
+				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1Raw}, nil)
 			},
 			expectedCount: 1,
 		},
@@ -275,6 +308,9 @@ func TestListVMCVEsByVM(t *testing.T) {
 					assert.Equal(t, v2.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, row.GetSeverity())
 					assert.True(t, row.GetIsFixable())
 					assert.Equal(t, float32(7.5), row.GetCvss())
+					assert.Equal(t, int32(3), row.GetAffectedComponentCount())
+					assert.Equal(t, "test vuln 1", row.GetSummary())
+					assert.Equal(t, "https://example.com/1", row.GetLink())
 				}
 			}
 		})

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -155,7 +156,7 @@ func TestGetVMVulnSummary(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), search.CVE).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount:         2,
 					FixableCriticalSeverityCount:  1,
 					ImportantSeverityCount:        3,
@@ -574,7 +575,7 @@ func TestGetVMCVEDetail(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), search.VirtualMachineID).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount: 2,
 				}, nil)
 				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return([]string{"vm-1"}, nil)
@@ -591,7 +592,7 @@ func TestGetVMCVEDetail(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), search.VirtualMachineID).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount: 2,
 				}, nil)
 				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return([]string{"vm-1"}, nil)
@@ -616,7 +617,7 @@ func TestGetVMCVEDetail(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{}, nil)
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), search.VirtualMachineID).Return(&commonViews.ResourceCountByImageCVESeverity{}, nil)
 				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return(nil, nil)
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(5, nil)
 			},

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -134,7 +134,7 @@ func TestGetVMVulnSummary(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount:         2,
 					FixableCriticalSeverityCount:  1,
 					ImportantSeverityCount:        3,
@@ -233,6 +233,7 @@ func TestListVMCVEsByVM(t *testing.T) {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().Count(ctx, gomock.Any()).Return(1, nil)
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
+				mockView.EXPECT().CountComponentsPerCVE(ctx, gomock.Any()).Return(map[string]int32{"CVE-2024-1234": 3}, nil)
 			},
 			expectedCount: 1,
 		},
@@ -541,7 +542,7 @@ func TestGetVMCVEDetail(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount: 2,
 				}, nil)
 				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return([]string{"vm-1"}, nil)
@@ -558,7 +559,7 @@ func TestGetVMCVEDetail(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount: 2,
 				}, nil)
 				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return([]string{"vm-1"}, nil)
@@ -583,7 +584,7 @@ func TestGetVMCVEDetail(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{}, nil)
+				mockView.EXPECT().CountBySeverity(ctx, gomock.Any(), gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{}, nil)
 				mockView.EXPECT().GetVMIDs(ctx, gomock.Any()).Return(nil, nil)
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(5, nil)
 			},


### PR DESCRIPTION
## Description

Fixes four bugs in the VM vulnerability API endpoints:

1. **Severity counts capped at 0/1** (`GetVMVulnSummary`, `ListVMs`): `CountBySeverity` and `CountBySeverityPerVM` used `COUNT(DISTINCT virtual_machine_id)` for all contexts. When filtered to a single VM or grouped per-VM, each severity bucket could only be 0 or 1. Fixed by parameterizing `CountBySeverity` with a `countOn` field — callers now pass `search.CVE` (count CVEs per VM) or `search.VirtualMachineID` (count VMs per CVE) as appropriate. `CountBySeverityPerVM` was similarly changed to count distinct CVEs.

2. **`GetVMCVEDetail` severity counts** were already semantically correct (counting VMs per CVE), but now explicitly pass `search.VirtualMachineID` via the new parameter.

3. **`ListVMCVEsByVM` returning 0 affected components**: The `VMCVERow` proto has an `affected_component_count` field that was never populated. Added `CountComponentsPerCVE` to the view and wired it into the endpoint.
4. **`convertCVEBaseInfo` never populated EPSS**: Previously, it never populated the Epss field on CVEInfo, so that column was always 0 in the database. The denormalized top-level column had the real data, but the search never queried it.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Updated existing unit tests to match the new `CountBySeverity` signature and the new `CountComponentsPerCVE` call
- Verified the fix matches the pattern used by the image CVE and node CVE views (`imagecve/view_impl.go`, `nodecve/view_impl.go`) which correctly count distinct CVEs
- Manual code review of generated SQL semantics: `COUNT(DISTINCT cve) FILTER (WHERE severity = ...)` grouped by VM gives correct per-VM CVE counts