### PR TITLE
ROX-36617: Group VM CVE rows and count components

### DIFF
--- a/central/convert/storagetov2/virtual_machine_v2.go
+++ b/central/convert/storagetov2/virtual_machine_v2.go
@@ -91,25 +91,6 @@ func SeverityCountsToProto(counts common.ResourceCountByCVESeverity) *v2.VulnCou
 	}
 }
 
-// VirtualMachineCVEV2ToRow converts a storage CVE V2 to an API CVE row.
-func VirtualMachineCVEV2ToRow(cve *storage.VirtualMachineCVEV2) *v2.VMCVERow {
-	if cve == nil {
-		return nil
-	}
-	return &v2.VMCVERow{
-		Cve:             cve.GetCveBaseInfo().GetCve(),
-		Severity:        v2.VulnerabilitySeverity(cve.GetSeverity()),
-		IsFixable:       cve.GetIsFixable(),
-		Cvss:            cve.GetPreferredCvss(),
-		NvdCvss:         cve.GetNvdcvss(),
-		EpssProbability: cve.GetEpssProbability(),
-		PublishedOn:     cve.GetCveBaseInfo().GetPublishedOn(),
-		Summary:         cve.GetCveBaseInfo().GetSummary(),
-		Link:            cve.GetCveBaseInfo().GetLink(),
-		Advisory:        advisoryToProto(cve.GetAdvisory()),
-	}
-}
-
 // VirtualMachineComponentV2ToRow converts a storage component V2 to an API component row.
 func VirtualMachineComponentV2ToRow(comp *storage.VirtualMachineComponentV2) *v2.VMComponentRow {
 	if comp == nil {
@@ -126,16 +107,6 @@ func VirtualMachineComponentV2ToRow(comp *storage.VirtualMachineComponentV2) *v2
 		Source:     v2.SourceType(comp.GetSource()),
 		ScanStatus: scanStatus,
 		CveCount:   comp.GetCveCount(),
-	}
-}
-
-func advisoryToProto(adv *storage.Advisory) *v2.Advisory {
-	if adv == nil {
-		return nil
-	}
-	return &v2.Advisory{
-		Name: adv.GetName(),
-		Link: adv.GetLink(),
 	}
 }
 

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -184,3 +184,28 @@ func (r *affectedVMResponse) GetIsFixable() bool             { return r.FixableC
 func (r *affectedVMResponse) GetMaxCVSS() float32            { return r.MaxCVSS }
 func (r *affectedVMResponse) GetGuestOS() string             { return r.GuestOS }
 func (r *affectedVMResponse) GetAffectedComponentCount() int { return r.AffectedComponentCount }
+
+type cveByVMResponse struct {
+	CVE                    string     `db:"cve"`
+	MaxSeverity            int32      `db:"severity_max"`
+	FixableCount           int        `db:"fixable_count"`
+	MaxCVSS                float32    `db:"cvss_max"`
+	MaxNVDCVSS             float32    `db:"nvd_cvss_max"`
+	EPSSProbabilityMax     *float32   `db:"epss_probability_max"`
+	Published              *time.Time `db:"cve_published_on_min"`
+	AffectedComponentCount int        `db:"component_id_count"`
+}
+
+func (r *cveByVMResponse) GetCVE() string                 { return r.CVE }
+func (r *cveByVMResponse) GetMaxSeverity() int32          { return r.MaxSeverity }
+func (r *cveByVMResponse) GetIsFixable() bool             { return r.FixableCount > 0 }
+func (r *cveByVMResponse) GetMaxCVSS() float32            { return r.MaxCVSS }
+func (r *cveByVMResponse) GetMaxNVDCVSS() float32         { return r.MaxNVDCVSS }
+func (r *cveByVMResponse) GetPublishedOn() *time.Time     { return r.Published }
+func (r *cveByVMResponse) GetAffectedComponentCount() int { return r.AffectedComponentCount }
+func (r *cveByVMResponse) GetEPSSProbability() float32 {
+	if r.EPSSProbabilityMax == nil {
+		return 0
+	}
+	return *r.EPSSProbabilityMax
+}

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -379,6 +379,21 @@ func (mr *MockCveViewMockRecorder) GetCVEComponents(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEComponents", reflect.TypeOf((*MockCveView)(nil).GetCVEComponents), ctx, q)
 }
 
+// GetCVEsByVM mocks base method.
+func (m *MockCveView) GetCVEsByVM(ctx context.Context, q *v1.Query) ([]vmcve.CVEByVMCore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCVEsByVM", ctx, q)
+	ret0, _ := ret[0].([]vmcve.CVEByVMCore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCVEsByVM indicates an expected call of GetCVEsByVM.
+func (mr *MockCveViewMockRecorder) GetCVEsByVM(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEsByVM", reflect.TypeOf((*MockCveView)(nil).GetCVEsByVM), ctx, q)
+}
+
 // GetVMIDs mocks base method.
 func (m *MockCveView) GetVMIDs(ctx context.Context, q *v1.Query) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -566,4 +581,140 @@ func (m *MockAffectedVMCore) GetVMName() string {
 func (mr *MockAffectedVMCoreMockRecorder) GetVMName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMName", reflect.TypeOf((*MockAffectedVMCore)(nil).GetVMName))
+}
+
+// MockCVEByVMCore is a mock of CVEByVMCore interface.
+type MockCVEByVMCore struct {
+	ctrl     *gomock.Controller
+	recorder *MockCVEByVMCoreMockRecorder
+	isgomock struct{}
+}
+
+// MockCVEByVMCoreMockRecorder is the mock recorder for MockCVEByVMCore.
+type MockCVEByVMCoreMockRecorder struct {
+	mock *MockCVEByVMCore
+}
+
+// NewMockCVEByVMCore creates a new mock instance.
+func NewMockCVEByVMCore(ctrl *gomock.Controller) *MockCVEByVMCore {
+	mock := &MockCVEByVMCore{ctrl: ctrl}
+	mock.recorder = &MockCVEByVMCoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCVEByVMCore) EXPECT() *MockCVEByVMCoreMockRecorder {
+	return m.recorder
+}
+
+// GetAffectedComponentCount mocks base method.
+func (m *MockCVEByVMCore) GetAffectedComponentCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAffectedComponentCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetAffectedComponentCount indicates an expected call of GetAffectedComponentCount.
+func (mr *MockCVEByVMCoreMockRecorder) GetAffectedComponentCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAffectedComponentCount", reflect.TypeOf((*MockCVEByVMCore)(nil).GetAffectedComponentCount))
+}
+
+// GetCVE mocks base method.
+func (m *MockCVEByVMCore) GetCVE() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCVE")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetCVE indicates an expected call of GetCVE.
+func (mr *MockCVEByVMCoreMockRecorder) GetCVE() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVE", reflect.TypeOf((*MockCVEByVMCore)(nil).GetCVE))
+}
+
+// GetEPSSProbability mocks base method.
+func (m *MockCVEByVMCore) GetEPSSProbability() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEPSSProbability")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetEPSSProbability indicates an expected call of GetEPSSProbability.
+func (mr *MockCVEByVMCoreMockRecorder) GetEPSSProbability() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEPSSProbability", reflect.TypeOf((*MockCVEByVMCore)(nil).GetEPSSProbability))
+}
+
+// GetIsFixable mocks base method.
+func (m *MockCVEByVMCore) GetIsFixable() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIsFixable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetIsFixable indicates an expected call of GetIsFixable.
+func (mr *MockCVEByVMCoreMockRecorder) GetIsFixable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsFixable", reflect.TypeOf((*MockCVEByVMCore)(nil).GetIsFixable))
+}
+
+// GetMaxCVSS mocks base method.
+func (m *MockCVEByVMCore) GetMaxCVSS() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxCVSS")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetMaxCVSS indicates an expected call of GetMaxCVSS.
+func (mr *MockCVEByVMCoreMockRecorder) GetMaxCVSS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxCVSS", reflect.TypeOf((*MockCVEByVMCore)(nil).GetMaxCVSS))
+}
+
+// GetMaxNVDCVSS mocks base method.
+func (m *MockCVEByVMCore) GetMaxNVDCVSS() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxNVDCVSS")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetMaxNVDCVSS indicates an expected call of GetMaxNVDCVSS.
+func (mr *MockCVEByVMCoreMockRecorder) GetMaxNVDCVSS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxNVDCVSS", reflect.TypeOf((*MockCVEByVMCore)(nil).GetMaxNVDCVSS))
+}
+
+// GetMaxSeverity mocks base method.
+func (m *MockCVEByVMCore) GetMaxSeverity() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxSeverity")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetMaxSeverity indicates an expected call of GetMaxSeverity.
+func (mr *MockCVEByVMCoreMockRecorder) GetMaxSeverity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxSeverity", reflect.TypeOf((*MockCVEByVMCore)(nil).GetMaxSeverity))
+}
+
+// GetPublishedOn mocks base method.
+func (m *MockCVEByVMCore) GetPublishedOn() *time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublishedOn")
+	ret0, _ := ret[0].(*time.Time)
+	return ret0
+}
+
+// GetPublishedOn indicates an expected call of GetPublishedOn.
+func (mr *MockCVEByVMCoreMockRecorder) GetPublishedOn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishedOn", reflect.TypeOf((*MockCVEByVMCore)(nil).GetPublishedOn))
 }

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -47,6 +47,8 @@ type CveView interface {
 	CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]VMSeverityCounts, error)
 	GetAffectedVMs(ctx context.Context, q *v1.Query) ([]AffectedVMCore, error)
 	CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error)
