### PR TITLE
ROX-36824: redact sensitive secret annotations in bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ## [4.11.4]
 
+### Technical Changes
+- ROX-36824: Diagnostic bundles now redact the value of the `openshift.io/token-secret.value` annotation on secrets. Previously this OpenShift-managed annotation, which contains a plaintext service account token on generated dockercfg secrets, was included unredacted in the bundle.
+
 **Full Changelog**: [4.11.3...4.11.4](https://github.com/stackrox/stackrox/compare/4.11.3...4.11.4)
 
 For a description of the changes, review the [Release Notes](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.11/html/release_notes/index) on the Red Hat Documentation portal.

--- a/pkg/k8sintrospect/redact.go
+++ b/pkg/k8sintrospect/redact.go
@@ -4,6 +4,18 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const redactedValue = "***REDACTED***"
+
+// sensitiveSecretAnnotations enumerates annotation keys whose values may contain
+// sensitive data and therefore must be redacted before a secret is included in a
+// diagnostic bundle. Unlike the secret `data` field, these values are not covered
+// by the data redaction below.
+var sensitiveSecretAnnotations = []string{
+	// OpenShift stores a plaintext copy of the service account token in this
+	// annotation on the generated dockercfg secrets (ROX-36824).
+	"openshift.io/token-secret.value",
+}
+
 // RedactGeneric removes fields we don't care about for any object type. This includes:
 // - the `kubectl.kubernetes.io/last-applied-configuration`
 // - the selfLink field (this is not object-specific and fully captured by name, namespace, and kind)
@@ -23,11 +35,28 @@ func RedactSecret(secret *unstructured.Unstructured) {
 	if found && err == nil {
 		redactedStringData := make(map[string]string, len(dataMap))
 		for key := range dataMap {
-			redactedStringData[key] = "***REDACTED***"
+			redactedStringData[key] = redactedValue
 		}
 		_ = unstructured.SetNestedStringMap(secret.UnstructuredContent(), redactedStringData, "stringData")
 	}
 	unstructured.RemoveNestedField(secret.UnstructuredContent(), "data")
+
+	// Some secrets carry sensitive values in their annotations (e.g. the plaintext
+	// service account token OpenShift stores on dockercfg secrets). Redact those
+	// values while keeping the annotation key, so the bundle still shows the
+	// annotation was present.
+	if annotations := secret.GetAnnotations(); len(annotations) > 0 {
+		modified := false
+		for _, key := range sensitiveSecretAnnotations {
+			if _, ok := annotations[key]; ok {
+				annotations[key] = redactedValue
+				modified = true
+			}
+		}
+		if modified {
+			secret.SetAnnotations(annotations)
+		}
+	}
 }
 
 // FilterOutServiceAccountSecrets filters out secrets that are associated with a Kubernetes service account.

--- a/pkg/k8sintrospect/redact_test.go
+++ b/pkg/k8sintrospect/redact_test.go
@@ -86,3 +86,42 @@ func TestRedactSecret(t *testing.T) {
 	assert.Equal(t, redactedSecret.StringData, expectedStringData)
 	assert.Empty(t, redactedSecret.Data)
 }
+
+func TestRedactSecretSensitiveAnnotations(t *testing.T) {
+	secret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "stackrox",
+			Name:      "builder-dockercfg-abcde",
+			Annotations: map[string]string{
+				"openshift.io/token-secret.value":    "test-only-placeholder-token-not-a-real-secret",
+				"openshift.io/token-secret.name":     "builder-token-abcde",
+				"kubernetes.io/service-account.name": "builder",
+			},
+		},
+		Type: v1.SecretTypeDockercfg,
+		Data: map[string][]byte{
+			".dockercfg": []byte(`{"registry":{"auth":"c2VjcmV0"}}`),
+		},
+	}
+
+	var unstructuredSecret unstructured.Unstructured
+	require.NoError(t, scheme.Scheme.Convert(&secret, &unstructuredSecret, nil))
+
+	RedactSecret(&unstructuredSecret)
+
+	var redactedSecret v1.Secret
+	require.NoError(t, scheme.Scheme.Convert(&unstructuredSecret, &redactedSecret, nil))
+
+	// The sensitive token annotation value must be redacted...
+	assert.Equal(t, "***REDACTED***", redactedSecret.Annotations["openshift.io/token-secret.value"])
+	// ...while non-sensitive annotations are preserved verbatim.
+	assert.Equal(t, "builder-token-abcde", redactedSecret.Annotations["openshift.io/token-secret.name"])
+	assert.Equal(t, "builder", redactedSecret.Annotations["kubernetes.io/service-account.name"])
+	// The data field is still redacted as before.
+	assert.Empty(t, redactedSecret.Data)
+	assert.Equal(t, "***REDACTED***", redactedSecret.StringData[".dockercfg"])
+}


### PR DESCRIPTION
Manual backport of #22681 to `release-4.11` (automated backport failed with a cherry-pick conflict in `CHANGELOG.md`).

## Description

The ACS diagnostic bundle included the unredacted value of the `openshift.io/token-secret.value` annotation on OpenShift dockercfg secrets, leaking a plaintext copy of the service account token. See #22681 for full root-cause analysis, validation, and testing details.

Cherry-pick of 315f7745efa2c1557bd7d6f7866b8ac9db4331ac. Only conflict was in `CHANGELOG.md` (release-branch history diverged from master); resolved by placing the changelog entry under the current unreleased `## [4.11.4]` section. `pkg/k8sintrospect/redact.go` and `redact_test.go` applied without conflicts, verified identical to the original PR, and `go test ./pkg/k8sintrospect/...` passes.