### PR TITLE
ROX-35847: increase BuiltinPoliciesTest wait on OpenShift

### DIFF
--- a/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/BuiltinPoliciesTest.groovy
@@ -1,6 +1,8 @@
 import static Services.getPolicies
 import static Services.waitForViolation
 
+import orchestratormanager.OrchestratorTypes
+
 import io.stackrox.proto.api.v1.PolicyServiceOuterClass.PatchPolicyRequest
 
 import objects.Deployment
@@ -72,6 +74,11 @@ class BuiltinPoliciesTest extends BaseSpecification {
                     .setImage("non-existent:image"),
     ]
 
+    // Enabling disabled deploy-time policies re-evaluates every cluster workload.
+    // OpenShift platform namespaces make that queue several minutes long.
+    static final private Integer WAIT_FOR_VIOLATION_TIMEOUT =
+            (isRaceBuild() || Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT) ? 450 : 120
+
     @Shared
     private List<String> disabledPolicyIds
 
@@ -127,7 +134,7 @@ class BuiltinPoliciesTest extends BaseSpecification {
 
         then:
         "Verify Violation for #policyName is triggered"
-        assert waitForViolation(deploymentName, policyName, isRaceBuild() ? 450 : 120)
+        assert waitForViolation(deploymentName, policyName, WAIT_FOR_VIOLATION_TIMEOUT)
 
         where:
         "Data inputs are:"


### PR DESCRIPTION
## Description

`BuiltinPoliciesTest` turns on every disabled builtin policy, then waits 120 seconds for each expected violation. One of those policies, "Container using read-write root filesystem", matches almost every OpenShift platform workload. Central has to re-evaluate that inventory before it looks at the test deployment.

The first failing OCP 4.12 nightly dump shows this is a wait that is too short, not a wrong security setting:

- The live Deployment and Pod both had `readOnlyRootFilesystem: false` (SCC `anyuid`).
- Central stored the same bit.
- The policy was enabled.
- Runtime alerts on `trigger-most` (for example `chkconfig Execution`) fired on time.
- The deploy-time alert for this policy was created 41 seconds after the 120 second wait expired. Every other deploy-time alert on that same deployment arrived in the same burst. Later cases in the class then passed immediately.

That is why only OCP 4.12 jobs fail: they have a large read-write-root platform surface, so the re-evaluation queue outruns 120 seconds. GKE does not. Sensor conversion is not involved.

This change waits 450 seconds on OpenShift, the same budget race builds already use. The extra time is spent once, on the first deploy-time case. After Central catches up, the rest of the unroll still returns immediately.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI for OCP 4.12 QA e2e `/test ocp-4-12-qa-e2e-tests`

1. [2095446429794308096](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22613/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2095446429794308096) aborted: Gradle could not resolve `services.gradle.org`.
2. [2095481378622672896](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22613/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2095481378622672896) job failed on unrelated `GlobalSearch` / `initializationError`. The RW-root case passed in 128s (would have timed out at 120s).
3. [2095579111966642176](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22613/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2095579111966642176) full job SUCCESS. RW-root case passed in 107s.
4. [2095637787440058368](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22613/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2095637787440058368) same `GlobalSearch` flake. RW-root case passed in 168s.

Summary analysis after the night:

From the [Prow history for #22613](https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=22613), every run that actually executed `BuiltinPoliciesTest` passed `Verify policy 'Container using read-write root filesystem' is triggered`. Two of those waits **were longer than the old 120s budget,** so they would have failed without the 450s OpenShift wait.

AI-Assisted: cursor, CI dump analysis and the timeout change, user reviewing before commit