### PR TITLE
chore: Enable feature flag for Risk AI integration + tests connection

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -156,7 +156,7 @@ var (
 	ACMAccessControlDelegation = registerFeature("Enable ACS access control integration with Red Hat Advanced Cluster Management", "ROX_ACM_ACCESS_CONTROL_DELEGATION")
 
 	// LightspeedRiskSummary enables Lightspeed AI risk summary
-	LightspeedRiskSummary = registerFeature("Enable Lightspeed AI risk summary", "ROX_LIGHTSPEED_RISK_SUMMARY")
+	LightspeedRiskSummary = registerFeature("Enable Lightspeed AI risk summary", "ROX_LIGHTSPEED_RISK_SUMMARY", enabled)
 )
 
 // The following feature flags are related to Scanner V4.

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -7,6 +7,7 @@ import configureApolloClient from 'init/configureApolloClient';
 import { setAnalyticsSource } from 'init/initializeAnalytics';
 import { UserPermissionProvider } from 'providers/UserPermissionProvider';
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
+import { LightspeedStatusProvider } from 'providers/LightspeedStatusProvider';
 import { MetadataProvider } from 'providers/MetadataProvider';
 import { PublicConfigProvider } from 'providers/PublicConfigProvider';
 import { TelemetryConfigProvider } from 'providers/TelemetryConfigProvider';
