### PR TITLE
ROX-36103: Node reporting view based jobs

### DIFF
--- a/ui/apps/platform/src/Components/ReportJob/MyLastJobStatus.test.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/MyLastJobStatus.test.tsx
@@ -8,6 +8,7 @@ import type { ReportStatus } from 'types/reportJob';
 import MyLastJobStatus from './MyLastJobStatus';
 
 const baseReportSnapshot: Omit<ConfiguredReportSnapshot, 'reportStatus' | 'isDownloadAvailable'> = {
+    type: 'VULNERABILITY',
     reportConfigId: 'report-config-id-1',
     reportJobId: 'report-job-id-1',
     name: 'test-name-1',

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobStatusFilter.test.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobStatusFilter.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
-import ReportJobStatusFilter, { ensureReportJobStatuses } from './ReportJobStatusFilter';
+import ReportJobStatusFilter, { isReportJobStatus } from './ReportJobStatusFilter';
 import type { ReportJobStatus } from './types';
 
 const getCheckboxOption = (name: string) => {
@@ -93,22 +93,17 @@ describe('ReportJobStatusFilter', () => {
         expect(checkboxOptionForError).toBeChecked();
     });
 
-    // Tests for the "ensureReportJobStatuses" helper function
-    describe('ensureReportJobStatuses', () => {
+    // Tests for the "isReportJobStatus" helper function
+    describe('isReportJobStatus', () => {
         test('should filter out all incorrect values', async () => {
-            expect(ensureReportJobStatuses('')).toEqual([]);
-            expect(ensureReportJobStatuses(['TEST', 'BLAH', 'LOADING'])).toEqual([]);
+            expect(['TEST', 'BLAH', 'LOADING'].filter(isReportJobStatus)).toEqual([]);
         });
 
         test('should filter to show all correct values', async () => {
             expect(
-                ensureReportJobStatuses([
-                    'PREPARING',
-                    'WAITING',
-                    'DOWNLOAD_GENERATED',
-                    'EMAIL_DELIVERED',
-                    'ERROR',
-                ])
+                ['PREPARING', 'WAITING', 'DOWNLOAD_GENERATED', 'EMAIL_DELIVERED', 'ERROR'].filter(
+                    isReportJobStatus
+                )
             ).toEqual(['PREPARING', 'WAITING', 'DOWNLOAD_GENERATED', 'EMAIL_DELIVERED', 'ERROR']);
         });
     });

--- a/ui/apps/platform/src/Components/ReportJob/ReportJobStatusFilter.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/ReportJobStatusFilter.tsx
@@ -5,30 +5,8 @@ import CheckboxSelect from 'Components/CheckboxSelect';
 import { reportJobStatusLabels, reportJobStatuses } from './types';
 import type { ReportJobStatus } from './types';
 
-function isReportJobStatus(value: string): value is ReportJobStatus {
+export function isReportJobStatus(value: string): value is ReportJobStatus {
     return value in reportJobStatuses;
-}
-
-/**
- * Ensures that the given search filter value is converted to an array of valid report job status values.
- *
- * Example:
- * ensureReportJobStatuses(["WAITING", "PREPARING"]);  // returns ["WAITING", "PREPARING"]
- * ensureReportJobStatuses("WAITING");                 // returns [] (since input is not an array)
- * ensureReportJobStatuses(undefined);                 // returns []
- *
- * @param searchFilterValue - The input value, which can be a string, an array of strings, or undefined.
- * @returns {ReportJobStatus[]} - If the input is an array of strings, it filters the values that match valid "ReportJobStatus"s
- *                         and returns them as an array.
- *                         If the input is not an array or undefined, it returns an empty array.
- */
-export function ensureReportJobStatuses(
-    searchFilterValue: string | string[] | undefined
-): ReportJobStatus[] {
-    if (Array.isArray(searchFilterValue)) {
-        return searchFilterValue.filter((value) => isReportJobStatus(value));
-    }
-    return [];
 }
 
 export type ReportJobStatusFilterProps = {

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/components/ReportJobs.tsx
@@ -31,7 +31,7 @@ import { getTableUIState } from 'utils/getTableUIState';
 import useDeleteDownloadModal from 'Containers/Vulnerabilities/VulnerablityReporting/hooks/useDeleteDownloadModal';
 import DeleteModal from 'Components/PatternFly/DeleteModal';
 import ReportJobStatusFilter, {
-    ensureReportJobStatuses,
+    isReportJobStatus,
 } from 'Components/ReportJob/ReportJobStatusFilter';
 import MyJobsFilter from 'Components/ReportJob/MyJobsFilter';
 import type { ReportJobStatus } from 'Components/ReportJob/types';
@@ -45,7 +45,7 @@ function getConfigName(snapshot: ComplianceReportSnapshot) {
     return snapshot.name;
 }
 
-function createQueryFromReportJobStatusFilters(jobStatusFilters: string[]) {
+function createQueryFromReportJobStatusFilters(reportJobStatuses: ReportJobStatus[]) {
     const query: Record<string, string[]> = {
         'Compliance Report State': [],
         'Compliance Report Notification Method': [],
@@ -69,8 +69,6 @@ function createQueryFromReportJobStatusFilters(jobStatusFilters: string[]) {
             value: 'PARTIAL_SCAN_ERROR_EMAIL',
         },
     };
-
-    const reportJobStatuses = ensureReportJobStatuses(jobStatusFilters);
 
     reportJobStatuses.forEach((jobStatus) => {
         const queryMapping = jobStatusQueryMappings[jobStatus];
@@ -103,7 +101,9 @@ function ReportJobs({ scanConfigId }: ReportJobsProps) {
         'true',
     ]);
 
-    const reportJobStatusFilters = ensureStringArray(searchFilter['Compliance Report Job Status']);
+    const reportJobStatusFilters = ensureStringArray(
+        searchFilter['Compliance Report Job Status']
+    ).filter(isReportJobStatus);
 
     const query = getRequestQueryStringForSearchFilter({
         ...createQueryFromReportJobStatusFilters(reportJobStatusFilters),
@@ -151,10 +151,8 @@ function ReportJobs({ scanConfigId }: ReportJobsProps) {
     const onReportJobStatusFilterChange = (_checked: boolean, selectedStatus: ReportJobStatus) => {
         const isStatusIncluded = reportJobStatusFilters.includes(selectedStatus);
         const newFilters = isStatusIncluded
-            ? ensureReportJobStatuses(
-                  reportJobStatusFilters.filter((status) => status !== selectedStatus)
-              )
-            : ensureReportJobStatuses([...reportJobStatusFilters, selectedStatus]);
+            ? reportJobStatusFilters.filter((status) => status !== selectedStatus)
+            : [...reportJobStatusFilters, selectedStatus];
         analyticsTrack({
             event: 'Compliance Report Job Status Filtered',
             properties: {
@@ -197,7 +195,7 @@ function ReportJobs({ scanConfigId }: ReportJobsProps) {
                                 'PARTIAL_SCAN_ERROR_EMAIL',
                                 'ERROR',
                             ]}
-                            selectedStatuses={ensureReportJobStatuses(reportJobStatusFilters)}
+                            selectedStatuses={reportJobStatusFilters}
                             onChange={onReportJobStatusFilterChange}
                         />
                     </ToolbarItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsPage.tsx
@@ -4,6 +4,7 @@ import usePermissions from 'hooks/usePermissions';
 
 import NodeConfigurationsList from './Configurations/NodeConfigurationsList';
 import NodeVulnerabilityReportsLayout from './NodeVulnerabilityReportsLayout';
+import NodeViewBasedJobsPage from './ViewBasedJobs/NodeViewBasedJobsPage';
 
 function NodeVulnerabilityReportsPage() {
     const { hasReadAccess } = usePermissions();
@@ -23,7 +24,7 @@ function NodeVulnerabilityReportsPage() {
                         )
                     }
                 />
-                <Route path="view-based-jobs" element={<div>View-based reports</div>} />
+                <Route path="view-based-jobs" element={<NodeViewBasedJobsPage />} />
             </Route>
         </Routes>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/ViewBasedJobs/NodeViewBasedJobsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/ViewBasedJobs/NodeViewBasedJobsPage.tsx
@@ -9,59 +9,40 @@ import {
     useInterval,
 } from '@patternfly/react-core';
 
-import { getTableUIState } from 'utils/getTableUIState';
-import { ensureBoolean, ensureStringArray } from 'utils/ensure';
-import { toggleItemInArray } from 'utils/arrayUtils';
-import { createFilterTracker } from 'utils/analyticsEventTracking';
-import useRestQuery from 'hooks/useRestQuery';
-import useURLPagination from 'hooks/useURLPagination';
-import useURLSort from 'hooks/useURLSort';
-import useURLSearch from 'hooks/useURLSearch';
-import useURLStringUnion from 'hooks/useURLStringUnion';
-import { fetchViewBasedReportHistory } from 'services/ReportsService';
 import PageTitle from 'Components/PageTitle';
+import MyJobsFilter from 'Components/ReportJob/MyJobsFilter';
 import ReportJobStatusFilter, {
     isReportJobStatus,
 } from 'Components/ReportJob/ReportJobStatusFilter';
-import MyJobsFilter from 'Components/ReportJob/MyJobsFilter';
 import type { ReportJobStatus } from 'Components/ReportJob/types';
-import useAnalytics, { VIEW_BASED_REPORT_FILTER_APPLIED } from 'hooks/useAnalytics';
-import ViewBasedReportsTable from './ViewBasedReportsTable';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import {
+    getViewBasedMyNodeReportHistory,
+    getViewBasedNodeReportHistory,
+} from 'services/NodeReportsService';
+import { toggleItemInArray } from 'utils/arrayUtils';
+import { ensureBoolean, ensureStringArray } from 'utils/ensure';
+import { getTableUIState } from 'utils/getTableUIState';
+
+import NodeViewBasedReportsTable from './NodeViewBasedJobsTable';
 
 const sortOptions = {
     sortFields: ['Report Completion Time'],
     defaultSortOption: { field: 'Report Completion Time', direction: 'desc' } as const,
 };
 
-function createQueryFromReportJobStatusFilters(reportJobStatuses: ReportJobStatus[]) {
-    const query: Record<string, string[]> = {
-        'Report State': [],
-    };
+const reportStateByJobStatus: Partial<Record<ReportJobStatus, string>> = {
+    WAITING: 'WAITING',
+    PREPARING: 'PREPARING',
+    ERROR: 'FAILURE',
+    DOWNLOAD_GENERATED: 'GENERATED',
+};
 
-    const jobStatusQueryMappings: Record<string, { category: string; value: string }> = {
-        PREPARING: { category: 'Report State', value: 'PREPARING' },
-        WAITING: { category: 'Report State', value: 'WAITING' },
-        ERROR: { category: 'Report State', value: 'FAILURE' },
-        DOWNLOAD_GENERATED: {
-            category: 'Report State',
-            value: 'GENERATED',
-        },
-    };
-
-    reportJobStatuses.forEach((jobStatus) => {
-        const queryMapping = jobStatusQueryMappings[jobStatus];
-        if (queryMapping) {
-            const { category, value } = queryMapping;
-            query[category].push(value);
-        }
-    });
-
-    return query;
-}
-
-function ViewBasedReportsTab() {
-    const { analyticsTrack } = useAnalytics();
-    const trackAppliedFilter = createFilterTracker(analyticsTrack);
+function NodeViewBasedJobsPage() {
     const { page, perPage, setPage, setPerPage } = useURLPagination(10);
     const { sortOption, getSortParams } = useURLSort(sortOptions);
     const { searchFilter, setSearchFilter } = useURLSearch();
@@ -74,23 +55,30 @@ function ViewBasedReportsTab() {
         return ensureStringArray(searchFilter['Report Job Status']).filter(isReportJobStatus);
     }, [searchFilter]);
 
-    const fetchViewBasedReportsHistoryCallback = useCallback(() => {
-        const modifiedSearchFilter = {
-            ...createQueryFromReportJobStatusFilters(reportJobStatusFilters),
-        };
+    const fetchViewBasedNodeReportsHistoryCallback = useCallback(() => {
+        const fetchHistory =
+            isViewingOnlyMyJobs === 'true'
+                ? getViewBasedMyNodeReportHistory
+                : getViewBasedNodeReportHistory;
 
-        return fetchViewBasedReportHistory({
-            searchFilter: modifiedSearchFilter,
+        return fetchHistory({
+            searchFilter: {
+                'Report State': reportJobStatusFilters.flatMap(
+                    (status) => reportStateByJobStatus[status] ?? []
+                ),
+            },
             page,
             perPage,
             sortOption,
-            showMyHistory: isViewingOnlyMyJobs === 'true',
         });
     }, [reportJobStatusFilters, page, perPage, sortOption, isViewingOnlyMyJobs]);
 
-    const { data, isLoading, error, refetch } = useRestQuery(fetchViewBasedReportsHistoryCallback, {
-        clearErrorBeforeRequest: false,
-    });
+    const { data, isLoading, error, refetch } = useRestQuery(
+        fetchViewBasedNodeReportsHistoryCallback,
+        {
+            clearErrorBeforeRequest: false,
+        }
+    );
 
     const tableState = getTableUIState({
         isLoading,
@@ -100,51 +88,25 @@ function ViewBasedReportsTab() {
         isPolling: true,
     });
 
-    const onReportJobStatusFilterChange = (checked: boolean, selectedStatus: ReportJobStatus) => {
-        const newFilters = toggleItemInArray(
-            reportJobStatusFilters,
-            selectedStatus,
-            (a, b) => a === b
-        );
+    const onReportJobStatusFilterChange = (_checked: boolean, selectedStatus: ReportJobStatus) => {
+        const newFilters = toggleItemInArray(reportJobStatusFilters, selectedStatus);
         setSearchFilter({
             ...searchFilter,
             'Report Job Status': newFilters,
         });
         setPage(1);
-
-        // Track filter interaction for additions only
-        if (checked) {
-            trackAppliedFilter(VIEW_BASED_REPORT_FILTER_APPLIED, [
-                {
-                    action: 'SELECT_INCLUSIVE',
-                    category: 'Report Job Status',
-                    value: selectedStatus,
-                },
-            ]);
-        }
     };
 
     const onMyJobsFilterChange = (checked: boolean) => {
         setIsViewingOnlyMyJobs(String(checked));
         setPage(1);
-
-        // Track filter interaction for enabling my jobs only
-        if (checked) {
-            trackAppliedFilter(VIEW_BASED_REPORT_FILTER_APPLIED, [
-                {
-                    action: 'SELECT_INCLUSIVE',
-                    category: 'My Jobs',
-                    value: 'true',
-                },
-            ]);
-        }
     };
 
     useInterval(refetch, 10000);
 
     return (
         <>
-            <PageTitle title="Image vulnerability reports - View-based jobs" />
+            <PageTitle title="Node vulnerability reports - View-based jobs" />
             <PageSection>
                 <Content component="p">
                     Check job status and download view-based reports in CSV format. Jobs are purged
@@ -166,7 +128,7 @@ function ViewBasedReportsTab() {
                                 onChange={onReportJobStatusFilterChange}
                             />
                         </ToolbarItem>
-                        <ToolbarItem className="pf-v6-u-flex-grow-1" alignSelf="center">
+                        <ToolbarItem alignSelf="center">
                             <MyJobsFilter
                                 isViewingOnlyMyJobs={ensureBoolean(isViewingOnlyMyJobs)}
                                 onMyJobsFilterChange={onMyJobsFilterChange}
@@ -192,7 +154,7 @@ function ViewBasedReportsTab() {
                         </ToolbarItem>
                     </ToolbarContent>
                 </Toolbar>
-                <ViewBasedReportsTable
+                <NodeViewBasedReportsTable
                     tableState={tableState}
                     getSortParams={getSortParams}
                     onClearFilters={() => {
@@ -205,4 +167,4 @@ function ViewBasedReportsTab() {
     );
 }
 
-export default ViewBasedReportsTab;
+export default NodeViewBasedJobsPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/ViewBasedJobs/NodeViewBasedJobsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/ViewBasedJobs/NodeViewBasedJobsTable.tsx
@@ -1,0 +1,89 @@
+import { Link } from 'react-router-dom-v5-compat';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import ReportJobStatus from 'Components/ReportJob/ReportJobStatus';
+import { onDownloadReport } from 'Components/ReportJob/utils';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useAuthStatus from 'hooks/useAuthStatus';
+import type { GetSortParams } from 'hooks/useURLSort';
+import { vulnerabilitiesNodeCvesPath } from 'routePaths';
+import type { NodeViewBasedReportSnapshot } from 'services/ReportsService.types';
+import { getDateTime } from 'utils/dateUtils';
+import type { TableUIState } from 'utils/getTableUIState';
+
+export type NodeViewBasedJobsTableProps = {
+    tableState: TableUIState<NodeViewBasedReportSnapshot>;
+    getSortParams: GetSortParams;
+    onClearFilters: () => void;
+};
+
+function NodeViewBasedJobsTable({
+    tableState,
+    getSortParams,
+    onClearFilters,
+}: NodeViewBasedJobsTableProps) {
+    const { currentUser } = useAuthStatus();
+
+    return (
+        <Table aria-label="Node view-based jobs table">
+            <Thead>
+                <Tr>
+                    <Th width={20}>Job name</Th>
+                    <Th>Requester</Th>
+                    <Th>Job status</Th>
+                    <Th sort={getSortParams('Report Completion Time')}>Completed</Th>
+                </Tr>
+            </Thead>
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={4}
+                emptyProps={{
+                    title: 'No view-based jobs found',
+                    message:
+                        'From the Node CVEs page, select "Export report as CSV" to generate a view-based report.',
+                    children: <Link to={vulnerabilitiesNodeCvesPath}>Go to Node CVEs</Link>,
+                }}
+                filteredEmptyProps={{ onClearFilters }}
+                renderer={({ data }) =>
+                    data.map((snapshot) => {
+                        const { user, reportStatus, isDownloadAvailable, reportJobId, name } =
+                            snapshot;
+                        const areDownloadActionsDisabled = currentUser.userId !== user.id;
+
+                        return (
+                            <Tbody key={reportJobId}>
+                                <Tr>
+                                    <Td dataLabel="Job name">{name}</Td>
+                                    <Td dataLabel="Requester">{user.name}</Td>
+                                    <Td dataLabel="Job status">
+                                        <ReportJobStatus
+                                            reportStatus={reportStatus}
+                                            isDownloadAvailable={isDownloadAvailable}
+                                            areDownloadActionsDisabled={areDownloadActionsDisabled}
+                                            onDownload={() =>
+                                                onDownloadReport({
+                                                    reportJobId,
+                                                    name,
+                                                    completedAt: reportStatus.completedAt,
+                                                    baseDownloadURL:
+                                                        '/api/reports/node/jobs/download',
+                                                })
+                                            }
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Completed">
+                                        {reportStatus.completedAt
+                                            ? getDateTime(reportStatus.completedAt)
+                                            : '-'}
+                                    </Td>
+                                </Tr>
+                            </Tbody>
+                        );
+                    })
+                }
+            />
+        </Table>
+    );
+}
+
+export default NodeViewBasedJobsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTable.tsx
@@ -96,7 +96,7 @@ function ViewBasedReportsTable<T extends ViewBasedReportSnapshot>({
             <Table aria-label="View-based jobs table">
                 <Thead>
                     <Tr>
-                        <Th width={20}>Job ID</Th>
+                        <Th width={20}>Job name</Th>
                         <Th>Requester</Th>
                         <Th>Job status</Th>
                         <Th sort={getSortParams('Report Completion Time')}>Completed</Th>
@@ -119,7 +119,7 @@ function ViewBasedReportsTable<T extends ViewBasedReportSnapshot>({
                             return (
                                 <Tbody key={reportJobId}>
                                     <Tr>
-                                        <Td dataLabel="Job ID">
+                                        <Td dataLabel="Job name">
                                             <Button
                                                 variant="link"
                                                 isInline

--- a/ui/apps/platform/src/services/NodeReportsService.ts
+++ b/ui/apps/platform/src/services/NodeReportsService.ts
@@ -1,13 +1,20 @@
 import queryString from 'qs';
 
 import type { SearchFilter, SearchQueryOptions } from 'types/search';
-import { getListQueryParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+import {
+    buildNestedRawQueryParams,
+    getListQueryParams,
+    getRequestQueryStringForSearchFilter,
+} from 'utils/searchUtils';
 
 import { makeCancellableAxiosRequest } from './cancellationUtils';
 import type { CancellableRequest } from './cancellationUtils';
-import type { NodeVulnerabilityReportConfiguration } from './ReportsService.types';
-import type { Empty } from './types';
 import axios from './instance';
+import type {
+    NodeViewBasedReportSnapshot,
+    NodeVulnerabilityReportConfiguration,
+} from './ReportsService.types';
+import type { Empty } from './types';
 
 // https://github.com/stackrox/stackrox/blob/master/proto/api/v2/node_report_service.proto
 
@@ -114,7 +121,39 @@ export function deleteNodeReportConfiguration(reportId: string): Promise<Empty> 
 // PostViewBasedNodeReport
 
 // GetViewBasedNodeReportHistory
+export function getViewBasedNodeReportHistory({
+    searchFilter,
+    page,
+    perPage,
+    sortOption,
+}: SearchQueryOptions): Promise<NodeViewBasedReportSnapshot[]> {
+    const params = buildNestedRawQueryParams(
+        { searchFilter, page, perPage, sortOption },
+        'reportParamQuery'
+    );
+
+    return axios
+        .get<{
+            reportSnapshots: NodeViewBasedReportSnapshot[];
+        }>(`/v2/reports/node/view-based/history?${params}`)
+        .then((response) => response.data?.reportSnapshots ?? []);
+}
 
 // GetViewBasedMyNodeReportHistory
+export function getViewBasedMyNodeReportHistory({
+    searchFilter,
+    page,
+    perPage,
+    sortOption,
+}: SearchQueryOptions): Promise<NodeViewBasedReportSnapshot[]> {
+    const params = buildNestedRawQueryParams(
+        { searchFilter, page, perPage, sortOption },
+        'reportParamQuery'
+    );
 
-// Job download
+    return axios
+        .get<{
+            reportSnapshots: NodeViewBasedReportSnapshot[];
+        }>(`/v2/reports/node/view-based/my-history?${params}`)
+        .then((response) => response.data?.reportSnapshots ?? []);
+}

--- a/ui/apps/platform/src/services/ReportsService.types.ts
+++ b/ui/apps/platform/src/services/ReportsService.types.ts
@@ -271,11 +271,17 @@ export type ReportHistoryResponse = {
 };
 
 export type ViewBasedReportSnapshot = Snapshot & {
+    type: 'VULNERABILITY';
     viewBasedVulnReportFilters: ViewBasedVulnerabilityReportFilters;
     areaOfConcern: string;
 };
 
-// TODO temporary disjunction until snapshot has type property.
+export type NodeViewBasedReportSnapshot = Snapshot & {
+    type: 'NODE_VULNERABILITY';
+    nodeVulnReportFilters: NodeVulnerabilityReportFilters;
+    areaOfConcern: string;
+};
+
 type VulnerabilityReportFilters =
     | NodeVulnerabilityReportFilters
     | ImageVulnerabilityReportFiltersForCollection
@@ -283,6 +289,7 @@ type VulnerabilityReportFilters =
 
 // TODO distinguish configured versus view-based instead of combining them.
 export type ConfiguredReportSnapshot = Snapshot & {
+    type: ReportType;
     reportConfigId: string;
     vulnReportFilters: VulnerabilityReportFilters;
     collectionSnapshot: CollectionSnapshot;
@@ -290,7 +297,10 @@ export type ConfiguredReportSnapshot = Snapshot & {
     notifiers: NotifierConfiguration[];
 };
 
-export type ReportSnapshot = ConfiguredReportSnapshot | ViewBasedReportSnapshot;
+export type ReportSnapshot =
+    | ConfiguredReportSnapshot
+    | ViewBasedReportSnapshot
+    | NodeViewBasedReportSnapshot;
 
 // Type guard functions
 


### PR DESCRIPTION
## Description

Adds the Node vulnerability view-based jobs list

Notes and potential tech debt tasks:
- Removed `ensureReportJobStatuses`. It was re-validating an already valid array every time it got read (3x per component). Now it just gets validated once at the source instead. Did the same cleanup on Image and Compliance since they had the exact same pattern.
- Download isn't actually backed by a proto RPC, it's just a raw HTTP route with its own permission check (Node vs Image) so I left it out of the `ReportsService` file. Also found we already have 3+ different implementations of "download report by job id" floating around. Reused the existing generic one (`onDownloadReport`).
- Didn't add analytics tracking to the Node page. Analytics is broken on image view based jobs page, our allow list strips out the actual filter value before it ever reaches analytics. Left Image alone for now, probably needs a follow up.
- Removed `createQueryFromReportJobStatusFilters` from Node only since it collapsed down to basically one line (only one search category involved). Left Image as is to keep this PR scoped down. Compliance needs to keep its own version since it spans two categories, not one.
- Compliance shares `ReportJobStatusFilter`/`ReportJobStatus` with Image/Node right now, but they're actually backed by two different backend enums that only partially overlap and happen to share the same name. Not touching that here, but should probably be split out on a separate branch later.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Tested against a local mock server (filters, pagination, empty state, download)

#### Default view
<img width="1233" height="650" alt="Screenshot 2026-09-01 at 7 34 41 PM" src="https://github.com/user-attachments/assets/e76bf525-2dea-4098-924a-5ec77a4ae375" />

---

#### Job status filter (Waiting/Prepared)
<img width="1233" height="668" alt="Screenshot 2026-09-01 at 7 35 03 PM" src="https://github.com/user-attachments/assets/0fe91e39-82a6-426a-b2d9-a82c535e38fe" />

---

#### Only my jobs filter
<img width="1233" height="668" alt="Screenshot 2026-09-01 at 7 34 54 PM" src="https://github.com/user-attachments/assets/5e407588-b61a-4d22-9055-cf0d24cca8c6" />
