### PR TITLE
ROX-36605: make image signature verification timeout configurable

### DIFF
--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -17,4 +17,13 @@ var (
 	// RedHatSigningKeyWatchInterval controls how often the watcher polls the key bundle file.
 	// Set to 0 to disable the watcher entirely.
 	RedHatSigningKeyWatchInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL", 4*time.Hour, WithDurationZeroAllowed())
+
+	// ImageSignatureVerificationTimeout bounds how long the enricher waits for signature verification
+	// of a single image against all configured signature integrations.
+	// Keyless (cosign) verification performs remote RPCs (fetching the Sigstore TUF trust root and
+	// Fulcio/Rekor material, and querying the transparency log), which can take several seconds,
+	// especially on the first call before the TUF root is cached or when the Sigstore CDN is slow.
+	// The default is generous enough to accommodate keyless verification while still bounding the
+	// enrichment hot path.
+	ImageSignatureVerificationTimeout = registerDurationSetting("ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT", 30*time.Second)
 )

--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -814,10 +814,12 @@ func (e *enricherImpl) enrichWithSignatureVerificationData(ctx context.Context, 
 		return false, nil
 	}
 
-	// Timeout is based on benchmark test result for 200 integrations with 1 config each (roughly 0.1 sec) + a grace
-	// timeout on top. Currently, signature verification is done without remote RPCs, this will need to be
-	// changed accordingly when RPCs are required (i.e. cosign keyless).
-	verifySignatureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	// Bound the time spent verifying signatures for a single image against all configured integrations.
+	// Public-key verification is local and fast, but keyless (cosign) verification performs remote RPCs
+	// (Sigstore TUF trust root, Fulcio/Rekor material, transparency log lookups) and can take several
+	// seconds. The timeout is configurable via ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT so it can be
+	// tuned for slow Sigstore infrastructure without silently marking valid signatures as unverified.
+	verifySignatureCtx, cancel := context.WithTimeout(ctx, env.ImageSignatureVerificationTimeout.DurationSetting())
 	defer cancel()
 
 	res := e.signatureVerifier(verifySignatureCtx, sigIntegrations, img)

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	delegatorMocks "github.com/stackrox/rox/pkg/delegatedregistry/mocks"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/integration"
@@ -1046,6 +1047,43 @@ func TestEnrichWithSignatureVerificationData_Failure(t *testing.T) {
 		EnrichmentContext{FetchOpt: ForceRefetch}, img)
 	require.Error(t, err)
 	assert.False(t, updated)
