### PR TITLE
feat: add Central version header for roxctl skew detection

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -667,7 +667,6 @@ func startGRPCServer() {
 	)
 
 	config.UnaryInterceptors = append(config.UnaryInterceptors, versionheader.UnaryServerInterceptor())
-	config.StreamInterceptors = append(config.StreamInterceptors, versionheader.StreamServerInterceptor())
 
 	// Telemetry client has to add interceptors before starting the server.
 	c := phonehomeClient.Singleton()

--- a/central/main.go
+++ b/central/main.go
@@ -218,6 +218,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/ratelimit"
 	"github.com/stackrox/rox/pkg/grpc/routes"
+	"github.com/stackrox/rox/pkg/grpc/versionheader"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/memlimit"
@@ -664,6 +665,9 @@ func startGRPCServer() {
 	config.PreAuthContextEnrichers = append(config.PreAuthContextEnrichers,
 		centralSAC.GetEnricher().GetPreAuthContextEnricher(authzTraceSink),
 	)
+
+	config.UnaryInterceptors = append(config.UnaryInterceptors, versionheader.UnaryServerInterceptor())
+	config.StreamInterceptors = append(config.StreamInterceptors, versionheader.StreamServerInterceptor())
 
 	// Telemetry client has to add interceptors before starting the server.
 	c := phonehomeClient.Singleton()

--- a/pkg/clientconn/roxctl_command_header.go
+++ b/pkg/clientconn/roxctl_command_header.go
@@ -16,4 +16,4 @@ const ExecutionEnvironment = "Rh-Execution-Environment"
 // CentralVersionHeader is the gRPC response metadata key carrying the
 // Central version. Set by Central for authenticated requests so that
 // clients (e.g. roxctl) can detect version skew without an extra RPC.
-const CentralVersionHeader = "rh-central-version"
+const CentralVersionHeader = "Rh-Central-Version"

--- a/pkg/clientconn/roxctl_command_header.go
+++ b/pkg/clientconn/roxctl_command_header.go
@@ -12,3 +12,8 @@ const RoxctlCommandIndexHeader = "Rh-Roxctl-Command-Index"
 // ExecutionEnvironment is the HTTP header name with the custom execution
 // environment string. Can be supplied by roxctl, or any other API client.
 const ExecutionEnvironment = "Rh-Execution-Environment"
+
+// CentralVersionHeader is the gRPC response metadata key carrying the
+// Central version. Set by Central for authenticated requests so that
+// clients (e.g. roxctl) can detect version skew without an extra RPC.
+const CentralVersionHeader = "rh-central-version"

--- a/pkg/grpc/versionheader/interceptor.go
+++ b/pkg/grpc/versionheader/interceptor.go
@@ -1,0 +1,36 @@
+package versionheader
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/version"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor that sets the
+// Central version in the response metadata for authenticated requests.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		setVersionHeader(ctx)
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns a gRPC stream server interceptor that sets
+// the Central version in the response metadata for authenticated requests.
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		setVersionHeader(ss.Context())
+		return handler(srv, ss)
+	}
+}
+
+func setVersionHeader(ctx context.Context) {
+	if authn.IdentityFromContextOrNil(ctx) == nil {
+		return
+	}
+	_ = grpc.SetHeader(ctx, metadata.Pairs(clientconn.CentralVersionHeader, version.GetMainVersion()))
+}

--- a/pkg/grpc/versionheader/interceptor.go
+++ b/pkg/grpc/versionheader/interceptor.go
@@ -19,15 +19,6 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamServerInterceptor returns a gRPC stream server interceptor that sets
-// the Central version in the response metadata for authenticated requests.
-func StreamServerInterceptor() grpc.StreamServerInterceptor {
-	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		setVersionHeader(ss.Context())
-		return handler(srv, ss)
-	}
-}
-
 func setVersionHeader(ctx context.Context) {
 	if authn.IdentityFromContextOrNil(ctx) == nil {
 		return

--- a/pkg/grpc/versionheader/interceptor_test.go
+++ b/pkg/grpc/versionheader/interceptor_test.go
@@ -53,7 +53,7 @@ func TestUnaryServerInterceptor_Anonymous(t *testing.T) {
 }
 
 func TestVersionHeaderKey(t *testing.T) {
-	assert.Equal(t, "rh-central-version", clientconn.CentralVersionHeader)
+	assert.Equal(t, "Rh-Central-Version", clientconn.CentralVersionHeader)
 }
 
 func TestSetVersionHeader_UsesCurrentVersion(t *testing.T) {

--- a/pkg/grpc/versionheader/interceptor_test.go
+++ b/pkg/grpc/versionheader/interceptor_test.go
@@ -2,61 +2,105 @@ package versionheader
 
 import (
 	"context"
+	"net"
 	"testing"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/grpc/authn"
-	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
 )
+
+func TestUnaryServerInterceptor(t *testing.T) {
+	cases := map[string]struct {
+		authenticated bool
+		expectHeader  bool
+	}{
+		"authenticated request sets version header": {
+			authenticated: true,
+			expectHeader:  true,
+		},
+		"anonymous request does not set version header": {
+			authenticated: false,
+			expectHeader:  false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			testutils.SetMainVersion(t, "4.8.0")
+
+			var interceptors []grpc.UnaryServerInterceptor
+			if tc.authenticated {
+				interceptors = append(interceptors, injectIdentityInterceptor(t))
+			}
+			interceptors = append(interceptors, UnaryServerInterceptor())
+
+			conn := setupServer(t, interceptors...)
+
+			var md metadata.MD
+			client := v1.NewMetadataServiceClient(conn)
+			_, err := client.GetMetadata(context.Background(), &v1.Empty{}, grpc.Header(&md))
+			require.NoError(t, err)
+
+			vals := md.Get(clientconn.CentralVersionHeader)
+			if tc.expectHeader {
+				require.Len(t, vals, 1)
+				assert.Equal(t, "4.8.0", vals[0])
+			} else {
+				assert.Empty(t, vals)
+			}
+		})
+	}
+}
+
+// --- helpers and mocks ---
 
 type fakeIdentity struct {
 	authn.Identity
 }
 
-func TestUnaryServerInterceptor_Authenticated(t *testing.T) {
-	testutils.SetMainVersion(t, "4.8.0")
-	ctx := authn.ContextWithIdentity(context.Background(), fakeIdentity{}, t)
+type fakeMetadataServer struct {
+	v1.UnimplementedMetadataServiceServer
+}
 
-	interceptor := UnaryServerInterceptor()
+func (f *fakeMetadataServer) GetMetadata(_ context.Context, _ *v1.Empty) (*v1.Metadata, error) {
+	return &v1.Metadata{Version: "test"}, nil
+}
 
-	var handlerCalled bool
-	handler := func(ctx context.Context, req any) (any, error) {
-		handlerCalled = true
-		return "response", nil
+func injectIdentityInterceptor(t testing.TB) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ctx = authn.ContextWithIdentity(ctx, fakeIdentity{}, t)
+		return handler(ctx, req)
 	}
-
-	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
-	assert.NoError(t, err)
-	assert.Equal(t, "response", resp)
-	assert.True(t, handlerCalled)
 }
 
-func TestUnaryServerInterceptor_Anonymous(t *testing.T) {
-	testutils.SetMainVersion(t, "4.8.0")
-	ctx := context.Background()
+func setupServer(t *testing.T, interceptors ...grpc.UnaryServerInterceptor) *grpc.ClientConn {
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.ChainUnaryInterceptor(interceptors...))
+	v1.RegisterMetadataServiceServer(server, &fakeMetadataServer{})
 
-	interceptor := UnaryServerInterceptor()
+	go func() {
+		assert.NoError(t, server.Serve(listener))
+	}()
 
-	var handlerCalled bool
-	handler := func(ctx context.Context, req any) (any, error) {
-		handlerCalled = true
-		return "response", nil
-	}
+	conn, err := grpc.DialContext(context.Background(), "",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
 
-	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
-	assert.NoError(t, err)
-	assert.Equal(t, "response", resp)
-	assert.True(t, handlerCalled)
-}
-
-func TestVersionHeaderKey(t *testing.T) {
-	assert.Equal(t, "Rh-Central-Version", clientconn.CentralVersionHeader)
-}
-
-func TestSetVersionHeader_UsesCurrentVersion(t *testing.T) {
-	testutils.SetMainVersion(t, "5.1.0")
-	assert.Equal(t, "5.1.0", version.GetMainVersion())
+	t.Cleanup(func() {
+		_ = listener.Close()
+		server.Stop()
+	})
+	return conn
 }

--- a/pkg/grpc/versionheader/interceptor_test.go
+++ b/pkg/grpc/versionheader/interceptor_test.go
@@ -98,9 +98,6 @@ func setupServer(t *testing.T, interceptors ...grpc.UnaryServerInterceptor) *grp
 	)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		_ = listener.Close()
-		server.Stop()
-	})
+	t.Cleanup(server.Stop)
 	return conn
 }

--- a/pkg/grpc/versionheader/interceptor_test.go
+++ b/pkg/grpc/versionheader/interceptor_test.go
@@ -1,0 +1,62 @@
+package versionheader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/version"
+	"github.com/stackrox/rox/pkg/version/testutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+type fakeIdentity struct {
+	authn.Identity
+}
+
+func TestUnaryServerInterceptor_Authenticated(t *testing.T) {
+	testutils.SetMainVersion(t, "4.8.0")
+	ctx := authn.ContextWithIdentity(context.Background(), fakeIdentity{}, t)
+
+	interceptor := UnaryServerInterceptor()
+
+	var handlerCalled bool
+	handler := func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "response", nil
+	}
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+	assert.NoError(t, err)
+	assert.Equal(t, "response", resp)
+	assert.True(t, handlerCalled)
+}
+
+func TestUnaryServerInterceptor_Anonymous(t *testing.T) {
+	testutils.SetMainVersion(t, "4.8.0")
+	ctx := context.Background()
+
+	interceptor := UnaryServerInterceptor()
+
+	var handlerCalled bool
+	handler := func(ctx context.Context, req any) (any, error) {
+		handlerCalled = true
+		return "response", nil
+	}
+
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+	assert.NoError(t, err)
+	assert.Equal(t, "response", resp)
+	assert.True(t, handlerCalled)
+}
+
+func TestVersionHeaderKey(t *testing.T) {
+	assert.Equal(t, "rh-central-version", clientconn.CentralVersionHeader)
+}
+
+func TestSetVersionHeader_UsesCurrentVersion(t *testing.T) {
+	testutils.SetMainVersion(t, "5.1.0")
+	assert.Equal(t, "5.1.0", version.GetMainVersion())
+}

