### PR TITLE
fix(ci): Enable JUnit reporting for GHA-based upgrade tests

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1877,7 +1877,7 @@ handle_e2e_progress_failures() {
     fi
 
     case "$CI_JOB_NAME" in
-    *gke-upgrade-tests)
+    *gke-upgrade-tests*)
         record_upgrade_test_progess
         ;;
     *operator-e2e-tests|*-version-compatibility-tests|*-nongroovy-compatibility-tests)

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1910,13 +1910,16 @@ record_upgrade_test_progess() {
     # tracking files that the upgrade test leaves in its wake as it progresses.
 
     # tests/upgrade/postgres_sensor_run.sh
-    record_progress_step "${UPGRADE_PROGRESS_SENSOR_BUNDLE}" "${STATE_DEPLOYED}" \
-        "postgres_sensor_run" "roxctl sensor bundle test"
-    record_progress_step "${UPGRADE_PROGRESS_UPGRADER}" "${UPGRADE_PROGRESS_SENSOR_BUNDLE}" \
-        "postgres_sensor_run" "bin/upgrader tests"
+    if [[ "$CI_JOB_NAME" == "gke-upgrade-tests-sensor" ]]; then
+        record_progress_step "${UPGRADE_PROGRESS_SENSOR_BUNDLE}" "${STATE_DEPLOYED}" \
+            "postgres_sensor_run" "roxctl sensor bundle test"
+        record_progress_step "${UPGRADE_PROGRESS_UPGRADER}" "${UPGRADE_PROGRESS_SENSOR_BUNDLE}" \
+            "postgres_sensor_run" "bin/upgrader tests"
+        return
+    fi
 
-    # tests/upgrade/postgres_run.sh
-    record_progress_step "${UPGRADE_PROGRESS_POSTGRES_PREP}" "${UPGRADE_PROGRESS_UPGRADER}" \
+    # tests/upgrade/postgres_run.sh or tests/upgrade/postgres_upgrade_run.sh
+    record_progress_step "${UPGRADE_PROGRESS_POSTGRES_PREP}" "${STATE_DEPLOYED}" \
         "postgres_run" "Preparation for postgres testing"
     record_progress_step "${UPGRADE_PROGRESS_POSTGRES_EARLIER_CENTRAL}" "${UPGRADE_PROGRESS_POSTGRES_PREP}" \
         "postgres_run" "Deployed earlier postgres central"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1918,7 +1918,7 @@ record_upgrade_test_progess() {
         return
     fi
 
-    # tests/upgrade/postgres_run.sh or tests/upgrade/postgres_upgrade_run.sh
+    # tests/upgrade/postgres_run.sh and tests/upgrade/postgres_upgrade_run.sh
     record_progress_step "${UPGRADE_PROGRESS_POSTGRES_PREP}" "${STATE_DEPLOYED}" \
         "postgres_run" "Preparation for postgres testing"
     record_progress_step "${UPGRADE_PROGRESS_POSTGRES_EARLIER_CENTRAL}" "${UPGRADE_PROGRESS_POSTGRES_PREP}" \
@@ -1927,6 +1927,9 @@ record_upgrade_test_progess() {
         "postgres_run" "Bounced central"
     record_progress_step "${UPGRADE_PROGRESS_POSTGRES_CENTRAL_DB_BOUNCE}" "${UPGRADE_PROGRESS_POSTGRES_CENTRAL_BOUNCE}" \
         "postgres_run" "Bounced central-db"
+
+    # tests/upgrade/postgres_run.sh only
+    [[ "$CI_JOB_NAME" == "gke-upgrade-tests-central" ]] || return
     record_progress_step "${UPGRADE_PROGRESS_POSTGRES_MIGRATIONS}" "${UPGRADE_PROGRESS_POSTGRES_CENTRAL_DB_BOUNCE}" \
         "postgres_run" "Test migrations with an upgrade to current"
     record_progress_step "${UPGRADE_PROGRESS_POSTGRES_ROLLBACK}" "${UPGRADE_PROGRESS_POSTGRES_MIGRATIONS}" \


### PR DESCRIPTION
## Description

It was lost during transitioning these tests from prow to GHA but is probably important for us to receive JIRA tickets if/when these tests fail.

The change was inspired by https://github.com/stackrox/stackrox/pull/22548/changes#r3914685030

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Checked summaries of all three upgrade tests.