### PR TITLE
ROX-36615: Count distinct CVEs in VM severity chips

### DIFF
--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -334,6 +334,21 @@ func (mr *MockCveViewMockRecorder) CountBySeverityPerVM(ctx, q any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverityPerVM", reflect.TypeOf((*MockCveView)(nil).CountBySeverityPerVM), ctx, q)
 }
 
+// CountCVEsBySeverity mocks base method.
+func (m *MockCveView) CountCVEsBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountCVEsBySeverity", ctx, q)
+	ret0, _ := ret[0].(common.ResourceCountByCVESeverity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountCVEsBySeverity indicates an expected call of CountCVEsBySeverity.
+func (mr *MockCveViewMockRecorder) CountCVEsBySeverity(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountCVEsBySeverity", reflect.TypeOf((*MockCveView)(nil).CountCVEsBySeverity), ctx, q)
+}
+
 // Get mocks base method.
 func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, error) {
 	m.ctrl.T.Helper()

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -40,7 +40,10 @@ type CVEComponentCore interface {
 //go:generate mockgen-wrapper
 type CveView interface {
 	Count(ctx context.Context, q *v1.Query) (int, error)
+	// CountBySeverity counts distinct VMs per severity. CVE-detail pages use this.
 	CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error)
+	// CountCVEsBySeverity counts distinct CVEs per severity. VM vuln summary uses this.
+	CountCVEsBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error)
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 	GetVMIDs(ctx context.Context, q *v1.Query) ([]string, error)
 	GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error)

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -36,6 +36,14 @@ func (v *vmCVECoreViewImpl) Count(ctx context.Context, q *v1.Query) (int, error)
 }
 
 func (v *vmCVECoreViewImpl) CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error) {
+	return v.countBySeverity(ctx, q, search.VirtualMachineID)
+}
+
+func (v *vmCVECoreViewImpl) CountCVEsBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error) {
+	return v.countBySeverity(ctx, q, search.CVE)
+}
+
+func (v *vmCVECoreViewImpl) countBySeverity(ctx context.Context, q *v1.Query, countOn search.FieldLabel) (common.ResourceCountByCVESeverity, error) {
 	if err := common.ValidateQuery(q); err != nil {
 		return nil, err
 	}
@@ -43,7 +51,7 @@ func (v *vmCVECoreViewImpl) CountBySeverity(ctx context.Context, q *v1.Query) (c
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
 	defer cancel()
 
-	result, err := pgSearch.RunSelectOneForSchema[resourceCountByVMCVESeverity](queryCtx, v.db, v.schema, common.WithCountBySeverityAndFixabilityQuery(q, search.VirtualMachineID))
+	result, err := pgSearch.RunSelectOneForSchema[resourceCountByVMCVESeverity](queryCtx, v.db, v.schema, common.WithCountBySeverityAndFixabilityQuery(q, countOn))
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +127,7 @@ func (v *vmCVECoreViewImpl) CountBySeverityPerVM(ctx context.Context, q *v1.Quer
 		return nil, err
 	}
 
-	cloned := common.WithCountBySeverityAndFixabilityQuery(q, search.VirtualMachineID)
+	cloned := common.WithCountBySeverityAndFixabilityQuery(q, search.CVE)
 	cloned.Selects = append([]*v1.QuerySelect{
 		search.NewQuerySelect(search.VirtualMachineID).Proto(),
 	}, cloned.GetSelects()...)

--- a/central/views/vmcve/view_test.go
+++ b/central/views/vmcve/view_test.go
@@ -1,0 +1,269 @@
+//go:build sql_integration
+
+package vmcve
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/central/views/common"
+	componentStore "github.com/stackrox/rox/central/virtualmachine/component/v2/datastore/store/postgres"
+	cveStore "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore/store/postgres"
+	scanStore "github.com/stackrox/rox/central/virtualmachine/scan/v2/datastore/store/postgres"
+	vmV2Store "github.com/stackrox/rox/central/virtualmachine/v2/datastore/store"
+	vmV2Postgres "github.com/stackrox/rox/central/virtualmachine/v2/datastore/store/postgres"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	sharedCriticalCVE = "CVE-2024-0001"
+	criticalCVE2      = "CVE-2024-0002"
+	criticalCVE3      = "CVE-2024-0003"
+	importantCVE      = "CVE-2024-0004"
+	moderateCVE       = "CVE-2024-0005"
+	lowCVE            = "CVE-2024-0006"
+)
+
+type severityWant struct {
+	critical, criticalFixable   int
+	important, importantFixable int
+	moderate, moderateFixable   int
+	low, lowFixable             int
+}
+
+func TestVMCVEView(t *testing.T) {
+	t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
+	if !features.VirtualMachinesEnhancedDataModel.Enabled() {
+		t.Skip("VM enhanced data model is not enabled")
+	}
+	suite.Run(t, new(vmCVEViewTestSuite))
+}
+
+type vmCVEViewTestSuite struct {
+	suite.Suite
+
+	db      *pgtest.TestPostgres
+	cveView CveView
+	ctx     context.Context
+
+	vmPG        vmV2Store.Store
+	scanPG      scanStore.Store
+	componentPG componentStore.Store
+	cvePG       cveStore.Store
+
+	vmA     string
+	vmB     string
+	vmEmpty string
+}
+
+func (s *vmCVEViewTestSuite) SetupSuite() {
+	s.ctx = sac.WithAllAccess(context.Background())
+	s.db = pgtest.ForT(s.T())
+	s.cveView = NewCVEView(s.db)
+	s.vmPG = vmV2Postgres.New(s.db, concurrency.NewKeyFence())
+	s.scanPG = scanStore.New(s.db)
+	s.componentPG = componentStore.New(s.db)
+	s.cvePG = cveStore.New(s.db)
+
+	s.vmA = s.insertVM("vm-a")
+	s.vmB = s.insertVM("vm-b")
+	s.vmEmpty = s.insertVM("vm-empty")
+
+	scanA := s.insertScan(s.vmA)
+	opensslA := s.insertComponent(scanA, "openssl")
+	glibcA := s.insertComponent(scanA, "glibc")
+	s.insertCVE(s.vmA, opensslA, sharedCriticalCVE, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, true)
+	s.insertCVE(s.vmA, glibcA, sharedCriticalCVE, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, true)
+	s.insertCVE(s.vmA, glibcA, criticalCVE2, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, false)
+	s.insertCVE(s.vmA, opensslA, criticalCVE3, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, false)
+	s.insertCVE(s.vmA, opensslA, importantCVE, storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY, true)
+	s.insertCVE(s.vmA, opensslA, moderateCVE, storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY, false)
+	s.insertCVE(s.vmA, glibcA, lowCVE, storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY, true)
+
+	scanB := s.insertScan(s.vmB)
+	opensslB := s.insertComponent(scanB, "openssl")
+	s.insertCVE(s.vmB, opensslB, sharedCriticalCVE, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, true)
+}
+
+func (s *vmCVEViewTestSuite) TearDownSuite() {
+	s.db.Close()
+}
+
+func (s *vmCVEViewTestSuite) TestCountCVEsBySeverity() {
+	cases := map[string]struct {
+		q    *v1.Query
+		want severityWant
+	}{
+		"should count distinct CVEs on one VM, not components or VM IDs": {
+			q: search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, s.vmA).ProtoQuery(),
+			want: severityWant{
+				critical: 3, criticalFixable: 1,
+				important: 1, importantFixable: 1,
+				moderate: 1,
+				low:      1, lowFixable: 1,
+			},
+		},
+		"should return zeros when the VM has no CVEs": {
+			q:    search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, s.vmEmpty).ProtoQuery(),
+			want: severityWant{},
+		},
+		"should count distinct CVEs across VMs, not affected VMs": {
+			q: search.EmptyQuery(),
+			want: severityWant{
+				critical: 3, criticalFixable: 1,
+				important: 1, importantFixable: 1,
+				moderate: 1,
+				low:      1, lowFixable: 1,
+			},
+		},
+	}
+	for name, tc := range cases {
+		s.Run(name, func() {
+			got, err := s.cveView.CountCVEsBySeverity(s.ctx, tc.q)
+			s.Require().NoError(err)
+			s.assertSeverityCounts(got, tc.want)
+		})
+	}
+}
+
+func (s *vmCVEViewTestSuite) TestCountBySeverityPerVM() {
+	rows, err := s.cveView.CountBySeverityPerVM(s.ctx, search.EmptyQuery())
+	s.Require().NoError(err)
+
+	byVM := make(map[string]common.ResourceCountByCVESeverity, len(rows))
+	for _, row := range rows {
+		byVM[row.GetVMID()] = row.GetSeverityCounts()
+	}
+
+	s.Require().Contains(byVM, s.vmA)
+	s.assertSeverityCounts(byVM[s.vmA], severityWant{
+		critical: 3, criticalFixable: 1,
+		important: 1, importantFixable: 1,
+		moderate: 1,
+		low:      1, lowFixable: 1,
+	})
+
+	s.Require().Contains(byVM, s.vmB)
+	s.assertSeverityCounts(byVM[s.vmB], severityWant{
+		critical: 1, criticalFixable: 1,
+	})
+
+	s.NotContains(byVM, s.vmEmpty)
+}
+
+func (s *vmCVEViewTestSuite) TestCountBySeverity() {
+	cases := map[string]struct {
+		q    *v1.Query
+		want severityWant
+	}{
+		"should count VMs that have a CVE, not the CVEs themselves": {
+			q: search.NewQueryBuilder().AddExactMatches(search.CVE, sharedCriticalCVE).ProtoQuery(),
+			want: severityWant{
+				critical: 2, criticalFixable: 2,
+			},
+		},
+		"should count distinct VMs per severity across the fleet": {
+			q: search.EmptyQuery(),
+			want: severityWant{
+				critical: 2, criticalFixable: 2,
+				important: 1, importantFixable: 1,
+				moderate: 1,
+				low:      1, lowFixable: 1,
+			},
+		},
+	}
+	for name, tc := range cases {
+		s.Run(name, func() {
+			got, err := s.cveView.CountBySeverity(s.ctx, tc.q)
+			s.Require().NoError(err)
+			s.assertSeverityCounts(got, tc.want)
+		})
+	}
+}
+
+func (s *vmCVEViewTestSuite) TestGet_countsVMsPerSeverity() {
+	got, err := s.cveView.Get(s.ctx, search.NewQueryBuilder().AddExactMatches(search.CVE, sharedCriticalCVE).ProtoQuery())
+	s.Require().NoError(err)
+	s.Require().Len(got, 1)
+	s.Equal(2, got[0].GetAffectedVMCount())
+	s.assertSeverityCounts(got[0].GetVMsBySeverity(), severityWant{
+		critical: 2, criticalFixable: 2,
+	})
+}
+
+func (s *vmCVEViewTestSuite) assertSeverityCounts(got common.ResourceCountByCVESeverity, want severityWant) {
+	s.Equal(want.critical, got.GetCriticalSeverityCount().GetTotal(), "critical total")
+	s.Equal(want.criticalFixable, got.GetCriticalSeverityCount().GetFixable(), "critical fixable")
+	s.Equal(want.important, got.GetImportantSeverityCount().GetTotal(), "important total")
+	s.Equal(want.importantFixable, got.GetImportantSeverityCount().GetFixable(), "important fixable")
+	s.Equal(want.moderate, got.GetModerateSeverityCount().GetTotal(), "moderate total")
+	s.Equal(want.moderateFixable, got.GetModerateSeverityCount().GetFixable(), "moderate fixable")
+	s.Equal(want.low, got.GetLowSeverityCount().GetTotal(), "low total")
+	s.Equal(want.lowFixable, got.GetLowSeverityCount().GetFixable(), "low fixable")
+}
+
+func (s *vmCVEViewTestSuite) insertVM(name string) string {
+	vmID := uuid.NewV5FromNonUUIDs(testconsts.Cluster1, name).String()
+	s.Require().NoError(s.vmPG.UpsertVM(s.ctx, &storage.VirtualMachineV2{
+		Id:          vmID,
+		Name:        name,
+		Namespace:   testconsts.NamespaceA,
+		ClusterId:   testconsts.Cluster1,
+		ClusterName: "cluster-1",
+	}))
+	return vmID
+}
+
+func (s *vmCVEViewTestSuite) insertScan(vmID string) string {
+	scanID := uuid.NewV5FromNonUUIDs(vmID, "scan").String()
+	s.Require().NoError(s.scanPG.Upsert(s.ctx, &storage.VirtualMachineScanV2{
+		Id:       scanID,
+		VmV2Id:   vmID,
+		ScanOs:   "rhel:9",
+		ScanTime: timestamppb.Now(),
+	}))
+	return scanID
+}
+
+func (s *vmCVEViewTestSuite) insertComponent(scanID, name string) string {
+	componentID := uuid.NewV5FromNonUUIDs(scanID, name).String()
+	s.Require().NoError(s.componentPG.Upsert(s.ctx, &storage.VirtualMachineComponentV2{
+		Id:              componentID,
+		VmScanId:        scanID,
+		Name:            name,
+		Version:         "1.0.0",
+		Source:          storage.SourceType_OS,
+		OperatingSystem: "rhel:9",
+	}))
+	return componentID
+}
+
+func (s *vmCVEViewTestSuite) insertCVE(vmID, componentID, cve string, severity storage.VulnerabilitySeverity, fixable bool) {
+	rowID := uuid.NewV5FromNonUUIDs(componentID, cve).String()
+	obj := &storage.VirtualMachineCVEV2{
+		Id:            rowID,
+		VmV2Id:        vmID,
+		VmComponentId: componentID,
+		CveBaseInfo: &storage.CVEInfo{
+			Cve:         cve,
+			PublishedOn: timestamppb.Now(),
+			CreatedAt:   timestamppb.Now(),
+		},
+		Severity:  severity,
+		IsFixable: fixable,
+	}
+	if fixable {
+		obj.HasFixedBy = &storage.VirtualMachineCVEV2_FixedBy{FixedBy: "1.0.1"}
+	}
+	s.Require().NoError(s.cvePG.Upsert(s.ctx, obj))
+}

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -303,7 +303,7 @@ func (s *serviceImpl) GetVMVulnSummary(ctx context.Context, request *v2.GetVMVul
 		vmFilter = search.ConjunctionQuery(vmFilter, additionalQuery)
 	}
 
