### PR TITLE
ROX-32458: `central-db` PV monitoring

### DIFF
--- a/deploy/charts/monitoring/templates/prometheus.yaml
+++ b/deploy/charts/monitoring/templates/prometheus.yaml
@@ -58,6 +58,27 @@ data:
 {{ toYaml .Values.cadvisorMetricRelabelConfigs | indent 10 }}
 {{- end }}
 
+      # Kubelet /metrics exposes kubelet_volume_stats_* (PVC used/capacity),
+      # which cadvisor does not. Used for central-db PVC space alerting.
+      - job_name: "kubernetes-kubelet"
+        scheme: https
+        metrics_path: /metrics
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        authorization:
+          credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+          - role: node
+        relabel_configs:
+          - action: labelmap
+            regex: __meta_kubernetes_node_label_(.+)
+        metric_relabel_configs:
+          # Keep only the central-db PVC volume stats needed for space alerting.
+          - source_labels: [__name__, persistentvolumeclaim]
+            action: keep
+            regex: kubelet_volume_stats_(used|capacity)_bytes;central-db
+
       - job_name: stackrox
         tls_config:
           insecure_skip_verify: false
@@ -109,3 +130,31 @@ data:
           annotations:
             summary: Kubernetes ReplicaSet mismatch (replicaset {{ "{{" }} $labels.replicaset {{ "}}" }})
             description: "Replicas mismatch in ReplicaSet {{ "{{" }} $labels.exported_namespace {{ "}}" }}/{{ "{{" }} $labels.replicaset {{ "}}" }}"
+
+  rules_alerts_stackrox.yml: |-
+    groups:
+    - name: StackRox
+      rules:
+        # Central DB PVC space utilization (used / filesystem capacity) from the
+        # kubelet volume stats. Exposed as a stable metric for dashboards and
+        # reused by the alerts below.
+        - record: stackrox:central_db_pvc_usage_ratio
+          expr: kubelet_volume_stats_used_bytes{persistentvolumeclaim="central-db"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="central-db"}
+
+        - alert: StackRoxCentralDbPvcSpaceWarning
+          expr: stackrox:central_db_pvc_usage_ratio > {{ .Values.centralDbPvcUsageWarningRatio }}
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Central DB PVC filling up (pvc {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }})
+            description: "Central DB PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} is {{ "{{" }} $value | humanizePercentage {{ "}}" }} full."
+
+        - alert: StackRoxCentralDbPvcSpaceCritical
+          expr: stackrox:central_db_pvc_usage_ratio > {{ .Values.centralDbPvcUsageCriticalRatio }}
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Central DB PVC almost full (pvc {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }})
+            description: "Central DB PVC {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} is {{ "{{" }} $value | humanizePercentage {{ "}}" }} full."

--- a/deploy/charts/monitoring/values.yaml
+++ b/deploy/charts/monitoring/values.yaml
@@ -27,6 +27,12 @@ nodeSelector: {}
 # Metric relabel configs for kubernetes-cadvisor job to filter out metrics
 cadvisorMetricRelabelConfigs: []
 
+# Central DB PVC space-usage alerting. Utilization is used/capacity from the
+# kubelet volume stats (scraped by the kubernetes-kubelet job). The warning and
+# critical alerts fire when the central-db PVC exceeds these fill ratios.
+centralDbPvcUsageWarningRatio: 0.8
+centralDbPvcUsageCriticalRatio: 0.9
+
 kube-state-metrics:
   releaseNamespace: true
   # Align with the parent monitoring Deployment UIDs. Upstream defaults use

--- a/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-central/templates/99-openshift-monitoring.yaml
@@ -145,5 +145,45 @@ spec:
               rox_central_secured_vcpus{branding="RHACS"}
             )
           record: rhacs:telemetry:rox_central_secured_vcpus
+{{- /*
+Central DB PVC space alerting. Evaluated by the platform Prometheus (this rule
+lives in openshift-monitoring), which scrapes kubelet_volume_stats_* for every
+namespace, so it can see the central-db PVC in .Release.Namespace. The claim
+name is resolved from the volume config so it honours a custom claimName, and
+the group is only emitted when central-db is actually PVC-backed (skipped for
+external, hostPath or emptyDir persistence, which have no PVC volume stats).
+*/}}
+{{- $centralDBClaimName := "" -}}
+{{- with ._rox.central.db.persistence._volumeCfg -}}
+{{- with .persistentVolumeClaim -}}
+{{- $centralDBClaimName = .claimName -}}
+{{- end -}}
+{{- end -}}
+{{- if $centralDBClaimName }}
+    - name: rhacs.central-db
+      rules:
+        - alert: CentralDBPersistentVolumeFillingUp
+          expr: |
+            kubelet_volume_stats_used_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim="{{ $centralDBClaimName }}"}
+              / kubelet_volume_stats_capacity_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim="{{ $centralDBClaimName }}"}
+              > 0.8
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Central DB persistent volume is filling up"
+            description: "The Central DB PVC {{ $centralDBClaimName }} in namespace {{ .Release.Namespace }} is {{ "{{" }} $value | humanizePercentage {{ "}}" }} full (warning threshold 80%)."
+        - alert: CentralDBPersistentVolumeFillingUp
+          expr: |
+            kubelet_volume_stats_used_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim="{{ $centralDBClaimName }}"}
+              / kubelet_volume_stats_capacity_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim="{{ $centralDBClaimName }}"}
+              > 0.9
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Central DB persistent volume is almost full"
+            description: "The Central DB PVC {{ $centralDBClaimName }} in namespace {{ .Release.Namespace }} is {{ "{{" }} $value | humanizePercentage {{ "}}" }} full (critical threshold 90%)."
+{{- end }}
 
 {{- end -}}

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -54,6 +54,42 @@ tests:
     env.openshift: 4
   tests: *enabled-test
 
