### PR TITLE
ROX-36682: Stop calling Scanner V2 node-inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Removed Features
 
-- Compliance container no longer collects Scanner V2 node inventories. Node scanning continues via Scanner V4 index reports.
+- Compliance container no longer collects Scanner V2 node inventories. Node scanning continues via Scanner V4 index reports, as long as Scanner V4 is enabled.
 
 ### Deprecated Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Removed Features
 
+- Compliance container no longer collects Scanner V2 node inventories. Node scanning continues via Scanner V4 index reports.
+
 ### Deprecated Features
 
 - ROX-26281: block creation of new GCR integrations. Users are directed to use Google Artifact Registry instead.

--- a/central/clusters/zip/render_test.go
+++ b/central/clusters/zip/render_test.go
@@ -86,9 +86,8 @@ func doTestRenderOpenshif(t *testing.T, clusterType storage.ClusterType) {
 		assert.True(t, foundMain)
 		assert.Equal(t, "compliance", complianceCont.Name)
 
-		value, exists := getEnvVarValue(complianceCont.Env, env.NodeInventoryContainerEnabled.EnvVar())
-		assert.True(t, exists)
-		assert.Equal(t, "false", value, "compliance should have %s=false", env.NodeInventoryContainerEnabled.EnvVar())
+		_, exists := getEnvVarValue(complianceCont.Env, env.NodeInventoryContainerEnabled.EnvVar())
+		assert.False(t, exists, "compliance should not set %s; Go default is false", env.NodeInventoryContainerEnabled.EnvVar())
 
 		if clusterType == storage.ClusterType_OPENSHIFT4_CLUSTER {
 			nInvCont, found := findContainer(ds.Spec.Template.Spec.Containers, "node-inventory")

--- a/central/clusters/zip/render_test.go
+++ b/central/clusters/zip/render_test.go
@@ -86,6 +86,10 @@ func doTestRenderOpenshif(t *testing.T, clusterType storage.ClusterType) {
 		assert.True(t, foundMain)
 		assert.Equal(t, "compliance", complianceCont.Name)
 
+		value, exists := getEnvVarValue(complianceCont.Env, env.NodeInventoryContainerEnabled.EnvVar())
+		assert.True(t, exists)
+		assert.Equal(t, "false", value, "compliance should have %s=false", env.NodeInventoryContainerEnabled.EnvVar())
+
 		if clusterType == storage.ClusterType_OPENSHIFT4_CLUSTER {
 			nInvCont, found := findContainer(ds.Spec.Template.Spec.Containers, "node-inventory")
 			assert.True(t, found, "node-inventory container should exist under collector DS")
@@ -93,17 +97,9 @@ func doTestRenderOpenshif(t *testing.T, clusterType storage.ClusterType) {
 
 			expectedScannerParts := strings.Split(strings.ReplaceAll(complianceCont.Image, "/main:", "/scanner-slim:"), ":")
 			assert.Truef(t, strings.HasPrefix(nInvCont.Image, expectedScannerParts[0]), "scanner-slim image (%q) should be from the same registry as main (%q)", nInvCont.Image, complianceCont.Image)
-
-			value, exists := getEnvVarValue(complianceCont.Env, env.NodeInventoryContainerEnabled.EnvVar())
-			assert.True(t, exists)
-			assert.Equal(t, "true", value, "compliance should have %s=true", env.NodeInventoryContainerEnabled.EnvVar())
 		} else {
 			_, foundNInv := findContainer(ds.Spec.Template.Spec.Containers, "node-inventory")
 			assert.False(t, foundNInv, "node-inventory container must not exist under collector DS")
-
-			value, exists := getEnvVarValue(complianceCont.Env, env.NodeInventoryContainerEnabled.EnvVar())
-			assert.True(t, exists)
-			assert.Equalf(t, "false", value, "compliance should have %s=false", env.NodeInventoryContainerEnabled.EnvVar())
 		}
 	}
 

--- a/compliance/cmd/compliance/main.go
+++ b/compliance/cmd/compliance/main.go
@@ -31,7 +31,9 @@ func main() {
 	cfg := index.DefaultNodeIndexerConfig()
 
 	scanner := inventory.NewNodeInventoryComponentScanner(np)
-	scanner.Connect(env.NodeScanningEndpoint.Setting())
+	if env.NodeInventoryContainerEnabled.BooleanSetting() {
+		scanner.Connect(env.NodeScanningEndpoint.Setting())
+	}
 	cachedNodeIndexer := index.NewCachingNodeIndexer(cfg, env.NodeIndexCacheDuration.DurationSetting(), env.NodeIndexCachePath.Setting())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -175,8 +175,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: ROX_CALL_NODE_INVENTORY_ENABLED
-          value: "false"
       {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -176,7 +176,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROX_CALL_NODE_INVENTORY_ENABLED
-          value: {{ if eq ._rox.env.openshift 4 }}"true"{{ else }}"false"{{ end }}
+          value: "false"
       {{- if eq ._rox.env.openshift 4 }}
         - name: ROX_NODE_INDEX_HOST_PATH
           value: "/hostindex"

--- a/pkg/env/node_scan.go
+++ b/pkg/env/node_scan.go
@@ -18,8 +18,8 @@ var (
 	// scanning wait time.
 	NodeScanningMaxInitialWait = registerDurationSetting("ROX_NODE_SCANNING_MAX_INITIAL_WAIT", 5*time.Minute)
 
-	// NodeInventoryContainerEnabled is used to tell compliance whether a connection to the node-inventory container should be attempted
-	NodeInventoryContainerEnabled = RegisterBooleanSetting("ROX_CALL_NODE_INVENTORY_ENABLED", true)
+	// NodeInventoryContainerEnabled gates whether compliance connects to the node-inventory container.
+	NodeInventoryContainerEnabled = RegisterBooleanSetting("ROX_CALL_NODE_INVENTORY_ENABLED", false)
 
 	// NodeAnalysisDeadline is a time in which node-inventory component should reply to compliance
 	NodeAnalysisDeadline = registerDurationSetting("ROX_NODE_SCANNING_DEADLINE", 30*time.Second)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-compliance.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-compliance.test.yaml
@@ -6,6 +6,17 @@ values:
   imagePullSecrets:
     allowNone: true
 tests:
+- name: "does not enable Scanner V2 node inventory calls"
+  expect: |
+    envVars(.daemonsets.collector; "compliance")["ROX_CALL_NODE_INVENTORY_ENABLED"] | assertThat(. == "false")
+  tests:
+  - name: "on kubernetes"
+  - name: "on OpenShift 4"
+    server:
+      visibleSchemas:
+      - openshift-4.12
+      availableSchemas:
+      - openshift-4.12
 - name: "test securityContext"
   tests:
   - name: "by default seLinuxOptions are enabled and use container_runtime_t as container runtime"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-compliance.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-compliance.test.yaml
@@ -6,9 +6,9 @@ values:
   imagePullSecrets:
     allowNone: true
 tests:
-- name: "does not enable Scanner V2 node inventory calls"
+- name: "does not set Scanner V2 node inventory env (Go default is off)"
   expect: |
-    envVars(.daemonsets.collector; "compliance")["ROX_CALL_NODE_INVENTORY_ENABLED"] | assertThat(. == "false")
+    envVars(.daemonsets.collector; "compliance") | assertThat(has("ROX_CALL_NODE_INVENTORY_ENABLED") == false)
   tests:
   - name: "on kubernetes"
   - name: "on OpenShift 4"
@@ -17,6 +17,14 @@ tests:
       - openshift-4.12
       availableSchemas:
       - openshift-4.12
+- name: "customize.envVars can re-enable Scanner V2 node inventory calls"
+  values:
+    customize:
+      envVars:
+        ROX_CALL_NODE_INVENTORY_ENABLED: "true"
+  expect: |
+    envVars(.daemonsets.collector; "compliance")["ROX_CALL_NODE_INVENTORY_ENABLED"] | assertThat(. == "true")
+    [container(.daemonsets.collector; "compliance") | .env[] | select(.name == "ROX_CALL_NODE_INVENTORY_ENABLED")] | length | assertThat(. == 1)
 - name: "test securityContext"
   tests:
   - name: "by default seLinuxOptions are enabled and use container_runtime_t as container runtime"


### PR DESCRIPTION
## Description

TL;DR: Stop calling node-inventory and prevent it from scanning the disk.

Scanner V2 is being dropped. On OpenShift 4, compliance periodically called the node-inventory container over gRPC and forwarded returned node inventories to Sensor. 

This change turns the v2 inventory path off by default and leaves the node-inventory container in place so the PR stays small. Helm always sets `ROX_CALL_NODE_INVENTORY_ENABLED=false`, including OpenShift 4 where it was `"true"`. The Go default matches.

Compliance still respects that env var (a gate to enable this back). When it is `true`, it connects and the periodic `GetNodeInventory` loop runs as before. When it is `false`, `Connect` is a no-op, the scan loop never starts, and the sidecar is never asked to walk the disk.

Set `ROX_CALL_NODE_INVENTORY_ENABLED=true` on the compliance container to turn the v2 path back on without a code change.

The node-inventory container remains in the collector DaemonSet on OpenShift 4. Removing it is a task for separate PR.

AI-Assisted: cursor, generated the change; user reviewed logic.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [ ] CI

No manual validation beyond the automated tests.