### PR TITLE
ROX-36481: [UI] Add Top prefix to aggregate CVSS/CVE Severity columns

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/cveDetailPage.test.ts
@@ -144,11 +144,11 @@ describe('Node CVEs - CVE Detail Page', () => {
             );
 
             // check sorting of CVE Severity column
-            sortByTableHeader('CVE severity');
+            sortByTableHeader('Top CVE severity');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'Severity', reversed: true })
             );
-            sortByTableHeader('CVE severity');
+            sortByTableHeader('Top CVE severity');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'Severity', reversed: false })
             );
@@ -164,11 +164,11 @@ describe('Node CVEs - CVE Detail Page', () => {
             );
 
             // check sorting of CVSS column
-            sortByTableHeader('CVSS');
+            sortByTableHeader('Top CVSS');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'CVSS', reversed: true })
             );
-            sortByTableHeader('CVSS');
+            sortByTableHeader('Top CVSS');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'CVSS', reversed: false })
             );

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
@@ -122,11 +122,11 @@ describe('Node CVEs - Node Detail Page', () => {
             );
 
             // check sorting of Top Severity column
-            sortByTableHeader('Top severity');
+            sortByTableHeader('Top CVE severity');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'Severity', reversed: true })
             );
-            sortByTableHeader('Top severity');
+            sortByTableHeader('Top CVE severity');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'Severity', reversed: false })
             );
@@ -142,11 +142,11 @@ describe('Node CVEs - Node Detail Page', () => {
             );
 
             // check sorting of CVSS column
-            sortByTableHeader('CVSS');
+            sortByTableHeader('Top CVSS');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'CVSS', reversed: true })
             );
-            sortByTableHeader('CVSS');
+            sortByTableHeader('Top CVSS');
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedSort({ field: 'CVSS', reversed: false })
             );
