### PR TITLE
fix(api): Populate ListVMs scan_time from latest VM scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 - ROX-34535: Fixes an issue where if ScannerV2 is disabled or unavailable on initial startup the central deployment leaks GRPC connections until the scanner becomes available.
 - ROX-36509: Improved Central memory efficiency by optimizing process filter data structures in high-cardinality scenarios. The `ROX_PROCESS_FILTER_FAN_OUT_LEVELS` environment variable now accepts values up to 255; higher values are automatically clamped with a warning.
-- The Virtual Machine CVEs overview table now shows the latest scan time for each VM instead of "Not available".
 
 ## [4.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 - ROX-34535: Fixes an issue where if ScannerV2 is disabled or unavailable on initial startup the central deployment leaks GRPC connections until the scanner becomes available.
 - ROX-36509: Improved Central memory efficiency by optimizing process filter data structures in high-cardinality scenarios. The `ROX_PROCESS_FILTER_FAN_OUT_LEVELS` environment variable now accepts values up to 255; higher values are automatically clamped with a warning.
+- The Virtual Machine CVEs overview table now shows the latest scan time for each VM instead of "Not available".
 
 ## [4.11.0]
 

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -106,6 +107,11 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 		vmIDs = append(vmIDs, vm.GetId())
 	}
 
+	scanTimeByVM, err := s.latestScanTimeByVM(ctx, vmIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	// Fetch per-VM CVE severity counts via SQL GROUP BY.
 	vmFilter := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, vmIDs...).ProtoQuery()
 	severityRows, err := s.cveView.CountBySeverityPerVM(ctx, vmFilter)
@@ -134,6 +140,7 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 			item.CveSeverityCounts = &v2.VulnCountBySeverity{}
 		}
 		item.ComponentScanCount = componentCountsByVM[vm.GetId()]
+		item.ScanTime = scanTimeByVM[vm.GetId()]
 		items = append(items, item)
 	}
 
@@ -210,6 +217,32 @@ func (s *serviceImpl) GetVMDashboardCounts(ctx context.Context, request *v2.VMDa
 		VmCount:  int32(vmCount),
 		CveCount: int32(cveCount),
 	}, nil
+}
+
+// latestScanTimeByVM returns the latest scan timestamp per VM. Scan IDs are
+// UUIDv7, so the greatest ID is the latest scan (same rule as GetVM).
+func (s *serviceImpl) latestScanTimeByVM(ctx context.Context, vmIDs []string) (map[string]*timestamppb.Timestamp, error) {
+	result := make(map[string]*timestamppb.Timestamp, len(vmIDs))
+	if len(vmIDs) == 0 {
+		return result, nil
+	}
+
+	q := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, vmIDs...).ProtoQuery()
+	scans, err := s.scanDS.SearchRawVMScans(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	latestID := make(map[string]string, len(scans))
+	for _, scan := range scans {
+		vmID := scan.GetVmV2Id()
+		if prevID, ok := latestID[vmID]; ok && scan.GetId() <= prevID {
+			continue
+		}
+		latestID[vmID] = scan.GetId()
+		result[vmID] = scan.GetScanTime()
+	}
+	return result, nil
 }
 
 // batchComponentScanCounts fetches all components for the given VM IDs in one query

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -953,27 +953,32 @@ func TestListVMs(t *testing.T) {
 		},
 		"should use scan time from the greatest scan ID": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
