### PR TITLE
ROX-36651: Add CreateReportDropdown for node vulnerability pages

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Overview/NodeCvesOverviewPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import {
     Alert,
     DropdownItem,
@@ -25,9 +26,11 @@ import useAnalytics, {
     NODE_CVE_ENTITY_CONTEXT_VIEWED,
     NODE_CVE_FILTER_APPLIED,
 } from 'hooks/useAnalytics';
+import { runNodeViewBasedReport } from 'services/NodeReportsService';
 import { getHasSearchApplied } from 'utils/searchUtils';
 import { getVersionedDocs } from 'utils/versioning';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
+import { vulnerabilityNodeViewBasedJobsPath } from 'routePaths';
 
 import {
     clusterSearchFilterConfig,
@@ -36,6 +39,7 @@ import {
     nodeSearchFilterConfig,
 } from '../../searchFilterConfig';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
+import CreateViewBasedReportModal from '../../components/CreateViewBasedReportModal';
 import SnoozedCveToggleButton from '../../components/SnoozedCveToggleButton';
 import SnoozeCvesModal from '../../components/SnoozeCvesModal/SnoozeCvesModal';
 import useSnoozeCveModal from '../../components/SnoozeCvesModal/useSnoozeCveModal';
@@ -43,10 +47,12 @@ import useHasLegacySnoozeAbility from '../../hooks/useHasLegacySnoozeAbility';
 import useSnoozedCveCount from '../../hooks/useSnoozedCveCount';
 import TableEntityToolbar from '../../components/TableEntityToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
+import { createScheduledReportForNodeVulnerabilitiesURL } from '../../Reports/NodeVulnerabilityReports/nodeVulnerabilityReports.utils';
 import { nodeEntityTabValues } from '../../types';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
-import { parseQuerySearchFilter } from '../../utils/searchUtils';
+import { getRegexScopedQueryString, parseQuerySearchFilter } from '../../utils/searchUtils';
 
+import CreateReportDropdown from '../components/CreateReportDropdown';
 import CVEsTable, {
     defaultSortOption as cveDefaultSortOption,
     sortFields as cveSortFields,
@@ -93,6 +99,11 @@ function NodeCvesOverviewPage() {
     const { snoozeModalOptions, setSnoozeModalOptions, snoozeActionCreator } = useSnoozeCveModal();
     const snoozedCveCount = useSnoozedCveCount('Node');
     const { version } = useMetadata();
+    const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
+    const navigate = useNavigate();
+
+    // Unlike WorkloadCves pages, 'CVE Snoozed' is in search filter of NodeCves page.
+    const viewBasedQueryString = getRegexScopedQueryString(querySearchFilter);
 
     function onEntityTabChange(entityTab: 'CVE' | 'Node') {
         pagination.setPage(1);
@@ -138,7 +149,18 @@ function NodeCvesOverviewPage() {
                 pagination.setPage(1);
                 trackAppliedFilter(NODE_CVE_FILTER_APPLIED, searchPayload);
             }}
-        />
+        >
+            {isFeatureFlagEnabled('ROX_NODE_VULNERABILITY_REPORTS') && (
+                <CreateReportDropdown
+                    onSelectExportReportAsCSV={() => {
+                        setIsCreateViewBasedReportModalOpen(true);
+                    }}
+                    onSelectCreateScheduledReport={() => {
+                        navigate(createScheduledReportForNodeVulnerabilitiesURL(querySearchFilter));
+                    }}
+                />
+            )}
+        </AdvancedFiltersToolbar>
     );
 
     const entityToggleGroup = (
@@ -269,6 +291,16 @@ function NodeCvesOverviewPage() {
                     />
                 )}
             </PageSection>
+            {isFeatureFlagEnabled('ROX_NODE_VULNERABILITY_REPORTS') && (
+                <CreateViewBasedReportModal
+                    isOpen={isCreateViewBasedReportModalOpen}
+                    setIsOpen={setIsCreateViewBasedReportModalOpen}
+                    query={viewBasedQueryString}
+                    areaOfConcern="Nodes"
+                    runViewBasedReport={runNodeViewBasedReport}
+                    vulnerabilityViewBasedJobsPath={vulnerabilityNodeViewBasedJobsPath}
+                />
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/CreateReportDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/CreateReportDropdown.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import type { MouseEvent as ReactMouseEvent, Ref } from 'react';
+import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
+
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import usePermissions from 'hooks/usePermissions';
+import type { FeatureFlagEnvVar } from 'types/featureFlag';
+import type { ResourceName } from 'types/roleResources';
+import { ensureExhaustive } from 'utils/type.utils';
+
+// TODO move deduplicated file to Vulnerabilities/components folder after release.
+
+type DropdownItem = {
+    text: 'Export report as CSV' | 'Create scheduled report';
+    description: string;
+    featureFlagDependency?: FeatureFlagEnvVar;
+    writeAccessRequirement?: ResourceName;
+};
+
+const dropdownItems: DropdownItem[] = [
+    {
+        text: 'Export report as CSV',
+        description:
+            'Export a view-based CSV report from this view using the filters you’ve applied.',
+    },
+    {
+        text: 'Create scheduled report',
+        description: 'Create a scheduled report from this view using the filters you’ve applied.',
+        writeAccessRequirement: 'WorkflowAdministration',
+    },
+] as const;
+
+type DropdownItemText = (typeof dropdownItems)[number]['text'];
+
+export type CreateReportDropdownProps = {
+    onSelectExportReportAsCSV: () => void;
+    onSelectCreateScheduledReport: () => void;
+};
+
+function CreateReportDropdown({
+    onSelectExportReportAsCSV,
+    onSelectCreateScheduledReport,
+}: CreateReportDropdownProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const { hasReadWriteAccess } = usePermissions();
+
+    const onToggleClick = () => {
+        setIsOpen((prev) => !prev);
+    };
+
+    const onSelectHandler = (
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
+        value: DropdownItemText
+    ) => {
+        switch (value) {
+            case 'Export report as CSV':
+                onSelectExportReportAsCSV();
+                break;
+            case 'Create scheduled report':
+                onSelectCreateScheduledReport();
+                break;
+            default:
+                ensureExhaustive(value);
+        }
+        setIsOpen(false);
+    };
+
+    return (
+        <>
+            <Dropdown
+                isOpen={isOpen}
+                onSelect={onSelectHandler}
+                onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+                toggle={(toggleRef: Ref<MenuToggleElement>) => (
+                    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+                        Create report
+                    </MenuToggle>
+                )}
+                shouldFocusToggleOnSelect
+                popperProps={{ position: 'right', appendTo: () => document.body }}
+            >
+                <DropdownList>
+                    {dropdownItems.map((dropdownItem) => {
+                        const { description, text } = dropdownItem;
+                        const isEnabled =
+                            !('featureFlagDependency' in dropdownItem) ||
+                            !dropdownItem.featureFlagDependency ||
+                            isFeatureFlagEnabled(dropdownItem.featureFlagDependency);
+                        const hasAccess =
+                            !('writeAccessRequirement' in dropdownItem) ||
+                            !dropdownItem.writeAccessRequirement ||
+                            hasReadWriteAccess(dropdownItem.writeAccessRequirement);
+
+                        return isEnabled && hasAccess ? (
+                            <DropdownItem key={text} value={text} description={description}>
+                                {text}
+                            </DropdownItem>
+                        ) : null;
+                    })}
+                </DropdownList>
+            </Dropdown>
+        </>
+    );
+}
+
+export default CreateReportDropdown;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/nodeVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/nodeVulnerabilityReports.utils.ts
@@ -1,0 +1,13 @@
+import type { SearchFilter } from 'types/search';
+import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+import { vulnerabilityNodeConfigurationsReportsPath } from 'routePaths';
+
+// Unlike view-based report that receives request query directly,
+// (create) scheduled report (from filter) receives it indirectly:
+// 1. from search filter to URL query (navigate from results page to report wizard)
+// 2. from URL query to search filter (initialize configuration in report wizard)
+// 3. from search filter to request query (save report configuration)
+export function createScheduledReportForNodeVulnerabilitiesURL(searchFilter: SearchFilter) {
+    const query = getUrlQueryStringForSearchFilter(searchFilter);
+    return `${vulnerabilityNodeConfigurationsReportsPath}?action=createFromFilters&${query}`;
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -3,7 +3,10 @@ import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
 import usePermissions from 'hooks/usePermissions';
-import { vulnerabilityConfigurationsReportsPath, vulnerabilityViewBasedJobsPath } from 'routePaths';
+import {
+    vulnerabilityConfigurationsReportsPath,
+    vulnerabilityImageViewBasedJobsPath,
+} from 'routePaths';
 
 import ConfigReportsTab from './ConfigReportsTab';
 import ViewBasedReportsTab from './ViewBasedReportsTab';
@@ -29,7 +32,7 @@ function VulnReportingLayout() {
         {
             id: 'view-based-jobs',
             title: 'View-based jobs',
-            path: vulnerabilityViewBasedJobsPath,
+            path: vulnerabilityImageViewBasedJobsPath,
             content: <ViewBasedReportsTab />,
         },
     ];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -20,8 +20,10 @@ import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
+import { runImageViewBasedReport } from 'services/ReportsService';
 import type { VulnerabilityState } from 'types/cve.proto';
 import { wrapInQuotes } from 'utils/searchUtils';
+import { vulnerabilityImageViewBasedJobsPath } from 'routePaths';
 
 import DeploymentPageHeader, { deploymentMetadataFragment } from './DeploymentPageHeader';
 import type { DeploymentMetadata } from './DeploymentPageHeader';
@@ -34,7 +36,7 @@ import DeploymentPageDetails from './DeploymentPageDetails';
 import { createScheduledReportForImageVulnerabilitiesURL } from '../../Reports/ImageVulnerabilityReports/imageVulnerabilityReports.utils';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import CreateReportDropdown from '../components/CreateReportDropdown';
-import CreateViewBasedReportModal from '../components/CreateViewBasedReportModal';
+import CreateViewBasedReportModal from '../../components/CreateViewBasedReportModal';
 
 const deploymentMetadataQuery = gql`
     ${deploymentMetadataFragment}
@@ -194,6 +196,8 @@ function DeploymentPage({ showVulnerabilityStateTabs, vulnerabilityState }: Depl
                     setIsOpen={setIsCreateViewBasedReportModalOpen}
                     query={getRegexScopedQueryString(deploymentScopedSearchFilterForReport)}
                     areaOfConcern={viewContext}
+                    runViewBasedReport={runImageViewBasedReport}
+                    vulnerabilityViewBasedJobsPath={vulnerabilityImageViewBasedJobsPath}
                 />
             )}
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -35,6 +35,8 @@ import useURLSearch from 'hooks/useURLSearch';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import type { GenerateSbomImageParams } from 'services/ImageSbomService';
 import type { VulnerabilityState } from 'types/cve.proto';
+import { runImageViewBasedReport } from 'services/ReportsService';
+import { vulnerabilityImageViewBasedJobsPath } from 'routePaths';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
 import GenerateSbomModal, {
@@ -58,7 +60,7 @@ import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import type { defaultColumns as deploymentResourcesDefaultColumns } from './DeploymentResourceTable';
 import { createScheduledReportForImageVulnerabilitiesURL } from '../../Reports/ImageVulnerabilityReports/imageVulnerabilityReports.utils';
 import CreateReportDropdown from '../components/CreateReportDropdown';
-import CreateViewBasedReportModal from '../components/CreateViewBasedReportModal';
+import CreateViewBasedReportModal from '../../components/CreateViewBasedReportModal';
 
 const imageDetailsQuery = gql`
     ${imageDetailsFragment}
@@ -386,6 +388,8 @@ function ImagePage({
                     setIsOpen={setIsCreateViewBasedReportModalOpen}
                     query={getRegexScopedQueryString(imageScopedSearchFilterForReport)}
                     areaOfConcern={viewContext}
+                    runViewBasedReport={runImageViewBasedReport}
+                    vulnerabilityViewBasedJobsPath={vulnerabilityImageViewBasedJobsPath}
                 />
             )}
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -34,7 +34,9 @@ import type { SearchFilter } from 'types/search';
 import { useIsFirstRender } from 'hooks/useIsFirstRender';
 import { hideColumnIf } from 'hooks/useManagedColumns';
 import useURLSort from 'hooks/useURLSort';
+import { runImageViewBasedReport } from 'services/ReportsService';
 import type { VulnerabilityState } from 'types/cve.proto';
+import { vulnerabilityImageViewBasedJobsPath } from 'routePaths';
 
 import { searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport } from '../../searchFilterConfig';
 import { isVulnMgmtLocalStorage, workloadEntityTabValues } from '../../types';
@@ -63,7 +65,7 @@ import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import DefaultFilterModal from '../components/DefaultFilterModal';
 import CreateReportDropdown from '../components/CreateReportDropdown';
-import CreateViewBasedReportModal from '../components/CreateViewBasedReportModal';
+import CreateViewBasedReportModal from '../../components/CreateViewBasedReportModal';
 import { imageListQuery } from '../Tables/ImageOverviewTable';
 import { createScheduledReportForImageVulnerabilitiesURL } from '../../Reports/ImageVulnerabilityReports/imageVulnerabilityReports.utils';
 import useHasRequestExceptionsAbility from '../../hooks/useHasRequestExceptionsAbility';
@@ -483,6 +485,8 @@ function WorkloadCvesOverviewPage() {
                         setIsOpen={setIsCreateViewBasedReportModalOpen}
                         query={workloadCvesScopedQueryString}
                         areaOfConcern={viewContext}
+                        runViewBasedReport={runImageViewBasedReport}
+                        vulnerabilityViewBasedJobsPath={vulnerabilityImageViewBasedJobsPath}
                     />
                 )}
             </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CreateViewBasedReportModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CreateViewBasedReportModal.tsx
@@ -3,9 +3,8 @@ import { Alert, Button, Flex, FlexItem } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core/deprecated';
 import { Link } from 'react-router-dom';
 
-import { runViewBasedReport } from 'services/ReportsService';
-import { vulnerabilityViewBasedJobsPath } from 'routePaths';
 import useAnalytics, { VIEW_BASED_REPORT_GENERATED } from 'hooks/useAnalytics';
+import type { RunReportResponseViewBased } from 'services/ReportsService.types';
 
 type Message =
     | {
@@ -27,6 +26,14 @@ export type CreateViewBasedReportModalProps = {
     setIsOpen: (value: boolean) => void;
     query: string;
     areaOfConcern: string;
+    runViewBasedReport: ({
+        query,
+        areaOfConcern,
+    }: {
+        query: string;
+        areaOfConcern: string;
+    }) => Promise<RunReportResponseViewBased>;
+    vulnerabilityViewBasedJobsPath: string;
 };
 
 function CreateViewBasedReportModal({
@@ -34,6 +41,8 @@ function CreateViewBasedReportModal({
     setIsOpen,
     query,
     areaOfConcern,
+    runViewBasedReport,
+    vulnerabilityViewBasedJobsPath,
 }: CreateViewBasedReportModalProps) {
     const { analyticsTrack } = useAnalytics();
     const [isTriggeringReportGeneration, setIsTriggeringReportGeneration] = useState(false);

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -101,7 +101,7 @@ export const vulnerabilitiesViewPath = `${vulnerabilitiesBasePath}/results/:view
 export const vulnerabilityReportsPath = `${vulnerabilitiesBasePath}/reports`;
 export const vulnerabilityImageReportsPath = `${vulnerabilityReportsPath}/images`;
 export const vulnerabilityConfigurationsReportsPath = `${vulnerabilityImageReportsPath}/configurations`;
-export const vulnerabilityViewBasedJobsPath = `${vulnerabilityImageReportsPath}/view-based-jobs`;
+export const vulnerabilityImageViewBasedJobsPath = `${vulnerabilityImageReportsPath}/view-based-jobs`;
 
 export const vulnerabilityNodeReportsPath = `${vulnerabilityReportsPath}/nodes`;
 export const vulnerabilityNodeConfigurationsReportsPath = `${vulnerabilityNodeReportsPath}/configurations`;

--- a/ui/apps/platform/src/services/NodeReportsService.ts
+++ b/ui/apps/platform/src/services/NodeReportsService.ts
@@ -13,6 +13,8 @@ import axios from './instance';
 import type {
     NodeViewBasedReportSnapshot,
     NodeVulnerabilityReportConfiguration,
+    ReportRequestViewBased,
+    RunReportResponseViewBased,
 } from './ReportsService.types';
 import type { Empty } from './types';
 
@@ -119,6 +121,25 @@ export function deleteNodeReportConfiguration(reportId: string): Promise<Empty> 
 // View-based jobs
 
 // PostViewBasedNodeReport
+export function runNodeViewBasedReport({
+    query,
+    areaOfConcern,
+}: {
+    query: string;
+    areaOfConcern: string;
+}): Promise<RunReportResponseViewBased> {
+    const requestBody: ReportRequestViewBased = {
+        type: 'NODE_VULNERABILITY',
+        viewBasedVulnReportFilters: {
+            query,
+        },
+        areaOfConcern, // 'Nodes' for analytics ony
+    };
+
+    return axios
+        .post<RunReportResponseViewBased>('/v2/reports/node/view-based/run', requestBody)
+        .then((response) => response.data);
+}
 
 // GetViewBasedNodeReportHistory
 export function getViewBasedNodeReportHistory({

--- a/ui/apps/platform/src/services/NodeReportsService.ts
+++ b/ui/apps/platform/src/services/NodeReportsService.ts
@@ -130,7 +130,7 @@ export function runNodeViewBasedReport({
 }): Promise<RunReportResponseViewBased> {
     const requestBody: ReportRequestViewBased = {
         type: 'NODE_VULNERABILITY',
-        viewBasedVulnReportFilters: {
+        nodeVulnReportFilters: {
             query,
         },
         areaOfConcern, // 'Nodes' for analytics ony

--- a/ui/apps/platform/src/services/ReportsService.ts
+++ b/ui/apps/platform/src/services/ReportsService.ts
@@ -215,7 +215,7 @@ export function fetchViewBasedReportHistory({
 }
 
 // PostViewBasedReport
-export function runViewBasedReport({
+export function runImageViewBasedReport({
     query,
     areaOfConcern,
 }: {

--- a/ui/apps/platform/src/services/ReportsService.types.ts
+++ b/ui/apps/platform/src/services/ReportsService.types.ts
@@ -323,11 +323,21 @@ export type RunReportResponse = {
     reportId: string;
 };
 
-export type ReportRequestViewBased = {
-    type: ReportType;
+export type ImageReportRequestViewBased = {
+    type: 'VULNERABILITY';
     viewBasedVulnReportFilters: ViewBasedVulnerabilityReportFilters;
     areaOfConcern: string;
 };
+
+export type NodeReportRequestViewBased = {
+    type: 'NODE_VULNERABILITY';
+    // Although backend proto has NodeVulnerabilityReportFilters type,
+    // only query is relevant for view-based report.
+    nodeVulnReportFilters: ViewBasedVulnerabilityReportFilters;
+    areaOfConcern: string; // 'Nodes'
+};
+
+export type ReportRequestViewBased = ImageReportRequestViewBased | NodeReportRequestViewBased;
 
 export type RunReportResponseViewBased = {
     reportID: string;


### PR DESCRIPTION
## Description

### Objective

Follow pattern of image vulnerability reports for node vulnerability reports.

### Analysis

1. CreateReportDropdown.tsx file is theoretically reusable, BUT in worst case in which only one item is released, there would be a last-minute change to copy the file, instead of a lats-minute change to comment out an item.

2. CreateViewBasedReportModal.tsx file is reusable if the following become props:

    * `runViewBasedReport`
    * `vulnerabilityViewBasedJobsPath`

    Note that `areaOfConcern` is already a prop.

### Solution

1. Copy the component from from WorkloadCves/components to NodeCves/components folder.

2. Move the genralized modal component to Vulnerabilities/components folder.

3. Add button and modal elements in **Results** pages:

    * NodeCvesOverviewPage.tsx file

4. Because in changed files anyway, rename to add **Image** infix:

    * `runImageViewBasedReport`
    * `vulnerabilityImageViewBasedJobsPath`

5. Add `createScheduledReportForNodeVulnerabilitiesURL` function to utils file.

6. Add `runNodeViewBasedReport` function to NodeReportsService.ts file.

### Residue

1. Factor out the reusable component to Vulnerabilities/components folder.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /vulnerabilities/node-cves with `'ROX_NODE_VULNERABILITY_REPORTS'` feature flag disabled.

    See absence of **Create report** button.
    <img width="1440" height="640" alt="CVEs_absence" src="https://github.com/user-attachments/assets/6f27a2c6-844d-4103-a0da-824ac2b8e436" />

2. Temporarily edit code to enable `'ROX_NODE_VULNERABILITY_REPORTS'` feature flag.

    See presence of **Create report** button.
    <img width="1440" height="640" alt="CVEs_presence" src="https://github.com/user-attachments/assets/c88a3399-78ef-4aba-bbe1-a524c807f7ed" />

3. Select search filters, click **Create report**, and then click **Create scheduled report**

    Navigate to correct path, but do not see wizard because feature flag is not really enabled, not to mention that wizard code is not yet merged.

    /main/vulnerabilities/reports/nodes/configurations?action=createFromFilters&s[Severity]=CRITICAL_VULNERABILITY_SEVERITY&s[Severity]=IMPORTANT_VULNERABILITY_SEVERITY&s[Fixable]=true

4. Go back, click **Nodes** toggle to see **Create report** button!
