### PR TITLE
ROX-34863: Project detected guest OS onto API guest_os

### DIFF
--- a/central/convert/storagetov2/virtual_machine_v2.go
+++ b/central/convert/storagetov2/virtual_machine_v2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/views/common"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -21,7 +22,7 @@ func VirtualMachineV2ToListItem(vm *storage.VirtualMachineV2) *v2.VMListItem {
 		Namespace:   vm.GetNamespace(),
 		ClusterId:   vm.GetClusterId(),
 		ClusterName: vm.GetClusterName(),
-		GuestOs:     vm.GetGuestOs(),
+		GuestOs:     pkgVM.DisplayGuestOS(vm.GetFacts(), vm.GetGuestOs()),
 		State:       convertVirtualMachineV2State(vm.GetState()),
 		LastUpdated: vm.GetLastUpdated(),
 	}
@@ -42,7 +43,7 @@ func VirtualMachineV2ToDetail(vm *storage.VirtualMachineV2) *v2.VMDetail {
 		Namespace:   vm.GetNamespace(),
 		ClusterId:   vm.GetClusterId(),
 		ClusterName: vm.GetClusterName(),
-		GuestOs:     vm.GetGuestOs(),
+		GuestOs:     pkgVM.DisplayGuestOS(vm.GetFacts(), vm.GetGuestOs()),
 		State:       convertVirtualMachineV2State(vm.GetState()),
 		LastUpdated: vm.GetLastUpdated(),
 		Facts:       vm.GetFacts(),

--- a/central/convert/storagetov2/virtual_machine_v2_test.go
+++ b/central/convert/storagetov2/virtual_machine_v2_test.go
@@ -6,6 +6,8 @@ import (
 
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -86,6 +88,41 @@ func TestAgentStatusFromLastContact(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			require.Equal(t, tc.expected, AgentStatusFromLastContact(tc.ts, now, staleAfter))
+		})
+	}
+}
+
+func TestVirtualMachineV2GuestOsDisplay(t *testing.T) {
+	tests := map[string]struct {
+		facts    map[string]string
+		storedOS string
+		want     string
+	}{
+		"prefers detected guest OS": {
+			facts: map[string]string{
+				pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
+				pkgVM.GuestOSKey:         "Red Hat Enterprise Linux",
+			},
+			storedOS: "Red Hat Enterprise Linux",
+			want:     "Red Hat Enterprise Linux 9.2",
+		},
+		"falls back to stored guest OS": {
+			facts:    map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux"},
+			storedOS: "Red Hat Enterprise Linux",
+			want:     "Red Hat Enterprise Linux",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			vm := &storage.VirtualMachineV2{
+				Id:      "vm-1",
+				Facts:   tt.facts,
+				GuestOs: tt.storedOS,
+			}
+			assert.Equal(t, tt.want, VirtualMachineV2ToDetail(vm).GetGuestOs())
+			assert.Equal(t, tt.want, VirtualMachineV2ToListItem(vm).GetGuestOs())
+			assert.Equal(t, tt.storedOS, vm.GetGuestOs())
 		})
 	}
 }

--- a/pkg/virtualmachine/facts.go
+++ b/pkg/virtualmachine/facts.go
@@ -1,5 +1,7 @@
 package virtualmachine
 
+import "cmp"
+
 // Facts keys used in VirtualMachine.Facts maps.
 // Keep the keys camelCase to match the style used elsewhere in the UI.
 const (
@@ -29,3 +31,9 @@ const (
 	DNFMetadataStatusAvailable   = "available"
 	DNFMetadataStatusUnavailable = "unavailable"
 )
+
+// DisplayGuestOS prefers the agent-detected OS so callers can show a versioned
+// string while storage.GuestOs remains the informer value used for scan stamping.
+func DisplayGuestOS(facts map[string]string, fallback string) string {
+	return cmp.Or(facts[DetectedGuestOSKey], fallback)
+}

--- a/pkg/virtualmachine/facts_test.go
+++ b/pkg/virtualmachine/facts_test.go
@@ -1,0 +1,44 @@
+package virtualmachine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisplayGuestOS(t *testing.T) {
+	tests := map[string]struct {
+		facts    map[string]string
+		fallback string
+		want     string
+	}{
+		"prefers detected guest OS": {
+			facts: map[string]string{
+				DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
+				GuestOSKey:         "Red Hat Enterprise Linux",
+			},
+			fallback: "Red Hat Enterprise Linux",
+			want:     "Red Hat Enterprise Linux 9.2",
+		},
+		"falls back when detected is absent": {
+			facts:    map[string]string{GuestOSKey: "Red Hat Enterprise Linux"},
+			fallback: "Red Hat Enterprise Linux",
+			want:     "Red Hat Enterprise Linux",
+		},
+		"falls back when detected is empty": {
+			facts:    map[string]string{DetectedGuestOSKey: ""},
+			fallback: "Red Hat Enterprise Linux",
+			want:     "Red Hat Enterprise Linux",
+		},
+		"nil facts use fallback": {
+			fallback: "unknown",
+			want:     "unknown",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DisplayGuestOS(tt.facts, tt.fallback))
+		})
+	}
+}

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -108,6 +108,8 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				require.NotNil(t, detail.GetLatestScan())
 				require.NotNil(t, detail.GetLatestScan().GetScanTime())
 				requireForwardedAgentFacts(t, detail.GetFacts())
+				require.Equal(t, detail.GetFacts()[pkgVM.DetectedGuestOSKey], detail.GetGuestOs(),
+					"GetVM.guest_os should prefer facts.detectedGuestOS")
 			})
 
 			t.Run("VirtualMachineV2ListVMs", func(t *testing.T) {
@@ -119,6 +121,10 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				require.NotEmpty(t, listed.GetClusterId())
 				require.NotEmpty(t, listed.GetClusterName())
 				require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, listed.GetState())
+
+				detail := s.mustGetVMV2(snapshot.ID)
+				require.Equal(t, detail.GetGuestOs(), listed.GetGuestOs(),
+					"ListVMs.guest_os should match GetVM.guest_os")
 
 				cves, total, err := vmhelpers.ListAllVMCVEsByVM(s.ctx, s.vmV2Client, snapshot.ID)
 				require.NoError(t, err)


### PR DESCRIPTION
## Description

GetVM and ListVMs copy `storage.GuestOs` into the API `guest_os` field. That value comes from the KubeVirt informer and is typically a generic name such as "Red Hat Enterprise Linux". After a successful scrape, Sensor already stores a versioned string in `facts.detectedGuestOS`, for example "Red Hat Enterprise Linux 9.2". The API therefore returns the generic informer string when a more specific agent report is already on the VM.

This change fills `guest_os` from `facts.detectedGuestOS` when that fact is present and non-empty, and falls back to `storage.GuestOs` otherwise. Scan stamping still reads the stored informer field; this conversion does not write it.

`DisplayGuestOS` encodes that preference. The list and detail converters both call it, so the two endpoints stay consistent.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] Deploy to cluster and confirm that the Guest OS is not `Red Hat Enterprise Linux` but rather `RHEL 9.8`.

Before (agent stopped)

<img width="961" height="265" alt="Screenshot 2026-09-08 at 11 59 02" src="https://github.com/user-attachments/assets/8379af3b-91d6-43c2-9d83-493591424b93" />

After (agent started & sensor scrape done)

<img width="979" height="216" alt="Screenshot 2026-09-08 at 12 00 43" src="https://github.com/user-attachments/assets/b95c88e5-688d-4220-a636-5d48d47ebaf3" />

