### PR TITLE
test(queue): reproduce stale notEmptySignal spin

### DIFF
--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -491,6 +491,15 @@ func TestQueueSeq(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("Seq Stale Not Empty Signal Does Not Spin", func(t *testing.T) {
+		testStaleNotEmptySignalDoesNotSpin(t, func(q *Queue[int], ctx context.Context) int {
+			for item := range q.Seq(ctx) {
+				return item
+			}
+			return 0
+		})
+	})
 }
 
 func TestQueuePullBlocking(t *testing.T) {
@@ -514,5 +523,41 @@ func TestQueuePullBlocking(t *testing.T) {
 		testCancellationWithEmptyQueue(t, func(ctx context.Context, q *Queue[int]) int {
 			return q.PullBlocking(ctx)
 		})
+	})
+
+	t.Run("PullBlocking Stale Not Empty Signal Does Not Spin", func(t *testing.T) {
+		testStaleNotEmptySignalDoesNotSpin(t, func(q *Queue[int], ctx context.Context) int {
+			return q.PullBlocking(ctx)
+		})
+	})
+}
+
+// testStaleNotEmptySignalDoesNotSpin covers an empty queue whose notEmptySignal is
+// already triggered. Waiters must Reset that latch and block; otherwise synctest.Wait hangs.
+func testStaleNotEmptySignalDoesNotSpin(t *testing.T, consume func(*Queue[int], context.Context) int) {
+	synctest.Test(t, func(t *testing.T) {
+		q := NewQueue[int]()
+		q.notEmptySignal.Signal()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		got := make(chan int, 1)
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			got <- consume(q, ctx)
+		}()
+		<-started
+		synctest.Wait()
+		t.Logf("consumer blocked")
+		q.Push(7)
+		synctest.Wait()
+		select {
+		case item := <-got:
+			assert.Equal(t, 7, item)
+		default:
+			t.Fatal("consumer should have received the item after blocking")
+		}
 	})
 }


### PR DESCRIPTION
Leaves notEmptySignal triggered with an empty queue, the state that
makes synctest.Wait hang with a runnable PullBlocking goroutine.
This test times out on the current PR loop and is the ROX-35992
signature; it does not change production code.

User request: commit the reproduction test only on a tmp branch
stacked on fix-queue-seq-spin-loop.

This code was partially generated by AI.

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
