### PR TITLE
fix(tests): make e2e shell scripts portable on macOS

### DIFF
--- a/scripts/ci/logcheck/check.sh
+++ b/scripts/ci/logcheck/check.sh
@@ -11,6 +11,16 @@
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Block/allow lists use PCRE. BSD grep has no -P; Homebrew GNU grep is `ggrep`.
+if grep -P 'a' <<<'a' >/dev/null 2>&1; then
+    GREP_CMD="grep"
+elif command -v ggrep >/dev/null 2>&1; then
+    GREP_CMD="ggrep"
+else
+    echo "logcheck requires GNU grep (-P). On macOS: brew install grep" >&2
+    exit 2
+fi
+
 LINES_OF_CONTEXT=5
 BLOCKLIST_FILE="${DIR}/blocklist-patterns"
 allow_file="${ALLOWLIST_FILE:-${DIR}/allowlist-patterns}"
@@ -25,8 +35,8 @@ IFS=$'\n' read -d '' -r -a allowlist_subpatterns < <(egrep -v '^(#.*|\s*)$' "${a
 
 allowlist_pattern="$(join_by '|' "${allowlist_subpatterns[@]}")"
 
-if check_out="$(grep -vHP "$allowlist_pattern" "$@" | grep -"${LINES_OF_CONTEXT}" -Pi "$blocklist_pattern")"; then
-    first_occurence="$(grep -vhP "$allowlist_pattern" "$@" | grep -Pi "$blocklist_pattern" | head -1)"
+if check_out="$("${GREP_CMD}" -vHP "$allowlist_pattern" "$@" | "${GREP_CMD}" -"${LINES_OF_CONTEXT}" -Pi "$blocklist_pattern")"; then
+    first_occurence="$("${GREP_CMD}" -vhP "$allowlist_pattern" "$@" | "${GREP_CMD}" -Pi "$blocklist_pattern" | head -1)"
     echo "${first_occurence}"
     echo "${check_out}"
     exit 1

--- a/scripts/retry-kubectl.sh
+++ b/scripts/retry-kubectl.sh
@@ -20,10 +20,10 @@ The connection to the server [^ ]+ was refused
 EOT
 )
 
