### PR TITLE
ROX-36601: Virtual machine CVE severity widgets

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/getVMVulnSummary.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/getVMVulnSummary.json
@@ -1,0 +1,11 @@
+{
+    "severityCounts": {
+        "critical": { "total": 1, "fixable": 1 },
+        "important": { "total": 1, "fixable": 1 },
+        "moderate": { "total": 1, "fixable": 1 },
+        "low": { "total": 0, "fixable": 0 },
+        "unknown": { "total": 0, "fixable": 0 }
+    },
+    "fixableCount": 3,
+    "notFixableCount": 0
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/VirtualMachineCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/VirtualMachineCve.helpers.ts
@@ -7,6 +7,7 @@ export const getVirtualMachineAlias = 'getVirtualMachine';
 export const getVirtualMachineCveComponentsAlias = 'getVirtualMachineCveComponents';
 export const listVirtualMachineCvesAlias = 'listVirtualMachineCves';
 export const listVirtualMachineComponentsAlias = 'listVirtualMachineComponents';
+export const getVirtualMachineVulnSummaryAlias = 'getVirtualMachineVulnSummary';
 
 export const routeMatcherMapForVirtualMachines = {
     [listVirtualMachinesAlias]: {
@@ -27,6 +28,10 @@ export const routeMatcherMapForVirtualMachineVulnerabilities = {
     [listVirtualMachineCvesAlias]: {
         method: 'GET',
         url: '/v2/virtualmachines/*/cves?*',
+    },
+    [getVirtualMachineVulnSummaryAlias]: {
+        method: 'GET',
+        url: '/v2/virtualmachines/*/vuln-summary?*',
     },
 };
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
@@ -6,6 +6,7 @@ import { assertCannotFindThePage } from '../../../helpers/visit';
 import {
     getVirtualMachineAlias,
     getVirtualMachineCveComponentsAlias,
+    getVirtualMachineVulnSummaryAlias,
     listVirtualMachineComponentsAlias,
     listVirtualMachineCvesAlias,
     routeMatcherMapForVirtualMachineComponents,
@@ -20,10 +21,12 @@ const fixturePathGetVM = 'vulnerabilities/virtualMachineCves/getVM';
 const fixturePathListCves = 'vulnerabilities/virtualMachineCves/listVirtualMachineCves';
 const fixturePathListComponents = 'vulnerabilities/virtualMachineCves/listVirtualMachineComponents';
 const fixturePathCveComponents = 'vulnerabilities/virtualMachineCves/getVMCVEComponents';
+const fixturePathVulnSummary = 'vulnerabilities/virtualMachineCves/getVMVulnSummary';
 
 const staticResponseMapForVirtualMachineVulnerabilities = {
     [getVirtualMachineAlias]: { fixture: fixturePathGetVM },
     [listVirtualMachineCvesAlias]: { fixture: fixturePathListCves },
+    [getVirtualMachineVulnSummaryAlias]: { fixture: fixturePathVulnSummary },
 };
 
 function visitWithVulnFixtures() {
@@ -145,6 +148,19 @@ describe('Virtual Machine CVEs - Virtual Machine Page', () => {
                 },
                 [listVirtualMachineCvesAlias]: {
                     body: { cves: [], totalCount: 0 },
+                },
+                [getVirtualMachineVulnSummaryAlias]: {
+                    body: {
+                        severityCounts: {
+                            critical: { total: 0, fixable: 0 },
+                            important: { total: 0, fixable: 0 },
+                            moderate: { total: 0, fixable: 0 },
+                            low: { total: 0, fixable: 0 },
+                            unknown: { total: 0, fixable: 0 },
+                        },
+                        fixableCount: 0,
+                        notFixableCount: 0,
+                    },
                 },
             });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
@@ -12,17 +12,24 @@ import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
 import useURLSort from 'hooks/useURLSort';
-import { listVMCVEsByVM } from 'services/VirtualMachineService';
+import { getVMVulnSummary, listVMCVEsByVM } from 'services/VirtualMachineService';
 import { getTableUIState } from 'utils/getTableUIState';
 
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
+import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
+import CvesByStatusSummaryCard from '../../components/CvesByStatusSummaryCard';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import AffectedComponentsTable from '../components/AffectedComponentsTable';
-import VirtualMachineScanScopeAlert from '../components/VirtualMachineScanScopeAlert';
 import {
     virtualMachineCVESearchFilterConfig,
     virtualMachineComponentSearchFilterConfig,
 } from '../../searchFilterConfig';
+import {
+    getHiddenSeverities,
+    getHiddenStatuses,
+    parseQuerySearchFilter,
+} from '../../utils/searchUtils';
 import {
     CVE_EPSS_PROBABILITY_SORT_FIELD,
     CVE_SEVERITY_SORT_FIELD,
@@ -56,6 +63,7 @@ function VirtualMachinePageVulnerabilities({
 }: VirtualMachinePageVulnerabilitiesProps) {
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { searchFilter, setSearchFilter } = useURLSearch();
+    const querySearchFilter = parseQuerySearchFilter(searchFilter);
     const { sortOption, getSortParams } = useURLSort({
         sortFields,
         defaultSortOption,
@@ -63,6 +71,16 @@ function VirtualMachinePageVulnerabilities({
     });
     const expandedRowSet = useSet<string>();
     const colSpan = 7;
+
+    const fetchSummary = useCallback(
+        () => getVMVulnSummary(virtualMachineId, parseQuerySearchFilter(searchFilter)),
+        [virtualMachineId, searchFilter]
+    );
+    const {
+        data: summary,
+        isLoading: isLoadingSummary,
+        error: summaryError,
+    } = useRestQuery(fetchSummary);
 
     const fetchCVEs = useCallback(
         () => listVMCVEsByVM(virtualMachineId, { searchFilter, page, perPage, sortOption }),
@@ -84,7 +102,6 @@ function VirtualMachinePageVulnerabilities({
 
     return (
         <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-            <VirtualMachineScanScopeAlert />
             <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
                 <FlexItem fullWidth={{ default: 'fullWidth' }}>
                     <AdvancedFiltersToolbar
@@ -108,6 +125,29 @@ function VirtualMachinePageVulnerabilities({
                     }}
                 />
             </Flex>
+            <SummaryCardLayout error={summaryError} isLoading={isLoadingSummary}>
+                <SummaryCard
+                    data={summary}
+                    loadingText="Loading virtual machine vulnerabilities by severity summary"
+                    renderer={({ data }) => (
+                        <BySeveritySummaryCard
+                            title="CVEs by severity"
+                            severityCounts={data.severityCounts}
+                            hiddenSeverities={getHiddenSeverities(querySearchFilter)}
+                        />
+                    )}
+                />
+                <SummaryCard
+                    data={summary}
+                    loadingText="Loading virtual machine vulnerabilities by status summary"
+                    renderer={({ data }) => (
+                        <CvesByStatusSummaryCard
+                            cveStatusCounts={data.severityCounts}
+                            hiddenStatuses={getHiddenStatuses(querySearchFilter)}
+                        />
+                    )}
+                />
+            </SummaryCardLayout>
             <Table borders={tableState.type === 'COMPLETE'} variant="compact" aria-live="polite">
                 <Thead noWrap>
                     <Tr>

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -174,6 +174,12 @@ export type ListVMCVEsByVMResponse = {
     totalCount: number;
 };
 
+export type VMVulnSummary = {
+    severityCounts: VulnCountBySeverity;
+    fixableCount: number;
+    notFixableCount: number;
+};
+
 export type VMComponentScanStatus =
     | 'NOT_SCANNED'
     | 'SCAN_PENDING'
@@ -311,6 +317,26 @@ export function getVMCVEComponents(
 ): Promise<GetVMCVEComponentsResponse> {
     return axios
         .get<GetVMCVEComponentsResponse>(`/v2/virtualmachines/${vmId}/cves/${cveId}/components`)
+        .then((response) => response.data);
+}
+
+// Might consider updating buildNestedRawQueryParams to handle this case (no pagination).
+export function getVMVulnSummary(
+    virtualMachineId: string,
+    searchFilter: SearchFilter
+): Promise<VMVulnSummary> {
+    const params = qs.stringify(
+        {
+            query: {
+                query: getRequestQueryStringForSearchFilter(
+                    applyRegexSearchModifiers(searchFilter)
+                ),
+            },
+        },
+        { arrayFormat: 'repeat', allowDots: true }
+    );
+    return axios
+        .get<VMVulnSummary>(`/v2/virtualmachines/${virtualMachineId}/vuln-summary?${params}`)
         .then((response) => response.data);
 }
 


### PR DESCRIPTION
## Description

Adds the CVE severity and CVE status summary widgets to the virtual machine CVE page above the CVE table.



## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="2132" height="702" alt="Screenshot 2026-09-02 at 12 20 11 PM" src="https://github.com/user-attachments/assets/8ec09e83-78f5-4fd8-afcc-3a818ac435e1" />

