### PR TITLE
tests: Stop QA tests from requiring Scanner V2

### DIFF
--- a/central/certgen/central_scanner.go
+++ b/central/certgen/central_scanner.go
@@ -77,33 +77,19 @@ func (s *serviceImpl) scannerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Query().Get("v") != "4" {
+		httputil.WriteErrorf(w, http.StatusBadRequest,
+			"scanner v2 certificate generation is not supported; pass v=4 for Scanner V4")
+		return
+	}
+
 	secrets, ca, err := initializeSecretsWithCACertAndKey()
 	if err != nil {
 		httputil.WriteGRPCStyleError(w, codes.Internal, err)
 		return
 	}
 
-	namespace := env.Namespace.Setting()
-	if r.URL.Query().Get("v") == "4" {
-		s.scannerV4Handler(w, secrets, ca, namespace)
-		return
-	}
-
-	if err := certgen.IssueScannerCerts(secrets, ca, mtls.WithNamespace(namespace)); err != nil {
-		httputil.WriteGRPCStyleError(w, codes.Internal, err)
-		return
-	}
-
-	rendered, err := renderer.RenderScannerTLSSecretOnly(renderer.Config{
-		K8sConfig:      &renderer.K8sConfig{},
-		SecretsByteMap: secrets,
-	}, defaults.GetImageFlavorFromEnv())
-	if err != nil {
-		httputil.WriteGRPCStyleErrorf(w, codes.Internal, "failed to render scanner TLS file: %v", err)
-		return
-	}
-
-	writeFile(w, rendered, "scanner-tls.yaml")
+	s.scannerV4Handler(w, secrets, ca, env.Namespace.Setting())
 }
 
 func (s *serviceImpl) scannerV4Handler(w http.ResponseWriter, secrets map[string][]byte, ca mtls.CA, namespace string) {

--- a/central/certgen/central_scanner_test.go
+++ b/central/certgen/central_scanner_test.go
@@ -1,0 +1,42 @@
+package certgen
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScannerHandlerRejectsUnsupportedVersion(t *testing.T) {
+	s := &serviceImpl{}
+	cases := map[string]struct {
+		method string
+		rawURL string
+		want   int
+	}{
+		"should reject GET": {
+			method: http.MethodGet,
+			rawURL: "/api/extensions/certgen/scanner?v=4",
+			want:   http.StatusMethodNotAllowed,
+		},
+		"should reject scanner v2": {
+			method: http.MethodPost,
+			rawURL: "/api/extensions/certgen/scanner",
+			want:   http.StatusBadRequest,
+		},
+		"should reject unknown version": {
+			method: http.MethodPost,
+			rawURL: "/api/extensions/certgen/scanner?v=2",
+			want:   http.StatusBadRequest,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.rawURL, nil)
+			rec := httptest.NewRecorder()
+			s.scannerHandler(rec, req)
+			assert.Equal(t, tc.want, rec.Code)
+		})
+	}
+}

--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -63,8 +63,8 @@ _compatibility_test() {
         deploy_stackrox_with_custom_central_and_sensor_versions "${central_version}" "${sensor_version}"
         kubectl -n stackrox get deploy,ds -o wide
 
-        # Wait for scanner v2 deployment to be ready so that it can register its
-        # Clairify integration with Central before CertExpiryTest runs.
+        # Old versions under test may still deploy Scanner V2. Wait only when that
+        # workload exists; HEAD installs Scanner V4 instead.
         # TODO(https://github.com/stackrox/roxie/issues/269): replace with --early-readiness=false roxie flag,
         # once we no longer need to deploy 4.9
         if retrying_kubectl </dev/null -n stackrox get deployment scanner >/dev/null 2>&1; then

--- a/qa-tests-backend/src/main/groovy/services/CredentialExpiryService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/CredentialExpiryService.groovy
@@ -23,10 +23,4 @@ class CredentialExpiryService extends BaseService {
             GetCertExpiry.Request.newBuilder().setComponent(GetCertExpiry.Component.SCANNER).build()
         ).getExpiry()
     }
-
-    static Timestamp getScannerV4CertExpiry() {
-        return getCredentialExpiryServiceClient().getCertExpiry(
-            GetCertExpiry.Request.newBuilder().setComponent(GetCertExpiry.Component.SCANNER_V4).build()
-        ).getExpiry()
-    }
 }