-tmp_in="$(mktemp)"
-tmp_out="$(mktemp --suffix=-stdout.txt)"
-tmp_err="$(mktemp --suffix=-stderr.txt)"
-grep_out="$(mktemp)"
+tmp_in="$(mktemp "${TMPDIR:-/tmp}/rox-kubectl-stdin.XXXXXX")"
+tmp_out="$(mktemp "${TMPDIR:-/tmp}/rox-kubectl-stdout.XXXXXX")"
+tmp_err="$(mktemp "${TMPDIR:-/tmp}/rox-kubectl-stderr.XXXXXX")"
+grep_out="$(mktemp "${TMPDIR:-/tmp}/rox-kubectl-grep.XXXXXX")"
 trap 'cat ${tmp_out}; cat ${tmp_err} >&2; rm -f ${tmp_in} ${tmp_out} ${tmp_err} ${grep_out}' EXIT
 
 cat > "${tmp_in}"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1808,7 +1808,11 @@ restore_4_6_postgres_backup() {
     require_environment "API_ENDPOINT"
     require_environment "ROX_ADMIN_PASSWORD"
 
-    setup_gcp
+    # CI activates the stackrox SA via setup_gcp. Local runs keep the caller's
+    # gcloud credentials; this bucket is readable with typical ACS engineer ADC.
+    if is_CI; then
+        setup_gcp
+    fi
     gsutil cp gs://stackrox-ci-upgrade-test-fixtures/upgrade-test-dbs/postgres_db_4_6.sql.zip .
 
     roxctl -e "$API_ENDPOINT" --ca "" --insecure-skip-tls-verify \

--- a/tests/upgrade/lib.sh
+++ b/tests/upgrade/lib.sh
@@ -115,7 +115,7 @@ wait_for_background_migrations() {
 }
 
 get_target_bg_migration_seqnum() {
-    grep -oP 'CurrentBgMigrationSeqNum\s*=\s*\K[0-9]+' \
+    sed -n 's/^const CurrentBgMigrationSeqNum = \([0-9][0-9]*\)$/\1/p' \
         "$TEST_ROOT/central/backgroundmigrations/seq_num.go"
 }
 
@@ -128,7 +128,10 @@ deploy_earlier_postgres_central() {
     PATH="bin/$TEST_HOST_PLATFORM:$PATH" roxctl version
 
     # Let's try helm
-    ROX_ADMIN_PASSWORD="$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c12 || true)"
+    # BSD tr cannot filter /dev/urandom (NUL bytes). gen_admin_password
+    # produces a value shared with Helm --set and later restore/auth.
+    ROX_ADMIN_PASSWORD="$(gen_admin_password)"
+    export ROX_ADMIN_PASSWORD
     PATH="bin/$TEST_HOST_PLATFORM:$PATH" roxctl helm output central-services --image-defaults opensource --output-dir /tmp/early-stackrox-central-services-chart --remove
 
     helm install -n stackrox --create-namespace stackrox-central-services /tmp/early-stackrox-central-services-chart \


### PR DESCRIPTION
## Description

BSD/macOS cannot run several e2e helper scripts that CI assumes are GNU: `grep -P`, `mktemp --suffix`, and `tr` over `/dev/urandom`. This PR makes those scripts portable. Behavior on Linux CI is unchanged.

- `scripts/retry-kubectl.sh`: portable `mktemp` templates (no GNU `--suffix`).
- `scripts/ci/logcheck/check.sh`: use `grep` when it supports `-P`, otherwise Homebrew `ggrep` (`brew install grep`).
- `tests/upgrade/lib.sh`: read the background-migration seqnum with `sed`; generate the 4.6 admin password with `gen_admin_password` and export it so Helm `--set` and later restore/auth share the same value.
- `tests/e2e/lib.sh`: `restore_4_6_postgres_backup` calls `setup_gcp` only in CI. Local runs keep the caller's ADC; the fixture bucket is readable that way for ACS engineers.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Used these helpers on macOS (darwin arm64) while running `tests/upgrade/postgres_run.sh` against a pinned infractl GKE cluster: logcheck no longer died on `grep -P`, kubectl retries no longer died on `mktemp --suffix`, background-migration wait extracted seqnum `0`, 4.6 Helm install got a real admin password, and the 4.6 DB fixture restored with local ADC (no CI GCP SA).

On macOS, install GNU grep for logcheck: `brew install grep` (provides `ggrep`).

### Optional: run upgrade-central locally against an infractl cluster

Not in this tree (keeps secrets and a one-off runner out of git). Save the script below as `tests/upgrade/run-central-on-pinned-cluster.sh`, make it executable, and put credentials in `tests/upgrade/run-central-on-pinned-cluster.env` (do not commit the env file). `set -a` when sourcing the env file so Gradle smoke tests inherit registry creds.

Env file (no quotes around JSON except as shown; JSON service-account keys must be single-quoted):

```
CLUSTER_NAME=your-infractl-cluster
MAIN_IMAGE_TAG=...
QUAY_RHACS_ENG_RO_USERNAME=...
QUAY_RHACS_ENG_RO_PASSWORD=...
GOOGLE_CREDENTIALS_GCR_SCANNER_V2='{...service account json...}'
GOOGLE_ARTIFACT_REGISTRY_SERVICE_ACCOUNT_V2='{...service account json...}'
REDHAT_USERNAME=...
REDHAT_PASSWORD=...
SCANNER_V4_DB_STORAGE_CLASS=faster
```

Script:

```bash
#!/usr/bin/env bash
# shellcheck disable=SC1091
#
# Run gke-upgrade-tests-central (tests/upgrade/postgres_run.sh) against an
# existing infractl cluster, without GHA or pushing to origin.
#
# Usage:
#   1. Fill tests/upgrade/run-central-on-pinned-cluster.env (do not commit it).
#   2. tests/upgrade/run-central-on-pinned-cluster.sh
#
# Options:
#   --dry-run   Validate config and print the test command; do not run.
#   --help      Show this message.

set -euo pipefail

TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
ENV_FILE="${RUN_CENTRAL_ON_PINNED_CLUSTER_ENV:-${SCRIPT_DIR}/run-central-on-pinned-cluster.env}"
LOG_OUTPUT_DIR="${LOG_OUTPUT_DIR:-/tmp/postgres-upgrade-test-logs}"
ARTIFACTS_DIR="${ARTIFACTS_DIR:-/tmp/upgrade-pinned-cluster-artifacts}"
DRY_RUN=false

usage() {
    sed -n '2,14p' "$0"
}

while [[ $# -gt 0 ]]; do
    case "$1" in
        --dry-run) DRY_RUN=true; shift ;;
        --help|-h) usage; exit 0 ;;
        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
    esac
done

# shellcheck source=../../scripts/lib.sh
source "${TEST_ROOT}/scripts/lib.sh"

if [[ -f "${ENV_FILE}" ]]; then
    info "Loading config from ${ENV_FILE}"
    set -a
    # shellcheck disable=SC1090
    source "${ENV_FILE}"
    set +a
else
    info "No env file at ${ENV_FILE} (set RUN_CENTRAL_ON_PINNED_CLUSTER_ENV to override)"
fi

required_vars=(
    CLUSTER_NAME
    MAIN_IMAGE_TAG
    QUAY_RHACS_ENG_RO_USERNAME
    QUAY_RHACS_ENG_RO_PASSWORD
    GOOGLE_CREDENTIALS_GCR_SCANNER_V2
    GOOGLE_ARTIFACT_REGISTRY_SERVICE_ACCOUNT_V2
    REDHAT_USERNAME
    REDHAT_PASSWORD
)

missing=()
for var in "${required_vars[@]}"; do
    if [[ -z "${!var:-}" ]]; then
        missing+=("$var")
    fi
done
if [[ "${#missing[@]}" -gt 0 ]]; then
    die "Missing required variables: ${missing[*]}."
fi

if ! command -v infractl >/dev/null 2>&1; then
    die "infractl not found in PATH"
fi
if [[ "$(infractl whoami 2>/dev/null || true)" == "Anonymous" ]]; then
    die "infractl is not authenticated (infractl whoami => Anonymous)"
fi
if ! command -v kubectl >/dev/null 2>&1; then
    die "kubectl not found in PATH"
fi
if ! command -v helm >/dev/null 2>&1; then
    die "helm not found in PATH"
fi
if ! command -v jq >/dev/null 2>&1; then
    die "jq not found in PATH"
fi
if ! command -v yq >/dev/null 2>&1; then
    die "yq not found in PATH"
fi

info "Fetching kubeconfig for infractl cluster ${CLUSTER_NAME}"
rm -rf "${ARTIFACTS_DIR}"
mkdir -p "${ARTIFACTS_DIR}"
if ! infractl list --all | grep -F "${CLUSTER_NAME}" >/dev/null; then
    die "infractl cluster not found: ${CLUSTER_NAME}"
fi
infractl artifacts "${CLUSTER_NAME}" --download-dir "${ARTIFACTS_DIR}" >/dev/null
export KUBECONFIG="${ARTIFACTS_DIR}/kubeconfig"
if [[ ! -f "${KUBECONFIG}" ]]; then
    die "kubeconfig not found at ${KUBECONFIG}"
fi

info "Cluster access:"
kubectl cluster-info
kubectl get nodes

export MAIN_IMAGE_TAG
export BUILD_TAG="${MAIN_IMAGE_TAG}"
export LOAD_BALANCER="${LOAD_BALANCER:-lb}"
export SCANNER_V4_DB_STORAGE_CLASS="${SCANNER_V4_DB_STORAGE_CLASS:-faster}"
export REGISTRY_USERNAME="${QUAY_RHACS_ENG_RO_USERNAME}"
export REGISTRY_PASSWORD="${QUAY_RHACS_ENG_RO_PASSWORD}"
export QUAY_RHACS_ENG_RO_USERNAME
export QUAY_RHACS_ENG_RO_PASSWORD

info "HEAD image tag: ${MAIN_IMAGE_TAG}"
info "Log output dir: ${LOG_OUTPUT_DIR}"
info "WARNING: postgres_run.sh will remove existing stackrox resources on this cluster."

if [[ "${DRY_RUN}" == "true" ]]; then
    cat <<EOF
Dry run OK. Would run:

  export KUBECONFIG=${KUBECONFIG}
  export MAIN_IMAGE_TAG=${MAIN_IMAGE_TAG}
  export SCANNER_V4_DB_STORAGE_CLASS=${SCANNER_V4_DB_STORAGE_CLASS}
  cd ${TEST_ROOT}
  make cli
  ${TEST_ROOT}/tests/upgrade/postgres_run.sh ${LOG_OUTPUT_DIR}

EOF
    exit 0
fi

mkdir -p "${LOG_OUTPUT_DIR}"
RUN_LOG="${PINNED_CLUSTER_RUN_LOG:-${LOG_OUTPUT_DIR}/run-$(date +%Y%m%d-%H%M%S).log}"
info "Writing full run log to ${RUN_LOG}"
exec > >(tee -a "${RUN_LOG}") 2>&1

cd "${TEST_ROOT}"
make cli

"${TEST_ROOT}/tests/upgrade/postgres_run.sh" "${LOG_OUTPUT_DIR}"
```

The cluster should be empty of StackRox; the script wipes `stackrox` resources. Logs go to `/tmp/postgres-upgrade-test-logs/`.

AI-Assisted: cursor, ~70% generated, user reviewed logic