### PR TITLE
ROX-36660: Match unset FixedBy as not fixable (#22540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Put an entry in this file if your change is user-visible and you consider it _pa
 
 Changes should still be described appropriately in JIRA/doc input pages, for inclusion in downstream release notes.
 
+## [4.11.4]
+
+### Technical Changes
+
+- ROX-36660: The **Fixable → CVE is not yet fixable** policy criterion now matches Scanner V4 CVEs that have no fix version. Scanner V4 leaves `Fixed By` unset instead of empty (Scanner V2 always set an empty string), so the matcher previously skipped those CVEs.
+
+**Full Changelog**: [4.11.3...4.11.4](https://github.com/stackrox/stackrox/compare/4.11.3...4.11.4)
+
+For a description of the changes, review the [Release Notes](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.11/html/release_notes/index) on the Red Hat Documentation portal.
+
 ## [4.11.3]
 
 **Full Changelog**: [4.11.2...4.11.3](https://github.com/stackrox/stackrox/compare/4.11.2...4.11.3)

--- a/pkg/booleanpolicy/evaluator/path_evaluators.go
+++ b/pkg/booleanpolicy/evaluator/path_evaluators.go
@@ -61,7 +61,9 @@ func takeInterfaceMetaStep(metaStep pathutil.MetaStep, evaluator fieldEvaluator)
 	return fieldEvaluatorFunc(func(value pathutil.AugmentedValue) (*fieldResult, bool) {
 		underlying := value.Underlying()
 		if underlying.IsNil() {
-			return nil, false
+			// Unset protobuf oneof (e.g. Scanner V4 not-fixable CVE: no fixed_by).
+			// Evaluate against the field zero value so empty-string queries can match.
+			return evaluator.Evaluate(value.WithUnderlying(reflect.Zero(metaStep.Type)))
 		}
 		nextValue := value.Elem()
 		if nextValue.Underlying().Kind() == reflect.Pointer {

--- a/pkg/booleanpolicy/evaluator/pathutil/augmented_obj.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/augmented_obj.go
@@ -110,6 +110,10 @@ type AugmentedValue interface {
 	// It panics if Index(i) on the reflect.Value panics.
 	Index(int) AugmentedValue
 	PathFromRoot() *Path
+	// WithUnderlying returns a copy of this value with a different underlying
+	// reflect.Value, keeping the path from root and augment tree. Used when a
+	// protobuf oneof is unset so empty-string queries can still match.
+	WithUnderlying(newVal reflect.Value) AugmentedValue
 }
 
 type augmentedValue struct {
@@ -132,6 +136,12 @@ func (v *augmentedValue) Index(i int) AugmentedValue {
 
 func (v *augmentedValue) Underlying() reflect.Value {
 	return v.underlying
+}
+
+func (v *augmentedValue) WithUnderlying(newVal reflect.Value) AugmentedValue {
+	cp := *v
+	cp.underlying = newVal
+	return &cp
 }
 
 func (v *augmentedValue) TakeStep(metaStep MetaStep) (AugmentedValue, bool) {

--- a/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_test.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/augmented_obj_test.go
@@ -1,6 +1,7 @@
 package pathutil
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +20,11 @@ func TestAugmentedObj(t *testing.T) {
 	require.NoError(t, o.AddPlainObjAt(stringObj, FieldStep("Nested"), IndexStep(1), FieldStep("StringObj")))
 
 	value := o.Value()
+	assert.Equal(t, topLevelObj, value.Underlying().Interface())
+
+	zeroed := value.WithUnderlying(reflect.ValueOf(""))
+	assert.Equal(t, "", zeroed.Underlying().Interface())
+	assert.Equal(t, value.PathFromRoot().String(), zeroed.PathFromRoot().String())
 	assert.Equal(t, topLevelObj, value.Underlying().Interface())
 
 	intObjValue, found := value.TakeStep(MetaStep{FieldName: "IntObj"})

--- a/pkg/booleanpolicy/image_criteria_test.go
+++ b/pkg/booleanpolicy/image_criteria_test.go
@@ -176,6 +176,191 @@ func (suite *ImageCriteriaTestSuite) TestFixableAndFixTimestampAvailableCriteria
 
 }
 
+func (suite *ImageCriteriaTestSuite) TestFixableCriteriaWithUnsetFixedBy() {
+	dep := &storage.Deployment{
+		Id: "MIXEDFIXABLEDEPID",
+		Containers: []*storage.Container{
+			{
+				Name:  "nginx",
+				Image: &storage.ContainerImage{Id: "MIXEDFIXABLESHA"},
+			},
+		},
+	}
+
+	img := &storage.Image{
+		Id:   "MIXEDFIXABLESHA",
+		Name: &storage.ImageName{FullName: "mixed-fixable"},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{Name: "openssl", Version: "1.2", Vulns: []*storage.EmbeddedVulnerability{
+					{
+						Cve:        "CVE-FIXABLE",
+						Cvss:       9,
+						Severity:   storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+						SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{FixedBy: "v1.2"},
+					},
+					{
+						Cve:      "CVE-UNFIXABLE",
+						Cvss:     8,
+						Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+						// Scanner V4 leaves the oneof unset when there is no fix.
+					},
+					{
+						Cve:        "CVE-EMPTY-FIXEDBY",
+						Cvss:       7,
+						Severity:   storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+						SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{},
+					},
+				}},
+			},
+		},
+	}
+	suite.addDepAndImages(dep, img)
+
+	allCVEs := []string{"CVE-FIXABLE", "CVE-UNFIXABLE", "CVE-EMPTY-FIXEDBY"}
+
+	for name, tc := range map[string]struct {
+		policy       *storage.Policy
+		expectedCVEs []string
+	}{
+		"fixable true matches only CVEs with a fix version": {
+			policy:       policyWithSingleKeyValue(fieldnames.Fixable, "true", false),
+			expectedCVEs: []string{"CVE-FIXABLE"},
+		},
+		"fixable false matches unset and empty FixedBy": {
+			policy:       policyWithSingleKeyValue(fieldnames.Fixable, "false", false),
+			expectedCVEs: []string{"CVE-UNFIXABLE", "CVE-EMPTY-FIXEDBY"},
+		},
+		"negated Fixed By matches not-fixable CVEs": {
+			policy:       policyWithSingleKeyValue(fieldnames.FixedBy, "v1.2", true),
+			expectedCVEs: []string{"CVE-UNFIXABLE", "CVE-EMPTY-FIXEDBY"},
+		},
+		"fixable false combined with CVE stays linked to that CVE": {
+			policy: policyWithGroups(storage.EventSource_NOT_APPLICABLE,
+				policyGroupWithSingleKeyValue(fieldnames.Fixable, "false", false),
+				policyGroupWithSingleKeyValue(fieldnames.CVE, "CVE-UNFIXABLE", false),
+			),
+			expectedCVEs: []string{"CVE-UNFIXABLE"},
+		},
+		// Default policy "Fixable CVSS >= 7" stores Fixed By: .*, rewritten to .+ at match time.
+		"fixed by .* with CVSS >= 7 still matches only the fixable CVE": {
+			policy: policyWithGroups(storage.EventSource_NOT_APPLICABLE,
+				policyGroupWithSingleKeyValue(fieldnames.FixedBy, ".*", false),
+				policyGroupWithSingleKeyValue(fieldnames.CVSS, ">= 7", false),
+			),
+			expectedCVEs: []string{"CVE-FIXABLE"},
+		},
+	} {
+		suite.Run(name, func() {
+			expected := set.NewFrozenStringSet(tc.expectedCVEs...)
+
+			depMatcher, err := BuildDeploymentMatcher(tc.policy)
+			suite.Require().NoError(err)
+			depViolations, err := depMatcher.MatchDeployment(nil, enhancedDeployment(dep, suite.getImagesForDeployment(dep)))
+			suite.Require().NoError(err)
+			assertFixableCVEMatches(suite.T(), depViolations, allCVEs, expected)
+
+			imgMatcher, err := BuildImageMatcher(tc.policy)
+			suite.Require().NoError(err)
+			imgViolations, err := imgMatcher.MatchImage(nil, img)
+			suite.Require().NoError(err)
+			assertFixableCVEMatches(suite.T(), imgViolations, allCVEs, expected)
+		})
+	}
+}
+
+// TestCustomerFixableNotYetFixableOnMixedCVEDeployment reproduces the customer-reported regression where a
+// "Fixable → CVE is not yet fixable" policy (fieldnames.Fixable = "false") returned no violations in Policy
+// Preview even when the deployment's image contained unfixable CVEs (SetFixedBy unset, Scanner V4 style).
+// The test runs both the fixable=true and fixable=false policies against the same single deployment so that the
+// side-by-side comparison that exposed the bug is explicit.
+func (suite *ImageCriteriaTestSuite) TestCustomerFixableNotYetFixableOnMixedCVEDeployment() {
+	const (
+		fixableCVE   = "CVE-CUSTOMER-FIXABLE"
+		unfixableCVE = "CVE-CUSTOMER-UNFIXABLE"
+	)
+
+	dep := &storage.Deployment{
+		Id: "CUSTMIXEDDEPID",
+		Containers: []*storage.Container{
+			{
+				Name:  "app",
+				Image: &storage.ContainerImage{Id: "CUSTMIXEDIMGSHA"},
+			},
+		},
+	}
+
+	img := &storage.Image{
+		Id:   "CUSTMIXEDIMGSHA",
+		Name: &storage.ImageName{FullName: "registry.example.com/app:latest"},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{Name: "openssl", Version: "3.0", Vulns: []*storage.EmbeddedVulnerability{
+					{
+						Cve:        fixableCVE,
+						Cvss:       9,
+						Severity:   storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+						SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{FixedBy: "v1.2"},
+					},
+					{
+						Cve:      unfixableCVE,
+						Cvss:     8,
+						Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+						// Scanner V4 leaves SetFixedBy nil when no fix is available.
+					},
+				}},
+			},
+		},
+	}
+	suite.addDepAndImages(dep, img)
+
+	ed := enhancedDeployment(dep, suite.getImagesForDeployment(dep))
+
+	suite.Run("fixable=true matches only the fixable CVE", func() {
+		matcher, err := BuildDeploymentMatcher(policyWithSingleKeyValue(fieldnames.Fixable, "true", false))
+		suite.Require().NoError(err)
+		violations, err := matcher.MatchDeployment(nil, ed)
+		suite.Require().NoError(err)
+		suite.Require().Len(violations.AlertViolations, 1)
+		suite.Contains(violations.AlertViolations[0].GetMessage(), fixableCVE,
+			"fixable=true must produce a violation for the fixable CVE")
+		suite.NotContains(violations.AlertViolations[0].GetMessage(), unfixableCVE,
+			"fixable=true must not mention the unfixable CVE")
+	})
+
+	suite.Run("fixable=false matches only the not-yet-fixable CVE (regression)", func() {
+		matcher, err := BuildDeploymentMatcher(policyWithSingleKeyValue(fieldnames.Fixable, "false", false))
+		suite.Require().NoError(err)
+		violations, err := matcher.MatchDeployment(nil, ed)
+		suite.Require().NoError(err)
+		suite.Require().Len(violations.AlertViolations, 1,
+			"fixable=false must produce exactly one violation for the CVE with no fix (was zero before the fix)")
+		suite.Contains(violations.AlertViolations[0].GetMessage(), unfixableCVE,
+			"fixable=false must produce a violation for the not-yet-fixable CVE")
+		suite.NotContains(violations.AlertViolations[0].GetMessage(), fixableCVE,
+			"fixable=false must not mention the fixable CVE")
+	})
+}
+
+func assertFixableCVEMatches(t *testing.T, violations Violations, allCVEs []string, expected set.FrozenStringSet) {
+	t.Helper()
+	require.Len(t, violations.AlertViolations, expected.Cardinality())
+	for _, cve := range allCVEs {
+		var found bool
+		for _, v := range violations.AlertViolations {
+			if strings.Contains(v.GetMessage(), cve) {
+				found = true
+				break
+			}
+		}
+		if expected.Contains(cve) {
+			assert.True(t, found, "expected a violation mentioning %s, got %v", cve, violations.AlertViolations)
+			continue
+		}
+		assert.False(t, found, "did not expect a violation mentioning %s, got %v", cve, violations.AlertViolations)
+	}
+}
+
 func (suite *ImageCriteriaTestSuite) TestDaysSinceCVEPublishedCriteria() {
 	heartbleedDep := &storage.Deployment{
 		Id: "HEARTBLEEDDEPID",


### PR DESCRIPTION
## Description

Manual backport of https://github.com/stackrox/stackrox/pull/22540 to `release-4.11`.

Automated backport failed: #22540 was squash-merged, so `git cherry-pick --mainline 1` rejected the commit. Cherry-picked `e14d162a4371c945358d83d090365648bd5a1375` and resolved the `CHANGELOG.md` conflict by adding a `[4.11.4]` Technical Changes entry (4.11.3 is already released). Policy evaluator and `image_criteria_test.go` changes applied cleanly.

**Fixable=false** never matched Scanner V4 CVEs that have no fix version. Scanner V4 omits the `fixed_by` oneof; the matcher aborted on a nil oneof. This evaluates a nil oneof as the field zero value so **Fixable → CVE is not yet fixable** matches those CVEs.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- `go test` for `pkg/booleanpolicy/evaluator/pathutil`, `pkg/booleanpolicy/evaluator`, and `pkg/booleanpolicy` (`TestImageCriteria/TestFixableCriteriaWithUnsetFixedBy` and `TestCustomerFixableNotYetFixableOnMixedCVEDeployment`) exited 0.

Made with [Cursor](https://cursor.com)