--- a/roxctl/common/connection.go
+++ b/roxctl/common/connection.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -35,11 +36,11 @@ func WithRetryTimeout(timeout time.Duration) GRPCOption {
 }
 
 // WithVersionCheck enables version compatibility checking on gRPC responses.
-// The provided warn function is called at most once when a version mismatch
-// is detected from the Central version response header.
-func WithVersionCheck(warn versioncheck.WarnFunc) GRPCOption {
+// Warnings are written to w at most once when a version incompatibility is
+// detected from the Central version response header.
+func WithVersionCheck(w io.Writer) GRPCOption {
 	return func(config *grpcConfig) {
-		config.versionCheckWarn = warn
+		config.versionCheckWriter = w
 	}
 }
 
@@ -77,15 +78,15 @@ func GetGRPCConnection(am auth.Method, connectionOpts ...GRPCOption) (*grpc.Clie
 }
 
 type grpcConfig struct {
-	usePlaintext     bool
-	insecure         bool
-	opts             clientconn.Options
-	serverName       string
-	useDirectGRPC    bool
-	forceHTTP1       bool
-	endpoint         string
-	retryTimeout     time.Duration
-	versionCheckWarn versioncheck.WarnFunc
+	usePlaintext       bool
+	insecure           bool
+	opts               clientconn.Options
+	serverName         string
+	useDirectGRPC      bool
+	forceHTTP1         bool
+	endpoint           string
+	retryTimeout       time.Duration
+	versionCheckWriter io.Writer
 }
 
 func makeCtxWithCommandHeader(ctx context.Context) context.Context {
@@ -137,8 +138,8 @@ func createGRPCConn(c grpcConfig) (*grpc.ClientConn, error) {
 		addCommandHeaderUnaryInterceptor,
 		grpc_retry.UnaryClientInterceptor(retryOpts...),
 	}
-	if c.versionCheckWarn != nil {
-		unaryInterceptors = append(unaryInterceptors, versioncheck.UnaryClientInterceptor(c.versionCheckWarn))
+	if c.versionCheckWriter != nil {
+		unaryInterceptors = append(unaryInterceptors, versioncheck.UnaryClientInterceptor(c.versionCheckWriter))
 	}
 
 	grpcDialOpts := []grpc.DialOption{

--- a/roxctl/common/connection.go
+++ b/roxctl/common/connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/auth"
 	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/common/versioncheck"
 	http1DowngradeClient "golang.stackrox.io/grpc-http1/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -30,6 +31,15 @@ type GRPCOption func(*grpcConfig)
 func WithRetryTimeout(timeout time.Duration) GRPCOption {
 	return func(config *grpcConfig) {
 		config.retryTimeout = timeout
+	}
+}
+
+// WithVersionCheck enables version compatibility checking on gRPC responses.
+// The provided warn function is called at most once when a version mismatch
+// is detected from the Central version response header.
+func WithVersionCheck(warn versioncheck.WarnFunc) GRPCOption {
+	return func(config *grpcConfig) {
+		config.versionCheckWarn = warn
 	}
 }
 
@@ -67,14 +77,15 @@ func GetGRPCConnection(am auth.Method, connectionOpts ...GRPCOption) (*grpc.Clie
 }
 
 type grpcConfig struct {
-	usePlaintext  bool
-	insecure      bool
-	opts          clientconn.Options
-	serverName    string
-	useDirectGRPC bool
-	forceHTTP1    bool
-	endpoint      string
-	retryTimeout  time.Duration
+	usePlaintext     bool
+	insecure         bool
+	opts             clientconn.Options
+	serverName       string
+	useDirectGRPC    bool
+	forceHTTP1       bool
+	endpoint         string
+	retryTimeout     time.Duration
+	versionCheckWarn versioncheck.WarnFunc
 }
 
 func makeCtxWithCommandHeader(ctx context.Context) context.Context {
@@ -122,13 +133,19 @@ func createGRPCConn(c grpcConfig) (*grpc.ClientConn, error) {
 		grpc_retry.WithRetriable(shouldRetry),
 	}
 
+	unaryInterceptors := []grpc.UnaryClientInterceptor{
+		addCommandHeaderUnaryInterceptor,
+		grpc_retry.UnaryClientInterceptor(retryOpts...),
+	}
+	if c.versionCheckWarn != nil {
+		unaryInterceptors = append(unaryInterceptors, versioncheck.UnaryClientInterceptor(c.versionCheckWarn))
+	}
+
 	grpcDialOpts := []grpc.DialOption{
 		grpc.WithChainStreamInterceptor(
 			addCommandHeaderStreamInterceptor,
 			grpc_retry.StreamClientInterceptor(retryOpts...)),
-		grpc.WithChainUnaryInterceptor(
-			addCommandHeaderUnaryInterceptor,
-			grpc_retry.UnaryClientInterceptor(retryOpts...)),
+		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
 	}
 
 	if c.usePlaintext {

--- a/roxctl/common/environment/environment-impl.go
+++ b/roxctl/common/environment/environment-impl.go
@@ -94,6 +94,7 @@ func (c *cliEnvironmentImpl) GRPCConnection(connectionOpts ...common.GRPCOption)
 	if err != nil {
 		return nil, errors.Wrap(err, "determining auth method")
 	}
+	connectionOpts = append(connectionOpts, common.WithVersionCheck(c.logger.WarnfLn))
 	connection, err := common.GetGRPCConnection(am, connectionOpts...)
 	return connection, errors.WithStack(err)
 }

--- a/roxctl/common/environment/environment-impl.go
+++ b/roxctl/common/environment/environment-impl.go
@@ -94,7 +94,7 @@ func (c *cliEnvironmentImpl) GRPCConnection(connectionOpts ...common.GRPCOption)
 	if err != nil {
 		return nil, errors.Wrap(err, "determining auth method")
 	}
-	connectionOpts = append(connectionOpts, common.WithVersionCheck(c.logger.WarnfLn))
+	connectionOpts = append(connectionOpts, common.WithVersionCheck(c.io.ErrOut()))
 	connection, err := common.GetGRPCConnection(am, connectionOpts...)
 	return connection, errors.WithStack(err)
 }

--- a/roxctl/common/versioncheck/check.go
+++ b/roxctl/common/versioncheck/check.go
@@ -1,0 +1,75 @@
+package versioncheck
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/version"
+	"github.com/stackrox/rox/pkg/version/productstreams"
+	"github.com/stackrox/rox/pkg/version/versioncompatibility"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// WarnFunc is called when a version compatibility issue is detected.
+type WarnFunc func(format string, a ...interface{})
+
+// UnaryClientInterceptor returns a gRPC unary client interceptor that reads
+// the Central version from response metadata and emits a warning if the
+// versions are incompatible. The warning is emitted at most once per
+// interceptor instance.
+func UnaryClientInterceptor(warn WarnFunc) grpc.UnaryClientInterceptor {
+	var once sync.Once
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		var md metadata.MD
+		opts = append(opts, grpc.Header(&md))
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if vals := md.Get(clientconn.CentralVersionHeader); len(vals) > 0 {
+			once.Do(func() {
+				checkAndWarn(vals[0], warn)
+			})
+		}
+		return err
+	}
+}
+
+func checkAndWarn(centralVersion string, warn WarnFunc) {
+	remoteXY, err := productstreams.ParseXYFromVersionString(centralVersion)
+	if err != nil {
+		return
+	}
+	localVersion := version.GetMainVersion()
+	localXY, err := productstreams.ParseXYFromVersionString(localVersion)
+	if err != nil {
+		return
+	}
+	if localXY == remoteXY {
+		return
+	}
+
+	compat, err := versioncompatibility.ClassifyVersion(remoteXY)
+	if err != nil {
+		return
+	}
+
+	switch compat {
+	case versioncompatibility.CompatibleBehind, versioncompatibility.CompatibleAhead:
+		warn("roxctl version %s and Central version %s differ; some features may not work as expected",
+			localVersion, centralVersion)
+	case versioncompatibility.IncompatibleBehind, versioncompatibility.IncompatibleAhead:
+		warn(incompatibleMessage(localVersion, centralVersion))
+	}
+}
+
+func incompatibleMessage(localVersion, centralVersion string) string {
+	versions, err := versioncompatibility.CompatibleVersions()
+	if err != nil || len(versions) == 0 {
+		return fmt.Sprintf("roxctl version %s is incompatible with Central version %s", localVersion, centralVersion)
+	}
+	return fmt.Sprintf(
+		"roxctl version %s is incompatible with Central version %s; supported Central range for this roxctl is %s to %s",
+		localVersion, centralVersion, versions[0], versions[len(versions)-1],
+	)
+}

--- a/roxctl/common/versioncheck/check.go
+++ b/roxctl/common/versioncheck/check.go
@@ -53,6 +53,9 @@ func checkAndWarn(centralVersion string, w io.Writer) bool {
 	if err != nil {
 		return false
 	}
+	if compat != versioncompatibility.IncompatibleAhead && compat != versioncompatibility.IncompatibleBehind {
+		return false
+	}
 
 	versionRange, err := versioncompatibility.CompatibleVersions()
 	if err != nil {
@@ -60,25 +63,19 @@ func checkAndWarn(centralVersion string, w io.Writer) bool {
 	}
 	compatRange := formatVersionRange(versionRange)
 
-	switch compat {
-	case versioncompatibility.IncompatibleAhead:
-		fmt.Fprintf(w, "Warning: Your roxctl %s is too old for this Central %s. "+
-			"Correct functioning is not guaranteed. "+
-			"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
-			roxctlVersion, centralVersion)
-		fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
-			roxctlVersion, centralVersion, compatRange)
-		return true
-	case versioncompatibility.IncompatibleBehind:
-		fmt.Fprintf(w, "Warning: Your roxctl %s is too new for this Central %s. "+
-			"Correct functioning is not guaranteed. "+
-			"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
-			roxctlVersion, centralVersion)
-		fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
-			roxctlVersion, centralVersion, compatRange)
-		return true
+	var direction string
+	if compat == versioncompatibility.IncompatibleAhead {
+		direction = "too old"
+	} else {
+		direction = "too new"
 	}
-	return false
+	fmt.Fprintf(w, "Warning: Your roxctl %s is %s for this Central %s. "+
+		"Correct functioning is not guaranteed. "+
+		"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
+		roxctlVersion, direction, centralVersion)
+	fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
+		roxctlVersion, centralVersion, compatRange)
+	return true
 }
 
 // headerSource returns a function that, when called after the RPC completes,

--- a/roxctl/common/versioncheck/check.go
+++ b/roxctl/common/versioncheck/check.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"sync/atomic"
+
 	"github.com/stackrox/rox/pkg/clientconn"
-	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/version"
 	"github.com/stackrox/rox/pkg/version/productstreams"
 	"github.com/stackrox/rox/pkg/version/versioncompatibility"
@@ -21,46 +22,51 @@ type WarnFunc func(format string, a ...interface{})
 // versions are incompatible. The warning is emitted at most once per
 // interceptor instance.
 func UnaryClientInterceptor(warn WarnFunc) grpc.UnaryClientInterceptor {
-	var once sync.Once
+	var warned atomic.Bool
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		var md metadata.MD
 		opts = append(opts, grpc.Header(&md))
 		err := invoker(ctx, method, req, reply, cc, opts...)
-		if vals := md.Get(clientconn.CentralVersionHeader); len(vals) > 0 {
-			once.Do(func() {
-				checkAndWarn(vals[0], warn)
-			})
+		if !warned.Load() {
+			if vals := md.Get(clientconn.CentralVersionHeader); len(vals) > 0 {
+				if checkAndWarn(vals[0], warn) {
+					warned.Store(true)
+				}
+			}
 		}
 		return err
 	}
 }
 
-func checkAndWarn(centralVersion string, warn WarnFunc) {
+func checkAndWarn(centralVersion string, warn WarnFunc) bool {
 	remoteXY, err := productstreams.ParseXYFromVersionString(centralVersion)
 	if err != nil {
-		return
+		return false
 	}
 	localVersion := version.GetMainVersion()
 	localXY, err := productstreams.ParseXYFromVersionString(localVersion)
 	if err != nil {
-		return
+		return false
 	}
 	if localXY == remoteXY {
-		return
+		return false
 	}
 
 	compat, err := versioncompatibility.ClassifyVersion(remoteXY)
 	if err != nil {
-		return
+		return false
 	}
 
 	switch compat {
 	case versioncompatibility.CompatibleBehind, versioncompatibility.CompatibleAhead:
 		warn("roxctl version %s and Central version %s differ; some features may not work as expected",
 			localVersion, centralVersion)
+		return true
 	case versioncompatibility.IncompatibleBehind, versioncompatibility.IncompatibleAhead:
 		warn(incompatibleMessage(localVersion, centralVersion))
+		return true
 	}
+	return false
 }
 
 func incompatibleMessage(localVersion, centralVersion string) string {

--- a/roxctl/common/versioncheck/check.go
+++ b/roxctl/common/versioncheck/check.go
@@ -15,9 +15,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// WriteFunc writes the version warning to the given writer.
-type WriteFunc func(w io.Writer)
-
 // UnaryClientInterceptor returns a gRPC unary client interceptor that reads
 // the Central version from response metadata and emits a warning if the
 // versions are incompatible. The warning is emitted at most once per
@@ -25,11 +22,10 @@ type WriteFunc func(w io.Writer)
 func UnaryClientInterceptor(w io.Writer) grpc.UnaryClientInterceptor {
 	var warned atomic.Bool
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		var md metadata.MD
-		opts = append(opts, grpc.Header(&md))
+		getHeader := headerSource(&opts)
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if !warned.Load() {
-			if vals := md.Get(clientconn.CentralVersionHeader); len(vals) > 0 {
+			if vals := getHeader().Get(clientconn.CentralVersionHeader); len(vals) > 0 {
 				if checkAndWarn(vals[0], w) {
 					warned.Store(true)
 				}
@@ -83,6 +79,20 @@ func checkAndWarn(centralVersion string, w io.Writer) bool {
 		return true
 	}
 	return false
+}
+
+// headerSource returns a function that, when called after the RPC completes,
+// yields the response metadata. If opts already contains a grpc.Header option
+// the existing pointer is reused; otherwise a new one is appended.
+func headerSource(opts *[]grpc.CallOption) func() metadata.MD {
+	for _, o := range *opts {
+		if h, ok := o.(grpc.HeaderCallOption); ok {
+			return func() metadata.MD { return *h.HeaderAddr }
+		}
+	}
+	var md metadata.MD
+	*opts = append(*opts, grpc.Header(&md))
+	return func() metadata.MD { return md }
 }
 
 func formatVersionRange(versions []productstreams.XYVersion) string {

--- a/roxctl/common/versioncheck/check.go
+++ b/roxctl/common/versioncheck/check.go
@@ -3,7 +3,8 @@ package versioncheck
 import (
 	"context"
 	"fmt"
-
+	"io"
+	"strings"
 	"sync/atomic"
 
 	"github.com/stackrox/rox/pkg/clientconn"
@@ -14,14 +15,14 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// WarnFunc is called when a version compatibility issue is detected.
-type WarnFunc func(format string, a ...interface{})
+// WriteFunc writes the version warning to the given writer.
+type WriteFunc func(w io.Writer)
 
 // UnaryClientInterceptor returns a gRPC unary client interceptor that reads
 // the Central version from response metadata and emits a warning if the
 // versions are incompatible. The warning is emitted at most once per
 // interceptor instance.
-func UnaryClientInterceptor(warn WarnFunc) grpc.UnaryClientInterceptor {
+func UnaryClientInterceptor(w io.Writer) grpc.UnaryClientInterceptor {
 	var warned atomic.Bool
 	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		var md metadata.MD
@@ -29,7 +30,7 @@ func UnaryClientInterceptor(warn WarnFunc) grpc.UnaryClientInterceptor {
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if !warned.Load() {
 			if vals := md.Get(clientconn.CentralVersionHeader); len(vals) > 0 {
-				if checkAndWarn(vals[0], warn) {
+				if checkAndWarn(vals[0], w) {
 					warned.Store(true)
 				}
 			}
@@ -38,13 +39,13 @@ func UnaryClientInterceptor(warn WarnFunc) grpc.UnaryClientInterceptor {
 	}
 }
 
-func checkAndWarn(centralVersion string, warn WarnFunc) bool {
+func checkAndWarn(centralVersion string, w io.Writer) bool {
 	remoteXY, err := productstreams.ParseXYFromVersionString(centralVersion)
 	if err != nil {
 		return false
 	}
-	localVersion := version.GetMainVersion()
-	localXY, err := productstreams.ParseXYFromVersionString(localVersion)
+	roxctlVersion := version.GetMainVersion()
+	localXY, err := productstreams.ParseXYFromVersionString(roxctlVersion)
 	if err != nil {
 		return false
 	}
@@ -57,25 +58,37 @@ func checkAndWarn(centralVersion string, warn WarnFunc) bool {
 		return false
 	}
 
+	versionRange, err := versioncompatibility.CompatibleVersions()
+	if err != nil {
+		return false
+	}
+	compatRange := formatVersionRange(versionRange)
+
 	switch compat {
-	case versioncompatibility.CompatibleBehind, versioncompatibility.CompatibleAhead:
-		warn("roxctl version %s and Central version %s differ; some features may not work as expected",
-			localVersion, centralVersion)
+	case versioncompatibility.IncompatibleAhead:
+		fmt.Fprintf(w, "Warning: Your roxctl %s is too old for this Central %s. "+
+			"Correct functioning is not guaranteed. "+
+			"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
+			roxctlVersion, centralVersion)
+		fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
+			roxctlVersion, centralVersion, compatRange)
 		return true
-	case versioncompatibility.IncompatibleBehind, versioncompatibility.IncompatibleAhead:
-		warn(incompatibleMessage(localVersion, centralVersion))
+	case versioncompatibility.IncompatibleBehind:
+		fmt.Fprintf(w, "Warning: Your roxctl %s is too new for this Central %s. "+
+			"Correct functioning is not guaranteed. "+
+			"Use roxctl version matching the Central version or at least such that the Central version is within the roxctl compatibility range.\n",
+			roxctlVersion, centralVersion)
+		fmt.Fprintf(w, "         roxctl: %s | Central: %s | Compatible Centrals: %s\n",
+			roxctlVersion, centralVersion, compatRange)
 		return true
 	}
 	return false
 }
 
-func incompatibleMessage(localVersion, centralVersion string) string {
-	versions, err := versioncompatibility.CompatibleVersions()
-	if err != nil || len(versions) == 0 {
-		return fmt.Sprintf("roxctl version %s is incompatible with Central version %s", localVersion, centralVersion)
+func formatVersionRange(versions []productstreams.XYVersion) string {
+	strs := make([]string, len(versions))
+	for i, v := range versions {
+		strs[i] = v.String()
 	}
-	return fmt.Sprintf(
-		"roxctl version %s is incompatible with Central version %s; supported Central range for this roxctl is %s to %s",
-		localVersion, centralVersion, versions[0], versions[len(versions)-1],
-	)
+	return strings.Join(strs, ", ")
 }

--- a/roxctl/common/versioncheck/check_test.go
+++ b/roxctl/common/versioncheck/check_test.go
@@ -1,6 +1,7 @@
 package versioncheck
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stackrox/rox/pkg/version/testutils"
@@ -27,26 +28,24 @@ func TestCheckAndWarn(t *testing.T) {
 		"compatible behind within range": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.6.0",
-			expectWarning:  true,
-			warnContains:   "differ",
+			expectWarning:  false,
 		},
 		"compatible ahead within range": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.10.0",
-			expectWarning:  true,
-			warnContains:   "differ",
+			expectWarning:  false,
 		},
 		"incompatible behind": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.3.0",
 			expectWarning:  true,
-			warnContains:   "incompatible",
+			warnContains:   "too new",
 		},
 		"incompatible ahead": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.15.0",
 			expectWarning:  true,
-			warnContains:   "incompatible",
+			warnContains:   "too old",
 		},
 		"invalid central version": {
 			localVersion:   "4.8.0",
@@ -59,19 +58,15 @@ func TestCheckAndWarn(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testutils.SetMainVersion(t, tc.localVersion)
 
-			var warned bool
-			var warnMsg string
-			warn := func(format string, a ...interface{}) {
-				warned = true
-				warnMsg = format
-			}
+			var buf bytes.Buffer
+			result := checkAndWarn(tc.centralVersion, &buf)
 
-			result := checkAndWarn(tc.centralVersion, warn)
-
-			assert.Equal(t, tc.expectWarning, warned, "warning expectation mismatch")
-			assert.Equal(t, tc.expectWarning, result, "return value should match warning emission")
+			assert.Equal(t, tc.expectWarning, result, "return value mismatch")
 			if tc.warnContains != "" {
-				assert.Contains(t, warnMsg, tc.warnContains)
+				assert.Contains(t, buf.String(), tc.warnContains)
+				assert.Contains(t, buf.String(), "Compatible Centrals:")
+			} else {
+				assert.Empty(t, buf.String())
 			}
 		})
 	}

--- a/roxctl/common/versioncheck/check_test.go
+++ b/roxctl/common/versioncheck/check_test.go
@@ -66,9 +66,10 @@ func TestCheckAndWarn(t *testing.T) {
 				warnMsg = format
 			}
 
-			checkAndWarn(tc.centralVersion, warn)
+			result := checkAndWarn(tc.centralVersion, warn)
 
 			assert.Equal(t, tc.expectWarning, warned, "warning expectation mismatch")
+			assert.Equal(t, tc.expectWarning, result, "return value should match warning emission")
 			if tc.warnContains != "" {
 				assert.Contains(t, warnMsg, tc.warnContains)
 			}

--- a/roxctl/common/versioncheck/check_test.go
+++ b/roxctl/common/versioncheck/check_test.go
@@ -1,0 +1,77 @@
+package versioncheck
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/version/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckAndWarn(t *testing.T) {
+	cases := map[string]struct {
+		localVersion   string
+		centralVersion string
+		expectWarning  bool
+		warnContains   string
+	}{
+		"same version": {
+			localVersion:   "4.8.0",
+			centralVersion: "4.8.0",
+			expectWarning:  false,
+		},
+		"same XY different patch": {
+			localVersion:   "4.8.0",
+			centralVersion: "4.8.1",
+			expectWarning:  false,
+		},
+		"compatible behind within range": {
+			localVersion:   "4.8.0",
+			centralVersion: "4.6.0",
+			expectWarning:  true,
+			warnContains:   "differ",
+		},
+		"compatible ahead within range": {
+			localVersion:   "4.8.0",
+			centralVersion: "4.10.0",
+			expectWarning:  true,
+			warnContains:   "differ",
+		},
+		"incompatible behind": {
+			localVersion:   "4.8.0",
+			centralVersion: "4.3.0",
+			expectWarning:  true,
+			warnContains:   "incompatible",
+		},
+		"incompatible ahead": {
+			localVersion:   "4.8.0",
+			centralVersion: "4.15.0",
+			expectWarning:  true,
+			warnContains:   "incompatible",
+		},
+		"invalid central version": {
+			localVersion:   "4.8.0",
+			centralVersion: "invalid",
+			expectWarning:  false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			testutils.SetMainVersion(t, tc.localVersion)
+
+			var warned bool
+			var warnMsg string
+			warn := func(format string, a ...interface{}) {
+				warned = true
+				warnMsg = format
+			}
+
+			checkAndWarn(tc.centralVersion, warn)
+
+			assert.Equal(t, tc.expectWarning, warned, "warning expectation mismatch")
+			if tc.warnContains != "" {
+				assert.Contains(t, warnMsg, tc.warnContains)
+			}
+		})
+	}
+}

--- a/roxctl/common/versioncheck/check_test.go
+++ b/roxctl/common/versioncheck/check_test.go
@@ -2,10 +2,21 @@ package versioncheck
 
 import (
 	"bytes"
+	"context"
+	"net"
 	"testing"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	"github.com/stackrox/rox/pkg/grpc/versionheader"
 	"github.com/stackrox/rox/pkg/version/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 func TestCheckAndWarn(t *testing.T) {
@@ -18,22 +29,18 @@ func TestCheckAndWarn(t *testing.T) {
 		"same version": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.8.0",
-			expectWarning:  false,
 		},
 		"same XY different patch": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.8.1",
-			expectWarning:  false,
 		},
 		"compatible behind within range": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.6.0",
-			expectWarning:  false,
 		},
 		"compatible ahead within range": {
 			localVersion:   "4.8.0",
 			centralVersion: "4.10.0",
-			expectWarning:  false,
 		},
 		"incompatible behind": {
 			localVersion:   "4.8.0",
@@ -50,7 +57,6 @@ func TestCheckAndWarn(t *testing.T) {
 		"invalid central version": {
 			localVersion:   "4.8.0",
 			centralVersion: "invalid",
-			expectWarning:  false,
 		},
 	}
 
@@ -69,5 +75,139 @@ func TestCheckAndWarn(t *testing.T) {
 				assert.Empty(t, buf.String())
 			}
 		})
+	}
+}
+
+func TestUnaryClientInterceptor(t *testing.T) {
+	cases := map[string]struct {
+		authenticated  bool
+		centralVersion string
+		expectWarning  bool
+		warnContains   string
+	}{
+		"incompatible version warns": {
+			authenticated:  true,
+			centralVersion: "4.2.0",
+			expectWarning:  true,
+			warnContains:   "too new",
+		},
+		"compatible version is silent": {
+			authenticated:  true,
+			centralVersion: "",
+		},
+		"anonymous request is silent": {
+			authenticated:  false,
+			centralVersion: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			testutils.SetMainVersion(t, "4.8.0")
+
+			var serverInterceptors []grpc.UnaryServerInterceptor
+			if tc.authenticated {
+				serverInterceptors = append(serverInterceptors, injectIdentityInterceptor(t))
+			}
+			if tc.centralVersion != "" {
+				serverInterceptors = append(serverInterceptors, fakeVersionHeaderInterceptor(tc.centralVersion))
+			} else {
+				serverInterceptors = append(serverInterceptors, versionheader.UnaryServerInterceptor())
+			}
+
+			var buf bytes.Buffer
+			conn := setupServer(t,
+				serverInterceptors,
+				[]grpc.UnaryClientInterceptor{UnaryClientInterceptor(&buf)},
+			)
+
+			client := v1.NewMetadataServiceClient(conn)
+			_, err := client.GetMetadata(context.Background(), &v1.Empty{})
+			require.NoError(t, err)
+
+			if tc.expectWarning {
+				assert.Contains(t, buf.String(), tc.warnContains)
+				assert.Contains(t, buf.String(), "Compatible Centrals:")
+			} else {
+				assert.Empty(t, buf.String())
+			}
+		})
+	}
+}
+
+func TestUnaryClientInterceptor_WarnsOnlyOnce(t *testing.T) {
+	testutils.SetMainVersion(t, "4.8.0")
+
+	var buf bytes.Buffer
+	conn := setupServer(t,
+		[]grpc.UnaryServerInterceptor{
+			injectIdentityInterceptor(t),
+			fakeVersionHeaderInterceptor("4.2.0"),
+		},
+		[]grpc.UnaryClientInterceptor{UnaryClientInterceptor(&buf)},
+	)
+
+	client := v1.NewMetadataServiceClient(conn)
+	_, err := client.GetMetadata(context.Background(), &v1.Empty{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, buf.String())
+
+	buf.Reset()
+
+	_, err = client.GetMetadata(context.Background(), &v1.Empty{})
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "warning should not be emitted a second time")
+}
+
+// --- helpers and mocks ---
+
+type fakeIdentity struct {
+	authn.Identity
+}
+
+type fakeMetadataServer struct {
+	v1.UnimplementedMetadataServiceServer
+}
+
+func (f *fakeMetadataServer) GetMetadata(_ context.Context, _ *v1.Empty) (*v1.Metadata, error) {
+	return &v1.Metadata{Version: "test"}, nil
+}
+
+func setupServer(t *testing.T, serverInterceptors []grpc.UnaryServerInterceptor, clientInterceptors []grpc.UnaryClientInterceptor) *grpc.ClientConn {
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer(grpc.ChainUnaryInterceptor(serverInterceptors...))
+	v1.RegisterMetadataServiceServer(server, &fakeMetadataServer{})
+
+	go func() {
+		assert.NoError(t, server.Serve(listener))
+	}()
+
+	conn, err := grpc.DialContext(context.Background(), "",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithChainUnaryInterceptor(clientInterceptors...),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = listener.Close()
+		server.Stop()
+	})
+	return conn
+}
+
+func injectIdentityInterceptor(t testing.TB) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ctx = authn.ContextWithIdentity(ctx, fakeIdentity{}, t)
+		return handler(ctx, req)
+	}
+}
+
+func fakeVersionHeaderInterceptor(centralVersion string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		_ = grpc.SetHeader(ctx, metadata.Pairs(clientconn.CentralVersionHeader, centralVersion))
+		return handler(ctx, req)
 	}
 }

--- a/roxctl/common/versioncheck/check_test.go
+++ b/roxctl/common/versioncheck/check_test.go
@@ -191,10 +191,7 @@ func setupServer(t *testing.T, serverInterceptors []grpc.UnaryServerInterceptor,
 	)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		_ = listener.Close()
-		server.Stop()
-	})
+	t.Cleanup(server.Stop)
 	return conn
 }
 


### PR DESCRIPTION
## Description

Central now sets an `Rh-Central-Version` gRPC response header on every authenticated request.
roxctl reads this header and warns the user (once per invocation) when the versions are
incompatible, removing the need for a dedicated preflight RPC to detect version skew.

**Why a response header instead of a preflight call:**
Every roxctl command that talks to Central via gRPC gets the check for free — no extra round-trip,
no latency cost. Commands that do not talk to Central (e.g. `roxctl netpol`) do not need the
check and are unaffected.

**Security consideration:**
The header is only set for authenticated requests (`authn.IdentityFromContextOrNil != nil`),
so Central version is not leaked to anonymous callers. The version is already available to
authenticated users via `MetadataService.GetMetadata`, so this header does not expose new
information.

**Known limitations:**
- Commands that use HTTP instead of gRPC (e.g. `central backup`, `central db restore`,
  `scanner downloaddb`, `image sbom`) do not get the version check. The majority of user-facing
  commands (whoami, image check/scan, deployment check, sensor generate, init-bundles, cluster
  operations) use gRPC and are covered. HTTP client support can be added as a follow-up — Central
  already exposes the header in HTTP responses via the gRPC-gateway as
  `Grpc-Metadata-Rh-Central-Version`.
- Calls to methods unknown to the server return `Unimplemented` without running interceptors,
  so the version header is not set. This only affects extreme version skew where Central
  does not have the service at all — the `Unimplemented` error itself is a clear signal.
- Centrals older than 5.0 do not send the header. roxctl silently moves on.

**Warning placement:**
The warning is emitted during the first gRPC response (before command output), not at the end.
This is a tradeoff of the interceptor approach — we cannot control placement from within the
interceptor. The warning goes to stderr while command output goes to stdout, so piped usage
separates them cleanly.

**Alternatives considered:**
- Preflight RPC on every command: adds latency to every invocation
- Check only in `roxctl central whoami` / `roxctl central version`: misses most commands

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Server interceptor tests use a real gRPC server (bufconn) and verify the header is set for authenticated requests and absent for anonymous ones
- Client interceptor tests use a real gRPC round-trip to verify warnings on incompatible versions, silence on compatible/anonymous, and warn-only-once behavior
- Unit tests cover the version check logic for all compatibility states (matched, compatible, incompatible, invalid)
- Manual testing against a real Central deployment: built roxctl with an overridden embedded version (`-ldflags "-X .../internal.MainVersion=4.2.0"`) and confirmed the incompatible version warning is emitted on `roxctl central whoami`
- Verified that commands not using gRPC (e.g. `central cert`, `central backup`) do not produce warnings (expected, as they bypass the gRPC interceptor)