### PR TITLE
ROX-36432: add node scan_time diagnostic logging

### DIFF
--- a/central/node/datastore/datastore_impl_postgres_test.go
+++ b/central/node/datastore/datastore_impl_postgres_test.go
@@ -4,8 +4,11 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	nodeCVEDS "github.com/stackrox/rox/central/cve/node/datastore"
 	nodeCVEPostgres "github.com/stackrox/rox/central/cve/node/datastore/store/postgres"
@@ -31,6 +34,7 @@ import (
 	pkgSearch "github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -76,6 +80,99 @@ func (suite *NodePostgresDataStoreTestSuite) SetupTest() {
 func (suite *NodePostgresDataStoreTestSuite) TearDownTest() {
 	suite.mockCtrl.Finish()
 	suite.db.Close()
+}
+
+// TestConcurrentUpsertNode_KeyedMutexPreventsRegression is the datastore-layer counterpart of
+// store_test.go's TestStore_ConcurrentUpsert_BypassingOuterLock. That test proves the store layer alone has
+// a check-then-act race in isUpdated(): the read-old-scan-and-decide step isn't covered by the store's own
+// keyFence lock. This test drives the same workload through UpsertNode, the production call path, which
+// wraps the entire read-decide-write sequence in a per-node-ID keyedMutex (see UpsertNode in
+// datastore_impl.go). Every caller in this codebase reaches the store exclusively through UpsertNode, so
+// this path determines whether concurrent upserts can regress scan_time; the test asserts scan_time never
+// regresses even under heavy concurrency.
+func (suite *NodePostgresDataStoreTestSuite) TestConcurrentUpsertNode_KeyedMutexPreventsRegression() {
+	allowAllCtx := sac.WithAllAccess(context.Background())
+
+	node := getTestNodeForPostgres(fixtureconsts.Node1, "concurrent-node")
+	baseTime := time.Now().Add(-24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&baseTime)
+	suite.NoError(suite.datastore.UpsertNode(allowAllCtx, node))
+
+	const iterations = 500
+	const freshWriters = 4
+	const metaWriters = 4
+	var wg sync.WaitGroup
+	// A writer that fails leaves the intended workload incomplete, so a zero regression count would be
+	// meaningless. Track upsert failures and assert none happened.
+	var upsertFailures atomic.Int64
+
+	// Simulates the nodeindex pipeline: always a fresh, monotonically increasing ScanTime.
+	for w := range freshWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				fresh := node.CloneVT()
+				t := baseTime.Add(time.Duration(w*iterations+i+1) * time.Millisecond)
+				fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&t)
+				if err := suite.datastore.UpsertNode(allowAllCtx, fresh); err != nil {
+					upsertFailures.Add(1)
+				}
+			}
+		})
+	}
+
+	// Simulates the nodes pipeline: frequent metadata-only churn, Scan explicitly nil.
+	for w := range metaWriters {
+		wg.Go(func() {
+			for i := range iterations {
+				metaOnly := node.CloneVT()
+				metaOnly.Scan = nil
+				metaOnly.Labels = map[string]string{"writer": fmt.Sprintf("%d-%d", w, i)}
+				if err := suite.datastore.UpsertNode(allowAllCtx, metaOnly); err != nil {
+					upsertFailures.Add(1)
+				}
+			}
+		})
+	}
+
+	var regressions atomic.Int64
+	stop := make(chan struct{})
+	var pollWG sync.WaitGroup
+	for range 2 {
+		pollWG.Go(func() {
+			lastSeen := baseTime
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				current, exists, err := suite.datastore.GetNode(allowAllCtx, node.GetId())
+				if err == nil && exists {
+					st := current.GetScan().GetScanTime().AsTime()
+					if st.Before(lastSeen) {
+						regressions.Add(1)
+					} else {
+						lastSeen = st
+					}
+				}
+				// Yield between reads so the pollers don't hammer the DB in a tight busy-loop.
+				time.Sleep(time.Millisecond)
+			}
+		})
+	}
+
+	wg.Wait()
+	close(stop)
+	pollWG.Wait()
+
+	suite.Zero(upsertFailures.Load(),
+		"every concurrent UpsertNode must succeed; a failure means the intended workload did not complete, "+
+			"which would make the regression assertion below meaningless")
+	suite.Zero(regressions.Load(),
+		"scan_time must never regress through UpsertNode, since every real caller (nodeindex and nodes "+
+			"pipelines alike) goes through the per-node-ID keyedMutex that wraps the entire read-decide-write "+
+			"sequence; a non-zero count here would mean the keyedMutex itself has a bug, not just the store "+
+			"layer's already-known gap")
 }
 
 func (suite *NodePostgresDataStoreTestSuite) TestBasicOps() {

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -529,6 +529,17 @@ func (s *storeImpl) isUpdated(ctx context.Context, node *storage.Node) (bool, er
 	// We skip rewriting components and vulnerabilities if the node scan is older.
 	scanUpdated := protocompat.CompareTimestamps(oldNode.GetScan().GetScanTime(), node.GetScan().GetScanTime()) <= 0
 	if !scanUpdated {
+		// Metadata-only upserts (e.g. from the informer-driven nodes pipeline) intentionally send no scan at
+		// all, relying on this method to preserve the stored one; only warn when a real, incoming scan with
+		// its own scan_time was rejected as not newer than what's stored.
+		if node.GetScan().GetScanTime() != nil {
+			log.Warnf("Rejecting incoming node scan for node %s (%s) in cluster %s (%s) as not newer than the "+
+				"stored one: stored scan_time=%s, incoming scan_time=%s. The incoming scan and its "+
+				"component/CVE data will be discarded and the previously stored scan will be kept.",
+				node.GetId(), node.GetName(), node.GetClusterName(), node.GetClusterId(),
+				protocompat.ConvertTimestampToString(oldNode.GetScan().GetScanTime(), time.RFC3339Nano),
+				protocompat.ConvertTimestampToString(node.GetScan().GetScanTime(), time.RFC3339Nano))
+		}
 		node.Scan = oldNode.GetScan()
 		node.RiskScore = oldNode.GetRiskScore()
 		node.SetComponents = oldNode.GetSetComponents()

--- a/central/node/datastore/store/postgres/store_test.go
+++ b/central/node/datastore/store/postgres/store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -21,8 +22,21 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+const rejectionWarnSnippet = "Rejecting incoming node scan for node"
+
+func swapObservedLogger(t interface{ Cleanup(func()) }) *observer.ObservedLogs {
+	core, logs := observer.New(zap.WarnLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+	return logs
+}
 
 type NodesStoreSuite struct {
 	suite.Suite
@@ -149,6 +163,73 @@ func (s *NodesStoreSuite) TestStore_UpsertWithoutScan() {
 	// We expect only LastUpdated to have changed.
 	foundNode.LastUpdated = newNode.GetLastUpdated()
 	protoassert.Equal(s.T(), foundNode, newNode)
+}
+
+// TestStore_FreshScanAlwaysWinsSequential covers the sequential happy path of the isUpdated() freshness
+// guard: upsert an old scan, then upsert a strictly newer one for the same node ID, and confirm the newer
+// one is persisted (both scan_time and payload advance). This isolates single-threaded correctness of the
+// guard from the concurrency behavior exercised elsewhere.
+func (s *NodesStoreSuite) TestStore_FreshScanAlwaysWinsSequential() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+
+	oldTime := time.Now().Add(-60 * 24 * time.Hour)
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&oldTime)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	fresh := node.CloneVT()
+	freshTime := time.Now()
+	fresh.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&freshTime)
+	fresh.Scan.Components = fresh.GetScan().GetComponents()[:1] // Change the payload shape too, not just the timestamp.
+	s.NoError(store.Upsert(s.ctx, fresh))
+
+	found, exists, err := store.Get(s.ctx, node.GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(freshTime.Unix(), found.GetScan().GetScanTime().AsTime().Unix(),
+		"a strictly newer scan must always replace an older one when applied sequentially")
+	s.Len(found.GetScan().GetComponents(), 1)
+}
+
+// TestStore_RejectionWarningFiresOnlyForRealStaleScan validates the rejection warning in isUpdated():
+// a real, non-nil incoming scan that is older than the stored one is rejected AND warned about, while a
+// metadata-only upsert (Scan == nil) - which is also "not newer" - is rejected silently (the gate).
+func (s *NodesStoreSuite) TestStore_RejectionWarningFiresOnlyForRealStaleScan() {
+	store := New(s.pool, false, concurrency.NewKeyFence())
+	logs := swapObservedLogger(s.T())
+
+	node := &storage.Node{}
+	s.NoError(testutils.FullInit(node, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+	for _, comp := range node.GetScan().GetComponents() {
+		comp.Vulns = nil
+	}
+	newer := time.Now()
+	node.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&newer)
+	s.NoError(store.Upsert(s.ctx, node))
+
+	// A real, non-nil, older scan must be rejected and warned about.
+	stale := node.CloneVT()
+	older := newer.Add(-time.Hour)
+	stale.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&older)
+	s.NoError(store.Upsert(s.ctx, stale))
+
+	found, exists, err := store.Get(s.ctx, node.GetId())
+	s.NoError(err)
+	s.True(exists)
+	s.Equal(newer.Unix(), found.GetScan().GetScanTime().AsTime().Unix(), "stale scan must be rejected")
+	require.Len(s.T(), logs.FilterMessageSnippet(rejectionWarnSnippet).All(), 1)
+
+	// A metadata-only upsert (Scan == nil) is also "not newer" but must NOT emit the warning.
+	metaOnly := found.CloneVT()
+	metaOnly.Scan = nil
+	s.NoError(store.Upsert(s.ctx, metaOnly))
+	require.Len(s.T(), logs.FilterMessageSnippet(rejectionWarnSnippet).All(), 1,
+		"metadata-only upserts must not emit the rejection warning")
 }
 
 func (s *NodesStoreSuite) TestStore_OrphanedCVEs() {

--- a/central/sensor/service/pipeline/nodeindex/pipeline.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline.go
@@ -2,6 +2,7 @@ package nodeindex
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
@@ -19,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/nodes/enricher"
+	"github.com/stackrox/rox/pkg/protocompat"
 )
 
 var (
@@ -115,11 +117,39 @@ func (p *pipelineImpl) Run(ctx context.Context, _ string, msg *central.MsgFromSe
 	}
 	log.Infof("Scanned index report and found %d components for node %s",
 		len(node.GetScan().GetComponents()), nodeDatastore.NodeString(node))
+	incomingScanTime := node.GetScan().GetScanTime()
 
 	// Update the whole node in the database with the new and previous information.
 	err = p.riskManager.CalculateRiskAndUpsertNode(node)
 	if err != nil {
 		return errors.Wrapf(err, "failed calculating risk and upserting node %s", nodeDatastore.NodeString(node))
+	}
+
+	// The store may have rejected this scan as not newer than what's already persisted, in which case it
+	// rewrites node.Scan in place to the previously stored one before returning - see isUpdated() in
+	// central/node/datastore/store/postgres/store.go. Comparing scan times here, on the same object we just
+	// tried to upsert, tells us definitively whether the fresh scan we just processed actually landed.
+	persistedScanTime := node.GetScan().GetScanTime()
+	switch cmp := protocompat.CompareTimestamps(incomingScanTime, persistedScanTime); {
+	case cmp > 0:
+		// The store kept a scan_time older than the one we just processed. isUpdated() only rejects scans
+		// that are not strictly newer than the stored one, so a fresh scan should have been accepted here;
+		// a persisted scan older than the processed one means the fresh scan was silently dropped, which the
+		// freshness guard should never do.
+		log.Warnf("Persisted scan_time for node %s is older than the freshly processed scan_time: "+
+			"processed=%s persisted=%s. The store kept an older scan than the one just processed, which the "+
+			"freshness guard should have accepted - possible scan regression.",
+			nodeDatastore.NodeString(node),
+			protocompat.ConvertTimestampToString(incomingScanTime, time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(persistedScanTime, time.RFC3339Nano))
+	case cmp < 0:
+		// The store kept a scan_time newer than the one we just processed - the expected shape of an
+		// isUpdated() rejection, where node.Scan was rewritten back to the newer stored scan.
+		log.Warnf("Persisted scan_time for node %s does not match the freshly processed scan_time: "+
+			"processed=%s persisted=%s. The store rejected this scan as not newer than the stored one.",
+			nodeDatastore.NodeString(node),
+			protocompat.ConvertTimestampToString(incomingScanTime, time.RFC3339Nano),
+			protocompat.ConvertTimestampToString(persistedScanTime, time.RFC3339Nano))
 	}
 
 	sendComplianceAck(ctx, node, injector)

--- a/central/sensor/service/pipeline/nodeindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeindex/pipeline_test.go
@@ -2,6 +2,7 @@ package nodeindex
 
 import (
 	"testing"
+	"time"
 
 	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
@@ -10,10 +11,111 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
 	nodesEnricherMocks "github.com/stackrox/rox/pkg/nodes/enricher/mocks"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+const (
+	scanRejectedWarnSnippet   = "rejected this scan as not newer than the stored one"
+	scanRegressionWarnSnippet = "possible scan regression"
+)
+
+func swapObservedLogger(t *testing.T) *observer.ObservedLogs {
+	core, logs := observer.New(zap.WarnLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+	return logs
+}
+
+// TestPipelineWarnsWhenPersistedScanTimeRegresses validates the post-upsert diagnostic: after the upsert,
+// the pipeline compares the scan_time it processed against what the store actually kept (the store rewrites
+// node.Scan in place when it rejects a scan as not-newer) and warns on a mismatch.
+func TestPipelineWarnsWhenPersistedScanTimeRegresses(t *testing.T) {
+	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+
+	processed := time.Now()
+
+	cases := map[string]struct {
+		// persistedScanTime is what the store leaves on node.Scan after the upsert returns.
+		persistedScanTime time.Time
+		// expectSnippet is the warning we expect to see; empty means no warning at all.
+		expectSnippet string
+	}{
+		// A genuine isUpdated() rejection keeps a scan strictly newer than the one we just processed.
+		"warns (rejection) when the store kept a newer scan": {
+			persistedScanTime: processed.Add(time.Hour),
+			expectSnippet:     scanRejectedWarnSnippet,
+		},
+		// The store kept an older scan than the fresh one - a scan the freshness guard should have accepted.
+		"warns (regression) when the store kept an older scan": {
+			persistedScanTime: processed.Add(-time.Hour),
+			expectSnippet:     scanRegressionWarnSnippet,
+		},
+		"silent when the fresh scan was accepted": {
+			persistedScanTime: processed,
+			expectSnippet:     "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			logs := swapObservedLogger(t)
+			node := &storage.Node{Id: "1", Name: "node-name", ClusterId: "cluster-id"}
+
+			ctrl := gomock.NewController(t)
+			nodeDatastore := nodeDatastoreMocks.NewMockDataStore(ctrl)
+			riskManager := riskManagerMocks.NewMockManager(ctrl)
+			enricher := nodesEnricherMocks.NewMockNodeEnricher(ctrl)
+
+			gomock.InOrder(
+				nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(node, true, nil),
+				// Enrichment stamps a fresh scan_time, as the real enricher does with TimestampNow().
+				enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), nil, gomock.Any()).Times(1).
+					DoAndReturn(func(n *storage.Node, _ *storage.NodeInventory, _ *v4.IndexReport) error {
+						n.Scan = &storage.NodeScan{ScanTime: protocompat.ConvertTimeToTimestampOrNil(&processed)}
+						return nil
+					}),
+				// Upsert rewrites node.Scan in place to whatever was persisted (mimics isUpdated()).
+				riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).
+					DoAndReturn(func(n *storage.Node) error {
+						n.Scan.ScanTime = protocompat.ConvertTimeToTimestampOrNil(&tc.persistedScanTime)
+						return nil
+					}),
+			)
+
+			p := &pipelineImpl{
+				nodeDatastore: nodeDatastore,
+				riskManager:   riskManager,
+				enricher:      enricher,
+			}
+
+			err := p.Run(t.Context(), node.GetClusterId(), createMsg(mockIndexReport), nil)
+			require.NoError(t, err)
+
+			rejections := logs.FilterMessageSnippet(scanRejectedWarnSnippet).All()
+			regressions := logs.FilterMessageSnippet(scanRegressionWarnSnippet).All()
+			switch tc.expectSnippet {
+			case scanRejectedWarnSnippet:
+				assert.Len(t, rejections, 1)
+				assert.Empty(t, regressions)
+			case scanRegressionWarnSnippet:
+				assert.Len(t, regressions, 1)
+				assert.Empty(t, rejections)
+			default:
+				assert.Empty(t, rejections)
+				assert.Empty(t, regressions)
+			}
+		})
+	}
+}
 
 func TestPipelineWithEmptyIndex(t *testing.T) {
 	t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")

--- a/pkg/nodes/enricher/enricher_impl.go
+++ b/pkg/nodes/enricher/enricher_impl.go
@@ -100,11 +100,13 @@ func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage
 		return errorList.ToError()
 	}
 
+	skippedScannerTypes := make([]string, 0, len(scanners))
 	for _, scanner := range scanners {
 		// Prevent unnecessary scanner calls - v4 only works on indexReports, v2/Clairify only on nodeInventory.
 		// If both, indexReport and nodeInventory, are unset, we do not skip to keep the legacy NodeScan v1 working.
 		if (scanner.GetNodeScanner().Type() == types.ScannerV4 && indexReport == nil && nodeInventory != nil) ||
 			(scanner.GetNodeScanner().Type() == types.Clairify && nodeInventory == nil && indexReport != nil) {
+			skippedScannerTypes = append(skippedScannerTypes, scanner.GetNodeScanner().Type())
 			continue
 		}
 		log.Debugf("Enriching Node with Scanner %s / %s", scanner.GetNodeScanner().Type(), scanner.GetNodeScanner().Name())
@@ -113,6 +115,21 @@ func (e *enricherImpl) enrichWithScan(node *storage.Node, nodeInventory *storage
 			continue
 		}
 		return nil
+	}
+
+	// Only warn for the v4/nodeindex path (indexReport != nil). A v4-only Central that still receives
+	// legacy v2 NodeInventory reports would otherwise log this on every such report indefinitely - benign
+	// noise, since v2-on-a-v4-only-Central is an expected transitional state. When an IndexReport arrives and
+	// every registered scanner was still skipped, ScannerV4 is not registered and the node scan silently
+	// never refreshes - the condition worth surfacing.
+	if indexReport != nil && errorList.Empty() && len(skippedScannerTypes) == len(scanners) {
+		// node.Scan is left completely untouched by this call (this is NOT surfaced as an error - ToError()
+		// returns nil below), so the caller will upsert whatever scan the node already had. That upsert looks
+		// identical to a successful no-op scan refresh in logs/metrics downstream.
+		log.Warnf("No applicable node scanner ran for node %s:%s (inventory=%t, indexReport=%t); registered "+
+			"scanner types were all skipped as inapplicable: %v. The node's existing scan, if any, was not "+
+			"refreshed by this call.",
+			node.GetClusterName(), node.GetName(), nodeInventory != nil, indexReport != nil, skippedScannerTypes)
 	}
 
 	return errorList.ToError()

--- a/pkg/nodes/enricher/enricher_impl_test.go
+++ b/pkg/nodes/enricher/enricher_impl_test.go
@@ -6,13 +6,28 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/logging"
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/scanners/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/sync/semaphore"
 )
+
+const allSkippedWarnSnippet = "No applicable node scanner ran"
+
+// swapObservedLogger replaces the package-level logger with an observer-backed one at Warn level and
+// returns the observed logs plus a restore func. Lets us assert exactly which diagnostic warnings fire.
+func swapObservedLogger(t *testing.T) *observer.ObservedLogs {
+	core, logs := observer.New(zap.WarnLevel)
+	orig := log
+	log = &logging.LoggerImpl{InnerLogger: zap.New(core).Sugar()}
+	t.Cleanup(func() { log = orig })
+	return logs
+}
 
 var _ types.NodeScannerWithDataSource = (*fakeNodeScannerWithDataSource)(nil)
 
@@ -22,12 +37,14 @@ type fakeNodeScannerWithDataSource struct {
 
 type opts struct {
 	requestedScan bool
+	scannerType   string
 }
 
 func newFakeNodeScannerWithDataSource(opts opts) types.NodeScannerWithDataSource {
 	return &fakeNodeScannerWithDataSource{
 		nodeScanner: &fakeNodeScanner{
 			requestedScan: opts.requestedScan,
+			scannerType:   opts.scannerType,
 		},
 	}
 }
@@ -44,6 +61,7 @@ var _ types.NodeScanner = (*fakeNodeScanner)(nil)
 
 type fakeNodeScanner struct {
 	requestedScan bool
+	scannerType   string
 }
 
 func (*fakeNodeScanner) MaxConcurrentNodeScanSemaphore() *semaphore.Weighted {
@@ -96,7 +114,10 @@ func (*fakeNodeScanner) TestNodeScanner() error {
 	return nil
 }
 
-func (*fakeNodeScanner) Type() string {
+func (f *fakeNodeScanner) Type() string {
+	if f.scannerType != "" {
+		return f.scannerType
+	}
 	return "type"
 }
 
@@ -259,6 +280,61 @@ func TestZeroIntegrations(t *testing.T) {
 	assert.Error(t, err)
 	expectedErrMsg := "error scanning node cluster:node error: no node scanners are integrated"
 	assert.Equal(t, expectedErrMsg, err.Error())
+}
+
+// TestEnrichWithScan_AllScannersSkippedWarning validates the ROX-36432 diagnostic: when an IndexReport
+// arrives but every registered scanner is inapplicable (no ScannerV4 registered), we warn - and, per
+// review, only for the v4/nodeindex path (indexReport != nil), not for benign v2-on-a-v4-only-Central.
+func TestEnrichWithScan_AllScannersSkippedWarning(t *testing.T) {
+	node := &storage.Node{Id: fixtureconsts.Node1, ClusterName: "cluster", Name: "node"}
+
+	newEnricher := func(scanner types.NodeScannerWithDataSource) *enricherImpl {
+		return &enricherImpl{
+			cves: &fakeCVESuppressor{},
+			scanners: map[string]types.NodeScannerWithDataSource{
+				scanner.GetNodeScanner().Type(): scanner,
+			},
+			metrics: newMetrics(pkgMetrics.CentralSubsystem),
+		}
+	}
+
+	t.Run("warns when only v2 registered and an IndexReport arrives", func(t *testing.T) {
+		logs := swapObservedLogger(t)
+		clairify := newFakeNodeScannerWithDataSource(opts{scannerType: types.Clairify})
+		e := newEnricher(clairify)
+		testNode := node.CloneVT()
+
+		err := e.enrichWithScan(testNode, nil, &v4.IndexReport{})
+		require.NoError(t, err)
+		assert.Nil(t, testNode.GetScan(), "node scan must be left untouched when every scanner is skipped")
+		assert.Len(t, logs.FilterMessageSnippet(allSkippedWarnSnippet).All(), 1)
+	})
+
+	t.Run("does not warn on the v2 path (indexReport == nil)", func(t *testing.T) {
+		logs := swapObservedLogger(t)
+		// Only ScannerV4 registered; a v2 NodeInventory arrives - v4 is skipped, all skipped, but the gate
+		// (indexReport != nil) must suppress the warning.
+		v4Scanner := newFakeNodeScannerWithDataSource(opts{scannerType: types.ScannerV4})
+		e := newEnricher(v4Scanner)
+		testNode := node.CloneVT()
+
+		err := e.enrichWithScan(testNode, &storage.NodeInventory{}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, logs.FilterMessageSnippet(allSkippedWarnSnippet).All(),
+			"must not warn for the routine v2-on-a-v4-only-Central case")
+	})
+
+	t.Run("does not warn when a scanner actually runs", func(t *testing.T) {
+		logs := swapObservedLogger(t)
+		v4Scanner := newFakeNodeScannerWithDataSource(opts{scannerType: types.ScannerV4})
+		e := newEnricher(v4Scanner)
+		testNode := node.CloneVT()
+
+		err := e.enrichWithScan(testNode, nil, &v4.IndexReport{})
+		require.NoError(t, err)
+		assert.NotNil(t, testNode.GetScan(), "scanner should have populated the scan")
+		assert.Empty(t, logs.FilterMessageSnippet(allSkippedWarnSnippet).All())
+	})
 }
 
 func TestFillScanStatsWithPostgres(t *testing.T) {


### PR DESCRIPTION
## Description

Manual backport of #22504 to `release-4.10` (automatic backport failed, see [backport comment](https://github.com/stackrox/stackrox/pull/22504#issuecomment-5510782042)).

Logging-only change, no behavior change — see #22504 for full context.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- `go vet` clean on all three touched packages after cherry-pick.
- `go test ./central/sensor/service/pipeline/nodeindex/... ./pkg/nodes/enricher/...` passes.
- `go test -tags sql_integration ./central/node/datastore/...` passes against a local Postgres 15.
- Diff of the cherry-picked commit compared against the original master commit to confirm the mergiraf-resolved conflict introduced no semantic difference.