--- a/qa-tests-backend/src/main/groovy/services/CredentialExpiryService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/CredentialExpiryService.groovy
@@ -23,4 +23,10 @@ class CredentialExpiryService extends BaseService {
             GetCertExpiry.Request.newBuilder().setComponent(GetCertExpiry.Component.SCANNER).build()
         ).getExpiry()
     }
+
+    static Timestamp getScannerV4CertExpiry() {
+        return getCredentialExpiryServiceClient().getCertExpiry(
+            GetCertExpiry.Request.newBuilder().setComponent(GetCertExpiry.Component.SCANNER_V4).build()
+        ).getExpiry()
+    }
 }

--- a/qa-tests-backend/src/main/groovy/services/CredentialExpiryService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/CredentialExpiryService.groovy
@@ -17,10 +17,4 @@ class CredentialExpiryService extends BaseService {
             GetCertExpiry.Request.newBuilder().setComponent(GetCertExpiry.Component.CENTRAL).build()
         ).getExpiry()
     }
-
-    static Timestamp getScannerCertExpiry() {
-        return getCredentialExpiryServiceClient().getCertExpiry(
-            GetCertExpiry.Request.newBuilder().setComponent(GetCertExpiry.Component.SCANNER).build()
-        ).getExpiry()
-    }
 }

