### PR TITLE
ROX-36719: Render NodeVulnerabilityFiltersSince in Step 3 of wizard

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityFiltersView.tsx
@@ -1,5 +1,13 @@
 import type { ReactElement } from 'react';
-import { DescriptionList, Flex, FlexItem, Title } from '@patternfly/react-core';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    FlexItem,
+    Title,
+} from '@patternfly/react-core';
 import type { BreakpointModifiers } from '@patternfly/react-core';
 
 import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
@@ -49,6 +57,10 @@ function NodeVulnerabilityFiltersView({
                         attributes={attributes}
                         searchFilter={searchFilter}
                     />
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>CVEs discovered in node since</DescriptionListTerm>
+                        <DescriptionListDescription>All time</DescriptionListDescription>
+                    </DescriptionListGroup>
                 </DescriptionList>
             </FlexItem>
         </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersSince.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersSince.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { FormGroup, Grid, GridItem, SelectOption } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import SelectSingle from 'Components/SelectSingle/SelectSingle';
+import type { NodeVulnerabilityReportFiltersConfiguration } from 'services/ReportsService.types';
+
+export type NodeVulnerabilityFiltersSinceProps<
+    T extends NodeVulnerabilityReportFiltersConfiguration =
+        NodeVulnerabilityReportFiltersConfiguration,
+> = {
+    formik: FormikProps<T>;
+};
+
+function NodeVulnerabilityFiltersSince<
+    T extends NodeVulnerabilityReportFiltersConfiguration =
+        NodeVulnerabilityReportFiltersConfiguration,
+>({ formik }: NodeVulnerabilityFiltersSinceProps<T>): ReactElement {
+    const value = 'allVuln' in formik.values.nodeVulnReportFilters ? 'allVuln' : ''; // just so formik prop is used
+    // Grid renders the related form groups side-by-side.
+    // https://www.patternfly.org/components/forms/form#grid-form
+    return (
+        <Grid hasGutter>
+            <GridItem span={6}>
+                <FormGroup label="CVEs discovered in node since" isRequired>
+                    <SelectSingle
+                        id="CvesSince"
+                        isDisabled
+                        value={value}
+                        handleSelect={() => {}}
+                        menuAppendTo={() => document.body}
+                    >
+                        <SelectOption
+                            value="sinceLastSentScheduledReport"
+                            description="At least one delivery destination and schedule will be required in the next step."
+                        >
+                            Last scheduled report that was successfully sent
+                        </SelectOption>
+                        <SelectOption
+                            value="sinceStartDate"
+                            description="Custom start date for the discovered CVE that were run on-demand or downloaded"
+                        >
+                            Custom start date
+                        </SelectOption>
+                        <SelectOption
+                            value="allVuln"
+                            description="Show all detected CVEs from the beginning of cluster setup"
+                        >
+                            All time
+                        </SelectOption>
+                    </SelectSingle>
+                </FormGroup>
+            </GridItem>
+        </Grid>
+    );
+}
+
+export default NodeVulnerabilityFiltersSince;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/Wizard/Step3/NodeVulnerabilityFiltersStep.tsx
@@ -12,6 +12,8 @@ import FiltersQuery from 'Components/Reports/Step/FiltersQuery';
 
 import type { NodeVulnerabilityReportFiltersConfiguration } from 'services/ReportsService.types';
 
+import NodeVulnerabilityFiltersSince from './NodeVulnerabilityFiltersSince';
+
 export type NodeVulnerabilityFiltersStepProps<
     T extends NodeVulnerabilityReportFiltersConfiguration =
         NodeVulnerabilityReportFiltersConfiguration,
@@ -41,6 +43,7 @@ function NodeVulnerabilityFiltersStep<
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
                 <Form isHorizontal isWidthLimited>
+                    <NodeVulnerabilityFiltersSince formik={formik} />
                     <FiltersQuery
                         attributesSeparateFromConfig={attributesSeparateFromConfig}
                         error={getIn(formik.errors, queryPath)}


### PR DESCRIPTION
## Description


### Objective

Follow pattern of image vulnerability reports for node vulnerability reports.

### Problem

Because **CVEs discovered in node since** does not have data for any option other that **All time** I skipped implementing the form elelemnt.

Thank you **Brad** for brainstorming the principle that **Node** wizard follows pattern in **Image** vulnerability report configuration wizard.

### Solution

Make the input field visible.

That is, copy ImageVulnerabilityFiltersSince.tsx file and delete what is not yet implemented.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
