### PR TITLE
ROX-36802: Populate GetVM agent_status from scrape freshness

### DIFF
--- a/central/convert/storagetov2/virtual_machine_v2.go
+++ b/central/convert/storagetov2/virtual_machine_v2.go
@@ -2,10 +2,12 @@ package storagetov2
 
 import (
 	"slices"
+	"time"
 
 	"github.com/stackrox/rox/central/views/common"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // VirtualMachineV2ToListItem converts a storage VM V2 to an API list item.
@@ -47,6 +49,18 @@ func VirtualMachineV2ToDetail(vm *storage.VirtualMachineV2) *v2.VMDetail {
 		VsockCid:    vm.GetVsockCid(),
 		Notes:       notes,
 	}
+}
+
+// AgentStatusFromLastContact maps scrape freshness onto the GetVM enum.
+// A nil/invalid timestamp is UNKNOWN; age >= staleAfter is INACTIVE.
+func AgentStatusFromLastContact(ts *timestamppb.Timestamp, now time.Time, staleAfter time.Duration) v2.AgentStatus {
+	if ts == nil || !ts.IsValid() {
+		return v2.AgentStatus_AGENT_STATUS_UNKNOWN
+	}
+	if now.Sub(ts.AsTime()) < staleAfter {
+		return v2.AgentStatus_AGENT_STATUS_ACTIVE
+	}
+	return v2.AgentStatus_AGENT_STATUS_INACTIVE
 }
 
 func convertVMNote(note storage.VirtualMachineV2_Note) v2.VMNote {

--- a/central/convert/storagetov2/virtual_machine_v2_test.go
+++ b/central/convert/storagetov2/virtual_machine_v2_test.go
@@ -2,10 +2,12 @@ package storagetov2
 
 import (
 	"testing"
+	"time"
 
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestVirtualMachineV2ToDetail_Notes(t *testing.T) {
@@ -47,6 +49,43 @@ func TestVirtualMachineV2ToDetail_Notes(t *testing.T) {
 				Notes: []storage.VirtualMachineV2_Note{tc.note},
 			})
 			require.Equal(t, []v2.VMNote{tc.expected}, detail.GetNotes())
+		})
+	}
+}
+
+func TestAgentStatusFromLastContact(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	staleAfter := 12 * time.Hour
+
+	tests := map[string]struct {
+		ts       *timestamppb.Timestamp
+		expected v2.AgentStatus
+	}{
+		"should return unknown when never scraped": {
+			ts:       nil,
+			expected: v2.AgentStatus_AGENT_STATUS_UNKNOWN,
+		},
+		"should return unknown when timestamp is invalid": {
+			ts:       &timestamppb.Timestamp{Nanos: 2_000_000_000},
+			expected: v2.AgentStatus_AGENT_STATUS_UNKNOWN,
+		},
+		"should return active when last scrape is still inside the window": {
+			ts:       timestamppb.New(now.Add(-time.Hour)),
+			expected: v2.AgentStatus_AGENT_STATUS_ACTIVE,
+		},
+		"should return inactive when last scrape is exactly the window": {
+			ts:       timestamppb.New(now.Add(-staleAfter)),
+			expected: v2.AgentStatus_AGENT_STATUS_INACTIVE,
+		},
+		"should return inactive when last scrape is older than the window": {
+			ts:       timestamppb.New(now.Add(-13 * time.Hour)),
+			expected: v2.AgentStatus_AGENT_STATUS_INACTIVE,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, AgentStatusFromLastContact(tc.ts, now, staleAfter))
 		})
 	}
 }

--- a/central/virtualmachine/v2/datastore/datastore.go
+++ b/central/virtualmachine/v2/datastore/datastore.go
@@ -32,7 +32,8 @@ type DataStore interface {
 
 	// UpsertScan upserts scan data (scan, components, CVEs) for a VM.
 	// Hash-based change detection avoids unnecessary writes. CVE created_at
-	// timestamps are preserved across scan replacements.
+	// timestamps are preserved across scan replacements. Also stamps
+	// last_agent_contact: this is the scrape-derived path.
 	UpsertScan(ctx context.Context, vmID string, parts common.VMScanParts) error
 
 	// DeleteVirtualMachines removes VMs and all associated data (FK cascade).

--- a/central/virtualmachine/v2/datastore/store/postgres/store.go
+++ b/central/virtualmachine/v2/datastore/store/postgres/store.go
@@ -69,8 +69,8 @@ func (s *storeImpl) EnsureExists(ctx context.Context, vmID, clusterID string) er
 		}
 
 		const stmt = "INSERT INTO " + vmTable +
-			" (Id, Name, Namespace, ClusterId, ClusterName, GuestOs, State, LastUpdated, serialized)" +
-			" VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)" +
+			" (Id, Name, Namespace, ClusterId, ClusterName, GuestOs, State, LastUpdated, LastAgentContact, serialized)" +
+			" VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)" +
 			" ON CONFLICT(Id) DO NOTHING"
 
 		_, err := s.db.Exec(ctx, stmt,
@@ -82,6 +82,7 @@ func (s *storeImpl) EnsureExists(ctx context.Context, vmID, clusterID string) er
 			vm.GetGuestOs(),
 			vm.GetState(),
 			protocompat.NilOrTime(vm.GetLastUpdated()),
+			protocompat.NilOrTime(vm.GetLastAgentContact()),
 			serialized,
 		)
 		return err
@@ -124,6 +125,11 @@ func (s *storeImpl) upsertVM(ctx context.Context, vm *storage.VirtualMachineV2) 
 				return errors.Wrapf(rbErr, "rollback after: %v", err)
 			}
 			return err
