### PR TITLE
ROX-36616, ROX-36627: Fix virtctl fallback and retry scan waits

### DIFF
--- a/tests/e2e/run-vm-scanning.sh
+++ b/tests/e2e/run-vm-scanning.sh
@@ -28,20 +28,15 @@ test_vm_scanning_e2e() {
 
     deploy_optional_e2e_components
 
-    if ! ensure_virtctl_binary; then
-        if is_CI; then
-            if [[ "${_VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP:-0}" != 1 ]]; then
-                warn "Secure virtctl download failed. Falling back to insecure curl -k download path in CI."
-                ensure_virtctl_binary_insecure || true
-            fi
-            if ! command -v virtctl >/dev/null; then
-                warn "Cluster ConsoleCLIDownload did not serve virtctl. Falling back to the matching KubeVirt GitHub release."
-                _install_virtctl_from_kubevirt_release \
-                    || die "Failed to install virtctl from cluster ConsoleCLIDownload and KubeVirt GitHub release"
-            fi
-        else
-            die "Secure virtctl download failed. Refusing insecure curl -k fallback outside CI. Set VIRTCTL_PATH or fix cluster ingress trust material."
-        fi
+    # TEMPORARY — revert this commit before merge.
+    # Skip ConsoleCLIDownload so CI always exercises the GitHub virtctl path
+    # (digest skip + latest release) instead of waiting for a CNV OOM flake.
+    if is_CI; then
+        warn "TEMPORARY: skipping ConsoleCLIDownload virtctl install; using GitHub release only. Revert before merge."
+        _install_virtctl_from_kubevirt_release \
+            || die "TEMPORARY: GitHub virtctl install failed (forced path; revert this commit before merge)"
+    elif ! ensure_virtctl_binary; then
+        die "Secure virtctl download failed. Refusing insecure curl -k fallback outside CI. Set VIRTCTL_PATH or fix cluster ingress trust material."
     fi
 
     deploy_stackrox

--- a/tests/e2e/run-vm-scanning.sh
+++ b/tests/e2e/run-vm-scanning.sh
@@ -28,15 +28,20 @@ test_vm_scanning_e2e() {
 
     deploy_optional_e2e_components
 
-    # TEMPORARY — revert this commit before merge.
-    # Skip ConsoleCLIDownload so CI always exercises the GitHub virtctl path
-    # (digest skip + latest release) instead of waiting for a CNV OOM flake.
-    if is_CI; then
-        warn "TEMPORARY: skipping ConsoleCLIDownload virtctl install; using GitHub release only. Revert before merge."
-        _install_virtctl_from_kubevirt_release \
-            || die "TEMPORARY: GitHub virtctl install failed (forced path; revert this commit before merge)"
-    elif ! ensure_virtctl_binary; then
-        die "Secure virtctl download failed. Refusing insecure curl -k fallback outside CI. Set VIRTCTL_PATH or fix cluster ingress trust material."
+    if ! ensure_virtctl_binary; then
+        if is_CI; then
+            if [[ "${_VIRTCTL_CLUSTER_DOWNLOAD_NONGZIP:-0}" != 1 ]]; then
+                warn "Secure virtctl download failed. Falling back to insecure curl -k download path in CI."
+                ensure_virtctl_binary_insecure || true
+            fi
+            if ! command -v virtctl >/dev/null; then
+                warn "Cluster ConsoleCLIDownload did not serve virtctl. Falling back to the matching KubeVirt GitHub release."
+                _install_virtctl_from_kubevirt_release \
+                    || die "Failed to install virtctl from cluster ConsoleCLIDownload and KubeVirt GitHub release"
+            fi
+        else
+            die "Secure virtctl download failed. Refusing insecure curl -k fallback outside CI. Set VIRTCTL_PATH or fix cluster ingress trust material."
+        fi
     fi
 
     deploy_stackrox

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -171,9 +171,9 @@ _download_and_install_virtctl() {
 }
 
 # True when $1 is a kubevirt/kubevirt GitHub release tag (v1.6.0 or 1.6.0).
-# Image digests (sha256:...) are not release tags.
+# Image digests (sha256:...) and two-part versions (v1.6) are not release tags.
 _is_kubevirt_github_release_tag() {
-    [[ "$1" =~ ^v?[0-9]+\.[0-9]+([.][0-9]+)?(-[0-9A-Za-z.-]+)?$ ]]
+    [[ "$1" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
 }
 
 _normalize_kubevirt_github_tag() {

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -170,18 +170,61 @@ _download_and_install_virtctl() {
     return 1
 }
 
-# Installs virtctl from the KubeVirt GitHub release matching the cluster's observed version.
+# True when $1 is a kubevirt/kubevirt GitHub release tag (v1.6.0 or 1.6.0).
+# Image digests (sha256:...) are not release tags.
+_is_kubevirt_github_release_tag() {
+    [[ "$1" =~ ^v?[0-9]+\.[0-9]+([.][0-9]+)?(-[0-9A-Za-z.-]+)?$ ]]
+}
+
+_normalize_kubevirt_github_tag() {
+    local v="$1"
+    if [[ "$v" == v* ]]; then
+        printf '%s\n' "$v"
+    else
+        printf 'v%s\n' "$v"
+    fi
+}
+
+# Prints a kubevirt/kubevirt GitHub release tag to stdout (logs go to stderr).
+# CNV digest-pins operand images, so observedKubeVirtVersion is often sha256:...;
+# those values are skipped. If the CR has no tag, use GitHub's latest release.
+_kubevirt_github_release_tag() {
+    local v
+    while IFS= read -r v; do
+        [[ -n "$v" ]] || continue
+        if _is_kubevirt_github_release_tag "$v"; then
+            _normalize_kubevirt_github_tag "$v"
+            return 0
+        fi
+        warn "Ignoring KubeVirt version ${v}: not a GitHub release tag" >&2
+    done <<EOF
+$(oc get kubevirt -n openshift-cnv -o jsonpath='{.items[0].status.observedKubeVirtVersion}' 2>/dev/null || true)
+$(oc get kubevirt -n openshift-cnv -o jsonpath='{.items[0].status.targetKubeVirtVersion}' 2>/dev/null || true)
+$(oc get deploy virt-operator -n openshift-cnv -o jsonpath='{range .spec.template.spec.containers[*].env[?(@.name=="KUBEVIRT_VERSION")]}{.value}{"\n"}{end}' 2>/dev/null || true)
+EOF
+
+    local latest_url tag
+    latest_url="$(curl -fsSL --connect-timeout 30 --max-time 60 -o /dev/null -w '%{url_effective}' \
+        https://github.com/kubevirt/kubevirt/releases/latest)" || return 1
+    tag="${latest_url##*/}"
+    if ! _is_kubevirt_github_release_tag "$tag"; then
+        warn "GitHub latest release URL did not end in a tag: ${latest_url}" >&2
+        return 1
+    fi
+    tag="$(_normalize_kubevirt_github_tag "$tag")"
+    info "No cluster KubeVirt GitHub tag; using latest release ${tag}" >&2
+    printf '%s\n' "$tag"
+    return 0
+}
+
+# Installs virtctl from a kubevirt/kubevirt GitHub release.
 # ConsoleCLIDownload can stay on HTML while CNV's CSV is Installing or Failed.
 _install_virtctl_from_kubevirt_release() {
     local version dest url bin
-    version="$(oc get kubevirt -n openshift-cnv -o jsonpath='{.items[0].status.observedKubeVirtVersion}' 2>/dev/null || true)"
-    if [[ -z "$version" ]]; then
-        version="$(oc get kubevirt -n openshift-cnv -o jsonpath='{.items[0].status.targetKubeVirtVersion}' 2>/dev/null || true)"
-    fi
-    if [[ -z "$version" ]]; then
-        warn "No observedKubeVirtVersion on kubevirt CRs; cannot download virtctl from GitHub"
+    version="$(_kubevirt_github_release_tag)" || {
+        warn "Could not resolve a kubevirt/kubevirt GitHub release tag for virtctl"
         return 1
-    fi
+    }
 
     dest="$(_virtctl_install_dir)"
     _virtctl_add_install_dir_to_path "$dest"

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -204,7 +204,7 @@ $(oc get deploy virt-operator -n openshift-cnv -o jsonpath='{range .spec.templat
 EOF
 
     local latest_url tag
-    latest_url="$(curl -fsSL --connect-timeout 30 --max-time 60 -o /dev/null -w '%{url_effective}' \
+    latest_url="$(curl -fsSL --connect-timeout 30 --max-time 60 --retry 5 --retry-delay 5 -o /dev/null -w '%{url_effective}' \
         https://github.com/kubevirt/kubevirt/releases/latest)" || return 1
     tag="${latest_url##*/}"
     if ! _is_kubevirt_github_release_tag "$tag"; then

--- a/tests/vmhelpers/central_v2.go
+++ b/tests/vmhelpers/central_v2.go
@@ -286,9 +286,9 @@ func WaitForV2ScanMissingComponent(
 			if err != nil {
 				return false, "", err
 			}
-			if filtered.GetTotalCount() > 0 {
+			if n := max(int(filtered.GetTotalCount()), len(filtered.GetComponents())); n > 0 {
 				return false, fmt.Sprintf("scan_time advances=%d but package %q still present (matches=%d)",
-					advances, packageName, filtered.GetTotalCount()), nil
+					advances, packageName, n), nil
 			}
 
 			comps, total, err := ListAllVMComponents(ctx, client, id)

--- a/tests/vmhelpers/central_v2.go
+++ b/tests/vmhelpers/central_v2.go
@@ -182,8 +182,8 @@ func ListAllVMComponents(ctx context.Context, client v2.VirtualMachineV2ServiceC
 		}
 		total = resp.GetTotalCount()
 		all = append(all, resp.GetComponents()...)
-		if int32(len(all)) >= total || len(resp.GetComponents()) == 0 {
-			return all, total, nil
+		if v2ListExhausted(len(all), len(resp.GetComponents()), total) {
+			return all, max(total, int32(len(all))), nil
 		}
 	}
 	return nil, 0, fmt.Errorf("ListVMComponents: exceeded %d pages for vm %s (collected %d, total_count=%d)", v2ListMaxPages, vmID, len(all), total)
@@ -210,11 +210,17 @@ func ListAllVMCVEsByVM(ctx context.Context, client v2.VirtualMachineV2ServiceCli
 		}
 		total = resp.GetTotalCount()
 		all = append(all, resp.GetCves()...)
-		if int32(len(all)) >= total || len(resp.GetCves()) == 0 {
-			return all, total, nil
+		if v2ListExhausted(len(all), len(resp.GetCves()), total) {
+			return all, max(total, int32(len(all))), nil
 		}
 	}
 	return nil, 0, fmt.Errorf("ListVMCVEsByVM: exceeded %d pages for vm %s (collected %d, total_count=%d)", v2ListMaxPages, vmID, len(all), total)
+}
+
+// v2ListExhausted is true on a short page, or when a positive total_count has
+// already been collected. A zero total_count with a full page is not exhausted.
+func v2ListExhausted(collected, pageLen int, total int32) bool {
+	return pageLen < int(v2ListPageSize) || (total > 0 && int32(collected) >= total)
 }
 
 // VulnCountBySeverityTotal sums the per-severity total fields.

--- a/tests/vmhelpers/central_v2_test.go
+++ b/tests/vmhelpers/central_v2_test.go
@@ -11,6 +11,8 @@ import (
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -274,6 +276,38 @@ func TestWaitForV2ScanReady(t *testing.T) {
 					TotalCount: 1,
 					Components: []*v2.VMComponentRow{{Name: "bash", ScanStatus: v2.ScanStatus_NOT_SCANNED}},
 				}, nil
+			}
+			return &v2.ListVMComponentsResponse{
+				TotalCount: 1,
+				Components: []*v2.VMComponentRow{{Name: "bash", ScanStatus: v2.ScanStatus_SCANNED}},
+			}, nil
+		},
+	}
+	vm, err := WaitForV2ScanReady(ctx, client, opts, "vid")
+	require.NoError(t, err)
+	require.Equal(t, "vid", vm.GetId())
+	require.GreaterOrEqual(t, calls, 2)
+}
+
+func TestWaitForV2ScanReady_RetriesTransientListError(t *testing.T) {
+	ctx := t.Context()
+	opts := WaitOptions{Timeout: 400 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var calls int
+	client := &stubV2Client{
+		getVMFn: func(_ context.Context, req *v2.GetVMRequest) (*v2.VMDetail, error) {
+			return &v2.VMDetail{
+				Id:      req.GetId(),
+				GuestOs: "rhel",
+				LatestScan: &v2.VMScanInfo{
+					ScanTime: timestamppb.Now(),
+					ScanOs:   "rhel",
+				},
+			}, nil
+		},
+		listVMComponentsFn: func(context.Context, *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error) {
+			calls++
+			if calls == 1 {
+				return nil, status.Error(codes.Unavailable, "central busy")
 			}
 			return &v2.ListVMComponentsResponse{
 				TotalCount: 1,

--- a/tests/vmhelpers/central_v2_test.go
+++ b/tests/vmhelpers/central_v2_test.go
@@ -147,52 +147,154 @@ func TestWaitForV2VMRunningInCentral(t *testing.T) {
 }
 
 func TestListAllVMCVEsByVM_Pages(t *testing.T) {
-	ctx := t.Context()
-	client := &stubV2Client{
-		listVMCVEsByVMFn: func(_ context.Context, req *v2.ListVMCVEsByVMRequest) (*v2.ListVMCVEsByVMResponse, error) {
-			switch req.GetQuery().GetPagination().GetOffset() {
-			case 0:
+	page0 := make([]*v2.VMCVERow, v2ListPageSize)
+	for i := range page0 {
+		page0[i] = &v2.VMCVERow{Cve: "CVE-full"}
+	}
+	tests := map[string]struct {
+		resp      func(offset int32) *v2.ListVMCVEsByVMResponse
+		wantLen   int
+		wantTotal int32
+		wantCalls int
+		wantLast  string
+	}{
+		"short first page": {
+			resp: func(offset int32) *v2.ListVMCVEsByVMResponse {
+				if offset != 0 {
+					return &v2.ListVMCVEsByVMResponse{TotalCount: 2}
+				}
 				return &v2.ListVMCVEsByVMResponse{
 					TotalCount: 2,
 					Cves:       []*v2.VMCVERow{{Cve: "CVE-1"}, {Cve: "CVE-2"}},
-				}, nil
-			default:
-				return &v2.ListVMCVEsByVMResponse{TotalCount: 2}, nil
-			}
+				}
+			},
+			wantLen:   2,
+			wantTotal: 2,
+			wantCalls: 1,
+			wantLast:  "CVE-2",
+		},
+		"zero total_count still pages a full first page": {
+			resp: func(offset int32) *v2.ListVMCVEsByVMResponse {
+				switch offset {
+				case 0:
+					return &v2.ListVMCVEsByVMResponse{TotalCount: 0, Cves: page0}
+				case v2ListPageSize:
+					return &v2.ListVMCVEsByVMResponse{
+						TotalCount: 0,
+						Cves:       []*v2.VMCVERow{{Cve: "CVE-last"}},
+					}
+				default:
+					return &v2.ListVMCVEsByVMResponse{TotalCount: 0}
+				}
+			},
+			wantLen:   v2ListPageSize + 1,
+			wantTotal: int32(v2ListPageSize + 1),
+			wantCalls: 2,
+			wantLast:  "CVE-last",
 		},
 	}
-	cves, total, err := ListAllVMCVEsByVM(ctx, client, "vid")
-	require.NoError(t, err)
-	require.Equal(t, int32(2), total)
-	require.Equal(t, []string{"CVE-1", "CVE-2"}, []string{cves[0].GetCve(), cves[1].GetCve()})
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			calls := 0
+			client := &stubV2Client{
+				listVMCVEsByVMFn: func(_ context.Context, req *v2.ListVMCVEsByVMRequest) (*v2.ListVMCVEsByVMResponse, error) {
+					calls++
+					return tc.resp(req.GetQuery().GetPagination().GetOffset()), nil
+				},
+			}
+			cves, total, err := ListAllVMCVEsByVM(t.Context(), client, "vid")
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTotal, total)
+			require.Len(t, cves, tc.wantLen)
+			require.Equal(t, tc.wantCalls, calls)
+			require.Equal(t, tc.wantLast, cves[len(cves)-1].GetCve())
+		})
+	}
 }
 
 func TestListAllVMComponents_Pages(t *testing.T) {
-	ctx := t.Context()
 	page0 := make([]*v2.VMComponentRow, v2ListPageSize)
 	for i := range page0 {
 		page0[i] = &v2.VMComponentRow{Name: "pkg"}
 	}
-	client := &stubV2Client{
-		listVMComponentsFn: func(_ context.Context, req *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error) {
-			switch req.GetQuery().GetPagination().GetOffset() {
-			case 0:
-				return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize + 1), Components: page0}, nil
-			case v2ListPageSize:
-				return &v2.ListVMComponentsResponse{
-					TotalCount: int32(v2ListPageSize + 1),
-					Components: []*v2.VMComponentRow{{Name: "last"}},
-				}, nil
-			default:
-				return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize + 1)}, nil
-			}
+	tests := map[string]struct {
+		resp      func(offset int32) *v2.ListVMComponentsResponse
+		wantLen   int
+		wantTotal int32
+		wantCalls int
+		wantLast  string
+	}{
+		"accurate total across two pages": {
+			resp: func(offset int32) *v2.ListVMComponentsResponse {
+				switch offset {
+				case 0:
+					return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize + 1), Components: page0}
+				case v2ListPageSize:
+					return &v2.ListVMComponentsResponse{
+						TotalCount: int32(v2ListPageSize + 1),
+						Components: []*v2.VMComponentRow{{Name: "last"}},
+					}
+				default:
+					return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize + 1)}
+				}
+			},
+			wantLen:   v2ListPageSize + 1,
+			wantTotal: int32(v2ListPageSize + 1),
+			wantCalls: 2,
+			wantLast:  "last",
+		},
+		"zero total_count still pages a full first page": {
+			resp: func(offset int32) *v2.ListVMComponentsResponse {
+				switch offset {
+				case 0:
+					return &v2.ListVMComponentsResponse{TotalCount: 0, Components: page0}
+				case v2ListPageSize:
+					return &v2.ListVMComponentsResponse{
+						TotalCount: 0,
+						Components: []*v2.VMComponentRow{{Name: "last"}},
+					}
+				default:
+					return &v2.ListVMComponentsResponse{TotalCount: 0}
+				}
+			},
+			wantLen:   v2ListPageSize + 1,
+			wantTotal: int32(v2ListPageSize + 1),
+			wantCalls: 2,
+			wantLast:  "last",
+		},
+		"full page matching total does not fetch next": {
+			resp: func(offset int32) *v2.ListVMComponentsResponse {
+				if offset != 0 {
+					return &v2.ListVMComponentsResponse{
+						TotalCount: int32(v2ListPageSize),
+						Components: page0,
+					}
+				}
+				return &v2.ListVMComponentsResponse{TotalCount: int32(v2ListPageSize), Components: page0}
+			},
+			wantLen:   v2ListPageSize,
+			wantTotal: int32(v2ListPageSize),
+			wantCalls: 1,
+			wantLast:  "pkg",
 		},
 	}
-	comps, total, err := ListAllVMComponents(ctx, client, "vid")
-	require.NoError(t, err)
-	require.Equal(t, int32(v2ListPageSize+1), total)
-	require.Len(t, comps, v2ListPageSize+1)
-	require.Equal(t, "last", comps[len(comps)-1].GetName())
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			calls := 0
+			client := &stubV2Client{
+				listVMComponentsFn: func(_ context.Context, req *v2.ListVMComponentsRequest) (*v2.ListVMComponentsResponse, error) {
+					calls++
+					return tc.resp(req.GetQuery().GetPagination().GetOffset()), nil
+				},
+			}
+			comps, total, err := ListAllVMComponents(t.Context(), client, "vid")
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTotal, total)
+			require.Len(t, comps, tc.wantLen)
+			require.Equal(t, tc.wantCalls, calls)
+			require.Equal(t, tc.wantLast, comps[len(comps)-1].GetName())
+		})
+	}
 }
 
 func TestVulnCountBySeverityTotal(t *testing.T) {

--- a/tests/vmhelpers/wait.go
+++ b/tests/vmhelpers/wait.go
@@ -93,10 +93,31 @@ func validateWaitOptions(desc string, opts WaitOptions) error {
 	return nil
 }
 
+// isTransientPollError reports gRPC failures that should not abort a Central wait.
+// Unavailable/DeadlineExceeded/ResourceExhausted/Aborted are typical of a busy
+// Central or a short network blip; Unimplemented and InvalidArgument are not.
+func isTransientPollError(err error) bool {
+	if err == nil || IsAuthenticationExpired(err) {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return true
+	default:
+		return false
+	}
+}
+
 // pollUntil is the poll loop for Central gRPC scan-lifecycle waits.
 // Use this instead of k8s wait.PollUntilContextCancel when you need:
 //   - auth-expiry fail-fast: aborts immediately on expired kubeconfig tokens
 //     instead of burning the full timeout,
+//   - retry of transient gRPC codes until Timeout (v2 scan waits issue more
+//     RPCs per poll than the legacy GetVirtualMachine path),
 //   - structured diagnostics: each poll returns a detail string so timeout
 //     errors report exactly which stage was stuck.
 //
@@ -121,15 +142,21 @@ func pollUntil(ctx context.Context, opts WaitOptions, desc string, poll func(ctx
 			if IsAuthenticationExpired(err) {
 				return fmt.Errorf("vmhelpers: %s: %w: %v", desc, ErrAuthenticationExpired, err)
 			}
-			return fmt.Errorf("vmhelpers: %s: %w", desc, err)
-		}
-		if done {
+			if !isTransientPollError(err) {
+				return fmt.Errorf("vmhelpers: %s: %w", desc, err)
+			}
+			if lastDetail == "" {
+				lastDetail = err.Error()
+			}
+			if opts.Logf != nil {
+				opts.Logf("poll %s: waiting (transient: %v)", desc, err)
+			}
+		} else if done {
 			if opts.Logf != nil && detail != "" {
 				opts.Logf("poll %s: done (%s)", desc, detail)
 			}
 			return nil
-		}
-		if opts.Logf != nil && detail != "" {
+		} else if opts.Logf != nil && detail != "" {
 			opts.Logf("poll %s: waiting (%s)", desc, detail)
 		}
 		if time.Now().After(deadline) {

--- a/tests/vmhelpers/wait_test.go
+++ b/tests/vmhelpers/wait_test.go
@@ -41,6 +41,38 @@ func TestPollUntil_TimesOutWithDetail(t *testing.T) {
 	require.Contains(t, err.Error(), "still waiting")
 }
 
+func TestPollUntil_RetriesTransientThenSucceeds(t *testing.T) {
+	ctx := t.Context()
+	var polls int
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      400 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	}, "transient-test", func(context.Context) (bool, string, error) {
+		polls++
+		if polls == 1 {
+			return false, "", status.Error(codes.Unavailable, "central busy")
+		}
+		return true, "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, polls)
+}
+
+func TestPollUntil_UnimplementedIsTerminal(t *testing.T) {
+	ctx := t.Context()
+	var polls int
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      400 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	}, "unimplemented-test", func(context.Context) (bool, string, error) {
+		polls++
+		return false, "", status.Error(codes.Unimplemented, "not registered")
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, polls)
+	require.Contains(t, err.Error(), "Unimplemented")
+}
+
 func TestPollUntil_RejectsInvalidOptions(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
⚠️ Not release critical, but could be useful on the release branch (more coverage & less flakes).

Fixes the red streak in https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-ocp-4-22-ocp-vm-scanning-e2e-tests (note that VM nightlies pass for other OCP versions).

## Description

Follow-up to #22516. Two VM e2e reliability issues: 
1. virtctl install on OpenShift 4.22, and  - fixes current issues on OCP 4.22 nightly runs,
2. Central scan-wait RPCs that fail once then succeed.

On OCP 4.22, CNV's CLI-download pod can stay at 0/1 (`Init:OOMKilled`), so the job never gets `virtctl` from the cluster. The GitHub fallback then used KubeVirt's `observedKubeVirtVersion` as the release tag. On this channel that field is an image digest (`sha256:…`), not `vX.Y.Z`, so we requested `virtctl-sha256:…-linux-amd64` and GitHub returned 404. The job failed before the suite ran (`Was Stackrox deployed to the cluster?`). 4.14/4.18 on the same PR got virtctl from the cluster and passed.

GitHub download now accepts only a `vX.Y.Z` tag. A digest is skipped. The tag comes from the HyperConverged CR (`spec.version` / `status.versions[kubevirt]`) or from the `virt-operator` container's `KUBEVIRT_VERSION`. If none of those is a release tag, we follow `https://github.com/kubevirt/kubevirt/releases/latest`. Diagnostic logs go to stderr so command substitution captures only the tag. curl uses connect/max timeouts, and the downloaded file must be ELF.

~⚠️⚠️⚠️ **TEMPORARY (revert before merge):** in CI the runner skips ConsoleCLIDownload and always uses this GitHub path, so the 4.22 job actually exercises the fallback. Local runs still prefer the cluster download. Do not merge the `TEMPORARY: force GitHub virtctl in CI` commit.~

The other change retries transient gRPC failures (`Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, `Aborted`) inside the Central VM scan wait loop. Auth errors and `Unimplemented` still fail immediately. That matches [review feedback on #22516](https://github.com/stackrox/stackrox/pull/22516#discussion_r3928990608). `WaitForV2ScanMissingComponent` treats a package as present when `max(total_count, len(rows)) > 0`, so a truncated page cannot look like "package gone."

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] ✅ [4.14](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22643/pull-ci-stackrox-stackrox-master-ocp-4-14-vm-scanning-e2e-tests/2095804113303375872)
- [x] ✅ [4.18](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22643/pull-ci-stackrox-stackrox-master-ocp-4-18-vm-scanning-e2e-tests/2095804116688179200) (I checked the logs and saw it passing. Decided to push the TMP commit revert without waiting for the run to properly finish).
- [x] ✅ [4.22](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22643/pull-ci-stackrox-stackrox-master-ocp-4-22-vm-scanning-e2e-tests/2095804119179595776)
- [ ] :x: [4.22](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22643/pull-ci-stackrox-stackrox-master-ocp-4-22-vm-scanning-e2e-tests/2095866806618034176) - fallback failed because of network issues with:
- [x] ✅ [4.22](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22643/pull-ci-stackrox-stackrox-master-ocp-4-22-vm-scanning-e2e-tests/2096713297834283008)  

```
INFO: Fri Sep  4 15:01:39 UTC 2026: virtctl tarball not ready yet (attempt 29/30), retrying in 10s
INFO: Fri Sep  4 15:01:49 UTC 2026: virtctl tarball not ready yet (attempt 30/30), retrying in 10s
WARNING: Fri Sep  4 15:02:00 UTC 2026: Failed to download virtctl from https://hyperconverged-cluster-cli-download-openshift-cnv.apps.rox-ci-18034176.ocp.ci.rox.systems/amd64/linux/virtctl.tar.gz
WARNING: Fri Sep  4 15:02:00 UTC 2026: Cluster ConsoleCLIDownload did not serve virtctl. Falling back to the matching KubeVirt GitHub release.
WARNING: Fri Sep  4 15:02:00 UTC 2026: Ignoring KubeVirt version sha256:041c9f8999af1379aa2664e1725cdeacf0ccb847fb61100397bc6d36690adcb7: not a GitHub release tag
WARNING: Fri Sep  4 15:02:00 UTC 2026: Ignoring KubeVirt version sha256:041c9f8999af1379aa2664e1725cdeacf0ccb847fb61100397bc6d36690adcb7: not a GitHub release tag
WARNING: Fri Sep  4 15:02:00 UTC 2026: Ignoring KubeVirt version sha256:041c9f8999af1379aa2664e1725cdeacf0ccb847fb61100397bc6d36690adcb7: not a GitHub release tag
curl: (6) Could not resolve host: github.com
WARNING: Fri Sep  4 15:02:10 UTC 2026: Could not resolve a kubevirt/kubevirt GitHub release tag for virtctl
ERROR: Failed to install virtctl from cluster ConsoleCLIDownload and KubeVirt GitHub release
```
 

Relevant log fragment for passing test:

```
daemon set "virt-handler" successfully rolled out

INFO: Fri Sep  4 10:25:53 UTC 2026: KubeVirt CR already has VSOCK feature gate
NAME                                       DISPLAY                    VERSION   RELEASE   REPLACES                                   PHASE
kubevirt-hyperconverged-operator.v4.22.6   OpenShift Virtualization   4.22.6              kubevirt-hyperconverged-operator.v4.22.2   Installing

WARNING: Fri Sep  4 10:25:53 UTC 2026: TEMPORARY: skipping ConsoleCLIDownload virtctl install; using GitHub release only. Revert before merge.

WARNING: Fri Sep  4 10:25:59 UTC 2026: Ignoring KubeVirt version sha256:041c9f8999af1379aa2664e1725cdeacf0ccb847fb61100397bc6d36690adcb7: not a GitHub release tag
WARNING: Fri Sep  4 10:25:59 UTC 2026: Ignoring KubeVirt version sha256:041c9f8999af1379aa2664e1725cdeacf0ccb847fb61100397bc6d36690adcb7: not a GitHub release tag
INFO: Fri Sep  4 10:25:59 UTC 2026: No cluster KubeVirt GitHub tag; using latest release v1.9.0
INFO: Fri Sep  4 10:25:59 UTC 2026: Downloading virtctl v1.9.0 from https://github.com/kubevirt/kubevirt/releases/download/v1.9.0/virtctl-v1.9.0-linux-amd64
INFO: Fri Sep  4 10:25:59 UTC 2026: virtctl installed at /tmp/tmp.aFZKJeAcG8/virtctl
INFO: Fri Sep  4 10:25:59 UTC 2026: About to deploy StackRox (Central + Sensor).
```

Wait until `ocp-4-22-vm-scanning-e2e-tests` logs `Ignoring KubeVirt version sha256:` and `Downloading virtctl v…` (not `virtctl-sha256:`), then revert the ⚠️TEMPORARY commit ⚠️ and merge.

AI-Assisted: cursor, ~70% generated, user directed virtctl GitHub-tag fix, TEMPORARY CI skip, and wait-loop retry.