### PR TITLE
ROX-36595: Use jobs an plural noun for view-based reports

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsLayout.tsx
@@ -46,7 +46,7 @@ function NodeVulnerabilityReportsLayout() {
                     )}
                     <Tab
                         eventKey="view-based-jobs"
-                        title="View-based reports"
+                        title="View-based jobs"
                         tabContentId="view-based-jobs-tab-content"
                     />
                 </Tabs>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTab.tsx
@@ -146,11 +146,11 @@ function ViewBasedReportsTab() {
 
     return (
         <>
-            <PageTitle title="Image vulnerability reports - View-based reports" />
+            <PageTitle title="Image vulnerability reports - View-based jobs" />
             <PageSection>
                 <Content component="p">
-                    Check job status and download view-based reports in CSV format. Requests are
-                    purged according to retention settings.
+                    Check job status and download view-based reports in CSV format. Jobs are purged
+                    according to retention settings.
                 </Content>
             </PageSection>
             <PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTable.tsx
@@ -93,10 +93,10 @@ function ViewBasedReportsTable<T extends ViewBasedReportSnapshot>({
 
     return (
         <>
-            <Table aria-label="View-based reports table">
+            <Table aria-label="View-based jobs table">
                 <Thead>
                     <Tr>
-                        <Th width={20}>Request name</Th>
+                        <Th width={20}>Job ID</Th>
                         <Th>Requester</Th>
                         <Th>Job status</Th>
                         <Th sort={getSortParams('Report Completion Time')}>Completed</Th>
@@ -119,7 +119,7 @@ function ViewBasedReportsTable<T extends ViewBasedReportSnapshot>({
                             return (
                                 <Tbody key={reportJobId}>
                                     <Tr>
-                                        <Td dataLabel="Request name">
+                                        <Td dataLabel="Job ID">
                                             <Button
                                                 variant="link"
                                                 isInline

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -27,8 +27,8 @@ function VulnReportingLayout() {
               ]
             : []),
         {
-            id: 'view-based-reports',
-            title: 'View-based reports',
+            id: 'view-based-jobs',
+            title: 'View-based jobs',
             path: vulnerabilityViewBasedJobsPath,
             content: <ViewBasedReportsTab />,
         },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateViewBasedReportModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateViewBasedReportModal.tsx
@@ -103,8 +103,8 @@ function CreateViewBasedReportModal({
             <Flex gap={{ default: 'gapMd' }}>
                 <FlexItem>
                     Generate a CSV report based on this view and the filters you’ve applied. Once
-                    completed, this report will be available in the view-based reports section until
-                    it is purged according to your retention settings.
+                    completed, this report will be available on the View-based jobs tab until it is
+                    purged according to your retention settings.
                 </FlexItem>
                 {message?.type === 'success' && (
                     <Alert


### PR DESCRIPTION
## Description

### Problems

1. `view-based` in page address is adjective instead of plural noun.

2. Although **View-based reports** has a plural noun, it conflates report job, and downloadable file.

3. The page has 2 occurrences of **request** as synonym with **job**.

4. **Request** is a key word in **Exception Management**. In that context, **request** might be approved or denied.

### Analysis

**Brad** and I found `/v2/reports/node/jobs` as service endpoints and occurrences of **Jobs** in visible text for both scheduled and view-based reports.

Integration tests do not refer to **View-based reports** tab.

Docs use **job** as key word. Only impact (noted in Jira issue) is change to tab.

https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.11/html/operating/managing-vulnerabilities#checking-job-status-and-downloading-a-vulnerability-report-in-csv-format_vulnerability-reporting

1. Procedure step 1
    * replace: in the **View-based reports** list
    * with:  in the **View-based jobs** list

2. Procedure step 2
    * replace: the **View-based reports** list
    * with:  the **View-based jobs** list

### Solution

Agreed in cross-team meeting:

1. Replace **Request name** with **Job ID** as table column.
2. Replace **Requests are purged…** with **Jobs are purged…** in sentence following page heading.
3. Replace **View-based reports** with **View-based jobs** as tab.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed because Jira has comment about 2 small changes

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit https://localhost:3000/main/vulnerabilities/reports/images/view-based-jobs?viewOnlyMyJobs=false

    * Before changes, see presence of **Request**
        <img width="1440" height="400" alt="with_Request" src="https://github.com/user-attachments/assets/1f24c0a5-00b4-4f3e-bf76-629755c85d52" />

    * After changes, see absence of **Request**
        <img width="1441" height="400" alt="without_Request" src="https://github.com/user-attachments/assets/558e5374-67fe-4df3-93ff-28d82747b37a" />
