### PR TITLE
fix(ui): remove VM tech preview label

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachineCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachineCvesOverviewPage.test.ts
@@ -54,6 +54,7 @@ describe('Virtual Machine CVEs - Overview Page', () => {
         );
 
         cy.get('h1').contains('Virtual machine vulnerabilities');
+        cy.contains('Technology preview').should('not.exist');
         cy.get('body').contains('Prioritize and remediate observed CVEs across virtual machines');
     });
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachineCvesOverviewPage.tsx
@@ -1,7 +1,6 @@
 import { Content, Flex, PageSection, Title } from '@patternfly/react-core';
 
 import PageTitle from 'Components/PageTitle';
-import TechnologyPreviewLabel from 'Components/PatternFly/PreviewLabel/TechnologyPreviewLabel';
 import { useManagedColumns } from 'hooks/useManagedColumns';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLPagination from 'hooks/useURLPagination';
@@ -37,10 +36,7 @@ function VirtualMachineCvesOverviewPage() {
             <PageTitle title="Virtual Machine CVEs Overview" />
             <PageSection component="div">
                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
-                    <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                        <Title headingLevel="h1">Virtual machine vulnerabilities</Title>
-                        <TechnologyPreviewLabel />
-                    </Flex>
+                    <Title headingLevel="h1">Virtual machine vulnerabilities</Title>
                     <Content component="p">
                         Prioritize and remediate observed CVEs across virtual machines
                     </Content>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeaderLegacy.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageHeaderLegacy.tsx
@@ -1,6 +1,5 @@
 import { Alert, Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
 
-import TechnologyPreviewLabel from 'Components/PatternFly/PreviewLabel/TechnologyPreviewLabel';
 import type { VirtualMachine } from 'services/VirtualMachineService';
 import { getDateTime } from 'utils/dateUtils';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -46,10 +45,7 @@ function VirtualMachinePageHeaderLegacy({
 
     return (
         <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsFlexStart' }}>
-            <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                <Title headingLevel="h1">{virtualMachine.name}</Title>
-                <TechnologyPreviewLabel />
-            </Flex>
+            <Title headingLevel="h1">{virtualMachine.name}</Title>
             <LabelGroup numLabels={5}>
                 <Label>
                     In: {virtualMachine.clusterName}/{virtualMachine.namespace}


### PR DESCRIPTION
## Description

Virtual machine scanning is Generally Available this release, but the Virtual machine vulnerabilities page still showed a Technology preview pill next to the heading. This PR removes that pill from the overview page and from the leftover legacy VM detail header. The current VM detail header already has no pill. Integration pages that are still in Technology Preview keep their labels.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
No CHANGELOG entry: that file is a merge-conflict magnet this close to code freeze.

- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI

AI-Assisted: cursor, generated the label removal and Cypress assertion; user directed the change.