### PR TITLE
tests: restore node pipeline coverage under ROX_LEGACY_SCANNER

### DIFF
--- a/central/sensor/service/pipeline/nodeindex/three_pipelines_test.go
+++ b/central/sensor/service/pipeline/nodeindex/three_pipelines_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/types"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -42,6 +43,55 @@ const (
 )
 
 func Test_ThreePipelines_Run(t *testing.T) {
+	nodeWithScore := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{storage.Node_MISSING_SCAN_DATA},
+		RiskScore:     1,
+	}
+
+	nodeWithV4Scan := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{storage.Node_MISSING_SCAN_DATA},
+		RiskScore:     1,
+		Scan:          &storage.NodeScan{ScannerVersion: storage.NodeScan_SCANNER_V4},
+	}
+
+	nodeWithScanWithKernelV2 := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{},
+		RiskScore:     1,
+		Scan:          nodeScanFixtureWithKernel("v2"),
+		SetComponents: &storage.Node_Components{Components: 1},
+		SetCves:       &storage.Node_Cves{Cves: 1},
+		SetTopCvss:    &storage.Node_TopCvss{TopCvss: 1},
+	}
+
+	nodeWithScanWithKernelV4 := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{},
+		RiskScore:     1,
+		Scan:          nodeScanFixtureWithKernel("v4"),
+		SetComponents: &storage.Node_Components{Components: 1},
+		SetCves:       &storage.Node_Cves{Cves: 1},
+		SetTopCvss:    &storage.Node_TopCvss{TopCvss: 1},
+	}
+
 	type usedMocks struct {
 		clusterStore      *clusterDatastoreMocks.MockDataStore
 		nodeDatastore     *nodeDatastoreMocks.MockDataStore
@@ -77,6 +127,168 @@ func Test_ThreePipelines_Run(t *testing.T) {
 				)
 			},
 			wantNodeExists: false,