+}
+
+// TestEnrichWithSignatureVerificationData_Timeout verifies that the signature verification
+// context is bounded by ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT. This guards against
+// regressing to a timeout too short for keyless (remote-RPC) verification, which caused valid
+// keyless Sigstore signatures to be marked unverified (ROX-36605).
+func TestEnrichWithSignatureVerificationData_Timeout(t *testing.T) {
+	t.Setenv(env.ImageSignatureVerificationTimeout.EnvVar(), "17s")
+
+	var observedDeadline time.Duration
+	haveDeadline := false
+	e := enricherImpl{
+		signatureIntegrationGetter: fakeSignatureIntegrationGetter("verifier1", false),
+		signatureVerifier: func(ctx context.Context, _ []*storage.SignatureIntegration,
+			_ *storage.Image) []*storage.ImageSignatureVerificationResult {
+			if deadline, ok := ctx.Deadline(); ok {
+				haveDeadline = true
+				observedDeadline = time.Until(deadline)
+			}
+			return []*storage.ImageSignatureVerificationResult{
+				createSignatureVerificationResult("verifier1",
+					storage.ImageSignatureVerificationResult_VERIFIED, "test:1.0"),
+			}
+		},
+	}
+	img := &storage.Image{Id: "id", Name: &storage.ImageName{FullName: "test:1.0"},
+		Signature: &storage.ImageSignature{Signatures: []*storage.Signature{createSignature("sig1", "payload1")}}}
+
+	updated, err := e.enrichWithSignatureVerificationData(emptyCtx,
+		EnrichmentContext{FetchOpt: ForceRefetch}, img)
+	require.NoError(t, err)
+	assert.True(t, updated)
+	require.True(t, haveDeadline, "verification context should carry a deadline")
+	// The observed remaining time must reflect the configured 17s timeout (allowing for scheduling
+	// slack), and must be well above the old hardcoded 1s that was insufficient for keyless verification.
+	assert.Greater(t, observedDeadline, 10*time.Second)
+	assert.LessOrEqual(t, observedDeadline, 17*time.Second)
 }
 
 func TestDelegateEnrichImage(t *testing.T) {

--- a/pkg/images/enricher/enricher_impl_test.go
+++ b/pkg/images/enricher/enricher_impl_test.go
@@ -1054,18 +1054,18 @@ func TestEnrichWithSignatureVerificationData_Failure(t *testing.T) {
 // regressing to a timeout too short for keyless (remote-RPC) verification, which caused valid
 // keyless Sigstore signatures to be marked unverified (ROX-36605).
 func TestEnrichWithSignatureVerificationData_Timeout(t *testing.T) {
-	t.Setenv(env.ImageSignatureVerificationTimeout.EnvVar(), "17s")
+	// Use an arbitrary, non-default value so the assertion proves the deadline is driven by the
+	// env var rather than by the 30s default (or the old hardcoded 1s).
+	const timeout = 17 * time.Second
+	t.Setenv(env.ImageSignatureVerificationTimeout.EnvVar(), timeout.String())
 
-	var observedDeadline time.Duration
+	var deadline time.Time
 	haveDeadline := false
 	e := enricherImpl{
 		signatureIntegrationGetter: fakeSignatureIntegrationGetter("verifier1", false),
 		signatureVerifier: func(ctx context.Context, _ []*storage.SignatureIntegration,
 			_ *storage.Image) []*storage.ImageSignatureVerificationResult {
-			if deadline, ok := ctx.Deadline(); ok {
-				haveDeadline = true
-				observedDeadline = time.Until(deadline)
-			}
+			deadline, haveDeadline = ctx.Deadline()
 			return []*storage.ImageSignatureVerificationResult{
 				createSignatureVerificationResult("verifier1",
 					storage.ImageSignatureVerificationResult_VERIFIED, "test:1.0"),
@@ -1075,15 +1075,18 @@ func TestEnrichWithSignatureVerificationData_Timeout(t *testing.T) {
 	img := &storage.Image{Id: "id", Name: &storage.ImageName{FullName: "test:1.0"},
 		Signature: &storage.ImageSignature{Signatures: []*storage.Signature{createSignature("sig1", "payload1")}}}
 
+	// The verifier is a stub that returns immediately, so this call does not wait for the timeout;
+	// it only checks the deadline the enricher put on the verification context.
+	start := time.Now()
 	updated, err := e.enrichWithSignatureVerificationData(emptyCtx,
 		EnrichmentContext{FetchOpt: ForceRefetch}, img)
 	require.NoError(t, err)
 	assert.True(t, updated)
 	require.True(t, haveDeadline, "verification context should carry a deadline")
-	// The observed remaining time must reflect the configured 17s timeout (allowing for scheduling
-	// slack), and must be well above the old hardcoded 1s that was insufficient for keyless verification.
-	assert.Greater(t, observedDeadline, 10*time.Second)
-	assert.LessOrEqual(t, observedDeadline, 17*time.Second)
+	// The deadline must be start+timeout. A 1s tolerance absorbs the negligible work between
+	// capturing start and creating the context; it is unrelated to the old hardcoded 1s timeout.
+	assert.WithinDuration(t, start.Add(timeout), deadline, time.Second,
+		"verification deadline should reflect ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT")
 }
 
 func TestDelegateEnrichImage(t *testing.T) {

--- a/pkg/images/enricher/enricher_v2_impl.go
+++ b/pkg/images/enricher/enricher_v2_impl.go
@@ -794,10 +794,12 @@ func (e *enricherV2Impl) enrichWithSignatureVerificationData(ctx context.Context
 		return false, nil
 	}
 
-	// Timeout is based on benchmark test result for 200 integrations with 1 config each (roughly 0.1 sec) + a grace
-	// timeout on top. Currently, signature verification is done without remote RPCs, this will need to be
-	// changed accordingly when RPCs are required (i.e. cosign keyless).
-	verifySignatureCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	// Bound the time spent verifying signatures for a single image against all configured integrations.
+	// Public-key verification is local and fast, but keyless (cosign) verification performs remote RPCs
+	// (Sigstore TUF trust root, Fulcio/Rekor material, transparency log lookups) and can take several
+	// seconds. The timeout is configurable via ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT so it can be
+	// tuned for slow Sigstore infrastructure without silently marking valid signatures as unverified.
+	verifySignatureCtx, cancel := context.WithTimeout(ctx, env.ImageSignatureVerificationTimeout.DurationSetting())
 	defer cancel()
 
 	res := e.signatureVerifier(verifySignatureCtx, sigIntegrations, utils.ConvertToV1(imgV2))

--- a/pkg/images/enricher/enricher_v2_impl_test.go
+++ b/pkg/images/enricher/enricher_v2_impl_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	delegatorMocks "github.com/stackrox/rox/pkg/delegatedregistry/mocks"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/integration"
@@ -1069,6 +1070,48 @@ func TestEnrichWithSignatureVerificationDataV2_Failure(t *testing.T) {
 		EnrichmentContext{FetchOpt: ForceRefetch}, img)
 	require.Error(t, err)
 	assert.False(t, updated)
+}
+
+// TestEnrichWithSignatureVerificationDataV2_Timeout verifies that the signature verification
+// context is bounded by ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT for the V2 (flattened image
+// data) path. This guards against regressing to a timeout too short for keyless (remote-RPC)
+// verification, which caused valid keyless Sigstore signatures to be marked unverified
+// (ROX-36605).
+func TestEnrichWithSignatureVerificationDataV2_Timeout(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.FlattenImageData, true)
+	t.Setenv(env.ImageSignatureVerificationTimeout.EnvVar(), "17s")
+
+	var observedDeadline time.Duration
+	haveDeadline := false
+	e := enricherV2Impl{
+		signatureIntegrationGetter: fakeSignatureIntegrationGetter("verifier1", false),
+		signatureVerifier: func(ctx context.Context, _ []*storage.SignatureIntegration,
+			_ *storage.Image) []*storage.ImageSignatureVerificationResult {
+			if deadline, ok := ctx.Deadline(); ok {
+				haveDeadline = true
+				observedDeadline = time.Until(deadline)
+			}
+			return []*storage.ImageSignatureVerificationResult{
+				createSignatureVerificationResult("verifier1",
+					storage.ImageSignatureVerificationResult_VERIFIED, "test:1.0"),
+			}
+		},
+	}
+	img := &storage.ImageV2{
+		Id:        utils.NewImageV2ID(&storage.ImageName{FullName: "test:1.0"}, "sha"),
+		Digest:    "sha",
+		Name:      &storage.ImageName{FullName: "test:1.0"},
+		Signature: &storage.ImageSignature{Signatures: []*storage.Signature{createSignature("sig1", "payload1")}}}
+
+	updated, err := e.enrichWithSignatureVerificationData(emptyCtx,
+		EnrichmentContext{FetchOpt: ForceRefetch}, img)
+	require.NoError(t, err)
+	assert.True(t, updated)
+	require.True(t, haveDeadline, "verification context should carry a deadline")
+	// The observed remaining time must reflect the configured 17s timeout (allowing for scheduling
+	// slack), and must be well above the old hardcoded 1s that was insufficient for keyless verification.
+	assert.Greater(t, observedDeadline, 10*time.Second)
+	assert.LessOrEqual(t, observedDeadline, 17*time.Second)
 }
 
 func TestDelegateEnrichImageV2(t *testing.T) {

--- a/pkg/images/enricher/enricher_v2_impl_test.go
+++ b/pkg/images/enricher/enricher_v2_impl_test.go
@@ -1079,18 +1079,18 @@ func TestEnrichWithSignatureVerificationDataV2_Failure(t *testing.T) {
 // (ROX-36605).
 func TestEnrichWithSignatureVerificationDataV2_Timeout(t *testing.T) {
 	testutils.MustUpdateFeature(t, features.FlattenImageData, true)
-	t.Setenv(env.ImageSignatureVerificationTimeout.EnvVar(), "17s")
+	// Use an arbitrary, non-default value so the assertion proves the deadline is driven by the
+	// env var rather than by the 30s default (or the old hardcoded 1s).
+	const timeout = 17 * time.Second
+	t.Setenv(env.ImageSignatureVerificationTimeout.EnvVar(), timeout.String())
 
-	var observedDeadline time.Duration
+	var deadline time.Time
 	haveDeadline := false
 	e := enricherV2Impl{
 		signatureIntegrationGetter: fakeSignatureIntegrationGetter("verifier1", false),
 		signatureVerifier: func(ctx context.Context, _ []*storage.SignatureIntegration,
 			_ *storage.Image) []*storage.ImageSignatureVerificationResult {
-			if deadline, ok := ctx.Deadline(); ok {
-				haveDeadline = true
-				observedDeadline = time.Until(deadline)
-			}
+			deadline, haveDeadline = ctx.Deadline()
 			return []*storage.ImageSignatureVerificationResult{
 				createSignatureVerificationResult("verifier1",
 					storage.ImageSignatureVerificationResult_VERIFIED, "test:1.0"),
@@ -1103,15 +1103,18 @@ func TestEnrichWithSignatureVerificationDataV2_Timeout(t *testing.T) {
 		Name:      &storage.ImageName{FullName: "test:1.0"},
 		Signature: &storage.ImageSignature{Signatures: []*storage.Signature{createSignature("sig1", "payload1")}}}
 
+	// The verifier is a stub that returns immediately, so this call does not wait for the timeout;
+	// it only checks the deadline the enricher put on the verification context.
+	start := time.Now()
 	updated, err := e.enrichWithSignatureVerificationData(emptyCtx,
 		EnrichmentContext{FetchOpt: ForceRefetch}, img)
 	require.NoError(t, err)
 	assert.True(t, updated)
 	require.True(t, haveDeadline, "verification context should carry a deadline")
-	// The observed remaining time must reflect the configured 17s timeout (allowing for scheduling
-	// slack), and must be well above the old hardcoded 1s that was insufficient for keyless verification.
-	assert.Greater(t, observedDeadline, 10*time.Second)
-	assert.LessOrEqual(t, observedDeadline, 17*time.Second)
+	// The deadline must be start+timeout. A 1s tolerance absorbs the negligible work between
+	// capturing start and creating the context; it is unrelated to the old hardcoded 1s timeout.
+	assert.WithinDuration(t, start.Add(timeout), deadline, time.Second,
+		"verification deadline should reflect ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT")
 }
 
 func TestDelegateEnrichImageV2(t *testing.T) {


### PR DESCRIPTION
## Description

`ImageSignatureVerificationTest` e2e: the 'Keyless-Sigstore-Matching' policy violation on a keyless-signed deployment stays active longer than expected, causing flaky/failing assertions (ROX-36605).

This makes the image signature verification timeout configurable via `ROX_IMAGE_SIGNATURE_VERIFICATION_TIMEOUT` (default 30s), replacing a value that had been hardcoded to 1 second in both `pkg/images/enricher/enricher_impl.go` and `enricher_v2_impl.go` since 2022.

Why this is needed: that 1s bound wraps the signature-*verification* step (`signatures.VerifyAgainstSignatureIntegrations`). For public-key integrations that step is purely local CPU work, which is what the 1s was sized for. Keyless (cosign/Fulcio) verification, added later, turns that same step into a path that makes **real network RPCs to public Sigstore infrastructure**:

- TUF trusted-root fetch from `tuf-repo-cdn.sigstore.dev` (`cosign.TrustedRoot`), which also backs the Rekor and CT-log public-key lookups (`GetRekorPubs` / `GetCTLogPubs`). Cached on disk at `/tmp/tuf-roots` (per-pod emptyDir, so cold on every Central restart).
- For SimpleSigning signatures without an inline proof, a live transparency-log lookup against `rekor.sigstore.dev`.

A code comment added with the original 1s value in 2022 explicitly flagged this: *"will need to change when RPCs required (cosign keyless)"* — that follow-up never happened. Pinning external calls to a fixed 1s is fragile: their latency depends on egress conditions (slow or proxied networks, CDN hiccups, a cold cache plus a live Rekor round-trip). When the step is cut off, verification is recorded as failed and the resulting violation only clears on the next forced re-verification. A larger, configurable default removes that fragility.

Scope note: the image metadata fetch and the signature *discovery/fetch* from the registry (which retries up to 5×500ms) are separate enrichment steps and are **not** bounded by this timeout.

The underlying cause of the specific CI flake (whether it was this timeout under slow CI egress, signature-fetch reliability, or alert re-evaluation timing) is still under investigation and tracked separately; this change removes one clear fragility on that path and makes the bound tunable.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Unit tests:
- `TestEnrichWithSignatureVerificationData_Timeout` (V1) and `TestEnrichWithSignatureVerificationDataV2_Timeout` (V2/flattened image data) assert the verification context deadline reflects the configured timeout. They inject a stub verifier that returns immediately and only inspect `ctx.Deadline()`, so they do not sleep; the assertion uses `assert.WithinDuration(start+timeout, deadline, 1s)` tied to a single configured value.
- `go build` and `go test ./pkg/images/enricher/... ./pkg/env/...` pass.

Live cluster measurement (instrumented, then reverted):

I deployed a Central build with temporary timing instrumentation to a live OCP cluster (`ga-08-31-wash-cabin-village`) placed at exactly the operation the timeout bounds (the `signatureVerifier` call) and around the TUF fetch (`cosign.TrustedRoot`). Cold caches were forced by restarting the Central pod. The QA suite's real keyless fixture (`quay.io/rhacs-eng/qa-signatures@sha256:98ad9d1a...`) was verified against unmodified Sigstore infrastructure.

Observed, on this cluster:
- Cold TUF fetch: 78ms / 99ms / 101ms across three fresh-pod restarts.
- Full verification step (cold): 242ms / 269ms / 271ms; warm ~90–150ms.
- With the timeout set back to the old `1s` and a cold cache, the fixture still verified (`VERIFIED`) in ~116ms.

Honest interpretation: on a well-connected cluster the verification step is ~100–270ms and 1s was not breached, so I did **not** reproduce a "verification routinely exceeds 1s" scenario here. The larger, configurable timeout is justified because the step now performs real internet RPCs to Sigstore whose latency is environment-dependent, not because 1s is always exceeded. An earlier "~12s" figure I had cited was end-to-end enrichment time (registry metadata + signature fetch with retries + verify + store), not the verification step this timeout guards.

This change was partially generated with AI assistance (investigation, measurement, and drafting by Claude Code, reviewed and validated by me).