@@ -177,7 +177,7 @@ describe('Node CVEs - Node Detail Page', () => {
             waitAndYieldRequestBodyVariables().then(
                 expectRequestedQuery('Severity:LOW_VULNERABILITY_SEVERITY')
             );
-            assertOnEachRowForColumn('Top severity', (_, cell) => {
+            assertOnEachRowForColumn('Top CVE severity', (_, cell) => {
                 expect(cell.innerText).to.contain('Low');
             });
             filterHelpers.clearFilters();
@@ -195,7 +195,7 @@ describe('Node CVEs - Node Detail Page', () => {
             // filtering by CVSS should only display rows with a CVSS in range
             filterHelpers.addNumericFilter('CVE', 'CVSS', 'Is less than', 8);
             waitAndYieldRequestBodyVariables().then(expectRequestedQuery('CVSS:<8'));
-            assertOnEachRowForColumn('CVSS', (_, cell) => {
+            assertOnEachRowForColumn('Top CVSS', (_, cell) => {
                 const cvss = parseFloat(cell.innerText.replace(/[^0-9.]/g, ''));
                 expect(cvss).to.be.lessThan(8);
             });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
@@ -74,9 +74,9 @@ describe('Virtual Machine CVEs - Virtual Machine Page', () => {
                 .eq(0)
                 .within(() => {
                     cy.get('td[data-label="CVE"]').contains('CVE-2024-0001');
-                    cy.get('td[data-label="CVE severity"]').contains('Critical');
+                    cy.get('td[data-label="Top CVE severity"]').contains('Critical');
                     cy.get('td[data-label="CVE status"]').contains('Fixable');
-                    cy.get('td[data-label="CVSS"]').contains('9.8');
+                    cy.get('td[data-label="Top CVSS"]').contains('9.8');
                     cy.get('td[data-label="EPSS probability"]').contains('85.000%');
                     cy.get('td[data-label="Affected components"]').contains('1 component');
                 });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
@@ -73,7 +73,7 @@ describe('Workload CVE Deployment Single page', () => {
         cy.get(vulnSelectors.summaryCard('CVEs by status'));
         // Check table exists with the correct headers
         cy.get('table thead tr th').contains('CVE');
-        cy.get('table thead tr th').contains('CVE severity');
+        cy.get('table thead tr th').contains('Top CVE severity');
         cy.get('table thead tr th').contains('CVE status');
         cy.get('table thead tr th').contains('Affected components');
         cy.get('table thead tr th').contains('First discovered');

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/CVEsTable.tsx
@@ -79,9 +79,9 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
                 <Tr>
                     <ExpandRowTh />
                     <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
-                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top severity</Th>
+                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top CVE severity</Th>
                     <Th sort={getSortParams(CVE_STATUS_SORT_FIELD)}>CVE status</Th>
-                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>Top CVSS</Th>
                     <Th>Affected components</Th>
                 </Tr>
             </Thead>
@@ -114,13 +114,13 @@ function CVEsTable({ tableState, getSortParams, onClearFilters }: CVEsTableProps
                                     <Td dataLabel="CVE" modifier="nowrap">
                                         <Link to={getNodeEntityPagePath('CVE', cve)}>{cve}</Link>
                                     </Td>
-                                    <Td dataLabel="Top severity">
+                                    <Td dataLabel="Top CVE severity">
                                         <VulnerabilitySeverityIconText severity={topSeverity} />
                                     </Td>
                                     <Td dataLabel="CVE status">
                                         <VulnerabilityFixableIconText isFixable={isFixableInNode} />
                                     </Td>
-                                    <Td dataLabel="CVSS">
+                                    <Td dataLabel="Top CVSS">
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
                                     <Td dataLabel="Affected components">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.cy.jsx
@@ -173,7 +173,7 @@ describe(Cypress.spec.relative, () => {
                 cy.findAllByRole('row')
                     .eq(rowIndex)
                     .within(() => {
-                        cy.get(`td[data-label="CVE severity"]:contains("${expectedSeverity}")`);
+                        cy.get(`td[data-label="Top CVE severity"]:contains("${expectedSeverity}")`);
                     });
             });
         });
@@ -277,7 +277,7 @@ describe(Cypress.spec.relative, () => {
                     .eq(rowIndex)
                     .within(() => {
                         cy.get(
-                            `td[data-label="CVSS"]:contains("${expectedCVSS} (${expectedVersion})")`
+                            `td[data-label="Top CVSS"]:contains("${expectedCVSS} (${expectedVersion})")`
                         );
                     });
             });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/NodeCve/AffectedNodesTable.tsx
@@ -109,9 +109,9 @@ function AffectedNodesTable({
                 <Tr>
                     <Th screenReaderText="Row expansion" />
                     <Th sort={getSortParams(NODE_SORT_FIELD)}>Node</Th>
-                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>CVE severity</Th>
+                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top CVE severity</Th>
                     <Th sort={getSortParams(CVE_STATUS_SORT_FIELD)}>CVE status</Th>
-                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>Top CVSS</Th>
                     <Th sort={getSortParams(CLUSTER_SORT_FIELD)}>Cluster</Th>
                     <Th sort={getSortParams(OPERATING_SYSTEM_SORT_FIELD)}>Operating system</Th>
                     <Th>Affected components</Th>
@@ -152,13 +152,13 @@ function AffectedNodesTable({
                                             <Truncate position="middle" content={name} />
                                         </Link>
                                     </Td>
-                                    <Td dataLabel="CVE severity" modifier="nowrap">
+                                    <Td dataLabel="Top CVE severity" modifier="nowrap">
                                         <VulnerabilitySeverityIconText severity={topSeverity} />
                                     </Td>
                                     <Td dataLabel="CVE status" modifier="nowrap">
                                         <VulnerabilityFixableIconText isFixable={isFixableInNode} />
                                     </Td>
-                                    <Td dataLabel="CVSS" modifier="nowrap">
+                                    <Td dataLabel="Top CVSS" modifier="nowrap">
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>
                                     <Td dataLabel="Cluster">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
@@ -112,9 +112,9 @@ function VirtualMachinePageVulnerabilities({
                     <Tr>
                         <Th screenReaderText="Row expansion" />
                         <Th sort={getSortParams(CVE_SORT_FIELD)}>CVE</Th>
-                        <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>CVE severity</Th>
+                        <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top CVE severity</Th>
                         <Th sort={getSortParams(CVE_STATUS_SORT_FIELD)}>CVE status</Th>
-                        <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS</Th>
+                        <Th sort={getSortParams(CVSS_SORT_FIELD)}>Top CVSS</Th>
                         <Th sort={getSortParams(CVE_EPSS_PROBABILITY_SORT_FIELD)}>
                             EPSS probability
                         </Th>
@@ -144,7 +144,7 @@ function VirtualMachinePageVulnerabilities({
                                         <Td dataLabel="CVE">
                                             <Truncate position="middle" content={cve.cve} />
                                         </Td>
-                                        <Td dataLabel="CVE severity" modifier="nowrap">
+                                        <Td dataLabel="Top CVE severity" modifier="nowrap">
                                             <VulnerabilitySeverityIconText
                                                 severity={cve.severity}
                                             />
@@ -154,7 +154,7 @@ function VirtualMachinePageVulnerabilities({
                                                 isFixable={cve.isFixable}
                                             />
                                         </Td>
-                                        <Td dataLabel="CVSS" modifier="nowrap">
+                                        <Td dataLabel="Top CVSS" modifier="nowrap">
                                             <CvssFormatted cvss={cve.cvss} />
                                         </Td>
                                         <Td dataLabel="EPSS probability">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineVulnerabilitiesTable.tsx
@@ -34,7 +34,7 @@ export const defaultColumns = {
         isUntoggleAble: true,
     },
     cveSeverity: {
-        title: 'CVE severity',
+        title: 'Top CVE severity',
         isShownByDefault: true,
     },
     cveStatus: {
@@ -42,7 +42,7 @@ export const defaultColumns = {
         isShownByDefault: true,
     },
     cvss: {
-        title: 'CVSS',
+        title: 'Top CVSS',
         isShownByDefault: true,
     },
     epssProbability: {
@@ -90,14 +90,14 @@ function VirtualMachineVulnerabilitiesTable({
                         className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}
                     >
-                        CVE severity
+                        Top CVE severity
                     </Th>
                     <Th className={getVisibilityClass('cveStatus')}>CVE status</Th>
                     <Th
                         className={getVisibilityClass('cvss')}
                         sort={getSortParams(CVSS_SORT_FIELD)}
                     >
-                        CVSS
+                        Top CVSS
                     </Th>
                     <Th
                         className={getVisibilityClass('epssProbability')}
@@ -140,7 +140,7 @@ function VirtualMachineVulnerabilitiesTable({
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('cveSeverity')}
-                                        dataLabel="CVE severity"
+                                        dataLabel="Top CVE severity"
                                     >
                                         <VulnerabilitySeverityIconText
                                             severity={vulnerability.severity}
@@ -154,7 +154,7 @@ function VirtualMachineVulnerabilitiesTable({
                                             isFixable={vulnerability.isFixable}
                                         />
                                     </Td>
-                                    <Td className={getVisibilityClass('cvss')} dataLabel="CVSS">
+                                    <Td className={getVisibilityClass('cvss')} dataLabel="Top CVSS">
                                         <CvssFormatted
                                             cvss={vulnerability.cvss}
                                             scoreVersion="v3"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/AffectedVirtualMachinesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/AffectedVirtualMachinesTable.tsx
@@ -50,9 +50,9 @@ function AffectedVirtualMachinesTable({
                 <Tr>
                     <Th screenReaderText="Row expansion" />
                     <Th sort={getSortParams(VIRTUAL_MACHINE_SORT_FIELD)}>Virtual machine</Th>
-                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>CVE severity</Th>
+                    <Th sort={getSortParams(CVE_SEVERITY_SORT_FIELD)}>Top CVE severity</Th>
                     <Th>CVE status</Th>
-                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>CVSS</Th>
+                    <Th sort={getSortParams(CVSS_SORT_FIELD)}>Top CVSS</Th>
                     <Th sort={getSortParams(GUEST_OS_SORT_FIELD)}>Guest OS</Th>
                     <Th>Affected components</Th>
                 </Tr>
@@ -92,7 +92,7 @@ function AffectedVirtualMachinesTable({
                                             />
                                         </Link>
                                     </Td>
-                                    <Td dataLabel="CVE severity" modifier="nowrap">
+                                    <Td dataLabel="Top CVE severity" modifier="nowrap">
                                         <VulnerabilitySeverityIconText
                                             severity={virtualMachine.severity}
                                         />
@@ -102,7 +102,7 @@ function AffectedVirtualMachinesTable({
                                             isFixable={virtualMachine.isFixable}
                                         />
                                     </Td>
-                                    <Td dataLabel="CVSS" modifier="nowrap">
+                                    <Td dataLabel="Top CVSS" modifier="nowrap">
                                         <CvssFormatted cvss={virtualMachine.cvss} />
                                     </Td>
                                     <Td dataLabel="Guest OS">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -47,7 +47,7 @@ export const defaultColumns = {
         isUntoggleAble: true,
     },
     cveSeverity: {
-        title: 'CVE severity',
+        title: 'Top CVE severity',
         isShownByDefault: true,
     },
     cveStatus: {
@@ -55,7 +55,7 @@ export const defaultColumns = {
         isShownByDefault: true,
     },
     cvss: {
-        title: 'CVSS',
+        title: 'Top CVSS',
         isShownByDefault: true,
     },
     nvdCvss: {
@@ -165,13 +165,13 @@ function AffectedImagesTable({
                         className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams('Severity')}
                     >
-                        CVE severity
+                        Top CVE severity
                     </Th>
                     <Th className={getVisibilityClass('cveStatus')}>
                         CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
-                    <Th className={getVisibilityClass('cvss')}>CVSS</Th>
+                    <Th className={getVisibilityClass('cvss')}>Top CVSS</Th>
                     <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
                     <Th
                         className={getVisibilityClass('operatingSystem')}
@@ -248,7 +248,7 @@ function AffectedImagesTable({
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('cveSeverity')}
-                                        dataLabel="CVE severity"
+                                        dataLabel="Top CVE severity"
                                         modifier="nowrap"
                                     >
                                         <VulnerabilitySeverityIconText severity={topSeverity} />
@@ -264,7 +264,7 @@ function AffectedImagesTable({
                                     </Td>
                                     <Td
                                         className={getVisibilityClass('cvss')}
-                                        dataLabel="CVSS"
+                                        dataLabel="Top CVSS"
                                         modifier="nowrap"
                                     >
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -49,7 +49,7 @@ export const defaultColumns = {
         isShownByDefault: true,
     },
     cveSeverity: {
-        title: 'CVE severity',
+        title: 'Top CVE severity',
         isShownByDefault: true,
     },
     cveStatus: {
@@ -145,7 +145,7 @@ function DeploymentVulnerabilitiesTable({
                         className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams('Severity')}
                     >
-                        CVE severity
+                        Top CVE severity
                     </Th>
                     <Th className={getVisibilityClass('cveStatus')}>
                         CVE status
@@ -263,7 +263,7 @@ function DeploymentVulnerabilitiesTable({
                                     <Td
                                         className={getVisibilityClass('cveSeverity')}
                                         modifier="nowrap"
-                                        dataLabel="CVE severity"
+                                        dataLabel="Top CVE severity"
                                     >
                                         <VulnerabilitySeverityIconText severity={severity} />
                                     </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -76,7 +76,7 @@ export const defaultColumns = {
         isUntoggleAble: true,
     },
     cveSeverity: {
-        title: 'CVE severity',
+        title: 'Top CVE severity',
         isShownByDefault: true,
     },
     cveStatus: {
@@ -84,7 +84,7 @@ export const defaultColumns = {
         isShownByDefault: true,
     },
     cvss: {
-        title: 'CVSS',
+        title: 'Top CVSS',
         isShownByDefault: true,
     },
     nvdCvss: {
@@ -214,14 +214,14 @@ function ImageVulnerabilitiesTable({
                         className={getVisibilityClass('cveSeverity')}
                         sort={getSortParams('Severity')}
                     >
-                        CVE severity
+                        Top CVE severity
                     </Th>
                     <Th className={getVisibilityClass('cveStatus')}>
                         CVE status
                         {isFiltered && <DynamicColumnIcon />}
                     </Th>
                     <Th className={getVisibilityClass('cvss')} sort={getSortParams('CVSS')}>
-                        CVSS
+                        Top CVSS
                     </Th>
                     <Th className={getVisibilityClass('nvdCvss')}>NVD CVSS</Th>
                     <Th
@@ -358,7 +358,7 @@ function ImageVulnerabilitiesTable({
                                     <Td
                                         className={getVisibilityClass('cveSeverity')}
                                         modifier="nowrap"
-                                        dataLabel="CVE severity"
+                                        dataLabel="Top CVE severity"
                                     >
                                         {isVulnerabilitySeverity(severity) && (
                                             <VulnerabilitySeverityIconText severity={severity} />
@@ -376,7 +376,7 @@ function ImageVulnerabilitiesTable({
                                     <Td
                                         className={getVisibilityClass('cvss')}
                                         modifier="nowrap"
-                                        dataLabel="CVSS"
+                                        dataLabel="Top CVSS"
                                     >
                                         <CvssFormatted cvss={cvss} scoreVersion={scoreVersion} />
                                     </Td>


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

"CVSS" and "CVE severity" column headings changed to "Top CVSS" and "Top CVE Severity" on pages where the values are aggregated, pages:

- Single CVE: /main/vulnerabilities/*/cves/<cve>
- Single Image: /main/vulnerabilities/*/images/<id>
- Single Deployment: /main/vulnerabilities/*/deployments/<id>

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed the UI and manually checked the fields. I also confirmed that filtering the columns is working. 

#### CVE page
<img width="1335" height="729" alt="image" src="https://github.com/user-attachments/assets/d608c049-ea01-4e85-80e0-f4ad27754276" />
<img width="1338" height="762" alt="image" src="https://github.com/user-attachments/assets/cdbbfee6-df8d-47b6-adba-8b61c4ecaa2f" />

#### Deployment Page
<img width="1294" height="780" alt="image" src="https://github.com/user-attachments/assets/e401450a-743e-49d3-b0d1-9853381084f9" />
<img width="1324" height="816" alt="image" src="https://github.com/user-attachments/assets/da4fe7bd-3b9b-4d25-b930-76f4d05ee922" />

#### Image Page
<img width="1253" height="815" alt="image" src="https://github.com/user-attachments/assets/1c442303-e944-4db5-a9a1-0786986ea669" />
<img width="1275" height="802" alt="image" src="https://github.com/user-attachments/assets/c9a71839-1391-4e73-9b9f-7059046e4f7c" />

#### Virtual Machines Page
- No VMs in the environment. Deemed unnecessary given the other screenshots

#### Nodes Page

<img width="1317" height="256" alt="image" src="https://github.com/user-attachments/assets/958b7739-9dfd-4df9-be45-2b495e3d4ad7" />
<img width="1257" height="774" alt="image" src="https://github.com/user-attachments/assets/a8375bcd-5651-485b-89cd-60908a5505f8" />


