### PR TITLE
ROX-36695: Enable Scanner V4 in GHA e2e tests

### DIFF
--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -45,7 +45,6 @@ jobs:
       SCANNER_V4_DB_STORAGE_CLASS: faster
       STORAGE: pvc
       STORAGE_CLASS: faster
-      ROX_SCANNER_V4: "false"
       PYTHONUNBUFFERED: "1"
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
## Description

Enable Scanner V4 in GHA e2e tests. 

`SCANNER_V4_MATCHER_READINESS` and `SCANNER_V4_MATCHER_VULN_BUNDLE_ALLOWLIST` (`SCANNER_V4_VULN_READINESS`) will be set following the same rules as the base CI shell scripts used by the equiv prow jobs:

https://github.com/stackrox/stackrox/blob/081b72da79569bab6b332c354eb11a6131bb3eee/tests/e2e/lib.sh#L28

https://github.com/stackrox/stackrox/blob/081b72da79569bab6b332c354eb11a6131bb3eee/tests/e2e/lib.sh#L450



## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI

Job / step timeouts may need to be adjusted given the extra time needed for Scanner V4 to load vulns.

Ongoing, will re-run a few times
- [first run success](https://github.com/stackrox/stackrox/actions/runs/33580044392/job/100093832311?pr=22569)


