### PR TITLE
ROX-36628: bump claircore to pseudo-version with ecosystem-filter fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1
-	github.com/quay/claircore v1.5.54
+	github.com/quay/claircore v1.5.55-0.20260720230557-3f07716d8b96
 	github.com/quay/claircore/toolkit v1.6.1
 	github.com/quay/zlog/v2 v2.1.1
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/quay/claircore v1.5.54 h1:NC7+QfwV8yo/KJ/B8mz1GD8BIG16aIJ3FuHcBTnsjL4=
-github.com/quay/claircore v1.5.54/go.mod h1:hOp0JqY8vOZPdBakFRt3JwG8q4K+gnRkG9RGzt1DoB4=
+github.com/quay/claircore v1.5.55-0.20260720230557-3f07716d8b96 h1:bpYvJiQTRbsyTPmdXX/a+05Hy5nHtCcjoswOPR/LgjM=
+github.com/quay/claircore v1.5.55-0.20260720230557-3f07716d8b96/go.mod h1:hOp0JqY8vOZPdBakFRt3JwG8q4K+gnRkG9RGzt1DoB4=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.6.1 h1:a3X1v28n5bo05T94cBlaoPU8xYCErRGPM3l6AlmYWj4=
 github.com/quay/claircore/toolkit v1.6.1/go.mod h1:dTzlp1pgNchc+CN73HJiG9+e0ygU54QPt397eXnGGo4=


### PR DESCRIPTION
## Description

Scanner V4 false-flags packages using the fixed-in version from an unrelated ecosystem when an OSV advisory covers multiple ecosystems — e.g. PyPI `langsmith` 0.10.16 was flagged vulnerable to CVE-2026-45134 (GHSA-3644-q5cj-c5c7) using npm's fix version (`0.6.0`, lower than the installed version) instead of PyPI's (`0.8.0`). Root cause: claircore's OSV updater ingests all `affected` entries from a multi-ecosystem advisory without filtering by `af.Package.Ecosystem`, so npm-only fix data leaks into PyPI vulnerability records, and the PyPI matcher can't parse the resulting non-PyPI fixedIn string and defaults to "vulnerable". Case 04522302, Jira ROX-36628.

The fix is merged upstream (quay/claircore@3f07716d, "osv: exclude advisories from non applicable ecosystems") but not in a tagged release — the latest tag `v1.5.54` predates it and no new tag is imminent. Rather than wait, this pins `go.mod` to a pseudo-version at that exact commit, so we get only the 31-line fix plus its test/migration, without the ~46 unrelated commits already ahead of it on claircore `main` (CPE parser rewrite, jsonblob iterator refactor, VEX/CEL rule changes, Postgres vulnerability-hashing changes) that haven't been through a release.

Follow-up: once claircore cuts a tagged release containing this commit, replace the pseudo-version with the tagged one.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

The only failing check is `go-bench`, a flaky timeout in `BenchmarkMany/walk_16_alerts` (`central/alert/datastore` Postgres store) that has no claircore/scanner dependency and is unrelated to this go.mod bump; all correctness checks (unit tests, compile, `go mod tidy`, lint) pass.

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

No new tests added here — the regression test for this exact scenario lives upstream in claircore (`TestInsert/skip_other_ecosystems`, GHSA-3644-q5cj-c5c7, pypi 0.8.0 vs npm 0.6.0) and now ships transitively via the pseudo-version bump.

### How I validated my change

- `go build ./...` and `go test ./pkg/scannerv4/...` pass with the bumped dependency.
- Diffed `go.mod`/`go.sum` to confirm the bump resolves to `v1.5.55-0.20260720230557-3f07716d8b96`, pinned exactly to the fix commit (verified via `git log`/`git show` on the claircore fork) rather than tip of `main`.
- **Real-cluster validation (OCP 4.x, Scanner V4): PASSED.** The fix is in claircore's OSV updater (bundle build-time), and the matcher consumes a pre-built bundle, so I rebuilt the bundle with the fixed claircore rather than only rebuilding the matcher image (match-time code is unaffected — the fix removes the bad record at ingestion).
  - Test image: `python:3.12-slim` + `pip install langsmith==0.10.16`.
  - Baseline (current dev bundle, buggy claircore): 149 vulns; `langsmith` 0.10.16 flagged for 3 CVEs — CVE-2026-45134 (fixedBy `0.6.0`), CVE-2026-25528 (fixedBy `0.4.6`), CVE-2026-41182 (fixedBy `0.5.19`).
  - Data-level: rebuilt only `osv.json.zst` with the fixed claircore (`updater export`). The buggy bundle's `osv/pypi` langsmith/GHSA-3644 record carries both `fixed=0.8.0` (correct) and `0.6.0` (npm's version, contaminated); the rebuilt bundle emits only `fixed=0.8.0`, and `0.6.0` appears solely under `osv/npm`.
  - End-to-end: spliced the fixed `osv.json.zst` into the dev `vulnerabilities.zip`, served it in-cluster, repointed the matcher at it, and re-scanned. Result: 146 vulns; `langsmith` 0.10.16 still detected as a component with 0 vulnerabilities; exactly those 3 langsmith CVEs removed, 0 added, all other findings unchanged.