+		},
+
+		"node index arriving after node should result in data from the node being overwritten": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error{
+				// V1 node-scan for node1 arrives over the node pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return np.Run(context.Background(), clusterID, createNodeMsg(nodeID, "v1"), nil)
+				},
+				// V4 node-scan (node index) for node1 arrives over the node index pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return nidxp.Run(context.Background(), clusterID, createNodeIndexMsg(nodeID, "v4"), nil)
+				},
+			},
+			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, false)
+				t.Setenv(features.ScannerV4.EnvVar(), "true")
+				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				gomock.InOrder(
+					// node arrives: non-RHCOS with LegacyScanner off upserts UNSUPPORTED and skips Clairify
+					m.clusterStore.EXPECT().GetClusterName(gomock.Any(), gomock.Eq(clusterID)).Times(1).Return(clusterID, true, nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), gomock.Any()).Times(1).Return(nil),
+					// node index arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).Times(1).Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).MinTimes(1).Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV4).Times(1).Return(nil),
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScanWithKernelV4, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v4",
+		},
+
+		"node index arriving after node inventory should result in inventory being overwritten": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error{
+
+				// V2 node-scan (node inventory) for node1 arrives over the node-inventory pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return ninvp.Run(context.Background(), clusterID, createNodeInventoryMsg(nodeID, "v2"), nil)
+				},
+				// V4 node-scan (node index) for node1 arrives
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return nidxp.Run(context.Background(), clusterID, createNodeIndexMsg(nodeID, "v3"), nil)
+				},
+			},
+			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				t.Setenv(features.ScannerV4.EnvVar(), "true")
+				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				gomock.InOrder(
+					// node inventory arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).Times(1).Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).MinTimes(1).Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV2).Times(1).Return(nil),
+
+					// node index arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).Times(1).Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).MinTimes(1).Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV4).Times(1).Return(nil),
+
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScanWithKernelV4, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v4",
+		},
+
+		"node index arriving before node inventory should result in inventory being discarded": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error{
+				// V4 node-scan (node index) for node1 arrives
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return nidxp.Run(context.Background(), clusterID, createNodeIndexMsg(nodeID, "v4"), nil)
+				},
+				// V2 node-scan (node inventory) for node1 arrives over the node-inventory pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return ninvp.Run(context.Background(), clusterID, createNodeInventoryMsg(nodeID, "v2"), nil)
+				},
+			},
+			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				t.Setenv(features.ScannerV4.EnvVar(), "true")
+				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				gomock.InOrder(
+					// node index arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).Times(1).Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).MinTimes(1).Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV4).Times(1).Return(nil),
+
+					// node inventory arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithV4Scan, true, nil),
+
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Times(1).Return(nodeWithScanWithKernelV4, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v4",
+		},
+
+		"node inventory and node index arriving while indexing is disabled results in inventory being persisted": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error{
+				// V2 node-scan (node inventory) for node1 arrives over the node-inventory pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return ninvp.Run(context.Background(), clusterID, createNodeInventoryMsg(nodeID, "v2"), nil)
+				},
+				// V4 node-scan (node index) for node1 arrives
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return nidxp.Run(context.Background(), clusterID, createNodeIndexMsg(nodeID, "v4"), nil)
+				},
+			},
+			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				t.Setenv(features.ScannerV4.EnvVar(), "false")
+				t.Setenv(features.NodeIndexEnabled.EnvVar(), "false")
+				gomock.InOrder(
+					// node inventory arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).AnyTimes().Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).AnyTimes().Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV2).AnyTimes().Return(nil),
+
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).AnyTimes().Return(nodeWithScanWithKernelV2, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v2",
+		},
+		"node inventory arriving on blank node while indexing is enabled still results in inventory being persisted": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error{
+				// V2 node-scan (node inventory) for node1 arrives over the node-inventory pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment, nidxp pipeline.Fragment) error {
+					return ninvp.Run(context.Background(), clusterID, createNodeInventoryMsg(nodeID, "v2"), nil)
+				},
+			},
+			setUpMocksAndEnv: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				t.Setenv(features.ScannerV4.EnvVar(), "true")
+				t.Setenv(features.NodeIndexEnabled.EnvVar(), "true")
+				gomock.InOrder(
+					// node inventory arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).AnyTimes().Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).AnyTimes().Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV2).AnyTimes().Return(nil),
+
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).AnyTimes().Return(nodeWithScanWithKernelV2, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v2",
 		},
 	}
 	for name, tt := range tests {
@@ -226,6 +438,41 @@ func createNodeIndexMsg(id, kernel string) *central.MsgFromSensor {
 				Id: id,
 				Resource: &central.SensorEvent_IndexReport{
 					IndexReport: createIndexReportWithKernel(kernel),
+				},
+			},
+		},
+	}
+}
+
+func createNodeInventory(id, kernelV string) *storage.NodeInventory {
+	return &storage.NodeInventory{
+		NodeId:   id,
+		NodeName: nodeName,
+		Components: &storage.NodeInventory_Components{
+			Namespace: "",
+			RhelComponents: []*storage.NodeInventory_Components_RHELComponent{
+				{
+					Id:          1,
+					Name:        kernelComponentName,
+					Namespace:   "",
+					Version:     kernelV,
+					Arch:        "",
+					Module:      "",
+					AddedBy:     "",
+					Executables: nil,
+				},
+			},
+			RhelContentSets: nil,
+		},
+	}
+}
+
+func createNodeInventoryMsg(id, kernel string) *central.MsgFromSensor {
+	return &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Resource: &central.SensorEvent_NodeInventory{
+					NodeInventory: createNodeInventory(id, kernel),
 				},
 			},
 		},

--- a/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	clusterDatastoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	nodeDatastoreMocks "github.com/stackrox/rox/central/node/datastore/mocks"
 	riskManagerMocks "github.com/stackrox/rox/central/risk/manager/mocks"
@@ -79,6 +80,84 @@ func Test_pipelineImpl_Run(t *testing.T) {
 			},
 			wantInjectorContain: []*central.NodeInventoryACK{{Action: central.NodeInventoryACK_ACK, NodeName: "test-node"}},
 		},
