### PR TITLE
test(queue): reproduce lost wakeup when Push races Reset

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -26,6 +26,9 @@ type Queue[T comparable] struct {
 	queue          *list.List
 	notEmptySignal concurrency.Signal
 	mutex          sync.Mutex
+	// afterEmptyPull runs after pullWait sees an empty queue and before it waits.
+	// Tests inject a Push in that window; production leaves it nil.
+	afterEmptyPull func()
 }
 
 // OptionFunc provides options for the queue.
@@ -124,6 +127,9 @@ func (q *Queue[T]) pullWait(waitable concurrency.Waitable) (T, bool) {
 	// This prevents lost wakeup: if we're signaled but another consumer
 	// takes the item before we pull, we must continue waiting.
 	for !ok {
+		if h := q.afterEmptyPull; h != nil {
+			h()
+		}
 		// Reset stale signal before waiting to prevent spin-loop
 		q.notEmptySignal.Reset()
 		select {

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -500,6 +500,15 @@ func TestQueueSeq(t *testing.T) {
 			return 0
 		})
 	})
+
+	t.Run("Seq Push Between Empty Pull And Reset Does Not Lose Item", func(t *testing.T) {
+		testPushBetweenEmptyPullAndResetDoesNotLoseItem(t, func(q *Queue[int], ctx context.Context) int {
+			for item := range q.Seq(ctx) {
+				return item
+			}
+			return 0
+		})
+	})
 }
 
 func TestQueuePullBlocking(t *testing.T) {
@@ -527,6 +536,12 @@ func TestQueuePullBlocking(t *testing.T) {
 
 	t.Run("PullBlocking Stale Not Empty Signal Does Not Spin", func(t *testing.T) {
 		testStaleNotEmptySignalDoesNotSpin(t, func(q *Queue[int], ctx context.Context) int {
+			return q.PullBlocking(ctx)
+		})
+	})
+
+	t.Run("PullBlocking Push Between Empty Pull And Reset Does Not Lose Item", func(t *testing.T) {
+		testPushBetweenEmptyPullAndResetDoesNotLoseItem(t, func(q *Queue[int], ctx context.Context) int {
 			return q.PullBlocking(ctx)
 		})
 	})
@@ -558,6 +573,38 @@ func testStaleNotEmptySignalDoesNotSpin(t *testing.T, consume func(*Queue[int], 
 			assert.Equal(t, 7, item)
 		default:
 			t.Fatal("consumer should have received the item after blocking")
+		}
+	})
+}
+
+// testPushBetweenEmptyPullAndResetDoesNotLoseItem covers the pullWait window
+// between an empty pull() and Reset(). synctest cannot preempt there, so
+// afterEmptyPull injects the Push.
+func testPushBetweenEmptyPullAndResetDoesNotLoseItem(t *testing.T, consume func(*Queue[int], context.Context) int) {
+	synctest.Test(t, func(t *testing.T) {
+		q := NewQueue[int]()
+		q.afterEmptyPull = func() {
+			q.Push(7)
+			q.afterEmptyPull = nil
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		got := make(chan int, 1)
+		started := make(chan struct{})
+		go func() {
+			close(started)
+			got <- consume(q, ctx)
+		}()
+		<-started
+		synctest.Wait()
+
+		select {
+		case item := <-got:
+			assert.Equal(t, 7, item)
+		default:
+			t.Fatal("Push between empty pull and Reset was lost; item is queued but the waiter is blocked")
 		}
 	})
 }


### PR DESCRIPTION
## Description

Fails on #22456: synctest cannot switch between pullWait's empty pull() and Reset(), so afterEmptyPull injects a Push in that window. Reset then clears the signal while the item is queued.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI