### PR TITLE
ROX-36824: redact sensitive secret annotations in diagnostic bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-35079: installation of the `app.k8s.io/v1beta1/Application` resource when central is installed is deprecated. It will be removed in a future release.
 
 ### Technical Changes
+- ROX-36824: Diagnostic bundles now redact the value of the `openshift.io/token-secret.value` annotation on secrets. Previously this OpenShift-managed annotation, which contains a plaintext service account token on generated dockercfg secrets, was included unredacted in the bundle.
 - ROX-36660: The **Fixable → CVE is not yet fixable** policy criterion now matches Scanner V4 CVEs that have no fix version. Scanner V4 leaves `Fixed By` unset instead of empty (Scanner V2 always set an empty string), so the matcher previously skipped those CVEs.
 - ROX-36490: The virtual machine enhanced data model (`ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL`) is now enabled by default.
 - ROX-32969: The `roxctl-linux` symlink has been removed from the `/assets/downloads/cli/` directory inside the main container image. Only the architecture-specific binaries (`roxctl-linux-amd64`, `roxctl-linux-arm64`, etc.) remain. This change does not affect CLI downloads from the Central UI or any other supported download path.

--- a/pkg/k8sintrospect/redact.go
+++ b/pkg/k8sintrospect/redact.go
@@ -4,6 +4,18 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const redactedValue = "***REDACTED***"
+
+// sensitiveSecretAnnotations enumerates annotation keys whose values may contain
+// sensitive data and therefore must be redacted before a secret is included in a
+// diagnostic bundle. Unlike the secret `data` field, these values are not covered
+// by the data redaction below.
+var sensitiveSecretAnnotations = []string{
+	// OpenShift stores a plaintext copy of the service account token in this
+	// annotation on the generated dockercfg secrets (ROX-36824).
+	"openshift.io/token-secret.value",
+}
+
 // RedactGeneric removes fields we don't care about for any object type. This includes:
 // - the `kubectl.kubernetes.io/last-applied-configuration`
 // - the selfLink field (this is not object-specific and fully captured by name, namespace, and kind)
@@ -23,11 +35,28 @@ func RedactSecret(secret *unstructured.Unstructured) {
 	if found && err == nil {
 		redactedStringData := make(map[string]string, len(dataMap))
 		for key := range dataMap {
-			redactedStringData[key] = "***REDACTED***"
+			redactedStringData[key] = redactedValue
 		}
 		_ = unstructured.SetNestedStringMap(secret.UnstructuredContent(), redactedStringData, "stringData")
 	}
 	unstructured.RemoveNestedField(secret.UnstructuredContent(), "data")
+
+	// Some secrets carry sensitive values in their annotations (e.g. the plaintext
+	// service account token OpenShift stores on dockercfg secrets). Redact those
+	// values while keeping the annotation key, so the bundle still shows the
+	// annotation was present.
+	if annotations := secret.GetAnnotations(); len(annotations) > 0 {
+		modified := false
+		for _, key := range sensitiveSecretAnnotations {
+			if _, ok := annotations[key]; ok {
+				annotations[key] = redactedValue
+				modified = true
+			}
+		}
+		if modified {
+			secret.SetAnnotations(annotations)
+		}
+	}
 }
 
 // FilterOutServiceAccountSecrets filters out secrets that are associated with a Kubernetes service account.

--- a/pkg/k8sintrospect/redact_test.go
+++ b/pkg/k8sintrospect/redact_test.go
@@ -86,3 +86,42 @@ func TestRedactSecret(t *testing.T) {
 	assert.Equal(t, redactedSecret.StringData, expectedStringData)
 	assert.Empty(t, redactedSecret.Data)
 }
