### PR TITLE
ROX-36796: Sensor metrics for mapping path mix and fetch health

### DIFF
--- a/sensor/common/scannerdefinitions/metrics.go
+++ b/sensor/common/scannerdefinitions/metrics.go
@@ -1,8 +1,16 @@
 package scannerdefinitions
 
 import (
+	"sync/atomic"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/metrics"
+)
+
+const (
+	repoCPEMappingFetchSuccess   = "success"
+	repoCPEMappingFetchUnchanged = "unchanged"
+	repoCPEMappingFetchError     = "error"
 )
 
 // repoCPEMappingHashChanges counts Sensor replacing its cached mapping when
@@ -15,6 +23,34 @@ var repoCPEMappingHashChanges = prometheus.NewCounter(prometheus.CounterOpts{
 	Help:      "Times Sensor replaced its cached repo-to-CPE mapping because the content hash from Central (and its upstream source) has changed. This answers the question 'How often does the repo-to-CPE mapping get updated in general?'",
 })
 
+// repoCPEMappingFetch counts each Central fetch attempt once: success is a
+// hash change, unchanged is HTTP 304 or same-hash 200, error is anything that
+// keeps last-good. It is not a per-VM VSOCK sync.
+var repoCPEMappingFetch = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: metrics.PrometheusNamespace,
+	Subsystem: metrics.SensorSubsystem.String(),
+	Name:      "repo_cpe_mapping_fetch_total",
+	Help:      "Central repo-to-CPE mapping fetches by result (success: content hash changed; unchanged: HTTP 304 or same-hash 200; error: request, validation, or unexpected status). Not a per-VM VSOCK sync.",
+}, []string{"result"})
+
+// repo2CPELastSuccessUnix is the Unix seconds of cache.lastSuccess, or 0
+// until the first successful fetch. The GaugeFunc reads this so scrapes stay
+// correct without a Sensor tick.
+var repo2CPELastSuccessUnix atomic.Int64
+
+func repo2CPELastSuccessSeconds() float64 {
+	return float64(repo2CPELastSuccessUnix.Load())
+}
+
+// repoCPEMappingLastSuccess is Unix seconds of Sensor's last successful
+// mapping fetch (304 and same-hash 200 count). Zero until the first success.
+var repoCPEMappingLastSuccess = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	Namespace: metrics.PrometheusNamespace,
+	Subsystem: metrics.SensorSubsystem.String(),
+	Name:      "repo_cpe_mapping_last_success_timestamp_seconds",
+	Help:      "Unix timestamp of Sensor's last successful repo-to-CPE mapping fetch from Central, including HTTP 304 and same-hash 200. Zero until the first success.",
+}, repo2CPELastSuccessSeconds)
+
 func init() {
-	metrics.EmplaceCollector(repoCPEMappingHashChanges)
+	metrics.EmplaceCollector(repoCPEMappingHashChanges, repoCPEMappingFetch, repoCPEMappingLastSuccess)
 }

