### PR TITLE
ROX-36600: Virtual machine affected components

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/getVMCVEComponents.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/getVMCVEComponents.json
@@ -1,0 +1,14 @@
+{
+    "components": [
+        {
+            "componentName": "openssl",
+            "componentVersion": "3.0.7-20.el9",
+            "source": "OS",
+            "fixedBy": "3.0.7-21.el9",
+            "advisory": {
+                "name": "RHSA-2024:1234",
+                "link": "https://access.redhat.com/errata/RHSA-2024:1234"
+            }
+        }
+    ]
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/VirtualMachineCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/VirtualMachineCve.helpers.ts
@@ -4,6 +4,7 @@ import { visit, visitWithStaticResponseForPermissions } from '../../../helpers/v
 
 export const listVirtualMachinesAlias = 'listVirtualMachines';
 export const getVirtualMachineAlias = 'getVirtualMachine';
+export const getVirtualMachineCveComponentsAlias = 'getVirtualMachineCveComponents';
 export const listVirtualMachineCvesAlias = 'listVirtualMachineCves';
 export const listVirtualMachineComponentsAlias = 'listVirtualMachineComponents';
 
@@ -33,6 +34,13 @@ export const routeMatcherMapForVirtualMachineComponents = {
     [listVirtualMachineComponentsAlias]: {
         method: 'GET',
         url: '/v2/virtualmachines/*/components?*',
+    },
+};
+
+export const routeMatcherMapForVirtualMachineCveComponents = {
+    [getVirtualMachineCveComponentsAlias]: {
+        method: 'GET',
+        url: '/v2/virtualmachines/*/cves/*/components',
     },
 };
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
@@ -5,9 +5,11 @@ import { assertCannotFindThePage } from '../../../helpers/visit';
 
 import {
     getVirtualMachineAlias,
+    getVirtualMachineCveComponentsAlias,
     listVirtualMachineComponentsAlias,
     listVirtualMachineCvesAlias,
     routeMatcherMapForVirtualMachineComponents,
+    routeMatcherMapForVirtualMachineCveComponents,
     routeMatcherMapForVirtualMachineVulnerabilities,
     visitVirtualMachinePage,
     visitVirtualMachinePageWithStaticPermissions,
@@ -17,6 +19,7 @@ const vmId = 'vm-001';
 const fixturePathGetVM = 'vulnerabilities/virtualMachineCves/getVM';
 const fixturePathListCves = 'vulnerabilities/virtualMachineCves/listVirtualMachineCves';
 const fixturePathListComponents = 'vulnerabilities/virtualMachineCves/listVirtualMachineComponents';
+const fixturePathCveComponents = 'vulnerabilities/virtualMachineCves/getVMCVEComponents';
 
 const staticResponseMapForVirtualMachineVulnerabilities = {
     [getVirtualMachineAlias]: { fixture: fixturePathGetVM },
@@ -103,11 +106,21 @@ describe('Virtual Machine CVEs - Virtual Machine Page', () => {
         it('should expand a row to show affected component details', () => {
             visitWithVulnFixtures();
 
+            // Components for a single CVE are fetched lazily on row expand, so stub that
+            // endpoint after the initial page load rather than in the visit route map.
+            interceptRequests(routeMatcherMapForVirtualMachineCveComponents, {
+                [getVirtualMachineCveComponentsAlias]: { fixture: fixturePathCveComponents },
+            });
+
             cy.get('tbody tr:not([class*="expandable"])').eq(0).find('td button').first().click();
+            cy.wait(`@${getVirtualMachineCveComponentsAlias}`);
 
             cy.get('tbody tr[class*="expandable"]')
                 .eq(0)
-                .should('contain.text', 'Affected component details coming soon');
+                .within(() => {
+                    cy.get('td[data-label="Component"]').contains('openssl');
+                    cy.get('td[data-label="Version"]').contains('3.0.7-20.el9');
+                });
         });
 
         it('should display an empty state when the VM has no vulnerabilities', () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
@@ -17,6 +17,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
+import AffectedComponentsTable from '../components/AffectedComponentsTable';
 import VirtualMachineScanScopeAlert from '../components/VirtualMachineScanScopeAlert';
 import {
     virtualMachineCVESearchFilterConfig,
@@ -168,7 +169,12 @@ function VirtualMachinePageVulnerabilities({
                                         <Td />
                                         <Td colSpan={colSpan - 1}>
                                             <ExpandableRowContent>
-                                                Affected component details coming soon
+                                                {isExpanded && (
+                                                    <AffectedComponentsTable
+                                                        virtualMachineId={virtualMachineId}
+                                                        cveId={cve.cve}
+                                                    />
+                                                )}
                                             </ExpandableRowContent>
                                         </Td>
                                     </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/AffectedVirtualMachinesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/AffectedVirtualMachinesTable.tsx
@@ -14,6 +14,7 @@ import type { TableUIState } from 'utils/getTableUIState';
 import type { VMCVEAffectedVMRow } from 'services/VirtualMachineService';
 
 import { getVirtualMachineEntityPagePath } from '../../utils/searchUtils';
+import AffectedComponentsTable from '../components/AffectedComponentsTable';
 import {
     CVE_SEVERITY_SORT_FIELD,
     CVSS_SORT_FIELD,
@@ -31,12 +32,14 @@ export const sortFields = [
 export const defaultSortOption = { field: CVE_SEVERITY_SORT_FIELD, direction: 'desc' } as const;
 
 export type AffectedVirtualMachinesTableProps = {
+    cveId: string;
     tableState: TableUIState<VMCVEAffectedVMRow>;
     getSortParams: UseURLSortResult['getSortParams'];
     onClearFilters: () => void;
 };
 
 function AffectedVirtualMachinesTable({
+    cveId,
     tableState,
     getSortParams,
     onClearFilters,
@@ -119,7 +122,12 @@ function AffectedVirtualMachinesTable({
                                     <Td />
                                     <Td colSpan={colSpan - 1}>
                                         <ExpandableRowContent>
-                                            Affected component details coming soon
+                                            {isExpanded && (
+                                                <AffectedComponentsTable
+                                                    virtualMachineId={virtualMachine.vmId}
+                                                    cveId={cveId}
+                                                />
+                                            )}
                                         </ExpandableRowContent>
                                     </Td>
                                 </Tr>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachineCve/VirtualMachineCvePage.tsx
@@ -7,11 +7,7 @@ import {
     Flex,
     PageSection,
     Pagination,
-    Split,
-    SplitItem,
-    Title,
 } from '@patternfly/react-core';
-import pluralize from 'pluralize';
 
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
@@ -146,27 +142,19 @@ function VirtualMachineCvePage() {
                     />
                 </SummaryCardLayout>
                 <Divider component="div" />
-                <Split hasGutter className="pf-v6-u-align-items-baseline">
-                    <SplitItem isFilled>
-                        <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                            <Title headingLevel="h2">
-                                {`${affectedVMCount} ${pluralize('virtual machine', affectedVMCount)} affected`}
-                            </Title>
-                        </Flex>
-                    </SplitItem>
-                    <SplitItem>
-                        <Pagination
-                            itemCount={affectedVMCount}
-                            perPage={perPage}
-                            page={page}
-                            onSetPage={(_, newPage) => setPage(newPage)}
-                            onPerPageSelect={(_, newPerPage) => {
-                                setPerPage(newPerPage);
-                            }}
-                        />
-                    </SplitItem>
-                </Split>
+                <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+                    <Pagination
+                        itemCount={affectedVMCount}
+                        perPage={perPage}
+                        page={page}
+                        onSetPage={(_, newPage) => setPage(newPage)}
+                        onPerPageSelect={(_, newPerPage) => {
+                            setPerPage(newPerPage);
+                        }}
+                    />
+                </Flex>
                 <AffectedVirtualMachinesTable
+                    cveId={cveId ?? ''}
                     tableState={tableState}
                     getSortParams={getSortParams}
                     onClearFilters={() => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/components/AffectedComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/components/AffectedComponentsTable.tsx
@@ -48,7 +48,7 @@ function AffectedComponentsTable({ virtualMachineId, cveId }: AffectedComponents
                     title: 'There was an error loading affected components',
                 }}
                 emptyProps={{
-                    message: 'There are no affected components for this virtual machine',
+                    message: 'There are no affected components',
                 }}
                 renderer={({ data }) => (
                     <Tbody>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/components/AffectedComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/components/AffectedComponentsTable.tsx
@@ -1,0 +1,77 @@
+import { useCallback } from 'react';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useRestQuery from 'hooks/useRestQuery';
+import { getVMCVEComponents } from 'services/VirtualMachineService';
+import { getTableUIState } from 'utils/getTableUIState';
+
+import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
+import FixedByVersion from '../../components/FixedByVersion';
+import { sourceTypeLabels } from '../../constants';
+
+export type AffectedComponentsTableProps = {
+    virtualMachineId: string;
+    cveId: string;
+};
+
+function AffectedComponentsTable({ virtualMachineId, cveId }: AffectedComponentsTableProps) {
+    const colSpan = 5;
+    const fetchComponents = useCallback(
+        () => getVMCVEComponents(virtualMachineId, cveId),
+        [virtualMachineId, cveId]
+    );
+    const { data, isLoading, error } = useRestQuery(fetchComponents);
+
+    const tableState = getTableUIState({
+        isLoading,
+        data: data?.components,
+        error,
+        searchFilter: {},
+    });
+
+    return (
+        <Table variant="compact">
+            <Thead noWrap>
+                <Tr>
+                    <Th>Component</Th>
+                    <Th>Version</Th>
+                    <Th>CVE fixed in</Th>
+                    <Th>Advisory</Th>
+                    <Th>Type</Th>
+                </Tr>
+            </Thead>
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={colSpan}
+                errorProps={{
+                    title: 'There was an error loading affected components',
+                }}
+                emptyProps={{
+                    message: 'There are no affected components for this virtual machine',
+                }}
+                renderer={({ data }) => (
+                    <Tbody>
+                        {data.map(
+                            ({ componentName, componentVersion, source, fixedBy, advisory }) => (
+                                <Tr key={`${componentName}-${componentVersion}`}>
+                                    <Td dataLabel="Component">{componentName}</Td>
+                                    <Td dataLabel="Version">{componentVersion}</Td>
+                                    <Td dataLabel="CVE fixed in">
+                                        <FixedByVersion fixedByVersion={fixedBy ?? ''} />
+                                    </Td>
+                                    <Td dataLabel="Advisory">
+                                        <AdvisoryLinkOrText advisory={advisory} />
+                                    </Td>
+                                    <Td dataLabel="Type">{sourceTypeLabels[source]}</Td>
+                                </Tr>
+                            )
+                        )}
+                    </Tbody>
+                )}
+            />
+        </Table>
+    );
+}
+
+export default AffectedComponentsTable;

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -3,6 +3,7 @@ import qs from 'qs';
 import axios from 'services/instance';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { ScanComponent, SourceType } from 'types/scanComponent.proto';
+import type { Advisory } from 'types/vulnerability.proto';
 import type { SearchFilter, SearchQueryOptions } from 'types/search';
 import {
     applyRegexSearchModifiers,
@@ -147,7 +148,7 @@ export type VMCVEComponentRow = {
     componentVersion: string;
     source: SourceType;
     fixedBy: string;
-    advisory?: { name: string; link: string };
+    advisory: Advisory | null;
 };
 
 export type GetVMCVEComponentsResponse = {
@@ -165,7 +166,7 @@ export type VMCVEByVMRow = {
     publishedOn?: string;
     summary: string;
     link: string;
-    advisory?: { name: string; link: string };
+    advisory: Advisory | null;
 };
 
 export type ListVMCVEsByVMResponse = {

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -142,6 +142,18 @@ export type ListVMCVEAffectedVMsResponse = {
     totalCount: number;
 };
 
+export type VMCVEComponentRow = {
+    componentName: string;
+    componentVersion: string;
+    source: SourceType;
+    fixedBy: string;
+    advisory?: { name: string; link: string };
+};
+
+export type GetVMCVEComponentsResponse = {
+    components: VMCVEComponentRow[];
+};
+
 export type VMCVEByVMRow = {
     cve: string;
     severity: VulnerabilitySeverity;
@@ -287,6 +299,15 @@ export function listVMCVEAffectedVMs(
     });
     return axios
         .get<ListVMCVEAffectedVMsResponse>(`/v2/virtualmachines/cves/${cveId}/vms?${params}`)
+        .then((response) => response.data);
+}
+
+export function getVMCVEComponents(
+    vmId: string,
+    cveId: string
+): Promise<GetVMCVEComponentsResponse> {
+    return axios
+        .get<GetVMCVEComponentsResponse>(`/v2/virtualmachines/${vmId}/cves/${cveId}/components`)
         .then((response) => response.data);
 }
 


### PR DESCRIPTION
## Description

Adds the affected components table to the single virtual machine page and the virtual machine CVE page.

Notes:
- Unlike other Vuln Management areas, VM CVE components come from a separate endpoint
  (`.../cves/{cveId}/components`), so there's no component to show inline in the row.
- Component data fetched lazily on row expand (the table only mounts when expanded).
- Considered caching fetched components in parent state to skip refetch on re-expand, decided against it for now.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


<img width="2141" height="557" alt="Screenshot 2026-09-02 at 11 57 59 AM" src="https://github.com/user-attachments/assets/9f9fb1bc-521d-4d8b-b6ac-2730c8f2bd8a" />
<img width="2141" height="518" alt="Screenshot 2026-09-02 at 11 58 59 AM" src="https://github.com/user-attachments/assets/3e5431a9-0f14-462c-9541-f8f3fb66bda8" />