+
+func TestRedactSecretSensitiveAnnotations(t *testing.T) {
+	secret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "stackrox",
+			Name:      "builder-dockercfg-abcde",
+			Annotations: map[string]string{
+				"openshift.io/token-secret.value":    "test-only-placeholder-token-not-a-real-secret",
+				"openshift.io/token-secret.name":     "builder-token-abcde",
+				"kubernetes.io/service-account.name": "builder",
+			},
+		},
+		Type: v1.SecretTypeDockercfg,
+		Data: map[string][]byte{
+			".dockercfg": []byte(`{"registry":{"auth":"c2VjcmV0"}}`),
+		},
+	}
+
+	var unstructuredSecret unstructured.Unstructured
+	require.NoError(t, scheme.Scheme.Convert(&secret, &unstructuredSecret, nil))
+
+	RedactSecret(&unstructuredSecret)
+
+	var redactedSecret v1.Secret
+	require.NoError(t, scheme.Scheme.Convert(&unstructuredSecret, &redactedSecret, nil))
+
+	// The sensitive token annotation value must be redacted...
+	assert.Equal(t, "***REDACTED***", redactedSecret.Annotations["openshift.io/token-secret.value"])
+	// ...while non-sensitive annotations are preserved verbatim.
+	assert.Equal(t, "builder-token-abcde", redactedSecret.Annotations["openshift.io/token-secret.name"])
+	assert.Equal(t, "builder", redactedSecret.Annotations["kubernetes.io/service-account.name"])
+	// The data field is still redacted as before.
+	assert.Empty(t, redactedSecret.Data)
+	assert.Equal(t, "***REDACTED***", redactedSecret.StringData[".dockercfg"])
+}


### PR DESCRIPTION
## Description

The ACS diagnostic bundle included the **unredacted** value of the `openshift.io/token-secret.value` annotation on OpenShift dockercfg secrets, leaking a plaintext copy of the service account token.

Root cause: `RedactSecret` (`pkg/k8sintrospect/redact.go`) only redacted the secret `data` field. OpenShift stores a plaintext copy of the SA token in the `openshift.io/token-secret.value` **annotation** on generated `kubernetes.io/dockercfg` secrets; annotations were never touched. `FilterOutServiceAccountSecrets` only drops `kubernetes.io/service-account-token`-typed secrets, so dockercfg secrets pass through. Secrets are collected via the **sensor** telemetry path (`DefaultConfigWithSecrets`), which is why the leaked values appeared under `kubernetes/<cluster>/.../secret-*-dockercfg-*.yaml` in bundles.

Fix: redact the values of known-sensitive secret annotations to `***REDACTED***` while keeping the annotation key (mirroring how `data` keys are preserved as `stringData`). A `sensitiveSecretAnnotations` list makes it easy to add more keys later.

### Considered alternatives
- Dropping the annotation entirely — rejected: keeping the key (with a redacted value) preserves diagnostic signal (you can see the annotation was present) and is consistent with the existing `data`→`stringData: ***REDACTED***` behavior.
- Filtering out dockercfg secrets like SA-token secrets — rejected: dockercfg secrets carry useful non-sensitive info; the targeted value is the token annotation.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

`TestRedactSecretSensitiveAnnotations` in `pkg/k8sintrospect/redact_test.go` verifies the annotation is redacted while non-sensitive annotations and the existing `data` redaction are preserved. Confirmed it **fails without** the fix and **passes with** it.

### How I validated my change

Reproduced and verified end-to-end on a live OpenShift cluster (Central + connected Sensor):

1. Injected a `kubernetes.io/dockercfg` secret in the sensor's `stackrox` namespace carrying `openshift.io/token-secret.value: <sentinel>`.
2. Downloaded a diagnostic bundle (`GET /api/extensions/diagnostics`) with the **stock** `main:5.0.x-214` sensor → the sentinel token appeared unredacted in `kubernetes/remote/stackrox/_ungrouped/secret-repro-dockercfg-rox36824.yaml` (bug reproduced).
3. Rebuilt the sensor with the fix, re-downloaded the bundle → the annotation value is `***REDACTED***` and the sentinel token is **absent** from the entire bundle.

Before (stock) vs after (fixed), sensor-collected secret YAML:

```diff
   annotations:
     kubernetes.io/service-account.name: repro-sa
     openshift.io/token-secret.name: repro-token-rox36824
-    openshift.io/token-secret.value: SUPER-SECRET-TOKEN-ROX36824-DO-NOT-LEAK-abc123def456
+    openshift.io/token-secret.value: '***REDACTED***'
   name: repro-dockercfg-rox36824
   namespace: stackrox
 stringData:
   .dockercfg: '***REDACTED***'
 type: kubernetes.io/dockercfg
```

`grep -rc "SUPER-SECRET-TOKEN-ROX36824"` across the bundle: **1** (stock) → **0** (fixed).