-				olderTime := timestamppb.New(time.Date(2025, time.April, 14, 8, 0, 0, 0, time.UTC))
-				newerTime := timestamppb.New(time.Date(2025, time.April, 15, 10, 30, 0, 0, time.UTC))
-				// UUIDv7 IDs sort lexicographically with time; smaller ID is returned first.
-				olderScan := &storage.VirtualMachineScanV2{
-					Id: "01800000-0000-7000-8000-000000000001", VmV2Id: "vm-1", ScanTime: olderTime,
+				// Greatest UUIDv7 ID sits in the middle with the earliest ScanTime
+				// so first-row, last-row, and max-timestamp picks fail.
+				lowID := &storage.VirtualMachineScanV2{
+					Id: "01800000-0000-7000-8000-000000000001", VmV2Id: "vm-1",
+					ScanTime: timestamppb.New(time.Date(2025, time.April, 16, 12, 0, 0, 0, time.UTC)),
 				}
-				newerScan := &storage.VirtualMachineScanV2{
-					Id: "01900000-0000-7000-8000-000000000002", VmV2Id: "vm-1", ScanTime: newerTime,
+				winID := &storage.VirtualMachineScanV2{
+					Id: "01900000-0000-7000-8000-000000000003", VmV2Id: "vm-1",
+					ScanTime: timestamppb.New(time.Date(2025, time.April, 14, 8, 0, 0, 0, time.UTC)),
+				}
+				midID := &storage.VirtualMachineScanV2{
+					Id: "01880000-0000-7000-8000-000000000002", VmV2Id: "vm-1",
+					ScanTime: timestamppb.New(time.Date(2025, time.April, 15, 10, 30, 0, 0, time.UTC)),
 				}
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
 				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil)
 				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return(nil, nil)
 				mockComp.EXPECT().SearchRawVMComponents(ctx, gomock.Any()).Return(nil, nil)
-				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{olderScan, newerScan}, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{lowID, winID, midID}, nil)
 				mockScan.EXPECT().GetBatch(ctx, gomock.Any()).Return(nil, nil)
 			},
 			expectedCount: 1,
 			checkResult: func(t *testing.T, resp *v2.ListVMsResponse) {
 				require.Len(t, resp.GetVms(), 1)
 				require.NotNil(t, resp.GetVms()[0].GetScanTime())
-				assert.Equal(t, time.Date(2025, time.April, 15, 10, 30, 0, 0, time.UTC), resp.GetVms()[0].GetScanTime().AsTime())
+				assert.Equal(t, time.Date(2025, time.April, 14, 8, 0, 0, 0, time.UTC), resp.GetVms()[0].GetScanTime().AsTime())
 			},
 		},
 		"vm count error": {

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -951,6 +951,31 @@ func TestListVMs(t *testing.T) {
 			},
 			expectedCount: 0,
 		},
+		"should use scan time from the greatest scan ID": {
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				olderTime := timestamppb.New(time.Date(2025, time.April, 14, 8, 0, 0, 0, time.UTC))
+				newerTime := timestamppb.New(time.Date(2025, time.April, 15, 10, 30, 0, 0, time.UTC))
+				// UUIDv7 IDs sort lexicographically with time; smaller ID is returned first.
+				olderScan := &storage.VirtualMachineScanV2{
+					Id: "01800000-0000-7000-8000-000000000001", VmV2Id: "vm-1", ScanTime: olderTime,
+				}
+				newerScan := &storage.VirtualMachineScanV2{
+					Id: "01900000-0000-7000-8000-000000000002", VmV2Id: "vm-1", ScanTime: newerTime,
+				}
+				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
+				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil)
+				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return(nil, nil)
+				mockComp.EXPECT().SearchRawVMComponents(ctx, gomock.Any()).Return(nil, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{olderScan, newerScan}, nil)
+				mockScan.EXPECT().GetBatch(ctx, gomock.Any()).Return(nil, nil)
+			},
+			expectedCount: 1,
+			checkResult: func(t *testing.T, resp *v2.ListVMsResponse) {
+				require.Len(t, resp.GetVms(), 1)
+				require.NotNil(t, resp.GetVms()[0].GetScanTime())
+				assert.Equal(t, time.Date(2025, time.April, 15, 10, 30, 0, 0, time.UTC), resp.GetVms()[0].GetScanTime().AsTime())
+			},
+		},
 		"vm count error": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(0, errors.New("count error"))

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -907,8 +907,9 @@ func TestListVMs(t *testing.T) {
 		Notes: []storage.VirtualMachineComponentV2_Note{storage.VirtualMachineComponentV2_UNSCANNED},
 	}
 