--- a/sensor/common/scannerdefinitions/repo2cpe.go
+++ b/sensor/common/scannerdefinitions/repo2cpe.go
@@ -182,6 +182,11 @@ func (r *Repo2CPE) FetchRepo2CPE(_ context.Context) (mapping []byte, hash string
 // mapping and updates the cache on success or "unchanged". It reports
 // whether the attempt succeeded, so the caller can pick the next delay.
 func (r *Repo2CPE) attemptRepo2CPERefresh(ctx context.Context) bool {
+	result := repoCPEMappingFetchError
+	defer func() {
+		repoCPEMappingFetch.WithLabelValues(result).Inc()
+	}()
+
 	etag, lastModified := concurrency.WithLock2(&r.cacheMu, func() (string, string) {
 		return r.cache.etag, r.cache.lastModified
 	})
@@ -202,6 +207,7 @@ func (r *Repo2CPE) attemptRepo2CPERefresh(ctx context.Context) bool {
 	switch resp.StatusCode {
 	case http.StatusNotModified:
 		r.recordRepo2CPEUnchanged(resp)
+		result = repoCPEMappingFetchUnchanged
 		return true
 	case http.StatusOK:
 		body, err := io.ReadAll(io.LimitReader(resp.Body, cpemapping.MaxMappingBytes+1))
@@ -213,7 +219,11 @@ func (r *Repo2CPE) attemptRepo2CPERefresh(ctx context.Context) bool {
 			log.Warnf("Repo-to-CPE mapping failed validation, keeping last-good: %v", err)
 			return false
 		}
-		r.recordRepo2CPESuccess(body, resp)
+		if r.recordRepo2CPESuccess(body, resp) {
+			result = repoCPEMappingFetchSuccess
+		} else {
+			result = repoCPEMappingFetchUnchanged
+		}
 		return true
 	default:
 		log.Warnf("Unexpected status %d fetching repo-to-CPE mapping from central", resp.StatusCode)
@@ -241,7 +251,7 @@ func (r *Repo2CPE) newRepo2CPERequest(ctx context.Context, etag, lastModified st
 
 func (r *Repo2CPE) recordRepo2CPEUnchanged(resp *http.Response) {
 	concurrency.WithLock(&r.cacheMu, func() {
-		r.cache.lastSuccess = time.Now()
+		r.markRepo2CPESuccessNoLock()
 		r.mergeRepo2CPEValidatorsNoLock(resp)
 	})
 	log.Debug("Repo-to-CPE mapping unchanged (304)")
@@ -249,12 +259,12 @@ func (r *Repo2CPE) recordRepo2CPEUnchanged(resp *http.Response) {
 
 // recordRepo2CPESuccess keeps the existing cached bytes when the new content
 // hashes the same as what's cached, treating a same-hash 200 like a 304.
-func (r *Repo2CPE) recordRepo2CPESuccess(body []byte, resp *http.Response) {
+func (r *Repo2CPE) recordRepo2CPESuccess(body []byte, resp *http.Response) bool {
 	hash := cpemapping.HashMapping(body)
 	var oldHash string
 	var changed bool
 	concurrency.WithLock(&r.cacheMu, func() {
-		r.cache.lastSuccess = time.Now()
+		r.markRepo2CPESuccessNoLock()
 		oldHash = r.cache.hash
 		if hash != r.cache.hash {
 			r.cache.mapping = body
@@ -268,6 +278,15 @@ func (r *Repo2CPE) recordRepo2CPESuccess(body []byte, resp *http.Response) {
 		log.Infof("Repo-to-CPE mapping content hash changed: old=%q new=%q", oldHash, hash)
 	}
 	log.Debugf("Fetched repo-to-CPE mapping from central, hash=%s", hash)
+	return changed
+}
+
+// markRepo2CPESuccessNoLock publishes lastSuccess to the last-success gauge
+// in the same critical section so scrapes cannot observe a stale timestamp.
+func (r *Repo2CPE) markRepo2CPESuccessNoLock() {
+	now := time.Now()
+	r.cache.lastSuccess = now
+	repo2CPELastSuccessUnix.Store(now.Unix())
 }
 
 // replaceRepo2CPEValidatorsNoLock copies validators from a 200, including

--- a/sensor/common/scannerdefinitions/repo2cpe_test.go
+++ b/sensor/common/scannerdefinitions/repo2cpe_test.go
@@ -76,6 +76,7 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 		wantEtag         string
 		wantLastModified string
 		wantHashChange   bool
+		wantFetchResult  string
 	}{
 		"first fetch succeeds and populates an empty cache": {
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -83,11 +84,12 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 				w.Header().Set(etagHeader, `"v1"`)
 				_, _ = w.Write([]byte(mappingV1))
 			},
-			wantOK:         true,
-			wantMapping:    mappingV1,
-			wantHash:       hashV1,
-			wantEtag:       `"v1"`,
-			wantHashChange: true,
+			wantOK:          true,
+			wantMapping:     mappingV1,
+			wantHash:        hashV1,
+			wantEtag:        `"v1"`,
+			wantHashChange:  true,
+			wantFetchResult: repoCPEMappingFetchSuccess,
 		},
 		"304 with matching validators keeps the cached mapping": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, etag: `"v1"`, lastModified: "old", lastSuccess: seededSuccess},
@@ -100,69 +102,77 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 			wantHash:         hashV1,
 			wantEtag:         `"v1"`,
 			wantLastModified: "old",
+			wantFetchResult:  repoCPEMappingFetchUnchanged,
 		},
 		"200 without validators replaces previously cached validators": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, etag: `"v1"`, lastModified: "old", lastSuccess: seededSuccess},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(mappingV2))
 			},
-			wantOK:         true,
-			wantMapping:    mappingV2,
-			wantHash:       hashV2,
-			wantHashChange: true,
+			wantOK:          true,
+			wantMapping:     mappingV2,
+			wantHash:        hashV2,
+			wantHashChange:  true,
+			wantFetchResult: repoCPEMappingFetchSuccess,
 		},
 		"200 with a same-hash body is treated as unchanged": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(mappingV1))
 			},
-			wantOK:      true,
-			wantMapping: mappingV1,
-			wantHash:    hashV1,
+			wantOK:          true,
+			wantMapping:     mappingV1,
+			wantHash:        hashV1,
+			wantFetchResult: repoCPEMappingFetchUnchanged,
 		},
 		"200 with a different hash replaces the cached mapping": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte(mappingV2))
 			},
