### PR TITLE
fix(ci): enable Scanner V4 for GHA qa-e2e and byodb

### DIFF
--- a/.github/workflows/e2e-byodb-tests.yaml
+++ b/.github/workflows/e2e-byodb-tests.yaml
@@ -42,6 +42,8 @@ jobs:
       POSTGRES_VERSION: "17"
       LONGTERM_LICENSE: "unused"
       BYODB_TEST: "true"
+      # roxctl helm values pin scannerV4.disable=true unless this is set.
+      ROX_SCANNER_V4: "true"
       ROX_RISK_REPROCESSING_INTERVAL: "15s"
       ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL: "30s"
       PYTHONUNBUFFERED: "1"

--- a/tests/e2e/lib-compat.sh
+++ b/tests/e2e/lib-compat.sh
@@ -177,8 +177,8 @@ roxie_config_from_environment_compat() {
     )
 
     info "Configuring scanner V4..."
-    handle_scanner_v4_setting "$config_file" ".central.spec.scannerV4.scannerComponent"
-    handle_scanner_v4_setting "$config_file" ".securedCluster.spec.scannerV4.scannerComponent"
+    handle_scanner_v4_setting "$config_file" ".central.spec.scannerV4.scannerComponent" "Enabled"
+    handle_scanner_v4_setting "$config_file" ".securedCluster.spec.scannerV4.scannerComponent" "AutoSense"
 
     info "Configuring declarative configuration..."
     handle_declarative_configuration "$config_file"
@@ -222,15 +222,18 @@ handle_pod_security_policies() {
     ci_export POD_SECURITY_POLICIES "$POD_SECURITY_POLICIES"
 }
 
+# handle_scanner_v4_setting patches scannerV4.scannerComponent. enabled_value is
+# the CRD enum when V4 is on: Central uses Enabled, SecuredCluster uses AutoSense.
 handle_scanner_v4_setting() {
     local config_file="$1"
     local path="$2"
+    local enabled_value="$3"
     # Scanner V4 is the default scanner. Jobs that must omit it set ROX_SCANNER_V4=false.
     local rox_scanner_v4="${ROX_SCANNER_V4:-true}"
 
     case "$rox_scanner_v4" in
         true)
-            patch_yaml "$config_file" "${path} = \"Enabled\""
+            patch_yaml "$config_file" "${path} = \"${enabled_value}\""
             ;;
         false)
             patch_yaml "$config_file" "${path} = \"Disabled\""


### PR DESCRIPTION
## Description

GHA qa-e2e and byodb still had no usable scanner after #22694, for two different reasons.

Roxie qa-e2e now defaults `ROX_SCANNER_V4` to true and patches both CRs with `scannerV4.scannerComponent: Enabled`. Central accepts that enum. SecuredCluster does not (`Default`, `AutoSense`, `Disabled` only), so the CR apply fails, `API_ENDPOINT` is never exported, and Groovy never runs. Parent: https://github.com/stackrox/stackrox/actions/runs/34230772463/job/102079154595

This matches the non-roxie operator path: Central `Enabled`, SecuredCluster `AutoSense`.

byodb does not use roxie. `roxctl central generate` still emits `scannerV4.disable: true`, and Helm only overrides that when `ROX_SCANNER_V4` is set. Unset leaves V4 off, so `AdmissionControllerTest` and `ImageManagementTest` fail in `setupSpec`. Parent: https://github.com/stackrox/stackrox/actions/runs/34230772463/job/102079153964

Set `ROX_SCANNER_V4: "true"` on the byodb workflow so Helm `--set scannerV4.disable=false`. Leave the renderer pin alone; that is install code.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Harness deploy only. Existing Groovy specs wait for any SCANNER integration.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI

The proof is `e2e-qa-tests-gke` (needs the `e2e-qa-tests-gke` label) and `e2e-byodb-tests`. After they run:

1. qa-e2e "Run Part 1 tests" completes deploy. Roxie config has Central `scannerComponent: Enabled` and SecuredCluster `AutoSense`. No CR validation error. `API_ENDPOINT` is set for post-test.
2. byodb logs `Scanner V4: enabled` (not `disabled`) and `Scanner integration available:`.
3. `AdmissionControllerTest` and `ImageManagementTest` get past `setupSpec`.

Skipped jobs do not prove the defaulting.

AI-Assisted: cursor, harness deploy, user reviewed the failure analysis