### PR TITLE
fix: honor namespace overrides related to scanner V4

### DIFF
--- a/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/indexer-config.yaml.tpl
@@ -11,7 +11,7 @@ indexer:
   enable: true
   database:
     conn_string: >
-      host=scanner-v4-db.{{ .Release.Namespace }}.svc
+      host=scanner-v4-db.{{ ._rox._namespace }}.svc
       port=5432
       sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
       user=postgres
@@ -29,11 +29,11 @@ indexer:
     password_file: /run/secrets/stackrox.io/secrets/password
   get_layer_timeout: 1m
   {{- if ._rox.env.centralServices }}
-  repository_to_cpe_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=repo2cpe
-  name_to_repos_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?file=name2repos
+  repository_to_cpe_url: https://central.{{ ._rox._namespace }}.svc/api/extensions/scannerdefinitions?file=repo2cpe
+  name_to_repos_url: https://central.{{ ._rox._namespace }}.svc/api/extensions/scannerdefinitions?file=name2repos
   {{- else }}
-  repository_to_cpe_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=repo2cpe
-  name_to_repos_url: https://sensor.{{ .Release.Namespace }}.svc/scanner/definitions?file=name2repos
+  repository_to_cpe_url: https://sensor.{{ ._rox._namespace }}.svc/scanner/definitions?file=repo2cpe
+  name_to_repos_url: https://sensor.{{ ._rox._namespace }}.svc/scanner/definitions?file=name2repos
   {{- end }}
   repository_to_cpe_file: /run/mappings/repository-to-cpe.json
   name_to_repos_file: /run/mappings/container-name-repos-map.json

--- a/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
+++ b/image/templates/helm/shared/config-templates/scanner-v4/matcher-config.yaml.tpl
@@ -13,7 +13,7 @@ matcher:
   enable: true
   database:
     conn_string: >
-      host=scanner-v4-db.{{ .Release.Namespace }}.svc
+      host=scanner-v4-db.{{ ._rox._namespace }}.svc
       port=5432
       sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
       user=postgres
@@ -29,8 +29,8 @@ matcher:
 {{- end }}
       client_encoding=UTF8
     password_file: /run/secrets/stackrox.io/secrets/password
-  vulnerabilities_url: https://central.{{ .Release.Namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VULNERABILITY_VERSION
-  indexer_addr: scanner-v4-indexer.{{ .Release.Namespace }}.svc:8443
+  vulnerabilities_url: https://central.{{ ._rox._namespace }}.svc/api/extensions/scannerdefinitions?version=ROX_VULNERABILITY_VERSION
+  indexer_addr: scanner-v4-indexer.{{ ._rox._namespace }}.svc:8443
 log_level: "{{ ._rox.scannerV4.matcher.logLevel }}"
 grpc_listen_addr: 0.0.0.0:8443
 http_listen_addr: 0.0.0.0:9443

--- a/image/templates/helm/shared/templates/02-scanner-v4-00-serviceaccount.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-00-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: scanner-v4
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "scanner-v4") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-01-psps.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-01-psps.yaml
@@ -24,7 +24,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: stackrox-scanner-v4-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "stackrox-scanner-v4-psp") | nindent 4 }}
   annotations:
@@ -36,7 +36,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: scanner-v4
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
 
 ---
 

--- a/image/templates/helm/shared/templates/02-scanner-v4-01-security.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-01-security.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: use-scanner-v4-scc
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "use-scanner-v4-scc") | nindent 4 }}
   annotations:
@@ -31,7 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: scanner-v4-use-scc
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "scanner-v4-use-scc") | nindent 4 }}
   annotations:
