### PR TITLE
fix(sensor): Improve VM scraper debug logging

### DIFF
--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -292,24 +292,25 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	}
 
 	due := s.dueKeys()
+	nDue := len(due)
 	nTracked := concurrency.WithLock1(&s.mu, func() int {
 		n := len(s.vmState)
 		metrics.PullTrackedVMs.Set(float64(n))
 		return n
 	})
-	metrics.PullDueVMs.Set(float64(len(due)))
+	metrics.PullDueVMs.Set(float64(nDue))
 	capN := min(s.concurrency, startBudget(nTracked, s.tickInterval, newVMIndexReportWindow(s.interval)))
-	if capN < len(due) {
+	if capN < nDue {
 		due = due[:capN]
 	}
-	log.Debugf("VMScraper: tick: %d due VMs %v (concurrency=%d, reconcile=%v)", len(due), due, s.concurrency, reconcile)
-	metrics.PullTicksTotal.Inc()
-
-	// A tick launches every due VM, so this is the start count.
 	started := len(due)
+	// Idle ticks stay silent so a 10s scheduler step does not look like an empty cluster.
 	if started > 0 {
+		log.Debugf("VMScraper: tick: %d due of %d tracked, starting %d %v (concurrency=%d, reconcile=%v)",
+			nDue, nTracked, started, due, s.concurrency, reconcile)
 		metrics.PullStartsPerTick.Observe(float64(started))
 	}
+	metrics.PullTicksTotal.Inc()
 
 	var successCount atomic.Int32
 	g, gCtx := errgroup.WithContext(ctx)
@@ -326,7 +327,10 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	_ = g.Wait()
 
 	elapsed := s.now().Sub(tickStart)
-	log.Debugf("VMScraper: tick done: %d/%d due VMs succeeded in %s", successCount.Load(), len(due), elapsed.Truncate(time.Millisecond))
+	if started > 0 {
+		log.Debugf("VMScraper: tick done: %d/%d started of %d tracked succeeded in %s",
+			successCount.Load(), started, nTracked, elapsed.Truncate(time.Millisecond))
+	}
 	metrics.PullTickDurationSeconds.Observe(elapsed.Seconds())
 }
 


### PR DESCRIPTION


## Description

This PR is to avoid confusion when looking at such logs:

```
VMScraper: tick: 0 due VMs [] (concurrency=20, reconcile=false)
VMScraper: tick done: 0/0 due VMs succeeded in 0s
```
which may suggest that there are no VMs being scraped. In fact there are VMs, just at that given 10s tick none are scheduled.

The new log should be clearer:

```
VMScraper: tick: 3 due of 12 tracked, starting 3 [ns/vm-a ns/vm-b ns/vm-c] (concurrency=20, reconcile=false)
VMScraper: tick done: 3/3 started of 12 tracked succeeded in 50ms
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

I haven't yet
