### PR TITLE
ROX-35596: set up nongroovy tests to run w roxie

### DIFF
--- a/.github/workflows/e2e-dispatch.yaml
+++ b/.github/workflows/e2e-dispatch.yaml
@@ -109,6 +109,7 @@ jobs:
             Job(name='e2e-db-backup-restore-tests'),
             Job(name='e2e-gke-upgrade-tests'),
             Job(name='e2e-nongroovy-tests'),
+            Job(name='e2e-nongroovy-tests-gke-konflux', require_konflux_build=True),
             Job(name='e2e-qa-tests-gke', require_pr_label=True),
             Job(name='e2e-qa-tests-gke-konflux', require_konflux_build=True),
             Job(name='e2e-qa-tests-ocp-4-22', require_pr_label=True),
@@ -275,6 +276,17 @@ jobs:
     secrets: inherit
     concurrency:
       group: e2e-nongroovy-tests-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
+  e2e-nongroovy-tests-gke-konflux:
+    needs: [ wait-for-konflux-images, should-dispatch ]
+    uses: ./.github/workflows/e2e-nongroovy-tests-gke-konflux.yaml
+    with:
+      tag: ${{ needs.wait-for-konflux-images.outputs.tag }}${{ needs.wait-for-konflux-images.outputs.tag_suffix }}
+      should-run: ${{ fromJSON(needs.should-dispatch.outputs.jobs).e2e-nongroovy-tests-gke-konflux }}
+    secrets: inherit
+    concurrency:
+      group: e2e-nongroovy-tests-gke-konflux-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
   e2e-qa-tests-gke:

--- a/.github/workflows/e2e-nongroovy-tests-gke-konflux.yaml
+++ b/.github/workflows/e2e-nongroovy-tests-gke-konflux.yaml
@@ -1,0 +1,35 @@
+name: e2e-nongroovy-tests-gke-konflux
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: |
+          Image tag to test. The caller needs to make sure that the tag carries the
+          "-fast" Konflux suffix if required (e.g. for development builds).
+        type: string
+        required: true
+      should-run:
+        description: true if should really run the job. false - otherwise, i.e. the job should be skipped.
+        type: boolean
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: |
+          Image tag to test. You need to make sure that the tag carries the
+          "-fast" Konflux suffix if required (e.g. for development builds).
+        type: string
+        required: true
+
+jobs:
+  run:
+    uses: ./.github/workflows/e2e-nongroovy-tests.yaml
+    with:
+      should-run: ${{ github.event_name == 'workflow_dispatch' || inputs.should-run }}
+      tag: ${{ inputs.tag }}
+      ci-job-name: gke-nongroovy-e2e-tests-konflux
+      extra-env-vars: |
+        USE_ROXIE_DEPLOY=true
+        USE_KONFLUX_IMAGES=true
+    secrets: inherit

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -11,6 +11,14 @@ on:
         description: true if should really run the job. false - otherwise, i.e. the job should be skipped.
         type: boolean
         required: true
+      ci-job-name:
+        description: Job name override, e.g. gke-nongroovy-e2e-tests-konflux, propagated as CI_JOB_NAME.
+        type: string
+        required: false
+      extra-env-vars:
+        description: "Additional environment variables as multi-line KEY=VALUE pairs (e.g., USE_ROXIE_DEPLOY=true)"
+        type: string
+        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -34,7 +42,7 @@ jobs:
       MAIN_IMAGE_TAG: ${{ inputs.tag }}
       BUILD_TAG: ${{ inputs.tag }}
       GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
-      CI_JOB_NAME: gke-nongroovy-e2e-tests
+      CI_JOB_NAME: ${{ inputs.ci-job-name || 'gke-nongroovy-e2e-tests' }}
       ARTIFACT_DIR: ./junit-reports
       LOAD_BALANCER: lb
       ORCHESTRATOR_FLAVOR: k8s
@@ -61,6 +69,17 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - name: Set additional env vars
+      if: inputs.extra-env-vars != ''
+      env:
+        EXTRA_ENV_VARS: ${{ inputs.extra-env-vars }}
+      run: |
+        while IFS= read -r line; do
+          if [[ -n "$line" ]]; then
+            echo "$line" >> "$GITHUB_ENV"
+          fi
+        done <<< "$EXTRA_ENV_VARS"
+
     - name: Docker login to Quay.io
       env:
         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
@@ -81,6 +100,15 @@ jobs:
       run: |
         scripts/ci/gke.sh provision_gke_cluster nongroovy
         echo "KUBECONFIG=${HOME}/.kube/config" >> "$GITHUB_ENV"
+
+    - name: Retrieving roxie version from repository
+      id: roxie-version
+      run: echo "version=$(cat ROXIE_VERSION)" >> "$GITHUB_OUTPUT"
+
+    - name: Install roxie
+      uses: stackrox/actions/roxie/install-cli@43bb707aa4f32ead5bfb8d5ab11fb409f971ffc8 # ratchet:stackrox/actions@v1
+      with:
+        version: "v${{ steps.roxie-version.outputs.version }}"
 
     - name: Build roxctl
       # roxctl is used for generate (deploy) and CLI e2e tests (token-file, etc).
