### PR TITLE
ROX-32329: Make mismatching scanner error more clear

### DIFF
--- a/pkg/images/enricher/enricher_impl.go
+++ b/pkg/images/enricher/enricher_impl.go
@@ -118,7 +118,7 @@ func (e *enricherImpl) EnrichWithVulnerabilities(image *storage.Image, component
 
 	return EnrichmentResult{
 		ScanResult: ScanNotDone,
-	}, errors.New("no image vulnerability retrievers are integrated")
+	}, noMatchingScannerErr(components.ScannerType())
 }
 
 func (e *enricherImpl) enrichWithVulnerabilities(scannerName string, dataSource *storage.DataSource, scanner scannerTypes.ImageVulnerabilityGetter,

--- a/pkg/images/enricher/enricher_v2_impl.go
+++ b/pkg/images/enricher/enricher_v2_impl.go
@@ -108,7 +108,26 @@ func (e *enricherV2Impl) EnrichWithVulnerabilities(imageV2 *storage.ImageV2, com
 
 	return EnrichmentResult{
 		ScanResult: ScanNotDone,
-	}, errors.New("no image vulnerability retrievers are integrated")
+	}, noMatchingScannerErr(components.ScannerType())
+}
+
+func noMatchingScannerErr(requiredType string) error {
+	return errors.Errorf(
+		"this scan request was produced by %s, but no scanner of that type is integrated",
+		scannerTypeDescription(requiredType))
+}
+
+// scannerTypeDescription returns a human-friendly name for a scanner type
+// string
+func scannerTypeDescription(scannerType string) string {
+	switch scannerType {
+	case scannerTypes.Clairify:
+		return "the legacy StackRox Scanner"
+	case scannerTypes.ScannerV4:
+		return "Scanner V4"
+	default:
+		return fmt.Sprintf("a scanner of type %q", scannerType)
+	}
 }
 
 func (e *enricherV2Impl) enrichWithVulnerabilities(scannerName string, dataSource *storage.DataSource, scanner scannerTypes.ImageVulnerabilityGetter,

--- a/pkg/images/enricher/enricher_v2_impl_test.go
+++ b/pkg/images/enricher/enricher_v2_impl_test.go
@@ -1506,6 +1506,105 @@ func TestForceRefetchMetadataOnly_Predicates(t *testing.T) {
 		"ForceRefetchMetadataOnly must not force refetch of cached DB values")
 }
 
+func TestScannerTypeDescription(t *testing.T) {
+	cases := map[string]struct {
+		scannerType string
+		expected    string
+	}{
+		"legacy StackRox Scanner": {
+			scannerType: scannertypes.Clairify,
+			expected:    "the legacy StackRox Scanner",
+		},
+		"Scanner V4": {
+			scannerType: scannertypes.ScannerV4,
+			expected:    "Scanner V4",
+		},
+		"unknown scanner type": {
+			scannerType: "some-future-scanner",
+			expected:    `a scanner of type "some-future-scanner"`,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := scannerTypeDescription(c.scannerType)
+			assert.Equal(t, c.expected, got)
+			// Internal-only names must never leak into user-facing text.
+			assert.NotContains(t, got, "V2")
+		})
+	}
+}
+
+func TestNoMatchingScannerErr(t *testing.T) {
+	cases := map[string]struct {
+		requiredType string
+		// mustContain lists substrings the error message must include.
+		mustContain []string
+	}{
+		"legacy scan but no matching scanner integrated": {
+			requiredType: scannertypes.Clairify,
+			mustContain: []string{
+				"the legacy StackRox Scanner",
+				"integrated",
+			},
+		},
+		"Scanner V4 scan but no matching scanner integrated": {
+			requiredType: scannertypes.ScannerV4,
+			mustContain: []string{
+				"Scanner V4",
+				"integrated",
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := noMatchingScannerErr(c.requiredType)
+			require.Error(t, err)
+
+			for _, substr := range c.mustContain {
+				assert.Contains(t, err.Error(), substr)
+			}
+			// Internal-only names must never leak into user-facing text.
+			assert.NotContains(t, err.Error(), "V2")
+		})
+	}
+}
+
+// TestEnrichWithVulnerabilitiesNoMatchingScannerV2 verifies the reachable case
+// where scanners are integrated (so scanners.IsEmpty() is false) but none matches
+// the scanner type that produced the scan (fakeScanner has type "type", not the
+// clairify type the scan components indicate).
+func TestEnrichWithVulnerabilitiesNoMatchingScannerV2(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	fsr := newFakeRegistryScanner(opts{})
+	scannerSet := scannerMocks.NewMockSet(ctrl)
+	scannerSet.EXPECT().IsEmpty().Return(false).AnyTimes()
+	scannerSet.EXPECT().GetAll().Return([]scannertypes.ImageScannerWithDataSource{fsr}).AnyTimes()
+
+	set := mocks.NewMockSet(ctrl)
+	set.EXPECT().ScannerSet().Return(scannerSet).AnyTimes()
+
+	mockReporter := reporterMocks.NewMockReporter(ctrl)
+	enricher := newEnricherV2(set, mockReporter)
+
+	img := &storage.ImageV2{
+		Id:     utils.NewImageV2ID(&storage.ImageName{Registry: "reg", FullName: "reg"}, "sha"),
+		Digest: "sha",
+		Name:   &storage.ImageName{Registry: "reg", FullName: "reg"},
+	}
+	// Empty indexer version => the components indicate the legacy (clairify) scanner.
+	components := scannertypes.NewScanComponents("", nil, nil)
+
+	result, err := enricher.EnrichWithVulnerabilities(img, components, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "the legacy StackRox Scanner")
+	assert.Contains(t, err.Error(), "integrated")
+	assert.Equal(t, ScanNotDone, result.ScanResult)
+	assert.False(t, result.ImageUpdated)
+}
+
 func newEnricherV2(set *mocks.MockSet, mockReporter *reporterMocks.MockReporter) ImageEnricherV2 {
 	return NewV2(&fakeCVESuppressorV2{}, nil, set, pkgMetrics.CentralSubsystem,
 		newCache(),


### PR DESCRIPTION
## Description

Minor improvement to the error message when no scanner is available to match vulnerabilities to the index report sent by Sensor (ie: delegated scan).

Prior the error was: `no image vulnerability retrievers are integrated`

Now the errors will be (when at least one scanner is integrated):

```
this scan request was produced by the legacy StackRox Scanner, but no scanner of that type is integrated

this scan request was produced by Scanner V4, but no scanner of that type is integrated
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit tests + Manually

Via roxctl:

```sh
$ rctl image scan --image=nginx -f --cluster=sat --retries=0
Pointed to: dc-08-31-2
ERROR:	image scan failed: retrieving image scan result: could not scan image: "nginx": rpc error: code = Internal desc = error delegating scan to cluster "9b90acd2-38e2-422d-bc27-99fae8047089" for image "docker.io/library/nginx:latest": this scan request was produced by the legacy StackRox Scanner, but no scanner of that type is integrated
```
Via delegated scans from sensor observed images (central log):

```sh
image/service: 2026/09/03 23:46:47.656598 service_impl.go:1097: Error: Enriching image with vulnerabilities {"cluster_id": "9b90acd2-38e2-422d-bc27-99fae8047089", "image": "gke.gcr.io/prometheus-to-sd:v0.11.1-gke.1", "error": "this scan request was produced by the legacy StackRox Scanner, but no scanner of that type is integrated", "request_image": "gke.gcr.io/prometheus-to-sd:v0.11.1-gke.1"}
```