+		}
+
+		// Sensor informer upserts never carry last_agent_contact; keep the scrape stamp.
+		if existingVM != nil && vm.GetLastAgentContact() == nil {
+			vm.LastAgentContact = existingVM.GetLastAgentContact()
 		}
 
 		if existingVM != nil && existingVM.GetHash() == hash {
@@ -174,17 +180,19 @@ func (s *storeImpl) insertVM(ctx context.Context, tx *postgres.Tx, vm *storage.V
 		vm.GetGuestOs(),
 		vm.GetState(),
 		protocompat.NilOrTime(vm.GetLastUpdated()),
+		protocompat.NilOrTime(vm.GetLastAgentContact()),
 		serialized,
 	}
 
 	const stmt = "INSERT INTO " + vmTable +
-		" (Id, Name, Namespace, ClusterId, ClusterName, GuestOs, State, LastUpdated, serialized)" +
-		" VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)" +
+		" (Id, Name, Namespace, ClusterId, ClusterName, GuestOs, State, LastUpdated, LastAgentContact, serialized)" +
+		" VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)" +
 		" ON CONFLICT(Id) DO UPDATE SET" +
 		" Id = EXCLUDED.Id, Name = EXCLUDED.Name, Namespace = EXCLUDED.Namespace," +
 		" ClusterId = EXCLUDED.ClusterId, ClusterName = EXCLUDED.ClusterName," +
 		" GuestOs = EXCLUDED.GuestOs, State = EXCLUDED.State," +
-		" LastUpdated = EXCLUDED.LastUpdated, serialized = EXCLUDED.serialized"
+		" LastUpdated = EXCLUDED.LastUpdated, LastAgentContact = EXCLUDED.LastAgentContact," +
+		" serialized = EXCLUDED.serialized"
 	_, err = tx.Exec(ctx, stmt, values...)
 	return err
 }
@@ -200,8 +208,8 @@ func (s *storeImpl) updateVMTimestamp(ctx context.Context, tx *postgres.Tx, vm *
 		return err
 	}
 
-	const stmt = "UPDATE " + vmTable + " SET LastUpdated = $2, serialized = $3 WHERE Id = $1"
-	_, err = tx.Exec(ctx, stmt, id, protocompat.NilOrTime(vm.GetLastUpdated()), serialized)
+	const stmt = "UPDATE " + vmTable + " SET LastUpdated = $2, LastAgentContact = $3, serialized = $4 WHERE Id = $1"
+	_, err = tx.Exec(ctx, stmt, id, protocompat.NilOrTime(vm.GetLastUpdated()), protocompat.NilOrTime(vm.GetLastAgentContact()), serialized)
 	return err
 }
 
@@ -313,7 +321,10 @@ func (s *storeImpl) touchVMLastUpdated(ctx context.Context, tx *postgres.Tx, vmI
 	if existingVM == nil {
 		return errox.NotFound.Newf("VM %s not found", vmID)
 	}
-	existingVM.LastUpdated = protocompat.ConvertTimeToTimestampOrNil(&t)
+	ts := protocompat.ConvertTimeToTimestampOrNil(&t)
+	existingVM.LastUpdated = ts
+	// UpsertScan is the scrape-derived path (index-report SYNC), so last contact moves with last_updated.
+	existingVM.LastAgentContact = ts
 	return s.updateVMTimestamp(ctx, tx, existingVM)
 }
 

--- a/central/virtualmachine/v2/datastore/store/postgres/store_test.go
+++ b/central/virtualmachine/v2/datastore/store/postgres/store_test.go
@@ -177,6 +177,38 @@ func (s *VMStoreTestSuite) TestUpsertVM_Changed() {
 	s.NotEqual(firstGet.GetHash(), secondGet.GetHash(), "hash should change when data changes")
 }
 
+func (s *VMStoreTestSuite) TestUpsertScan_StampsLastAgentContactAndInformerDoesNotRefresh() {
+	vm := s.newVM()
+	s.NoError(s.store.UpsertVM(s.ctx, vm))
+
+	beforeScan, _, err := s.store.Get(s.ctx, vm.GetId())
+	s.NoError(err)
+	s.Nil(beforeScan.GetLastAgentContact())
+
+	parts := s.newScanParts(vm.GetId())
+	s.NoError(s.store.UpsertScan(s.ctx, vm.GetId(), parts))
+
+	afterScan, _, err := s.store.Get(s.ctx, vm.GetId())
+	s.NoError(err)
+	s.NotNil(afterScan.GetLastAgentContact())
+	contact := afterScan.GetLastAgentContact().AsTime()
+
+	time.Sleep(10 * time.Millisecond)
+
+	informerUpdate := vm.CloneVT()
+	informerUpdate.LastUpdated = nil
+	informerUpdate.Hash = 0
+	informerUpdate.LastAgentContact = nil
+	informerUpdate.State = storage.VirtualMachineV2_STOPPED
+	s.NoError(s.store.UpsertVM(s.ctx, informerUpdate))
+
+	afterInformer, _, err := s.store.Get(s.ctx, vm.GetId())
+	s.NoError(err)
+	s.Equal(storage.VirtualMachineV2_STOPPED, afterInformer.GetState())
+	s.Equal(contact, afterInformer.GetLastAgentContact().AsTime())
+	s.True(afterInformer.GetLastUpdated().AsTime().After(afterScan.GetLastUpdated().AsTime()))
+}
+
 // endregion UpsertVM tests
 
 // region UpsertScan tests