@@ -43,6 +43,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: scanner-v4
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   {{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-02-db-password-secret.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-02-db-password-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: scanner-v4-db-password
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "secret" "scanner-v4-db-password") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-03-db-tls-secret.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-03-db-tls-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: scanner-v4-db-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     rhacs.redhat.com/tls: "true"
     {{- include "srox.labels" (list . "secret" "scanner-v4-db-tls") | nindent 4 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-03-indexer-tls-secret.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-03-indexer-tls-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: scanner-v4-indexer-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     rhacs.redhat.com/tls: "true"
     {{- include "srox.labels" (list . "secret" "scanner-v4-indexer-tls") | nindent 4 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-03-matcher-tls-secret.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-03-matcher-tls-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: scanner-v4-matcher-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     rhacs.redhat.com/tls: "true"
     {{- include "srox.labels" (list . "secret" "scanner-v4-matcher-tls") | nindent 4 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-04-db-config.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-04-db-config.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scanner-v4-db-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "configmap" "scanner-v4-db-config") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-04-indexer-config.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-04-indexer-config.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scanner-v4-indexer-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "configmap" "scanner-v4-indexer-config") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-04-matcher-config.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-04-matcher-config.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: scanner-v4-matcher-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "configmap" "scanner-v4-matcher-config") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-db-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-db-network-policy.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-db
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-db") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-indexer-network-policy.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-indexer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-indexer") | nindent 4 }}
   annotations:
@@ -48,7 +48,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-indexer-monitoring
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-indexer-monitoring") | nindent 4 }}
   annotations:
@@ -70,7 +70,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-indexer-monitoring-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-indexer-monitoring-tls") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-05-matcher-network-policy.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-matcher
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-matcher") | nindent 4 }}
   annotations:
@@ -32,7 +32,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-matcher-monitoring
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-matcher-monitoring") | nindent 4 }}
   annotations:
@@ -54,7 +54,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: scanner-v4-matcher-monitoring-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "scanner-v4-matcher-monitoring-tls") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-06-db-pvc.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-06-db-pvc.yaml
@@ -33,7 +33,7 @@ spec:
   accessModes:
   - ReadWriteOnce
   claimRef:
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ quote ._rox._namespace }}
     name: {{ $claimName }}
   {{- toYaml $pvcCfg.volume.volumeSpec | nindent 2 }}
 
@@ -44,7 +44,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ $claimName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     # this is used for backwards compatibility for operator if there are PVCs without annotation
     # owned by the operator it will assume they belong to the deprecated central-db

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scanner-v4-db
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     app: scanner-v4-db
     {{- include "srox.labels" (list . "deployment" "scanner-v4-db") | nindent 4 }}
@@ -20,7 +20,7 @@ spec:
     type: Recreate
   template:
     metadata:
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ quote ._rox._namespace }}
       labels:
         app: scanner-v4-db
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-db") | nindent 8 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-indexer-deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scanner-v4-indexer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     app: scanner-v4-indexer
     {{- include "srox.labels" (list . "deployment" "scanner-v4-indexer") | nindent 4 }}
@@ -22,7 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ quote ._rox._namespace }}
       labels:
         app: scanner-v4-indexer
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-indexer") | nindent 8 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-matcher-deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scanner-v4-matcher
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     app: scanner-v4-matcher
     {{- include "srox.labels" (list . "deployment" "scanner-v4-matcher") | nindent 4 }}
@@ -22,7 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ quote ._rox._namespace }}
       labels:
         app: scanner-v4-matcher
         {{- include "srox.podLabels" (list . "deployment" "scanner-v4-matcher") | nindent 8 }}

--- a/image/templates/helm/shared/templates/02-scanner-v4-08-db-service.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-08-db-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: scanner-v4-db
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "scanner-v4-db") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-08-indexer-service.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-08-indexer-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: scanner-v4-indexer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "scanner-v4-indexer") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-08-matcher-service.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-08-matcher-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: scanner-v4-matcher
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "scanner-v4-matcher") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-09-indexer-hpa.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-09-indexer-hpa.yaml
@@ -4,7 +4,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: scanner-v4-indexer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "horizontalpodautoscaler" "scanner-v4-indexer") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/02-scanner-v4-09-matcher-hpa.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-09-matcher-hpa.yaml
@@ -4,7 +4,7 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   name: scanner-v4-matcher
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ quote ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "horizontalpodautoscaler" "scanner-v4-matcher") | nindent 4 }}
   annotations:

--- a/image/templates/helm/shared/templates/99-scanner-v4-openshift-monitoring.yaml
+++ b/image/templates/helm/shared/templates/99-scanner-v4-openshift-monitoring.yaml
@@ -22,7 +22,7 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-      serverName: "scanner-v4-indexer.{{ .Release.Namespace }}.svc"
+      serverName: "scanner-v4-indexer.{{ ._rox._namespace }}.svc"
     {{- end }}
     {{- if ._rox.scannerV4._matcherEnabled }}
   - interval: 30s
