### PR TITLE
fix(ci): optimize Scanner V4 bundle loading for UI E2E tests

### DIFF
--- a/scripts/ci/jobs/gke_ui_e2e_tests.py
+++ b/scripts/ci/jobs/gke_ui_e2e_tests.py
@@ -19,6 +19,9 @@ os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "stackrox-gke-ssd"
 os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
+# Optimize Scanner V4 startup time by loading only RHEL vulnerability bundles
+# UI tests only scan RHEL/UBI images (StackRox components) - no user workloads deployed
+os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "rhel-vex,stackrox-rhel-csaf,manual,epss,nvd"
 
 ClusterTestRunner(
     cluster=GKECluster("ui-e2e-test"),

--- a/scripts/ci/jobs/ocp_ui_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_ui_e2e_tests.py
@@ -15,6 +15,9 @@ os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["INSTALL_COMPLIANCE_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
 os.environ["KUBERNETES_PROVIDER"] = "ocp"
+# Optimize Scanner V4 startup time by loading only RHEL vulnerability bundles
+# UI tests only scan RHEL/UBI images (OpenShift platform, StackRox, operators, nodes)
+os.environ["SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST"] = "rhel-vex,stackrox-rhel-csaf,manual,epss,nvd"
 
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),


### PR DESCRIPTION
## Description

Problem:
UI E2E tests were timing out after 2 hours because Scanner V4 matcher took 35+ minutes to load vulnerability bundles, including the massive OSV bundle with 1.5M+ language ecosystem vulnerabilities (npm, maven, pypi, go, rust, etc.) that are not used by UI tests.

Root cause:
- Scanner V4 matcher spent 30+ minutes loading OSV bundle
- This caused 31 minutes of "no children to pick from" gRPC errors
- Tests couldn't complete image/node scans during initialization
- Cumulative delays exceeded the 2-hour test timeout

Analysis of images being scanned:
UI E2E tests deploy NO user workloads. All scanned images are RHEL/UBI:
- OpenShift platform images (quay.io/openshift-release-dev/ocp-v4.0-art-dev)
- StackRox components (central-db, collector, scanner-v4, main)
- Compliance operator (RHEL-based)
- Red Hat operator catalogs (registry.redhat.io/redhat/*-operator-index)
- Cluster nodes (RHEL CoreOS)

Fix:
Configure UI E2E tests to use RHEL-only vulnerability bundles:
- rhel-vex, stackrox-rhel-csaf (RHEL vulnerability data)
- manual (manual StackRox vulnerability data)
- epss, nvd (enrichment data only)
- Removed: osv (~1.5M vulns), alpine, debian, ubuntu (not needed)

Expected impact:
- Scanner V4 matcher startup time: ~35 min → ~5 min (85% reduction)
- Vulnerabilities loaded: ~1.5M → ~50K (97% less data)
- UI E2E tests should complete well within 2-hour timeout
- Matches pattern used in nongroovy tests (same bundle list)

Testing:
This change affects CI test configuration only. The allowlist is passed via SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST to tests/e2e/lib.sh.

Relates-To: ROX-36604


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI