### PR TITLE
ROX-35584: Inject CI feature flags after release generate

### DIFF
--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -83,9 +83,16 @@ jobs:
         echo "KUBECONFIG=${HOME}/.kube/config" >> "$GITHUB_ENV"
 
     - name: Build roxctl
-      # roxctl is used for various CLI e2e tests (token-file, authz-trace, istio-support, etc.)
-      # Copy to /usr/local/bin so it survives bats tests which mv the binary out of bin/
+      # roxctl is used for generate (deploy) and CLI e2e tests (token-file, etc).
+      # Copy to /usr/local/bin so it survives bats tests which mv the binary out of bin/.
+      # A release Central must be generated with a release roxctl; otherwise generate
+      # copies ROX_* into the bundle and TestFeatureFlagSettings cannot fail the way
+      # nightlies do.
       run: |
+        if [[ "${GITHUB_REF}" =~ ^refs/tags/ ]] || [[ "${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-release-build') }}" == "true" ]]; then
+          export GOTAGS=release
+          echo "Building release roxctl (tag or ci-release-build)"
+        fi
         make roxctl_linux-amd64
         sudo cp bin/linux_amd64/roxctl /usr/local/bin/roxctl
         echo "${HOME}/go/bin" >> "$GITHUB_PATH"

--- a/deploy/common/feature-flag-env.sh
+++ b/deploy/common/feature-flag-env.sh
@@ -1,5 +1,37 @@
 #!/usr/bin/env bash
 
+# ROX_SCANNER_V4 and ROX_LEGACY_SCANNER are not ordinary feature-flag env.
+# The Central Helm chart already writes them onto the Central container from
+# scannerV4 / scanner config (01-central-13-deployment.yaml.htpl). Helm
+# customize.central.envVars is rendered by srox.envVars, which appends to
+# that list, so injecting the same name produces a second env entry.
+# Kubernetes keeps both (last wins at runtime), but kubectl apply cannot
+# patch a Deployment that has duplicate env names, and tests that expect a
+# single value fail. Scanner V4 / legacy scanner still follow the chart
+# values; this skip only avoids copying the env name twice.
+# Kubectl inject does not skip these flags: generated manifests omit those
+# names, and kubectl set env --local overwrites by name.
+is_helm_owned_feature_flag() {
+    case "$1" in
+        ROX_SCANNER_V4 | ROX_LEGACY_SCANNER) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# omit_helm_owned_feature_flags drops Helm-owned scanner flags from a stream
+# of VAR=value lines. Use on the Helm inject path only.
+omit_helm_owned_feature_flags() {
+    local assignment var
+    while IFS= read -r assignment; do
+        [[ -z "${assignment}" ]] && continue
+        var="${assignment%%=*}"
+        if is_helm_owned_feature_flag "${var}"; then
+            continue
+        fi
+        printf '%s\n' "${assignment}"
+    done
+}
+
 # feature_flag_env_assignments prints VAR=value for every pkg/features flag
 # that is set and non-empty in this process. Release roxctl generate does not
 # copy these into the bundle; callers apply them to Central after generate.

