### PR TITLE
ci: Fail add-vms action on skipped VMs and accept rhel8

### DIFF
--- a/.github/workflows/add-vms-to-cluster.yml
+++ b/.github/workflows/add-vms-to-cluster.yml
@@ -1,5 +1,5 @@
-name: "Add VMs to Cluster"
-run-name: "Add ${{ inputs.num-vms }} ${{ inputs.vm-os }} VMs to ${{ inputs.cluster-name }}"
+name: "Ensure VMs on Cluster"
+run-name: "Ensure ${{ inputs.num-vms }} ${{ inputs.vm-os }} VMs on ${{ inputs.cluster-name }}"
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       num-vms:
-        description: "Number of VMs to deploy"
+        description: "Desired count of {os}-1..N, not how many to add. Existing VMs are reused; 2 is a no-op if rhel9-1 and rhel9-2 already exist."
         required: false
         default: 1
         type: number
@@ -19,6 +19,7 @@ on:
         default: "rhel9"
         type: choice
         options:
+          - rhel8
           - rhel9
           - rhel10
       ssh-public-key:

--- a/scripts/ci/add-vms/action.yml
+++ b/scripts/ci/add-vms/action.yml
@@ -1,4 +1,4 @@
-name: "Add VMs to ACS Cluster"
+name: "Ensure VMs on ACS Cluster"
 description: "Install OpenShift Virtualization, deploy VMs, and install roxagent on an Infra-managed cluster"
 
 inputs:
@@ -6,11 +6,11 @@ inputs:
     description: "Infra cluster name (from `infractl list`)"
     required: true
   num-vms:
-    description: "Number of VMs to deploy"
+    description: "Desired count of {os}-1..N. Existing VMs are reused."
     required: false
     default: "1"
   vm-os:
-    description: "VM OS: rhel9 or rhel10"
+    description: "VM OS: rhel8, rhel9, or rhel10"
     required: false
     default: "rhel9"
   ssh-public-key:

--- a/scripts/ci/add-vms/add-vms.bats
+++ b/scripts/ci/add-vms/add-vms.bats
@@ -21,7 +21,7 @@ load "../../test_helpers.bats"
     ' _ "${BATS_TEST_DIRNAME}/add-vms.sh"
 
     assert_success
-    assert_output --partial "::error title=Add VMs incomplete"
+    assert_output --partial "::error title=Add VMs incomplete::Skipped: rhel10-3; agent failed: rhel10-3"
 
     run cat "$summary_file"
     assert_output --partial "## Add VMs to Cluster"

--- a/scripts/ci/add-vms/add-vms.bats
+++ b/scripts/ci/add-vms/add-vms.bats
@@ -21,6 +21,7 @@ load "../../test_helpers.bats"
     ' _ "${BATS_TEST_DIRNAME}/add-vms.sh"
 
     assert_success
+    assert_output --partial "::error title=Add VMs incomplete"
 
     run cat "$summary_file"
     assert_output --partial "## Add VMs to Cluster"

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -272,6 +272,8 @@ main() {
     accessible_vms+=("${MANAGED_VMS[@]}" "${ADOPTED_VMS[@]}")
 
     if [[ ${#accessible_vms[@]} -eq 0 ]]; then
+        # Summary first so the ::error annotation still names the skipped VMs.
+        print_summary
         die "No accessible VMs — cannot install agent. All VMs failed SSH readiness."
     else
         export AUTOMATION_SSH_PRIVKEY

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --cluster NAME       Infra cluster name (calls infractl for kubeconfig)
 #   --num-vms N          Number of VMs (default: 1)
-#   --os OS              VM OS: rhel9|rhel10 (default: rhel9)
+#   --os OS              VM OS: rhel8|rhel9|rhel10 (default: rhel9)
 #   --ssh-key PATH       Path to user SSH public key to add to target VMs
 #   --namespace NS       Target namespace (default: openshift-cnv)
 #   --vm-prefix PREFIX   VM name prefix (default: same as OS)
@@ -64,7 +64,7 @@ parse_args() {
     if ! [[ "$NUM_VMS" =~ ^[0-9]+$ ]] || (( NUM_VMS < 1 )); then
         die "--num-vms must be a positive integer"
     fi
-    [[ "$VM_OS" =~ ^rhel(9|10)$ ]] || die "--os must be rhel9 or rhel10"
+    [[ "$VM_OS" =~ ^rhel(8|9|10)$ ]] || die "--os must be rhel8, rhel9, or rhel10"
 }
 
 # Sets KUBECONFIG: either fetches it from infractl for the given cluster
@@ -218,7 +218,11 @@ write_github_summary() {
         echo ""
     } >> "$GITHUB_STEP_SUMMARY"
 
-    echo "::notice title=VM action summary::See the job summary for VM access, key download, and native service verification."
+    if [[ ${#SKIPPED_VMS[@]} -gt 0 || ${#NATIVE_AGENT_FAILED_VMS[@]} -gt 0 ]]; then
+        echo "::error title=Add VMs incomplete::Skipped: ${SKIPPED_VMS[*]}; agent failed: ${NATIVE_AGENT_FAILED_VMS[*]}. See the job summary."
+    else
+        echo "::notice title=VM action summary::See the job summary for VM access, key download, and native service verification."
+    fi
 }
 
 cleanup() {
@@ -278,6 +282,9 @@ main() {
 
     # Step 4: Summary
     print_summary
+    if [[ ${#SKIPPED_VMS[@]} -gt 0 || ${#NATIVE_AGENT_FAILED_VMS[@]} -gt 0 ]]; then
+        die "Some VMs were skipped or the native agent failed to start"
+    fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
⚠️ Merge post 5.0 code freeze!

## Description

The "Ensure VMs" workflow could finish green when a requested VM never came up. The script listed skipped VMs in the job summary, emitted a generic notice, and still exited 0 as long as at least one VM was reachable.

After printing the summary it now exits non-zero if any VM was skipped or the native agent did not start, and emits a `::error` annotation that names those VMs. A fully successful run still uses the existing notice.

`num-vms` is a desired count of `{os}-1` through `{os}-N`, not how many extra VMs to create. The workflow name, run name, and input descriptions say that, so `num-vms=2` with `rhel9` is a no-op when `rhel9-1` and `rhel9-2` already exist.

`rhel8` is an allowed OS. The image tag is already `quay.io/rhacs-eng/vm-images:${VM_OS}-dnf-primed-latest`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

The existing job-summary shell test already covers skipped and failed VMs. It now also asserts the `::error` annotation.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- Executed the action from this branch: 
    - 1️⃣ https://github.com/stackrox/stackrox/actions/runs/34261328003 - failed as expected - no resources left on the cluster.
    - 2️⃣  

AI-Assisted: cursor, generated the fail-on-incomplete and rhel8 allowlist changes; user chose the smaller reporting approach and the num-vms copy.