@@ -33,14 +33,14 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
       keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
-      serverName: "scanner-v4-matcher.{{ .Release.Namespace }}.svc"
+      serverName: "scanner-v4-matcher.{{ ._rox._namespace }}.svc"
     {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: scanner-v4
   namespaceSelector:
     matchNames:
-    - "{{ .Release.Namespace }}"
+    - "{{ ._rox._namespace }}"
 ---
 {{/* TODO(ROX-22188): Switch to a ClusterRoleBinding to avoid leaking to
      kube-system namespace. */ -}}
@@ -60,6 +60,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: scanner-v4
-    namespace: "{{ .Release.Namespace }}"
+    namespace: "{{ ._rox._namespace }}"
   {{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/_crypto.tpl
+++ b/image/templates/helm/shared/templates/_crypto.tpl
@@ -235,7 +235,7 @@
 {{ $ := index . 0 }}
 {{ $out := index . 1 }}
 {{ $svcName := index . 2 }}
-{{ $releaseNS := $.Release.Namespace }}
+{{ $releaseNS := $._rox._namespace }}
 {{ $sans := list }}
 {{ range $ns := list $releaseNS "stackrox" | uniq | sortAlpha }}
   {{ $baseDNS := printf "%s.%s" $svcName $ns }}

--- a/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
+++ b/image/templates/helm/shared/templates/_scanner-v4_init.tpl.htpl
@@ -67,7 +67,7 @@
         {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
         {{- if $.Release.IsUpgrade -}}
           {{- $lookupOut := dict -}}
-          {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-indexer-tls") -}}
+          {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $._rox._namespace "scanner-v4-indexer-tls") -}}
           {{- if not $lookupOut.result -}}
             {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
             {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
@@ -87,7 +87,7 @@
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
       {{- if $.Release.IsUpgrade -}}
         {{- $lookupOut := dict -}}
-        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-matcher-tls") -}}
+        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $._rox._namespace "scanner-v4-matcher-tls") -}}
         {{- if not $lookupOut.result -}}
           {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
           {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
@@ -105,7 +105,7 @@
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
       {{- if $.Release.IsUpgrade -}}
         {{- $lookupOut := dict -}}
-        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-tls") -}}
+        {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $._rox._namespace "scanner-v4-db-tls") -}}
         {{- if not $lookupOut.result -}}
           {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
           {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
@@ -117,7 +117,7 @@
       {{/* We need special handling here, because 'generate' will default to 'false' on upgrades. */}}
       {{/* And in case scanner V4 was not deployed earlier, we need to make sure that these resources are correctly initialized. */}}
       {{- $lookupOut := dict -}}
-      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $.Release.Namespace "scanner-v4-db-password") -}}
+      {{- $_ := include "srox.safeLookup" (list $ $lookupOut "v1" "Secret" $._rox._namespace "scanner-v4-db-password") -}}
       {{- if not $lookupOut.result -}}
         {{/* If generate=null and the resource does not exist yet, attempt to create it. */}}
         {{/* If lookup is not possible (e.g. in the operator), then 'generate' needs to be set correctly. */}}
@@ -139,7 +139,7 @@
   {{/* Special handling for the secured-cluster-services chart in case it gets deployed
        to the same namespace as central-services. */}}
   {{ $centralDeployment := dict }}
-  {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $.Release.Namespace "central") }}
+  {{ include "srox.safeLookup" (list $ $centralDeployment "apps/v1" "Deployment" $._rox._namespace "central") }}
   {{ if $centralDeployment.result }}
     {{ include "srox.note" (list $ "Detected central running in the same namespace. Not deploying scanner-v4-indexer from this chart and configuring sensor to use existing scanner-v4-indexer instance, if any.") }}
     {{ $_ := set $components "indexer" false }}

--- a/image/templates/helm/stackrox-central/internal/bootstrap-defaults.yaml.tpl
+++ b/image/templates/helm/stackrox-central/internal/bootstrap-defaults.yaml.tpl
@@ -11,6 +11,8 @@ allowNonstandardNamespace: false
 allowNonstandardReleaseName: false
 {{- end }}
 
