### PR TITLE
WIP: ROX-36462: Add helm-hook_storage annotations to scannerV4 DB resources

### DIFF
--- a/image/templates/helm/shared/templates/02-scanner-v4-06-db-pvc.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-06-db-pvc.yaml
@@ -23,7 +23,9 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "persistentvolume" $pvName) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "persistentvolume" $pvName) | nindent 4 }}
+    {{ - $annotations := dict - }}
+    {{ - $_ := include "srox.getAnnotationTemplate" (list . "helm-hook_storage" $annotations) - }}
+    {{- include "srox.annotations" (list . "persistentvolume" $pvName $annotations) | nindent 4 }}
 spec:
   {{- if $storageClassName }}
   storageClassName: {{ $storageClassName }}
@@ -51,7 +53,9 @@ metadata:
     {{- $labels := dict "target.pvc.stackrox.io" "scanner-v4-db" -}}
     {{- include "srox.labels" (list . "persistentvolumeclaim" "scanner-v4-db" $labels) | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "persistentvolumeclaim" "scanner-v4-db") | nindent 4 }}
+    {{ - $annotations := dict - }}
+    {{- $_ := include "srox.getAnnotationTemplate" (list . "helm-hook_storage" $annotations) -}}
+    {{- include "srox.annotations" (list . "persistentvolumeclaim" "scanner-v4-db" $annotations) | nindent 4 }}
 spec:
   {{- if $storageClassName }}
   storageClassName: {{ $storageClassName }}


### PR DESCRIPTION
## Description

Two related operator bugs caused by a missing `helm.sh/resource-policy: keep` annotation on the `scanner-v4-db` PVC template.

### Bug 1: Operator tries to shrink scanner-v4-db PVC on upgrade

The scanner-v4-db PVC is managed by Helm's default lifecycle (unlike central-db which uses ReconcilePVCExtension). The Helm chart has a hardcoded default of `50Gi` for `scanner-v4-db`. On upgrade, if the existing PVC is larger than `50Gi` and the Central CR does not explicitly set a size, Helm applies its template and tries to shrink the PVC. Kubernetes rejects this with:
```
spec.resources.requests.storage: Forbidden: field can not be less than previous value
```
This causes the Helm upgrade to fail, leaving ACS in a broken state.

### Bug 2: Helm rollback also fails after upgrade failure

When the upgrade fails, Helm automatically attempts to rollback to the previous release. The rollback also fails because the stored Helm release manifest (from the previous install) contains the PVC template with volumeName: "" and storageClassName: nil — fields that Kubernetes filled in dynamically at bind time. Applying that template clears those fields, which violates PVC immutability:
```
spec: Forbidden: spec is immutable after creation except resources.requests
- VolumeName: "pvc-..."
+ VolumeName: ""
- StorageClassName: &"thin-csi"
+ StorageClassName: nil
```
The result is the operator stuck in an infinite upgrade→fail→rollback→fail loop.

### Root Cause

`scanner-v4-db` PVC template (`02-scanner-v4-06-db-pvc.yaml`) is missing the `helm-hook_storage` annotation template that `central-db` has:
```
helm.sh/hook: pre-install,pre-upgrade
helm.sh/resource-policy: keep        ← prevents Helm from modifying existing PVC
helm.sh/hook-delete-policy: never
```
### Fix

Add the `helm-hook_storage` annotation to the `scanner-v4-db` PVC template in `image/templates/helm/shared/templates/02-scanner-v4-06-db-pvc.yaml`, identical to how it is done in `01-central-11-db-pvc.yaml`.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
E2E tests