--- a/deploy/common/feature-flag-env.sh
+++ b/deploy/common/feature-flag-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# feature_flag_env_assignments prints VAR=value for every pkg/features flag
+# that is set and non-empty in this process. Release roxctl generate does not
+# copy these into the bundle; callers apply them to Central after generate.
+feature_flag_env_assignments() {
+    local list_file="$1"
+    local var
+
+    if [[ ! -f "${list_file}" ]]; then
+        echo >&2 "WARNING: feature flag list ${list_file} not found; Central will not receive feature-flag env"
+        return 0
+    fi
+
+    while IFS= read -r var; do
+        if [[ -n "${!var:-}" ]]; then
+            printf '%s=%s\n' "${var}" "${!var}"
+        fi
+    done < <(grep -oE '"ROX_[A-Z0-9_]+"' "${list_file}" | tr -d '"' | sort -u)
+}

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck source=./feature-flag-env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/feature-flag-env.sh"
+
 function realpath {
 	[[ -n "$1" ]] || return 0
 	python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$1"
@@ -343,6 +346,16 @@ function launch_central {
     ${KUBE_COMMAND:-kubectl} get namespace "${central_namespace}" &>/dev/null || \
       ${KUBE_COMMAND:-kubectl} create namespace "${central_namespace}"
 
+    # Release roxctl generate omits feature-flag env from the bundle. Copy
+    # whatever is set in this process onto Central so CI/dev overrides apply.
+    local feature_flag_list_file
+    feature_flag_list_file="$(realpath "${common_dir}/../../pkg/features/list.go")"
+    local feature_flag_env=()
+    local _ff_assignment
+    while IFS= read -r _ff_assignment; do
+        feature_flag_env+=("${_ff_assignment}")
+    done < <(feature_flag_env_assignments "${feature_flag_list_file}")
+
     if [[ -f "$unzip_dir/values-public.yaml" ]]; then
       echo "Deploying central using Helm..."
       if [[ -n "${REGISTRY_USERNAME}" ]]; then
@@ -383,6 +396,16 @@ function launch_central {
 
       # Shorten signing key watcher poll for e2e tests (production default is 4h).
       helm_args+=(--set customize.central.envVars.ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s)
+
+      if (( ${#feature_flag_env[@]} > 0 )); then
+        echo "Injecting feature flag env into Central: ${feature_flag_env[*]}"
+        local _ff_var _ff_val
+        for _ff_assignment in "${feature_flag_env[@]}"; do
+          _ff_var="${_ff_assignment%%=*}"
+          _ff_val="${_ff_assignment#*=}"
+          helm_args+=(--set-string "customize.central.envVars.${_ff_var}=${_ff_val}")
+        done
+      fi
 
       if [[ -n "$POD_SECURITY_POLICIES" ]]; then
         helm_args+=(
@@ -509,8 +532,13 @@ function launch_central {
       # requiring a second rollout via a post-launch `set env`.
       central_deployment="${unzip_dir}/central/01-central-13-deployment.yaml"
       if [[ -f "${central_deployment}" ]]; then
+        local central_env=(ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s)
+        if (( ${#feature_flag_env[@]} > 0 )); then
+          echo "Injecting feature flag env into Central: ${feature_flag_env[*]}"
+          central_env+=("${feature_flag_env[@]}")
+        fi
         ${ORCH_CMD} set env --local -o yaml -f "${central_deployment}" -c central \
-          ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s > "${central_deployment}.tmp"
+          "${central_env[@]}" > "${central_deployment}.tmp"
         mv "${central_deployment}.tmp" "${central_deployment}"
       else
         echo >&2 "WARNING: ${central_deployment} not found; Central will deploy with the default signing key watch interval and rely on the test's set env fallback."

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -397,10 +397,19 @@ function launch_central {
       # Shorten signing key watcher poll for e2e tests (production default is 4h).
       helm_args+=(--set customize.central.envVars.ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s)
 
+      # Skip ROX_SCANNER_V4 / ROX_LEGACY_SCANNER: the chart already sets them
+      # from scanner config; customize.envVars would add a duplicate env name.
+      # See is_helm_owned_feature_flag in feature-flag-env.sh.
+      local helm_feature_flag_env=()
       if (( ${#feature_flag_env[@]} > 0 )); then
-        echo "Injecting feature flag env into Central: ${feature_flag_env[*]}"
+        while IFS= read -r _ff_assignment; do
+          helm_feature_flag_env+=("${_ff_assignment}")
+        done < <(printf '%s\n' "${feature_flag_env[@]}" | omit_helm_owned_feature_flags)
+      fi
+      if (( ${#helm_feature_flag_env[@]} > 0 )); then
+        echo "Injecting feature flag env into Central: ${helm_feature_flag_env[*]}"
         local _ff_var _ff_val
-        for _ff_assignment in "${feature_flag_env[@]}"; do
+        for _ff_assignment in "${helm_feature_flag_env[@]}"; do
           _ff_var="${_ff_assignment%%=*}"
           _ff_val="${_ff_assignment#*=}"
           helm_args+=(--set-string "customize.central.envVars.${_ff_var}=${_ff_val}")

--- a/tests/e2e/bats/feature_flag_env.bats
+++ b/tests/e2e/bats/feature_flag_env.bats
@@ -46,3 +46,52 @@ EOF
     assert_success
     assert_line "ROX_CISA_KEV=true"
 }
+
+@test "is_helm_owned_feature_flag covers Central chart first-class scanner env" {
+    run is_helm_owned_feature_flag ROX_SCANNER_V4
+    assert_success
+    run is_helm_owned_feature_flag ROX_LEGACY_SCANNER
+    assert_success
+    run is_helm_owned_feature_flag ROX_CISA_KEV
+    assert_failure
+    run is_helm_owned_feature_flag ROX_VIRTUAL_MACHINES
+    assert_failure
+}
+
+@test "omit_helm_owned_feature_flags drops chart-owned names and keeps the rest" {
+    run omit_helm_owned_feature_flags <<'EOF'
+ROX_CISA_KEV=true
+ROX_SCANNER_V4=true
+ROX_LEGACY_SCANNER=false
+ROX_NETWORK_GRAPH_EXTERNAL_IPS=false
+EOF
+    assert_success
+    assert_line "ROX_CISA_KEV=true"
+    assert_line "ROX_NETWORK_GRAPH_EXTERNAL_IPS=false"
+    refute_line --partial "ROX_SCANNER_V4"
+    refute_line --partial "ROX_LEGACY_SCANNER"
+}
+
+@test "feature_flag_env_assignments still emits helm-owned flags for kubectl inject" {
+    list_file="${BATS_TEST_TMPDIR}/list.go"
+    cat > "${list_file}" <<'EOF'
+	ScannerV4 = registerFeature("scanner v4", "ROX_SCANNER_V4")
+	Legacy = registerFeature("legacy scanner", "ROX_LEGACY_SCANNER")
+	Foo = registerFeature("foo", "ROX_CISA_KEV")
+EOF
+    export ROX_SCANNER_V4=true
+    export ROX_LEGACY_SCANNER=false
+    export ROX_CISA_KEV=true
+
+    run feature_flag_env_assignments "${list_file}"
+    assert_success
+    assert_line "ROX_SCANNER_V4=true"
+    assert_line "ROX_LEGACY_SCANNER=false"
+    assert_line "ROX_CISA_KEV=true"
+
+    run omit_helm_owned_feature_flags < <(feature_flag_env_assignments "${list_file}")
+    assert_success
+    assert_line "ROX_CISA_KEV=true"
+    refute_line --partial "ROX_SCANNER_V4"
+    refute_line --partial "ROX_LEGACY_SCANNER"
+}

--- a/tests/e2e/bats/feature_flag_env.bats
+++ b/tests/e2e/bats/feature_flag_env.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+# bats tests/e2e/bats/feature_flag_env.bats
+
+# shellcheck disable=SC1091
+load "../../../scripts/test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/../../../deploy/common/feature-flag-env.sh"
+}
+
+@test "feature_flag_env_assignments is empty when list.go is missing" {
+    run feature_flag_env_assignments "${BATS_TEST_TMPDIR}/does-not-exist.go"
+    assert_success
+    assert_output --partial "WARNING"
+    refute_line --regexp '^ROX_'
+}
+
+@test "feature_flag_env_assignments emits only set, non-empty feature flags" {
+    list_file="${BATS_TEST_TMPDIR}/list.go"
+    cat > "${list_file}" <<'EOF'
+	Foo = registerFeature("foo", "ROX_CISA_KEV")
+	Bar = registerFeature("bar", "ROX_VULN_MGMT_LEGACY_SNOOZE")
+	Baz = registerFeature("baz", "ROX_NETWORK_GRAPH_EXTERNAL_IPS")
+	// URL via the ROX_SCANNER_V4_MAVEN_SEARCH_URL environment variable.
+	Qux = registerFeature("qux", "ROX_SCANNER_V4_MAVEN_SEARCH")
+EOF
+    export ROX_CISA_KEV=true
+    export ROX_NETWORK_GRAPH_EXTERNAL_IPS=false
+    export ROX_SCANNER_V4_MAVEN_SEARCH_URL=http://example.invalid
+    unset ROX_VULN_MGMT_LEGACY_SNOOZE || true
+    export ROX_SCANNER_V4_MAVEN_SEARCH=""
+
+    run feature_flag_env_assignments "${list_file}"
+    assert_success
+    assert_line "ROX_CISA_KEV=true"
+    assert_line "ROX_NETWORK_GRAPH_EXTERNAL_IPS=false"
+    refute_line --partial "ROX_VULN_MGMT_LEGACY_SNOOZE"
+    refute_line --partial "ROX_SCANNER_V4_MAVEN_SEARCH_URL"
+    refute_line --partial "ROX_SCANNER_V4_MAVEN_SEARCH="
+}
+
+@test "feature_flag_env_assignments reads pkg/features/list.go" {
+    export ROX_CISA_KEV=true
+    run feature_flag_env_assignments "${BATS_TEST_DIRNAME}/../../../pkg/features/list.go"
+    assert_success
+    assert_line "ROX_CISA_KEV=true"
+}


### PR DESCRIPTION
## Description

GKE nongroovy nightlies fail `TestFeatureFlagSettings` after #22364. That PR made the test compare Central's live flags to `flag.Enabled()` in the e2e process. That comparison is only true when both sides see the same environment.

They do not on the nightly deploy path. `export_test_environment` sets changeable flags in the test runner (`ROX_CISA_KEV=true`, `ROX_NETWORK_GRAPH_EXTERNAL_IPS=false`, and the rest). Nightly `roxctl` is a release binary, and `roxctl central generate` copies feature-flag env into the bundle only for non-release builds. After generate, the kubectl path only sets CGO, log level, and `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL` on Central. Central therefore reports compile-time defaults. The seven flags whose CI values differ from `Default()` are the mismatch.

#22364 inverted an earlier OCP failure (operator injects those flags onto Central). It left GKE kubectl nightlies failing in the opposite direction. Skipping OpenShift hid one path; it did not give GKE the missing env.

This PR copies every set, non-empty `pkg/features` flag from the generating process onto Central after generate, using the same `kubectl set env --local` (and Helm `--set-string customize.central.envVars`) already used for the signing-key interval. Release `roxctl generate` is unchanged: baking ambient `ROX_*` into customer bundles from whoever ran roxctl is still wrong. The internal deploy scripts are the place CI and local kubectl deploys already patch Central.

Operator/roxie already inject the same overrides. After this, `Enabled()` in the test process and `GetFeatureFlags` from Central agree on GKE nightlies the same way they do when those flags actually reach the pod.

This PR is labeled `ci-release-build` and `e2e-nongroovy-tests` so GHA `gke-nongroovy-e2e-tests` runs against release images, which is the nightly configuration. A nongroovy run without `ci-release-build` uses a non-release `roxctl` that already copies flags, so it cannot catch this.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Confirmed `kubectl set env --local` writes the flag assignments into a dummy Central deployment manifest.
- [x] CI with labels `ci-release-build` and `e2e-nongroovy-tests`
    - ⚠️ Problem: GHA PR nongroovy never uses release version of `roxctl` -> CI check on the PR is not behaving the same as in nightlies -> addressed in https://github.com/stackrox/stackrox/pull/22519/commits/a2d7b5ba8167cde8fb87a2be9274e57b20b84cd1.
    From the [GKE run](https://github.com/stackrox/stackrox/actions/runs/33120489891/job/98687986805?pr=22519):
```
# roxctl

Building release roxctl (tag or ci-release-build)
go: downloading go1.26.5 (linux/amd64)

# test

=== RUN   TestFeatureFlagSettings
    connect_to_central.go:120: gRPC call /v1.FeatureFlagService/GetFeatureFlags succeeded in 72.259635ms
--- PASS: TestFeatureFlagSettings (0.07s)
```
- [x] CI without label `ci-release-build` - this requires a rebuild of images, thus [empty commit](https://github.com/stackrox/stackrox/pull/22519/commits/ffbaa3160a34d1dad424bf78439018261ad09bb7)
    - [x] [OCP 4.12](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22519/pull-ci-stackrox-stackrox-master-ocp-4-12-nongroovy-e2e-tests/2094328317736914944), [OCP 4.22](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22519/pull-ci-stackrox-stackrox-master-ocp-4-22-nongroovy-e2e-tests/2094328318399614976)
    - [x] [GKE Prow](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22519/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/2094328317560754176)
    - [x] [GKE GHA](https://github.com/stackrox/stackrox/actions/runs/33369083865/job/99417975657?pr=22519)
```
Run if [[ "$***GITHUB_REF***" =~ ^refs/tags/ ]] || [[ "false" == "true" ]]; then
(...)
# Note missing "Building release roxctl"
go: downloading go1.26.5 (linux/amd64)
```


AI-Assisted: cursor, ~58% generated, user reviewed logic