-			wantOK:         true,
-			wantMapping:    mappingV2,
-			wantHash:       hashV2,
-			wantHashChange: true,
+			wantOK:          true,
+			wantMapping:     mappingV2,
+			wantHash:        hashV2,
+			wantHashChange:  true,
+			wantFetchResult: repoCPEMappingFetchSuccess,
 		},
 		"an unexpected status leaves the cache untouched": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
-			wantOK:      false,
-			wantMapping: mappingV1,
-			wantHash:    hashV1,
+			wantOK:          false,
+			wantMapping:     mappingV1,
+			wantHash:        hashV1,
+			wantFetchResult: repoCPEMappingFetchError,
 		},
 		"a network error leaves the cache untouched": {
-			seedCache:   repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
-			networkErr:  true,
-			wantOK:      false,
-			wantMapping: mappingV1,
-			wantHash:    hashV1,
+			seedCache:       repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
+			networkErr:      true,
+			wantOK:          false,
+			wantMapping:     mappingV1,
+			wantHash:        hashV1,
+			wantFetchResult: repoCPEMappingFetchError,
 		},
 		"an oversized response leaves the cache untouched": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
 			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write(bytes.Repeat([]byte("a"), cpemapping.MaxMappingBytes+1))
 			},
-			wantOK:      false,
-			wantMapping: mappingV1,
-			wantHash:    hashV1,
+			wantOK:          false,
+			wantMapping:     mappingV1,
+			wantHash:        hashV1,
+			wantFetchResult: repoCPEMappingFetchError,
 		},
 		"an invalid mapping body leaves the cache untouched": {
 			seedCache: repo2CPECache{mapping: []byte(mappingV1), hash: hashV1, lastSuccess: seededSuccess},
 			serverHandler: func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte(`{"not":"a mapping"}`))
 			},
-			wantOK:      false,
-			wantMapping: mappingV1,
-			wantHash:    hashV1,
+			wantOK:          false,
+			wantMapping:     mappingV1,
+			wantHash:        hashV1,
+			wantFetchResult: repoCPEMappingFetchError,
 		},
 	}
 
@@ -179,23 +189,38 @@ func TestAttemptRepo2CPERefresh(t *testing.T) {
 				r.centralClient = newTestCentralClient(t, tt.serverHandler)
 			}
 
-			before := testutil.ToFloat64(repoCPEMappingHashChanges)
+			beforeHashChanges := testutil.ToFloat64(repoCPEMappingHashChanges)
+			beforeFetch := map[string]float64{
+				repoCPEMappingFetchSuccess:   testutil.ToFloat64(repoCPEMappingFetch.WithLabelValues(repoCPEMappingFetchSuccess)),
+				repoCPEMappingFetchUnchanged: testutil.ToFloat64(repoCPEMappingFetch.WithLabelValues(repoCPEMappingFetchUnchanged)),
+				repoCPEMappingFetchError:     testutil.ToFloat64(repoCPEMappingFetch.WithLabelValues(repoCPEMappingFetchError)),
+			}
+			beforeLastSuccess := testutil.ToFloat64(repoCPEMappingLastSuccess)
 			ok := r.attemptRepo2CPERefresh(t.Context())
 
 			assert.Equal(t, tt.wantOK, ok)
-			wantCount := before
+			wantCount := beforeHashChanges
 			if tt.wantHashChange {
 				wantCount++
 			}
 			assert.Equal(t, wantCount, testutil.ToFloat64(repoCPEMappingHashChanges))
