### PR TITLE
ROX-36628: guard mapper against cross-ecosystem fixedBy

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -989,6 +989,20 @@ func ccEnvironment(env *v4.Environment) (*claircore.Environment, error) {
 	}, nil
 }
 
+// ecosystemsRequiringEncodedFixedInVersion lists OSV ecosystems for which
+// claircore's OSV updater always encodes FixedInVersion as a URL query
+// string (see quay/claircore updater/osv/osv.go, ecosystemRange.Encode()).
+// A plain, non-url-encoded FixedInVersion on a vulnerability whose repo is
+// one of these indicates the OSV updater ingested another ecosystem's
+// affected-range data into this record (see ROX-36628): the ecosystem's
+// affected-range entries aren't filtered by `af.Package.Ecosystem`, so e.g.
+// an npm entry's plain semver fix version can end up on a PyPI record.
+var ecosystemsRequiringEncodedFixedInVersion = map[string]struct{}{
+	"pypi":     {},
+	"maven":    {},
+	"rubygems": {},
+}
+
 // fixedInVersion returns the fixed in string, typically provided the report's
 // `FixedInVersion` as a plain string, but, in some OSV updaters, it can be an
 // urlencoded string.
@@ -996,10 +1010,20 @@ func fixedInVersion(v *claircore.Vulnerability) string {
 	if v.FixedInVersion == "0" {
 		return ""
 	}
+	requiresEncoded := v.Repo != nil
+	if requiresEncoded {
+		_, requiresEncoded = ecosystemsRequiringEncodedFixedInVersion[strings.ToLower(v.Repo.Name)]
+	}
 	// Try to parse url encoded params; if expected values are not found, leave it.
 	q, err := url.ParseQuery(v.FixedInVersion)
 	switch {
 	case err != nil:
+		if requiresEncoded {
+			// This repo's FixedInVersion should always be url-encoded; an
+			// unparseable value is almost certainly contaminated data from a
+			// different ecosystem's advisory. Don't surface it.
+			return ""
+		}
 		// v.FixedInVersion is not url encoded, so just return it as-is.
 		return v.FixedInVersion
 	case q.Has("fixed"):
@@ -1007,6 +1031,11 @@ func fixedInVersion(v *claircore.Vulnerability) string {
 	case q.Has("introduced"), q.Has("lastAffected"):
 		return ""
 	default:
+		if requiresEncoded {
+			// Same reasoning as above: a plain value on a repo that should
+			// always be url-encoded indicates cross-ecosystem contamination.
+			return ""
+		}
 		return v.FixedInVersion
 	}
 }

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -2781,6 +2781,51 @@ func Test_versionID(t *testing.T) {
 	}
 }
 
+func Test_fixedInVersion(t *testing.T) {
+	tests := map[string]struct {
+		v    *claircore.Vulnerability
+		want string
+	}{
+		"zero FixedInVersion returns empty": {
+			v:    &claircore.Vulnerability{FixedInVersion: "0"},
+			want: "",
+		},
+		"plain version on a non-restricted repo is returned as-is": {
+			v:    &claircore.Vulnerability{FixedInVersion: "1.2.3", Repo: &claircore.Repository{Name: "npm"}},
+			want: "1.2.3",
+		},
+		"url-encoded fixed on pypi repo is decoded": {
+			v:    &claircore.Vulnerability{FixedInVersion: "fixed=0.8.0", Repo: &claircore.Repository{Name: "pypi"}},
+			want: "0.8.0",
+		},
+		"url-encoded introduced on pypi repo returns empty": {
+			v:    &claircore.Vulnerability{FixedInVersion: "introduced=0.1.0", Repo: &claircore.Repository{Name: "pypi"}},
+			want: "",
+		},
+		"plain version on pypi repo is contaminated cross-ecosystem data, suppressed (ROX-36628)": {
+			v:    &claircore.Vulnerability{FixedInVersion: "0.6.0", Repo: &claircore.Repository{Name: "pypi"}},
+			want: "",
+		},
+		"plain version on maven repo is contaminated cross-ecosystem data, suppressed (ROX-36628)": {
+			v:    &claircore.Vulnerability{FixedInVersion: "0.6.0", Repo: &claircore.Repository{Name: "Maven"}},
+			want: "",
+		},
+		"unparseable value on rubygems repo is suppressed (ROX-36628)": {
+			v:    &claircore.Vulnerability{FixedInVersion: "1.2.3;rc1", Repo: &claircore.Repository{Name: "rubygems"}},
+			want: "",
+		},
+		"nil repo falls back to plain value": {
+			v:    &claircore.Vulnerability{FixedInVersion: "1.2.3"},
+			want: "1.2.3",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, fixedInVersion(tt.v))
+		})
+	}
+}
+
 func TestIsVersionAgnostic(t *testing.T) {
 	tests := map[string]struct {
 		did  string


### PR DESCRIPTION
## Description

Scanner V4 was surfacing an incorrect `fixedBy` version for some PyPI CVEs (e.g. `langsmith` CVE-2026-45134 reported fixedBy `0.6.0`, lower than the installed `0.10.16`, producing a false positive). Root cause: claircore's OSV updater (`updater/osv/osv.go`) doesn't filter `affected` entries by `af.Package.Ecosystem`, so a multi-ecosystem GHSA advisory can leak another ecosystem's plain-semver fix version into a `pypi`/`maven`/`rubygems` vulnerability record. Those three ecosystems always encode `FixedInVersion` as a URL query string in claircore (`ecosystemRange.Encode()`), so a plain/unparseable value on one of them is a reliable signal of cross-ecosystem contamination rather than a genuine fix version.

This PR adds a defense-in-depth guard in `pkg/scannerv4/mappers/mappers.go`'s `fixedInVersion`: for vulnerabilities whose repo is `pypi`, `maven`, or `rubygems`, a `FixedInVersion` that isn't validly URL-encoded is suppressed (returns `""`) instead of being surfaced verbatim.

The actual root-cause fix (filtering OSV `affected` entries by ecosystem during ingestion) is being submitted upstream to `quay/claircore` separately; this PR is a stopgap so StackRox doesn't display incorrect data while that lands and releases.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Added `Test_fixedInVersion` in `pkg/scannerv4/mappers/mappers_test.go` covering: zero version, plain version on unrestricted repo (unchanged behavior), url-encoded `fixed`/`introduced` on pypi (unchanged behavior), plain/unparseable value on pypi/maven/rubygems (newly suppressed), nil repo fallback.
- `go test ./pkg/scannerv4/mappers/...` passes.
- Not yet tested end-to-end against a real cluster/scan — planned once a test cluster is available; this PR remains draft until then.

Companion to an upstream root-cause fix in `quay/claircore`, tracked separately.