+	scanTime := timestamppb.New(time.Date(2025, time.April, 15, 10, 30, 0, 0, time.UTC))
 	scan1 := &storage.VirtualMachineScanV2{
-		Id: "scan-1", VmV2Id: "vm-1",
+		Id: "scan-1", VmV2Id: "vm-1", ScanTime: scanTime,
 	}
 
 	tests := map[string]struct {
@@ -928,6 +929,7 @@ func TestListVMs(t *testing.T) {
 				}).AnyTimes()
 				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return([]vmcve.VMSeverityCounts{sevCounts}, nil)
 				mockComp.EXPECT().SearchRawVMComponents(ctx, gomock.Any()).Return([]*storage.VirtualMachineComponentV2{comp1, compUnscanned}, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{scan1}, nil)
 				mockScan.EXPECT().GetBatch(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{scan1}, nil)
 			},
 			expectedCount: 1,
@@ -938,6 +940,8 @@ func TestListVMs(t *testing.T) {
 				assert.Equal(t, int32(1), item.GetCveSeverityCounts().GetCritical().GetFixable())
 				assert.Equal(t, int32(2), item.GetComponentScanCount().GetTotal())
 				assert.Equal(t, int32(1), item.GetComponentScanCount().GetScanned())
+				require.NotNil(t, item.GetScanTime())
+				assert.Equal(t, scanTime.AsTime(), item.GetScanTime().AsTime())
 			},
 		},
 		"empty list": {

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -120,6 +120,14 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				require.NotEmpty(t, listed.GetClusterName())
 				require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, listed.GetState())
 
+				detail := s.mustGetVMV2(snapshot.ID)
+				require.NotNil(t, detail.GetLatestScan(),
+					"GetVM.latest_scan should be set for a scanned VM")
+				require.NotNil(t, listed.GetScanTime(),
+					"ListVMs.scan_time should be populated from the latest scan")
+				require.Equal(t, detail.GetLatestScan().GetScanTime().AsTime(), listed.GetScanTime().AsTime(),
+					"ListVMs.scan_time should match GetVM.latest_scan.scan_time")
+
 				cves, total, err := vmhelpers.ListAllVMCVEsByVM(s.ctx, s.vmV2Client, snapshot.ID)
 				require.NoError(t, err)
 				require.Greater(t, total, int32(0), "scanned RHEL guest should report CVEs via ListVMCVEsByVM")

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -119,14 +119,8 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				require.NotEmpty(t, listed.GetClusterId())
 				require.NotEmpty(t, listed.GetClusterName())
 				require.Equal(t, v2.VirtualMachineV2State_VM_STATE_RUNNING, listed.GetState())
-
-				detail := s.mustGetVMV2(snapshot.ID)
-				require.NotNil(t, detail.GetLatestScan(),
-					"GetVM.latest_scan should be set for a scanned VM")
 				require.NotNil(t, listed.GetScanTime(),
 					"ListVMs.scan_time should be populated from the latest scan")
-				require.Equal(t, detail.GetLatestScan().GetScanTime().AsTime(), listed.GetScanTime().AsTime(),
-					"ListVMs.scan_time should match GetVM.latest_scan.scan_time")
 
 				cves, total, err := vmhelpers.ListAllVMCVEsByVM(s.ctx, s.vmV2Client, snapshot.ID)
 				require.NoError(t, err)


### PR DESCRIPTION
## Description

The Virtual Machine CVEs overview table shows a Scan time column from `VMListItem.scan_time`. ListVMs left that field unset, so scanned VMs rendered as "Not available".

Scan timestamps live on VirtualMachineScanV2. GetVM already loads the latest scan for a single VM. ListVMs now loads scans for the page's VM IDs, keeps the latest per VM (greatest UUIDv7 scan ID, same rule as GetVM), and sets `scan_time`.

The table already displays the field when the API returns it. No UI change.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI (including VM e2e tests)
    - [x] 1: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22693/pull-ci-stackrox-stackrox-master-ocp-4-14-vm-scanning-e2e-tests/2097299732119425024
    - [x] 2:  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22693/pull-ci-stackrox-stackrox-master-ocp-4-18-vm-scanning-e2e-tests/2097299732954091520
- [x] Deploy on an cluster and look at the UI

<img width="1282" height="341" alt="Screenshot 2026-09-08 at 14 33 32" src="https://github.com/user-attachments/assets/b1f19b53-449f-48f5-a757-74ec80e90fae" />
(rhel10-2 was running without agent installed)


AI-Assisted: cursor, generated the ListVMs scan_time fill and tests