### PR TITLE
ROX-36598: use empty trusted root for sigstore bundle verification wh…

### DIFF
--- a/pkg/signatures/cosign_sig_verifier.go
+++ b/pkg/signatures/cosign_sig_verifier.go
@@ -564,9 +564,13 @@ func verifySigstoreBundle(ctx context.Context, sigstoreBundle []byte,
 ) ([]string, error) {
 	if cosignOpts.TrustedMaterial == nil {
 		var err error
-		cosignOpts.TrustedMaterial, err = sigstoreTrustedRoot()
+		if cosignOpts.IgnoreTlog {
+			cosignOpts.TrustedMaterial, err = root.NewTrustedRoot(root.TrustedRootMediaType01, nil, nil, nil, nil)
+		} else {
+			cosignOpts.TrustedMaterial, err = sigstoreTrustedRoot()
+		}
 		if err != nil {
-			return nil, fmt.Errorf("loading fallback trusted material for bundle verification: %w", err)
+			return nil, fmt.Errorf("loading trusted material for bundle verification: %w", err)
 		}
 	}
 


### PR DESCRIPTION
…en tlog is disabled

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When verifying referrer-based sigstore bundles with a public key and transparency log verification disabled, `TrustedMaterial` on the verifier opts is `nil`. `verifySigstoreBundle` fell back to downloading the public Sigstore TUF root, which is both unreliable in CI and semantically wrong for key-based verification without tlog.

Build an empty `TrustedRoot` instead when tlog is disabled. The Sigstore TUF root fallback is preserved for cases where tlog is enabled but no custom Rekor keys are configured.

This should fix the test failures observed in https://redhat.atlassian.net/browse/ROX-36598

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The oci referrer signature signed by public key test case is now green.