### PR TITLE
test(ui): accept empty Node CVEs table in Cypress

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/NodeCve.helpers.ts
@@ -1,14 +1,10 @@
 import type { RouteHandler, RouteMatcherOptions } from 'cypress/types/net-stubbing';
 
 import { graphql } from '../../../constants/apiEndpoints';
-import {
-    getRouteMatcherMapForGraphQL,
-    interactAndWaitForResponses,
-} from '../../../helpers/request';
 import { visit, visitWithStaticResponseForPermissions } from '../../../helpers/visit';
-import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 
 export const nodeCveBaseUrl = '/main/vulnerabilities/node-cves/cves';
+export const nodePageBaseUrl = '/main/vulnerabilities/node-cves/nodes';
 
 // Source of truth for keys in routeMatcherMap and staticResponseMap objects.
 // Overview page
@@ -100,6 +96,16 @@ export function visitNodeCvePage(
     return visit(mockNodeCvePageUrl, routeMatcherMap, staticResponseMap);
 }
 
+export function visitNodePage(
+    nodeId: string,
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>,
+    params?: Record<string, string>
+) {
+    const paramString = params ? `?${new URLSearchParams(params).toString()}` : '';
+    return visit(`${nodePageBaseUrl}/${nodeId}${paramString}`, routeMatcherMap, staticResponseMap);
+}
+
 export function visitNodeCvePageWithStaticPermissions(
     mockCveName: string,
     resourceToAccess: Record<string, string>,
@@ -130,22 +136,8 @@ export const staticResponseMapForNodePage = {
     },
 };
 