@@ -157,9 +185,13 @@ jobs:
       if: always()
       run: |
         source tests/e2e/lib.sh
-        wait_for_api
-        echo "API_ENDPOINT=${API_ENDPOINT}" >> "$GITHUB_ENV"
-        echo "ROX_ADMIN_PASSWORD=$(cat deploy/k8s/central-deploy/password)" >> "$GITHUB_ENV"
+
+        # When using roxie deployment, vars are already exported via ci_export()
+        if [[ "${USE_ROXIE_DEPLOY:-false}" != "true" ]]; then
+          wait_for_api
+          echo "API_ENDPOINT=${API_ENDPOINT}" >> "$GITHUB_ENV"
+          echo "ROX_ADMIN_PASSWORD=$(cat deploy/k8s/central-deploy/password)" >> "$GITHUB_ENV"
+        fi
 
     - name: Run post-test
       if: always()

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1066,7 +1066,7 @@ scanner-v4-db ${tag}
 roxctl ${tag}
 END
             ;;
-        *qa-e2e-tests*)
+        *nongroovy-e2e-tests*|*qa-e2e-tests*)
             if [[ "${USE_KONFLUX_IMAGES:-false}" == "true" ]]; then
                 cat >> "${image_list}" << END
 release-operator ${operator_controller_tag}

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -15,6 +15,8 @@ source "$ROOT/scripts/ci/sensor-wait.sh"
 source "$ROOT/tests/scripts/setup-certs.sh"
 # shellcheck source=../../tests/e2e/lib.sh
 source "$ROOT/tests/e2e/lib.sh"
+# shellcheck source=../../tests/e2e/lib-compat.sh
+source "$ROOT/tests/e2e/lib-compat.sh"
 # shellcheck source=../../qa-tests-backend/scripts/workload-identities/workload-identities.sh
 source "$ROOT/qa-tests-backend/scripts/workload-identities/workload-identities.sh"
 
@@ -39,11 +41,32 @@ test_e2e() {
     "$ROOT/tests/complianceoperator/create.sh"
     kubectl get compliancecheckresults.compliance.openshift.io -n openshift-compliance
 
-    image_prefetcher_prebuilt_await
+    # Deployment strategy: roxie vs helm
+    local use_roxie_deploy="${USE_ROXIE_DEPLOY:-false}"
+    if [[ "$use_roxie_deploy" == "true" ]]; then
+        info "Using roxie-based deployment for nongroovy e2e tests"
 
-    # If deploy_optional_e2e_components is called after deploy_stackrox it causes an unnecessary Sensor restart
-    deploy_optional_e2e_components
-    deploy_stackrox
+        # Create roxie config
+        local config_file; config_file="$(mktemp)"
+
+        # Set Konflux images flag if needed
+        if [[ "${USE_KONFLUX_IMAGES:-false}" == "true" ]] || pr_has_label test-konflux-images; then
+            patch_yaml "$config_file" ".roxie.konfluxImages = true"
+        fi
+
+        deploy_stackrox_with_roxie_compat "$config_file"
+
+        # Set up client TLS certs for tests (similar to qa-tests-backend/scripts/run-part-1.sh:82)
+        setup_client_TLS_certs
+    else
+        info "Using helm-based deployment for nongroovy e2e tests"
+
+        image_prefetcher_prebuilt_await
+
+        # If deploy_optional_e2e_components is called after deploy_stackrox it causes an unnecessary Sensor restart
+        deploy_optional_e2e_components
+        deploy_stackrox
+    fi
 
     # Background streamers are not explicitly stopped. They die when the CI
     # runner terminates, same as the port-forward processes in setup_proxy_tests.


### PR DESCRIPTION
## Description

This PR enables E2E nongroovy tests to run with Konflux-built images, following the pattern established by the QA E2E test suite.

  **Changes:**
  1. **New wrapper workflow**
  (`.github/workflows/e2e-nongroovy-tests-gke-konflux.yaml`) - Delegates to the base nongroovy workflow with Konflux-specific configuration
  2. **Enhanced base workflow** 
  (`.github/workflows/e2e-nongroovy-tests.yaml`) - Added optional `ci-job-name` and `extra-env-vars` inputs for flexibility
  3. **Roxie deployment support** 
  (`tests/e2e/run.sh`) - Added conditional logic to use roxie deployment when `USE_ROXIE_DEPLOY=true`, mirroring `qa-tests-backend/scripts/run-part-1.sh`
  4. **CI integration** 
  (`.github/workflows/e2e-dispatch.yaml`) - Registered new workflow to run automatically with Konflux builds

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

This is CI infrastructure - the workflow itself validates the change by running tests