+			for result, before := range beforeFetch {
+				want := before
+				if result == tt.wantFetchResult {
+					want++
+				}
+				assert.Equal(t, want, testutil.ToFloat64(repoCPEMappingFetch.WithLabelValues(result)), result)
+			}
 			assert.Equal(t, tt.wantMapping, string(r.cache.mapping))
 			assert.Equal(t, tt.wantHash, r.cache.hash)
 			assert.Equal(t, tt.wantEtag, r.cache.etag)
 			assert.Equal(t, tt.wantLastModified, r.cache.lastModified)
 			if tt.wantOK {
 				assert.False(t, r.cache.lastSuccess.IsZero())
+				assert.Equal(t, float64(r.cache.lastSuccess.Unix()), testutil.ToFloat64(repoCPEMappingLastSuccess))
 			} else {
 				assert.Equal(t, tt.seedCache.lastSuccess, r.cache.lastSuccess)
+				assert.Equal(t, beforeLastSuccess, testutil.ToFloat64(repoCPEMappingLastSuccess))
 			}
 		})
 	}

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -103,6 +103,14 @@ const (
 	PullSyncTimeout = "timeout"
 )
 
+// Mapping-path label values for PullTrackedVMsByMappingPath. Bounded to
+// the three RepoCPEMappingUpdatePath cases so cardinality stays fixed.
+const (
+	MappingPathSensor      = "sensor"
+	MappingPathURL         = "url"
+	MappingPathUnspecified = "unspecified"
+)
+
 // PullDialDurationSeconds measures time to establish a websocket connection per VM.
 var PullDialDurationSeconds = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
@@ -247,6 +255,19 @@ var PullTrackedVMs = prometheus.NewGauge(
 	},
 )
 
+// PullTrackedVMsByMappingPath is currently tracked VMs partitioned by
+// repo-to-CPE mapping update path. It is fleet mix, not scrape events;
+// the three series sum to vsock_pull_tracked_vms.
+var PullTrackedVMsByMappingPath = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "vsock_pull_tracked_vms_by_mapping_path",
+		Help:      "Number of VMs currently tracked for pull-mode scraping, partitioned by repo-to-CPE mapping update path (sensor, url, unspecified). This is fleet mix, not scrape events.",
+	},
+	[]string{"path"},
+)
+
 // PullDueVMs is how many VMs were eligible to scrape at the start of the last
 // tick (nextAttemptAt had arrived and they were not already in flight).
 var PullDueVMs = prometheus.NewGauge(
@@ -319,9 +340,13 @@ func init() {
 		PullSyncTotal,
 		PullTicksTotal,
 		PullTrackedVMs,
+		PullTrackedVMsByMappingPath,
 		PullDueVMs,
 		PullStartsPerTick,
 		PullForwardInterarrivalSeconds,
 		PullScheduleOffsetSeconds,
 	)
+	for _, path := range []string{MappingPathSensor, MappingPathURL, MappingPathUnspecified} {
+		PullTrackedVMsByMappingPath.WithLabelValues(path).Set(0)
+	}
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -140,6 +140,10 @@ type vmState struct {
 	backoff          time.Duration
 	vmID             virtualmachine.VMID
 	lastAgentVersion string
+	// mappingPath is the last RepoCPEMappingUpdatePath seen in ResponseMeta
+	// for this slot (sensor/url/unspecified). New and recreated slots start
+	// unspecified until a scrape with meta arrives.
+	mappingPath string
 }
 
 var _ common.SensorComponent = (*VMScraper)(nil)
@@ -328,9 +332,8 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 	due := s.dueKeys()
 	nDue := len(due)
 	nTracked := concurrency.WithLock1(&s.mu, func() int {
-		n := len(s.vmState)
-		metrics.PullTrackedVMs.Set(float64(n))
-		return n
+		s.setTrackedVMGaugesNoLock()
+		return len(s.vmState)
 	})
 	metrics.PullDueVMs.Set(float64(nDue))
 	capN := min(s.concurrency, startBudget(nTracked, s.tickInterval, newVMIndexReportWindow(s.interval)))
@@ -383,11 +386,19 @@ func (s *VMScraper) reconcile() {
 			liveKeys.Add(key)
 			st, ok := s.vmState[key]
 			if !ok {
-				st = &vmState{nextAttemptAt: now.Add(randOffset(newVMWindow, s.randFloat64())), vmID: vm.ID}
+				st = &vmState{
+					nextAttemptAt: now.Add(randOffset(newVMWindow, s.randFloat64())),
+					vmID:          vm.ID,
+					mappingPath:   metrics.MappingPathUnspecified,
+				}
 				s.vmState[key] = st
 			} else if st.vmID != vm.ID {
 				// namespace/name can outlive a KubeVirt recreate; do not inherit scrape state.
-				st = &vmState{nextAttemptAt: now, vmID: vm.ID}
+				st = &vmState{
+					nextAttemptAt: now,
+					vmID:          vm.ID,
+					mappingPath:   metrics.MappingPathUnspecified,
+				}
 				s.vmState[key] = st
 			}
 		}
@@ -398,6 +409,7 @@ func (s *VMScraper) reconcile() {
 		}
 		numVMs = len(s.vmState)
 		s.lastReconcile = now
+		s.setTrackedVMGaugesNoLock()
 	})
 	s.warnIfSpreadSaturated(numVMs)
 }