+- name: "Central DB PVC space alerts"
+  set:
+    monitoring.openshift.enabled: true
+    env.openshift: 4
+  tests:
+    - name: "warning and critical alerts are created"
+      expect: |
+        .prometheusrules["central-telemeter-stackrox"].spec.groups |
+          assertThat(any(.[]; .name == "rhacs.central-db"))
+        .prometheusrules["central-telemeter-stackrox"].spec.groups[] |
+          select(.name == "rhacs.central-db") | .rules | [
+            assertThat(length == 2),
+            assertThat(all(.[]; .alert == "CentralDBPersistentVolumeFillingUp")),
+            assertThat(any(.[]; .labels.severity == "warning")),
+            assertThat(any(.[]; .labels.severity == "critical"))
+          ]
+        .prometheusrules["central-telemeter-stackrox"].spec.groups[] |
+          select(.name == "rhacs.central-db") | .rules[] |
+          select(.labels.severity == "warning") |
+          assertThat(.expr | contains("persistentvolumeclaim=\"central-db\"") and contains("> 0.8"))
+
+    - name: "custom claim name is honoured"
+      set:
+        central.db.persistence.persistentVolumeClaim.claimName: my-central-db
+      expect: |
+        .prometheusrules["central-telemeter-stackrox"].spec.groups[] |
+          select(.name == "rhacs.central-db") | .rules[0] |
+          assertThat(.expr | contains("persistentvolumeclaim=\"my-central-db\""))
+
+    - name: "omitted when central-db is not PVC-backed"
+      set:
+        central.db.persistence.hostPath: /var/lib/central-db-test
+      expect: |
+        .prometheusrules["central-telemeter-stackrox"].spec.groups |
+          assertThat(all(.[]; .name != "rhacs.central-db"))
+
 - name: "When enabled with Scanner V4"
   set:
     monitoring.openshift.enabled: true


### PR DESCRIPTION
## Description

`central-db` PVC storage capacity had no default alert. OpenShift's built-in `KubePersistentVolumeFillingUp` only watches PVs in the `openshift-`, `kube-`, and `default` namespaces, so the `central-db` PVC in the ACS namespace (e.g. `stackrox`, `rhacs-operator`) was never covered.

This adds predefined PVC space alerts for `central-db` to both monitoring paths called out in ROX-32458.

**Bundled StackRox monitoring chart (`deploy/charts/monitoring`)** — for the self-managed Prometheus:
- New `kubernetes-kubelet` scrape job to collect `kubelet_volume_stats_*` (cAdvisor does not expose PVC used/capacity), kept to the `central-db` PVC only.
- Recording rule `stackrox:central_db_pvc_usage_ratio` (used / capacity) for dashboards and reuse by the alerts.
- `warning` (>80%) and `critical` (>90%) alerts, both `for: 5m`. Thresholds are configurable via the new `centralDbPvcUsageWarningRatio` / `centralDbPvcUsageCriticalRatio` values.

**OpenShift platform monitoring (`99-openshift-monitoring.yaml`)** — evaluated by the OCP platform Prometheus, which already scrapes `kubelet_volume_stats_*` in every namespace:
- New `rhacs.central-db` PrometheusRule group with `CentralDBPersistentVolumeFillingUp` at `warning` (>80%, `for: 1h`) and `critical` (>90%, `for: 5m`).
- The PVC claim name is resolved from the volume config, so a custom `claimName` is honoured.
- The group is only emitted when `central-db` is actually PVC-backed (skipped for external, `hostPath`, or `emptyDir` persistence, which expose no PVC stats).

### Considered alternatives

- Scraping cAdvisor instead of the kubelet: rejected because cAdvisor does not expose `kubelet_volume_stats_*`, so it cannot report PVC used/capacity.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Added helm-test cases in `openshift-monitoring.test.yaml` for the OpenShift PrometheusRule, asserting that:
  - both `warning` and `critical` `CentralDBPersistentVolumeFillingUp` alerts are rendered under the `rhacs.central-db` group;
  - a custom `central.db.persistence.persistentVolumeClaim.claimName` is honoured in the alert expressions;
  - the group is omitted when `central-db` is not PVC-backed (e.g. `hostPath`).
- The bundled `deploy/charts/monitoring` scrape job and rules are Prometheus config only; they are covered by CI chart rendering and still need a manual check against a live cluster that the kubelet scrape actually populates `kubelet_volume_stats_*` for the `central-db` PVC.
