### PR TITLE
fix(sensor): delay initial ClusterMetrics after connect

### DIFF
--- a/sensor/kubernetes/clustermetrics/cluster_metrics.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics.go
@@ -25,6 +25,10 @@ var (
 	log = logging.LoggerForModule()
 	// Interval for querying cluster metrics from Kubernetes and sending to Central.
 	defaultInterval = 5 * time.Minute
+	// Delay before the first metrics send after CentralReachable, giving
+	// ClusterStatusUpdate time to persist the sensor version so that the
+	// first telemetry event reports the correct compatibility status.
+	defaultFirstSendDelay = 1 * time.Minute
 	// Timeout for querying cluster metrics from Kubernetes.
 	defaultTimeout = 10 * time.Second
 )
@@ -62,6 +66,7 @@ func NewWithInterval(clusterID clusterIDPeeker, k8sClient kubernetes.Interface, 
 		pollTicker:      ticker,
 		clusterID:       clusterID,
 		vmStats:         vmStats,
+		firstSendDelay:  defaultFirstSendDelay,
 	}
 }
 
@@ -86,8 +91,10 @@ type clusterMetricsImpl struct {
 	k8sClient       kubernetes.Interface
 	pollTicker      *time.Ticker
 
-	clusterID clusterIDPeeker
-	vmStats   VMStatsSource
+	clusterID      clusterIDPeeker
+	vmStats        VMStatsSource
+	firstSendDelay time.Duration
+	firstSendTimer *time.Timer
 }
 
 func (cm *clusterMetricsImpl) Name() string {
@@ -101,6 +108,7 @@ func (cm *clusterMetricsImpl) Start() error {
 
 func (cm *clusterMetricsImpl) Stop() {
 	cm.pollTicker.Stop()
+	cm.stopFirstSendTimer()
 	cm.stopper.Client().Stop()
 	_ = cm.stopper.Client().Stopped().Wait()
 }
@@ -110,8 +118,18 @@ func (cm *clusterMetricsImpl) Notify(e common.SensorComponentEvent) {
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		cm.pollTicker.Reset(cm.pollingInterval)
+		cm.stopFirstSendTimer()
+		cm.firstSendTimer = time.AfterFunc(cm.firstSendDelay, cm.runPipeline)
 	case common.SensorComponentEventOfflineMode:
 		cm.pollTicker.Stop()
+		cm.stopFirstSendTimer()
+	}
+}
+
+func (cm *clusterMetricsImpl) stopFirstSendTimer() {
+	if cm.firstSendTimer != nil {
+		cm.firstSendTimer.Stop()
+		cm.firstSendTimer = nil
 	}
 }
 
@@ -128,7 +146,6 @@ func (cm *clusterMetricsImpl) ProcessIndicator(_ *storage.ProcessIndicator) {}
 func (cm *clusterMetricsImpl) Poll(tickerC <-chan time.Time) {
 	defer cm.stopper.Flow().ReportStopped()
 
-	cm.runPipeline()
 	go func() {
 		for {
 			select {

--- a/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
@@ -37,6 +37,7 @@ type ClusterMetricsTestSuite struct {
 func (s *ClusterMetricsTestSuite) SetupTest() {
 	s.client = fake.NewClientset()
 	defaultInterval = 10 * time.Millisecond
+	defaultFirstSendDelay = 1 * time.Millisecond
 }
 
 func (s *ClusterMetricsTestSuite) TestZeroNodes() {
@@ -78,16 +79,19 @@ func (s *ClusterMetricsTestSuite) TestOfflineMode() {
 	metrics := s.createNewClusterMetrics(50 * time.Millisecond)
 	s.Require().NoError(metrics.Start())
 	defer metrics.Stop()
-	// Read the first message. This is needed because we call runPipeline before entering the ticker loop.
-	// This first call will block the goroutine until the message is read.
-	select {
-	case <-metrics.ResponsesC():
-		break
-	case <-time.After(metricsTimeout):
-		s.Fail("timeout waiting for the first message")
-	}
+	// Drain the first-send message triggered by the initial CentralReachable
+	// notification, so the goroutine is not blocked on the output channel.
+	drainedFirst := false
 	for _, state := range states {
 		metrics.Notify(state)
+		if !drainedFirst && state == common.SensorComponentEventCentralReachable {
+			select {
+			case <-metrics.ResponsesC():
+			case <-time.After(metricsTimeout):
+				s.Fail("timeout waiting for the first-send message")
+			}
+			drainedFirst = true
+		}
 		s.assertOfflineMode(state, metrics)
 	}
 }


### PR DESCRIPTION
## Description

Fix the race condition where the first telemetry `"Updated Secured Cluster Identity"` event always reports `SENSOR_VERSION_COMPATIBILITY_UNKNOWN`.

**Root cause:** `ClusterMetrics.Poll()` called `runPipeline()` immediately on startup (added in 786a619245 / ROX-18274 to avoid a 5-minute gap in Prometheus metrics after sensor connects). This pre-queued message always arrived at Central before `ClusterStatusUpdate` (which only starts work on `CentralReachable` and needs K8s API calls before sending). Since sensor version is persisted by `ClusterStatusUpdate`, the first telemetry event always saw an empty sensor version, producing `UNKNOWN`. The correct `MATCHED` value only appeared on the next tick, 5 minutes later.

**Why the immediate send existed:** The eager send in `Poll()` was added intentionally ([786a619245](https://github.com/stackrox/stackrox/commit/786a619245), ROX-18274) so that Central receives cluster metrics (node count, CPU capacity) as soon as the sensor connects, rather than waiting for the first 5-minute ticker. Without it, Prometheus gauges and the secured-units usage store show zero for the first polling interval, which could be misinterpreted as a disconnect.

**Fix:** Move the initial send from `Poll()` into `Notify(CentralReachable)` with a 1-minute delay (`defaultFirstSendDelay`). This preserves the eager send (Prometheus metrics and usage data arrive ~1 min after connect instead of ~5 min) while giving `ClusterStatusUpdate` time to persist the sensor version (~30s in practice). The timer is cancelled on `OfflineMode` and `Stop()`.

**Alternative considered:** Removing the immediate send entirely and relying on the 5-minute ticker. Rejected because it regresses the Prometheus metrics and usage tracking — the original commit's rationale for the eager send still applies.

Follow-up to #22130.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

`TestOfflineMode` updated to drain the delayed first-send message (previously drained the immediate `runPipeline()` message). `SetupTest` overrides `defaultFirstSendDelay` to 1ms for fast tests.

### How I validated my change

- All existing `clustermetrics` unit tests pass (`go test ./sensor/kubernetes/clustermetrics/`)
- Verified by code analysis that the startup sequence is now:
  1. `CentralReachable` fires
  2. `ClusterStatusUpdate` persists sensor version (~30s)
  3. `firstSendTimer` fires after 1 min → `runPipeline()` → Central reads cluster with version → `MATCHED`
  4. Subsequent sends on the 5-min ticker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESZnhbC7NX8V33hrFzHUYx