--- a/central/virtualmachine/v2/datastore/store/postgres/store_test.go
+++ b/central/virtualmachine/v2/datastore/store/postgres/store_test.go
@@ -186,27 +186,19 @@ func (s *VMStoreTestSuite) TestUpsertScan_StampsLastAgentContact() {
 	s.Nil(beforeScan.GetLastAgentContact())
 
 	parts := s.newScanParts(vm.GetId())
+	before := time.Now()
 	s.NoError(s.store.UpsertScan(s.ctx, vm.GetId(), parts))
-
-	afterScan, _, err := s.store.Get(s.ctx, vm.GetId())
-	s.NoError(err)
-	s.NotNil(afterScan.GetLastAgentContact())
-}
-
-func (s *VMStoreTestSuite) TestUpsertVM_PreservesLastAgentContactWhenInformerOmitsIt() {
-	vm := s.newVM()
-	s.NoError(s.store.UpsertVM(s.ctx, vm))
-
-	parts := s.newScanParts(vm.GetId())
-	s.NoError(s.store.UpsertScan(s.ctx, vm.GetId(), parts))
+	after := time.Now()
 
 	afterScan, _, err := s.store.Get(s.ctx, vm.GetId())
 	s.NoError(err)
 	s.Require().NotNil(afterScan.GetLastAgentContact())
 	contact := afterScan.GetLastAgentContact().AsTime()
+	s.False(contact.Before(before), "LastAgentContact %v is before UpsertScan started at %v", contact, before)
+	s.False(contact.After(after), "LastAgentContact %v is after UpsertScan finished at %v", contact, after)
+}
 