@@ -458,6 +470,7 @@ func (s *VMScraper) scrapeKey(ctx context.Context, key string) bool {
 		concurrency.WithLock(&s.mu, func() {
 			if st, ok := s.vmState[key]; ok && st.vmID == vmID {
 				delete(s.vmState, key)
+				s.setTrackedVMGaugesNoLock()
 			}
 		})
 		return false
@@ -760,6 +773,9 @@ func isAbnormalClose(err error, target *closeCoder) bool {
 // Sensor-managed and its reported hash is stale. A URL-managed agent with
 // a stale hash is only logged and counted, since Sensor doesn't own it.
 func (s *VMScraper) maybeSyncRepoCPEMapping(ctx context.Context, vm *virtualmachine.Info, key string, port uint32, meta *pb.ResponseMeta) {
+	if meta != nil {
+		s.recordMappingPath(key, meta.GetRepoCpeMappingUpdatePath())
+	}
 	updatePath := meta.GetRepoCpeMappingUpdatePath()
 	if updatePath == pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED {
 		return
@@ -783,6 +799,52 @@ func (s *VMScraper) maybeSyncRepoCPEMapping(ctx context.Context, vm *virtualmach
 		log.Warnf("VMScraper: roxagent on %q reports a URL-managed repo-to-CPE mapping (hash=%s) that differs from Sensor's own cache (hash=%s)",
 			key, meta.GetRepoCpeMappingHash(), sensorHash)
 		metrics.PullSyncTotal.WithLabelValues(metrics.PullSyncURLHashMismatch).Inc()
+	}
+}
+
+// recordMappingPath stores path on a live slot and recounts the tracked-VM
+// gauges. Missing keys are ignored so a concurrent prune cannot resurrect a slot.
+func (s *VMScraper) recordMappingPath(key string, path pb.RepoCPEMappingUpdatePath) {
+	concurrency.WithLock(&s.mu, func() {
+		st, ok := s.vmState[key]
+		if !ok {
+			return
+		}
+		st.mappingPath = mappingPathLabel(path)
+		s.setTrackedVMGaugesNoLock()
+	})
+}
+
+func mappingPathLabel(path pb.RepoCPEMappingUpdatePath) string {
+	switch path {
+	case pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR:
+		return metrics.MappingPathSensor
+	case pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL:
+		return metrics.MappingPathURL
+	default:
+		return metrics.MappingPathUnspecified
+	}
+}
+
+// setTrackedVMGaugesNoLock writes vsock_pull_tracked_vms and the three
+// by-mapping-path series from vmState so the labeled counts always sum
+// to the unlabeled gauge.
+func (s *VMScraper) setTrackedVMGaugesNoLock() {
+	counts := map[string]int{
+		metrics.MappingPathSensor:      0,
+		metrics.MappingPathURL:         0,
+		metrics.MappingPathUnspecified: 0,
+	}
+	for _, st := range s.vmState {
+		path := st.mappingPath
+		if path == "" {
+			path = metrics.MappingPathUnspecified
+		}
+		counts[path]++
+	}
+	metrics.PullTrackedVMs.Set(float64(len(s.vmState)))
+	for path, n := range counts {
+		metrics.PullTrackedVMsByMappingPath.WithLabelValues(path).Set(float64(n))
 	}
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -802,15 +802,17 @@ func (s *VMScraper) maybeSyncRepoCPEMapping(ctx context.Context, vm *virtualmach
 	}
 }
 
-// recordMappingPath stores path on a live slot and recounts the tracked-VM
-// gauges. Missing keys are ignored so a concurrent prune cannot resurrect a slot.
+// recordMappingPath stores path on a live slot. Gauges are rewritten only
+// when the path changes; missing keys are ignored so a concurrent prune
+// cannot resurrect a slot.
 func (s *VMScraper) recordMappingPath(key string, path pb.RepoCPEMappingUpdatePath) {
+	label := mappingPathLabel(path)
 	concurrency.WithLock(&s.mu, func() {
 		st, ok := s.vmState[key]
-		if !ok {
+		if !ok || st.mappingPath == label {
 			return
 		}
-		st.mappingPath = mappingPathLabel(path)
+		st.mappingPath = label
 		s.setTrackedVMGaugesNoLock()
 	})
 }

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -331,8 +331,8 @@ func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
 
 	due := s.dueKeys()
 	nDue := len(due)
+	// Mapping-path gauges are rewritten on reconcile, removal, and path updates.
 	nTracked := concurrency.WithLock1(&s.mu, func() int {
-		s.setTrackedVMGaugesNoLock()
 		return len(s.vmState)
 	})
 	metrics.PullDueVMs.Set(float64(nDue))

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -1166,45 +1166,45 @@ func TestVMScraper_TrackedVMsByMappingPath(t *testing.T) {
 	tests := map[string]func(t *testing.T){
 		"a new VM starts as unspecified": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
-			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
 			assertTrackedByMappingPath(t, 0, 0, 1)
 		},
 		"SENSOR meta moves the recount to sensor": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
-			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
 			assertTrackedByMappingPath(t, 1, 0, 0)
 		},
 		"URL meta moves the recount to url": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
-			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL))
 			assertTrackedByMappingPath(t, 0, 1, 0)
 		},
 		"unspecified meta stays unspecified": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
-			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED))
 			assertTrackedByMappingPath(t, 0, 0, 1)
 		},
 		"nil meta does not change a live slot": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
