### PR TITLE
ROX-34114: whitelist ebs-csi-node Docker CIS 5.19

### DIFF
--- a/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/DefaultPoliciesTest.groovy
@@ -83,6 +83,8 @@ class DefaultPoliciesTest extends BaseSpecification {
             "tunnelfront - Secure Shell Server (sshd) Execution",
             "tunnelfront - Docker CIS 4.7: Alert on Update Instruction",
             "webhookserver - Kubernetes Actions: Port Forward to Pod",
+            // Newer EKS ebs-csi-node DaemonSets use bidirectional mount propagation.
+            "ebs-csi-node - Docker CIS 5.19: Ensure mount propagation mode is not enabled",
     ]
 
     static final private Deployment STRUTS_DEPLOYMENT = new Deployment()


### PR DESCRIPTION
## Description

EKS flavor drift introduced a Docker CIS 5.19 violation in the `ebs-csi-node` DaemonSet. This is an infrastructure-level violation (AWS CSI driver running privileged), not a product bug. Whitelists it in DefaultPoliciesTest to prevent false failures.

Seen identically on both IPv4 and IPv6 EKS clusters. Extracted from #22609 (IPv6 deploy fixes).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed — test-only change
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed — test-only change

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md) — test infrastructure only
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Verified the ebs-csi-node CIS 5.19 violation appears identically on IPv4 EKS runs — this is EKS flavor drift, not a test regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)