### PR TITLE
fix(CI): disable ROX_SCANNER_V4 in dispatch.sh

### DIFF
--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -43,7 +43,8 @@ create_exit_trap
 # dropped. Individual job scripts can opt out via os.environ["ROX_SCANNER_V4"].
 #
 # TODO(ROX-35345): remove this
-export ROX_SCANNER_V4=true
+# TODO: reenable scanner v4 once it's stable in tests
+# export ROX_SCANNER_V4=true
 
 ci_export CI_JOB_NAME "$ci_job"
 


### PR DESCRIPTION
## Description

Comment out export of ROX_SCANNER_V4 for stability.

Reverts: 
- https://github.com/stackrox/stackrox/pull/21503

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
