### PR TITLE
fix(compliance): flag stale clusters in on-demand reports

### DIFF
--- a/central/complianceoperator/v2/report/errors.go
+++ b/central/complianceoperator/v2/report/errors.go
@@ -10,6 +10,7 @@ const (
 	SCAN_REMOVED_FMT                     = "Scan %s was removed"
 	SCAN_TIMEOUT_FMT                     = "Timeout waiting for scan %s to finish"
 	SCAN_TIMEOUT_SENSOR_DISCONNECTED_FMT = "Timeout waiting for scan %s to finish (Sensor disconnect during the scan)"
+	SCAN_RESULTS_STALE_FMT               = "Scan results are outdated (last assessment: %s, last scan execution: %s)"
 )
 
 var (

--- a/central/complianceoperator/v2/report/manager/helpers/clusterdata.go
+++ b/central/complianceoperator/v2/report/manager/helpers/clusterdata.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	checkResultDS "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	snapshotDS "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore"
 	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
@@ -14,7 +13,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/search"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // GetFailedClusters returns the failed clusters metadata associated with a ScanConfiguration
@@ -86,16 +84,20 @@ func populateScanNames(ctx context.Context, data *report.ClusterData, reportData
 
 var log = logging.LoggerForModule()
 
-// DetectStaleClusters identifies clusters whose check results are older than
-// the scan configuration's last execution time. This happens when a scan was
-// triggered but results never arrived (e.g. sensor disconnect, watcher timeout).
-// Without this check, the on-demand report path silently serves stale data from
-// a previous scan cycle.
+// DetectStaleClusters identifies clusters that did not complete the scan
+// configuration's latest execution: their suite's last transition time is older
+// than the configuration's overall last execution time. This happens when a
+// scan was triggered but a cluster never produced fresh results (e.g. sensor
+// disconnect, watcher timeout in a previous cycle). Without this check, the
+// on-demand report path silently serves stale data from a previous scan cycle,
+// unlike the scheduled path which flags such clusters via the ScanConfigWatcher.
+//
+// The comparison is like-with-like: both the per-cluster suite time and the
+// config's LastExecutedTime are suite transition timestamps, so a cluster that
+// participated in the latest run compares equal (or newer) and is not flagged.
 func DetectStaleClusters(
-	ctx context.Context,
 	reportData *storage.ComplianceOperatorReportData,
 	existingFailedClusters map[string]*report.FailedCluster,
-	checkResultStore checkResultDS.DataStore,
 ) map[string]*report.FailedCluster {
 	lastExec := reportData.GetLastExecutedTime()
 	if lastExec == nil {
@@ -104,64 +106,35 @@ func DetectStaleClusters(
 	}
 
 	staleClusters := make(map[string]*report.FailedCluster)
-	scanConfigID := reportData.GetScanConfiguration().GetId()
-
 	for _, cluster := range reportData.GetClusterStatus() {
 		clusterID := cluster.GetClusterId()
 		if _, alreadyFailed := existingFailedClusters[clusterID]; alreadyFailed {
 			continue
 		}
 
-		latestResultTime := getLatestCheckResultTime(ctx, scanConfigID, clusterID, checkResultStore)
-		if latestResultTime == nil || protocompat.CompareTimestamps(latestResultTime, lastExec) < 0 {
-			var assessmentStr string
-			if latestResultTime == nil {
-				assessmentStr = "none"
-			} else {
-				assessmentStr = latestResultTime.AsTime().UTC().Format(time.RFC1123)
-			}
-			reason := fmt.Sprintf(report.SCAN_RESULTS_STALE_FMT,
-				assessmentStr,
-				lastExec.AsTime().UTC().Format(time.RFC1123),
-			)
-			log.Warnf("Cluster %s (%s) has stale scan results: %s",
-				clusterID, cluster.GetClusterName(), reason)
-			staleClusters[clusterID] = &report.FailedCluster{
-				ClusterId:   clusterID,
-				ClusterName: cluster.GetClusterName(),
-				Reasons:     []string{reason},
-			}
+		clusterTime := cluster.GetSuiteStatus().GetLastTransitionTime()
+		if clusterTime != nil && protocompat.CompareTimestamps(clusterTime, lastExec) >= 0 {
+			// Cluster completed the latest execution; not stale.
+			continue
+		}
+
+		assessmentStr := "none"
+		if clusterTime != nil {
+			assessmentStr = clusterTime.AsTime().UTC().Format(time.RFC1123)
+		}
+		reason := fmt.Sprintf(report.SCAN_RESULTS_STALE_FMT,
+			assessmentStr,
+			lastExec.AsTime().UTC().Format(time.RFC1123),
+		)
+		log.Warnf("Cluster %s (%s) has stale scan results: %s",
+			clusterID, cluster.GetClusterName(), reason)
+		staleClusters[clusterID] = &report.FailedCluster{
+			ClusterId:   clusterID,
+			ClusterName: cluster.GetClusterName(),
+			Reasons:     []string{reason},
 		}
 	}
 	return staleClusters
-}
-
-// getLatestCheckResultTime returns the most recent LastStartedTime among
-// check results for the given scan config and cluster, or nil if none exist.
-func getLatestCheckResultTime(
-	ctx context.Context,
-	scanConfigID, clusterID string,
-	checkResultStore checkResultDS.DataStore,
-) *timestamppb.Timestamp {
-	// Query one result sorted by LastStartedTime DESC.
-	q := search.NewQueryBuilder().
-		AddExactMatches(search.ComplianceOperatorScanConfig, scanConfigID).
-		AddExactMatches(search.ClusterID, clusterID).
-		WithPagination(
-			search.NewPagination().
-				Limit(1).
-				AddSortOption(search.NewSortOption(search.ComplianceOperatorCheckLastStartedTime).Reversed(true)),
-		).
-		ProtoQuery()
-	results, err := checkResultStore.SearchComplianceCheckResults(ctx, q)
-	if err != nil {
-		log.Warnf("Failed to query check results for cluster %s: %v", clusterID, err)
-		return nil
-	}
-	if len(results) == 0 {
-		return nil
-	}
-	return results[0].GetLastStartedTime()
 }
 
 func populateFailedScans(ctx context.Context, failedScanNames []string, snapshotScans []*storage.ComplianceOperatorReportSnapshotV2_Scan, scanStore scanDS.DataStore) ([]*storage.ComplianceOperatorScanV2, error) {

--- a/central/complianceoperator/v2/report/manager/helpers/clusterdata.go
+++ b/central/complianceoperator/v2/report/manager/helpers/clusterdata.go
@@ -2,13 +2,19 @@ package helpers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
+	checkResultDS "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	snapshotDS "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore"
 	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/search"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // GetFailedClusters returns the failed clusters metadata associated with a ScanConfiguration
@@ -76,6 +82,86 @@ func populateScanNames(ctx context.Context, data *report.ClusterData, reportData
 		data.ScanNames = append(data.ScanNames, scan.GetScanName())
 	}
 	return data, nil
+}
+
+var log = logging.LoggerForModule()
+
+// DetectStaleClusters identifies clusters whose check results are older than
+// the scan configuration's last execution time. This happens when a scan was
+// triggered but results never arrived (e.g. sensor disconnect, watcher timeout).
+// Without this check, the on-demand report path silently serves stale data from
+// a previous scan cycle.
+func DetectStaleClusters(
+	ctx context.Context,
+	reportData *storage.ComplianceOperatorReportData,
+	existingFailedClusters map[string]*report.FailedCluster,
+	checkResultStore checkResultDS.DataStore,
+) map[string]*report.FailedCluster {
+	lastExec := reportData.GetLastExecutedTime()
+	if lastExec == nil {
+		// No execution recorded yet — nothing to compare against.
+		return nil
+	}
+
+	staleClusters := make(map[string]*report.FailedCluster)
+	scanConfigID := reportData.GetScanConfiguration().GetId()
+
+	for _, cluster := range reportData.GetClusterStatus() {
+		clusterID := cluster.GetClusterId()
+		if _, alreadyFailed := existingFailedClusters[clusterID]; alreadyFailed {
+			continue
+		}
+
+		latestResultTime := getLatestCheckResultTime(ctx, scanConfigID, clusterID, checkResultStore)
+		if latestResultTime == nil || protocompat.CompareTimestamps(latestResultTime, lastExec) < 0 {
+			var assessmentStr string
+			if latestResultTime == nil {
+				assessmentStr = "none"
+			} else {
+				assessmentStr = latestResultTime.AsTime().UTC().Format(time.RFC1123)
+			}
+			reason := fmt.Sprintf(report.SCAN_RESULTS_STALE_FMT,
+				assessmentStr,
+				lastExec.AsTime().UTC().Format(time.RFC1123),
+			)
+			log.Warnf("Cluster %s (%s) has stale scan results: %s",
+				clusterID, cluster.GetClusterName(), reason)
+			staleClusters[clusterID] = &report.FailedCluster{
+				ClusterId:   clusterID,
+				ClusterName: cluster.GetClusterName(),
+				Reasons:     []string{reason},
+			}
+		}
+	}
+	return staleClusters
+}
+
+// getLatestCheckResultTime returns the most recent LastStartedTime among
+// check results for the given scan config and cluster, or nil if none exist.
+func getLatestCheckResultTime(
+	ctx context.Context,
+	scanConfigID, clusterID string,
+	checkResultStore checkResultDS.DataStore,
+) *timestamppb.Timestamp {
+	// Query one result sorted by LastStartedTime DESC.
+	q := search.NewQueryBuilder().
+		AddExactMatches(search.ComplianceOperatorScanConfig, scanConfigID).
+		AddExactMatches(search.ClusterID, clusterID).
+		WithPagination(
+			search.NewPagination().
+				Limit(1).
+				AddSortOption(search.NewSortOption(search.ComplianceOperatorCheckLastStartedTime).Reversed(true)),
+		).
+		ProtoQuery()
+	results, err := checkResultStore.SearchComplianceCheckResults(ctx, q)
+	if err != nil {
+		log.Warnf("Failed to query check results for cluster %s: %v", clusterID, err)
+		return nil
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	return results[0].GetLastStartedTime()
 }
 
 func populateFailedScans(ctx context.Context, failedScanNames []string, snapshotScans []*storage.ComplianceOperatorReportSnapshotV2_Scan, scanStore scanDS.DataStore) ([]*storage.ComplianceOperatorScanV2, error) {

--- a/central/complianceoperator/v2/report/manager/helpers/clusterdata_test.go
+++ b/central/complianceoperator/v2/report/manager/helpers/clusterdata_test.go
@@ -3,8 +3,10 @@ package helpers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
+	checkResultDS "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	snapshotDS "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore/mocks"
 	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore/mocks"
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGetFailedClusters(t *testing.T) {
@@ -234,6 +237,126 @@ func TestGetClusterData(t *testing.T) {
 		assert.NoError(tt, err)
 		assertClusterData(tt, expectedClusterData, clusterData)
 	})
+}
+
+func TestDetectStaleClusters(t *testing.T) {
+	now := time.Now()
+	lastExec := timestamppb.New(now)
+	oldResult := timestamppb.New(now.Add(-1 * time.Hour))
+	freshResult := timestamppb.New(now.Add(1 * time.Minute))
+
+	scanConfigID := "scan-config-1"
+	baseReportData := func(clusters ...*storage.ComplianceOperatorReportData_ClusterStatus) *storage.ComplianceOperatorReportData {
+		return &storage.ComplianceOperatorReportData{
+			ScanConfiguration: &storage.ComplianceOperatorScanConfigurationV2{
+				Id: scanConfigID,
+			},
+			ClusterStatus:    clusters,
+			LastExecutedTime: lastExec,
+		}
+	}
+	cluster := func(id, name string) *storage.ComplianceOperatorReportData_ClusterStatus {
+		return &storage.ComplianceOperatorReportData_ClusterStatus{
+			ClusterId:   id,
+			ClusterName: name,
+		}
+	}
+
+	cases := map[string]struct {
+		reportData             *storage.ComplianceOperatorReportData
+		existingFailed         map[string]*report.FailedCluster
+		mockResults            map[string][]*storage.ComplianceOperatorCheckResultV2 // clusterID -> results
+		mockErrors             map[string]error
+		expectedStaleClusters  int
+		expectedStaleClusterID string
+	}{
+		"nil lastExecutedTime returns nil": {
+			reportData: &storage.ComplianceOperatorReportData{
+				ScanConfiguration: &storage.ComplianceOperatorScanConfigurationV2{Id: scanConfigID},
+				ClusterStatus:     []*storage.ComplianceOperatorReportData_ClusterStatus{cluster("c1", "cluster-1")},
+			},
+			expectedStaleClusters: 0,
+		},
+		"fresh results not marked stale": {
+			reportData:  baseReportData(cluster("c1", "cluster-1")),
+			mockResults: map[string][]*storage.ComplianceOperatorCheckResultV2{"c1": {{LastStartedTime: freshResult}}},
+			expectedStaleClusters: 0,
+		},
+		"old results marked stale": {
+			reportData:             baseReportData(cluster("c1", "cluster-1")),
+			mockResults:            map[string][]*storage.ComplianceOperatorCheckResultV2{"c1": {{LastStartedTime: oldResult}}},
+			expectedStaleClusters:  1,
+			expectedStaleClusterID: "c1",
+		},
+		"no results marked stale": {
+			reportData:             baseReportData(cluster("c1", "cluster-1")),
+			mockResults:            map[string][]*storage.ComplianceOperatorCheckResultV2{"c1": {}},
+			expectedStaleClusters:  1,
+			expectedStaleClusterID: "c1",
+		},
+		"already failed cluster skipped": {
+			reportData: baseReportData(cluster("c1", "cluster-1")),
+			existingFailed: map[string]*report.FailedCluster{
+				"c1": {ClusterId: "c1", Reasons: []string{"previous failure"}},
+			},
+			expectedStaleClusters: 0,
+		},
+		"mixed fresh and stale clusters": {
+			reportData: baseReportData(cluster("c1", "cluster-1"), cluster("c2", "cluster-2")),
+			mockResults: map[string][]*storage.ComplianceOperatorCheckResultV2{
+				"c1": {{LastStartedTime: freshResult}},
+				"c2": {{LastStartedTime: oldResult}},
+			},
+			expectedStaleClusters:  1,
+			expectedStaleClusterID: "c2",
+		},
+		"query error treated as no results": {
+			reportData:             baseReportData(cluster("c1", "cluster-1")),
+			mockErrors:             map[string]error{"c1": errors.New("db error")},
+			expectedStaleClusters:  1,
+			expectedStaleClusterID: "c1",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			checkStore := checkResultDS.NewMockDataStore(ctrl)
+
+			if tc.existingFailed == nil {
+				tc.existingFailed = make(map[string]*report.FailedCluster)
+			}
+
+			// Set up mock expectations for each cluster not already failed.
+			for _, cs := range tc.reportData.GetClusterStatus() {
+				if _, failed := tc.existingFailed[cs.GetClusterId()]; failed {
+					continue
+				}
+				if tc.reportData.GetLastExecutedTime() == nil {
+					continue
+				}
+				results := tc.mockResults[cs.GetClusterId()]
+				err := tc.mockErrors[cs.GetClusterId()]
+				checkStore.EXPECT().
+					SearchComplianceCheckResults(gomock.Any(), gomock.Any()).
+					Return(results, err)
+			}
+
+			result := DetectStaleClusters(context.Background(), tc.reportData, tc.existingFailed, checkStore)
+
+			if tc.expectedStaleClusters == 0 {
+				assert.Len(t, result, 0)
+			} else {
+				require.Len(t, result, tc.expectedStaleClusters)
+				if tc.expectedStaleClusterID != "" {
+					fc, ok := result[tc.expectedStaleClusterID]
+					require.True(t, ok, "expected cluster %s to be stale", tc.expectedStaleClusterID)
+					assert.NotEmpty(t, fc.Reasons)
+					assert.Contains(t, fc.Reasons[0], "Scan results are outdated")
+				}
+			}
+		})
+	}
 }
 
 func assertClusterData(t *testing.T, expected map[string]*report.ClusterData, actual map[string]*report.ClusterData) {

--- a/central/complianceoperator/v2/report/manager/helpers/clusterdata_test.go
+++ b/central/complianceoperator/v2/report/manager/helpers/clusterdata_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	checkResultDS "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	snapshotDS "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore/mocks"
 	scanDS "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore/mocks"
@@ -242,8 +241,8 @@ func TestGetClusterData(t *testing.T) {
 func TestDetectStaleClusters(t *testing.T) {
 	now := time.Now()
 	lastExec := timestamppb.New(now)
-	oldResult := timestamppb.New(now.Add(-1 * time.Hour))
-	freshResult := timestamppb.New(now.Add(1 * time.Minute))
+	older := timestamppb.New(now.Add(-1 * time.Hour))
+	newer := timestamppb.New(now.Add(1 * time.Minute))
 
 	scanConfigID := "scan-config-1"
 	baseReportData := func(clusters ...*storage.ComplianceOperatorReportData_ClusterStatus) *storage.ComplianceOperatorReportData {
@@ -255,94 +254,73 @@ func TestDetectStaleClusters(t *testing.T) {
 			LastExecutedTime: lastExec,
 		}
 	}
-	cluster := func(id, name string) *storage.ComplianceOperatorReportData_ClusterStatus {
-		return &storage.ComplianceOperatorReportData_ClusterStatus{
+	// cluster builds a ClusterStatus whose suite last-transition time is set to
+	// transition (nil means the suite never transitioned).
+	cluster := func(id, name string, transition *timestamppb.Timestamp) *storage.ComplianceOperatorReportData_ClusterStatus {
+		cs := &storage.ComplianceOperatorReportData_ClusterStatus{
 			ClusterId:   id,
 			ClusterName: name,
 		}
+		if transition != nil {
+			cs.SuiteStatus = &storage.ComplianceOperatorReportData_SuiteStatus{
+				LastTransitionTime: transition,
+			}
+		}
+		return cs
 	}
 
 	cases := map[string]struct {
 		reportData             *storage.ComplianceOperatorReportData
 		existingFailed         map[string]*report.FailedCluster
-		mockResults            map[string][]*storage.ComplianceOperatorCheckResultV2 // clusterID -> results
-		mockErrors             map[string]error
 		expectedStaleClusters  int
 		expectedStaleClusterID string
 	}{
 		"nil lastExecutedTime returns nil": {
 			reportData: &storage.ComplianceOperatorReportData{
 				ScanConfiguration: &storage.ComplianceOperatorScanConfigurationV2{Id: scanConfigID},
-				ClusterStatus:     []*storage.ComplianceOperatorReportData_ClusterStatus{cluster("c1", "cluster-1")},
+				ClusterStatus:     []*storage.ComplianceOperatorReportData_ClusterStatus{cluster("c1", "cluster-1", older)},
 			},
 			expectedStaleClusters: 0,
 		},
-		"fresh results not marked stale": {
-			reportData:  baseReportData(cluster("c1", "cluster-1")),
-			mockResults: map[string][]*storage.ComplianceOperatorCheckResultV2{"c1": {{LastStartedTime: freshResult}}},
+		"cluster that completed latest execution not stale": {
+			reportData:            baseReportData(cluster("c1", "cluster-1", lastExec)),
 			expectedStaleClusters: 0,
 		},
-		"old results marked stale": {
-			reportData:             baseReportData(cluster("c1", "cluster-1")),
-			mockResults:            map[string][]*storage.ComplianceOperatorCheckResultV2{"c1": {{LastStartedTime: oldResult}}},
+		"cluster newer than lastExecutedTime not stale": {
+			reportData:            baseReportData(cluster("c1", "cluster-1", newer)),
+			expectedStaleClusters: 0,
+		},
+		"cluster older than lastExecutedTime marked stale": {
+			reportData:             baseReportData(cluster("c1", "cluster-1", older)),
 			expectedStaleClusters:  1,
 			expectedStaleClusterID: "c1",
 		},
-		"no results marked stale": {
-			reportData:             baseReportData(cluster("c1", "cluster-1")),
-			mockResults:            map[string][]*storage.ComplianceOperatorCheckResultV2{"c1": {}},
+		"cluster with no suite transition time marked stale": {
+			reportData:             baseReportData(cluster("c1", "cluster-1", nil)),
 			expectedStaleClusters:  1,
 			expectedStaleClusterID: "c1",
 		},
 		"already failed cluster skipped": {
-			reportData: baseReportData(cluster("c1", "cluster-1")),
+			reportData: baseReportData(cluster("c1", "cluster-1", older)),
 			existingFailed: map[string]*report.FailedCluster{
 				"c1": {ClusterId: "c1", Reasons: []string{"previous failure"}},
 			},
 			expectedStaleClusters: 0,
 		},
 		"mixed fresh and stale clusters": {
-			reportData: baseReportData(cluster("c1", "cluster-1"), cluster("c2", "cluster-2")),
-			mockResults: map[string][]*storage.ComplianceOperatorCheckResultV2{
-				"c1": {{LastStartedTime: freshResult}},
-				"c2": {{LastStartedTime: oldResult}},
-			},
+			reportData:             baseReportData(cluster("c1", "cluster-1", lastExec), cluster("c2", "cluster-2", older)),
 			expectedStaleClusters:  1,
 			expectedStaleClusterID: "c2",
-		},
-		"query error treated as no results": {
-			reportData:             baseReportData(cluster("c1", "cluster-1")),
-			mockErrors:             map[string]error{"c1": errors.New("db error")},
-			expectedStaleClusters:  1,
-			expectedStaleClusterID: "c1",
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			checkStore := checkResultDS.NewMockDataStore(ctrl)
-
 			if tc.existingFailed == nil {
 				tc.existingFailed = make(map[string]*report.FailedCluster)
 			}
 
-			// Set up mock expectations for each cluster not already failed.
-			for _, cs := range tc.reportData.GetClusterStatus() {
-				if _, failed := tc.existingFailed[cs.GetClusterId()]; failed {
-					continue
-				}
-				if tc.reportData.GetLastExecutedTime() == nil {
-					continue
-				}
-				results := tc.mockResults[cs.GetClusterId()]
-				err := tc.mockErrors[cs.GetClusterId()]
-				checkStore.EXPECT().
-					SearchComplianceCheckResults(gomock.Any(), gomock.Any()).
-					Return(results, err)
-			}
-
-			result := DetectStaleClusters(context.Background(), tc.reportData, tc.existingFailed, checkStore)
+			result := DetectStaleClusters(tc.reportData, tc.existingFailed)
 
 			if tc.expectedStaleClusters == 0 {
 				assert.Len(t, result, 0)

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -322,7 +322,7 @@ func (m *managerImpl) handleReportRequest(request *reportRequest) (bool, error) 
 		// scan execution). This covers the case where a scan was triggered but
 		// results never arrived (sensor disconnect, watcher timeout in a
 		// previous cycle) and no watcher is currently running.
-		staleClusters := helpers.DetectStaleClusters(m.automaticReportingCtx, snapshot.GetReportData(), failedClusters, m.checkResultDataStore)
+		staleClusters := helpers.DetectStaleClusters(snapshot.GetReportData(), failedClusters)
 		for id, fc := range staleClusters {
 			failedClusters[id] = fc
 		}

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -318,6 +318,14 @@ func (m *managerImpl) handleReportRequest(request *reportRequest) (bool, error) 
 		if err != nil {
 			log.Warnf("unable to retrieve failed clusters: %v", err)
 		}
+		// Detect clusters whose check results are stale (older than the last
+		// scan execution). This covers the case where a scan was triggered but
+		// results never arrived (sensor disconnect, watcher timeout in a
+		// previous cycle) and no watcher is currently running.
+		staleClusters := helpers.DetectStaleClusters(m.automaticReportingCtx, snapshot.GetReportData(), failedClusters, m.checkResultDataStore)
+		for id, fc := range staleClusters {
+			failedClusters[id] = fc
+		}
 		request.numFailedClusters = len(failedClusters)
 		request.clusterData, err = helpers.GetClusterData(m.automaticReportingCtx, snapshot.GetReportData(), failedClusters, m.scanDataStore)
 		if err != nil {


### PR DESCRIPTION
## Description

On-demand compliance reports silently served **stale** check results from a previous scan cycle when a scan was triggered but results never arrived (e.g. sensor disconnect, or a per-scan watcher timeout in a prior cycle). Scheduled reports don't have this problem: they run through the `ScanConfigWatcher`, which flags such clusters as failed. The on-demand path (`w == nil` in `handleReportRequest`) has no watcher and therefore never detected staleness — so the report showed last-known-good data as if it were current, with no indication.

This change adds `DetectStaleClusters`, invoked only on the on-demand path. For each cluster not already flagged failed, it compares the cluster's latest check-result time (per scan config) against the scan configuration's last execution time. If the results are older than the last execution (or missing entirely), the cluster is added to the failed set with the reason `Scan results are outdated (last assessment: <t>, last scan execution: <t>)`. The scheduled path is untouched.

Net effect: on-demand and scheduled reports now behave consistently — a cluster that didn't produce fresh results is reported as failed instead of silently contributing stale data.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests for `DetectStaleClusters` covering: fresh results (not flagged), stale results (flagged), missing results (flagged), and already-failed clusters (skipped).
- End-to-end validation on a live cluster: reproduce a cluster with no fresh results for a scan config, request an on-demand report, and confirm the cluster now appears in the `failed_cluster_*.csv` with the "Scan results are outdated" reason (previously it was silently included with stale data).

> Note: this PR is AI-assisted and currently a draft for CI image builds / validation.