--- a/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
@@ -158,6 +158,10 @@ class ImageIntegrationService extends BaseService {
     }
 
     static String addStackroxScannerIntegration() {
+        if (FeatureFlagService.isFeatureFlagEnabled("ROX_SCANNER_V4")) {
+            log.debug("Not adding ${Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION}; Scanner V4 is enabled")
+            return ""
+        }
         ImageIntegrationOuterClass.ImageIntegration existing =
             getImageIntegrationByName(Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION)
         if (existing) {

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -27,31 +27,9 @@ class CertExpiryTest extends BaseSpecification {
         assert Cert.loadBase64EncodedCert(centralTLSSecret.data["cert.pem"]).notAfter == centralCertExpiryFromCentral
     }
 
-    def "Test Scanner V4 cert expiry"() {
-        when:
-        "Fetch Scanner V4 TLS secrets and the expiry Central reports for SCANNER_V4"
-        def indexerTLSSecret = orchestrator.getSecret("scanner-v4-indexer-tls", "stackrox")
-        def matcherTLSSecret = orchestrator.getSecret("scanner-v4-matcher-tls", "stackrox")
-        Assume.assumeTrue("Scanner V4 TLS secrets are present",
-                indexerTLSSecret != null && matcherTLSSecret != null)
-        // Retry since scanner integration registration happens asynchronously.
-        def scannerCertExpiryFromCentral = Helpers.evaluateWithRetry(5, 5) {
-            return new Date(CredentialExpiryService.getScannerV4CertExpiry().getSeconds() * 1000)
-        }
-        assert scannerCertExpiryFromCentral
-
-        then:
-        "Make sure Central's expiry is the earlier of indexer and matcher leaf certs"
-        def indexerExpiry = Cert.loadBase64EncodedCert(indexerTLSSecret.data["cert.pem"]).notAfter
-        def matcherExpiry = Cert.loadBase64EncodedCert(matcherTLSSecret.data["cert.pem"]).notAfter
-        assert [indexerExpiry, matcherExpiry].min() == scannerCertExpiryFromCentral
-    }
-
     def "Test Scanner cert expiry"() {
         when:
-        "Fetch Scanner V2 TLS secret on mixed-version compatibility installs that still deploy V2"
-        Assume.assumeTrue("Scanner V4 is absent so the V2 expiry path applies",
-                orchestrator.getSecret("scanner-v4-indexer-tls", "stackrox") == null)
+        "Fetch the current scanner-tls secret, and the scanner cert expiry as returned by Central"
         def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
         Assume.assumeTrue("Scanner V2 TLS secret is present", scannerTLSSecret != null)
         def scannerCertExpiryFromCentral = Helpers.evaluateWithRetry(5, 5) {

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -1,5 +1,4 @@
-import static util.Helpers.shellCmdExitValue
-
+import org.junit.Assume
 import services.CredentialExpiryService
 import util.Cert
 
@@ -28,13 +27,33 @@ class CertExpiryTest extends BaseSpecification {
         assert Cert.loadBase64EncodedCert(centralTLSSecret.data["cert.pem"]).notAfter == centralCertExpiryFromCentral
     }
 
+    def "Test Scanner V4 cert expiry"() {
+        when:
+        "Fetch Scanner V4 TLS secrets and the expiry Central reports for SCANNER_V4"
+        def indexerTLSSecret = orchestrator.getSecret("scanner-v4-indexer-tls", "stackrox")
+        def matcherTLSSecret = orchestrator.getSecret("scanner-v4-matcher-tls", "stackrox")
+        Assume.assumeTrue("Scanner V4 TLS secrets are present",
+                indexerTLSSecret != null && matcherTLSSecret != null)
+        // Retry since scanner integration registration happens asynchronously.
+        def scannerCertExpiryFromCentral = Helpers.evaluateWithRetry(5, 5) {
+            return new Date(CredentialExpiryService.getScannerV4CertExpiry().getSeconds() * 1000)
+        }
+        assert scannerCertExpiryFromCentral
+
+        then:
+        "Make sure Central's expiry is the earlier of indexer and matcher leaf certs"
+        def indexerExpiry = Cert.loadBase64EncodedCert(indexerTLSSecret.data["cert.pem"]).notAfter
+        def matcherExpiry = Cert.loadBase64EncodedCert(matcherTLSSecret.data["cert.pem"]).notAfter
+        assert [indexerExpiry, matcherExpiry].min() == scannerCertExpiryFromCentral
+    }
+
     def "Test Scanner cert expiry"() {
         when:
-        "Fetch the current scanner-tls secret, and the scanner cert expiry as returned by Central"
-        assert shellCmdExitValue("./scripts/ci/is-scanner-v2-available.sh stackrox") == 0
+        "Fetch Scanner V2 TLS secret on mixed-version compatibility installs that still deploy V2"
+        Assume.assumeTrue("Scanner V4 is absent so the V2 expiry path applies",
+                orchestrator.getSecret("scanner-v4-indexer-tls", "stackrox") == null)
         def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
-        assert scannerTLSSecret
-        // Retry since scanner integration registration happens asynchronously.
+        Assume.assumeTrue("Scanner V2 TLS secret is present", scannerTLSSecret != null)
         def scannerCertExpiryFromCentral = Helpers.evaluateWithRetry(5, 5) {
             return new Date(CredentialExpiryService.getScannerCertExpiry().getSeconds() * 1000)
         }
@@ -46,4 +65,3 @@ class CertExpiryTest extends BaseSpecification {
     }
 
 }
-

--- a/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertExpiryTest.groovy
@@ -1,11 +1,9 @@
-import org.junit.Assume
 import services.CredentialExpiryService
 import util.Cert
 
 import spock.lang.Tag
 import spock.lang.IgnoreIf
 import util.Env
-import util.Helpers
 
 @Tag("BAT")
 @Tag("COMPATIBILITY")
@@ -25,21 +23,6 @@ class CertExpiryTest extends BaseSpecification {
         then:
         "Make sure they match"
         assert Cert.loadBase64EncodedCert(centralTLSSecret.data["cert.pem"]).notAfter == centralCertExpiryFromCentral
-    }
-
-    def "Test Scanner cert expiry"() {
-        when:
-        "Fetch the current scanner-tls secret, and the scanner cert expiry as returned by Central"
-        def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
-        Assume.assumeTrue("Scanner V2 TLS secret is present", scannerTLSSecret != null)
-        def scannerCertExpiryFromCentral = Helpers.evaluateWithRetry(5, 5) {
-            return new Date(CredentialExpiryService.getScannerCertExpiry().getSeconds() * 1000)
-        }
-        assert scannerCertExpiryFromCentral
-
-        then:
-        "Make sure they match"
-        assert Cert.loadBase64EncodedCert(scannerTLSSecret.data["cert.pem"]).notAfter == scannerCertExpiryFromCentral
     }
 
 }

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -111,23 +111,19 @@ class CertRotationTest extends BaseSpecification {
 
     def "Test Scanner cert rotation"() {
         when:
-        "Fetch Scanner V4 TLS secrets and regenerate certs"
-        def indexerTLSSecret = orchestrator.getSecret("scanner-v4-indexer-tls", "stackrox")
-        assert indexerTLSSecret
-        def matcherTLSSecret = orchestrator.getSecret("scanner-v4-matcher-tls", "stackrox")
-        assert matcherTLSSecret
-        def dbTLSSecret = orchestrator.getSecret("scanner-v4-db-tls", "stackrox")
-        assert dbTLSSecret
+        "Fetch the current scanner-tls and scanner-db-tls secrets, and regenerate new certs"
+        def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
+        def scannerDBTLSSecret = orchestrator.getSecret("scanner-db-tls", "stackrox")
+        Assume.assumeTrue("Scanner V2 TLS secrets are present",
+                scannerTLSSecret != null && scannerDBTLSSecret != null)
         def start = System.currentTimeMillis()
-        def regeneratedSecrets = generateCerts("api/extensions/certgen/scanner?v=4", "scanner-v4-tls.yaml")
+        def regeneratedSecrets = generateCerts("api/extensions/certgen/scanner", "scanner-tls.yaml")
 
         then:
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, indexerTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_V4_INDEXER_SERVICE", start)
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, matcherTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_V4_MATCHER_SERVICE", start)
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, dbTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_V4_DB_SERVICE", start)
+        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, scannerTLSSecret,
+            "cert.pem", "key.pem", "SCANNER_SERVICE", start)
+        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, scannerDBTLSSecret,
+            "cert.pem", "key.pem", "SCANNER_DB_SERVICE", start)
     }
 
     def "Test sensor cert rotation"() {

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -109,23 +109,6 @@ class CertRotationTest extends BaseSpecification {
             "cert.pem", "key.pem", "CENTRAL_SERVICE", start)
     }
 
-    def "Test Scanner cert rotation"() {
-        when:
-        "Fetch the current scanner-tls and scanner-db-tls secrets, and regenerate new certs"
-        def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
-        def scannerDBTLSSecret = orchestrator.getSecret("scanner-db-tls", "stackrox")
-        Assume.assumeTrue("Scanner V2 TLS secrets are present",
-                scannerTLSSecret != null && scannerDBTLSSecret != null)
-        def start = System.currentTimeMillis()
-        def regeneratedSecrets = generateCerts("api/extensions/certgen/scanner", "scanner-tls.yaml")
-
-        then:
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, scannerTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_SERVICE", start)
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, scannerDBTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_DB_SERVICE", start)
-    }
-
     def "Test sensor cert rotation"() {
         when:
         "Fetch the current sensor-tls, collector-tls and admission-control-tls secrets, and regenerate certs"

--- a/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CertRotationTest.groovy
@@ -111,19 +111,23 @@ class CertRotationTest extends BaseSpecification {
 
     def "Test Scanner cert rotation"() {
         when:
-        "Fetch the current scanner-tls and scanner-db-tls secrets, and regenerate new certs"
-        def scannerTLSSecret = orchestrator.getSecret("scanner-tls", "stackrox")
-        assert scannerTLSSecret
-        def scannerDBTLSSecret = orchestrator.getSecret("scanner-db-tls", "stackrox")
-        assert scannerDBTLSSecret
+        "Fetch Scanner V4 TLS secrets and regenerate certs"
+        def indexerTLSSecret = orchestrator.getSecret("scanner-v4-indexer-tls", "stackrox")
+        assert indexerTLSSecret
+        def matcherTLSSecret = orchestrator.getSecret("scanner-v4-matcher-tls", "stackrox")
+        assert matcherTLSSecret
+        def dbTLSSecret = orchestrator.getSecret("scanner-v4-db-tls", "stackrox")
+        assert dbTLSSecret
         def start = System.currentTimeMillis()
-        def regeneratedSecrets = generateCerts("api/extensions/certgen/scanner", "scanner-tls.yaml")
+        def regeneratedSecrets = generateCerts("api/extensions/certgen/scanner?v=4", "scanner-v4-tls.yaml")
 
         then:
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, scannerTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_SERVICE", start)
-        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, scannerDBTLSSecret,
-            "cert.pem", "key.pem", "SCANNER_DB_SERVICE", start)
+        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, indexerTLSSecret,
+            "cert.pem", "key.pem", "SCANNER_V4_INDEXER_SERVICE", start)
+        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, matcherTLSSecret,
+            "cert.pem", "key.pem", "SCANNER_V4_MATCHER_SERVICE", start)
+        testMatchingSecretFoundWithExpectedProperties(regeneratedSecrets, dbTLSSecret,
+            "cert.pem", "key.pem", "SCANNER_V4_DB_SERVICE", start)
     }
 
     def "Test sensor cert rotation"() {

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -63,7 +63,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         // TODO: re-activate once fixed against postgres
         //"image"      | "Image:main" | null | "Sort(null)" | "deployments"
 
-        "secret"     | "Secret:scanner-v4-db-password" | null | "Sort(null)" | "deployments"
+        "secret"     | "Secret:central-tls" | null | "Sort(null)" | "deployments"
 
         "subject"    | "Subject:kubelet" | null | "Sort(null)" | "k8sRoles"
 

--- a/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/GraphQLResourcePaginationTest.groovy
@@ -63,7 +63,7 @@ class GraphQLResourcePaginationTest extends BaseSpecification {
         // TODO: re-activate once fixed against postgres
         //"image"      | "Image:main" | null | "Sort(null)" | "deployments"
 
-        "secret"     | "Secret:scanner-db-password" | null | "Sort(null)" | "deployments"
+        "secret"     | "Secret:scanner-v4-db-password" | null | "Sort(null)" | "deployments"
 
         "subject"    | "Subject:kubelet" | null | "Sort(null)" | "k8sRoles"
 

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -158,7 +158,9 @@ class ImageScanningTest extends BaseSpecification {
     def cleanupSpec() {
         orchestrator.deleteNamespace(TEST_NAMESPACE)
 
-        ImageIntegrationService.addStackroxScannerIntegration()
+        if (!scannerV4Enabled) {
+            ImageIntegrationService.addStackroxScannerIntegration()
+        }
         addGCRImagePullSecret(orchestrator)
 
         for (Policy policy : policiesScopedForTest) {
@@ -480,7 +482,9 @@ class ImageScanningTest extends BaseSpecification {
     @Tag("BAT")
     @Tag("Integration")
     def "Verify Scan Results from Registries - #registry.name() - #component:#version - #image - #cve - #idx"() {
-        ImageIntegrationService.addStackroxScannerIntegration()
+        if (!scannerV4Enabled) {
+            ImageIntegrationService.addStackroxScannerIntegration()
+        }
 
         when:
         "Add scanner"
@@ -509,7 +513,9 @@ class ImageScanningTest extends BaseSpecification {
         vuln != null
 
         cleanup:
-        deleteStackroxScanner = true
+        if (!scannerV4Enabled) {
+            deleteStackroxScanner = true
+        }
         imageToCleanup = image
 
         where:

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -680,15 +680,13 @@ class ImageScanningTest extends BaseSpecification {
     @Unroll
     @Tag("Integration")
     def "Image scanning test to check if scan time is not null #image from stackrox"() {
+        Assume.assumeTrue(StackroxScannerIntegration.isTestable())
+
         when:
         "Add scanner"
-        String integrationId = scannerV4Enabled ?
-                ScannerV4Integration.createDefaultIntegration() :
-                StackroxScannerIntegration.createDefaultIntegration()
+        String integrationId = StackroxScannerIntegration.createDefaultIntegration()
         assert integrationId
-        if (!scannerV4Enabled) {
-            integrationIds.add(integrationId)
-        }
+        integrationIds.add(integrationId)
 
         and:
         "Image is scanned"

--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -681,10 +681,14 @@ class ImageScanningTest extends BaseSpecification {
     @Tag("Integration")
     def "Image scanning test to check if scan time is not null #image from stackrox"() {
         when:
-        "Add Stackrox scanner"
-        String integrationId = StackroxScannerIntegration.createDefaultIntegration()
+        "Add scanner"
+        String integrationId = scannerV4Enabled ?
+                ScannerV4Integration.createDefaultIntegration() :
+                StackroxScannerIntegration.createDefaultIntegration()
         assert integrationId
-        integrationIds.add(integrationId)
+        if (!scannerV4Enabled) {
+            integrationIds.add(integrationId)
+        }
 
         and:
         "Image is scanned"

--- a/qa-tests-backend/src/test/groovy/IntegrationHealthTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationHealthTest.groovy
@@ -1,5 +1,7 @@
+import objects.StackroxScannerIntegration
 import services.IntegrationHealthService
 
+import org.junit.Assume
 import spock.lang.Tag
 import spock.lang.Unroll
 
@@ -10,6 +12,7 @@ class IntegrationHealthTest extends BaseSpecification {
     def "Verify vulnerability definitions information is available"() {
         when:
         "Vulnerability definition is requested"
+        Assume.assumeTrue("Clairify integration is present", StackroxScannerIntegration.isTestable())
         def vulnDefInfo = IntegrationHealthService.getVulnDefinitionsInfo()
 
         then:

--- a/scripts/ci/is-scanner-v2-available.sh
+++ b/scripts/ci/is-scanner-v2-available.sh
@@ -1,22 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Asserts that scanner v2 is running and ready in the supplied namespace
+# Scanner V2 is not installed. Callers should skip V2-only assertions rather than
+# waiting for deploy/scanner.
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
-# shellcheck source=../../tests/e2e/lib.sh
-source "$ROOT/tests/e2e/lib.sh"
-
-verify_scannerV2_deployed_and_ready() {
-    if [[ "$#" -ne 1 ]]; then
-        die "missing arg. usage: verify_scannerV2_deployed_and_ready <namespace>"
-    fi
-    local namespace=${1:-stackrox}
-    info "Waiting for Scanner V2 deployment to appear in namespace ${namespace}..."
-    wait_for_object_to_appear "$namespace" deploy/scanner-db 600
-    wait_for_object_to_appear "$namespace" deploy/scanner 300
-    info "** Scanner V2 is deployed in namespace ${namespace}"
-    kubectl -n "${namespace}" wait --for=condition=ready pod -l app=scanner --timeout 5m
-}
-
-verify_scannerV2_deployed_and_ready "$@"
+echo "Scanner V2 is not deployed" >&2
+exit 1

--- a/scripts/ci/is-scanner-v2-available.sh
+++ b/scripts/ci/is-scanner-v2-available.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Scanner V2 is not installed. Callers should skip V2-only assertions rather than
-# waiting for deploy/scanner.
-
-echo "Scanner V2 is not deployed" >&2
-exit 1


### PR DESCRIPTION
## Description

Scanner V2 is no longer installed. Several BAT/PZ Groovy tests still required its Kubernetes objects (`scanner-tls`, `scanner-db-tls`, `scanner-db-password`) and the auto-registered Clairify integration named "Stackrox Scanner". Those jobs fail once install stops creating those objects.

This change points those tests at Scanner V4. Cert expiry compares Central's `SCANNER_V4` result to the earlier of the indexer and matcher leaf certs. Mixed-version compatibility still runs the V2 expiry check when Scanner V4 TLS secrets are missing. Cert rotation downloads `scanner-v4-tls.yaml` via `POST /api/extensions/certgen/scanner?v=4`. GraphQL pagination looks up `scanner-v4-db-password`. Image-scan cleanup does not recreate the Clairify integration when `ROX_SCANNER_V4` is enabled.

`POST /api/extensions/certgen/scanner` without `v=4` used a Helm render mode that no longer emits a Scanner V2 TLS secret, so it returned 500. It now returns 400. `scripts/ci/is-scanner-v2-available.sh` exits immediately instead of waiting for `deploy/scanner`. Compatibility still waits on `deployment/scanner` when that object exists on the old version under test.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] Running `/test gke-qa-e2e-tests` (same BAT/PZ tests as `ocp-*-qa-e2e-tests`) when the branch is targeted temporarily towards master.

Analysis of run https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22583/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/2095256650796503040 (when the branch was open against master):

<img width="800" height="394" alt="Screenshot 2026-09-03 at 07 36 20" src="https://github.com/user-attachments/assets/54d7438d-6606-4244-b0a6-256ff3e76cec" />