@@ -46,7 +47,9 @@ function PluginProviderContent({ children }: { children: ReactNode }) {
                     <MetadataProvider>
                         <PublicConfigProvider>
                             <TelemetryConfigProvider>
-                                <PluginContent>{children}</PluginContent>
+                                <LightspeedStatusProvider>
+                                    <PluginContent>{children}</PluginContent>
+                                </LightspeedStatusProvider>
                             </TelemetryConfigProvider>
                         </PublicConfigProvider>
                     </MetadataProvider>

--- a/ui/apps/platform/src/Containers/Risk/RiskDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetailsPage.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import type { ReactElement } from 'react';
 import {
     Breadcrumb,
@@ -28,9 +27,8 @@ import {
 } from 'routePaths';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
-import useRestQuery from 'hooks/useRestQuery';
+import useLightspeedStatus from 'hooks/useLightspeedStatus';
 import AiExperienceIcon from 'images/aiExperience.svg?react';
-import { testLightspeedConnection } from 'services/DeploymentsService';
 
 import RiskDetailTabs from './RiskDetailTabs';
 import useDeploymentWithRisk from './useDeploymentWithRisk';
@@ -62,16 +60,8 @@ function RiskDetailsPage(): ReactElement {
 
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isRiskSummaryEnabled = isFeatureFlagEnabled('ROX_LIGHTSPEED_RISK_SUMMARY');
-    const connectionTest = useRestQuery(
-        useCallback(
-            () =>
-                isRiskSummaryEnabled
-                    ? testLightspeedConnection()
-                    : Promise.resolve({ success: false, message: '' }),
-            [isRiskSummaryEnabled]
-        )
-    );
-    const isAiSummaryAvailable = isRiskSummaryEnabled && connectionTest.data?.success === true;
+    const { isAvailable } = useLightspeedStatus();
+    const isAiSummaryAvailable = isRiskSummaryEnabled && isAvailable;
     const aiRiskSummary = useAiRiskSummary(deploymentId);
     const hasAiRiskSummary = Boolean(aiRiskSummary.summary);
 

--- a/ui/apps/platform/src/hooks/useLightspeedStatus.tsx
+++ b/ui/apps/platform/src/hooks/useLightspeedStatus.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react';
+
+import type { LightspeedStatusContextType } from 'providers/LightspeedStatusProvider';
+
+export const LightspeedStatusContext = createContext<LightspeedStatusContextType | undefined>(
+    undefined
+);
+
+function useLightspeedStatus(): LightspeedStatusContextType {
+    const context = useContext(LightspeedStatusContext);
+    if (context === undefined) {
+        return {
+            isAvailable: false,
+            isLoading: false,
+            error: new Error(
+                'useLightspeedStatus must be used within a LightspeedStatusProvider - returning static default values'
+            ),
+        };
+    }
+
+    return context;
+}
+
+export default useLightspeedStatus;

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -31,6 +31,7 @@ import installRaven from 'init/installRaven';
 import configureApollo from 'init/configureApolloClient';
 import { setAnalyticsSource } from 'init/initializeAnalytics';
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
+import { LightspeedStatusProvider } from 'providers/LightspeedStatusProvider';
 import { PublicConfigProvider } from 'providers/PublicConfigProvider';
 import { TelemetryConfigProvider } from 'providers/TelemetryConfigProvider';
 import { MetadataProvider } from 'providers/MetadataProvider';
@@ -71,7 +72,9 @@ root.render(
                                 <PublicConfigProvider>
                                     <TelemetryConfigProvider>
                                         <MetadataProvider>
-                                            <AppPage />
+                                            <LightspeedStatusProvider>
+                                                <AppPage />
+                                            </LightspeedStatusProvider>
                                         </MetadataProvider>
                                     </TelemetryConfigProvider>
                                 </PublicConfigProvider>

--- a/ui/apps/platform/src/providers/LightspeedStatusProvider.tsx
+++ b/ui/apps/platform/src/providers/LightspeedStatusProvider.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+import { LightspeedStatusContext } from 'hooks/useLightspeedStatus';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import useRestQuery from 'hooks/useRestQuery';
+import { fetchLightspeedStatus } from 'services/MetadataService';
+
+export type LightspeedStatusProviderProps = {
+    children: ReactNode;
+};
+
+export type LightspeedStatusContextType = {
+    isAvailable: boolean;
+    isLoading: boolean;
+    error: Error | undefined;
+};
+
+export function LightspeedStatusProvider({ children }: LightspeedStatusProviderProps) {
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const isRiskSummaryEnabled = isFeatureFlagEnabled('ROX_LIGHTSPEED_RISK_SUMMARY');
+
+    const { data, isLoading, error } = useRestQuery(
+        useCallback(
+            () =>
+                isRiskSummaryEnabled
+                    ? fetchLightspeedStatus()
+                    : Promise.resolve({ available: false, message: 'Feature disabled' }),
+            [isRiskSummaryEnabled]
+        )
+    );
+
+    const value: LightspeedStatusContextType = useMemo(
+        () => ({
+            isAvailable: data?.available ?? false,
+            isLoading,
+            error,
+        }),
+        [data?.available, isLoading, error]
+    );
+
+    return (
+        <LightspeedStatusContext.Provider value={value}>
+            {children}
+        </LightspeedStatusContext.Provider>
+    );
+}

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -159,11 +159,6 @@ export type DeploymentRiskSummary = {
     summary: string;
 };
 
-export type TestLightspeedConnectionResponse = {
-    success: boolean;
-    message: string;
-};
-
 /**
  * Fetches an AI-generated risk summary for a deployment by ID.
  */
@@ -174,19 +169,4 @@ export function fetchDeploymentRiskSummary(id: string): Promise<DeploymentRiskSu
     return axios
         .get<DeploymentRiskSummary>(`${deploymentWithRiskUrl}/${id}/ai-summary`, { timeout: 60000 })
         .then((response) => response.data);
-}
-
-/**
- * Tests connectivity to the Lightspeed AI service.
- */
-export function testLightspeedConnection(): CancellableRequest<TestLightspeedConnectionResponse> {
-    return makeCancellableAxiosRequest((signal) =>
-        axios
-            .post<TestLightspeedConnectionResponse>(
-                `${deploymentWithRiskUrl}/ai-summary/test`,
-                undefined,
-                { signal }
-            )
-            .then((response) => response.data)
-    );
 }

--- a/ui/apps/platform/src/services/MetadataService.ts
+++ b/ui/apps/platform/src/services/MetadataService.ts
@@ -56,3 +56,12 @@ export function fetchCentralCapabilities(): Promise<CentralServicesCapabilities>
         .get<CentralServicesCapabilities>('/v1/central-capabilities')
         .then((response) => response.data);
 }
+
+export type LightspeedStatus = {
+    available: boolean;
+    message: string;
+};
+
+export function fetchLightspeedStatus(): Promise<LightspeedStatus> {
+    return axios.get<LightspeedStatus>('/v1/lightspeed/status').then((response) => response.data);
+}


### PR DESCRIPTION
## Description

Enables the OLS integration feature flag.

Updates the Lightspeed connectivity check to the endpoint used in https://github.com/stackrox/stackrox/pull/22635 and moves the check to a top level `Provider` in order to reduce the number of unnecessary network calls as users navigate through Risk.

Depends on:
- https://github.com/stackrox/stackrox/pull/22496
- https://github.com/stackrox/stackrox/pull/22622
- https://github.com/stackrox/stackrox/pull/22635


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual testing against https://central-stackrox.apps.ai-dev-01.ocp.infra.rox.systems/
CI
