### PR TITLE
ROX-32329: Point nongroovy e2e at Scanner V4 only

### DIFF
--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -39,13 +39,13 @@ jobs:
       LOAD_BALANCER: lb
       ORCHESTRATOR_FLAVOR: k8s
       KUBERNETES_PROVIDER: gke
-      SENSOR_SCANNER_SUPPORT: "true"
+      SENSOR_SCANNER_V4_SUPPORT: "true"
       ROX_DEPLOY_SENSOR_WITH_CRS: "true"
       SENSOR_HELM_MANAGED: "true"
       SCANNER_V4_DB_STORAGE_CLASS: faster
       STORAGE: pvc
       STORAGE_CLASS: faster
-      ROX_SCANNER_V4: "false"
+      ROX_SCANNER_V4: "true"
       PYTHONUNBUFFERED: "1"
     timeout-minutes: 120
     steps:

--- a/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
@@ -19,7 +19,7 @@ os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "faster"
 os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "rhel-vex,stackrox-rhel-csaf,manual,epss,nvd"
 
 # delegated scanning support in the secured cluster
-os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
+os.environ["SENSOR_SCANNER_V4_SUPPORT"] = "true"
 
 # Enable new CRS-based flow for registering secured clusters
 os.environ["ROX_DEPLOY_SENSOR_WITH_CRS"] = "true"

--- a/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
@@ -16,7 +16,7 @@ os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["KUBERNETES_PROVIDER"] = "ocp"
 
 # delegated scanning support in the secured cluster
-os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
+os.environ["SENSOR_SCANNER_V4_SUPPORT"] = "true"
 
 # Enable new CRS-based flow for registering secured clusters
 os.environ["ROX_DEPLOY_SENSOR_WITH_CRS"] = "true"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -39,9 +39,6 @@ POD_CONTAINERS_MAP["pod: central - container: central"]="central-[A-Za-z0-9]+-[A
 POD_CONTAINERS_MAP["pod: central-db - container: init-db"]="central-db-[A-Za-z0-9]+-[A-Za-z0-9]+-init-db-previous.log"
 POD_CONTAINERS_MAP["pod: central-db - container: central-db"]="central-db-[A-Za-z0-9]+-[A-Za-z0-9]+-central-db-previous.log"
 POD_CONTAINERS_MAP["pod: config-controller - container: manager"]="config-controller-[A-Za-z0-9]+-[A-Za-z0-9]+-manager-previous.log"
-POD_CONTAINERS_MAP["pod: scanner - container: scanner"]="scanner-[A-Za-z0-9]+-[A-Za-z0-9]+-scanner-previous.log"
-POD_CONTAINERS_MAP["pod: scanner-db - container: init-db"]="scanner-db-[A-Za-z0-9]+-[A-Za-z0-9]+-init-db-previous.log"
-POD_CONTAINERS_MAP["pod: scanner-db - container: db"]="scanner-db-[A-Za-z0-9]+-[A-Za-z0-9]+-db-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-v4 - container: matcher"]="scanner-v4-[A-Za-z0-9]+-[A-Za-z0-9]+-matcher-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-v4 - container: indexer"]="scanner-v4-[A-Za-z0-9]+-[A-Za-z0-9]+-indexer-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-v4-db - container: init-db"]="scanner-v4-db-[A-Za-z0-9]+-[A-Za-z0-9]+-init-db-previous.log"
@@ -50,7 +47,6 @@ POD_CONTAINERS_MAP["pod: sensor - container: sensor"]="sensor-[A-Za-z0-9]+-[A-Za
 POD_CONTAINERS_MAP["pod: admission-control - container: admission-control"]="admission-control-[A-Za-z0-9]+-[A-Za-z0-9]+-admission-control-previous.log"
 POD_CONTAINERS_MAP["pod: collector - container: collector"]="collector-[A-Za-z0-9]+-collector-previous.log"
 POD_CONTAINERS_MAP["pod: collector - container: compliance"]="collector-[A-Za-z0-9]+-compliance-previous.log"
-POD_CONTAINERS_MAP["pod: collector - container: node-inventory"]="collector-[A-Za-z0-9]+-node-inventory-previous.log"
 
 # Note: the caller must make sure to redirect stdin to /dev/null where needed.
 retrying_kubectl() {
@@ -740,10 +736,6 @@ deploy_sensor_via_operator() {
         --insecure-skip-tls-verify \
         --output -' \
     | retrying_kubectl -n "${sensor_namespace}" apply -f -
-
-    if [[ "${SENSOR_SCANNER_SUPPORT:-}" == "true" ]]; then
-        scanner_component_setting="AutoSense"
-    fi
 
     local secured_cluster_yaml_path="tests/e2e/yaml/secured-cluster-cr.envsubst.yaml"
     if [[ "${ROX_SCANNER_V4:-false}" == "true" ]]; then


### PR DESCRIPTION
## Description

#22559 stops installing Scanner V2. Nongroovy e2e still deployed as if V2 were the scanner. The GitHub Actions workflow sets `ROX_SCANNER_V4=false`, so Central has no scanner. Prow still sets `SENSOR_SCANNER_SUPPORT`, which used to enable V2 slim in the secured cluster and is now ignored. Delegated scanning then has no indexer to talk to.

The jobs set `ROX_SCANNER_V4=true` and `SENSOR_SCANNER_V4_SUPPORT=true`, which is what Helm Sensor uses to deploy a cluster indexer. Operator Sensor already switches to the V4 SecuredCluster CR when `ROX_SCANNER_V4` is true; `scanner.scannerComponent` stays Disabled. Restart checks drop V2 scanner / scanner-db and the collector `node-inventory` sidecar.

The bats fixture that still names `node-inventory` restart logs is unchanged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Harness env and restart-map only. Coverage is the nongroovy e2e job.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI (`gke-nongroovy-e2e-tests`) - https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22580/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/2095127150720978944 passed with this branch opened against master


#### Other CI falures

I checked other CI failures on this draft and they match #22559 (the state at the branching point) or are unrelated.