+		{
+			name: "when event action is CREATE_RESOURCE then do not ignore event",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				node := storage.Node{
+					Id: "test node id",
+				}
+				a.msg = createMsg(node.GetId())
+				a.msg.GetEvent().Action = central.ResourceAction_CREATE_RESOURCE
+				a.injector = &recordingInjector{}
+				gomock.InOrder(
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(&node, true, nil),
+					m.enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), gomock.Any(), nil).Times(1).Return(nil),
+					m.riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil),
+				)
+			},
+			wantInjectorContain: []*central.NodeInventoryACK{{Action: central.NodeInventoryACK_ACK}},
+		},
+		{
+			name: "when event has inventory then enrich and upsert with risk",
+			wantInjectorContain: []*central.NodeInventoryACK{
+				{Action: central.NodeInventoryACK_ACK},
+			},
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				node := storage.Node{
+					Id: "test node id",
+				}
+				a.msg = createMsg(node.GetId())
+				a.injector = &recordingInjector{}
+				gomock.InOrder(
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(&node, true, nil),
+					m.enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), gomock.Any(), nil).Times(1).Return(nil),
+					m.riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil),
+				)
+			},
+		},
+		{
+			name: "when injector is nil then handle normally and don't panic",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				node := storage.Node{
+					Id: "test node id",
+				}
+				a.msg = createMsg(node.GetId())
+				a.injector = nil
+				gomock.InOrder(
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(&node, true, nil),
+					m.enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), gomock.Any(), nil).Times(1).Return(nil),
+					m.riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil),
+				)
+			},
+		},
+		{
+			name:                "when event has inventory for unknown node then no ACK should be sent",
+			wantInjectorContain: []*central.NodeInventoryACK{},
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				a.msg = createMsg("node1")
+				a.injector = &recordingInjector{}
+				gomock.InOrder(
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq("node1")).Times(1).Return(nil, false, nil),
+				)
+			},
+		},
+		{
+			name:                "when fetching node errors then no ACK should be sent",
+			wantInjectorContain: []*central.NodeInventoryACK{},
+			wantErr:             "fetching error from DB",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				a.msg = createMsg("node1")
+				a.injector = &recordingInjector{}
+				gomock.InOrder(
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq("node1")).Times(1).Return(nil, false, errors.New("fetching error from DB")),
+				)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -111,6 +190,131 @@ func Test_pipelineImpl_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_pipelineImpl_Run_SendsSensorAndLegacyACKs(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+	ctrl := gomock.NewController(t)
+	clusterStore := clusterDatastoreMocks.NewMockDataStore(ctrl)
+	nodeDatastore := nodeDatastoreMocks.NewMockDataStore(ctrl)
+	riskManager := riskManagerMocks.NewMockManager(ctrl)
+	enricher := nodesEnricherMocks.NewMockNodeEnricher(ctrl)
+
+	clusterID := "cluster-1"
+	nodeName := "node-name"
+	node := storage.Node{
+		Id:        "node-id",
+		ClusterId: clusterID,
+	}
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_NodeInventory{
+					NodeInventory: &storage.NodeInventory{
+						NodeId:   node.GetId(),
+						NodeName: nodeName,
+					},
+				},
+			},
+		},
+	}
+	injector := &recordingInjector{
+		capabilities: map[centralsensor.SensorCapability]bool{
+			centralsensor.SensorACKSupport: true,
+		},
+	}
+
+	gomock.InOrder(
+		nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(&node, true, nil),
+		enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), gomock.Any(), nil).Times(1).Return(nil),
+		riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil),
+	)
+
+	p := &pipelineImpl{
+		clusterStore:  clusterStore,
+		nodeDatastore: nodeDatastore,
+		enricher:      enricher,
+		riskManager:   riskManager,
+	}
+
+	err := p.Run(context.Background(), clusterID, msg, injector)
+	assert.NoError(t, err)
+
+	protoassert.SlicesEqual(t, []*central.NodeInventoryACK{
+		{
+			ClusterId:   clusterID,
+			NodeName:    nodeName,
+			Action:      central.NodeInventoryACK_ACK,
+			MessageType: central.NodeInventoryACK_NodeInventory,
+		},
+	}, injector.getSentACKs(), "legacy ACKs")
+
+	protoassert.SlicesEqual(t, []*central.SensorACK{
+		{
+			Action:      central.SensorACK_ACK,
+			MessageType: central.SensorACK_NODE_INVENTORY,
+			ResourceId:  nodeName,
+		},
+	}, injector.getSentSensorACKs(), "sensor ACKs")
+}
+
+func Test_pipelineImpl_Run_SkipsSensorACKWhenCapabilityMissing(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+	ctrl := gomock.NewController(t)
+	clusterStore := clusterDatastoreMocks.NewMockDataStore(ctrl)
+	nodeDatastore := nodeDatastoreMocks.NewMockDataStore(ctrl)
+	riskManager := riskManagerMocks.NewMockManager(ctrl)
+	enricher := nodesEnricherMocks.NewMockNodeEnricher(ctrl)
+
+	clusterID := "cluster-1"
+	nodeName := "node-name"
+	node := storage.Node{
+		Id:        "node-id",
+		ClusterId: clusterID,
+	}
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_NodeInventory{
+					NodeInventory: &storage.NodeInventory{
+						NodeId:   node.GetId(),
+						NodeName: nodeName,
+					},
+				},
+			},
+		},
+	}
+	injector := &recordingInjector{
+		capabilities: map[centralsensor.SensorCapability]bool{},
+	}
+
+	gomock.InOrder(
+		nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(node.GetId())).Times(1).Return(&node, true, nil),
+		enricher.EXPECT().EnrichNodeWithVulnerabilities(gomock.Any(), gomock.Any(), nil).Times(1).Return(nil),
+		riskManager.EXPECT().CalculateRiskAndUpsertNode(gomock.Any()).Times(1).Return(nil),
+	)
+
+	p := &pipelineImpl{
+		clusterStore:  clusterStore,
+		nodeDatastore: nodeDatastore,
+		enricher:      enricher,
+		riskManager:   riskManager,
+	}
+
+	err := p.Run(context.Background(), clusterID, msg, injector)
+	assert.NoError(t, err)
+	assert.Empty(t, injector.getSentSensorACKs(), "sensor ACK should be skipped without SensorACKSupport")
+
+	protoassert.SlicesEqual(t, []*central.NodeInventoryACK{
+		{
+			ClusterId:   clusterID,
+			NodeName:    nodeName,
+			Action:      central.NodeInventoryACK_ACK,
+			MessageType: central.NodeInventoryACK_NodeInventory,
+		},
+	}, injector.getSentACKs(), "legacy ACKs")
 }
 
 var _ common.MessageInjector = (*recordingInjector)(nil)

