### PR TITLE
ROX-36278: fix(search): drop IMAGES_V2 from default global search set

### DIFF
--- a/central/search/category.go
+++ b/central/search/category.go
@@ -2,13 +2,19 @@ package search
 
 import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
 )
 
 // GetGlobalSearchCategories returns a set of search categories
 func GetGlobalSearchCategories() set.Set[v1.SearchCategory] {
 	// globalSearchCategories is exposed for e2e options test
+	//
+	// IMAGES_V2 is intentionally omitted. With FlattenImageData enabled, IMAGES is
+	// already routed to the imagesV2 store (see central/search/service), so adding
+	// IMAGES_V2 here would run the same image search twice and return every image
+	// twice (both labeled IMAGES). IMAGES remains the public category used by the UI
+	// and API clients; IMAGES_V2 is the internal storage/schema category and is still
+	// searchable when requested explicitly.
 	globalSearchCategories := set.NewSet(
 		v1.SearchCategory_ALERTS,
 		v1.SearchCategory_CLUSTERS,
@@ -25,8 +31,5 @@ func GetGlobalSearchCategories() set.Set[v1.SearchCategory] {
 		v1.SearchCategory_IMAGE_INTEGRATIONS,
 		v1.SearchCategory_POLICY_CATEGORIES,
 	)
-	if features.FlattenImageData.Enabled() {
-		globalSearchCategories.Add(v1.SearchCategory_IMAGES_V2)
-	}
 	return globalSearchCategories
 }

--- a/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
+++ b/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
@@ -34,10 +34,6 @@ class GlobalSearch extends BaseSpecification {
                                      SearchServiceOuterClass.SearchCategory.NAMESPACES,
                                      SearchServiceOuterClass.SearchCategory.IMAGES,
                                      SearchServiceOuterClass.SearchCategory.DEPLOYMENTS)
-        if (flattenImageDataEnabled) {
-            EXPECTED_DEPLOYMENT_CATEGORIES.add(SearchServiceOuterClass.SearchCategory.IMAGES_V2)
-            EXPECTED_IMAGE_CATEGORIES.add(SearchServiceOuterClass.SearchCategory.IMAGES_V2)
-        }
 
         orchestrator.createDeployment(DEPLOYMENT)
         assert Services.waitForDeployment(DEPLOYMENT)


### PR DESCRIPTION
With FlattenImageData enabled, global search ran the image searcher twice (once for IMAGES, once for IMAGES_V2, both wired to the same imagesV2 store), so the response repeated every image with an identical id, all labeled IMAGES. Duplicate ids produced duplicate React keys in the results table, corrupting list reconciliation: cycling between categories left orphaned image rows in the DOM even though the category count was 0. Reported as CVE/image duplication when clicking between search categories in a circle.

Fix it at the source (in the backend) by removing IMAGES_V2 from GetGlobalSearchCategories. Since #19119 already routes IMAGES to the imagesV2 store, IMAGES alone covers the flattened data; IMAGES_V2 only added a redundant second pass. IMAGES is kept as the public category used by the UI and API clients (dropping it would be a breaking change), and IMAGES_V2 remains searchable when requested explicitly.

Chosen over the earlier UI-side deduplication approach per reviewer feedback on PR #22542: the backend was returning incorrect (duplicated) data, so fixing it there is more robust and avoids per-render dedup work in the UI at scale.

Also stop expecting IMAGES_V2 in the default global-search counts in the GlobalSearch e2e test.

Partially generated with the assistance of an AI agent (Claude Code).

