### PR TITLE
tests: stop upgrade helpers from managing Scanner V2

### DIFF
--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -27,29 +27,6 @@ wait_for_central_reconciliation() {
     [[ "$success" == 1 ]]
 }
 
-wait_for_scanner_to_be_ready() {
-    echo "Waiting for scanner to be ready"
-    start_time="$(date '+%s')"
-    while true; do
-      scanner_json="$(kubectl -n stackrox get deploy/scanner -o json)"
-      replicas="$(jq '.status.replicas' <<<"${scanner_json}")"
-      readyReplicas="$(jq '.status.readyReplicas' <<<"${scanner_json}")"
-      echo "scanner replicas: $replicas"
-      echo "scanner readyReplicas: $readyReplicas"
-      if [[  "$replicas" == "$readyReplicas" ]]; then
-        break
-      fi
-      if (( $(date '+%s') - start_time > 1200 )); then
-        kubectl -n stackrox get pod -o wide
-        kubectl -n stackrox get deploy -o wide
-        echo >&2 "Timed out after 20m"
-        exit 1
-      fi
-      sleep 5
-    done
-    echo "Scanner is ready"
-}
-
 validate_upgrade() {
     if [[ "$#" -ne 3 ]]; then
         die "missing args. usage: validate_upgrade <stage name> <stage description> <upgrade_cluster_id>"

--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -11,7 +11,6 @@ EARLIER_TAG="4.6.2"
 EARLIER_SHA="ecff2a443c8b9a2dc7bf606162da89da81dd8e9e"
 CURRENT_TAG="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
 COLLECTOR_TAG="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory collector-tag)"}"
-SCANNER_TAG="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory scanner-tag)"}"
 PREVIOUS_RELEASES=("4.6.10" "4.7.9" "4.8.11" "4.9.10" "4.10.6" "4.11.2")
 
 # shellcheck source=../../scripts/lib.sh
@@ -242,12 +241,6 @@ test_upgrade_paths() {
     kubectl -n stackrox set image deploy/admission-control "*=$REGISTRY/main:$CURRENT_TAG"
     kubectl -n stackrox set image ds/collector "collector=$REGISTRY/collector:${COLLECTOR_TAG}" \
         "compliance=$REGISTRY/main:$CURRENT_TAG"
-    if [[ "$(kubectl -n stackrox get ds/collector -o=jsonpath='{$.spec.template.spec.containers[*].name}')" == *"node-inventory"* ]]; then
-        echo "Upgrading node-inventory container"
-        kubectl -n stackrox set image ds/collector "node-inventory=$REGISTRY/scanner-slim:${SCANNER_TAG}"
-    else
-        echo "Skipping node-inventory container as this is not Openshift 4"
-    fi
 
     sensor_wait
     # Bounce collectors to avoid restarts on initial module pull


### PR DESCRIPTION
## Description

Scanner V2 is no longer installed on ACS 5.0. These postgres upgrade helpers still had two leftover V2 actions that do not match that product change. This PR drops them. It does not stop installing Scanner V2 on the **old** Central used as the upgrade starting point.

`wait_for_scanner_to_be_ready` in `tests/upgrade/lib.sh` polled `deploy/scanner` until replicas were ready, with a 20 minute timeout. Nothing in the tree called it. On a 5.0 chart that object is gone, so a future caller would hang until timeout and fail. Dead code that can only become a `false`, so wait is deleted.

The `kubectl set image ds/collector node-inventory=...` block in `tests/upgrade/postgres_run.sh` ran **after** the old scaled Sensor was uninstalled and a **HEAD** `roxctl sensor get-bundle` was applied. HEAD collector has no `node-inventory` container, so that retag had nothing to point at (or would fail if `kubectl set image` is asked to name a missing container). `SCANNER_TAG` existed only to feed that one `set image`. Both go. The old 4.6 Helm install of Central still `--set scanner.image.tag` / `scanner.dbImage.tag`. That is the 4.6 chart, which still deploys Scanner V2, so the walk to HEAD still starts from a V2 Central.

This job does not Helm-upgrade `central-services` to HEAD. It `kubectl set image`s Central through previous releases, then installs a new HEAD Sensor. A leftover `deploy/scanner` from the 4.6 Helm release can still be present. That is the same leftover 22559 documents for non-Helm upgrades. This PR does not add a "V2 is gone" assert here, and it does not `kubectl delete` those objects.

**How to test**

`tests/upgrade/postgres_run.sh` is the GHA `gke-upgrade-tests-central` job (not `gke-upgrade-tests-postgres`, which runs `postgres_upgrade_run.sh`). Prow `gke-upgrade-tests` includes this script in its sequence.

On GKE the sidecar `set image` already took the "not OpenShift 4" skip path, so that job will not show a new pass/fail from removing the bump. Success there is: 4.6 Central still comes up with Scanner V2, the image walk to HEAD still runs, HEAD Sensor install does not try to retag `node-inventory`, smoke tests still start. Deleting the unused wait is a no-op at runtime unless something starts calling it.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Test-only: existing upgrade helpers, no new coverage. Runtime signal is the upgrade job named above.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [ ] CI `gke-upgrade-tests-central` / Prow `gke-upgrade-tests` 

AI-Assisted: cursor, dropped unused Scanner V2 upgrade helpers, user reviewed the diff