### PR TITLE
ROX-35986: bump scanner-v4-matcher CI memory to 4Gi

### DIFF
--- a/deploy/common/ci-values.yaml
+++ b/deploy/common/ci-values.yaml
@@ -23,9 +23,13 @@ scannerV4:
     replicas: 1
     autoscaling:
       disable: true
+    # 4Gi aims at covering the rhel-vex cold-import peak that OOMs at the original 3Gi Helm default.
     resources:
       requests:
         cpu: "400m"
+        memory: "4Gi"
+      limits:
+        memory: "4Gi"
   indexer:
     replicas: 1
     autoscaling:

--- a/deploy/common/scanner-v4-matcher-patch.yaml
+++ b/deploy/common/scanner-v4-matcher-patch.yaml
@@ -6,3 +6,6 @@ spec:
         resources:
           requests:
             cpu: "400m"
+            memory: "4Gi"
+          limits:
+            memory: "4Gi"

--- a/tests/e2e/yaml/central-cr-with-scanner-v4.envsubst.yaml
+++ b/tests/e2e/yaml/central-cr-with-scanner-v4.envsubst.yaml
@@ -59,10 +59,10 @@ $centralAdditionalCAIndented
       resources:
         requests:
           cpu: "400m"
-          memory: "2000Mi"
+          memory: "4Gi"
         limits:
           cpu: "6000m"
-          memory: "2000Mi"
+          memory: "4Gi"
     db:
       resources:
         requests:

--- a/tests/e2e/yaml/central-cr.envsubst.yaml
+++ b/tests/e2e/yaml/central-cr.envsubst.yaml
@@ -55,6 +55,9 @@ $centralAdditionalCAIndented
       resources:
         requests:
           cpu: "400m"
+          memory: "4Gi"
+        limits:
+          memory: "4Gi"
     db:
 $scannerV4DbPersistenceYaml
       resources:


### PR DESCRIPTION
## Description

CI matcher pods OOM during the initial rhel-vex vuln-store load. Helm defaults are 1.5Gi request / 3Gi limit; GOMEMLIMIT is 95% of the request (~1.43Gi). A cold import of ~3.3M rhel-vex records exceeds the 3Gi cgroup cap (exit 137). Those OOMs results in really many CI failures.

This PR changes the limit to 4Gi with the hope that less CI jobs will be failing.

This should be probably undone when the ClairCore memory optimization work is finished.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

CI resource YAML only. Coverage is the matcher OOM check on e2e jobs.

### How I validated my change

- CI running X times - not sure I should waste CI resources to get 20 non-OOM runs before merging...