-export function visitFirstNodeLinkFromTable(): Cypress.Chainable<string> {
-    // Get the name of the first node in the table and pass it to the caller
-    return cy
-        .get('tbody tr td[data-label="Node"] a')
-        .first()
-        .then(($link) => {
-            interactAndWaitForResponses(
-                () => cy.wrap($link).click(),
-                getRouteMatcherMapForGraphQL(['getNodeMetadata'])
-            );
-            return cy.wrap($link.text());
-        });
-}
-
-export function visitFirstNodeFromOverviewPage() {
-    visitNodeCveOverviewPage();
-    cy.get(vulnSelectors.entityTypeToggleItem('Node')).click();
-    visitFirstNodeLinkFromTable();
-}
+export const staticResponseMapForNodes = {
+    [getNodesOpname]: {
+        fixture: `vulnerabilities/nodeCves/${getNodesOpname}`,
+    },
+};

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -121,9 +121,8 @@ describe('Node CVEs - Overview Page', () => {
             .first()
             .then(($link) => {
                 const linkHref = $link.attr('href');
-                const linkName = $link.text();
                 expect(linkHref).to.match(/\/node-cves\/nodes\/1$/);
-                expect(linkName).to.eq('cypress-node-1');
+                expect($link.text()).to.include('cypress-node-1');
             });
     });
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeCvesOverviewPage.test.ts
@@ -12,7 +12,7 @@ import {
     routeMatcherMapForEntityCounts,
     routeMatcherMapForNodeCves,
     routeMatcherMapForNodes,
-    visitFirstNodeLinkFromTable,
+    staticResponseMapForNodes,
     visitNodeCveOverviewPage,
 } from './NodeCve.helpers';
 import {
@@ -111,12 +111,20 @@ describe('Node CVEs - Overview Page', () => {
     });
 
     it('should link a Node table row to the correct Node detail page', () => {
-        visitNodeCveOverviewPage();
-        visitEntityTab('Node');
-
-        visitFirstNodeLinkFromTable().then((name) => {
-            cy.get('h1').contains(name);
+        // This table lists nodes that have unsnoozed CVEs. A scan with none leaves
+        // it empty, so CI cannot rely on live rows. Mock the list and assert hrefs.
+        visitNodeCveOverviewPage(routeMatcherMapForNodes, staticResponseMapForNodes, {
+            entityTab: 'Node',
         });
+
+        cy.get('tbody tr td[data-label="Node"] a')
+            .first()
+            .then(($link) => {
+                const linkHref = $link.attr('href');
+                const linkName = $link.text();
+                expect(linkHref).to.match(/\/node-cves\/nodes\/1$/);
+                expect(linkName).to.eq('cypress-node-1');
+            });
     });
 
     it('should sort CVE table columns', () => {
@@ -187,6 +195,8 @@ describe('Node CVEs - Overview Page', () => {
     });
 
     it('should sort Node table columns', () => {
+        // Sorting asserts request payloads. The table may have zero rows when
+        // no unsnoozed Node CVEs exist; headers still trigger those requests.
         interceptAndWatchRequests(routeMatcherMapForNodes).then(
             ({
                 waitForRequests,
@@ -314,6 +324,7 @@ describe('Node CVEs - Overview Page', () => {
         // expectRequestedQueryToIncludeSubstrings asserts items to be independent
         // of order in concatenated query string
         // of CVE Snoozed that is outside scope of test
+        // Row-content checks no-op when the table is empty (no unsnoozed Node CVEs).
         interceptAndWatchRequests(routeMatcherMapForNodes).then(
             ({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
                 // Visit Node tab and wait for initial load

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../workloadCves/WorkloadCves.helpers';
 import {
     getNodeVulnerabilitiesOpname,
+    nodePageBaseUrl,
     routeMatcherMapForNodePage,
     routeMatcherMapForNodes,
     staticResponseMapForNodePage,
@@ -33,11 +34,10 @@ import {
 
 const { assertAvailableFilters } = filterHelpers;
 
-const nodeBaseUrl = '/main/vulnerabilities/node-cves/nodes';
 const mockNodeId = '1';
 const mockNodeName = 'cypress-node-1';
 
-const mockNodePageUrl = `${nodeBaseUrl}/${mockNodeId}`;
+const mockNodePageUrl = `${nodePageBaseUrl}/${mockNodeId}`;
 
 describe('Node CVEs - Node Detail Page', () => {
     withAuth();
@@ -103,7 +103,9 @@ describe('Node CVEs - Node Detail Page', () => {
                 waitForRequests();
 
                 const waitForVulnQuery = () =>
-                    waitAndYieldRequestBodyVariables([getNodeVulnerabilitiesOpname]);
+                    waitAndYieldRequestBodyVariables([getNodeVulnerabilitiesOpname]).then((vars) =>
+                        cy.wrap(Array.isArray(vars) ? vars[0] : vars)
+                    );
 
                 // check sorting of CVE column
                 sortByTableHeader('CVE');
@@ -145,7 +147,9 @@ describe('Node CVEs - Node Detail Page', () => {
                 waitForRequests();
 
                 const waitForVulnQuery = () =>
-                    waitAndYieldRequestBodyVariables([getNodeVulnerabilitiesOpname]);
+                    waitAndYieldRequestBodyVariables([getNodeVulnerabilitiesOpname]).then((vars) =>
+                        cy.wrap(Array.isArray(vars) ? vars[0] : vars)
+                    );
 
                 // Assert GraphQL query strings. Stubbed rows are not a live filter result.
                 filterHelpers.addAutocompleteFilter('CVE', 'Name', 'CVE-2021-1234');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/nodeCves/nodeDetailPage.test.ts
@@ -8,7 +8,6 @@ import {
     interceptAndWatchRequests,
 } from '../../../helpers/request';
 import {
-    assertOnEachRowForColumn,
     paginateNext,
     paginatePrevious,
     queryTableHeader,
@@ -29,7 +28,7 @@ import {
     routeMatcherMapForNodePage,
     routeMatcherMapForNodes,
     staticResponseMapForNodePage,
-    visitFirstNodeFromOverviewPage,
+    visitNodePage,
 } from './NodeCve.helpers';
 
 const { assertAvailableFilters } = filterHelpers;
@@ -70,7 +69,7 @@ describe('Node CVEs - Node Detail Page', () => {
     });
 
     it('should only show relevant filters for the Node Detail page', () => {
-        visitFirstNodeFromOverviewPage();
+        visitNodePage(mockNodeId, routeMatcherMapForNodePage, staticResponseMapForNodePage);
 
         assertAvailableFilters({
             CVE: ['Name', 'CVSS', 'Discovered Time'],
@@ -79,7 +78,7 @@ describe('Node CVEs - Node Detail Page', () => {
     });
 
     it('should follow the breadcrumb link to the Node list tab', () => {
-        visitFirstNodeFromOverviewPage();
+        visitNodePage(mockNodeId, routeMatcherMapForNodePage, staticResponseMapForNodePage);
 
         // clicking the Nodes breadcrumb should navigate to the overview page with the Node tab selected
         interactAndWaitForResponses(() => {
@@ -90,13 +89,7 @@ describe('Node CVEs - Node Detail Page', () => {
     });
 
     it('should link from a CVE in the table to the CVE detail page', () => {
-        interactAndWaitForResponses(
-            () => {
-                visitFirstNodeFromOverviewPage();
-            },
-            routeMatcherMapForNodePage,
-            staticResponseMapForNodePage
-        );
+        visitNodePage(mockNodeId, routeMatcherMapForNodePage, staticResponseMapForNodePage);
 
         // clicking a CVE name in the list should navigate to a Node CVE details page
         cy.get(`table td[data-label="CVE"]`).first().click();
@@ -104,132 +97,90 @@ describe('Node CVEs - Node Detail Page', () => {
     });
 
     it('should sort CVE table columns', () => {
-        interceptAndWatchRequests({
-            [getNodeVulnerabilitiesOpname]:
-                routeMatcherMapForNodePage[getNodeVulnerabilitiesOpname],
-        }).then(({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
-            visitFirstNodeFromOverviewPage();
-            waitForRequests();
+        interceptAndWatchRequests(routeMatcherMapForNodePage, staticResponseMapForNodePage).then(
+            ({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
+                visitNodePage(mockNodeId);
+                waitForRequests();
 
-            // check sorting of CVE column
-            sortByTableHeader('CVE');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'CVE', reversed: true })
-            );
-            sortByTableHeader('CVE');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'CVE', reversed: false })
-            );
+                const waitForVulnQuery = () =>
+                    waitAndYieldRequestBodyVariables([getNodeVulnerabilitiesOpname]);
 
-            // check sorting of Top Severity column
-            sortByTableHeader('Top CVE severity');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'Severity', reversed: true })
-            );
-            sortByTableHeader('Top CVE severity');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'Severity', reversed: false })
-            );
+                // check sorting of CVE column
+                sortByTableHeader('CVE');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'CVE', reversed: true }));
+                sortByTableHeader('CVE');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'CVE', reversed: false }));
 
-            // check sorting of CVE status column
-            sortByTableHeader('CVE status');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'Fixable', reversed: true })
-            );
-            sortByTableHeader('CVE status');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'Fixable', reversed: false })
-            );
+                // check sorting of Top Severity column
+                sortByTableHeader('Top CVE severity');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'Severity', reversed: true }));
+                sortByTableHeader('Top CVE severity');
+                waitForVulnQuery().then(
+                    expectRequestedSort({ field: 'Severity', reversed: false })
+                );
 
-            // check sorting of CVSS column
-            sortByTableHeader('Top CVSS');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'CVSS', reversed: true })
-            );
-            sortByTableHeader('Top CVSS');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedSort({ field: 'CVSS', reversed: false })
-            );
+                // check sorting of CVE status column
+                sortByTableHeader('CVE status');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'Fixable', reversed: true }));
+                sortByTableHeader('CVE status');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'Fixable', reversed: false }));
 
-            // check that the Affected components column is not sortable
-            queryTableHeader('Affected components');
-            queryTableSortHeader('Affected components').should('not.exist');
-        });
+                // check sorting of CVSS column
+                sortByTableHeader('Top CVSS');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'CVSS', reversed: true }));
+                sortByTableHeader('Top CVSS');
+                waitForVulnQuery().then(expectRequestedSort({ field: 'CVSS', reversed: false }));
+
+                // check that the Affected components column is not sortable
+                queryTableHeader('Affected components');
+                queryTableSortHeader('Affected components').should('not.exist');
+            }
+        );
     });
 
     it('should filter the CVE table', () => {
-        interceptAndWatchRequests({
-            [getNodeVulnerabilitiesOpname]:
-                routeMatcherMapForNodePage[getNodeVulnerabilitiesOpname],
-        }).then(({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
-            visitFirstNodeFromOverviewPage();
-            waitForRequests();
+        interceptAndWatchRequests(routeMatcherMapForNodePage, staticResponseMapForNodePage).then(
+            ({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
+                visitNodePage(mockNodeId);
+                waitForRequests();
 
-            // filtering by CVE name should only display rows with a matching name
-            filterHelpers.addAutocompleteFilter('CVE', 'Name', 'CVE-2021-1234');
-            waitAndYieldRequestBodyVariables().then(expectRequestedQuery('CVE:r/CVE-2021-1234'));
-            // Do not assert on cell contents as the filter value is mocked
-            filterHelpers.clearFilters();
-            waitForRequests();
+                const waitForVulnQuery = () =>
+                    waitAndYieldRequestBodyVariables([getNodeVulnerabilitiesOpname]);
 
-            // filtering by Severity should only display rows with a matching top severity
-            applyLocalSeverityFilters('Low');
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedQuery('Severity:LOW_VULNERABILITY_SEVERITY')
-            );
-            assertOnEachRowForColumn('Top CVE severity', (_, cell) => {
-                expect(cell.innerText).to.contain('Low');
-            });
-            filterHelpers.clearFilters();
-            waitForRequests();
+                // Assert GraphQL query strings. Stubbed rows are not a live filter result.
+                filterHelpers.addAutocompleteFilter('CVE', 'Name', 'CVE-2021-1234');
+                waitForVulnQuery().then(expectRequestedQuery('CVE:r/CVE-2021-1234'));
+                filterHelpers.clearFilters();
+                waitForRequests([getNodeVulnerabilitiesOpname]);
 
-            // filtering by CVE Status should only display rows with a matching status
-            applyLocalStatusFilters('Fixable');
-            waitAndYieldRequestBodyVariables().then(expectRequestedQuery('Fixable:true'));
-            assertOnEachRowForColumn('CVE status', (_, cell) => {
-                expect(cell.innerText).to.contain('Fixable');
-            });
-            filterHelpers.clearFilters();
-            waitForRequests();
+                applyLocalSeverityFilters('Low');
+                waitForVulnQuery().then(
+                    expectRequestedQuery('Severity:LOW_VULNERABILITY_SEVERITY')
+                );
+                filterHelpers.clearFilters();
+                waitForRequests([getNodeVulnerabilitiesOpname]);
 
-            // filtering by CVSS should only display rows with a CVSS in range
-            filterHelpers.addNumericFilter('CVE', 'CVSS', 'Is less than', 8);
-            waitAndYieldRequestBodyVariables().then(expectRequestedQuery('CVSS:<8'));
-            assertOnEachRowForColumn('Top CVSS', (_, cell) => {
-                const cvss = parseFloat(cell.innerText.replace(/[^0-9.]/g, ''));
-                expect(cvss).to.be.lessThan(8);
-            });
-            filterHelpers.clearFilters();
-            waitForRequests();
+                applyLocalStatusFilters('Fixable');
+                waitForVulnQuery().then(expectRequestedQuery('Fixable:true'));
+                filterHelpers.clearFilters();
+                waitForRequests([getNodeVulnerabilitiesOpname]);
 
-            // filtering by Component should only display rows with a nested table containing a matching component
-            //   - expand each row
-            //   - check that the component name exists in the table
-            const componentFilter = 'a';
-            filterHelpers.addAutocompleteFilter('Node component', 'Name', componentFilter);
-            waitAndYieldRequestBodyVariables().then(
-                expectRequestedQuery(`Component:r/${componentFilter}`)
-            );
-            // scope these assertions to the first parent table so that assertions run in the child tables
-            const columnDataLabel = 'Component';
-            cy.get(`table`)
-                .then(($el) =>
-                    $el.find(
-                        `table:has(th:contains("${columnDataLabel}")) td[data-label="${columnDataLabel}"]`
-                    )
-                )
-                .then(($cells) => {
-                    $cells.each((_, cell) => {
-                        expect(cell.innerText).to.contain(componentFilter);
-                    });
-                });
-        });
+                filterHelpers.addNumericFilter('CVE', 'CVSS', 'Is less than', 8);
+                waitForVulnQuery().then(expectRequestedQuery('CVSS:<8'));
+                filterHelpers.clearFilters();
+                waitForRequests([getNodeVulnerabilitiesOpname]);
+
+                const componentFilter = 'a';
+                filterHelpers.addAutocompleteFilter('Node component', 'Name', componentFilter);
+                waitForVulnQuery().then(expectRequestedQuery(`Component:r/${componentFilter}`));
+            }
+        );
     });
 
     it('should correctly paginate the CVE table', () => {
         interceptAndWatchRequests(routeMatcherMapForNodePage, staticResponseMapForNodePage).then(
             ({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
-                visitFirstNodeFromOverviewPage();
+                visitNodePage(mockNodeId);
                 waitForRequests();
 
                 paginateNext();
@@ -274,7 +225,7 @@ describe('Node CVEs - Node Detail Page', () => {
     it('should update summary cards when a filter is applied', () => {
         interceptAndWatchRequests(routeMatcherMapForNodePage, staticResponseMapForNodePage).then(
             ({ waitForRequests }) => {
-                visitFirstNodeFromOverviewPage();
+                visitNodePage(mockNodeId);
                 waitForRequests();
 
                 applyLocalSeverityFilters('Low');


### PR DESCRIPTION
## Description

Cypress Node CVE tests were clicking the first name on **Node CVEs → Nodes**. In CI that table is often empty, so the click times out. This PR updates those tests and leaves the page unchanged.

**Node CVEs → Nodes is a CVE results table**, not an inventory of cluster nodes. Observed asks the API for nodes that have at least one unsnoozed CVE (`CVE Snoozed:false`). A scanned node with zero CVEs does not get a row. The empty copy already says "No CVEs have been reported for your scanned nodes." Workload CVEs uses the same idea: the Images tab lists images that have CVEs, not every image in the cluster. Node inventory belongs under Infrastructure.

[#22669](https://github.com/stackrox/stackrox/pull/22669) recorded the two states these tests have to live with.

Scanner V2 still filled node inventory, so this tab showed one row per cluster node, including nodes with no CVEs:

<img width="1290" height="766" alt="Node CVEs Nodes tab with six cluster node rows" src="https://github.com/user-attachments/assets/25ee9f92-1d63-4005-96fe-58f064172012" />

Same tab when no unsnoozed Node CVEs exist (GKE never indexes nodes; OpenShift can also land here when a scan finds no CVEs):

<img width="1289" height="774" alt="Node CVEs Nodes tab with no rows" src="https://github.com/user-attachments/assets/6d7227ae-0b1c-4456-bd71-502dfc5fdb77" />

The empty table is the intended product. UI/product confirmed that six nodes with zero CVEs should produce no rows. This tab stays a CVE view. Cluster nodes without CVEs stay off it.

#22669 also restored Scanner V4 OpenShift node indexing, so OCP CI may show rows again when those packages have CVEs. GKE still shows an empty table. Both outcomes are valid. These tests must not require six rows, and they must not require zero rows.

Tests that need a row now mock GraphQL fixtures, which is how the CVE-row link test already worked. Sort, filter, and pagination still assert live request payloads. Row-content checks already no-op when the table is empty.

AI-Assisted: cursor, generated the Cypress change; user confirmed the empty table is the intended Node CVEs behavior.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI