### PR TITLE
ROX-35773: Bump wait time

### DIFF
--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -468,7 +468,7 @@ func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.Secu
 			}
 		}
 		assert.NotEmpty(collect, policyId)
-	}, time.Second*5, time.Millisecond*30)
+	}, time.Second*30, time.Millisecond*30)
 	return policyId
 }
 


### PR DESCRIPTION
## Description

Patch provided by CI fixing factory

```
Low priority. Consider increasing the EventuallyWithT timeout in
createCRAndObserveInCentral (tests/policy_as_code_test.go:459-471) from 5s
to a more generous window (e.g. 15-30s) to tolerate config-controller
reconcile latency under CI load.
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] let CI run
