### PR TITLE
fix(tests): null-safe doHTTPGetExpectCode logging

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkFlowTest.groovy
@@ -653,7 +653,7 @@ class NetworkFlowTest extends BaseSpecification {
                 log.warn("Failed calling ${targetUrl}. Trying again in 5 sec...", e)
             }
         }
-        log.info "Response: " + response.asString()
+        log.info "Response: " + (response?.asString() ?: "<no response: all HTTP attempts failed>")
         return response
     }
 


### PR DESCRIPTION
## Description

`doHTTPGetExpectCode` in NetworkFlowTest logs the HTTP response object, but when all HTTP attempts fail the response is null, causing an NPE that masks the actual test failure. This adds a null-safety check to the response logging.

Extracted from #22609 (IPv6 deploy fixes) — this is a general test robustness fix.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed — test-only change
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed — test-only change

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md) — test infrastructure only
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Code review — the fix is a straightforward null guard on a logging statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)