-			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, nil)
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, nil)
 			assertTrackedByMappingPath(t, 1, 0, 0)
 		},
 		"a VM leaving vmState drops its series": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
 			store := &mockStore{vms: []*virtualmachine.Info{vm}}
-			s, _ := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, store, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
 			require.Equal(t, 1.0, testutil.ToFloat64(metrics.PullTrackedVMsByMappingPath.WithLabelValues(metrics.MappingPathSensor)))
 			store.vms = nil
 			s.reconcile()
@@ -1213,9 +1213,9 @@ func TestVMScraper_TrackedVMsByMappingPath(t *testing.T) {
 		"a vmID recreate returns to unspecified": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
 			store := &mockStore{vms: []*virtualmachine.Info{vm}}
-			s, _ := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s, _ := newTestScraper(t, store, &mockDialer{}, &mockProtocolClient{})
 			s.reconcile()
-			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
 			store.vms = []*virtualmachine.Info{{
 				ID:        "uid-new",
 				Namespace: "ns1",

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -1158,6 +1158,88 @@ func TestVMScraper_IgnoresLateScrapeAfterVMReplacement(t *testing.T) {
 	})
 }
 
+// TestVMScraper_TrackedVMsByMappingPath covers the currently-tracked gauge
+// mix. Path updates use maybeSyncRepoCPEMapping so they do not need a VSOCK push.
+func TestVMScraper_TrackedVMsByMappingPath(t *testing.T) {
+	const key = "ns1/vm-a"
+
+	tests := map[string]func(t *testing.T){
+		"a new VM starts as unspecified": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			assertTrackedByMappingPath(t, 0, 0, 1)
+		},
+		"SENSOR meta moves the recount to sensor": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			assertTrackedByMappingPath(t, 1, 0, 0)
+		},
+		"URL meta moves the recount to url": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL))
+			assertTrackedByMappingPath(t, 0, 1, 0)
+		},
+		"unspecified meta stays unspecified": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_UNSPECIFIED))
+			assertTrackedByMappingPath(t, 0, 0, 1)
+		},
+		"nil meta does not change a live slot": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, nil)
+			assertTrackedByMappingPath(t, 1, 0, 0)
+		},
+		"a VM leaving vmState drops its series": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			store := &mockStore{vms: []*virtualmachine.Info{vm}}
+			s, _ := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			require.Equal(t, 1.0, testutil.ToFloat64(metrics.PullTrackedVMsByMappingPath.WithLabelValues(metrics.MappingPathSensor)))
+			store.vms = nil
+			s.reconcile()
+			assertTrackedByMappingPath(t, 0, 0, 0)
+		},
+		"a vmID recreate returns to unspecified": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			store := &mockStore{vms: []*virtualmachine.Info{vm}}
+			s, _ := newTestScraper(t, store, &mockSender{}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(context.Background(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			store.vms = []*virtualmachine.Info{{
+				ID:        "uid-new",
+				Namespace: "ns1",
+				Name:      "vm-a",
+				VSOCKCID:  new(uint32(101)),
+				Running:   true,
+			}}
+			s.reconcile()
+			assertTrackedByMappingPath(t, 0, 0, 1)
+		},
+	}
+	for name, fn := range tests {
+		t.Run(name, fn)
+	}
+}
+
+func assertTrackedByMappingPath(t *testing.T, sensor, url, unspecified float64) {
+	t.Helper()
+	assert.Equal(t, sensor, testutil.ToFloat64(metrics.PullTrackedVMsByMappingPath.WithLabelValues(metrics.MappingPathSensor)), "sensor")
+	assert.Equal(t, url, testutil.ToFloat64(metrics.PullTrackedVMsByMappingPath.WithLabelValues(metrics.MappingPathURL)), "url")
+	assert.Equal(t, unspecified, testutil.ToFloat64(metrics.PullTrackedVMsByMappingPath.WithLabelValues(metrics.MappingPathUnspecified)), "unspecified")
+	assert.Equal(t, sensor+url+unspecified, testutil.ToFloat64(metrics.PullTrackedVMs), "labeled series must sum to vsock_pull_tracked_vms")
+}
+
 // hasScheduleSlot reports whether key has a vmState slot (reconcile membership).
 func hasScheduleSlot(t *testing.T, s *VMScraper, key string) bool {
 	t.Helper()

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -1199,6 +1199,22 @@ func TestVMScraper_TrackedVMsByMappingPath(t *testing.T) {
 			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, nil)
 			assertTrackedByMappingPath(t, 1, 0, 0)
 		},
