### PR TITLE
ROX-36688: Use nginx-2.0.3 for Fixable CVSS policy test

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -114,7 +114,7 @@ class DefaultPoliciesTest extends BaseSpecification {
             .addLabel("app", "test"),
         new Deployment()
             .setName(GCR_NGINX)
-            .setImage("us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3")
             .addLabel ( "app", "test" )
             .setCommand(["sleep", "600"]),
         new Deployment()


### PR DESCRIPTION



## Description

`DefaultPoliciesTest` enables the built-in "Fixable CVSS >= 7" policy and waits for a deploy-time violation on the `qadefpolnginx` deployment. Since 2026-09-01 that case has failed constantly on merge and nightly QA e2e, including `ocp-4-22-qa-e2e-tests`: 300s timeout and 0 violations. Other policies in the same class still pass. 

👉**This is not a flake**👈.

#20990 is the first PR with this observed failing (but not a proven cause of this failing). 

The deployment used `us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12`. The probable root cause is that this image no longer has fixable vulnerabilities with CVSS >= 7, so the policy does not fire. The same policy still matches `quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3` on the BUILD CI/CD path in `ImageManagementTest`.

This PR points `qadefpolnginx` at that nginx-2.0.3 image. 👉 That is a probable fix only 👈  . If the miss is deploy-time detection or scanning rather than image contents, the case will keep failing.

The confirming test is `DefaultPoliciesTest: Verify policy Fixable CVSS >= 7 is triggered` on `ocp-4-22-qa-e2e-tests` (or `ocp-4-22-merge-qa-e2e-tests`). The case has not passed since the regression started, so one green run of that case is the confirmation.

Tracked as ROX-36688.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests. This change retargets the existing deploy-time "Fixable CVSS >= 7" case.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI `gke-qa-e2e-tests` https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22597/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/2095198977598164992

AI-Assisted: cursor, drafted the image swap and PR text