### PR TITLE
ROX-36793: Node report configuration details page

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityReportViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityReportViewPage.tsx
@@ -1,0 +1,181 @@
+import { useCallback } from 'react';
+import { generatePath, useNavigate, useParams } from 'react-router-dom-v5-compat';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    Bullseye,
+    Divider,
+    DropdownItem,
+    Flex,
+    FlexItem,
+    PageSection,
+    Spinner,
+    Title,
+} from '@patternfly/react-core';
+
+import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
+import PageTitle from 'Components/PageTitle';
+import MenuDropdown from 'Components/PatternFly/MenuDropdown';
+import usePermissions from 'hooks/usePermissions';
+import useRestQuery from 'hooks/useRestQuery';
+import {
+    vulnerabilityNodeConfigurationsReportsDetailsPath,
+    vulnerabilityNodeConfigurationsReportsPath,
+    vulnerabilityReportsPath,
+} from 'routePaths';
+import {
+    deleteNodeReportConfiguration,
+    fetchNodeReportConfiguration,
+} from 'services/NodeReportsService';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import DeleteReportsModal from '../../../components/DeleteReportsModal';
+import NodeVulnerabilityReportView from './NodeVulnerabilityReportView';
+import {
+    attributesSeparateFromConfigForNodeVulnerabilityReport,
+    searchFilterConfigForNodeVulnerabilityReport,
+} from '../../../../searchFilterConfig';
+import useDeleteModal from '../../../../VulnerablityReporting/hooks/useDeleteModal';
+
+function NodeVulnerabilityReportViewPage() {
+    const navigate = useNavigate();
+    const { reportId } = useParams() as { reportId: string };
+
+    const { hasReadWriteAccess, hasReadAccess } = usePermissions();
+    const hasDeleteAccessForReport = hasReadWriteAccess('WorkflowAdministration');
+    const hasWriteAccessForReport =
+        hasReadWriteAccess('WorkflowAdministration') && hasReadAccess('Integration');
+
+    const fetchReportConfigurationCallback = useCallback(
+        () => fetchNodeReportConfiguration(reportId),
+        [reportId]
+    );
+    const {
+        data: reportConfiguration,
+        isLoading,
+        error: fetchError,
+    } = useRestQuery(fetchReportConfigurationCallback);
+
+    const {
+        openDeleteModal,
+        isDeleteModalOpen,
+        closeDeleteModal,
+        isDeleting,
+        onDelete,
+        deleteResults,
+        reportIdsToDelete,
+    } = useDeleteModal({
+        deleteFunction: deleteNodeReportConfiguration,
+        onCompleted: () => {
+            navigate(vulnerabilityNodeConfigurationsReportsPath);
+        },
+    });
+
+    const reportPageURL = generatePath(vulnerabilityNodeConfigurationsReportsDetailsPath, {
+        reportId,
+    });
+
+    return (
+        <>
+            <PageTitle title="View node vulnerability report" />
+            {isLoading ? (
+                <Bullseye>
+                    <Spinner />
+                </Bullseye>
+            ) : fetchError || !reportConfiguration ? (
+                <NotFoundMessage
+                    title="Error fetching the node vulnerability report"
+                    message={fetchError ? getAxiosErrorMessage(fetchError) : 'No data available'}
+                    actionText="Go to node vulnerability reports"
+                    url={vulnerabilityNodeConfigurationsReportsPath}
+                />
+            ) : (
+                <>
+                    <PageSection type="breadcrumb">
+                        <Breadcrumb>
+                            <BreadcrumbItemLink to={vulnerabilityReportsPath}>
+                                Vulnerability reports
+                            </BreadcrumbItemLink>
+                            <BreadcrumbItemLink to={vulnerabilityNodeConfigurationsReportsPath}>
+                                Node vulnerability reports
+                            </BreadcrumbItemLink>
+                            <BreadcrumbItem isActive>{reportConfiguration.name}</BreadcrumbItem>
+                        </Breadcrumb>
+                    </PageSection>
+                    <PageSection>
+                        <Flex>
+                            <FlexItem flex={{ default: 'flex_1' }}>
+                                <Title headingLevel="h1">{reportConfiguration.name}</Title>
+                            </FlexItem>
+                            {(hasWriteAccessForReport || hasDeleteAccessForReport) && (
+                                <FlexItem>
+                                    <MenuDropdown
+                                        toggleText="Actions"
+                                        popperProps={{ position: 'end' }}
+                                    >
+                                        {hasWriteAccessForReport && (
+                                            <DropdownItem
+                                                onClick={() =>
+                                                    navigate(`${reportPageURL}?action=edit`)
+                                                }
+                                            >
+                                                Edit report
+                                            </DropdownItem>
+                                        )}
+                                        {hasWriteAccessForReport && (
+                                            <DropdownItem
+                                                onClick={() =>
+                                                    navigate(`${reportPageURL}?action=clone`)
+                                                }
+                                            >
+                                                Clone report
+                                            </DropdownItem>
+                                        )}
+                                        {hasDeleteAccessForReport && (
+                                            <>
+                                                {hasWriteAccessForReport && (
+                                                    <Divider component="li" />
+                                                )}
+                                                <DropdownItem
+                                                    isDanger
+                                                    onClick={() =>
+                                                        openDeleteModal([reportConfiguration.id])
+                                                    }
+                                                >
+                                                    Delete report
+                                                </DropdownItem>
+                                            </>
+                                        )}
+                                    </MenuDropdown>
+                                </FlexItem>
+                            )}
+                        </Flex>
+                    </PageSection>
+                    <PageSection isFilled hasOverflowScroll>
+                        <NodeVulnerabilityReportView
+                            attributesSeparateFromConfig={
+                                attributesSeparateFromConfigForNodeVulnerabilityReport
+                            }
+                            headingLevel="h2"
+                            horizontalTermWidthModifier={{ default: '24ch' }}
+                            values={reportConfiguration}
+                            searchFilterConfig={searchFilterConfigForNodeVulnerabilityReport}
+                        />
+                    </PageSection>
+                    <DeleteReportsModal
+                        isOpen={isDeleteModalOpen}
+                        onClose={closeDeleteModal}
+                        isDeleting={isDeleting}
+                        onDelete={onDelete}
+                        reportIdsToDelete={reportIdsToDelete}
+                        deleteResults={deleteResults}
+                        reportConfigurations={[reportConfiguration]}
+                    />
+                </>
+            )}
+        </>
+    );
+}
+
+export default NodeVulnerabilityReportViewPage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsLayout.tsx
@@ -13,7 +13,7 @@ function NodeVulnerabilityReportsLayout() {
     const navigate = useNavigate();
 
     const { hasReadAccess } = usePermissions();
-    const hasAccessForConfigurations = hasReadAccess('WorkflowAdministration');
+    const hasReadAccessForReport = hasReadAccess('WorkflowAdministration');
 
     const activeKey = location.pathname.startsWith(vulnerabilityNodeConfigurationsReportsPath)
         ? 'configurations'
@@ -37,7 +37,7 @@ function NodeVulnerabilityReportsLayout() {
                     }}
                     usePageInsets
                 >
