### PR TITLE
ROX-35132: Adapt from image to node vulnerability report wizard

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -6,13 +6,11 @@ import type {
     CompoundSearchFilterEntity,
     OnSearchCallback,
 } from '../types';
+import CompoundSearchFilterSelectInputField from './CompoundSearchFilterSelectInputField';
 import SearchFilterConditionDate from './SearchFilterConditionDate';
 import SearchFilterConditionNumber from './SearchFilterConditionNumber';
 import SearchFilterConditionText from './SearchFilterConditionText';
 import SearchFilterAutocompleteSelect from './SearchFilterAutocompleteSelect';
-import SearchFilterSelectExclusiveDouble from './SearchFilterSelectExclusiveDouble';
-import SearchFilterSelectExclusiveSingle from './SearchFilterSelectExclusiveSingle';
-import SearchFilterSelectInclusive from './SearchFilterSelectInclusive';
 import SearchFilterText from './SearchFilterText';
 
 export type CompoundSearchFilterInputFieldProps = {
@@ -78,26 +76,10 @@ function CompoundSearchFilterInputField({
                 />
             );
         case 'select-exclusive-double':
-            return (
-                <SearchFilterSelectExclusiveDouble
-                    attribute={attribute}
-                    isDisabled={isDisabled}
-                    onSearch={onSearch}
-                    searchFilter={searchFilter}
-                />
-            );
         case 'select-exclusive-single':
-            return (
-                <SearchFilterSelectExclusiveSingle
-                    attribute={attribute}
-                    isDisabled={isDisabled}
-                    onSearch={onSearch}
-                    searchFilter={searchFilter}
-                />
-            );
         case 'select':
             return (
-                <SearchFilterSelectInclusive
+                <CompoundSearchFilterSelectInputField
                     attribute={attribute}
                     isDisabled={isDisabled}
                     onSearch={onSearch}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterSelectInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterSelectInputField.tsx
@@ -1,0 +1,56 @@
+import type { SearchFilter } from 'types/search';
+import { ensureExhaustive } from 'utils/type.utils';
+
+import type { GenericSelectSearchFilterAttribute, OnSearchCallback } from '../types';
+import SearchFilterSelectExclusiveDouble from './SearchFilterSelectExclusiveDouble';
+import SearchFilterSelectExclusiveSingle from './SearchFilterSelectExclusiveSingle';
+import SearchFilterSelectInclusive from './SearchFilterSelectInclusive';
+
+export type CompoundSearchFilterSelectInputFieldProps = {
+    attribute: GenericSelectSearchFilterAttribute;
+    isDisabled?: boolean;
+    onSearch: OnSearchCallback;
+    searchFilter: SearchFilter;
+};
+
+function CompoundSearchFilterSelectInputField({
+    attribute,
+    isDisabled = false,
+    onSearch,
+    searchFilter,
+}: CompoundSearchFilterSelectInputFieldProps) {
+    const { inputType } = attribute;
+    switch (inputType) {
+        case 'select-exclusive-double':
+            return (
+                <SearchFilterSelectExclusiveDouble
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+            );
+        case 'select-exclusive-single':
+            return (
+                <SearchFilterSelectExclusiveSingle
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+            );
+        case 'select':
+            return (
+                <SearchFilterSelectInclusive
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+            );
+        default:
+            return ensureExhaustive(inputType);
+    }
+}
+
+export default CompoundSearchFilterSelectInputField;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -77,6 +77,9 @@ export type SelectExclusiveDoubleSearchFilterOption = {
 export type CompoundSearchFilterAttribute =
     | ConditionTextFilterAttribute
     | GenericSearchFilterAttribute
+    | GenericSelectSearchFilterAttribute;
+
+export type GenericSelectSearchFilterAttribute =
     | SelectSearchFilterAttribute
     | SelectExclusiveDoubleSearchFilterAttribute
     | SelectExclusiveSingleSearchFilterAttribute;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/types.ts
@@ -56,6 +56,10 @@ export type SelectExclusiveSingleSearchFilterAttribute = {
     inputProps: SelectSearchFilterOptions;
 } & BaseSearchFilterAttribute;
 
+export type SelectSingleSearchFilterAttribute =
+    | SelectSearchFilterAttribute
+    | SelectExclusiveSingleSearchFilterAttribute;
+
 export type SelectExclusiveDoubleSearchFilterAttribute = {
     inputType: 'select-exclusive-double';
     inputProps: SelectExclusiveDoubleSearchFilterInputProps;

--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -9,12 +9,11 @@ import {
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
-import SearchFilterSelectExclusiveSingle from 'Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveSingle';
-import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
+import CompoundSearchFilterSelectInputField from 'Components/CompoundSearchFilter/components/CompoundSearchFilterSelectInputField';
 import type {
     CompoundSearchFilterConfig,
+    GenericSelectSearchFilterAttribute,
     OnSearchPayload,
-    SelectSingleSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 import type { SearchFilter } from 'types/search';
@@ -27,7 +26,7 @@ import {
 // Because filter property name differs for different report types,
 // renderer is responsible to provide values from formik object.
 export type FiltersQueryProps = {
-    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
+    attributesSeparateFromConfig: GenericSelectSearchFilterAttribute[];
     error: string | undefined;
     query: string;
     searchFilterConfig: CompoundSearchFilterConfig;
@@ -59,19 +58,11 @@ function FiltersQuery({
         <>
             {attributesSeparateFromConfig.map((attribute) => (
                 <FormGroup key={attribute.searchTerm} label={attribute.displayName} fieldId="TODO">
-                    {attribute.inputType === 'select-exclusive-single' ? (
-                        <SearchFilterSelectExclusiveSingle
-                            attribute={attribute}
-                            onSearch={onSearch}
-                            searchFilter={searchFilter}
-                        />
-                    ) : (
-                        <SearchFilterSelectInclusive
-                            attribute={attribute}
-                            onSearch={onSearch}
-                            searchFilter={searchFilter}
-                        />
-                    )}
+                    <CompoundSearchFilterSelectInputField
+                        attribute={attribute}
+                        onSearch={onSearch}
+                        searchFilter={searchFilter}
+                    />
                 </FormGroup>
             ))}
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>

--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -9,11 +9,12 @@ import {
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
 import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
+import SearchFilterSelectExclusiveSingle from 'Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveSingle';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import type {
     CompoundSearchFilterConfig,
     OnSearchPayload,
-    SelectSearchFilterAttribute,
+    SelectSingleSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 import type { SearchFilter } from 'types/search';
@@ -26,7 +27,7 @@ import {
 // Because filter property name differs for different report types,
 // renderer is responsible to provide values from formik object.
 export type FiltersQueryProps = {
-    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
+    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
     error: string | undefined;
     query: string;
     searchFilterConfig: CompoundSearchFilterConfig;
@@ -58,11 +59,19 @@ function FiltersQuery({
         <>
             {attributesSeparateFromConfig.map((attribute) => (
                 <FormGroup key={attribute.searchTerm} label={attribute.displayName} fieldId="TODO">
-                    <SearchFilterSelectInclusive
-                        attribute={attribute}
-                        onSearch={onSearch}
-                        searchFilter={searchFilter}
-                    />
+                    {attribute.inputType === 'select-exclusive-single' ? (
+                        <SearchFilterSelectExclusiveSingle
+                            attribute={attribute}
+                            onSearch={onSearch}
+                            searchFilter={searchFilter}
+                        />
+                    ) : (
+                        <SearchFilterSelectInclusive
+                            attribute={attribute}
+                            onSearch={onSearch}
+                            searchFilter={searchFilter}
+                        />
+                    )}
                 </FormGroup>
             ))}
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { useApolloClient } from '@apollo/client';
 
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import PageTitle from 'Components/PageTitle';
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
@@ -29,12 +30,7 @@ import { getHasSearchApplied } from 'utils/searchUtils';
 import { getVersionedDocs } from 'utils/versioning';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 
-import {
-    clusterSearchFilterConfig,
-    nodeCVESearchFilterConfig,
-    nodeComponentSearchFilterConfig,
-    nodeSearchFilterConfig,
-} from '../../searchFilterConfig';
+import { searchFilterConfigForNodeVulnerabilityResultsAndViewBasedReport } from '../../searchFilterConfig';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import SnoozedCveToggleButton from '../../components/SnoozedCveToggleButton';
 import SnoozeCvesModal from '../../components/SnoozeCvesModal/SnoozeCvesModal';
@@ -56,13 +52,6 @@ import NodesTable, {
     sortFields as nodeSortFields,
 } from './NodesTable';
 import { useNodeCveEntityCounts } from './useNodeCveEntityCounts';
-
-const searchFilterConfig = [
-    clusterSearchFilterConfig,
-    nodeCVESearchFilterConfig,
-    nodeSearchFilterConfig,
-    nodeComponentSearchFilterConfig,
-];
 
 function NodeCvesOverviewPage() {
     const apolloClient = useApolloClient();
@@ -127,6 +116,12 @@ function NodeCvesOverviewPage() {
         CVE: data?.nodeCVECount ?? 0,
         Node: data?.nodeCount ?? 0,
     };
+
+    // Keep getSearchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4.
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        searchFilterConfigForNodeVulnerabilityResultsAndViewBasedReport
+    );
 
     const filterToolbar = (
         <AdvancedFiltersToolbar

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/NodeVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/NodeVulnerabilityReportWizard.tsx
@@ -11,7 +11,7 @@ import * as yup from 'yup';
 
 import type {
     CompoundSearchFilterConfig,
-    SelectSingleSearchFilterAttribute,
+    GenericSelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import DeliveryStep from 'Components/Reports/Step/DeliveryStep';
 import DetailsStep from 'Components/Reports/Step/DetailsStep';
@@ -70,7 +70,7 @@ function ValidatingWizardFooter({ formik, stepId, onClose }: ValidatingWizardFoo
 }
 
 export type NodeVulnerabilityReportWizardProps = {
-    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
+    attributesSeparateFromConfig: GenericSelectSearchFilterAttribute[];
     initialValues: NodeVulnerabilityReportConfiguration;
     pageAction: ReportPageAction;
     searchFilterConfig: CompoundSearchFilterConfig;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/NodeVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/NodeVulnerabilityReportWizard.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import { generatePath, useNavigate } from 'react-router-dom-v5-compat';
+import { Wizard, WizardFooter, WizardStep, useWizardContext } from '@patternfly/react-core';
+import type { WizardStepType } from '@patternfly/react-core';
+import { useFormik } from 'formik';
+import type { FormikProps } from 'formik';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
+import * as yup from 'yup';
+
+import type {
+    CompoundSearchFilterConfig,
+    SelectSingleSearchFilterAttribute,
+} from 'Components/CompoundSearchFilter/types';
+import DeliveryStep from 'Components/Reports/Step/DeliveryStep';
+import DetailsStep from 'Components/Reports/Step/DetailsStep';
+import type { ReportPageAction } from 'Components/Reports/reports.types';
+import useAnalytics, { NODE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED } from 'hooks/useAnalytics';
+import {
+    createNodeReportConfiguration,
+    updateNodeReportConfiguration,
+} from 'services/NodeReportsService';
+import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+import { vulnerabilityNodeConfigurationsReportsDetailsPath } from 'routePaths';
+
+import { getValidationSchema, isWizardStepId } from './nodeVulnerabilityReportValidationSchemas';
+import type { WizardStepId } from './nodeVulnerabilityReportValidationSchemas';
+import NodeVulnerabilityResourcesStep from './Step2/NodeVulnerabilityResourcesStep';
+import NodeVulnerabilityFiltersStep from './Step3/NodeVulnerabilityFiltersStep';
+import NodeVulnerabilityReviewStep from './Step5/NodeVulnerabilityReviewStep';
+
+type ValidatingWizardFooterProps = {
+    formik: FormikProps<NodeVulnerabilityReportConfiguration>;
+    stepId: WizardStepId;
+    onClose: () => void;
+};
+
+function ValidatingWizardFooter({ formik, stepId, onClose }: ValidatingWizardFooterProps) {
+    const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
+
+    function handleNext() {
+        try {
+            // abortEarly is false so all errors on the current step are returned and can be touched
+            getValidationSchema(stepId).validateSync(formik.values, { abortEarly: false });
+            Promise.resolve(goToNextStep()).catch(() => {});
+        } catch (error) {
+            // touches fields that failed validation on the current step so errors are displayed
+            if (error instanceof yup.ValidationError) {
+                const touched: Record<string, unknown> = {};
+                error.inner.forEach((err) => {
+                    if (err.path) {
+                        set(touched, err.path, true);
+                    }
+                });
+                formik.setTouched(merge({}, formik.touched, touched));
+            }
+        }
+    }
+
+    return (
+        <WizardFooter
+            activeStep={activeStep}
+            isBackDisabled={stepId === 'details'}
+            onNext={handleNext}
+            onBack={goToPrevStep}
+            onClose={onClose}
+        />
+    );
+}
+
+export type NodeVulnerabilityReportWizardProps = {
+    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
+    initialValues: NodeVulnerabilityReportConfiguration;
+    pageAction: ReportPageAction;
+    searchFilterConfig: CompoundSearchFilterConfig;
+};
+
+function NodeVulnerabilityReportWizard({
+    attributesSeparateFromConfig,
+    initialValues,
+    pageAction,
+    searchFilterConfig,
+}: NodeVulnerabilityReportWizardProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
+    const navigate = useNavigate();
+    const [error, setError] = useState<Error | null>(null);
+    const [stepId, setStepId] = useState<WizardStepId>('details');
+
+    const formik = useFormik({
+        initialValues,
+        validateOnMount: true,
+        validationSchema: getValidationSchema(stepId),
+        onSubmit: (values: NodeVulnerabilityReportConfiguration, { setSubmitting }) => {
+            const request =
+                pageAction === 'edit'
+                    ? updateNodeReportConfiguration(values.id, values)
+                    : createNodeReportConfiguration(values);
+
+            request
+                .then((data) => {
+                    const { notifiers, resourceScope, schedule } = values;
+                    analyticsTrack({
+                        event: NODE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED,
+                        properties: {
+                            action: pageAction,
+                            cvesSince: 'allVuln', // getValueForCvesSince(nodeVulnReportFilters),
+                            intervalType: schedule?.intervalType ?? 'UNSET',
+                            notifiers: notifiers.length,
+                            resourceScope: Object.keys(resourceScope)[0] ?? '',
+                        },
+                    });
+
+                    if (pageAction === 'edit') {
+                        // Go back either to reports table or page for existing report.
+                        navigate(-1);
+                    } else {
+                        // Go to page for new report.
+                        const reportURL = generatePath(
+                            vulnerabilityNodeConfigurationsReportsDetailsPath,
+                            {
+                                reportId: data.id,
+                            }
+                        );
+                        navigate(reportURL);
+                    }
+                })
+                .catch((errorCaught) => {
+                    setError(errorCaught);
+                })
+                .finally(() => {
+                    setSubmitting(false);
+                });
+        },
+    });
+
+    const { dirty, isSubmitting, isValid, submitForm, validateForm, values } = formik;
+
+    useEffect(() => {
+        validateForm(values).catch(() => {});
+    }, [stepId, validateForm, values]);
+
+    function isStepValid(id: WizardStepId): boolean {
+        try {
+            getValidationSchema(id).validateSync(formik.values);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function onStepChange(_event: unknown, currentStep: WizardStepType): void {
+        const id = String(currentStep.id);
+        if (isWizardStepId(id)) {
+            setStepId(id);
+        }
+    }
+
+    function onClose() {
+        // Go back either to reports table or page for existing report ore results page (for createFromFilters).
+        navigate(-1);
+    }
+
+    const isDetailsValid = isStepValid('details');
+    const isResourcesValid = isStepValid('resources');
+    const isFiltersValid = isStepValid('filters');
+    const isDeliveryValid = isStepValid('delivery');
+
+    return (
+        <Wizard
+            onClose={onClose}
+            onSave={submitForm}
+            onStepChange={onStepChange}
+            isVisitRequired={pageAction !== 'edit' && pageAction !== 'clone'}
+        >
+            <WizardStep
+                id="details"
+                name="Details"
+                body={{ hasNoPadding: true }}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="details" onClose={onClose} />
+                }
+            >
+                <DetailsStep formik={formik} pageAction={pageAction} />
+            </WizardStep>
+            <WizardStep
+                id="resources"
+                name="Resources"
+                body={{ hasNoPadding: true }}
+                isDisabled={!isDetailsValid}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="resources" onClose={onClose} />
+                }
+            >
+                <NodeVulnerabilityResourcesStep formik={formik} />
+            </WizardStep>
+            <WizardStep
+                id="filters"
+                name="Filters"
+                body={{ hasNoPadding: true }}
+                isDisabled={!isDetailsValid || !isResourcesValid}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="filters" onClose={onClose} />
+                }
+            >
+                <NodeVulnerabilityFiltersStep
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
+                    formik={formik}
+                    searchFilterConfig={searchFilterConfig}
+                />
+            </WizardStep>
+            <WizardStep
+                id="delivery"
+                name="Delivery"
+                body={{ hasNoPadding: true }}
+                isDisabled={!isDetailsValid || !isResourcesValid || !isFiltersValid}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="delivery" onClose={onClose} />
+                }
+            >
+                <DeliveryStep formik={formik} />
+            </WizardStep>
+            <WizardStep
+                id="review"
+                name="Review"
+                body={{ hasNoPadding: true }}
+                isDisabled={
+                    !isDetailsValid || !isResourcesValid || !isFiltersValid || !isDeliveryValid
+                }
+                footer={{
+                    isNextDisabled: !(
+                        (dirty || pageAction === 'clone') &&
+                        isValid &&
+                        !isSubmitting
+                    ),
+                    nextButtonProps: { isLoading: isSubmitting },
+                    nextButtonText: 'Save',
+                }}
+            >
+                <NodeVulnerabilityReviewStep
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
+                    error={error}
+                    searchFilterConfig={searchFilterConfig}
+                    values={formik.values}
+                />
+            </WizardStep>
+        </Wizard>
+    );
+}
+
+export default NodeVulnerabilityReportWizard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/NodeVulnerabilityReportWizardPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/NodeVulnerabilityReportWizardPage.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import { useParams } from 'react-router-dom-v5-compat';
+import {
+    Alert,
+    Breadcrumb,
+    BreadcrumbItem,
+    Bullseye,
+    PageSection,
+    Spinner,
+    Title,
+} from '@patternfly/react-core';
+import { cloneDeep } from 'lodash';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
+import {
+    getEntityScopeRulesFromSearchFilterForCluster,
+    getSearchFilterWithoutEntityScope,
+} from 'Components/EntityScope/utils';
+import PageTitle from 'Components/PageTitle';
+import type { ReportPageAction } from 'Components/Reports/reports.types';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useURLSearch from 'hooks/useURLSearch';
+import { fetchNodeReportConfiguration } from 'services/NodeReportsService';
+import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+import {
+    applyRegexSearchModifiers,
+    deleteKeysCaseInsensitive,
+    getHasSearchApplied,
+    getRequestQueryStringForSearchFilter,
+    // getValueByCaseInsensitiveKey,
+} from 'utils/searchUtils';
+import { vulnerabilityNodeConfigurationsReportsPath } from 'routePaths';
+
+import {
+    attributesSeparateFromConfigForNodeVulnerabilityReport,
+    searchFilterConfigForNodeVulnerabilityReport,
+} from '../../../../searchFilterConfig';
+
+import { defaultNodeVulnerabilityReportConfiguration } from './nodeVulnerabilityReportConfiguration.defaults';
+
+import NodeVulnerabilityReportWizard from './NodeVulnerabilityReportWizard';
+
+type NodeVulnerabilityReportWizardPageProps = {
+    pageAction: ReportPageAction;
+};
+
+function NodeVulnerabilityReportWizardPage({
+    pageAction,
+}: NodeVulnerabilityReportWizardPageProps): ReactElement {
+    const { reportId } = useParams();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { searchFilter } = useURLSearch();
+
+    // Keep getSearchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4.
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        searchFilterConfigForNodeVulnerabilityReport
+    );
+
+    // Initialize null for conditional (non) rendering of wizard element
+    // until after asynchronous clone, edit, or createFromFilters updates state,
+    const [reportConfiguration, setReportConfiguration] =
+        useState<NodeVulnerabilityReportConfiguration | null>(null);
+    const [error, setError] = useState<Error | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        if (reportId) {
+            // action is 'clone' or 'edit'
+            setIsLoading(true);
+            fetchNodeReportConfiguration(reportId)
+                .then((data) => {
+                    setError(null);
+                    setReportConfiguration(
+                        pageAction === 'clone'
+                            ? { ...data, id: '', name: `${data.name} (COPY)` }
+                            : data
+                    );
+                })
+                .catch((error) => {
+                    setError(error);
+                    setReportConfiguration(defaultNodeVulnerabilityReportConfiguration);
+                })
+                .finally(() => {
+                    setIsLoading(false);
+                });
+        } else if (pageAction === 'createFromFilters' && getHasSearchApplied(searchFilter)) {
+            const reportConfigurationFromFilters: NodeVulnerabilityReportConfiguration = cloneDeep(
+                defaultNodeVulnerabilityReportConfiguration
+            );
+
+            const rules = getEntityScopeRulesFromSearchFilterForCluster(searchFilter);
+
+            reportConfigurationFromFilters.resourceScope.entityScope.rules = rules;
+
+            // Inconsistency in time filter:
+            // CVE Created Time from results means first discovered in system not in node.
+            // sinceStartTime in report configuration means first discovered in node.
+            // Therefore:
+            // Call deleteKeysCaseInsensitive function to delete from search filter for query.
+            // If relation is After then set corresponding property of report configuration.
+            const searchFieldLabelForTime = 'CVE Created Time';
+            // allVuln only for MVP because data does not yet exist for sinceStartDate filter.
+            /*
+            const value = getValueByCaseInsensitiveKey(searchFilter, searchFieldLabelForTime);
+            if (typeof value === 'string' && value.startsWith('>')) {
+                const result = />(\d\d)\/(\d\d)\/(\d\d\d\d)/.exec(value);
+                if (Array.isArray(result)) {
+                    // Date format differs!
+                    const [, mm, dd, yyyy] = result;
+                    const { query } = reportConfigurationFromFilters.nodeVulnReportFilters;
+                    reportConfigurationFromFilters.nodeVulnReportFilters = {
+                        query,
+                        sinceStartDate: `${yyyy}-${mm}-${dd}T00:00:00.000Z`,
+                    };
+                }
+            }
+            */
+
+            const searchFilterWithoutEntityScope = getSearchFilterWithoutEntityScope(
+                deleteKeysCaseInsensitive(searchFilter, [searchFieldLabelForTime])
+            );
+
+            reportConfigurationFromFilters.nodeVulnReportFilters.query =
+                getRequestQueryStringForSearchFilter(
+                    applyRegexSearchModifiers(searchFilterWithoutEntityScope)
+                );
+
+            setReportConfiguration(reportConfigurationFromFilters);
+        } else {
+            setReportConfiguration(defaultNodeVulnerabilityReportConfiguration); // create
+        }
+    }, [pageAction, reportId, searchFilter]);
+
+    const heading = reportConfiguration?.name || 'Create report';
+
+    return (
+        <>
+            <PageTitle title="Node vulnerability reports - Scheduled report" />
+            {isLoading ? (
+                <Bullseye>
+                    <Spinner />
+                </Bullseye>
+            ) : (
+                <>
+                    <PageSection type="breadcrumb">
+                        <Breadcrumb>
+                            <BreadcrumbItemLink to={vulnerabilityNodeConfigurationsReportsPath}>
+                                Node vulnerability reports
+                            </BreadcrumbItemLink>
+                            <BreadcrumbItem isActive>{heading}</BreadcrumbItem>
+                        </Breadcrumb>
+                    </PageSection>
+                    <PageSection>
+                        <Title headingLevel="h1">{heading}</Title>
+                        <div>Configure scheduled reports for node vulnerabilities.</div>
+                    </PageSection>
+                    {error ? (
+                        <PageSection isFilled>
+                            <Alert
+                                variant="danger"
+                                title="Unable to fetch report"
+                                isInline
+                                component="p"
+                            >
+                                {getAxiosErrorMessage(error)}
+                            </Alert>
+                        </PageSection>
+                    ) : reportConfiguration !== null ? (
+                        <PageSection
+                            hasBodyWrapper={false}
+                            isFilled
+                            hasOverflowScroll
+                            padding={{ default: 'noPadding' }}
+                        >
+                            <NodeVulnerabilityReportWizard
+                                attributesSeparateFromConfig={
+                                    attributesSeparateFromConfigForNodeVulnerabilityReport
+                                }
+                                initialValues={reportConfiguration}
+                                pageAction={pageAction}
+                                searchFilterConfig={searchFilterConfig}
+                            />
+                        </PageSection>
+                    ) : null}
+                </>
+            )}
+        </>
+    );
+}
+
+export default NodeVulnerabilityReportWizardPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step2/validationSchemaResources.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step2/validationSchemaResources.ts
@@ -1,0 +1,21 @@
+import * as yup from 'yup';
+
+import type {
+    NodeVulnerabilityReportResourceScope,
+    NodeVulnerabilityReportResourcesConfiguration,
+} from 'services/ReportsService.types';
+
+export const validationSchemaResources: yup.ObjectSchema<NodeVulnerabilityReportResourcesConfiguration> =
+    yup.object().shape({
+        resourceScope: yup
+            .object()
+            .test('resource-scope-required', 'Resource scope is required', (value) => {
+                // resourceScope can be either EntityScope, or possible future saved scope,
+                // which .shape() can't express. Cast so property access is type checked.
+                const resourceScope = value as NodeVulnerabilityReportResourceScope;
+                if ('entityScope' in resourceScope) {
+                    return resourceScope.entityScope.rules.length > 0;
+                }
+                return false;
+            }) as unknown as yup.Schema<NodeVulnerabilityReportResourceScope>,
+    });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
@@ -5,7 +5,7 @@ import type { FormikProps } from 'formik';
 
 import type {
     CompoundSearchFilterConfig,
-    SelectSingleSearchFilterAttribute,
+    GenericSelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 
 import FiltersQuery from 'Components/Reports/Step/FiltersQuery';
@@ -16,7 +16,7 @@ export type NodeVulnerabilityFiltersStepProps<
     T extends NodeVulnerabilityReportFiltersConfiguration =
         NodeVulnerabilityReportFiltersConfiguration,
 > = {
-    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
+    attributesSeparateFromConfig: GenericSelectSearchFilterAttribute[];
     formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
@@ -5,7 +5,7 @@ import type { FormikProps } from 'formik';
 
 import type {
     CompoundSearchFilterConfig,
-    SelectSearchFilterAttribute,
+    SelectSingleSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 
 import FiltersQuery from 'Components/Reports/Step/FiltersQuery';
@@ -16,7 +16,7 @@ export type NodeVulnerabilityFiltersStepProps<
     T extends NodeVulnerabilityReportFiltersConfiguration =
         NodeVulnerabilityReportFiltersConfiguration,
 > = {
-    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
+    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
     formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/validationSchemaFilters.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/validationSchemaFilters.ts
@@ -1,0 +1,51 @@
+import * as yup from 'yup';
+// import { isValid, parse } from 'date-fns';
+
+import type {
+    // CvesSince,
+    // NodeVulnerabilityReportFilters
+    NodeVulnerabilityReportFiltersConfiguration,
+} from 'services/ReportsService.types';
+
+// allVuln only for MVP because data does not yet exist for sinceStartDate filter.
+/*
+function isCvesSinceValid(filters: CvesSince): boolean {
+    if ('allVuln' in filters) {
+        return true;
+    }
+    if ('sinceLastSentScheduledReport' in filters) {
+        return true;
+    }
+    if ('sinceStartDate' in filters) {
+        if (!filters.sinceStartDate) {
+            return false;
+        }
+        // parse() is lenient. partial strings like "2026-10" pass isValid.
+        // Checking for "T" ensures the value is likely a full ISO timestamp.
+        return filters.sinceStartDate.includes('T') && isValid(parse(filters.sinceStartDate));
+    }
+    return false;
+}
+*/
+
+export const validationSchemaFilters: yup.ObjectSchema<NodeVulnerabilityReportFiltersConfiguration> =
+    yup.object().shape({
+        nodeVulnReportFilters: yup.object().shape({
+            allVuln: yup.boolean().required(), // temporary for MVP scope
+            query: yup.string().required('At least one filter is required'),
+        }),
+        /*
+        .test('cves-since-entity', 'CVE date range is required', function test(reportFilters) {
+            // CvesSince is a union type that .shape() can't express.
+            // cast so property access is type checked.
+            const filters = reportFilters as NodeVulnerabilityReportFilters;
+            if ('sinceStartDate' in filters && !isCvesSinceValid(filters)) {
+                return this.createError({
+                    path: 'nodeVulnReportFilters.sinceStartDate',
+                    message: 'A valid start date is required',
+                });
+            }
+            return isCvesSinceValid(filters);
+        }),
+        */
+    });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step5/NodeVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step5/NodeVulnerabilityReviewStep.tsx
@@ -3,7 +3,7 @@ import { Alert, Flex, PageSection, Title } from '@patternfly/react-core';
 
 import type {
     CompoundSearchFilterConfig,
-    SelectSingleSearchFilterAttribute,
+    GenericSelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -11,7 +11,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import NodeVulnerabilityReportView from '../../View/NodeVulnerabilityReportView';
 
 export type NodeVulnerabilityReviewStepProps = {
-    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
+    attributesSeparateFromConfig: GenericSelectSearchFilterAttribute[];
     error: Error | null;
     searchFilterConfig: CompoundSearchFilterConfig;
     values: NodeVulnerabilityReportConfiguration;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step5/NodeVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step5/NodeVulnerabilityReviewStep.tsx
@@ -3,7 +3,7 @@ import { Alert, Flex, PageSection, Title } from '@patternfly/react-core';
 
 import type {
     CompoundSearchFilterConfig,
-    SelectSearchFilterAttribute,
+    SelectSingleSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -11,7 +11,7 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import NodeVulnerabilityReportView from '../../View/NodeVulnerabilityReportView';
 
 export type NodeVulnerabilityReviewStepProps = {
-    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
+    attributesSeparateFromConfig: SelectSingleSearchFilterAttribute[];
     error: Error | null;
     searchFilterConfig: CompoundSearchFilterConfig;
     values: NodeVulnerabilityReportConfiguration;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/nodeVulnerabilityReportConfiguration.defaults.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/nodeVulnerabilityReportConfiguration.defaults.ts
@@ -1,0 +1,31 @@
+import type { NodeVulnerabilityReportConfiguration } from 'services/ReportsService.types';
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+
+import { defaultStorage } from '../../../../WorkloadCves/Overview/WorkloadCvesOverviewPage';
+import { fixableStatusToFixability, severityLabelToSeverity } from '../../../../utils/searchUtils';
+
+const {
+    preferences: { defaultFilters },
+} = defaultStorage;
+
+export const defaultNodeVulnerabilityReportConfiguration: NodeVulnerabilityReportConfiguration = {
+    type: 'NODE_VULNERABILITY',
+    id: '',
+    name: '',
+    description: '',
+    notifiers: [],
+    schedule: null,
+    nodeVulnReportFilters: {
+        allVuln: true,
+        query: getRequestQueryStringForSearchFilter({
+            Severity: defaultFilters.Severity.map(severityLabelToSeverity),
+            Fixable: defaultFilters.Fixable.map(fixableStatusToFixability),
+            'CVE Snoozed': 'false',
+        }),
+    },
+    resourceScope: {
+        entityScope: {
+            rules: [],
+        },
+    },
+} as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/nodeVulnerabilityReportValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/nodeVulnerabilityReportValidationSchemas.ts
@@ -1,0 +1,32 @@
+import * as yup from 'yup';
+
+import { validationSchemaDelivery } from 'Components/Reports/Step/validationSchemaDelivery';
+import { validationSchemaDetails } from 'Components/Reports/Step/validationSchemaDetails';
+import { ensureExhaustive } from 'utils/type.utils';
+
+import { validationSchemaResources } from './Step2/validationSchemaResources';
+import { validationSchemaFilters } from './Step3/validationSchemaFilters';
+
+export const wizardStepIds = ['details', 'resources', 'filters', 'delivery', 'review'] as const;
+export type WizardStepId = (typeof wizardStepIds)[number];
+
+export function isWizardStepId(id: string): id is WizardStepId {
+    return wizardStepIds.includes(id as WizardStepId);
+}
+
+export function getValidationSchema(stepId: WizardStepId): yup.Schema | yup.Lazy<unknown> {
+    switch (stepId) {
+        case 'details':
+            return validationSchemaDetails;
+        case 'resources':
+            return validationSchemaResources;
+        case 'filters':
+            return validationSchemaFilters;
+        case 'delivery':
+            return validationSchemaDelivery;
+        case 'review':
+            return yup.object().shape({});
+        default:
+            return ensureExhaustive(stepId);
+    }
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -10,10 +10,10 @@
 
 import type {
     CompoundSearchFilterEntity,
+    GenericSelectSearchFilterAttribute,
     SelectExclusiveSingleSearchFilterAttribute,
     SelectSearchFilterAttribute,
     SelectSearchFilterOption,
-    SelectSingleSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import {
     clusterIdAttribute,
@@ -334,7 +334,7 @@ export const attributesSeparateFromConfigForImageVulnerabilityReport = [
     attributeForFixableInBackendAndViewBasedReport,
 ];
 
-export const attributesSeparateFromConfigForNodeVulnerabilityReport: SelectSingleSearchFilterAttribute[] =
+export const attributesSeparateFromConfigForNodeVulnerabilityReport: GenericSelectSearchFilterAttribute[] =
     [
         attributeForSnoozed,
         attributeForSeverityInBackendAndViewBasedReport, // Formerly under Vulnerability parameters

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -13,6 +13,7 @@ import type {
     SelectExclusiveSingleSearchFilterAttribute,
     SelectSearchFilterAttribute,
     SelectSearchFilterOption,
+    SelectSingleSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import {
     clusterIdAttribute,
@@ -278,6 +279,25 @@ export const searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport
     namespaceSearchFilterConfig,
 ];
 
+// Scheduled report has resources instead of cluster.
+export const searchFilterConfigForNodeVulnerabilityReport = [
+    {
+        ...nodeCVESearchFilterConfig,
+        attributes: nodeCVESearchFilterConfig.attributes.filter(
+            ({ searchTerm }) => searchTerm !== 'CVE Created Time'
+        ),
+    },
+    nodeSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
+];
+
+export const searchFilterConfigForNodeVulnerabilityResultsAndViewBasedReport = [
+    clusterSearchFilterConfig,
+    nodeCVESearchFilterConfig,
+    nodeSearchFilterConfig,
+    nodeComponentSearchFilterConfig,
+];
+
 export const attributeForPlatformComponent: SelectSearchFilterAttribute = {
     displayName: 'Area of concern', // corresponds to horizontal navigation
     filterChipLabel: 'Area of concern',
@@ -313,3 +333,10 @@ export const attributesSeparateFromConfigForImageVulnerabilityReport = [
     attributeForSeverityInBackendAndViewBasedReport, // Formerly under Vulnerability parameters
     attributeForFixableInBackendAndViewBasedReport,
 ];
+
+export const attributesSeparateFromConfigForNodeVulnerabilityReport: SelectSingleSearchFilterAttribute[] =
+    [
+        attributeForSnoozed,
+        attributeForSeverityInBackendAndViewBasedReport, // Formerly under Vulnerability parameters
+        attributeForFixableInBackendAndViewBasedReport,
+    ];

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -64,6 +64,8 @@ export const AGING_IMAGES_WIDGET_CLICKED = 'Aging Images Widget Link Clicked';
 
 export const IMAGE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED =
     'Image Vulnerability Reports Wizard Save Clicked';
+export const NODE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED =
+    'Node Vulnerability Reports Wizard Save Clicked';
 
 // cluster-init-bundles
 export const CREATE_INIT_BUNDLE_CLICKED = 'Create Init Bundle Clicked';
@@ -379,6 +381,16 @@ export type AnalyticsEvent =
               action: ReportPageAction;
               cvesSince: 'allVuln' | 'sinceLastSentScheduledReport' | 'sinceStartDate';
               imageTypes: ImageType[];
+              intervalType: 'DAILY' | 'MONTHLY' | 'WEEKLY' | 'UNSET';
+              notifiers: number;
+              resourceScope: string;
+          };
+      }
+    | {
+          event: typeof NODE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED;
+          properties: {
+              action: ReportPageAction;
+              cvesSince: 'allVuln'; // | 'sinceLastSentScheduledReport' | 'sinceStartDate'
               intervalType: 'DAILY' | 'MONTHLY' | 'WEEKLY' | 'UNSET';
               notifiers: number;
               resourceScope: string;

--- a/ui/apps/platform/src/services/NodeReportsService.ts
+++ b/ui/apps/platform/src/services/NodeReportsService.ts
@@ -16,28 +16,23 @@ import axios from './instance';
 // PostNodeReportConfiguration
 export function createNodeReportConfiguration(
     configuration: NodeVulnerabilityReportConfiguration
-): CancellableRequest<NodeVulnerabilityReportConfiguration> {
-    return makeCancellableAxiosRequest((signal) =>
-        axios
-            .post<NodeVulnerabilityReportConfiguration>(
-                '/v2/reports/node/configurations',
-                configuration,
-                { signal }
-            )
-            .then((response) => response.data)
-    );
+): Promise<NodeVulnerabilityReportConfiguration> {
+    return axios
+        .post<NodeVulnerabilityReportConfiguration>(
+            '/v2/reports/node/configurations',
+            configuration
+        )
+        .then((response) => response.data);
 }
 
 // UpdateNodeReportConfiguration
 export function updateNodeReportConfiguration(
     reportId: string,
     configuration: NodeVulnerabilityReportConfiguration
-): CancellableRequest<Empty> {
-    return makeCancellableAxiosRequest((signal) =>
-        axios
-            .put<Empty>(`/v2/reports/node/configurations/${reportId}`, configuration, { signal })
-            .then((response) => response.data)
-    );
+): Promise<Empty> {
+    return axios
+        .put<Empty>(`/v2/reports/node/configurations/${reportId}`, configuration)
+        .then((response) => response.data);
 }
 
 // ListNodeReportConfigurations
@@ -75,15 +70,10 @@ export function fetchNodeReportConfigurationsCount(
 // GetNodeReportConfiguration
 export function fetchNodeReportConfiguration(
     reportId: string
-): CancellableRequest<NodeVulnerabilityReportConfiguration> {
-    return makeCancellableAxiosRequest((signal) =>
-        axios
-            .get<NodeVulnerabilityReportConfiguration>(
-                `/v2/reports/node/configurations/${reportId}`,
-                { signal }
-            )
-            .then((response) => response.data)
-    );
+): Promise<NodeVulnerabilityReportConfiguration> {
+    return axios
+        .get<NodeVulnerabilityReportConfiguration>(`/v2/reports/node/configurations/${reportId}`)
+        .then((response) => response.data);
 }
 
 // DeleteNodeReportConfiguration


### PR DESCRIPTION
## Description

TL;DR Follow up node vulnerability report steps in #22426

### Objective

Follow pattern of image vulnerability reports for node vulnerability reports.

### Discovery

**Results** pages for **Nodes** do not use default filters. Ditto for **Virtual Machines**.

* One side of coin: Too little time to confirm a change, let alone implement it.
* Other side of coin: Leaning in the direction of future consensus that **Results** pages consistently use default filters, use default filters to **Create report** from list page.
    By the way, create report and view-based report from filters receive the search filter from the page, regardless of how the use configured it.

### Suggestion

Thank you, **Brad** for suggestion about generic compound search item **without** `entity` prop.

I added `CompoundSearchFilterSelectInputField` component. Another long name ;)

### Analysis part 1

1. imageVulnerabilityReportValidationSchema.ts file

    Reusable business logic:

    * `validationSchemaDetails`
    * `isCvesSinceValid`
        If we assume that validation is for a superset of possible options, even if node vulnerability reports have only `allVuln` for now.
    * `validationSchemaDelivery`

    Adaptable business logic:

    * `validationSchemaResources`
    * `validationSchemaFilters`

2. ImageVulnerabilityReportWizard.tsx file

    Adaptable with changes for **Resources** step:

    * Add props for entity scope
    * Delete conditional rendering for collection versus entity scope 

3. ImageVulnerabilityReportWizardPage.tsx file

    Adaptable:

    * Add props for entity scope
    * Delete heuristic for `imageTypes` property

### Solution part 1

1. ValidationSchema files

    * Add files for reusable validation schemas in src/Components/Reports/Step folder.
    * Edit imageVulnerabilityReportValidationSchema.ts file
    * Add nodeVulnerabilityReportValidationSchema.ts file

2. Add NodeVulnerabilityReportWizard.tsx file

3. Add NodeVulnerabilityReportWizardPage.tsx file4.

4. Add nodeVulnerabilityReportConfiguration.defaults file.

### Analysis part 2

1. Search filter `'CVE Snoozed'` which is counterpart for node vulnerabilities to `'Vulnerability State'` for image vulnerabilities has **exclusive** instead of **inclusive** select element. The attributes separate from configuration for image vulnerabilities have inclusive select elements.

2. `NodeCvesOverviewPage` component has `searchFilterConfig` at module scope.

### Solution part 2

1. Add `SelectSingleSearchFilterAttribute` type for either **exclusive** or **inclsive** select element and conditionally render element in `FltersQuery` component.

2. Add single sources of truth for search filter config of **Results** and **Reports** plus `getSearchFilterConfigWithFeatureFlagDependency` call in page component for sustainability.

### Residue

1. Rebase and finish changes to display `'CVE Snoozed'` search filter as **Vulnerability state** in #21238

    See **Manual testing** part 1 step 4

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

Temporarily substitute node vulnerability wizard `VulnReportingPage` component.

Temporarily add `console.log` of entity scope for **Resources** and search query for **Filters** steps.
#### Manual testing part 1

Simulate **Create report** on list page.

1. Visit /main/vulnerabilities/reports/configuration?action=create

2. Enter **Name** and then click **Next**

    <img width="1440" height="400" alt="create_Step1" src="https://github.com/user-attachments/assets/3807afe3-2edf-489b-b59d-30db9238032b" />

3. Select a cluster and then click **Next**

    ```json
    {
        "rules": [
            {
            "entity": "SCOPE_ENTITY_CLUSTER",
            "field": "FIELD_NAME",
            "values": [
                {
                "matchType": "EXACT",
                "value": "staging-secured-cluster"
                }
            ]
            }
        ]
    }
    ```

    <img width="1440" height="400" alt="create_Step2" src="https://github.com/user-attachments/assets/f67cd4cf-3291-4bb1-86a7-da51a6f7e5f9" />

4. Update search filters and then click **Next**

    **Vulnerability State Observed** will supersede **CVE Snoozed false** when we merge changes in #21238

    `Severity:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY,MODERATE_VULNERABILITY_SEVERITY+Fixable:true+CVE Snoozed:false+CVSS:>=7`

    <img width="1440" height="500" alt="create_Step3" src="https://github.com/user-attachments/assets/5bb02637-ed78-421d-8bf6-4b2f9e9dc8f3" />

5. Click **Next** review report configuration, and then click **Cancel**

    <img width="1440" height="892" alt="create_Step5" src="https://github.com/user-attachments/assets/5ee75034-c057-4a9a-bd69-15261ac88a07" />

#### Manual testing part 2

Simulate **Create scheduled report** from results page.

1. Visit /main/vulnerabilities/reports/images/configurations?action=createFromFilters&s[Platform%20Component]=false&s[Severity]=CRITICAL_VULNERABILITY_SEVERITY&s[Severity]=IMPORTANT_VULNERABILITY_SEVERITY&s[Fixable]=true&s[Cluster]=staging-central-cluster&s[Vulnerability%20State]=OBSERVED

2. Enter **Name** and then click **Next**

3. See selected cluster and then click **Next**

    ```json
    {
    "rules": [
        {
        "entity": "SCOPE_ENTITY_CLUSTER",
        "field": "FIELD_NAME",
        "values": [
            {
            "matchType": "REGEX",
            "value": "staging-central-cluster"
            }
        ]
        }
    ]
    }
    ```

    <img width="1439" height="400" alt="createFromFilters_step2" src="https://github.com/user-attachments/assets/a0062edf-0e47-4d7c-9d84-4bc9fa0a4a58" />

4. Update search filters and then click **Next**

    `Platform Component:false+Severity:CRITICAL_VULNERABILITY_SEVERITY+Fixable:true+Vulnerability State:OBSERVED`

    <img width="1440" height="480" alt="createFromFilters_Step3" src="https://github.com/user-attachments/assets/62b65ee2-9f92-4280-a627-2ca12ed417aa" />

5. Click **Next** review report configuration, and then click **Cancel**
    <img width="1440" height="892" alt="create_Step5" src="https://github.com/user-attachments/assets/6e5da878-289d-47a1-ae17-0d7c76fcfef6" />