--- a/central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go
+++ b/central/sensor/service/pipeline/nodeinventory/two_pipelines_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/metrics"
 	nodeEnricher "github.com/stackrox/rox/pkg/nodes/enricher"
 	"github.com/stackrox/rox/pkg/scancomponent"
 	"github.com/stackrox/rox/pkg/scanners"
 	"github.com/stackrox/rox/pkg/scanners/types"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -40,6 +42,44 @@ const (
 )
 
 func Test_TwoPipelines_Run(t *testing.T) {
+	nodeWithScore := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{storage.Node_MISSING_SCAN_DATA},
+		RiskScore:     1,
+	}
+
+	nodeWithScanWithKernelV1 := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{},
+		RiskScore:     1,
+		Scan:          nodeScanFixtureWithKernel("v1"),
+		SetComponents: &storage.Node_Components{Components: 1},
+		SetCves:       &storage.Node_Cves{Cves: 1},
+		SetTopCvss:    &storage.Node_TopCvss{TopCvss: 1},
+	}
+
+	nodeWithScanWithKernelV2 := &storage.Node{
+		Id:            nodeID,
+		Name:          nodeName,
+		ClusterId:     clusterID,
+		ClusterName:   clusterID,
+		KernelVersion: "v1",
+		Notes:         []storage.Node_Note{},
+		RiskScore:     1,
+		Scan:          nodeScanFixtureWithKernel("v2"),
+		SetComponents: &storage.Node_Components{Components: 1},
+		SetCves:       &storage.Node_Cves{Cves: 1},
+		SetTopCvss:    &storage.Node_TopCvss{TopCvss: 1},
+	}
+
 	type usedMocks struct {
 		clusterStore      *clusterDatastoreMocks.MockDataStore
 		nodeDatastore     *nodeDatastoreMocks.MockDataStore
@@ -67,10 +107,75 @@ func Test_TwoPipelines_Run(t *testing.T) {
 				},
 			},
 			setUpMocks: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
 				m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).MinTimes(1).Return(nil, false, nil)
 			},
 			wantNodeExists:        false,
 			wantKernelVersionNode: "",