+_namespace: {{ quote .Release.Namespace }}
+
 meta:
   useLookup: true
   fileOverrides: {}

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -242,7 +242,7 @@ spec:
           value: {{ quote ._rox._configFP }}
         {{- if ._rox._scannerV4Enabled }}
         - name: ROX_SCANNER_V4_INDEXER_ENDPOINT
-          value: {{ printf "scanner-v4-indexer.%s.svc:8443" .Release.Namespace }}
+          value: {{ printf "scanner-v4-indexer.%s.svc:8443" ._rox._namespace }}
         - name: ROX_SCANNER_V4
           value: "true"
         {{- end }}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/upgrade.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/upgrade.test.yaml
@@ -22,3 +22,11 @@ tests:
     meta.namespaceOverride: my-stackrox
   expect: |
     verifyNamespace("my-stackrox")
+- name: "should honor the namespace override for scanner V4 indexer endpoint"
+  release:
+    namespace: default
+  set:
+    meta.namespaceOverride: my-stackrox
+  expect: |
+    envVars(.deployments.sensor; "sensor")["ROX_SCANNER_V4_INDEXER_ENDPOINT"]
+      | assertThat(. == "scanner-v4-indexer.my-stackrox.svc:8443")

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/upgrade.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/upgrade.test.yaml
@@ -30,3 +30,21 @@ tests:
   expect: |
     envVars(.deployments.sensor; "sensor")["ROX_SCANNER_V4_INDEXER_ENDPOINT"]
       | assertThat(. == "scanner-v4-indexer.my-stackrox.svc:8443")
+- name: "should honor the namespace override for scanner V4 monitoring"
+  server:
+    availableSchemas:
+    - openshift-4.12
+    - com.coreos
+  release:
+    namespace: default
+  set:
+    meta.namespaceOverride: my-stackrox
+    env.openshift: 4
+    monitoring.openshift.enabled: true
+  expect: |
+    .servicemonitors["scanner-v4-monitor-default"]
+      | assertThat(.spec.namespaceSelector.matchNames[0] == "my-stackrox")
+    .servicemonitors["scanner-v4-monitor-default"]
+      | .spec.endpoints[] | .tlsConfig.serverName | assertThat(endswith(".my-stackrox.svc"))
+    .rolebindings["rhacs-scanner-v4-auth-reader-default"]
+      | .subjects[] | select(.name == "scanner-v4") | assertThat(.namespace == "my-stackrox")

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/upgrade.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/upgrade.test.yaml
@@ -1,4 +1,6 @@
 values:
+  scannerV4:
+    disable: false
   imagePullSecrets:
     allowNone: true
 release:


### PR DESCRIPTION
## Description

Required for https://redhat.atlassian.net/browse/ROX-36653.

Scanner V4 templates used `.Release.Namespace` directly instead of the resolved
`._rox._namespace`, causing all V4 resources to ignore `meta.namespaceOverride`
in the secured-cluster chart. This affected:

- All scanner V4 resource templates (namespace field)
- Scanner V4 config templates (service endpoint FQDNs)
- Sensor's `ROX_SCANNER_V4_INDEXER_ENDPOINT` env var
- OpenShift monitoring resources (ServiceMonitor `namespaceSelector`, TLS
  `serverName`, RoleBinding subject namespace)
- `safeLookup` calls in scanner V4 init (secret existence checks, central
  co-location detection)
- Certificate SAN generation in `computeSANs` (shared, not scanner V4 specific)

The bug was latent because V4 was previously disabled for pre-4.8 upgrades, and
the upgrade test was the only test exercising `namespaceOverride`.

The fix adds `_namespace` to the central-services bootstrap defaults (set to
`.Release.Namespace`, matching the secured-cluster pattern without the override
feature) and replaces all `.Release.Namespace` references in scanner V4 code
paths with `._rox._namespace`.

Non-scanner-V4 resources have the same inconsistency but are not addressed here
to limit scope. A separate JIRA issue tracks those.

## User-facing documentation

Not needed.

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Just automated tests.