### PR TITLE
ROX-35778: Guard absence of resourceScope in reportSnapshots

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
@@ -11,9 +11,20 @@ import {
 import type { BreakpointModifiers } from '@patternfly/react-core';
 
 import EntityScopeDescriptionListGroups from 'Components/EntityScope/EntityScopeDescriptionListGroups';
-import type { ImageVulnerabilityReportResourcesConfiguration } from 'services/ReportsService.types';
+import type {
+    ConfiguredReportSnapshot,
+    ImageVulnerabilityReportResourcesConfiguration,
+} from 'services/ReportsService.types';
 
 import { imageTypeLabelMap } from '../imageVulnerabilityReports.utils';
+
+// Although migration might have moved collectionScope into resourceScope
+// for report configurations, old snapshots might lack the resourceScope property.
+// Therefore, 'resourceScope' in values && … && (…) below.
+// Return collection name from legacy property in report configuration of job snapshot.
+function collectionSnapshotName(values: ConfiguredReportSnapshot): string | undefined {
+    return values.collectionSnapshot?.name;
+}
 
 export type ImageVulnerabilityResourcesViewProps = {
     headingLevel: 'h2' | 'h3';
@@ -28,6 +39,8 @@ function ImageVulnerabilityResourcesView({
 }: ImageVulnerabilityResourcesViewProps): ReactElement {
     const { resourceScope, vulnReportFilters } = values;
     const { imageTypes } = vulnReportFilters;
+
+    const collectionName = collectionSnapshotName(values as unknown as ConfiguredReportSnapshot);
 
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
@@ -56,7 +69,15 @@ function ImageVulnerabilityResourcesView({
                             )}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
-                    {'collectionScope' in resourceScope && (
+                    {collectionName && (
+                        <DescriptionListGroup>
+                            <DescriptionListTerm>Collection</DescriptionListTerm>
+                            <DescriptionListDescription>
+                                {collectionName}
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    )}
+                    {resourceScope && 'collectionScope' in resourceScope && (
                         <DescriptionListGroup>
                             <DescriptionListTerm>Collection</DescriptionListTerm>
                             <DescriptionListDescription>
@@ -64,7 +85,7 @@ function ImageVulnerabilityResourcesView({
                             </DescriptionListDescription>
                         </DescriptionListGroup>
                     )}
-                    {'entityScope' in resourceScope && (
+                    {resourceScope && 'entityScope' in resourceScope && (
                         <EntityScopeDescriptionListGroups entityScope={resourceScope.entityScope} />
                     )}
                 </DescriptionList>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
@@ -20,7 +20,7 @@ import { imageTypeLabelMap } from '../imageVulnerabilityReports.utils';
 
 // Although migration might have moved collectionScope into resourceScope
 // for report configurations, old snapshots might lack the resourceScope property.
-// Therefore, 'resourceScope' in values && … && (…) below.
+// Therefore, resourceScope && … && (…) below.
 // Return collection name from legacy property in report configuration of job snapshot.
 function collectionSnapshotName(values: ConfiguredReportSnapshot): string | undefined {
     return values.collectionSnapshot?.name;
@@ -69,7 +69,7 @@ function ImageVulnerabilityResourcesView({
                             )}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
-                    {collectionName && (
+                    {!resourceScope && collectionName && (
                         <DescriptionListGroup>
                             <DescriptionListTerm>Collection</DescriptionListTerm>
                             <DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -25,16 +25,19 @@ import { vulnerabilityConfigurationsReportsPath } from 'routePaths';
 // entityScope implies query but not fixability nore severities
 // collectionScope implies fixability and severities but not query
 
+// Although migration might have moved collectionScope into resourceScope
+// for report configurations, old snapshots might lack the resourceScope property.
+
 export function hasConfigurationForCollection(
     values: ImageVulnerabilityReportConfiguration
 ): values is ImageVulnerabilityReportConfigurationForCollection {
-    return 'collectionScope' in values.resourceScope;
+    return Boolean(values.resourceScope) && 'collectionScope' in values.resourceScope;
 }
 
 export function hasConfigurationForEntity(
     values: ImageVulnerabilityReportConfiguration
 ): values is ImageVulnerabilityReportConfigurationForEntity {
-    return 'entityScope' in values.resourceScope;
+    return Boolean(values.resourceScope) && 'entityScope' in values.resourceScope;
 }
 
 export function getTextForCvesSince(vulnReportFilters: CvesSince) {


### PR DESCRIPTION
## Description

### Problem

Click an image vulnerabilty report configuration that has old job snapshots, and then click **All report jobs** tab.

Page crash!

### Analysis

1. `ImageVulnerabilityReportView` element is used in 3 context:

    * Details page for report configuration.

    * **Review** step of wizard.

    * Job details. I assumed that `ReportSnapshot` was a superset of `ReportCOnfiguration` type.

        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/report_service.proto#L203-L226

2. Although migration might have moved `collectionScope` into `resourceScope` for report **configurations**, old report job **snapshots** might lack the `resourceScope` property.

### Solution

1. Edit ImageVulnerabilityResourcesView.tsx file to fix error.

    * Add `collectionSnapshotName` function for collection name from legacy property.

    * Update conditional rendering not to assume property exists `resourceScope && … && (…)`

2. Edit imageVulnerabilityReports.utils.ts file to fix similar error for filters.

    Update condition not to assume property exists `Boolean(values.resourceScope) && …`

    * `hasConfigurationForCollection`
    * `hasConfigurationForEntity` 

### Residue

1. **Brad** and I discussed pro and con of **links** to pages instead of modal or row expansion for job details, whether configuration-based or view-based reports.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. /main/vulnerabilities/reports/images/configurations

2. Click a report configuration that has recent job snapshots (for example, **brad report**)

3. Click **All report jobs** tab.

    GET /v2/reports/configurations/id/history?reportParamQuery.query=Report%20state%3A&reportParamQuery.pagination.offset=0&reportParamQuery.pagination.limit=10&reportParamQuery.pagination.sortOption.field=Report%20Completion%20Time&reportParamQuery.pagination.sortOption.reversed=true

    * See presence of `resourceScope.entityScope.rules` array
    * See `"collectionSnapshot": null` property

    <img width="1440" height="400" alt="happy" src="https://github.com/user-attachments/assets/a80ec0b8-126c-4f94-aa9a-b65836718b30" />

4. Go back, click a report configuration that has recent job snapshots (for example, **brad report**)

    * See absence of `resourceScope` property
    * See `"collectionSnapshot": {"id: "…", "name": "…"}` property

    Before changes, see error page.

    > Cannot use 'in' operator to search for 'entityScope' in null
    <img width="1439" height="892" alt="unhappy_with_error" src="https://github.com/user-attachments/assets/f3c642b5-214d-4be9-8ebc-d537a7edfe54" />

    After changes, expand row to see details.
    <img width="1440" height="892" alt="unhappy_without_error" src="https://github.com/user-attachments/assets/a722deba-8842-4ee2-9a9b-6d040fdab6bb" />