-                    {hasAccessForConfigurations && (
+                    {hasReadAccessForReport && (
                         <Tab
                             eventKey="configurations"
                             title="Report configurations"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/NodeVulnerabilityReportsPage.tsx
@@ -1,31 +1,55 @@
 import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
+import PageNotFound from 'Components/PageNotFound';
+import type { ReportPageAction } from 'Components/Reports/reports.types';
+import usePageAction from 'hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
 
 import NodeConfigurationsList from './Configurations/NodeConfigurationsList';
+import NodeVulnerabilityReportWizardPage from './Configurations/Wizard/NodeVulnerabilityReportWizardPage';
+import NodeVulnerabilityReportViewPage from './Configurations/View/NodeVulnerabilityReportViewPage';
 import NodeVulnerabilityReportsLayout from './NodeVulnerabilityReportsLayout';
 import NodeViewBasedJobsPage from './ViewBasedJobs/NodeViewBasedJobsPage';
 
 function NodeVulnerabilityReportsPage() {
-    const { hasReadAccess } = usePermissions();
-    const hasAccessForConfiguration = hasReadAccess('WorkflowAdministration');
+    const { pageAction } = usePageAction<ReportPageAction>();
+    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+
+    const hasReadAccessForReport = hasReadAccess('WorkflowAdministration');
+    const hasWriteAccessForReport =
+        hasReadWriteAccess('WorkflowAdministration') && hasReadAccess('Integration');
 
     return (
         <Routes>
             <Route element={<NodeVulnerabilityReportsLayout />}>
-                <Route index element={<Navigate to="configurations" replace />} />
                 <Route
-                    path="configurations"
+                    index
                     element={
-                        hasAccessForConfiguration ? (
-                            <NodeConfigurationsList />
+                        <Navigate
+                            to={hasReadAccessForReport ? 'configurations' : 'view-based-jobs'}
+                            replace
+                        />
+                    }
+                />
+                {hasReadAccessForReport && (
+                    <Route path="configurations" element={<NodeConfigurationsList />} />
+                )}
+                <Route path="view-based-jobs" element={<NodeViewBasedJobsPage />} />
+            </Route>
+            {hasReadAccessForReport && (
+                <Route
+                    path="configurations/:reportId"
+                    element={
+                        (pageAction === 'clone' || pageAction === 'edit') &&
+                        hasWriteAccessForReport ? (
+                            <NodeVulnerabilityReportWizardPage pageAction={pageAction} />
                         ) : (
-                            <Navigate to="../view-based-jobs" replace />
+                            <NodeVulnerabilityReportViewPage />
                         )
                     }
                 />
-                <Route path="view-based-jobs" element={<NodeViewBasedJobsPage />} />
-            </Route>
+            )}
+            <Route path="*" element={<PageNotFound />} />
         </Routes>
     );
 }


### PR DESCRIPTION
## Description

New `NodeVulnerabilityReportViewPage` fetches the config by id, renders the existing `NodeVulnerabilityReportView` with an Actions menu (Edit/Clone/Delete) and `DeleteReportsModal`.

Note: Routes are permission gated, not rerouted. No access means "Page not found", only the index picks its initial `Navigate` target.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="2199" height="1107" alt="Screenshot 2026-09-03 at 4 49 01 PM" src="https://github.com/user-attachments/assets/60155441-ba9a-4201-af36-78800e1729d7" />
<img width="2199" height="1107" alt="Screenshot 2026-09-03 at 4 49 08 PM" src="https://github.com/user-attachments/assets/1f0bb659-9c20-4182-9785-2022ff6c8dff" />