+		"repeating SENSOR meta keeps the mix": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			assertTrackedByMappingPath(t, 1, 0, 0)
+		},
+		"URL meta after SENSOR recounts to url": func(t *testing.T) {
+			vm := makeVM("ns1", "vm-a", 100)
+			s, _ := newTestScraper(t, &mockStore{vms: []*virtualmachine.Info{vm}}, &mockDialer{}, &mockProtocolClient{})
+			s.reconcile()
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_SENSOR))
+			s.maybeSyncRepoCPEMapping(t.Context(), vm, key, 1, metaWithMapping("h", pb.RepoCPEMappingUpdatePath_REPO_CPE_MAPPING_UPDATE_PATH_URL))
+			assertTrackedByMappingPath(t, 0, 1, 0)
+		},
 		"a VM leaving vmState drops its series": func(t *testing.T) {
 			vm := makeVM("ns1", "vm-a", 100)
 			store := &mockStore{vms: []*virtualmachine.Info{vm}}


### PR DESCRIPTION
## Description

Sensor already counts how often Central's repo-to-CPE mapping content hash changes (`repo_cpe_mapping_hash_changes_total`) and how often a mapping is pushed to a VM over VSOCK (`vsock_pull_sync_total`). Operators still need the mix of currently tracked VMs by mapping update path, and a signal for whether Sensor's Central fetch is healthy or the cached mapping is going stale.

This PR adds three Sensor Prometheus signals (`rox_sensor_*`):

- `vsock_pull_tracked_vms_by_mapping_path{path=sensor|url|unspecified}`: currently tracked VMs by last-known mapping path. New and recreated slots start as `unspecified`. The path updates when Sensor has `ResponseMeta` (successful forward, Unchanged GetReport, `MAPPING_REQUIRED`).
- `repo_cpe_mapping_fetch_total{result=success|unchanged|error}`: one increment per Central fetch. `success` is a content-hash change; `unchanged` is HTTP 304 or same-hash 200; `error` is request, validation, or unexpected status.
- `repo_cpe_mapping_last_success_timestamp_seconds`: Unix seconds of the last successful fetch, including 304 and same-hash 200. Zero until the first success.

The path gauge is recounted from `vmState` and Set after membership or path changes, rather than Inc/Dec, so the three series always sum to `vsock_pull_tracked_vms`. The unlabeled `repo_cpe_mapping_hash_changes_total` stays a dedicated counter: folding content changes into the fetch `result` label would hide a sparse signal inside a high-volume fetch counter. Mapping hash and VM identity are not used as labels.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI

AI-Assisted: cursor, ~70% generated, user reviewed logic