-	severityCounts, err := s.cveView.CountBySeverity(ctx, vmFilter)
+	severityCounts, err := s.cveView.CountCVEsBySeverity(ctx, vmFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -134,7 +134,7 @@ func TestGetVMVulnSummary(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
-				mockView.EXPECT().CountBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
+				mockView.EXPECT().CountCVEsBySeverity(ctx, gomock.Any()).Return(&commonViews.ResourceCountByImageCVESeverity{
 					CriticalSeverityCount:         2,
 					FixableCriticalSeverityCount:  1,
 					ImportantSeverityCount:        3,


### PR DESCRIPTION
## Description

`ListVMs` and `GetVMVulnSummary` fill severity chips from Central aggregation. Both counted distinct virtual-machine IDs per severity. On a query already scoped to one VM, that count is 0 or 1, so a guest with hundreds of CVEs still showed 1 Critical / 1 Important / 1 Moderate / 1 Low.

Those two paths now count distinct CVE IDs. `CountBySeverityPerVM` still groups by VM for the list page. `GetVMVulnSummary` uses a new `CountCVEsBySeverity` helper.

`CountBySeverity` still counts VMs. The CVE detail page and the global CVE list use that to answer how many VMs have a given CVE at each severity.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Deployed to a cluster and looked at the UI

#### Before
<img width="1416" height="494" alt="Screenshot 2026-08-31 at 13 44 42" src="https://github.com/user-attachments/assets/4aebd0a6-5827-490d-8db7-36d3b6753a68" />


#### After
<img width="1267" height="504" alt="Screenshot 2026-08-31 at 13 47 25" src="https://github.com/user-attachments/assets/9fd8bc2b-19a0-4b51-8dd2-e267898998b4" />


AI-Assisted: cursor, generated the view/service change and postgres regression tests; user reviewed before commit.