+	// GetCVEsByVM groups by CVE and counts distinct components. ListVMCVEsByVM uses this.
+	GetCVEsByVM(ctx context.Context, q *v1.Query) ([]CVEByVMCore, error)
 }
 
 // VMSeverityCounts provides per-VM severity counts.
@@ -63,5 +65,17 @@ type AffectedVMCore interface {
 	GetIsFixable() bool
 	GetMaxCVSS() float32
 	GetGuestOS() string
+	GetAffectedComponentCount() int
+}
+
+// CVEByVMCore is one distinct CVE on a VM, with how many components it hits.
+type CVEByVMCore interface {
+	GetCVE() string
+	GetMaxSeverity() int32
+	GetIsFixable() bool
+	GetMaxCVSS() float32
+	GetMaxNVDCVSS() float32
+	GetEPSSProbability() float32
+	GetPublishedOn() *time.Time
 	GetAffectedComponentCount() int
 }

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -192,6 +192,44 @@ func (v *vmCVECoreViewImpl) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]
 	return ret, nil
 }
 
+func (v *vmCVECoreViewImpl) GetCVEsByVM(ctx context.Context, q *v1.Query) ([]CVEByVMCore, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return nil, err
+	}
+
+	cloned := q.CloneVT()
+	cloned = common.UpdateSortAggs(cloned)
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(search.CVE).Proto(),
+		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.Fixable).AggrFunc(aggregatefunc.Count).
+			Filter("fixable_count",
+				search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery(),
+			).Proto(),
+		search.NewQuerySelect(search.CVSS).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.NVDCVSS).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.EPSSProbablity).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.CVEPublishedOn).AggrFunc(aggregatefunc.Min).Proto(),
+		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{search.CVE.String()},
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	ret := make([]CVEByVMCore, 0, paginated.GetLimit(q.GetPagination().GetLimit(), 100))
+	err := pgSearch.RunSelectRequestForSchemaFn[cveByVMResponse](queryCtx, v.db, v.schema, cloned, func(r *cveByVMResponse) error {
+		ret = append(ret, r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (v *vmCVECoreViewImpl) GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error) {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{

--- a/central/views/vmcve/view_test.go
+++ b/central/views/vmcve/view_test.go
@@ -1,0 +1,160 @@
+//go:build sql_integration
+
+package vmcve
+
+import (
+	"context"
+	"testing"
+
+	componentStore "github.com/stackrox/rox/central/virtualmachine/component/v2/datastore/store/postgres"
+	cveStore "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore/store/postgres"
+	scanStore "github.com/stackrox/rox/central/virtualmachine/scan/v2/datastore/store/postgres"
+	vmV2Store "github.com/stackrox/rox/central/virtualmachine/v2/datastore/store"
+	vmV2Postgres "github.com/stackrox/rox/central/virtualmachine/v2/datastore/store/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	sharedCVE = "CVE-2024-1001"
+	lonelyCVE = "CVE-2024-1002"
+)
+
+func TestVMCVEView(t *testing.T) {
+	t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
+	if !features.VirtualMachinesEnhancedDataModel.Enabled() {
+		t.Skip("VM enhanced data model is not enabled")
+	}
+	suite.Run(t, new(vmCVEViewTestSuite))
+}
+
+type vmCVEViewTestSuite struct {
+	suite.Suite
+
+	db      *pgtest.TestPostgres
+	cveView CveView
+	ctx     context.Context
+
+	vmPG        vmV2Store.Store
+	scanPG      scanStore.Store
+	componentPG componentStore.Store
+	cvePG       cveStore.Store
+
+	vmID string
+}
+
+func (s *vmCVEViewTestSuite) SetupSuite() {
+	s.ctx = sac.WithAllAccess(context.Background())
+	s.db = pgtest.ForT(s.T())
+	s.cveView = NewCVEView(s.db)
+	s.vmPG = vmV2Postgres.New(s.db, concurrency.NewKeyFence())
+	s.scanPG = scanStore.New(s.db)
+	s.componentPG = componentStore.New(s.db)
+	s.cvePG = cveStore.New(s.db)
+
+	s.vmID = s.insertVM("vm-a")
+	scanID := s.insertScan(s.vmID)
+	openssl := s.insertComponent(scanID, "openssl")
+	glibc := s.insertComponent(scanID, "glibc")
+	s.insertCVE(s.vmID, openssl, sharedCVE, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, true)
+	s.insertCVE(s.vmID, glibc, sharedCVE, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, true)
+	s.insertCVE(s.vmID, openssl, lonelyCVE, storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY, false)
+}
+
+func (s *vmCVEViewTestSuite) TearDownSuite() {
+	s.db.Close()
+}
+
+func (s *vmCVEViewTestSuite) TestCount_distinctCVEsNotStorageRows() {
+	q := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, s.vmID).ProtoQuery()
+	got, err := s.cveView.Count(s.ctx, q)
+	s.Require().NoError(err)
+	s.Equal(2, got)
+}
+
+func (s *vmCVEViewTestSuite) TestGetCVEsByVM() {
+	q := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, s.vmID).ProtoQuery()
+	got, err := s.cveView.GetCVEsByVM(s.ctx, q)
+	s.Require().NoError(err)
+	s.Require().Len(got, 2)
+
+	byCVE := make(map[string]CVEByVMCore, len(got))
+	for _, row := range got {
+		s.NotContains(byCVE, row.GetCVE(), "duplicate CVE %s", row.GetCVE())
+		byCVE[row.GetCVE()] = row
+	}
+
+	s.Require().Contains(byCVE, sharedCVE)
+	s.Equal(2, byCVE[sharedCVE].GetAffectedComponentCount())
+	s.Equal(int32(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY), byCVE[sharedCVE].GetMaxSeverity())
+	s.True(byCVE[sharedCVE].GetIsFixable())
+
+	s.Require().Contains(byCVE, lonelyCVE)
+	s.Equal(1, byCVE[lonelyCVE].GetAffectedComponentCount())
+	s.Equal(int32(storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY), byCVE[lonelyCVE].GetMaxSeverity())
+	s.False(byCVE[lonelyCVE].GetIsFixable())
+}
+
+func (s *vmCVEViewTestSuite) insertVM(name string) string {
+	vmID := uuid.NewV5FromNonUUIDs(testconsts.Cluster1, name).String()
+	s.Require().NoError(s.vmPG.UpsertVM(s.ctx, &storage.VirtualMachineV2{
+		Id:          vmID,
+		Name:        name,
+		Namespace:   testconsts.NamespaceA,
+		ClusterId:   testconsts.Cluster1,
+		ClusterName: "cluster-1",
+	}))
+	return vmID
+}
+
+func (s *vmCVEViewTestSuite) insertScan(vmID string) string {
+	scanID := uuid.NewV5FromNonUUIDs(vmID, "scan").String()
+	s.Require().NoError(s.scanPG.Upsert(s.ctx, &storage.VirtualMachineScanV2{
+		Id:       scanID,
+		VmV2Id:   vmID,
+		ScanOs:   "rhel:9",
+		ScanTime: timestamppb.Now(),
+	}))
+	return scanID
+}
+
+func (s *vmCVEViewTestSuite) insertComponent(scanID, name string) string {
+	componentID := uuid.NewV5FromNonUUIDs(scanID, name).String()
+	s.Require().NoError(s.componentPG.Upsert(s.ctx, &storage.VirtualMachineComponentV2{
+		Id:              componentID,
+		VmScanId:        scanID,
+		Name:            name,
+		Version:         "1.0.0",
+		Source:          storage.SourceType_OS,
+		OperatingSystem: "rhel:9",
+	}))
+	return componentID
+}
+
+func (s *vmCVEViewTestSuite) insertCVE(vmID, componentID, cve string, severity storage.VulnerabilitySeverity, fixable bool) {
+	rowID := uuid.NewV5FromNonUUIDs(componentID, cve).String()
+	obj := &storage.VirtualMachineCVEV2{
+		Id:            rowID,
+		VmV2Id:        vmID,
+		VmComponentId: componentID,
+		CveBaseInfo: &storage.CVEInfo{
+			Cve:         cve,
+			PublishedOn: timestamppb.Now(),
+			CreatedAt:   timestamppb.Now(),
+		},
+		Severity:  severity,
+		IsFixable: fixable,
+	}
+	if fixable {
+		obj.HasFixedBy = &storage.VirtualMachineCVEV2_FixedBy{FixedBy: "1.0.1"}
+	}
+	s.Require().NoError(s.cvePG.Upsert(s.ctx, obj))
+}

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -339,19 +339,28 @@ func (s *serviceImpl) ListVMCVEsByVM(ctx context.Context, request *v2.ListVMCVEs
 
 	countQuery := searchQuery.CloneVT()
 	countQuery.Pagination = nil
-	totalCount, err := s.cveDS.Count(ctx, countQuery)
+	totalCount, err := s.cveView.Count(ctx, countQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	cves, err := s.cveDS.SearchRawVMCVEs(ctx, searchQuery)
+	cves, err := s.cveView.GetCVEsByVM(ctx, searchQuery)
 	if err != nil {
 		return nil, err
 	}
 
 	items := make([]*v2.VMCVERow, 0, len(cves))
 	for _, cve := range cves {
-		items = append(items, storagetov2.VirtualMachineCVEV2ToRow(cve))
+		items = append(items, &v2.VMCVERow{
+			Cve:                    cve.GetCVE(),
+			Severity:               v2.VulnerabilitySeverity(cve.GetMaxSeverity()),
+			IsFixable:              cve.GetIsFixable(),
+			Cvss:                   cve.GetMaxCVSS(),
+			NvdCvss:                cve.GetMaxNVDCVSS(),
+			EpssProbability:        cve.GetEPSSProbability(),
+			AffectedComponentCount: int32(cve.GetAffectedComponentCount()),
+			PublishedOn:            protocompat.ConvertTimeToTimestampOrNil(cve.GetPublishedOn()),
+		})
 	}
 
 	return &v2.ListVMCVEsByVMResponse{

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -189,21 +189,6 @@ func TestGetVMVulnSummary(t *testing.T) {
 func TestListVMCVEsByVM(t *testing.T) {
 	ctx := context.Background()
 
-	cve1 := &storage.VirtualMachineCVEV2{
-		Id:            "cve-uuid-1",
-		VmV2Id:        "vm-1",
-		VmComponentId: "comp-1",
-		CveBaseInfo: &storage.CVEInfo{
-			Cve:     "CVE-2024-1234",
-			Summary: "test vuln 1",
-			Link:    "https://example.com/1",
-		},
-		PreferredCvss:   7.5,
-		Severity:        storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
-		IsFixable:       true,
-		EpssProbability: 0.5,
-	}
-
 	tests := map[string]struct {
 		request       *v2.ListVMCVEsByVMRequest
 		setupMock     func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView)
@@ -231,8 +216,17 @@ func TestListVMCVEsByVM(t *testing.T) {
 				VmId: fixtureconsts.VirtualMachine1,
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
-				mockCVE.EXPECT().Count(ctx, gomock.Any()).Return(1, nil)
-				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
+				mockView.EXPECT().Count(ctx, gomock.Any()).Return(1, nil)
+				row := cveViewMocks.NewMockCVEByVMCore(gomock.NewController(t))
+				row.EXPECT().GetCVE().Return("CVE-2024-1234").AnyTimes()
+				row.EXPECT().GetMaxSeverity().Return(int32(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY)).AnyTimes()
+				row.EXPECT().GetIsFixable().Return(true).AnyTimes()
+				row.EXPECT().GetMaxCVSS().Return(float32(7.5)).AnyTimes()
+				row.EXPECT().GetMaxNVDCVSS().Return(float32(0)).AnyTimes()
+				row.EXPECT().GetEPSSProbability().Return(float32(0.5)).AnyTimes()
+				row.EXPECT().GetPublishedOn().Return(nil).AnyTimes()
+				row.EXPECT().GetAffectedComponentCount().Return(2).AnyTimes()
+				mockView.EXPECT().GetCVEsByVM(ctx, gomock.Any()).Return([]vmcve.CVEByVMCore{row}, nil)
 			},
 			expectedCount: 1,
 		},
@@ -274,6 +268,7 @@ func TestListVMCVEsByVM(t *testing.T) {
 					assert.Equal(t, v2.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, row.GetSeverity())
 					assert.True(t, row.GetIsFixable())
 					assert.Equal(t, float32(7.5), row.GetCvss())
+					assert.Equal(t, int32(2), row.GetAffectedComponentCount())
 				}
 			}
 		})


### PR DESCRIPTION
## Description

`ListVMCVEsByVM` listed one API row per storage record. Storage is one row per (VM, component, CVE), so a CVE that hits glibc and openssl appeared twice, and `affected_component_count` stayed 0 because that field does not exist on the storage proto.

The endpoint now uses the same grain as the global CVE list: distinct CVE IDs. `Count` is a distinct-CVE count. A new `GetCVEsByVM` query groups by CVE and fills `affected_component_count` with `COUNT(DISTINCT component_id)`, the inverse of the existing affected-VM query.

`summary`, `link`, and `advisory` on the list row are left empty. Those fields are not search-indexed, so they cannot be selected in the grouped query, and the VM CVE table does not render them.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [ ] Deployed to a cluster and looked at the UI


AI-Assisted: cursor, generated the view query, service mapping, and postgres regression tests; user reviewed before commit.