-	time.Sleep(10 * time.Millisecond)
-
+func (s *VMStoreTestSuite) TestUpsertVM_PreservesLastAgentContactWhenInformerOmitsIt() {
 	for name, mutate := range map[string]func(*storage.VirtualMachineV2){
 		"unchanged upsert": func(*storage.VirtualMachineV2) {},
 		"changed upsert": func(informerUpdate *storage.VirtualMachineV2) {
@@ -214,6 +206,17 @@ func (s *VMStoreTestSuite) TestUpsertVM_PreservesLastAgentContactWhenInformerOmi
 		},
 	} {
 		s.Run(name, func() {
+			vm := s.newVM()
+			s.NoError(s.store.UpsertVM(s.ctx, vm))
+
+			parts := s.newScanParts(vm.GetId())
+			s.NoError(s.store.UpsertScan(s.ctx, vm.GetId(), parts))
+
+			afterScan, _, err := s.store.Get(s.ctx, vm.GetId())
+			s.NoError(err)
+			s.Require().NotNil(afterScan.GetLastAgentContact())
+			contact := afterScan.GetLastAgentContact().AsTime()
+
 			informerUpdate := vm.CloneVT()
 			informerUpdate.LastUpdated = nil
 			informerUpdate.Hash = 0

--- a/central/virtualmachine/v2/datastore/store/postgres/store_test.go
+++ b/central/virtualmachine/v2/datastore/store/postgres/store_test.go
@@ -177,7 +177,7 @@ func (s *VMStoreTestSuite) TestUpsertVM_Changed() {
 	s.NotEqual(firstGet.GetHash(), secondGet.GetHash(), "hash should change when data changes")
 }
 
-func (s *VMStoreTestSuite) TestUpsertScan_StampsLastAgentContactAndInformerDoesNotRefresh() {
+func (s *VMStoreTestSuite) TestUpsertScan_StampsLastAgentContact() {
 	vm := s.newVM()
 	s.NoError(s.store.UpsertVM(s.ctx, vm))
 
@@ -191,22 +191,41 @@ func (s *VMStoreTestSuite) TestUpsertScan_StampsLastAgentContactAndInformerDoesN
 	afterScan, _, err := s.store.Get(s.ctx, vm.GetId())
 	s.NoError(err)
 	s.NotNil(afterScan.GetLastAgentContact())
+}
+
+func (s *VMStoreTestSuite) TestUpsertVM_PreservesLastAgentContactWhenInformerOmitsIt() {
+	vm := s.newVM()
+	s.NoError(s.store.UpsertVM(s.ctx, vm))
+
+	parts := s.newScanParts(vm.GetId())
+	s.NoError(s.store.UpsertScan(s.ctx, vm.GetId(), parts))
+
+	afterScan, _, err := s.store.Get(s.ctx, vm.GetId())
+	s.NoError(err)
+	s.Require().NotNil(afterScan.GetLastAgentContact())
 	contact := afterScan.GetLastAgentContact().AsTime()
 
 	time.Sleep(10 * time.Millisecond)
 
-	informerUpdate := vm.CloneVT()
-	informerUpdate.LastUpdated = nil
-	informerUpdate.Hash = 0
-	informerUpdate.LastAgentContact = nil
-	informerUpdate.State = storage.VirtualMachineV2_STOPPED
-	s.NoError(s.store.UpsertVM(s.ctx, informerUpdate))
+	for name, mutate := range map[string]func(*storage.VirtualMachineV2){
+		"unchanged upsert": func(*storage.VirtualMachineV2) {},
+		"changed upsert": func(informerUpdate *storage.VirtualMachineV2) {
+			informerUpdate.State = storage.VirtualMachineV2_STOPPED
+		},
+	} {
+		s.Run(name, func() {
+			informerUpdate := vm.CloneVT()
+			informerUpdate.LastUpdated = nil
+			informerUpdate.Hash = 0
+			informerUpdate.LastAgentContact = nil
+			mutate(informerUpdate)
+			s.NoError(s.store.UpsertVM(s.ctx, informerUpdate))
 
-	afterInformer, _, err := s.store.Get(s.ctx, vm.GetId())
-	s.NoError(err)
-	s.Equal(storage.VirtualMachineV2_STOPPED, afterInformer.GetState())
-	s.Equal(contact, afterInformer.GetLastAgentContact().AsTime())
-	s.True(afterInformer.GetLastUpdated().AsTime().After(afterScan.GetLastUpdated().AsTime()))
+			got, _, err := s.store.Get(s.ctx, vm.GetId())
+			s.NoError(err)
+			s.Equal(contact, got.GetLastAgentContact().AsTime())
+		})
+	}
 }
 
 // endregion UpsertVM tests

--- a/central/virtualmachine/v2/datastore/store/store.go
+++ b/central/virtualmachine/v2/datastore/store/store.go
@@ -27,7 +27,8 @@ type Store interface {
 	// UpsertScan upserts scan data (scan, components, CVEs) for a VM.
 	// Hash-comparison determines whether a full replace or scan_time-only
 	// update is performed. CVE created_at timestamps are preserved across
-	// delete/re-insert cycles.
+	// delete/re-insert cycles. Also stamps last_agent_contact: this is the
+	// scrape-derived path.
 	// NOTE: Mutates parts in-place (Scan.ScanTime, Scan.Hash, CVE CreatedAt).
 	UpsertScan(ctx context.Context, vmID string, parts common.VMScanParts) error
 

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"slices"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
@@ -17,6 +18,7 @@ import (
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
@@ -654,6 +656,11 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 	}
 
 	detail := storagetov2.VirtualMachineV2ToDetail(vm)
+	detail.AgentStatus = storagetov2.AgentStatusFromLastContact(
+		vm.GetLastAgentContact(),
+		time.Now(),
+		env.VirtualMachinesAgentStaleAfter.DurationSetting(),
+	)
 
 	// Get the latest scan for this VM. Scan IDs are UUIDv7 (time-sortable),
 	// so sorting by the primary key is equivalent to sorting by time and avoids

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type testCVEForVM struct {
@@ -753,6 +754,85 @@ func TestGetVM(t *testing.T) {
 				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, nil)
 			},
 			expectedResult: storagetov2.VirtualMachineV2ToDetail(vm1),
+		},
+		"never scraped stays unknown with vsock cid and agent version": {
+			request: &v2.GetVMRequest{
+				Id: testVMID,
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				neverScraped := &storage.VirtualMachineV2{
+					Id:       testVMID,
+					Name:     "test-vm-1",
+					State:    storage.VirtualMachineV2_RUNNING,
+					VsockCid: 42,
+					Facts:    map[string]string{"agentVersion": "5.0.x-174-g6b7ccc2192"},
+				}
+				mockVM.EXPECT().GetVirtualMachine(ctx, testVMID).Return(neverScraped, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, nil)
+			},
+			expectedResult: func() *v2.VMDetail {
+				detail := storagetov2.VirtualMachineV2ToDetail(&storage.VirtualMachineV2{
+					Id:       testVMID,
+					Name:     "test-vm-1",
+					State:    storage.VirtualMachineV2_RUNNING,
+					VsockCid: 42,
+					Facts:    map[string]string{"agentVersion": "5.0.x-174-g6b7ccc2192"},
+				})
+				detail.AgentStatus = v2.AgentStatus_AGENT_STATUS_UNKNOWN
+				return detail
+			}(),
+		},
+		"fresh scrape is active": {
+			request: &v2.GetVMRequest{
+				Id: testVMID,
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				fresh := vm1.CloneVT()
+				fresh.LastAgentContact = timestamppb.New(time.Now().Add(-time.Hour))
+				mockVM.EXPECT().GetVirtualMachine(ctx, testVMID).Return(fresh, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, nil)
+			},
+			expectedResult: func() *v2.VMDetail {
+				detail := storagetov2.VirtualMachineV2ToDetail(vm1)
+				detail.AgentStatus = v2.AgentStatus_AGENT_STATUS_ACTIVE
+				return detail
+			}(),
+		},
+		"activation status does not affect agent status": {
+			request: &v2.GetVMRequest{
+				Id: testVMID,
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				fresh := vm1.CloneVT()
+				fresh.Facts = map[string]string{"activationStatus": "inactive"}
+				fresh.LastAgentContact = timestamppb.New(time.Now().Add(-time.Hour))
+				mockVM.EXPECT().GetVirtualMachine(ctx, testVMID).Return(fresh, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, nil)
+			},
+			expectedResult: func() *v2.VMDetail {
+				detail := storagetov2.VirtualMachineV2ToDetail(vm1)
+				detail.Facts = map[string]string{"activationStatus": "inactive"}
+				detail.AgentStatus = v2.AgentStatus_AGENT_STATUS_ACTIVE
+				return detail
+			}(),
+		},
+		"stale scrape is inactive even when agent version is still set": {
+			request: &v2.GetVMRequest{
+				Id: testVMID,
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				stale := vm1.CloneVT()
+				stale.Facts = map[string]string{"agentVersion": "5.0.x-174-g6b7ccc2192"}
+				stale.LastAgentContact = timestamppb.New(time.Now().Add(-13 * time.Hour))
+				mockVM.EXPECT().GetVirtualMachine(ctx, testVMID).Return(stale, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, nil)
+			},
+			expectedResult: func() *v2.VMDetail {
+				detail := storagetov2.VirtualMachineV2ToDetail(vm1)
+				detail.Facts = map[string]string{"agentVersion": "5.0.x-174-g6b7ccc2192"}
+				detail.AgentStatus = v2.AgentStatus_AGENT_STATUS_INACTIVE
+				return detail
+			}(),
 		},
 		"datastore error": {
 			request: &v2.GetVMRequest{

--- a/generated/api/v2/virtual_machine_v2_service.pb.go
+++ b/generated/api/v2/virtual_machine_v2_service.pb.go
@@ -179,12 +179,14 @@ func (VMNote) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_virtual_machine_v2_service_proto_rawDescGZIP(), []int{2}
 }
 
-// Agent status enriched from a separate data source (not on VirtualMachineV2 storage).
+// AgentStatus is roxagent liveness from scrape freshness, computed on GetVM
+// (not a stored enum). UNKNOWN means never scraped; INACTIVE means scraped, then quiet.
 type AgentStatus int32
 
 const (
-	AgentStatus_AGENT_STATUS_UNKNOWN AgentStatus = 0
-	AgentStatus_AGENT_STATUS_ACTIVE  AgentStatus = 1
+	AgentStatus_AGENT_STATUS_UNKNOWN  AgentStatus = 0
+	AgentStatus_AGENT_STATUS_ACTIVE   AgentStatus = 1
+	AgentStatus_AGENT_STATUS_INACTIVE AgentStatus = 2
 )
 
 // Enum value maps for AgentStatus.
@@ -192,10 +194,12 @@ var (
 	AgentStatus_name = map[int32]string{
 		0: "AGENT_STATUS_UNKNOWN",
 		1: "AGENT_STATUS_ACTIVE",
+		2: "AGENT_STATUS_INACTIVE",
 	}
 	AgentStatus_value = map[string]int32{
-		"AGENT_STATUS_UNKNOWN": 0,
-		"AGENT_STATUS_ACTIVE":  1,
+		"AGENT_STATUS_UNKNOWN":  0,
+		"AGENT_STATUS_ACTIVE":   1,
+		"AGENT_STATUS_INACTIVE": 2,
 	}
 )
 
@@ -2537,10 +2541,11 @@ const file_api_v2_virtual_machine_v2_service_proto_rawDesc = "" +
 	"\x19VM_NOTE_MISSING_SIGNATURE\x10\x02\x12/\n" +
 	"+VM_NOTE_MISSING_SIGNATURE_VERIFICATION_DATA\x10\x03\x12\x1b\n" +
 	"\x17VM_NOTE_MISSING_SCANNER\x10\x04\x12\x17\n" +
-	"\x13VM_NOTE_SCAN_FAILED\x10\x05*@\n" +
+	"\x13VM_NOTE_SCAN_FAILED\x10\x05*[\n" +
 	"\vAgentStatus\x12\x18\n" +
 	"\x14AGENT_STATUS_UNKNOWN\x10\x00\x12\x17\n" +
-	"\x13AGENT_STATUS_ACTIVE\x10\x01*_\n" +
+	"\x13AGENT_STATUS_ACTIVE\x10\x01\x12\x19\n" +
+	"\x15AGENT_STATUS_INACTIVE\x10\x02*_\n" +
 	"\n" +
 	"ScanStatus\x12\x0f\n" +
 	"\vNOT_SCANNED\x10\x00\x12\x10\n" +

--- a/generated/api/v2/virtual_machine_v2_service.swagger.json
+++ b/generated/api/v2/virtual_machine_v2_service.swagger.json
@@ -767,10 +767,11 @@
       "type": "string",
       "enum": [
         "AGENT_STATUS_UNKNOWN",
-        "AGENT_STATUS_ACTIVE"
+        "AGENT_STATUS_ACTIVE",
+        "AGENT_STATUS_INACTIVE"
       ],
       "default": "AGENT_STATUS_UNKNOWN",
-      "description": "Agent status enriched from a separate data source (not on VirtualMachineV2 storage)."
+      "description": "AgentStatus is roxagent liveness from scrape freshness, computed on GetVM\n(not a stored enum). UNKNOWN means never scraped; INACTIVE means scraped, then quiet."
     },
     "v2AggregateBy": {
       "type": "object",

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/virtual_machine_v2.pb.go
+++ b/generated/storage/virtual_machine_v2.pb.go
@@ -144,11 +144,14 @@ type VirtualMachineV2 struct {
 	// KubeVirt facts about the VM.
 	Facts map[string]string `protobuf:"bytes,6,rep,name=facts,proto3" json:"facts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Guest OS reported by KubeVirt facts, extracted as a queryable column.
-	GuestOs     string                  `protobuf:"bytes,7,opt,name=guest_os,json=guestOs,proto3" json:"guest_os,omitempty" search:"Guest OS" sql:"index=btree"`                          // @gotags: search:"Guest OS" sql:"index=btree"
-	State       VirtualMachineV2_State  `protobuf:"varint,8,opt,name=state,proto3,enum=storage.VirtualMachineV2_State" json:"state,omitempty" search:"Virtual Machine State"`        // @gotags: search:"Virtual Machine State"
-	LastUpdated *timestamppb.Timestamp  `protobuf:"bytes,9,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty" search:"Last Updated,hidden" sql:"type(timestamptz)" hash:"ignore"`              // @gotags: search:"Last Updated,hidden" sql:"type(timestamptz)" hash:"ignore"
-	Notes       []VirtualMachineV2_Note `protobuf:"varint,10,rep,packed,name=notes,proto3,enum=storage.VirtualMachineV2_Note" json:"notes,omitempty" hash:"set"` // @gotags: hash:"set"
-	VsockCid    int32                   `protobuf:"varint,11,opt,name=vsock_cid,json=vsockCid,proto3" json:"vsock_cid,omitempty"`
+	GuestOs     string                 `protobuf:"bytes,7,opt,name=guest_os,json=guestOs,proto3" json:"guest_os,omitempty" search:"Guest OS" sql:"index=btree"`                   // @gotags: search:"Guest OS" sql:"index=btree"
+	State       VirtualMachineV2_State `protobuf:"varint,8,opt,name=state,proto3,enum=storage.VirtualMachineV2_State" json:"state,omitempty" search:"Virtual Machine State"` // @gotags: search:"Virtual Machine State"
+	LastUpdated *timestamppb.Timestamp `protobuf:"bytes,9,opt,name=last_updated,json=lastUpdated,proto3" json:"last_updated,omitempty" search:"Last Updated,hidden" sql:"type(timestamptz)" hash:"ignore"`       // @gotags: search:"Last Updated,hidden" sql:"type(timestamptz)" hash:"ignore"
+	// last_agent_contact is the last successful pull-mode scrape that landed in Central.
+	// Unset means never scraped; GetVM maps age against ROX_VIRTUAL_MACHINES_AGENT_STALE_AFTER.
+	LastAgentContact *timestamppb.Timestamp  `protobuf:"bytes,13,opt,name=last_agent_contact,json=lastAgentContact,proto3" json:"last_agent_contact,omitempty" search:"Last Agent Contact,hidden" sql:"type(timestamptz)" hash:"ignore"` // @gotags: search:"Last Agent Contact,hidden" sql:"type(timestamptz)" hash:"ignore"
+	Notes            []VirtualMachineV2_Note `protobuf:"varint,10,rep,packed,name=notes,proto3,enum=storage.VirtualMachineV2_Note" json:"notes,omitempty" hash:"set"`      // @gotags: hash:"set"
+	VsockCid         int32                   `protobuf:"varint,11,opt,name=vsock_cid,json=vsockCid,proto3" json:"vsock_cid,omitempty"`
 	// Hash of VM data fields for change detection (excludes last_updated).
 	Hash          uint64 `protobuf:"varint,12,opt,name=hash,proto3" json:"hash,omitempty" hash:"ignore"` // @gotags: hash:"ignore"
 	unknownFields protoimpl.UnknownFields
@@ -248,6 +251,13 @@ func (x *VirtualMachineV2) GetLastUpdated() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *VirtualMachineV2) GetLastAgentContact() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastAgentContact
+	}
+	return nil
+}
+
 func (x *VirtualMachineV2) GetNotes() []VirtualMachineV2_Note {
 	if x != nil {
 		return x.Notes
@@ -273,7 +283,7 @@ var File_storage_virtual_machine_v2_proto protoreflect.FileDescriptor
 
 const file_storage_virtual_machine_v2_proto_rawDesc = "" +
 	"\n" +
-	" storage/virtual_machine_v2.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd0\x05\n" +
+	" storage/virtual_machine_v2.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\"\x9a\x06\n" +
 	"\x10VirtualMachineV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
@@ -284,7 +294,8 @@ const file_storage_virtual_machine_v2_proto_rawDesc = "" +
 	"\x05facts\x18\x06 \x03(\v2$.storage.VirtualMachineV2.FactsEntryR\x05facts\x12\x19\n" +
 	"\bguest_os\x18\a \x01(\tR\aguestOs\x125\n" +
 	"\x05state\x18\b \x01(\x0e2\x1f.storage.VirtualMachineV2.StateR\x05state\x12=\n" +
-	"\flast_updated\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x124\n" +
+	"\flast_updated\x18\t \x01(\v2\x1a.google.protobuf.TimestampR\vlastUpdated\x12H\n" +
+	"\x12last_agent_contact\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\x10lastAgentContact\x124\n" +
 	"\x05notes\x18\n" +
 	" \x03(\x0e2\x1e.storage.VirtualMachineV2.NoteR\x05notes\x12\x1b\n" +
 	"\tvsock_cid\x18\v \x01(\x05R\bvsockCid\x12\x12\n" +
@@ -331,12 +342,13 @@ var file_storage_virtual_machine_v2_proto_depIdxs = []int32{
 	3, // 0: storage.VirtualMachineV2.facts:type_name -> storage.VirtualMachineV2.FactsEntry
 	0, // 1: storage.VirtualMachineV2.state:type_name -> storage.VirtualMachineV2.State
 	4, // 2: storage.VirtualMachineV2.last_updated:type_name -> google.protobuf.Timestamp
-	1, // 3: storage.VirtualMachineV2.notes:type_name -> storage.VirtualMachineV2.Note
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	4, // 3: storage.VirtualMachineV2.last_agent_contact:type_name -> google.protobuf.Timestamp
+	1, // 4: storage.VirtualMachineV2.notes:type_name -> storage.VirtualMachineV2.Note
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_storage_virtual_machine_v2_proto_init() }

--- a/generated/storage/virtual_machine_v2_vtproto.pb.go
+++ b/generated/storage/virtual_machine_v2_vtproto.pb.go
@@ -35,6 +35,7 @@ func (m *VirtualMachineV2) CloneVT() *VirtualMachineV2 {
 	r.GuestOs = m.GuestOs
 	r.State = m.State
 	r.LastUpdated = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.LastUpdated).CloneVT())
+	r.LastAgentContact = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.LastAgentContact).CloneVT())
 	r.VsockCid = m.VsockCid
 	r.Hash = m.Hash
 	if rhs := m.Facts; rhs != nil {
@@ -117,6 +118,9 @@ func (this *VirtualMachineV2) EqualVT(that *VirtualMachineV2) bool {
 	if this.Hash != that.Hash {
 		return false
 	}
+	if !(*timestamppb1.Timestamp)(this.LastAgentContact).EqualVT((*timestamppb1.Timestamp)(that.LastAgentContact)) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -156,6 +160,16 @@ func (m *VirtualMachineV2) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.LastAgentContact != nil {
+		size, err := (*timestamppb1.Timestamp)(m.LastAgentContact).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x6a
 	}
 	if m.Hash != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Hash))
@@ -324,6 +338,10 @@ func (m *VirtualMachineV2) SizeVT() (n int) {
 	}
 	if m.Hash != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Hash))
+	}
+	if m.LastAgentContact != nil {
+		l = (*timestamppb1.Timestamp)(m.LastAgentContact).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -839,6 +857,42 @@ func (m *VirtualMachineV2) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastAgentContact", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastAgentContact == nil {
+				m.LastAgentContact = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastAgentContact).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1403,6 +1457,42 @@ func (m *VirtualMachineV2) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastAgentContact", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastAgentContact == nil {
+				m.LastAgentContact = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastAgentContact).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -87,4 +87,9 @@ var (
 	// Valid range is [0.01, 1] so W is not effectively zero; out-of-range values fall back to the default.
 	VirtualMachinesScraperSteadySpreadFraction = RegisterFloatSetting("ROX_VIRTUAL_MACHINES_SCRAPER_STEADY_SPREAD_FRACTION", 2.0/3).
 							WithMinimum(0.01).WithMaximum(1)
+
+	// VirtualMachinesAgentStaleAfter is the GetVM Active window after the last
+	// successful scrape. Default 12h is larger than one healthy poll cycle
+	// (4h + up to 2/3 spread ≈ 6.7h), so one retryable VSOCK miss stays Active.
+	VirtualMachinesAgentStaleAfter = registerDurationSetting("ROX_VIRTUAL_MACHINES_AGENT_STALE_AFTER", 12*time.Hour)
 )

--- a/pkg/postgres/schema/virtual_machine_v2.go
+++ b/pkg/postgres/schema/virtual_machine_v2.go
@@ -56,13 +56,14 @@ const (
 
 // VirtualMachineV2 holds the Gorm model for Postgres table `virtual_machine_v2`.
 type VirtualMachineV2 struct {
-	ID          string                         `gorm:"column:id;type:uuid;primaryKey"`
-	Name        string                         `gorm:"column:name;type:varchar"`
-	Namespace   string                         `gorm:"column:namespace;type:varchar"`
-	ClusterID   string                         `gorm:"column:clusterid;type:uuid"`
-	ClusterName string                         `gorm:"column:clustername;type:varchar"`
-	GuestOs     string                         `gorm:"column:guestos;type:varchar"`
-	State       storage.VirtualMachineV2_State `gorm:"column:state;type:integer"`
-	LastUpdated *time.Time                     `gorm:"column:lastupdated;type:timestamptz"`
-	Serialized  []byte                         `gorm:"column:serialized;type:bytea"`
+	ID               string                         `gorm:"column:id;type:uuid;primaryKey"`
+	Name             string                         `gorm:"column:name;type:varchar"`
+	Namespace        string                         `gorm:"column:namespace;type:varchar"`
+	ClusterID        string                         `gorm:"column:clusterid;type:uuid"`
+	ClusterName      string                         `gorm:"column:clustername;type:varchar"`
+	GuestOs          string                         `gorm:"column:guestos;type:varchar"`
+	State            storage.VirtualMachineV2_State `gorm:"column:state;type:integer"`
+	LastUpdated      *time.Time                     `gorm:"column:lastupdated;type:timestamptz"`
+	LastAgentContact *time.Time                     `gorm:"column:lastagentcontact;type:timestamptz"`
+	Serialized       []byte                         `gorm:"column:serialized;type:bytea"`
 }

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -499,14 +499,15 @@ var (
 	AuthProviderName = newFieldLabel("AuthProvider Name")
 
 	// Virtual Machine fields.
-	VirtualMachineID       = newFieldLabel("Virtual Machine ID")
-	VirtualMachineName     = newFieldLabel("Virtual Machine Name")
-	GuestOS                = newFieldLabel("Guest OS")
-	VirtualMachineState    = newFieldLabel("Virtual Machine State")
-	VirtualMachineScanID   = newFieldLabel("Virtual Machine Scan ID")
-	VirtualMachineScanTime = newFieldLabel("Virtual Machine Scan Time")
-	VirtualMachineScanOS   = newFieldLabel("Virtual Machine Scan OS")
-	VirtualMachineTopCVSS  = newFieldLabel("Virtual Machine Top CVSS")
+	VirtualMachineID               = newFieldLabel("Virtual Machine ID")
+	VirtualMachineName             = newFieldLabel("Virtual Machine Name")
+	GuestOS                        = newFieldLabel("Guest OS")
+	VirtualMachineState            = newFieldLabel("Virtual Machine State")
+	VirtualMachineScanID           = newFieldLabel("Virtual Machine Scan ID")
+	VirtualMachineScanTime         = newFieldLabel("Virtual Machine Scan Time")
+	VirtualMachineScanOS           = newFieldLabel("Virtual Machine Scan OS")
+	VirtualMachineTopCVSS          = newFieldLabel("Virtual Machine Top CVSS")
+	VirtualMachineLastAgentContact = newFieldLabel("Last Agent Contact")
 
 	// Test Search Fields
 	TestKey               = newFieldLabel("Test Key")

--- a/proto/api/v2/virtual_machine_v2_service.proto
+++ b/proto/api/v2/virtual_machine_v2_service.proto
@@ -125,10 +125,12 @@ enum VMNote {
   VM_NOTE_SCAN_FAILED = 5;
 }
 
-// Agent status enriched from a separate data source (not on VirtualMachineV2 storage).
+// AgentStatus is roxagent liveness from scrape freshness, computed on GetVM
+// (not a stored enum). UNKNOWN means never scraped; INACTIVE means scraped, then quiet.
 enum AgentStatus {
   AGENT_STATUS_UNKNOWN = 0;
   AGENT_STATUS_ACTIVE = 1;
+  AGENT_STATUS_INACTIVE = 2;
 }
 
 message VMDetail {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -20501,6 +20501,11 @@
                 "type": "google.protobuf.Timestamp"
               },
               {
+                "id": 13,
+                "name": "last_agent_contact",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
                 "id": 10,
                 "name": "notes",
                 "type": "Note",

--- a/proto/storage/virtual_machine_v2.proto
+++ b/proto/storage/virtual_machine_v2.proto
@@ -34,6 +34,10 @@ message VirtualMachineV2 {
 
   google.protobuf.Timestamp last_updated = 9; // @gotags: search:"Last Updated,hidden" sql:"type(timestamptz)" hash:"ignore"
 
+  // last_agent_contact is the last successful pull-mode scrape that landed in Central.
+  // Unset means never scraped; GetVM maps age against ROX_VIRTUAL_MACHINES_AGENT_STALE_AFTER.
+  google.protobuf.Timestamp last_agent_contact = 13; // @gotags: search:"Last Agent Contact,hidden" sql:"type(timestamptz)" hash:"ignore"
+
   enum Note {
     MISSING_METADATA = 0;
     MISSING_SCAN_DATA = 1;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/virtualMachineUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/virtualMachineUtils.ts
@@ -9,4 +9,5 @@ export const stateDisplayMap: Record<VirtualMachineV2State, string> = {
 export const agentStatusDisplayMap: Record<AgentStatus, string> = {
     AGENT_STATUS_UNKNOWN: 'Unknown',
     AGENT_STATUS_ACTIVE: 'Active',
+    AGENT_STATUS_INACTIVE: 'Inactive',
 };

--- a/ui/apps/platform/src/services/VirtualMachineService.ts
+++ b/ui/apps/platform/src/services/VirtualMachineService.ts
@@ -217,7 +217,7 @@ export type VMNote =
     | 'VM_NOTE_MISSING_SCANNER'
     | 'VM_NOTE_SCAN_FAILED';
 
-export type AgentStatus = 'AGENT_STATUS_UNKNOWN' | 'AGENT_STATUS_ACTIVE';
+export type AgentStatus = 'AGENT_STATUS_UNKNOWN' | 'AGENT_STATUS_ACTIVE' | 'AGENT_STATUS_INACTIVE';
 
 export type VMScanInfo = {
     scanId: string;


### PR DESCRIPTION
## Description

GetVM never sets `agent_status`, so the VM page Agent label is always Unknown.

<img width="1110" height="662" alt="Screenshot 2026-09-04 at 14 36 14" src="https://github.com/user-attachments/assets/9a871664-7239-4693-8fa3-979e63e22fef" />


This field is roxagent liveness: can Sensor still pull from this VM. It is not guest OS subscription (`facts.activationStatus`) and not the agent build string (`facts.agentVersion`). Last-known `agentVersion` stays on the VM after the agent dies, so it cannot be the Active signal.

Central persists `last_agent_contact` on `storage.VirtualMachineV2`. Schema-only: GORM AutoMigrate, unset means never scraped. The index-report path (`UpsertScan`) stamps it on a successful scrape, including the ~4h mandatory refresh of an unchanged report. KubeVirt informer upserts keep the existing stamp and do not refresh it.

Sensor's in-memory scrape clock is not the source of truth. A Sensor restart must not reset a previously Active VM to Unknown.

GetVM compares that timestamp to `ROX_VIRTUAL_MACHINES_AGENT_STALE_AFTER` (default 12h):

- `UNKNOWN`: never scraped (RUNNING and a vsock CID are not enough)
- `ACTIVE`: last scrape is still inside the window
- `INACTIVE`: scraped before, then went quiet (new enum value `2`)

Default 12h is larger than one healthy poll cycle (4h plus up to 2/3 spread, about 6.7h), so one retryable VSOCK miss stays Active. Stopped VMs stop scraping and age into Inactive after the window.

The public API enum should land before the first VM GA release. Adding `AGENT_STATUS_INACTIVE` later is still proto3-compatible on the wire, but released UIs and generated clients would not know the value (the TypeScript union is currently Unknown | Active). Shipping all three values with the first release avoids that client split. The storage timestamp is internal and AutoMigrate would be fine later; the enum is the part that should be complete before customers take a dependency.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

No new Cypress. The details page already renders the display map, and the TypeScript `Record<AgentStatus, string>` fails compile if Inactive is missing.

### How I validated my change

- [ ] CI
- [ ] Manually on a cluster:

<details>
<summary><b>Manual verification: PASS</b> - GetVM agent_status UNKNOWN → ACTIVE → INACTIVE from scrape freshness</summary>

**Setup:** 1× RHEL9 VM with native roxagent, image `5.0.x-196-g066e4c167b`. 

Shortened test window: 
- Central `ROX_VIRTUAL_MACHINES_AGENT_STALE_AFTER=2m`, 
- Sensor `ROX_VIRTUAL_MACHINES_SCRAPER_POLL_INTERVAL=1m`.

1. Before first successful scrape → expect `AGENT_STATUS_UNKNOWN`
   ```
   "agentStatus": "AGENT_STATUS_UNKNOWN"
   "latestScan": null
   ```

2. After Sensor pulls roxagent and Central ACKs index report → expect `AGENT_STATUS_ACTIVE` and `lastagentcontact` in DB
   ```
   agentStatus= AGENT_STATUS_ACTIVE
    name   |       lastagentcontact
   rhel9-1 | 2026-09-07 09:40:47.714216+00
   ```

3. Stop agent, wait >2m (`ROX_VIRTUAL_MACHINES_AGENT_STALE_AFTER`) → expect `AGENT_STATUS_INACTIVE` while VM still RUNNING
   ```
   sudo systemctl stop roxagent-serve
   "state": "VM_STATE_RUNNING",
   "agentStatus": "AGENT_STATUS_INACTIVE"
   ```

</details>

<img width="857" height="292" alt="Screenshot 2026-09-07 at 11 49 47" src="https://github.com/user-attachments/assets/d66af8f3-eb7e-4ec3-a050-accc590849ba" />


AI-Assisted: cursor, implementation and tests generated, user reviewed scope and dropped changelog