### PR TITLE
ROX-36571: Fix sensor race condition

### DIFF
--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -112,6 +112,24 @@ func (ed *EntityData) AddContainerID(containerID string, container ContainerMeta
 	ed.containerIDs[containerID] = container
 }
 
+// Clone returns a deep copy of the EntityData that can be mutated independently of the original.
+func (ed *EntityData) Clone() *EntityData {
+	if ed == nil {
+		return nil
+	}
+	clone := &EntityData{
+		ips:          maps.Clone(ed.ips),
+		containerIDs: maps.Clone(ed.containerIDs),
+	}
+	if ed.endpoints != nil {
+		clone.endpoints = make(map[net.NumericEndpoint][]EndpointTargetInfo, len(ed.endpoints))
+		for ep, infos := range ed.endpoints {
+			clone.endpoints[ep] = slices.Clone(infos)
+		}
+	}
+	return clone
+}
+
 // Store is a store for managing cluster entities (currently deployments only) and allows looking them up by
 // endpoint.
 type Store struct {
@@ -249,13 +267,20 @@ func (e *Store) applyHeritageData(dg dataGetter) bool {
 		return false
 	}
 
-	e.currentSensorLock.RLock()
-	defer e.currentSensorLock.RUnlock()
+	var deploymentID string
+	var modEntityData *EntityData
+	// Clone under the read lock and mutate the private copy. The shared currentSensorEntityData
+	// is also referenced by concurrent Apply() calls (see onDeploymentCreateOrUpdate), so mutating
+	// it in place would race with those readers.
+	concurrency.WithRLock(&e.currentSensorLock, func() {
+		deploymentID = e.currentSensorDeploymentID
+		modEntityData = e.currentSensorEntityData.Clone()
+	})
+
 	for _, entry := range past {
-		log.Infof("Applying heritage data %q to current Sensor deploymentID %s", entry.String(), e.currentSensorDeploymentID)
-		modEntityData := e.currentSensorEntityData
+		log.Infof("Applying heritage data %q to current Sensor deploymentID %s", entry.String(), deploymentID)
 		if applyPastToEntityData(modEntityData, entry) {
-			e.Apply(map[string]*EntityData{e.currentSensorDeploymentID: modEntityData}, true)
+			e.Apply(map[string]*EntityData{deploymentID: modEntityData}, true)
 		}
 	}
 	return true

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -281,11 +281,18 @@ func (e *Store) applyHeritageData(dg dataGetter) bool {
 	// this immutable snapshot; deriving from modEntityData.endpoints instead would compound the
 	// endpoints added for earlier past entries, growing exponentially with the number of entries.
 	srcEndpoints := maps.Clone(modEntityData.endpoints)
+	changed := false
 	for _, entry := range past {
 		log.Infof("Applying heritage data %q to current Sensor deploymentID %s", entry.String(), deploymentID)
 		if applyPastToEntityData(modEntityData, srcEndpoints, entry) {
-			e.Apply(map[string]*EntityData{deploymentID: modEntityData}, true)
+			changed = true
 		}
+	}
+	// modEntityData accumulates every past entry, so a single Apply after the loop suffices.
+	// Applying inside the loop re-sent the whole growing object as an incremental update on each
+	// iteration; the store dedupes with sets so the result was identical, just extra work.
+	if changed {
+		e.Apply(map[string]*EntityData{deploymentID: modEntityData}, true)
 	}
 	return true
 }

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -128,6 +128,10 @@ type Store struct {
 	pastSensors HeritageManager
 	// heritageApplied ensures that past heritage data is applied to the current instance only once.
 	heritageApplied concurrency.Signal
+	// applyHeritageLock serializes concurrent ApplyDataFromHeritageOnce calls. With the PubSub
+	// concurrent lane, deployment events are processed on separate goroutines, so the heritage
+	// apply can be entered concurrently; without this lock the "apply once" guard would race.
+	applyHeritageLock sync.Mutex
 
 	// Cache enriched data for the current instance of Sensor.
 	// This data won't be stored into config map.
@@ -201,6 +205,13 @@ func (e *Store) GetHeritageManager() HeritageManager {
 
 // ApplyDataFromHeritageOnce adds heritage data about past sensors to the store if that hasn't happened yet.
 func (e *Store) ApplyDataFromHeritageOnce() {
+	if e.heritageApplied.IsDone() {
+		return
+	}
+	// Serialize concurrent callers and re-check under the lock: the initial IsDone check above
+	// is only a fast path. Two goroutines could both pass it before either signals completion.
+	e.applyHeritageLock.Lock()
+	defer e.applyHeritageLock.Unlock()
 	if e.heritageApplied.IsDone() {
 		return
 	}

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -277,9 +277,13 @@ func (e *Store) applyHeritageData(dg dataGetter) bool {
 		modEntityData = e.currentSensorEntityData.Clone()
 	})
 
+	// Snapshot the current Sensor's endpoints once. Each past entry derives its endpoints from
+	// this immutable snapshot; deriving from modEntityData.endpoints instead would compound the
+	// endpoints added for earlier past entries, growing exponentially with the number of entries.
+	srcEndpoints := maps.Clone(modEntityData.endpoints)
 	for _, entry := range past {
 		log.Infof("Applying heritage data %q to current Sensor deploymentID %s", entry.String(), deploymentID)
-		if applyPastToEntityData(modEntityData, entry) {
+		if applyPastToEntityData(modEntityData, srcEndpoints, entry) {
 			e.Apply(map[string]*EntityData{deploymentID: modEntityData}, true)
 		}
 	}
@@ -302,7 +306,11 @@ func (e *Store) HasCurrentSensorMetadata() bool {
 }
 
 // applyPastToEntityData returns true if the `past` data was added to `data`; false otherwise.
-func applyPastToEntityData(data *EntityData, past *heritage.SensorMetadata) bool {
+// srcEndpoints is an immutable snapshot of the current Sensor's endpoints; past endpoints are
+// derived from it rather than from data.endpoints so that endpoints added for earlier past entries
+// are neither re-derived (which compounds exponentially across past entries) nor mutated while
+// being ranged over.
+func applyPastToEntityData(data *EntityData, srcEndpoints map[net.NumericEndpoint][]EndpointTargetInfo, past *heritage.SensorMetadata) bool {
 	if _, found := data.containerIDs[past.ContainerID]; found {
 		// The cluster entities store knows about this past instance of sensor. Skip adding.
 		log.Debugf("Cluster entities store already knows about container %s. Skipping.", past.ContainerID)
@@ -313,8 +321,8 @@ func applyPastToEntityData(data *EntityData, past *heritage.SensorMetadata) bool
 	pastIP := net.ParseIP(past.PodIP)
 	// Adding additional pod IP to the Sensor deployment
 	data.AddIP(pastIP)
-	for endpoint, infos := range data.endpoints {
-		// Craft endpoint with the same port and proto but with past IP
+	// Craft endpoints with the same port and proto but with the past IP.
+	for endpoint, infos := range srcEndpoints {
 		newEndpoint := net.MakeNumericEndpoint(pastIP, endpoint.IPAndPort.Port, endpoint.L4Proto)
 		// Container port and port name included in `infos` remain the same
 		for _, info := range infos {

--- a/sensor/common/clusterentities/store.go
+++ b/sensor/common/clusterentities/store.go
@@ -324,6 +324,11 @@ func applyPastToEntityData(data *EntityData, srcEndpoints map[net.NumericEndpoin
 	// Craft endpoints with the same port and proto but with the past IP.
 	for endpoint, infos := range srcEndpoints {
 		newEndpoint := net.MakeNumericEndpoint(pastIP, endpoint.IPAndPort.Port, endpoint.L4Proto)
+		if _, exists := data.endpoints[newEndpoint]; exists {
+			// The past pod IP coincides with an endpoint that already exists (e.g. the current
+			// Sensor's IP was previously used by this past instance); nothing new to add.
+			continue
+		}
 		// Container port and port name included in `infos` remain the same
 		for _, info := range infos {
 			data.AddEndpoint(newEndpoint, info)

--- a/sensor/common/clusterentities/store_heritage_test.go
+++ b/sensor/common/clusterentities/store_heritage_test.go
@@ -166,6 +166,40 @@ func TestStore_ApplyHeritageDataOnce_Concurrent(t *testing.T) {
 	assert.True(t, store.heritageApplied.IsDone())
 }
 
+// TestStore_ApplyHeritage_ConcurrentWithApply is a regression test for a data race between the
+// heritage apply and a concurrent Apply() call on the same EntityData. onDeploymentCreateOrUpdate
+// stores the deployment's EntityData via RememberCurrentSensorMetadata and then passes that same
+// object to Apply(); with the PubSub concurrent lane these run on separate goroutines. Serializing
+// the heritage apply is not enough: it must not mutate the shared object in place while Apply reads
+// it. Run with -race.
+func TestStore_ApplyHeritage_ConcurrentWithApply(t *testing.T) {
+	mockHM := &mockHeritageManager{
+		data: []*heritage.SensorMetadata{
+			{ContainerID: "past123", PodIP: "10.1.1.1", SensorStart: time.Now().Add(-time.Hour)},
+		},
+		isEnabled: true,
+	}
+	store := NewStore(0, mockHM, false)
+
+	// The same object is remembered as current sensor metadata and passed to Apply below.
+	shared := createSensorEntityData("current123", "10.2.2.2")
+	shared.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 8443, net.TCP), EndpointTargetInfo{ContainerPort: 8443})
+	shared.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 9090, net.TCP), EndpointTargetInfo{ContainerPort: 9090})
+	store.RememberCurrentSensorMetadata("sensor-deploy-1", shared)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		store.ApplyDataFromHeritageOnce()
+	}()
+	go func() {
+		defer wg.Done()
+		store.Apply(map[string]*EntityData{"sensor-deploy-1": shared}, false)
+	}()
+	wg.Wait()
+}
+
 func TestApplyPastToEntityData(t *testing.T) {
 	tests := map[string]struct {
 		currentData    *EntityData

--- a/sensor/common/clusterentities/store_heritage_test.go
+++ b/sensor/common/clusterentities/store_heritage_test.go
@@ -253,7 +253,7 @@ func TestApplyPastToEntityData(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := applyPastToEntityData(tt.currentData, tt.pastSensor)
+			result := applyPastToEntityData(tt.currentData, maps.Clone(tt.currentData.endpoints), tt.pastSensor)
 			assert.Equal(t, tt.expectedResult, result)
 			containerIDs := tt.currentData.GetContainerIDs("sensor")
 			podIPs := tt.currentData.GetValidIPs()
@@ -291,7 +291,7 @@ func TestApplyPastToEntityData_NoDuplicateEndpoints(t *testing.T) {
 		data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), port, net.TCP), EndpointTargetInfo{ContainerPort: port})
 	}
 
-	added := applyPastToEntityData(data, &heritage.SensorMetadata{ContainerID: "past456", PodIP: "10.1.1.1"})
+	added := applyPastToEntityData(data, maps.Clone(data.endpoints), &heritage.SensorMetadata{ContainerID: "past456", PodIP: "10.1.1.1"})
 	assert.True(t, added)
 
 	// Every endpoint (current and past) must carry exactly one info; a longer slice means the map
@@ -311,6 +311,8 @@ func TestApplyPastToEntityData_MultiplePastNoCompounding(t *testing.T) {
 	data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 8443, net.TCP), EndpointTargetInfo{ContainerPort: 8443})
 	data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 9090, net.TCP), EndpointTargetInfo{ContainerPort: 9090})
 
+	// Mirror applyHeritageData: snapshot once, then apply every past entry against that snapshot.
+	srcEndpoints := maps.Clone(data.endpoints)
 	past := []*heritage.SensorMetadata{
 		{ContainerID: "past1", PodIP: "10.1.1.1"},
 		{ContainerID: "past2", PodIP: "10.1.1.2"},
@@ -318,7 +320,7 @@ func TestApplyPastToEntityData_MultiplePastNoCompounding(t *testing.T) {
 		{ContainerID: "past4", PodIP: "10.1.1.4"},
 	}
 	for _, entry := range past {
-		assert.True(t, applyPastToEntityData(data, entry))
+		assert.True(t, applyPastToEntityData(data, srcEndpoints, entry))
 	}
 
 	// 2 ports for the current IP plus 2 ports per past IP, each with exactly one info.

--- a/sensor/common/clusterentities/store_heritage_test.go
+++ b/sensor/common/clusterentities/store_heritage_test.go
@@ -278,6 +278,56 @@ func TestApplyPastToEntityData(t *testing.T) {
 	}
 }
 
+// TestApplyPastToEntityData_NoDuplicateEndpoints is a regression test for endpoints being
+// duplicated because applyPastToEntityData added entries to data.endpoints while ranging over it.
+// Adding keys to a map during iteration is nondeterministic in Go (a new key "may be produced or
+// may be skipped"); with enough endpoints the buggy version reliably re-visited freshly added
+// past-IP endpoints and appended their info a second time.
+func TestApplyPastToEntityData_NoDuplicateEndpoints(t *testing.T) {
+	const nPorts = 64
+	data := createSensorEntityData("current123", "10.2.2.2")
+	for i := range nPorts {
+		port := uint16(1000 + i)
+		data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), port, net.TCP), EndpointTargetInfo{ContainerPort: port})
+	}
+
+	added := applyPastToEntityData(data, &heritage.SensorMetadata{ContainerID: "past456", PodIP: "10.1.1.1"})
+	assert.True(t, added)
+
+	// Every endpoint (current and past) must carry exactly one info; a longer slice means the map
+	// was mutated while being ranged over and an entry was processed twice.
+	assert.Len(t, data.endpoints, 2*nPorts, "expected current + past endpoints and nothing else")
+	for ep, infos := range data.endpoints {
+		assert.Lenf(t, infos, 1, "endpoint %v has duplicate infos: %v", ep, infos)
+	}
+}
+
+// TestApplyPastToEntityData_MultiplePastNoCompounding is a regression test for endpoints compounding
+// across past entries: applyHeritageData reuses a single EntityData for all past sensors, so deriving
+// past endpoints from data.endpoints (which grows each entry) rather than from an immutable snapshot
+// caused the per-endpoint info slice to double with every additional past sensor (1, 2, 4, 8, ...).
+func TestApplyPastToEntityData_MultiplePastNoCompounding(t *testing.T) {
+	data := createSensorEntityData("current123", "10.2.2.2")
+	data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 8443, net.TCP), EndpointTargetInfo{ContainerPort: 8443})
+	data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 9090, net.TCP), EndpointTargetInfo{ContainerPort: 9090})
+
+	past := []*heritage.SensorMetadata{
+		{ContainerID: "past1", PodIP: "10.1.1.1"},
+		{ContainerID: "past2", PodIP: "10.1.1.2"},
+		{ContainerID: "past3", PodIP: "10.1.1.3"},
+		{ContainerID: "past4", PodIP: "10.1.1.4"},
+	}
+	for _, entry := range past {
+		assert.True(t, applyPastToEntityData(data, entry))
+	}
+
+	// 2 ports for the current IP plus 2 ports per past IP, each with exactly one info.
+	assert.Len(t, data.endpoints, 2*(1+len(past)), "unexpected number of endpoints")
+	for ep, infos := range data.endpoints {
+		assert.Lenf(t, infos, 1, "endpoint %v has duplicate infos: %v", ep, infos)
+	}
+}
+
 func TestEntityData_String_SlicesCollectFix(t *testing.T) {
 	// Test justification: Validates the slices.Collect fix for proper formatting
 	tests := map[string]struct {

--- a/sensor/common/clusterentities/store_heritage_test.go
+++ b/sensor/common/clusterentities/store_heritage_test.go
@@ -198,6 +198,8 @@ func TestStore_ApplyHeritage_ConcurrentWithApply(t *testing.T) {
 		store.Apply(map[string]*EntityData{"sensor-deploy-1": shared}, false)
 	}()
 	wg.Wait()
+
+	assert.True(t, store.heritageApplied.IsDone())
 }
 
 func TestApplyPastToEntityData(t *testing.T) {

--- a/sensor/common/clusterentities/store_heritage_test.go
+++ b/sensor/common/clusterentities/store_heritage_test.go
@@ -330,6 +330,23 @@ func TestApplyPastToEntityData_MultiplePastNoCompounding(t *testing.T) {
 	}
 }
 
+// TestApplyPastToEntityData_PastIPEqualsCurrent is a regression test for a past pod IP that coincides
+// with the current Sensor's endpoint IP: deriving a past endpoint would collide with an existing key
+// and append a duplicate info to it. Applying the same past entry must leave one info per endpoint.
+func TestApplyPastToEntityData_PastIPEqualsCurrent(t *testing.T) {
+	data := createSensorEntityData("current123", "10.2.2.2")
+	data.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 8443, net.TCP), EndpointTargetInfo{ContainerPort: 8443})
+
+	srcEndpoints := maps.Clone(data.endpoints)
+	// Past sensor reused the current pod IP but has a different container ID.
+	assert.True(t, applyPastToEntityData(data, srcEndpoints, &heritage.SensorMetadata{ContainerID: "past456", PodIP: "10.2.2.2"}))
+
+	assert.Len(t, data.endpoints, 1, "no new endpoint expected for a coinciding IP")
+	for ep, infos := range data.endpoints {
+		assert.Lenf(t, infos, 1, "endpoint %v has duplicate infos: %v", ep, infos)
+	}
+}
+
 func TestEntityData_String_SlicesCollectFix(t *testing.T) {
 	// Test justification: Validates the slices.Collect fix for proper formatting
 	tests := map[string]struct {

--- a/sensor/common/clusterentities/store_heritage_test.go
+++ b/sensor/common/clusterentities/store_heritage_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common/heritage"
 	"github.com/stretchr/testify/assert"
 )
@@ -132,6 +133,37 @@ func TestStore_applyHeritageData(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestStore_ApplyHeritageDataOnce_Concurrent is a regression test for a "concurrent map writes"
+// crash: with the PubSub concurrent lane, deployment events are processed on separate goroutines,
+// so ApplyDataFromHeritageOnce could be entered concurrently. Both callers passed the "once" guard
+// and mutated the shared currentSensorEntityData maps at the same time. Run with -race.
+func TestStore_ApplyHeritageDataOnce_Concurrent(t *testing.T) {
+	mockHM := &mockHeritageManager{
+		data: []*heritage.SensorMetadata{
+			{ContainerID: "past123", PodIP: "10.1.1.1", SensorStart: time.Now().Add(-time.Hour)},
+			{ContainerID: "past456", PodIP: "10.1.1.2", SensorStart: time.Now().Add(-2 * time.Hour)},
+		},
+		isEnabled: true,
+	}
+	store := NewStore(0, mockHM, false)
+
+	currentData := createSensorEntityData("current123", "10.2.2.2")
+	// Endpoints are required to exercise EntityData.AddEndpoint, the site of the original crash.
+	currentData.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 8443, net.TCP), EndpointTargetInfo{ContainerPort: 8443})
+	currentData.AddEndpoint(net.MakeNumericEndpoint(net.ParseIP("10.2.2.2"), 9090, net.TCP), EndpointTargetInfo{ContainerPort: 9090})
+	store.RememberCurrentSensorMetadata("sensor-deploy-1", currentData)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			store.ApplyDataFromHeritageOnce()
+		})
+	}
+	wg.Wait()
+
+	assert.True(t, store.heritageApplied.IsDone())
 }
 
 func TestApplyPastToEntityData(t *testing.T) {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR started from an investigation of the sensor crash here https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-nongroovy-compatibility-tests/2092435311828144128

```
common/clusterentities: 2026/08/26 03:51:11.666067 store.go:242: Info: Applying heritage data "(77a38fe40e38, 10.69.64.27) start=2026-08-26 03:51:09.839483674 +0000 UTC m=+0.119573892" to current Sensor deploymentID 05a1b3ad-97e8-4df6-85cd-cb389e0d6ea2
common/clusterentities: 2026/08/26 03:51:11.666384 store.go:242: Info: Applying heritage data "(d5e1bd72586d, 10.69.64.26) start=2026-08-26 03:50:07.509543963 +0000 UTC" to current Sensor deploymentID 05a1b3ad-97e8-4df6-85cd-cb389e0d6ea2
common/clusterentities: 2026/08/26 03:51:11.666029 store.go:242: Info: Applying heritage data "(77a38fe40e38, 10.69.64.27) start=2026-08-26 03:51:09.839483674 +0000 UTC m=+0.119573892" to current Sensor deploymentID 05a1b3ad-97e8-4df6-85cd-cb389e0d6ea2
common/clusterentities: 2026/08/26 03:51:11.666557 store.go:242: Info: Applying heritage data "(d5e1bd72586d, 10.69.64.26) start=2026-08-26 03:50:07.509543963 +0000 UTC" to current Sensor deploymentID 05a1b3ad-97e8-4df6-85cd-cb389e0d6ea2
common/clusterentities: 2026/08/26 03:51:11.666617 store.go:242: Info: Applying heritage data "(5610bfca3303, 10.69.65.25) start=2026-08-26 03:31:58.8185256 +0000 UTC" to current Sensor deploymentID 05a1b3ad-97e8-4df6-85cd-cb389e0d6ea2
common/clusterentities: 2026/08/26 03:51:11.666672 store.go:242: Info: Applying heritage data "(5610bfca3303, 10.69.65.25) start=2026-08-26 03:31:58.8185256 +0000 UTC" to current Sensor deploymentID 05a1b3ad-97e8-4df6-85cd-cb389e0d6ea2
fatal error: concurrent map writes

goroutine 1824 [running]:
internal/runtime/maps.fatal({0x6485bf3?, 0x5957be0?})
        runtime/panic.go:1181 +0x18
github.com/stackrox/rox/sensor/common/clusterentities.(*EntityData).AddEndpoint(...)
        github.com/stackrox/rox/sensor/common/clusterentities/store.go:102
github.com/stackrox/rox/sensor/common/clusterentities.applyPastToEntityData(0x3efcc2264798, 0x3efcbf8de0f0)
        github.com/stackrox/rox/sensor/common/clusterentities/store.go:283 +0x4c5
github.com/stackrox/rox/sensor/common/clusterentities.(*Store).applyHeritageData(0x3efcb9fee160, {0x78ff5c1c5c28, 0x3efcb9fee0b0})
        github.com/stackrox/rox/sensor/common/clusterentities/store.go:244 +0x367
github.com/stackrox/rox/sensor/common/clusterentities.(*Store).ApplyDataFromHeritageOnce(0x3efcb9fee160)
        github.com/stackrox/rox/sensor/common/clusterentities/store.go:210 +0xcf
github.com/stackrox/rox/sensor/kubernetes/listener/resources.(*endpointManagerImpl).onDeploymentCreateOrUpdate(0x3efcb9ff4540, 0x3efcbf899b20)
        github.com/stackrox/rox/sensor/kubernetes/listener/resources/endpoints.go:267 +0x258
github.com/stackrox/rox/sensor/kubernetes/listener/resources.(*endpointManagerImpl).OnDeploymentCreateOrUpdateByID(0x3efcb9ff4540, {0x3efcbd278930?, 0x6e69727453797265?})
        github.com/stackrox/rox/sensor/kubernetes/listener/resources/endpoints.go:243 +0x37
github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver.(*resolverImpl).resolveDeployment(0x3efcb9d4a910, 0x3efcbedc6990, 0x3efcbf820d50)
        github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go:155 +0x1c7
github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver.(*resolverImpl).processMessage(0x3efcb9d4a910, 0x3efcbedc6990)
        github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go:250 +0x1bf
github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver.(*resolverImpl).ProcessResourceEvent(0x3efcb9d4a910, {0x698ade0, 0x3efcbedc6990})
        github.com/stackrox/rox/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go:105 +0x74
github.com/stackrox/rox/sensor/common/pubsub/consumer.(*DefaultConsumer).Consume.func1()
        github.com/stackrox/rox/sensor/common/pubsub/consumer/default.go:28 +0x7e
created by github.com/stackrox/rox/sensor/common/pubsub/consumer.(*DefaultConsumer).Consume in goroutine 179
        github.com/stackrox/rox/sensor/common/pubsub/consumer/default.go:25 +0xc5
```

It seems that the `endpoints` map was being written multiple times simultaneously.

There were two other problems that were fixed in other commits.

The second issue fixed is another data race with unintended mutations. This is fixed by cloning instances of `EntityData`.

The third issue fixed is a case in which a map is added to while being looped over, resulting in duplicates in slices in the values of the map. In addition, in cases in which there were multiple past sensors, the data for each past sensor would be duplicated for each sensor, leading to exponential growth.

This PR has alternating commits that adds failing tests and commits that fix the failing tests.

Some or all of these fixes may need to be backported to 4.10 and 4.11.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

The failures are either in scanner, which is not touched by this PR, or is a known flake.

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The commits have alternating failing tests and fixes to those tests. Unit tests have been run in each of the commits to confirm that the code was indeed broken and that the changes fixed the bugs.
