### PR TITLE
ROX-36548: Update sbom scan CLI command description

### DIFF
--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -54,8 +54,11 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c := &cobra.Command{
 		Use:   "scan",
-		Short: "[DEV PREVIEW] Scan the specified SBOM and return scan results",
-		Long:  "[DEV PREVIEW] Scan the specified SBOM and return scan results. You must have write permissions to the `Image` resource. Currently supports SPDX 2.3 JSON documents with content types: [`application/spdx+json`, `text/spdx+json`].",
+		Short: "(Technology Preview) Scan the specified SBOM and return scan results",
+		Long: "(Technology Preview) Scan the specified SBOM and return scan results. " +
+			"You must have write permissions to the `Image` resource. Currently supports SPDX 2.3 JSON documents with content types: " +
+			"[`application/spdx+json`, `text/spdx+json`]." +
+			common.TechPreviewLongText,
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
 			if err := sbomScanCmd.Construct(nil, c, objectPrinterFactory); err != nil {
 				return err


### PR DESCRIPTION
## Description

Update the `roxctl sbom scan` command description (`roxctl sbom scan -h`) from dev preview to tech preview.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

```
❯ make SKIP_CLI_BUILD= cli_host-arch # make cli_host-arch if you don't have skip cli builds by default
❯ ./bin/darwin_arm64/roxctl sbom -h
Commands that you can run on SBOMs.

Available Commands:
  scan   (Technology Preview) Scan the specified SBOM and return scan results

...
❯ ./bin/darwin_arm64/roxctl sbom scan -h
(Technology Preview) Scan the specified SBOM and return scan results.

(Technology Preview) Scan the specified SBOM and return scan results. You must have write permissions to the `Image` resource. Currently supports SPDX 2.3 JSON 
documents with content types: [`application/spdx+json`, `text/spdx+json`].

** This is a Technology Preview feature **
Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
Red Hat does not recommend using them in production.
These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
...
```