+		},
+		"node inventory arriving after node should result in data from the node being overwritten": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error{
+				// Old node-scan for node1 arrives over the node pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error {
+					return np.Run(context.Background(), clusterID, createNodeMsg(nodeID, "v1"), nil)
+				},
+				// New node-scan (node-inventory) for node1 arrives over the node-inventory pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error {
+					return ninvp.Run(context.Background(), clusterID, createNodeInventoryMsg(nodeID, "v2"), nil)
+				},
+			},
+			setUpMocks: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				gomock.InOrder(
+					// node arrives
+					m.clusterStore.EXPECT().GetClusterName(gomock.Any(), gomock.Eq(clusterID)).Times(1).Return(clusterID, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).AnyTimes().Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), gomock.Any()).AnyTimes().Return(nil),
+
+					// node inventory arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).AnyTimes().Return(nodeWithScore, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()).AnyTimes().Return(),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).AnyTimes().Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), nodeWithScanWithKernelV2).AnyTimes().Return(nil),
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).AnyTimes().Return(nodeWithScanWithKernelV2, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v2",
+		},
+		"node inventory arriving first should result in data from it being lost": {
+			operations: []func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error{
+				// New node-scan (node-inventory) for node1 arrives over the node-inventory pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error {
+					return ninvp.Run(context.Background(), clusterID, createNodeInventoryMsg(nodeID, "v2"), nil)
+				},
+				// Old node-scan for node1 arrives over the node pipeline
+				func(t *testing.T, np pipeline.Fragment, ninvp pipeline.Fragment) error {
+					return np.Run(context.Background(), clusterID, createNodeMsg(nodeID, "v1"), nil)
+				},
+			},
+			setUpMocks: func(t *testing.T, m *usedMocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				gomock.InOrder(
+					// node inventory arrives
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).Return(nil, false, nil),
+
+					// node arrives
+					m.clusterStore.EXPECT().GetClusterName(gomock.Any(), gomock.Eq(clusterID)).Return(clusterID, true, nil),
+					m.cveDatastore.EXPECT().EnrichNodeWithSuppressedCVEs(gomock.Any()),
+					m.riskStorage.EXPECT().UpsertRisk(gomock.Any(), gomock.Any()).Times(1).Return(nil),
+					m.nodeDatastore.EXPECT().UpsertNode(gomock.Any(), gomock.Any()).Return(nil),
+
+					// check what got stored in the DB
+					m.nodeDatastore.EXPECT().GetNode(gomock.Any(), gomock.Eq(nodeID)).AnyTimes().Return(nodeWithScanWithKernelV1, true, nil),
+				)
+			},
+			wantNodeExists:            true,
+			wantKernelVersionNode:     "v1",
+			wantKernelVersionNodeScan: "v1",
 		},
 	}
 	for name, tt := range tests {

--- a/central/sensor/service/pipeline/nodes/pipeline_test.go
+++ b/central/sensor/service/pipeline/nodes/pipeline_test.go
@@ -75,6 +75,31 @@ func Test_pipelineImpl_Run(t *testing.T) {
 			},
 		},
 		{
+			name: "when node is not full host scanned then enrich and upsert with risk",
+			setUp: func(t *testing.T, a *args, m *mocks) {
+				testutils.MustUpdateFeature(t, features.LegacyScanner, true)
+				a.msg = createMsg("Something that is not RHCOS")
+				a.clusterID = "test cluster id"
+				gomock.InOrder(
+					m.clusterStore.EXPECT().
+						GetClusterName(gomock.Any(), gomock.Eq(a.clusterID)).
+						Times(1).
+						Return("test cluster name", true, nil),
+					m.enricher.EXPECT().
+						EnrichNode(gomock.Any()).
+						Times(1).
+						Return(nil),
+					m.riskManager.EXPECT().
+						CalculateRiskAndUpsertNode(gomock.Any()).
+						DoAndReturn(func(node *storage.Node) error {
+							assert.Equal(t, node.GetClusterName(), "test cluster name")
+							assert.Equal(t, node.GetClusterId(), a.clusterID)
+							return nil
+						}).Times(1),
+				)
+			},
+		},
+		{
 			name: "when LegacyScanner is disabled and node is non-RHCOS then set UNSUPPORTED note",
 			setUp: func(t *testing.T, a *args, m *mocks) {
 				testutils.MustUpdateFeature(t, features.LegacyScanner, false)

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -149,8 +149,8 @@ var (
 	// UISecretsPageMigration enables the secrets list page under the Risk section
 	UISecretsPageMigration = registerFeature("Display secrets list page under Risk section", "ROX_UI_SECRETS_PAGE_MIGRATION")
 
-	// LegacyScanner enables the legacy scanner (Scanner V2) integration.
-	LegacyScanner = registerFeature("Enable legacy scanner (Scanner V2) integration", "ROX_LEGACY_SCANNER", withUnchangeable(true))
+	// LegacyScanner enables Scanner V2 integration. Off by default; locked in release builds.
+	LegacyScanner = registerFeature("Enable legacy scanner (Scanner V2) integration", "ROX_LEGACY_SCANNER", unchangeableInProd)
 
 	// ACMAccessControlDelegation enables AuthProviders with role lookup delegation to ACM access control information.
 	ACMAccessControlDelegation = registerFeature("Enable ACS access control integration with Red Hat Advanced Cluster Management", "ROX_ACM_ACCESS_CONTROL_DELEGATION")


### PR DESCRIPTION
## Description

22559 locked `ROX_LEGACY_SCANNER` off in every build (`withUnchangeable(true)`) and deleted Central unit tests whose mocks still assumed the old default (Scanner V2 enrichment on). The node inventory, nodes, and node index pipelines are still in tree. Those tests failed on unmet gomock expectations, then were removed.

This PR keeps the flag off by default and locked in **release** builds (`unchangeableInProd`). Development unit tests can enable it with `MustUpdateFeature`. The deleted Scanner V2 cases are restored and gated that way. They still send `NodeInventory` / Clairify traffic; they are not retargeted at Scanner V4.

One case is rewritten for the default-off path: a non-RHCOS node event followed by a V4 node index. With the flag off, the nodes pipeline upserts `UNSUPPORTED` and the index overwrites it. That is the HEAD production path, not a new V4 scenario.

Sidecar and Helm "re-enable node-inventory" tests stay gone. Those objects are no longer installed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI: go unit tests passing https://github.com/stackrox/stackrox/actions/runs/33650707909/job/100316733020?pr=22594
- [x] Local test passing

```
$ go test ./central/sensor/service/pipeline/nodeinventory \
        ./central/sensor/service/pipeline/nodes \
        ./central/sensor/service/pipeline/nodeindex \
        ./pkg/scanners \
        ./central/imageintegration/... \
        ./central/cve/fetcher -count=1
ok  	github.com/stackrox/rox/central/sensor/service/pipeline/nodeinventory	1.333s
ok  	github.com/stackrox/rox/central/sensor/service/pipeline/nodes	1.850s
ok  	github.com/stackrox/rox/central/sensor/service/pipeline/nodeindex	2.814s
ok  	github.com/stackrox/rox/pkg/scanners	3.721s
?   	github.com/stackrox/rox/central/imageintegration	[no test files]
ok  	github.com/stackrox/rox/central/imageintegration/datastore	4.723s
?   	github.com/stackrox/rox/central/imageintegration/datastore/mocks	[no test files]
ok  	github.com/stackrox/rox/central/imageintegration/service	5.786s
ok  	github.com/stackrox/rox/central/imageintegration/store	6.633s
?   	github.com/stackrox/rox/central/imageintegration/store/mocks	[no test files]
?   	github.com/stackrox/rox/central/imageintegration/store/postgres	[no test files]
?   	github.com/stackrox/rox/central/imageintegration/tlscheckcache	[no test files]
ok  	github.com/stackrox/rox/central/cve/fetcher	7.751s
```
(same result for `-tags release`)

This also passing, not skipped (will be skipped with `-tags release`)
```
$ go test ./pkg/scanners -count=1 -v -run TestNewFactory_ClairifyRegistration

=== RUN   TestNewFactory_ClairifyRegistration
=== RUN   TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_enabled,_Clairify_creator_is_registered
=== RUN   TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_disabled,_Clairify_creator_is_not_registered
--- PASS: TestNewFactory_ClairifyRegistration (0.00s)
    --- PASS: TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_enabled,_Clairify_creator_is_registered (0.00s)
    --- PASS: TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_disabled,_Clairify_creator_is_not_registered (0.00s)
PASS
ok  	github.com/stackrox/rox/pkg/scanners	5.521s
```

here with `-tags release` - SKIP as expected: 
```
$ go test ./pkg/scanners -count=1 -tags release -v -run TestNewFactory_ClairifyRegistration

=== RUN   TestNewFactory_ClairifyRegistration
=== RUN   TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_enabled,_Clairify_creator_is_registered
    feature_flag.go:23: Skipping test, feature "ROX_LEGACY_SCANNER" cannot be set to desired value: true
=== RUN   TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_disabled,_Clairify_creator_is_not_registered
--- PASS: TestNewFactory_ClairifyRegistration (0.00s)
    --- SKIP: TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_enabled,_Clairify_creator_is_registered (0.00s)
    --- PASS: TestNewFactory_ClairifyRegistration/when_LegacyScanner_is_disabled,_Clairify_creator_is_not_registered (0.00s)
PASS
ok  	github.com/stackrox/rox/pkg/scanners	1.255s
```


AI-Assisted: cursor, restored tests and flag option from review, user directed approach