### PR TITLE
ROX-36549: Document SBOM scanning API

### DIFF
--- a/central/docs/api_custom_routes/imageService.swagger.json
+++ b/central/docs/api_custom_routes/imageService.swagger.json
@@ -48,6 +48,44 @@
           "ImageService"
         ]
       }
+    },
+    "/api/v1/sboms/scan": {
+      "post": {
+        "summary": "(Technology Preview) Scan an SBOM and return vulnerability scan results.",
+        "description": "Technology Preview feature. The request body is an SPDX 2.3 JSON document. Supported content types are application/spdx+json and text/spdx+json. Caller needs write permission on the Image resource.",
+        "operationId": "ScanSBOM",
+        "consumes": [
+          "application/spdx+json",
+          "text/spdx+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SBOMScanResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SBOM-SPDX23-Document"
+            }
+          }
+        ],
+        "tags": [
+          "ImageService"
+        ]
+      }
     }
   },
   "definitions": {
@@ -121,7 +159,11 @@
                 ]
               }
             }
-          }
+          },
+          "required": [
+            "creators",
+            "created"
+          ]
         },
         "packages": {
           "type": "array",
@@ -174,6 +216,55 @@
               "relationshipType": {
                 "type": "string",
                 "example": "CONTAINED_BY"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "spdxVersion",
+        "dataLicense",
+        "SPDXID",
+        "name",
+        "documentNamespace",
+        "creationInfo"
+      ]
+    },
+    "v1SBOMScanResponse": {
+      "description": "SBOMScanResponse wraps metadata and scan results for an SBOM. Components must be JSON marshal/unmarshal compatible with storage.Image so that output formatting via roxctl is consistent.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The SBOM document ID."
+        },
+        "scan": {
+          "type": "object",
+          "properties": {
+            "scannerVersion": {
+              "type": "string"
+            },
+            "scanTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "components": {
+              "type": "array",
+              "description": "Components with matched vulnerabilities.",
+              "items": {
+                "$ref": "#/definitions/storageEmbeddedImageScanComponent"
+              }
+            },
+            "dataSource": {
+              "type": "object",
+              "description": "Scanner integration that produced the scan.",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/central/docs/api_custom_routes/imageService.swagger.yaml
+++ b/central/docs/api_custom_routes/imageService.swagger.yaml
@@ -30,6 +30,31 @@ paths:
             $ref: '#/definitions/imageSBOMRequest'
       tags:
         - ImageService
+  /api/v1/sboms/scan:
+    post:
+      summary: "(Technology Preview) Scan an SBOM and return vulnerability scan results."
+      description: "Technology Preview feature. The request body is an SPDX 2.3 JSON document. Supported content types are application/spdx+json and text/spdx+json. Caller needs write permission on the Image resource."
+      operationId: ScanSBOM
+      consumes:
+        - application/spdx+json
+        - text/spdx+json
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SBOMScanResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SBOM-SPDX23-Document'
+      tags:
+        - ImageService
 definitions:
   imageSBOMRequest:
     type: object
@@ -82,6 +107,9 @@ definitions:
             items:
               type: string
               example: ["Tool: Claircore-<version>", "Tool: scanner-v4-matcher-<version>"]
+        required:
+        - creators
+        - created
       packages:
         type: array
         items:
@@ -121,6 +149,41 @@ definitions:
             relationshipType:
               type: string
               example: "CONTAINED_BY"
+    required:
+    - spdxVersion
+    - dataLicense
+    - SPDXID
+    - name
+    - documentNamespace
+    - creationInfo
+  v1SBOMScanResponse:
+    description: "SBOMScanResponse wraps metadata and scan results for an SBOM. Components must be JSON marshal/unmarshal compatible with storage.Image so that output formatting via roxctl is consistent."
+    type: object
+    properties:
+      id:
+        type: string
+        description: "The SBOM document ID."
+      scan:
+        type: object
+        properties:
+          scannerVersion:
+            type: string
+          scanTime:
+            type: string
+            format: date-time
+          components:
+            type: array
+            description: "Components with matched vulnerabilities."
+            items:
+              $ref: '#/definitions/storageEmbeddedImageScanComponent'
+          dataSource:
+            type: object
+            description: "Scanner integration that produced the scan."
+            properties:
+              id:
+                type: string
+              name:
+                type: string
   googlerpcStatus:
     type: object
     properties:


### PR DESCRIPTION
## Description

Adds Swagger documentation for the SBOM scanning API.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Deployed stackrox with these changes and checked `/main/apidocs`

<img width="2110" height="1878" alt="CleanShot 2026-09-09 at 15 39 35@2x" src="https://github.com/user-attachments/assets/8f90004d-0e8d-468c-b458-13e26a2a22dd" />
