### PR TITLE
fix(ci): Match scanner-v4-matcher restart log names

### DIFF
--- a/tests/e2e/bats/fixtures/check-restart-logs-output.txt
+++ b/tests/e2e/bats/fixtures/check-restart-logs-output.txt
@@ -3,6 +3,6 @@ collector-11111-node-inventory-previous.log copied to Artifacts
 Example for DaemonSet container
 collector-22222-node-inventory-previous.log copied to Artifacts
 Example for deployment container
-scanner-v4-111111111-11111-matcher-previous.log copied to Artifacts
+scanner-v4-matcher-111111111-11111-matcher-previous.log copied to Artifacts
 Example for unknown pod
 unknown-pod-111111111-11111-container-previous.log copied to Artifacts

--- a/tests/e2e/bats/junit_report_pod_restarts.bats
+++ b/tests/e2e/bats/junit_report_pod_restarts.bats
@@ -2,6 +2,23 @@
 
 load "../../../scripts/test_helpers.bats"
 
+# Real previous-log names from collect-service-logs.sh: <pod>-<container>-previous.log.
+# Matcher/indexer pods are scanner-v4-matcher-* / scanner-v4-indexer-*, not scanner-v4-*.
+@test "POD_CONTAINERS_MAP matches scanner-v4-matcher and indexer previous logs" {
+    source "${BATS_TEST_DIRNAME}/../lib.sh"
+
+    local matcher_re indexer_re
+    matcher_re="${POD_CONTAINERS_MAP["pod: scanner-v4-matcher - container: matcher"]}"
+    indexer_re="${POD_CONTAINERS_MAP["pod: scanner-v4-indexer - container: indexer"]}"
+
+    [[ -n "${matcher_re}" ]]
+    [[ -n "${indexer_re}" ]]
+    [[ "scanner-v4-matcher-b49db6cbf-kg6p8-matcher-previous.log" =~ ${matcher_re} ]]
+    [[ "scanner-v4-indexer-65d57884b9-c8dt2-indexer-previous.log" =~ ${indexer_re} ]]
+    # Combined scanner-v4-<rs>-<hash> names must not match (those pods do not exist).
+    [[ ! "scanner-v4-111111111-11111-matcher-previous.log" =~ ${matcher_re} ]]
+}
+
 @test "junit_report_pod_restarts - clean" {
     source "${BATS_TEST_DIRNAME}/../lib.sh"
 
@@ -37,7 +54,7 @@ load "../../../scripts/test_helpers.bats"
     POD_CONTAINERS_MAP=()
 
     # Deployment failure
-    POD_CONTAINERS_MAP["pod: scanner-v4 - container: matcher"]="scanner-v4-[A-Za-z0-9]+-[A-Za-z0-9]+-matcher-previous.log"
+    POD_CONTAINERS_MAP["pod: scanner-v4-matcher - container: matcher"]="scanner-v4-matcher-[A-Za-z0-9]+-[A-Za-z0-9]+-matcher-previous.log"
     # DaemonSet failure (with two pods failed)
     POD_CONTAINERS_MAP["pod: collector - container: node-inventory"]="collector-[A-Za-z0-9]+-node-inventory-previous.log"
     # No failure
@@ -49,7 +66,7 @@ load "../../../scripts/test_helpers.bats"
     # 1 without failure and 3 failed (4 in output, but 1 de-duplicated)
     [ "${#lines[@]}" -eq 4 ]
     assert_line 'Success: Check unexpected pod restarts pod: sensor - container: sensor'
-    assert_line 'Fail: Check unexpected pod restarts pod: scanner-v4 - container: matcher'
+    assert_line 'Fail: Check unexpected pod restarts pod: scanner-v4-matcher - container: matcher'
     assert_line 'Fail: Check unexpected pod restarts pod: collector - container: node-inventory'
     assert_line 'Fail: Check unexpected pod restarts unknown'
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -42,8 +42,9 @@ POD_CONTAINERS_MAP["pod: config-controller - container: manager"]="config-contro
 POD_CONTAINERS_MAP["pod: scanner - container: scanner"]="scanner-[A-Za-z0-9]+-[A-Za-z0-9]+-scanner-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-db - container: init-db"]="scanner-db-[A-Za-z0-9]+-[A-Za-z0-9]+-init-db-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-db - container: db"]="scanner-db-[A-Za-z0-9]+-[A-Za-z0-9]+-db-previous.log"
-POD_CONTAINERS_MAP["pod: scanner-v4 - container: matcher"]="scanner-v4-[A-Za-z0-9]+-[A-Za-z0-9]+-matcher-previous.log"
-POD_CONTAINERS_MAP["pod: scanner-v4 - container: indexer"]="scanner-v4-[A-Za-z0-9]+-[A-Za-z0-9]+-indexer-previous.log"
+# Matcher and indexer are separate deployments: scanner-v4-matcher-*, scanner-v4-indexer-*.
+POD_CONTAINERS_MAP["pod: scanner-v4-matcher - container: matcher"]="scanner-v4-matcher-[A-Za-z0-9]+-[A-Za-z0-9]+-matcher-previous.log"
+POD_CONTAINERS_MAP["pod: scanner-v4-indexer - container: indexer"]="scanner-v4-indexer-[A-Za-z0-9]+-[A-Za-z0-9]+-indexer-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-v4-db - container: init-db"]="scanner-v4-db-[A-Za-z0-9]+-[A-Za-z0-9]+-init-db-previous.log"
 POD_CONTAINERS_MAP["pod: scanner-v4-db - container: db"]="scanner-v4-db-[A-Za-z0-9]+-[A-Za-z0-9]+-db-previous.log"
 POD_CONTAINERS_MAP["pod: sensor - container: sensor"]="sensor-[A-Za-z0-9]+-[A-Za-z0-9]+-sensor-previous.log"


### PR DESCRIPTION
## Description

When Scanner V4 matcher or indexer restarts, CI saves a previous-container log named after the real pod, for example `scanner-v4-matcher-b49db6cbf-kg6p8-matcher-previous.log`.

The restart-check name map expected a pod called `scanner-v4`. Those files do not match. Unmatched names become the first token before `-`, so junit reports a failure named `scanner`. Flake rules then look for `scanner` and miss the matcher.

This PR maps matcher and indexer to their real pod names. Scanner V2 map entries stay; those pods still exist on current installs.

Same matcher restart, same log file, different junit name in Prow:

Today:

```
Check unexpected pod restarts / scanner
```

After this PR:

```
Check unexpected pod restarts / pod: scanner-v4-matcher - container: matcher
```

An indexer restart of the same shape would go from `scanner` to `pod: scanner-v4-indexer - container: indexer`.

The OOM post-check already names the matcher (`OOM Check / Check for scanner-v4-matcher OOM kills`). This PR does not change that.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

No manual validation beyond the automated tests.

AI-Assisted: cursor, generated the map/regex change and bats coverage; user chose a master PR
