### PR TITLE
ROX-36616: Cover VirtualMachineV2Service for VM in e2e test

### DIFF
--- a/tests/e2e/run-vm-scanning.sh
+++ b/tests/e2e/run-vm-scanning.sh
@@ -30,8 +30,15 @@ test_vm_scanning_e2e() {
 
     if ! ensure_virtctl_binary; then
         if is_CI; then
-            warn "Secure virtctl download failed. Falling back to insecure curl -k download path in CI."
-            ensure_virtctl_binary_insecure
+            if [[ "${_VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP:-0}" != 1 ]]; then
+                warn "Secure virtctl download failed. Falling back to insecure curl -k download path in CI."
+                ensure_virtctl_binary_insecure || true
+            fi
+            if ! command -v virtctl >/dev/null; then
+                warn "Cluster ConsoleCLIDownload did not serve virtctl. Falling back to the matching KubeVirt GitHub release."
+                _install_virtctl_from_kubevirt_release \
+                    || die "Failed to install virtctl from cluster ConsoleCLIDownload and KubeVirt GitHub release"
+            fi
         else
             die "Secure virtctl download failed. Refusing insecure curl -k fallback outside CI. Set VIRTCTL_PATH or fix cluster ingress trust material."
         fi

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -93,28 +93,56 @@ _fetch_cluster_ingress_ca() {
 #          _download_and_install_virtctl -k
 _download_and_install_virtctl() {
     # CI Prow workers are always Linux x86_64 (n2-standard-8 machine type).
-    local download_url
-    download_url="$(oc get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged \
-        -o jsonpath='{.spec.links[?(@.text=="Download virtctl for Linux for x86_64")].href}' 2>/dev/null || true)"
-    if [[ -z "$download_url" ]]; then
-        die "virtctl not found on PATH and ConsoleCLIDownload resource not available"
-    fi
-
     local dest="/usr/local/bin"
     if [[ ! -w "$dest" ]]; then
         dest="$(mktemp -d)"
         export PATH="${dest}:${PATH}"
     fi
 
+    # ConsoleCLIDownload can exist while the ingress backend still serves HTML.
+    # Wait for the href, then retry until the body is a gzip tarball.
+    local download_url=""
+    local attempt=0
+    while (( attempt < 30 )); do
+        attempt=$((attempt + 1))
+        download_url="$(oc get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged \
+            -o jsonpath='{.spec.links[?(@.text=="Download virtctl for Linux for x86_64")].href}' 2>/dev/null || true)"
+        if [[ -n "$download_url" ]]; then
+            break
+        fi
+        info "Waiting for ConsoleCLIDownload virtctl href (${attempt}/30)"
+        sleep 10
+    done
+    if [[ -z "$download_url" ]]; then
+        die "virtctl not found on PATH and ConsoleCLIDownload resource not available"
+    fi
+
+    local cli_deploy="hyperconverged-cluster-cli-download"
+    if oc get deploy -n openshift-cnv "$cli_deploy" >/dev/null 2>&1; then
+        info "Waiting for ${cli_deploy} rollout..."
+        oc rollout status "deploy/${cli_deploy}" -n openshift-cnv --timeout=300s || true
+    fi
+
+    local archive
+    archive="$(mktemp)"
     info "Downloading virtctl from ${download_url}"
-    if ! curl -sSL "$@" "$download_url" | tar xz -C "$dest" virtctl; then
-        die "Failed to download virtctl from ${download_url}"
-    fi
-    if [[ ! -f "${dest}/virtctl" ]]; then
-        die "Downloaded archive from ${download_url} does not contain virtctl"
-    fi
-    chmod +x "${dest}/virtctl"
-    info "virtctl installed at ${dest}/virtctl"
+    attempt=0
+    while (( attempt < 30 )); do
+        attempt=$((attempt + 1))
+        if curl -sSL "$@" -o "$archive" "$download_url" \
+            && gzip -t "$archive" 2>/dev/null \
+            && tar xz -C "$dest" virtctl -f "$archive" \
+            && [[ -f "${dest}/virtctl" ]]; then
+            rm -f "$archive"
+            chmod +x "${dest}/virtctl"
+            info "virtctl installed at ${dest}/virtctl"
+            return 0
+        fi
+        info "virtctl tarball not ready yet (attempt ${attempt}/30), retrying in 10s"
+        sleep 10
+    done
+    rm -f "$archive"
+    die "Failed to download virtctl from ${download_url}"
 }
 
 # Downloads virtctl from ConsoleCLIDownload using verified TLS only.

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -87,14 +87,20 @@ _fetch_cluster_ingress_ca() {
     printf '%s\n' "$ca_bundle"
 }
 
-# Directory to install a downloaded virtctl binary into (PATH is updated when dest is a temp dir).
+# Directory to install a downloaded virtctl binary into.
+# PATH is not updated here: callers invoke this via command substitution, which
+# would discard an export. Call _virtctl_add_install_dir_to_path after assigning dest.
 _virtctl_install_dir() {
     local dest="/usr/local/bin"
     if [[ ! -w "$dest" ]]; then
         dest="$(mktemp -d)"
-        export PATH="${dest}:${PATH}"
     fi
     printf '%s\n' "$dest"
+}
+
+_virtctl_add_install_dir_to_path() {
+    local dest="$1"
+    [[ "$dest" == "/usr/local/bin" ]] || export PATH="${dest}:${PATH}"
 }
 
 # Set to 1 when ConsoleCLIDownload returned a body that was not a gzip tarball.
@@ -110,6 +116,7 @@ _download_and_install_virtctl() {
     # CI Prow workers are always Linux x86_64 (n2-standard-8 machine type).
     local dest
     dest="$(_virtctl_install_dir)"
+    _virtctl_add_install_dir_to_path "$dest"
     _VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP=0
 
     # ConsoleCLIDownload can exist while the ingress backend still serves HTML.
@@ -143,7 +150,7 @@ _download_and_install_virtctl() {
     attempt=0
     while (( attempt < 30 )); do
         attempt=$((attempt + 1))
-        if curl -sSL "$@" -o "$archive" "$download_url"; then
+        if curl -sSL --connect-timeout 30 --max-time 120 "$@" -o "$archive" "$download_url"; then
             if gzip -t "$archive" 2>/dev/null \
                 && tar xz -C "$dest" virtctl -f "$archive" \
                 && [[ -f "${dest}/virtctl" ]]; then
@@ -177,10 +184,11 @@ _install_virtctl_from_kubevirt_release() {
     fi
 
     dest="$(_virtctl_install_dir)"
+    _virtctl_add_install_dir_to_path "$dest"
     url="https://github.com/kubevirt/kubevirt/releases/download/${version}/virtctl-${version}-linux-amd64"
     bin="${dest}/virtctl"
     info "Downloading virtctl ${version} from ${url}"
-    if ! curl -fsSL --retry 5 --retry-delay 5 -o "$bin" "$url"; then
+    if ! curl -fsSL --connect-timeout 30 --max-time 120 --retry 5 --retry-delay 5 -o "$bin" "$url"; then
         warn "GitHub virtctl download failed from ${url}"
         rm -f "$bin"
         return 1

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -87,17 +87,30 @@ _fetch_cluster_ingress_ca() {
     printf '%s\n' "$ca_bundle"
 }
 
-# Downloads and installs virtctl using the provided curl TLS arguments.
-# Usage: _download_and_install_virtctl [curl_tls_args...]
-# Example: _download_and_install_virtctl --cacert /path/to/ca.pem
-#          _download_and_install_virtctl -k
-_download_and_install_virtctl() {
-    # CI Prow workers are always Linux x86_64 (n2-standard-8 machine type).
+# Directory to install a downloaded virtctl binary into (PATH is updated when dest is a temp dir).
+_virtctl_install_dir() {
     local dest="/usr/local/bin"
     if [[ ! -w "$dest" ]]; then
         dest="$(mktemp -d)"
         export PATH="${dest}:${PATH}"
     fi
+    printf '%s\n' "$dest"
+}
+
+# Set to 1 when ConsoleCLIDownload returned a body that was not a gzip tarball.
+# TLS retry (-k) cannot help in that case; callers should skip it.
+_VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP=0
+
+# Downloads and installs virtctl using the provided curl TLS arguments.
+# Returns 1 on failure (does not die) so callers can fall back.
+# Usage: _download_and_install_virtctl [curl_tls_args...]
+# Example: _download_and_install_virtctl --cacert /path/to/ca.pem
+#          _download_and_install_virtctl -k
+_download_and_install_virtctl() {
+    # CI Prow workers are always Linux x86_64 (n2-standard-8 machine type).
+    local dest
+    dest="$(_virtctl_install_dir)"
+    _VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP=0
 
     # ConsoleCLIDownload can exist while the ingress backend still serves HTML.
     # Wait for the href, then retry until the body is a gzip tarball.
@@ -114,7 +127,8 @@ _download_and_install_virtctl() {
         sleep 10
     done
     if [[ -z "$download_url" ]]; then
-        die "virtctl not found on PATH and ConsoleCLIDownload resource not available"
+        warn "virtctl not found on PATH and ConsoleCLIDownload resource not available"
+        return 1
     fi
 
     local cli_deploy="hyperconverged-cluster-cli-download"
@@ -123,36 +137,73 @@ _download_and_install_virtctl() {
         oc rollout status "deploy/${cli_deploy}" -n openshift-cnv --timeout=300s || true
     fi
 
-    local archive
+    local archive saw_nongzip=0
     archive="$(mktemp)"
     info "Downloading virtctl from ${download_url}"
     attempt=0
     while (( attempt < 30 )); do
         attempt=$((attempt + 1))
-        if curl -sSL "$@" -o "$archive" "$download_url" \
-            && gzip -t "$archive" 2>/dev/null \
-            && tar xz -C "$dest" virtctl -f "$archive" \
-            && [[ -f "${dest}/virtctl" ]]; then
-            rm -f "$archive"
-            chmod +x "${dest}/virtctl"
-            info "virtctl installed at ${dest}/virtctl"
-            return 0
+        if curl -sSL "$@" -o "$archive" "$download_url"; then
+            if gzip -t "$archive" 2>/dev/null \
+                && tar xz -C "$dest" virtctl -f "$archive" \
+                && [[ -f "${dest}/virtctl" ]]; then
+                rm -f "$archive"
+                chmod +x "${dest}/virtctl"
+                info "virtctl installed at ${dest}/virtctl"
+                return 0
+            fi
+            saw_nongzip=1
         fi
         info "virtctl tarball not ready yet (attempt ${attempt}/30), retrying in 10s"
         sleep 10
     done
     rm -f "$archive"
-    die "Failed to download virtctl from ${download_url}"
+    _VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP=$saw_nongzip
+    warn "Failed to download virtctl from ${download_url}"
+    return 1
+}
+
+# Installs virtctl from the KubeVirt GitHub release matching the cluster's observed version.
+# ConsoleCLIDownload can stay on HTML while CNV's CSV is Installing or Failed.
+_install_virtctl_from_kubevirt_release() {
+    local version dest url bin
+    version="$(oc get kubevirt -n openshift-cnv -o jsonpath='{.items[0].status.observedKubeVirtVersion}' 2>/dev/null || true)"
+    if [[ -z "$version" ]]; then
+        version="$(oc get kubevirt -n openshift-cnv -o jsonpath='{.items[0].status.targetKubeVirtVersion}' 2>/dev/null || true)"
+    fi
+    if [[ -z "$version" ]]; then
+        warn "No observedKubeVirtVersion on kubevirt CRs; cannot download virtctl from GitHub"
+        return 1
+    fi
+
+    dest="$(_virtctl_install_dir)"
+    url="https://github.com/kubevirt/kubevirt/releases/download/${version}/virtctl-${version}-linux-amd64"
+    bin="${dest}/virtctl"
+    info "Downloading virtctl ${version} from ${url}"
+    if ! curl -fsSL --retry 5 --retry-delay 5 -o "$bin" "$url"; then
+        warn "GitHub virtctl download failed from ${url}"
+        rm -f "$bin"
+        return 1
+    fi
+    if [[ "$(head -c 4 "$bin")" != $'\x7fELF' ]]; then
+        warn "GitHub virtctl download was not an ELF binary"
+        rm -f "$bin"
+        return 1
+    fi
+    chmod +x "$bin"
+    info "virtctl installed at ${bin}"
+    return 0
 }
 
 # Downloads virtctl from ConsoleCLIDownload using verified TLS only.
 ensure_virtctl_binary() {
     _use_existing_virtctl_binary_if_available && return
 
-    local ca_bundle
+    local ca_bundle rc=0
     ca_bundle="$(_fetch_cluster_ingress_ca)"
-    _download_and_install_virtctl --cacert "$ca_bundle"
+    _download_and_install_virtctl --cacert "$ca_bundle" || rc=$?
     rm -f "$ca_bundle"
+    return "$rc"
 }
 
 # Downloads virtctl from ConsoleCLIDownload with curl -k.

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -108,8 +108,12 @@ type VMScanningSuite struct {
 	dynamicClient dynamic.Interface
 	namespace     string
 
-	conn     *grpc.ClientConn
-	vmClient v2.VirtualMachineServiceClient
+	conn       *grpc.ClientConn
+	vmClient   v2.VirtualMachineServiceClient
+	vmV2Client v2.VirtualMachineV2ServiceClient
+	// enhancedVMModel follows Central's ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL.
+	// That flag selects VirtualMachineV2Service vs VirtualMachineService.
+	enhancedVMModel bool
 
 	virtctl vmhelpers.Virtctl
 
@@ -158,10 +162,12 @@ func (s *VMScanningSuite) SetupSuite() {
 	s.logf("VM scanning setup: connect to Central gRPC")
 	s.conn = centralgrpc.GRPCConnectionToCentral(t)
 	s.vmClient = v2.NewVirtualMachineServiceClient(s.conn)
+	s.vmV2Client = v2.NewVirtualMachineV2ServiceClient(s.conn)
 
 	s.logf("VM scanning setup: verify central/sensor connectivity and feature gates")
 	s.mustWaitForHealthyCentralSensorConnection()
 	s.mustVerifyVirtualMachinesFeatureEnabled()
+	s.resolveVMAPI()
 	s.logf("VM scanning setup: verify cluster VSOCK readiness")
 	mustVerifyClusterVSOCKReady(t, s.ctx, s.k8sClient, s.dynamicClient)
 
@@ -311,6 +317,57 @@ func waitForNamespaceDeleted(ctx context.Context, k8s kubernetes.Interface, name
 func (s *VMScanningSuite) mustWaitForHealthyCentralSensorConnection() {
 	s.waitUntilK8sDeploymentReady(s.ctx, namespaces.StackRox, sensorDeployment)
 	waitUntilCentralSensorConnectionIs(s.T(), s.ctx, storage.ClusterHealthStatus_HEALTHY)
+}
+
+// resolveVMAPI reads ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL from Central and
+// checks that the matching gRPC service is registered.
+func (s *VMScanningSuite) resolveVMAPI() {
+	t := s.T()
+	t.Helper()
+
+	flag := features.VirtualMachinesEnhancedDataModel
+	s.enhancedVMModel = s.centralFeatureEnabled(flag)
+	s.logf("VM scanning setup: Central %s=%v", flag.EnvVar(), s.enhancedVMModel)
+
+	if s.enhancedVMModel {
+		_, err := s.vmV2Client.ListVMs(s.ctx, &v2.ListVMsRequest{})
+		require.NoError(t, err, "VirtualMachineV2Service must be registered when %s is enabled", flag.EnvVar())
+		return
+	}
+	_, err := s.vmClient.ListVirtualMachines(s.ctx, &v2.ListVirtualMachinesRequest{})
+	require.NoError(t, err, "VirtualMachineService must be registered when %s is disabled", flag.EnvVar())
+}
+
+// centralFeatureEnabled reports whether flag is on in the Central deployment,
+// matching features.Enabled: explicit true/false, otherwise the flag default.
+func (s *VMScanningSuite) centralFeatureEnabled(flag features.FeatureFlag) bool {
+	t := s.T()
+	t.Helper()
+
+	obj, err := s.k8sClient.AppsV1().Deployments(namespaces.StackRox).Get(s.ctx, "central", metaV1.GetOptions{})
+	require.NoError(t, err, "get Deployment %s/central", namespaces.StackRox)
+	for _, c := range obj.Spec.Template.Spec.Containers {
+		if c.Name != "central" {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name != flag.EnvVar() {
+				continue
+			}
+			switch strings.ToLower(strings.TrimSpace(e.Value)) {
+			case "false":
+				return false
+			case "true":
+				return true
+			default:
+				return flag.Default()
+			}
+		}
+		return flag.Default()
+	}
+	require.FailNowf(t, "container central not found in Deployment stackrox/central",
+		"available containers: %s", formatContainerNames(obj.Spec.Template.Spec.Containers))
+	return false
 }
 
 func (s *VMScanningSuite) mustVerifyVirtualMachinesFeatureEnabled() {
@@ -678,6 +735,20 @@ func (s *VMScanningSuite) vmSpecToRequest(sp vmhelpers.VMSpec) vmhelpers.VMReque
 	}
 }
 
+func (s *VMScanningSuite) skipUnlessLegacyVMAPI(t *testing.T) {
+	t.Helper()
+	if s.enhancedVMModel {
+		t.Skip("VirtualMachineService is not used when ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL is enabled")
+	}
+}
+
+func (s *VMScanningSuite) skipUnlessV2VMAPI(t *testing.T) {
+	t.Helper()
+	if !s.enhancedVMModel {
+		t.Skip("VirtualMachineV2Service is not used when ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL is disabled")
+	}
+}
+
 func (s *VMScanningSuite) mustListVMByNamespaceAndName(namespace, name string) *v2.VirtualMachine {
 	t := s.T()
 	t.Helper()
@@ -691,6 +762,24 @@ func (s *VMScanningSuite) mustGetVM(id string) *v2.VirtualMachine {
 	t := s.T()
 	t.Helper()
 	resp, err := s.vmClient.GetVirtualMachine(s.ctx, &v2.GetVirtualMachineRequest{Id: id})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+func (s *VMScanningSuite) mustListV2VMByNamespaceAndName(namespace, name string) *v2.VMListItem {
+	t := s.T()
+	t.Helper()
+	vm, err := vmhelpers.ListV2VMByNamespaceName(s.ctx, s.vmV2Client, namespace, name)
+	require.NoError(t, err)
+	require.NotNil(t, vm, "ListVMs: no VM for namespace=%q name=%q", namespace, name)
+	return vm
+}
+
+func (s *VMScanningSuite) mustGetVMV2(id string) *v2.VMDetail {
+	t := s.T()
+	t.Helper()
+	resp, err := s.vmV2Client.GetVM(s.ctx, &v2.GetVMRequest{Id: id})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	return resp
@@ -727,15 +816,40 @@ func (s *VMScanningSuite) ensureRoxagentServing(ctx context.Context, vm *VMHandl
 	return vmhelpers.EnsureRoxagentServing(ctx, virt, vm.Namespace, vm.Name)
 }
 
-// waitForScan polls Central in order until scan data is visible.
-func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.VirtualMachine, error) {
+// centralScanSnapshot is the scan-ready view from the VM API selected by Central's flag.
+type centralScanSnapshot struct {
+	ID     string
+	Legacy *v2.VirtualMachine
+	Detail *v2.VMDetail
+}
+
+// waitForScan polls the VM API selected by ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL.
+func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*centralScanSnapshot, error) {
 	if vm == nil {
 		return nil, errors.New("waitForScan: nil VM handle")
 	}
-	s.logf("scan wait %s/%s: start (timeout=%v poll=%v)", vm.Namespace, vm.Name, s.cfg.ScanTimeout, s.cfg.ScanPollInterval)
+	s.logf("scan wait %s/%s: start (timeout=%v poll=%v enhancedVMModel=%v)",
+		vm.Namespace, vm.Name, s.cfg.ScanTimeout, s.cfg.ScanPollInterval, s.enhancedVMModel)
 	waitCtx, cancel := context.WithTimeout(ctx, s.cfg.ScanTimeout)
 	defer cancel()
 
+	if s.enhancedVMModel {
+		detail, err := s.waitForV2Scan(waitCtx, vm)
+		if err != nil {
+			return nil, err
+		}
+		vm.ID = detail.GetId()
+		return &centralScanSnapshot{ID: vm.ID, Detail: detail}, nil
+	}
+	legacy, err := s.waitForLegacyScan(waitCtx, vm)
+	if err != nil {
+		return nil, err
+	}
+	vm.ID = legacy.GetId()
+	return &centralScanSnapshot{ID: vm.ID, Legacy: legacy}, nil
+}
+
+func (s *VMScanningSuite) waitForLegacyScan(waitCtx context.Context, vm *VMHandle) (*v2.VirtualMachine, error) {
 	baseOpts := vmhelpers.WaitOptions{
 		Timeout:      s.cfg.ScanTimeout,
 		PollInterval: s.cfg.ScanPollInterval,
@@ -748,7 +862,7 @@ func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.Vi
 	}
 	vm.ID = present.GetId()
 
-	s.logf("%s/%s: VM appeared in Central (id=%q), waiting for namespace/name fields to be populated", vm.Namespace, vm.Name, vm.ID)
+	s.logf("%s/%s: VM appeared in Central via VirtualMachineService (id=%q), waiting for namespace/name fields", vm.Namespace, vm.Name, vm.ID)
 	if _, err := vmhelpers.WaitForVMIdentityFields(waitCtx, s.vmClient, baseOpts, present.GetId(), vm.Namespace, vm.Name); err != nil {
 		return nil, err
 	}
@@ -766,6 +880,35 @@ func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.Vi
 	}
 	s.logf("%s/%s: waiting for all components to be vulnerability-matched (no UNSCANNED)", vm.Namespace, vm.Name)
 	return vmhelpers.WaitForScanReady(waitCtx, s.vmClient, baseOpts, present.GetId())
+}
+
+func (s *VMScanningSuite) waitForV2Scan(waitCtx context.Context, vm *VMHandle) (*v2.VMDetail, error) {
+	baseOpts := vmhelpers.WaitOptions{
+		Timeout:      s.cfg.ScanTimeout,
+		PollInterval: s.cfg.ScanPollInterval,
+		Logf:         s.logf,
+	}
+
+	present, err := vmhelpers.WaitForV2VMPresentInCentral(waitCtx, s.vmV2Client, baseOpts, vm.Namespace, vm.Name)
+	if err != nil {
+		return nil, err
+	}
+	vm.ID = present.GetId()
+
+	s.logf("%s/%s: VM appeared in Central via VirtualMachineV2Service (id=%q), waiting for namespace/name fields", vm.Namespace, vm.Name, vm.ID)
+	if _, err := vmhelpers.WaitForV2VMIdentityFields(waitCtx, s.vmV2Client, baseOpts, present.GetId(), vm.Namespace, vm.Name); err != nil {
+		return nil, err
+	}
+	s.logf("%s/%s: waiting for Central to report VM as VM_STATE_RUNNING", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForV2VMRunningInCentral(waitCtx, s.vmV2Client, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("%s/%s: waiting for latest_scan to arrive in Central", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForV2VMLatestScan(waitCtx, s.vmV2Client, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("%s/%s: waiting for all v2 components to be vulnerability-matched (no NOT_SCANNED)", vm.Namespace, vm.Name)
+	return vmhelpers.WaitForV2ScanReady(waitCtx, s.vmV2Client, baseOpts, present.GetId())
 }
 
 func (s *VMScanningSuite) resourceDeleteTimeout() time.Duration {

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -126,7 +126,6 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				}
 
 				distinct := distinctCVEIDs(cves)
-				require.Equal(t, len(cves), len(distinct), "ListVMCVEsByVM CVE IDs must be unique")
 				require.Equal(t, int32(len(distinct)), vmhelpers.VulnCountBySeverityTotal(listed.GetCveSeverityCounts()),
 					"ListVMs.cveSeverityCounts totals must match distinct CVEs from ListVMCVEsByVM")
 
@@ -145,7 +144,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				for _, row := range cves {
 					require.NotEmpty(t, row.GetCve())
 				}
-				require.Equal(t, len(cves), len(distinctCVEIDs(cves)), "CVE IDs must be unique")
+				require.Equal(t, len(cves), len(distinctCVEIDs(cves)), "ListVMCVEsByVM CVE IDs must be unique")
 
 				var found bool
 				for _, row := range cves {

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -28,7 +28,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 		}
 
 		s.T().Run(vm.Name, func(t *testing.T) {
-			var first *v2.VirtualMachine
+			var snapshot *centralScanSnapshot
 			roxagentOK := false
 
 			t.Run("EnsureRoxagentServing", func(t *testing.T) {
@@ -45,16 +45,20 @@ func (s *VMScanningSuite) TestScanPipeline() {
 
 			t.Run("WaitForScan", func(t *testing.T) {
 				var err error
-				first, err = s.waitForScan(s.ctx, vm)
+				snapshot, err = s.waitForScan(s.ctx, vm)
 				require.NoError(t, err)
-				vm.ID = first.GetId()
+				require.NotEmpty(t, snapshot.ID)
+				vm.ID = snapshot.ID
 			})
-			if first == nil {
+			if snapshot == nil {
 				t.Log("skipping remaining subtests: scan did not appear in Central")
 				return
 			}
 
 			t.Run("CentralVMMetadata", func(t *testing.T) {
+				s.skipUnlessLegacyVMAPI(t)
+				first := snapshot.Legacy
+				require.NotNil(t, first, "WaitForScan returned no VirtualMachine")
 				listed := s.mustListVMByNamespaceAndName(vm.Namespace, vm.Name)
 				require.Equal(t, listed.GetId(), first.GetId())
 				require.Equal(t, vm.Name, first.GetName())
@@ -67,6 +71,9 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			})
 
 			t.Run("CentralScanComponents", func(t *testing.T) {
+				s.skipUnlessLegacyVMAPI(t)
+				first := snapshot.Legacy
+				require.NotNil(t, first)
 				for _, component := range first.GetScan().GetComponents() {
 					require.NotContains(t, component.GetNotes(), v2.ScanComponent_UNSCANNED)
 				}
@@ -74,28 +81,109 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			})
 
 			t.Run("CentralScanOperatingSystem", func(t *testing.T) {
-				os := first.GetScan().GetOperatingSystem()
+				s.skipUnlessLegacyVMAPI(t)
+				os := snapshot.Legacy.GetScan().GetOperatingSystem()
 				require.NotEmpty(t, os,
 					"scan.operating_system should be populated via Sensor DiscoveredData")
 			})
 
 			t.Run("ConsistencyCheck", func(t *testing.T) {
-				fetched := s.mustGetVM(first.GetId())
-				require.Equal(t, first.GetId(), fetched.GetId(),
+				s.skipUnlessLegacyVMAPI(t)
+				fetched := s.mustGetVM(snapshot.ID)
+				require.Equal(t, snapshot.ID, fetched.GetId(),
 					"VM ID should remain stable after pull-mode scan")
+			})
+
+			t.Run("VirtualMachineV2GetVM", func(t *testing.T) {
+				s.skipUnlessV2VMAPI(t)
+				detail := s.mustGetVMV2(snapshot.ID)
+				require.Equal(t, snapshot.ID, detail.GetId())
+				require.Equal(t, vm.Name, detail.GetName())
+				require.Equal(t, vm.Namespace, detail.GetNamespace())
+				require.NotEmpty(t, detail.GetClusterId())
+				require.NotEmpty(t, detail.GetClusterName())
+				require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, detail.GetState())
+				require.NotNil(t, detail.GetLatestScan())
+				require.NotNil(t, detail.GetLatestScan().GetScanTime())
+			})
+
+			t.Run("VirtualMachineV2ListVMs", func(t *testing.T) {
+				s.skipUnlessV2VMAPI(t)
+				listed := s.mustListV2VMByNamespaceAndName(vm.Namespace, vm.Name)
+				require.Equal(t, snapshot.ID, listed.GetId())
+				require.Equal(t, vm.Name, listed.GetName())
+				require.Equal(t, vm.Namespace, listed.GetNamespace())
+				require.NotEmpty(t, listed.GetClusterId())
+				require.NotEmpty(t, listed.GetClusterName())
+				require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, listed.GetState())
+
+				cves, total, err := vmhelpers.ListAllVMCVEsByVM(s.ctx, s.vmV2Client, snapshot.ID)
+				require.NoError(t, err)
+				require.Greater(t, total, int32(0), "scanned RHEL guest should report CVEs via ListVMCVEsByVM")
+				require.Equal(t, int(total), len(cves), "paginated CVE rows should cover total_count")
+				for _, row := range cves {
+					require.NotEmpty(t, row.GetCve())
+				}
+
+				distinct := distinctCVEIDs(cves)
+				require.Equal(t, len(cves), len(distinct), "ListVMCVEsByVM CVE IDs must be unique")
+				require.Equal(t, int32(len(distinct)), vmhelpers.VulnCountBySeverityTotal(listed.GetCveSeverityCounts()),
+					"ListVMs.cveSeverityCounts totals must match distinct CVEs from ListVMCVEsByVM")
+
+				summary, err := s.vmV2Client.GetVMVulnSummary(s.ctx, &v2.GetVMVulnSummaryRequest{Id: snapshot.ID})
+				require.NoError(t, err)
+				require.Equal(t, int32(len(distinct)), vmhelpers.VulnCountBySeverityTotal(summary.GetSeverityCounts()),
+					"GetVMVulnSummary severity totals must match distinct CVEs from ListVMCVEsByVM")
+			})
+
+			t.Run("VirtualMachineV2ListVMCVEsByVM", func(t *testing.T) {
+				s.skipUnlessV2VMAPI(t)
+				cves, total, err := vmhelpers.ListAllVMCVEsByVM(s.ctx, s.vmV2Client, snapshot.ID)
+				require.NoError(t, err)
+				require.Greater(t, total, int32(0))
+				require.NotEmpty(t, cves)
+				for _, row := range cves {
+					require.NotEmpty(t, row.GetCve())
+				}
+				require.Equal(t, len(cves), len(distinctCVEIDs(cves)), "CVE IDs must be unique")
+
+				var found bool
+				for _, row := range cves {
+					comps, err := s.vmV2Client.GetVMCVEComponents(s.ctx, &v2.GetVMCVEComponentsRequest{
+						VmId:  snapshot.ID,
+						CveId: row.GetCve(),
+					})
+					require.NoError(t, err)
+					if len(comps.GetComponents()) == 0 {
+						continue
+					}
+					require.GreaterOrEqual(t, row.GetAffectedComponentCount(), int32(1),
+						"CVE %q has %d components from GetVMCVEComponents but affected_component_count=%d",
+						row.GetCve(), len(comps.GetComponents()), row.GetAffectedComponentCount())
+					found = true
+					break
+				}
+				require.True(t, found, "at least one ListVMCVEsByVM row should have components from GetVMCVEComponents")
+			})
+
+			t.Run("VirtualMachineV2ListVMComponents", func(t *testing.T) {
+				s.skipUnlessV2VMAPI(t)
+				comps, total, err := vmhelpers.ListAllVMComponents(s.ctx, s.vmV2Client, snapshot.ID)
+				require.NoError(t, err)
+				require.Greater(t, total, int32(0), "completed scan should list components")
+				require.NotEmpty(t, comps)
+				require.Equal(t, int(total), len(comps), "paginated component rows should cover total_count")
+				for _, c := range comps {
+					require.NotEqual(t, v2.ScanStatus_NOT_SCANNED, c.GetScanStatus())
+					require.NotEqual(t, v2.ScanStatus_SCAN_PENDING, c.GetScanStatus())
+				}
 			})
 
 			// Regression test for ROX-36273: after a change to the RPM database (package removal), the agent should
 			// detect the change on a later periodic rescan without being restarted.
 			t.Run("Changes to RPM DB are detected by periodic rescan", func(t *testing.T) {
-				require.NotNil(t, first.GetScan().GetScanTime())
-				baselineScanTime := first.GetScan().GetScanTime().AsTime()
-				baselineCount := len(first.GetScan().GetComponents())
-				// bc is installed by stackrox/vm-images into every VM
-				// container-disk so this test has a known removable probe package.
 				removed := vmhelpers.VMImageProbePackage
-				require.Contains(t, scanComponentNames(first), removed,
-					"baseline scan must include %q from the VM image build", removed)
+				baselineCount := s.requireProbePackagePresent(t, snapshot, removed)
 
 				beforeInvocationID, err := vmhelpers.RoxagentServeInvocationID(s.ctx, virt, vm.Namespace, vm.Name)
 				require.NoError(t, err)
@@ -107,19 +195,32 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				// Central moves scan_time.
 				const minScanAdvances = 2
 				waitTimeout := max(s.cfg.ScanTimeout, 2*vmhelpers.E2ERescanInterval+2*vmhelpers.E2EScraperPollInterval+3*time.Minute)
-				t.Logf("removed package %q; waiting for %d scan_time advances (rescan=%s scraper=%s timeout=%s; baseline components=%d scan_time=%s)",
+				t.Logf("removed package %q; waiting for %d scan_time advances (rescan=%s scraper=%s timeout=%s; baseline components=%d)",
 					removed, minScanAdvances, vmhelpers.E2ERescanInterval, vmhelpers.E2EScraperPollInterval, waitTimeout,
-					baselineCount, baselineScanTime.UTC().Format(time.RFC3339))
+					baselineCount)
 
-				updated, err := vmhelpers.WaitForScanMissingComponent(
-					s.ctx, s.vmClient, vmhelpers.WaitOptions{
-						Timeout:      waitTimeout,
-						PollInterval: s.cfg.ScanPollInterval,
-						Logf:         s.logf,
-					}, first.GetId(), removed, baselineScanTime, minScanAdvances)
-				require.NoError(t, err)
-				require.Equal(t, baselineCount-1, len(updated.GetScan().GetComponents()),
-					"exactly one component should disappear after removing %q", removed)
+				opts := vmhelpers.WaitOptions{
+					Timeout:      waitTimeout,
+					PollInterval: s.cfg.ScanPollInterval,
+					Logf:         s.logf,
+				}
+				if s.enhancedVMModel {
+					require.NotNil(t, snapshot.Detail.GetLatestScan().GetScanTime())
+					baselineScanTime := snapshot.Detail.GetLatestScan().GetScanTime().AsTime()
+					updated, err := vmhelpers.WaitForV2ScanMissingComponent(
+						s.ctx, s.vmV2Client, opts, snapshot.ID, removed, baselineScanTime, minScanAdvances)
+					require.NoError(t, err)
+					require.Equal(t, baselineCount-1, len(updated),
+						"exactly one component should disappear after removing %q", removed)
+				} else {
+					require.NotNil(t, snapshot.Legacy.GetScan().GetScanTime())
+					baselineScanTime := snapshot.Legacy.GetScan().GetScanTime().AsTime()
+					updated, err := vmhelpers.WaitForScanMissingComponent(
+						s.ctx, s.vmClient, opts, snapshot.ID, removed, baselineScanTime, minScanAdvances)
+					require.NoError(t, err)
+					require.Equal(t, baselineCount-1, len(updated.GetScan().GetComponents()),
+						"exactly one component should disappear after removing %q", removed)
+				}
 
 				require.NoError(t, vmhelpers.RoxagentServeDidNotRestart(
 					s.ctx, virt, vm.Namespace, vm.Name, beforeInvocationID),
@@ -127,6 +228,21 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			})
 		})
 	}
+}
+
+func (s *VMScanningSuite) requireProbePackagePresent(t *testing.T, snapshot *centralScanSnapshot, pkg string) int {
+	t.Helper()
+	if s.enhancedVMModel {
+		comps, _, err := vmhelpers.ListAllVMComponents(s.ctx, s.vmV2Client, snapshot.ID)
+		require.NoError(t, err)
+		require.Contains(t, componentRowNames(comps), pkg,
+			"baseline v2 component list must include %q from the VM image build", pkg)
+		return len(comps)
+	}
+	require.NotNil(t, snapshot.Legacy)
+	require.Contains(t, scanComponentNames(snapshot.Legacy), pkg,
+		"baseline scan must include %q from the VM image build", pkg)
+	return len(snapshot.Legacy.GetScan().GetComponents())
 }
 
 func scanComponentNames(vm *v2.VirtualMachine) []string {
@@ -138,4 +254,31 @@ func scanComponentNames(vm *v2.VirtualMachine) []string {
 		}
 	}
 	return names
+}
+
+func componentRowNames(comps []*v2.VMComponentRow) []string {
+	names := make([]string, 0, len(comps))
+	for _, c := range comps {
+		if name := c.GetName(); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func distinctCVEIDs(cves []*v2.VMCVERow) []string {
+	seen := make(map[string]struct{}, len(cves))
+	ids := make([]string, 0, len(cves))
+	for _, row := range cves {
+		id := row.GetCve()
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
 }

--- a/tests/vmhelpers/central_v2.go
+++ b/tests/vmhelpers/central_v2.go
@@ -1,0 +1,306 @@
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+// v2ListPageSize matches VirtualMachineV2Service's server-side defaultPageSize.
+// Requests above that are clamped, so callers must page.
+const (
+	v2ListPageSize = 100
+	v2ListMaxPages = 200
+)
+
+// ListV2VMByNamespaceName returns the first VM matching namespace and name.
+// Returns (nil, nil) when no match is found.
+func ListV2VMByNamespaceName(ctx context.Context, client v2.VirtualMachineV2ServiceClient, namespace, name string) (*v2.VMListItem, error) {
+	resp, err := client.ListVMs(ctx, &v2.ListVMsRequest{
+		Query: &v2.RawQuery{
+			Query: rawListQueryNamespaceAndName(namespace, name),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if vms := resp.GetVms(); len(vms) > 0 {
+		return vms[0], nil
+	}
+	return nil, nil
+}
+
+// WaitForV2VMPresentInCentral polls ListVMs until a VM matches namespace and name.
+func WaitForV2VMPresentInCentral(ctx context.Context, client v2.VirtualMachineV2ServiceClient, opts WaitOptions, namespace, name string) (*v2.VMListItem, error) {
+	var found *v2.VMListItem
+	err := pollUntil(ctx, opts, fmt.Sprintf("V2 VM present in Central (namespace=%q name=%q)", namespace, name), func(ctx context.Context) (bool, string, error) {
+		vm, err := ListV2VMByNamespaceName(ctx, client, namespace, name)
+		if err != nil {
+			return false, "", err
+		}
+		if vm == nil {
+			return false, "list returned no matching virtual machine", nil
+		}
+		found = vm
+		return true, fmt.Sprintf("id=%s", vm.GetId()), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return found, nil
+}
+
+type vmV2ConditionCheck func(vm *v2.VMDetail) (done bool, detail string)
+
+func waitForV2VMCondition(ctx context.Context, client v2.VirtualMachineV2ServiceClient, opts WaitOptions, id, desc string, check vmV2ConditionCheck) (*v2.VMDetail, error) {
+	var vm *v2.VMDetail
+	err := pollUntil(ctx, opts, desc, func(ctx context.Context) (bool, string, error) {
+		cur, err := client.GetVM(ctx, &v2.GetVMRequest{Id: id})
+		if err != nil {
+			return false, "", err
+		}
+		done, detail := check(cur)
+		if done {
+			vm = cur
+		}
+		return done, detail, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return vm, nil
+}
+
+// WaitForV2VMIdentityFields polls GetVM until id maps to the expected namespace and name.
+func WaitForV2VMIdentityFields(ctx context.Context, client v2.VirtualMachineV2ServiceClient, opts WaitOptions, id, expectedNamespace, expectedName string) (*v2.VMDetail, error) {
+	return waitForV2VMCondition(ctx, client, opts, id, fmt.Sprintf("V2 VM identity fields (id=%q)", id), func(vm *v2.VMDetail) (bool, string) {
+		detail := fmt.Sprintf("namespace=%q name=%q", vm.GetNamespace(), vm.GetName())
+		return vm.GetNamespace() == expectedNamespace && vm.GetName() == expectedName, detail
+	})
+}
+
+// WaitForV2VMRunningInCentral polls until the VM state is VM_STATE_RUNNING.
+func WaitForV2VMRunningInCentral(ctx context.Context, client v2.VirtualMachineV2ServiceClient, opts WaitOptions, id string) (*v2.VMDetail, error) {
+	return waitForV2VMCondition(ctx, client, opts, id, fmt.Sprintf("V2 VM RUNNING (id=%q)", id), func(vm *v2.VMDetail) (bool, string) {
+		st := vm.GetState()
+		return st == v2.VirtualMachineV2State_VM_STATE_RUNNING, fmt.Sprintf("state=%s", st)
+	})
+}
+
+// WaitForV2VMLatestScan polls until latest_scan is present with scan_time set.
+func WaitForV2VMLatestScan(ctx context.Context, client v2.VirtualMachineV2ServiceClient, opts WaitOptions, id string) (*v2.VMDetail, error) {
+	return waitForV2VMCondition(ctx, client, opts, id, fmt.Sprintf("V2 VM latest_scan (id=%q)", id), func(vm *v2.VMDetail) (bool, string) {
+		scan := vm.GetLatestScan()
+		if scan == nil {
+			return false, "latest_scan is nil"
+		}
+		if scan.GetScanTime() == nil {
+			return false, "latest_scan.scan_time is nil"
+		}
+		return true, "latest_scan present"
+	})
+}
+
+// WaitForV2ScanReady polls until the VM has scanned components and none are NOT_SCANNED.
+func WaitForV2ScanReady(ctx context.Context, client v2.VirtualMachineV2ServiceClient, opts WaitOptions, id string) (*v2.VMDetail, error) {
+	var detail *v2.VMDetail
+	err := pollUntil(ctx, opts, fmt.Sprintf("V2 scan ready (id=%q)", id), func(ctx context.Context) (bool, string, error) {
+		vm, err := client.GetVM(ctx, &v2.GetVMRequest{Id: id})
+		if err != nil {
+			return false, "", err
+		}
+		scan := vm.GetLatestScan()
+		if scan == nil {
+			return false, "latest_scan is nil", nil
+		}
+
+		comps, total, err := ListAllVMComponents(ctx, client, id)
+		if err != nil {
+			return false, "", err
+		}
+
+		var ready, pending []string
+		if total > 0 {
+			ready = append(ready, fmt.Sprintf("components=%d", total))
+		} else {
+			pending = append(pending, "components")
+		}
+
+		if total > 0 && !slices.ContainsFunc(comps, func(c *v2.VMComponentRow) bool {
+			return c.GetScanStatus() == v2.ScanStatus_NOT_SCANNED || c.GetScanStatus() == v2.ScanStatus_SCAN_PENDING
+		}) {
+			ready = append(ready, "all-scanned")
+		} else {
+			pending = append(pending, "all-scanned")
+		}
+
+		if os := scan.GetScanOs(); os != "" {
+			ready = append(ready, fmt.Sprintf("os=%q", os))
+		} else if guestOS := vm.GetGuestOs(); guestOS != "" {
+			ready = append(ready, fmt.Sprintf("guest_os=%q", guestOS))
+		} else if len(pending) == 0 {
+			ready = append(ready, "os=<not reported>")
+		} else {
+			pending = append(pending, "os")
+		}
+
+		pollDetail := fmt.Sprintf("ready:[%s] waiting:[%s]", strings.Join(ready, ","), strings.Join(pending, ","))
+		if len(pending) == 0 {
+			detail = vm
+		}
+		return len(pending) == 0, pollDetail, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return detail, nil
+}
+
+// ListAllVMComponents pages through ListVMComponents until every component is collected.
+func ListAllVMComponents(ctx context.Context, client v2.VirtualMachineV2ServiceClient, vmID string) ([]*v2.VMComponentRow, int32, error) {
+	var all []*v2.VMComponentRow
+	var total int32
+	for page := range v2ListMaxPages {
+		offset := int32(page) * v2ListPageSize
+		resp, err := client.ListVMComponents(ctx, &v2.ListVMComponentsRequest{
+			VmId: vmID,
+			Query: &v2.RawQuery{
+				Pagination: &v2.Pagination{
+					Limit:      v2ListPageSize,
+					Offset:     offset,
+					SortOption: &v2.SortOption{Field: search.Component.String()},
+				},
+			},
+		})
+		if err != nil {
+			return nil, 0, err
+		}
+		total = resp.GetTotalCount()
+		all = append(all, resp.GetComponents()...)
+		if int32(len(all)) >= total || len(resp.GetComponents()) == 0 {
+			return all, total, nil
+		}
+	}
+	return nil, 0, fmt.Errorf("ListVMComponents: exceeded %d pages for vm %s (collected %d, total_count=%d)", v2ListMaxPages, vmID, len(all), total)
+}
+
+// ListAllVMCVEsByVM pages through ListVMCVEsByVM until every CVE row is collected.
+func ListAllVMCVEsByVM(ctx context.Context, client v2.VirtualMachineV2ServiceClient, vmID string) ([]*v2.VMCVERow, int32, error) {
+	var all []*v2.VMCVERow
+	var total int32
+	for page := range v2ListMaxPages {
+		offset := int32(page) * v2ListPageSize
+		resp, err := client.ListVMCVEsByVM(ctx, &v2.ListVMCVEsByVMRequest{
+			VmId: vmID,
+			Query: &v2.RawQuery{
+				Pagination: &v2.Pagination{
+					Limit:      v2ListPageSize,
+					Offset:     offset,
+					SortOption: &v2.SortOption{Field: search.CVE.String()},
+				},
+			},
+		})
+		if err != nil {
+			return nil, 0, err
+		}
+		total = resp.GetTotalCount()
+		all = append(all, resp.GetCves()...)
+		if int32(len(all)) >= total || len(resp.GetCves()) == 0 {
+			return all, total, nil
+		}
+	}
+	return nil, 0, fmt.Errorf("ListVMCVEsByVM: exceeded %d pages for vm %s (collected %d, total_count=%d)", v2ListMaxPages, vmID, len(all), total)
+}
+
+// VulnCountBySeverityTotal sums the per-severity total fields.
+func VulnCountBySeverityTotal(c *v2.VulnCountBySeverity) int32 {
+	if c == nil {
+		return 0
+	}
+	var n int32
+	for _, sev := range []*v2.VulnFixableCount{
+		c.GetCritical(),
+		c.GetImportant(),
+		c.GetModerate(),
+		c.GetLow(),
+		c.GetUnknown(),
+	} {
+		n += sev.GetTotal()
+	}
+	return n
+}
+
+// WaitForV2ScanMissingComponent polls until packageName is absent from a scan
+// whose latest_scan.scan_time has advanced at least minScanAdvances times past after.
+func WaitForV2ScanMissingComponent(
+	ctx context.Context,
+	client v2.VirtualMachineV2ServiceClient,
+	opts WaitOptions,
+	id, packageName string,
+	after time.Time,
+	minScanAdvances int,
+) ([]*v2.VMComponentRow, error) {
+	if minScanAdvances < 1 {
+		minScanAdvances = 1
+	}
+	advances := 0
+	lastSeen := after
+	var components []*v2.VMComponentRow
+	err := pollUntil(ctx, opts,
+		fmt.Sprintf("V2 scan missing package %q after %d scan_time advance(s) past %s (id=%q)",
+			packageName, minScanAdvances, after.UTC().Format(time.RFC3339), id),
+		func(ctx context.Context) (bool, string, error) {
+			vm, err := client.GetVM(ctx, &v2.GetVMRequest{Id: id})
+			if err != nil {
+				return false, "", err
+			}
+			scan := vm.GetLatestScan()
+			if scan == nil {
+				return false, "latest_scan is nil", nil
+			}
+			st := scan.GetScanTime()
+			if st == nil {
+				return false, "latest_scan.scan_time is nil", nil
+			}
+			scanTime := st.AsTime()
+			if scanTime.After(lastSeen) {
+				advances++
+				lastSeen = scanTime
+			}
+			if advances < minScanAdvances {
+				return false, fmt.Sprintf("scan_time advances=%d/%d last=%s",
+					advances, minScanAdvances, scanTime.UTC().Format(time.RFC3339)), nil
+			}
+
+			filtered, err := client.ListVMComponents(ctx, &v2.ListVMComponentsRequest{
+				VmId: id,
+				Query: &v2.RawQuery{
+					Query: fmt.Sprintf("%s:%q", search.Component, packageName),
+				},
+			})
+			if err != nil {
+				return false, "", err
+			}
+			if filtered.GetTotalCount() > 0 {
+				return false, fmt.Sprintf("scan_time advances=%d but package %q still present (matches=%d)",
+					advances, packageName, filtered.GetTotalCount()), nil
+			}
+
+			comps, total, err := ListAllVMComponents(ctx, client, id)
+			if err != nil {
+				return false, "", err
+			}
+			components = comps
+			return true, fmt.Sprintf("scan_time advances=%d package %q gone (components=%d)",
+				advances, packageName, total), nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return components, nil
+}

--- a/tests/vmhelpers/central_v2_test.go
+++ b/tests/vmhelpers/central_v2_test.go
@@ -1,0 +1,288 @@
+//go:build test && !test_e2e && !test_e2e_vm
+
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type stubV2Client struct {
+	listVMsFn            func(ctx context.Context, req *v2.ListVMsRequest) (*v2.ListVMsResponse, error)
+	getVMFn              func(ctx context.Context, req *v2.GetVMRequest) (*v2.VMDetail, error)
+	listVMComponentsFn   func(ctx context.Context, req *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error)
+	listVMCVEsByVMFn     func(ctx context.Context, req *v2.ListVMCVEsByVMRequest) (*v2.ListVMCVEsByVMResponse, error)
+	getVMCVEComponentsFn func(ctx context.Context, req *v2.GetVMCVEComponentsRequest) (*v2.GetVMCVEComponentsResponse, error)
+	getVMVulnSummaryFn   func(ctx context.Context, req *v2.GetVMVulnSummaryRequest) (*v2.VMVulnSummary, error)
+}
+
+func (s *stubV2Client) GetVM(ctx context.Context, in *v2.GetVMRequest, _ ...grpc.CallOption) (*v2.VMDetail, error) {
+	if s.getVMFn == nil {
+		return nil, errors.New("GetVM not stubbed")
+	}
+	return s.getVMFn(ctx, in)
+}
+
+func (s *stubV2Client) GetVMVulnSummary(ctx context.Context, in *v2.GetVMVulnSummaryRequest, _ ...grpc.CallOption) (*v2.VMVulnSummary, error) {
+	if s.getVMVulnSummaryFn == nil {
+		return &v2.VMVulnSummary{}, nil
+	}
+	return s.getVMVulnSummaryFn(ctx, in)
+}
+
+func (s *stubV2Client) ListVMCVEsByVM(ctx context.Context, in *v2.ListVMCVEsByVMRequest, _ ...grpc.CallOption) (*v2.ListVMCVEsByVMResponse, error) {
+	if s.listVMCVEsByVMFn == nil {
+		return &v2.ListVMCVEsByVMResponse{}, nil
+	}
+	return s.listVMCVEsByVMFn(ctx, in)
+}
+
+func (s *stubV2Client) GetVMCVEComponents(ctx context.Context, in *v2.GetVMCVEComponentsRequest, _ ...grpc.CallOption) (*v2.GetVMCVEComponentsResponse, error) {
+	if s.getVMCVEComponentsFn == nil {
+		return &v2.GetVMCVEComponentsResponse{}, nil
+	}
+	return s.getVMCVEComponentsFn(ctx, in)
+}
+
+func (s *stubV2Client) ListVMComponents(ctx context.Context, in *v2.ListVMComponentsRequest, _ ...grpc.CallOption) (*v2.ListVMComponentsResponse, error) {
+	if s.listVMComponentsFn == nil {
+		return &v2.ListVMComponentsResponse{}, nil
+	}
+	return s.listVMComponentsFn(ctx, in)
+}
+
+func (s *stubV2Client) ListVMs(ctx context.Context, in *v2.ListVMsRequest, _ ...grpc.CallOption) (*v2.ListVMsResponse, error) {
+	if s.listVMsFn == nil {
+		return &v2.ListVMsResponse{}, nil
+	}
+	return s.listVMsFn(ctx, in)
+}
+
+func (s *stubV2Client) ListVMCVEs(context.Context, *v2.ListVMCVEsRequest, ...grpc.CallOption) (*v2.ListVMCVEsResponse, error) {
+	return &v2.ListVMCVEsResponse{}, nil
+}
+
+func (s *stubV2Client) GetVMDashboardCounts(context.Context, *v2.VMDashboardCountsRequest, ...grpc.CallOption) (*v2.VMDashboardCountsResponse, error) {
+	return &v2.VMDashboardCountsResponse{}, nil
+}
+
+func (s *stubV2Client) GetVMCVEDetail(context.Context, *v2.GetVMCVEDetailRequest, ...grpc.CallOption) (*v2.VMCVEDetail, error) {
+	return &v2.VMCVEDetail{}, nil
+}
+
+func (s *stubV2Client) ListVMCVEAffectedVMs(context.Context, *v2.ListVMCVEAffectedVMsRequest, ...grpc.CallOption) (*v2.ListVMCVEAffectedVMsResponse, error) {
+	return &v2.ListVMCVEAffectedVMsResponse{}, nil
+}
+
+func TestWaitForV2VMPresentInCentral_UsesListVMs(t *testing.T) {
+	ctx := t.Context()
+	opts := WaitOptions{Timeout: 200 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var sawQuery string
+	client := &stubV2Client{
+		listVMsFn: func(_ context.Context, req *v2.ListVMsRequest) (*v2.ListVMsResponse, error) {
+			sawQuery = req.GetQuery().GetQuery()
+			return &v2.ListVMsResponse{
+				Vms: []*v2.VMListItem{
+					{Id: "id-1", Namespace: "ns1", Name: "vm1"},
+				},
+			}, nil
+		},
+	}
+	vm, err := WaitForV2VMPresentInCentral(ctx, client, opts, "ns1", "vm1")
+	require.NoError(t, err)
+	require.Equal(t, "id-1", vm.GetId())
+	require.Contains(t, sawQuery, `Namespace:"ns1"`)
+	require.Contains(t, sawQuery, `Virtual Machine Name:"vm1"`)
+}
+
+func TestWaitForV2VMLatestScan(t *testing.T) {
+	ctx := t.Context()
+	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var calls int
+	client := &stubV2Client{
+		getVMFn: func(_ context.Context, req *v2.GetVMRequest) (*v2.VMDetail, error) {
+			calls++
+			if calls < 3 {
+				return &v2.VMDetail{Id: req.GetId()}, nil
+			}
+			return &v2.VMDetail{
+				Id: req.GetId(),
+				LatestScan: &v2.VMScanInfo{
+					ScanTime: timestamppb.Now(),
+				},
+			}, nil
+		},
+	}
+	vm, err := WaitForV2VMLatestScan(ctx, client, opts, "vid")
+	require.NoError(t, err)
+	require.NotNil(t, vm.GetLatestScan().GetScanTime())
+	require.GreaterOrEqual(t, calls, 3)
+}
+
+func TestWaitForV2VMRunningInCentral(t *testing.T) {
+	ctx := t.Context()
+	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var calls int
+	client := &stubV2Client{
+		getVMFn: func(_ context.Context, _ *v2.GetVMRequest) (*v2.VMDetail, error) {
+			calls++
+			if calls < 2 {
+				return &v2.VMDetail{Id: "r1", State: v2.VirtualMachineV2State_VM_STATE_STOPPED}, nil
+			}
+			return &v2.VMDetail{Id: "r1", State: v2.VirtualMachineV2State_VM_STATE_RUNNING}, nil
+		},
+	}
+	vm, err := WaitForV2VMRunningInCentral(ctx, client, opts, "r1")
+	require.NoError(t, err)
+	require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, vm.GetState())
+}
+
+func TestListAllVMCVEsByVM_Pages(t *testing.T) {
+	ctx := t.Context()
+	client := &stubV2Client{
+		listVMCVEsByVMFn: func(_ context.Context, req *v2.ListVMCVEsByVMRequest) (*v2.ListVMCVEsByVMResponse, error) {
+			switch req.GetQuery().GetPagination().GetOffset() {
+			case 0:
+				return &v2.ListVMCVEsByVMResponse{
+					TotalCount: 2,
+					Cves:       []*v2.VMCVERow{{Cve: "CVE-1"}, {Cve: "CVE-2"}},
+				}, nil
+			default:
+				return &v2.ListVMCVEsByVMResponse{TotalCount: 2}, nil
+			}
+		},
+	}
+	cves, total, err := ListAllVMCVEsByVM(ctx, client, "vid")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), total)
+	require.Equal(t, []string{"CVE-1", "CVE-2"}, []string{cves[0].GetCve(), cves[1].GetCve()})
+}
+
+func TestListAllVMComponents_Pages(t *testing.T) {
+	ctx := t.Context()
+	page0 := make([]*v2.VMComponentRow, v2ListPageSize)
+	for i := range page0 {
+		page0[i] = &v2.VMComponentRow{Name: "pkg"}
+	}
+	client := &stubV2Client{
+		listVMComponentsFn: func(_ context.Context, req *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error) {
+			switch req.GetQuery().GetPagination().GetOffset() {
+			case 0:
+				return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize + 1), Components: page0}, nil
+			case v2ListPageSize:
+				return &v2.ListVMComponentsResponse{
+					TotalCount: int32(v2ListPageSize + 1),
+					Components: []*v2.VMComponentRow{{Name: "last"}},
+				}, nil
+			default:
+				return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize + 1)}, nil
+			}
+		},
+	}
+	comps, total, err := ListAllVMComponents(ctx, client, "vid")
+	require.NoError(t, err)
+	require.Equal(t, int32(v2ListPageSize+1), total)
+	require.Len(t, comps, v2ListPageSize+1)
+	require.Equal(t, "last", comps[len(comps)-1].GetName())
+}
+
+func TestVulnCountBySeverityTotal(t *testing.T) {
+	tests := map[string]struct {
+		in   *v2.VulnCountBySeverity
+		want int32
+	}{
+		"nil":   {in: nil, want: 0},
+		"empty": {in: &v2.VulnCountBySeverity{}, want: 0},
+		"sums": {in: &v2.VulnCountBySeverity{
+			Critical:  &v2.VulnFixableCount{Total: 3},
+			Important: &v2.VulnFixableCount{Total: 2},
+			Moderate:  &v2.VulnFixableCount{Total: 1},
+			Low:       &v2.VulnFixableCount{Total: 4},
+			Unknown:   &v2.VulnFixableCount{Total: 0},
+		}, want: 10},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, VulnCountBySeverityTotal(tc.in))
+		})
+	}
+}
+
+func TestWaitForV2ScanMissingComponent(t *testing.T) {
+	ctx := t.Context()
+	opts := WaitOptions{Timeout: 400 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	baseline := time.Now().Add(-time.Minute)
+	var calls int
+	client := &stubV2Client{
+		getVMFn: func(_ context.Context, req *v2.GetVMRequest) (*v2.VMDetail, error) {
+			calls++
+			scanTime := baseline.Add(time.Duration(calls) * time.Second)
+			return &v2.VMDetail{
+				Id: req.GetId(),
+				LatestScan: &v2.VMScanInfo{
+					ScanTime: timestamppb.New(scanTime),
+				},
+			}, nil
+		},
+		listVMComponentsFn: func(_ context.Context, req *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error) {
+			if req.GetQuery().GetQuery() != "" {
+				if calls < 3 {
+					return &v2.ListVMComponentsResponse{
+						TotalCount: 1,
+						Components: []*v2.VMComponentRow{{Name: "bc"}},
+					}, nil
+				}
+				return &v2.ListVMComponentsResponse{}, nil
+			}
+			return &v2.ListVMComponentsResponse{
+				TotalCount: 2,
+				Components: []*v2.VMComponentRow{{Name: "bash"}, {Name: "coreutils"}},
+			}, nil
+		},
+	}
+	comps, err := WaitForV2ScanMissingComponent(ctx, client, opts, "vid", "bc", baseline, 2)
+	require.NoError(t, err)
+	require.Len(t, comps, 2)
+}
+
+func TestWaitForV2ScanReady(t *testing.T) {
+	ctx := t.Context()
+	opts := WaitOptions{Timeout: 200 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var calls int
+	client := &stubV2Client{
+		getVMFn: func(_ context.Context, req *v2.GetVMRequest) (*v2.VMDetail, error) {
+			return &v2.VMDetail{
+				Id:      req.GetId(),
+				GuestOs: "rhel",
+				LatestScan: &v2.VMScanInfo{
+					ScanTime: timestamppb.Now(),
+					ScanOs:   "rhel",
+				},
+			}, nil
+		},
+		listVMComponentsFn: func(context.Context, *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error) {
+			calls++
+			if calls == 1 {
+				return &v2.ListVMComponentsResponse{
+					TotalCount: 1,
+					Components: []*v2.VMComponentRow{{Name: "bash", ScanStatus: v2.ScanStatus_NOT_SCANNED}},
+				}, nil
+			}
+			return &v2.ListVMComponentsResponse{
+				TotalCount: 1,
+				Components: []*v2.VMComponentRow{{Name: "bash", ScanStatus: v2.ScanStatus_SCANNED}},
+			}, nil
+		},
+	}
+	vm, err := WaitForV2ScanReady(ctx, client, opts, "vid")
+	require.NoError(t, err)
+	require.Equal(t, "vid", vm.GetId())
+	require.GreaterOrEqual(t, calls, 2)
+}

--- a/tests/vmhelpers/roxagent_quadlet.go
+++ b/tests/vmhelpers/roxagent_quadlet.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -129,11 +130,63 @@ func installGuestPodmanAuth(ctx context.Context, virt Virtctl, namespace, vm, po
 }
 
 func scpToGuest(ctx context.Context, virt Virtctl, namespace, vm, src, dst string) error {
-	stderr, err := virt.SCPTo(ctx, namespace, vm, src, dst)
-	if err != nil {
-		return fmt.Errorf("virtctl scp %s -> %s: %w: %s", src, dst, err, strings.TrimSpace(stderr))
+	return retryCopyToGuest(ctx, virt.Logf, src, dst, defaultSSHTransportRetryAttempts, defaultSSHTransportRetryInterval, func() (string, error) {
+		return virt.SCPTo(ctx, namespace, vm, src, dst)
+	})
+}
+
+// wrapSCPError maps virtctl scp failures onto the same SSH-transport sentinels
+// as runSSHCommandWithFramework so retryOnSSHTransport can retry a banner timeout.
+func wrapSCPError(src, dst, stderr string, err error) error {
+	trimmed := strings.TrimSpace(stderr)
+	isSSH, retryable, category := classifySSHFailure(stderr, err)
+	if !isSSH {
+		return fmt.Errorf("virtctl scp %s -> %s: %w: %s", src, dst, err, trimmed)
 	}
-	return nil
+	kind := "retryable"
+	if !retryable {
+		kind = "terminal"
+	}
+	wrapped := err
+	if isSSHBannerTimeoutFailure(stderr) {
+		wrapped = errors.Join(err, ErrSSHConnectivityStalled)
+	}
+	return fmt.Errorf("%w: virtctl scp %s -> %s: %s SSH %s failure: %w: %s",
+		errSSHTransport, src, dst, kind, category, wrapped, trimmed)
+}
+
+func retryCopyToGuest(ctx context.Context, logf func(string, ...any), src, dst string, attempts int, interval time.Duration, copyFn func() (string, error)) error {
+	if attempts <= 0 {
+		attempts = defaultSSHTransportRetryAttempts
+	}
+	if interval <= 0 {
+		interval = defaultSSHTransportRetryInterval
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		stderr, err := copyFn()
+		if err == nil {
+			return nil
+		}
+		lastErr = wrapSCPError(src, dst, stderr, err)
+		isSSH, retryable, category := classifySSHFailure(stderr, err)
+		if !isSSH || !retryable || attempt >= attempts {
+			return lastErr
+		}
+		if logf != nil {
+			logf("virtctl scp %s -> %s: retryable SSH %s (attempt %d/%d)", src, dst, category, attempt, attempts)
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("%w: virtctl scp %s -> %s: context done during retry backoff: %w",
+				errSSHTransport, src, dst, ctx.Err())
+		case <-timer.C:
+		}
+	}
+	return lastErr
 }
 
 func stageQuadletInstall(image, repo2cpeURL, podmanAuthPath string) (string, error) {

--- a/tests/vmhelpers/roxagent_quadlet.go
+++ b/tests/vmhelpers/roxagent_quadlet.go
@@ -135,24 +135,27 @@ func scpToGuest(ctx context.Context, virt Virtctl, namespace, vm, src, dst strin
 	})
 }
 
-// wrapSCPError maps virtctl scp failures onto the same SSH-transport sentinels
-// as runSSHCommandWithFramework so retryOnSSHTransport can retry a banner timeout.
+// wrapSCPError attaches errSSHTransport only for retryable SSH failures so
+// retryOnSSHTransport does not spin on terminal auth errors.
 func wrapSCPError(src, dst, stderr string, err error) error {
 	trimmed := strings.TrimSpace(stderr)
 	isSSH, retryable, category := classifySSHFailure(stderr, err)
 	if !isSSH {
 		return fmt.Errorf("virtctl scp %s -> %s: %w: %s", src, dst, err, trimmed)
 	}
-	kind := "retryable"
-	if !retryable {
-		kind = "terminal"
-	}
 	wrapped := err
 	if isSSHBannerTimeoutFailure(stderr) {
 		wrapped = errors.Join(err, ErrSSHConnectivityStalled)
 	}
-	return fmt.Errorf("%w: virtctl scp %s -> %s: %s SSH %s failure: %w: %s",
-		errSSHTransport, src, dst, kind, category, wrapped, trimmed)
+	if isSSHAuthenticationFailure(stderr) {
+		wrapped = errors.Join(wrapped, ErrSSHAuthenticationFailed)
+	}
+	if retryable {
+		return fmt.Errorf("%w: virtctl scp %s -> %s: retryable SSH %s failure: %w: %s",
+			errSSHTransport, src, dst, category, wrapped, trimmed)
+	}
+	return fmt.Errorf("virtctl scp %s -> %s: terminal SSH %s failure: %w: %s",
+		src, dst, category, wrapped, trimmed)
 }
 
 func retryCopyToGuest(ctx context.Context, logf func(string, ...any), src, dst string, attempts int, interval time.Duration, copyFn func() (string, error)) error {

--- a/tests/vmhelpers/roxagent_quadlet_test.go
+++ b/tests/vmhelpers/roxagent_quadlet_test.go
@@ -3,10 +3,12 @@
 package vmhelpers
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -131,6 +133,90 @@ func TestIsVsockUnavailableOutput(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.want, isVsockUnavailableOutput(tc.output))
+		})
+	}
+}
+
+const scpBannerTimeoutStderr = "Connection timed out during banner exchange\nConnection to UNKNOWN port 65535 timed out\nscp: Connection closed\nexit status 255"
+
+func TestWrapSCPError(t *testing.T) {
+	t.Parallel()
+	copyErr := errors.New("exit status 1")
+	tests := map[string]struct {
+		stderr        string
+		wantTransport bool
+		wantStalled   bool
+	}{
+		"banner timeout is SSH transport": {
+			stderr:        scpBannerTimeoutStderr,
+			wantTransport: true,
+			wantStalled:   true,
+		},
+		"remote command failure is not SSH transport": {
+			stderr:        "install.sh: no such file\nexit status 1",
+			wantTransport: false,
+			wantStalled:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := wrapSCPError("/tmp/install.sh", "/guest/install.sh", tc.stderr, copyErr)
+			require.Error(t, err)
+			require.Equal(t, tc.wantTransport, errors.Is(err, errSSHTransport))
+			require.Equal(t, tc.wantStalled, errors.Is(err, ErrSSHConnectivityStalled))
+		})
+	}
+}
+
+func TestRetryCopyToGuest(t *testing.T) {
+	t.Parallel()
+	copyErr := errors.New("exit status 1")
+	tests := map[string]struct {
+		stderr           string
+		succeedOnAttempt int
+		wantAttempts     int
+		wantErr          bool
+		wantTransport    bool
+		wantStalled      bool
+	}{
+		"retries banner timeout then succeeds": {
+			stderr:           scpBannerTimeoutStderr,
+			succeedOnAttempt: 3,
+			wantAttempts:     3,
+		},
+		"gives up on persistent banner timeout": {
+			stderr:        scpBannerTimeoutStderr,
+			wantAttempts:  3,
+			wantErr:       true,
+			wantTransport: true,
+			wantStalled:   true,
+		},
+		"does not retry remote command failure": {
+			stderr:       "install.sh: permission denied",
+			wantAttempts: 1,
+			wantErr:      true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			attempts := 0
+			err := retryCopyToGuest(t.Context(), nil, "/tmp/install.sh", "/guest/install.sh", 3, time.Millisecond, func() (string, error) {
+				attempts++
+				if tc.succeedOnAttempt > 0 && attempts >= tc.succeedOnAttempt {
+					return "", nil
+				}
+				return tc.stderr, copyErr
+			})
+			require.Equal(t, tc.wantAttempts, attempts)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, tc.wantTransport, errors.Is(err, errSSHTransport))
+			require.Equal(t, tc.wantStalled, errors.Is(err, ErrSSHConnectivityStalled))
 		})
 	}
 }

--- a/tests/vmhelpers/roxagent_quadlet_test.go
+++ b/tests/vmhelpers/roxagent_quadlet_test.go
@@ -146,16 +146,19 @@ func TestWrapSCPError(t *testing.T) {
 		stderr        string
 		wantTransport bool
 		wantStalled   bool
+		wantAuth      bool
 	}{
 		"banner timeout is SSH transport": {
 			stderr:        scpBannerTimeoutStderr,
 			wantTransport: true,
 			wantStalled:   true,
 		},
+		"auth failure is terminal not transport": {
+			stderr:   "Permission denied (publickey).\r\n",
+			wantAuth: true,
+		},
 		"remote command failure is not SSH transport": {
-			stderr:        "install.sh: no such file\nexit status 1",
-			wantTransport: false,
-			wantStalled:   false,
+			stderr: "install.sh: no such file\nexit status 1",
 		},
 	}
 	for name, tc := range tests {
@@ -165,6 +168,7 @@ func TestWrapSCPError(t *testing.T) {
 			require.Error(t, err)
 			require.Equal(t, tc.wantTransport, errors.Is(err, errSSHTransport))
 			require.Equal(t, tc.wantStalled, errors.Is(err, ErrSSHConnectivityStalled))
+			require.Equal(t, tc.wantAuth, errors.Is(err, ErrSSHAuthenticationFailed))
 		})
 	}
 }
@@ -179,6 +183,7 @@ func TestRetryCopyToGuest(t *testing.T) {
 		wantErr          bool
 		wantTransport    bool
 		wantStalled      bool
+		wantAuth         bool
 	}{
 		"retries banner timeout then succeeds": {
 			stderr:           scpBannerTimeoutStderr,
@@ -191,6 +196,12 @@ func TestRetryCopyToGuest(t *testing.T) {
 			wantErr:       true,
 			wantTransport: true,
 			wantStalled:   true,
+		},
+		"does not retry terminal SSH auth": {
+			stderr:       "Permission denied (publickey).\r\n",
+			wantAttempts: 1,
+			wantErr:      true,
+			wantAuth:     true,
 		},
 		"does not retry remote command failure": {
 			stderr:       "install.sh: permission denied",
@@ -217,6 +228,7 @@ func TestRetryCopyToGuest(t *testing.T) {
 			require.Error(t, err)
 			require.Equal(t, tc.wantTransport, errors.Is(err, errSSHTransport))
 			require.Equal(t, tc.wantStalled, errors.Is(err, ErrSSHConnectivityStalled))
+			require.Equal(t, tc.wantAuth, errors.Is(err, ErrSSHAuthenticationFailed))
 		})
 	}
 }

--- a/tests/vmhelpers/wait_test.go
+++ b/tests/vmhelpers/wait_test.go
@@ -66,6 +66,7 @@ func TestIsAuthenticationExpired(t *testing.T) {
 		"wrapped ErrAuthenticationExpired": {err: fmt.Errorf("op: %w", ErrAuthenticationExpired), want: true},
 		"unrelated error":                  {err: errors.New("connection refused"), want: false},
 		"gRPC unavailable (not auth)":      {err: status.Error(codes.Unavailable, "service down"), want: false},
+		"gRPC Unimplemented":               {err: status.Error(codes.Unimplemented, "not registered"), want: false},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Central registers either `VirtualMachineV2Service` or `VirtualMachineService` from `ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL`. After that flag defaulted on, the Go VM e2e suite still waited on the legacy client. When the flag is on, those RPCs return Unimplemented, so `waitForScan` cannot finish.

The GA UI reads the v2 service (`ListVMs`, `GetVM`, `GetVMVulnSummary`, `ListVMCVEsByVM`, `ListVMComponents`). A green legacy `GetVirtualMachine` path does not mean those responses are correct.

SetupSuite reads the flag from the Central deployment (same true/false/default rules as `features.Enabled`) and calls the matching List RPC as a registration check. `waitForScan` and the RPM-rescan wait follow that API. The suite does not flip the flag or restart Central.

Legacy metadata, component, OS, and consistency subtests skip when the flag is on. v2 GetVM, ListVMs, ListVMCVEsByVM, and ListVMComponents skip when it is off. Wait and paginated-list helpers for v2 live in `tests/vmhelpers/central_v2.go`.

The v2 ListVMs and ListVMCVEsByVM subtests require severity totals to match distinct CVE IDs, and `affected_component_count >= 1` for a row that `GetVMCVEComponents` also returns. Those asserts fail on current master: [ROX-36615](https://redhat.atlassian.net/browse/ROX-36615) (severity counts) and [ROX-36617](https://redhat.atlassian.net/browse/ROX-36617) (`affected_component_count`) are still open. This branch is on master, not stacked on those fixes.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI: failing correctly
    - The test will be failing as long as the following are not fixed:
        - https://redhat.atlassian.net/browse/ROX-36615 
        - and https://redhat.atlassian.net/browse/ROX-36617 
- [x] CI e2e passing after merging the blockers (one passing is sufficient):
    - [x] 4.14 ✅ https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22516/pull-ci-stackrox-stackrox-master-ocp-4-14-vm-scanning-e2e-tests/2095097412644245504
    - [x] 4.18 ✅  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22516/pull-ci-stackrox-stackrox-master-ocp-4-18-vm-scanning-e2e-tests/2095097412673605632
    - [ ] 4.22 :x: this one fails on downloading the `virtctl` from the virtualization operator pods - one of their pods is going OOM. This looks like not our issue (and not related to this PR), but I will monitor it


[ROX-36615]: https://redhat.atlassian.net/browse/ROX-36615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