### PR TITLE
test(qa): ignore AdmissionControllerTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -11,10 +11,12 @@ import services.ImageService
 import services.PolicyService
 import util.Timer
 
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
 
+@Ignore("Temporarily disabled for EKS IPv6 investigation")
 @Tag("PZ")
 class AdmissionControllerTest extends BaseSpecification {
     @Shared


### PR DESCRIPTION
Temporarily ignoring AdmissionControllerTest to investigate and unmask other failures in EKS IPv6 E2E tests.

This is a draft PR for verification on both IPv4 and IPv6 clusters.