### PR TITLE
fix(migrator): use proto getters in policy migration test helper

### DIFF
--- a/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
+++ b/migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go
@@ -357,7 +357,7 @@ func (s *postgresPolicyMigratorTestSuite) getAllCategories(ctx context.Context) 
 	}
 	categoryMap := make(map[string]string, len(categories))
 	for _, c := range categories {
-		categoryMap[c.Name] = c.Id
+		categoryMap[c.GetName()] = c.GetId()
 	}
 	return categoryMap, nil
 }


### PR DESCRIPTION
## Description

`getAllCategories` in `migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go` read proto fields directly (`c.Name`, `c.Id`) instead of using the generated getters (`c.GetName()`, `c.GetId()`). This is inconsistent with the codebase's style, enforced elsewhere by the `protogetter` golangci-lint linter, and matches the exact pattern that caused a real protogetter CI failure when working with a new migration.

`getAllCategories` is the reference implementation that other migration authors copy when implementing the `getCategories` callback for `policymigrationhelper.MigratePoliciesWithStoreV2` / `MigratePoliciesWithDiffsAndStoreV2`, so fixing it here prevents the same style issue from being copy-pasted again. Note: `protogetter` does not currently flag this specific occurrence (confirmed with both golangci-lint and the standalone CLI), so this is a style-consistency fix rather than a CI-required one.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

No new tests added since this only changes how an existing test helper reads already-tested data (map key/value construction); behavior is unchanged.

### How I validated my change

- `go build ./migrator/...` — passes.
- `go vet ./migrator/migrations/policymigrationhelper/...` — passes.
- `gofmt -l migrator/migrations/policymigrationhelper/postgres_policy_migrator_test.go` — no output (already formatted).
- `POSTGRES_USER="$USER" go test -count=1 -tags sql_integration ./migrator/migrations/policymigrationhelper/... -v` against a local Postgres — all subtests of `TestPostgresPolicyMigrator` pass.
- Ran the standalone `protogetter` analyzer against `./migrator/migrations/policymigrationhelper/...` before and after the change — no findings either way (confirms this fix does not affect lint status, it's purely a style consistency fix).
