### PR TITLE
ROX-36628: bump claircore to mainline for OSV ecosystem-filter fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
-	github.com/quay/claircore v1.5.54
+	github.com/quay/claircore v1.5.55-0.20260720230557-3f07716d8b96
 	github.com/quay/claircore/toolkit v1.6.1
 	github.com/quay/zlog/v2 v2.1.1
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
-github.com/quay/claircore v1.5.54 h1:NC7+QfwV8yo/KJ/B8mz1GD8BIG16aIJ3FuHcBTnsjL4=
-github.com/quay/claircore v1.5.54/go.mod h1:hOp0JqY8vOZPdBakFRt3JwG8q4K+gnRkG9RGzt1DoB4=
+github.com/quay/claircore v1.5.55-0.20260720230557-3f07716d8b96 h1:bpYvJiQTRbsyTPmdXX/a+05Hy5nHtCcjoswOPR/LgjM=
+github.com/quay/claircore v1.5.55-0.20260720230557-3f07716d8b96/go.mod h1:hOp0JqY8vOZPdBakFRt3JwG8q4K+gnRkG9RGzt1DoB4=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.6.1 h1:a3X1v28n5bo05T94cBlaoPU8xYCErRGPM3l6AlmYWj4=
 github.com/quay/claircore/toolkit v1.6.1/go.mod h1:dTzlp1pgNchc+CN73HJiG9+e0ygU54QPt397eXnGGo4=


### PR DESCRIPTION
## Description

This backports PR #22585 to release-4.11 by bumping claircore from v1.5.54 to the mainline pseudo-version v1.5.55-0.20260720230557-3f07716d8b96, which contains the fix for CVE-2026-45134 / GHSA-3644-q5cj-c5c7 (OSV "exclude advisories from non-applicable ecosystems"). This stops Scanner V4 from producing cross-ecosystem false positives.

The GitHub auto-backport bot's cherry-pick attempt failed on a go.sum context conflict. This PR reproduces master's go.mod bump cleanly on release-4.11. The source code already uses the post-fix claircore API, so no source changes are needed. The diff is only go.mod and go.sum.

This is the release-4.11 companion to the release-4.10 backport PR #22676.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

No new tests needed - this is a dependency bump only.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Build passed: `go build ./...` exited cleanly
- Unit tests passed for all affected packages: `./pkg/scannerv4/...`, `./scanner/enricher/...`, `./scanner/sbom/...`, `./scanner/services/...`, `./scanner/updater/...`, `./compliance/node/index/...` all show `ok`
- No Go source files changed (only go.mod and go.sum)
- E2E tests not run - they require a live PostgreSQL database and are infrastructure-gated (will run in CI)
