### PR TITLE
spike(policy): Container Age > N days policy criterion

### DIFF
--- a/pkg/booleanpolicy/container_age_criteria_test.go
+++ b/pkg/booleanpolicy/container_age_criteria_test.go
@@ -1,0 +1,118 @@
+package booleanpolicy
+
+// SPIKE: Container Age criterion tests.
+//
+// These tests will not compile until make proto-generated-srcs is run to add
+// OldestContainerStarted to the generated storage.Container struct.
+//
+// To run once proto is regenerated:
+//   go test ./pkg/booleanpolicy/... -run TestContainerAgeCriteria
+//
+// The test intentionally uses the same structure as image_criteria_test.go so the
+// pattern is familiar to reviewers.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestContainerAgeCriteria(t *testing.T) {
+	suite.Run(t, new(ContainerAgeCriteriaTestSuite))
+}
+
+type ContainerAgeCriteriaTestSuite struct {
+	basePoliciesTestSuite
+}
+
+// helper: deployment with a single container whose oldest_container_started is set
+// to `daysAgo` days before now. This simulates what the enrichment step would set.
+func depWithContainerAge(daysAgo int) *storage.Deployment {
+	started := time.Now().AddDate(0, 0, -daysAgo)
+	protoTs, err := protocompat.ConvertTimeToTimestampOrError(started)
+	if err != nil {
+		panic(err)
+	}
+	return &storage.Deployment{
+		Id:        "test-dep",
+		Namespace: "default",
+		Containers: []*storage.Container{
+			{
+				Name: "app",
+				// SPIKE: OldestContainerStarted is set transiently by the enrichment step
+				// (sensor-side or central-side, see sensor/common/detector/container_age_enrichment.go).
+				// In production it is never persisted; in tests we set it directly.
+				OldestContainerStarted: protoTs,
+			},
+		},
+	}
+}
+
+func (suite *ContainerAgeCriteriaTestSuite) TestContainerAge_ViolatesWhenOlderThanThreshold() {
+	dep := depWithContainerAge(35)
+	suite.addDepAndImages(dep)
+
+	policy := policyWithSingleKeyValue(fieldnames.ContainerAge, "30", false)
+	matcher, err := BuildDeploymentMatcher(policy)
+	require.NoError(suite.T(), err)
+
+	violations, err := matcher.MatchDeployment(nil, enhancedDeployment(dep, suite.getImagesForDeployment(dep)))
+	require.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), violations.AlertViolations, "expected violation for 35-day-old container against 30-day threshold")
+}
+
+func (suite *ContainerAgeCriteriaTestSuite) TestContainerAge_NoViolationWhenYoungerThanThreshold() {
+	dep := depWithContainerAge(10)
+	suite.addDepAndImages(dep)
+
+	policy := policyWithSingleKeyValue(fieldnames.ContainerAge, "30", false)
+	matcher, err := BuildDeploymentMatcher(policy)
+	require.NoError(suite.T(), err)
+
+	violations, err := matcher.MatchDeployment(nil, enhancedDeployment(dep, suite.getImagesForDeployment(dep)))
+	require.NoError(suite.T(), err)
+	assert.Empty(suite.T(), violations.AlertViolations, "expected no violation for 10-day-old container against 30-day threshold")
+}
+
+func (suite *ContainerAgeCriteriaTestSuite) TestContainerAge_NoViolationWhenFieldNotPopulated() {
+	// Simulates a deployment where the enrichment step has not run or the container
+	// has no live pod instances (e.g., replica count = 0). oldest_container_started
+	// is nil, so the criterion must not fire.
+	dep := &storage.Deployment{
+		Id:        "empty-dep",
+		Namespace: "default",
+		Containers: []*storage.Container{
+			{Name: "app"},
+		},
+	}
+	suite.addDepAndImages(dep)
+
+	policy := policyWithSingleKeyValue(fieldnames.ContainerAge, "1", false)
+	matcher, err := BuildDeploymentMatcher(policy)
+	require.NoError(suite.T(), err)
+
+	violations, err := matcher.MatchDeployment(nil, enhancedDeployment(dep, suite.getImagesForDeployment(dep)))
+	require.NoError(suite.T(), err)
+	assert.Empty(suite.T(), violations.AlertViolations, "criterion must not fire when oldest_container_started is nil")
+}
+
+func (suite *ContainerAgeCriteriaTestSuite) TestContainerAge_ViolationMessageIncludesContainerName() {
+	dep := depWithContainerAge(35)
+	suite.addDepAndImages(dep)
+
+	policy := policyWithSingleKeyValue(fieldnames.ContainerAge, "30", false)
+	matcher, err := BuildDeploymentMatcher(policy)
+	require.NoError(suite.T(), err)
+
+	violations, err := matcher.MatchDeployment(nil, enhancedDeployment(dep, suite.getImagesForDeployment(dep)))
+	require.NoError(suite.T(), err)
+	require.NotEmpty(suite.T(), violations.AlertViolations)
+	assert.Contains(suite.T(), violations.AlertViolations[0].GetMessage(), "app",
+		"violation message should reference the container name")
+}

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -502,6 +502,24 @@ func initializeFieldMetadata() FieldMetadata {
 		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
 
+	// SPIKE: ContainerAge uses oldest_container_started on Deployment.Container, which is
+	// populated transiently at detection time from pod store data (not persisted).
+	// Lifecycle stages are DEPLOY and RUNTIME only — BUILD has no running containers.
+	// No imageEnrichmentRequired since the data comes from pod records, not image scans.
+	//
+	// OPEN QUESTION: Should this also apply at RUNTIME lifecycle? If a container trips the
+	// criterion mid-run (no K8s event), the 4-hour reprocess loop fires it. If limited to
+	// DEPLOY, the policy only fires on pod create/update events, missing mid-run aging.
+	// Recommend DEPLOY+RUNTIME to match customer's compliance use case.
+	f.registerFieldMetadataRegex(fieldnames.ContainerAge,
+		querybuilders.ForDays(search.ContainerStartTime),
+		violationmessages.ContainerAgeContextFields,
+		func(*validateConfiguration) *regexp.Regexp {
+			return integerValueRegex
+		},
+		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
+
 	f.registerFieldMetadataRegex(fieldnames.ImageAge,
 		querybuilders.ForDays(search.ImageCreatedTime),
 		violationmessages.ImageContextFields,

--- a/pkg/booleanpolicy/fieldnames/list.go
+++ b/pkg/booleanpolicy/fieldnames/list.go
@@ -40,6 +40,7 @@ var (
 	HostIPC                        = newFieldName("Host IPC")
 	HostNetwork                    = newFieldName("Host Network")
 	HostPID                        = newFieldName("Host PID")
+	ContainerAge                   = newFieldName("Container Age")
 	ImageAge                       = newFieldName("Image Age")
 	ImageComponent                 = newFieldName("Image Component")
 	ImageOS                        = newFieldName("Image OS")

--- a/pkg/booleanpolicy/query_to_field_value_mappers.go
+++ b/pkg/booleanpolicy/query_to_field_value_mappers.go
@@ -21,6 +21,7 @@ var (
 		search.DeploymentAnnotation:          newMapper(fieldnames.DisallowedAnnotation, leftRightCompoundMap),
 		search.ImageLabel:                    newMapper(fieldnames.DisallowedImageLabel, leftRightCompoundMap),
 		search.VolumeReadonly:                newMapper(fieldnames.WritableMountedVolume, invertBooleanMap),
+		search.ContainerStartTime:            newMapper(fieldnames.ContainerAge, numberOfDaysSinceMap),
 		search.ImageCreatedTime:              newMapper(fieldnames.ImageAge, numberOfDaysSinceMap),
 		search.ImageScanTime:                 newMapper(fieldnames.ImageScanAge, numberOfDaysSinceMap),
 		search.ServiceAccountPermissionLevel: newMapper(fieldnames.MinimumRBACPermissions, serviceAccountPermissionLevelMap),

--- a/pkg/booleanpolicy/violationmessages/context.go
+++ b/pkg/booleanpolicy/violationmessages/context.go
@@ -24,6 +24,11 @@ var (
 	ContainerContextFields = newContextFields(
 		nil,
 		[]string{augmentedobjs.ContainerNameCustomTag})
+	// ContainerAgeContextFields extends ContainerContextFields with the container start time so
+	// the violation message printer can display when the container instance started.
+	ContainerAgeContextFields = newContextFields(
+		nil,
+		[]string{augmentedobjs.ContainerNameCustomTag, search.ContainerStartTime.String()})
 	ResourceContextFields = newContextFields(
 		nil,
 		[]string{augmentedobjs.ContainerNameCustomTag})

--- a/pkg/booleanpolicy/violationmessages/printer.go
+++ b/pkg/booleanpolicy/violationmessages/printer.go
@@ -47,6 +47,7 @@ var (
 		fieldnames.HostIPC:                        {{required: set.NewStringSet(search.HostIPC.String()), printerFuncKey: printer.HostIPCKey}},
 		fieldnames.HostNetwork:                    {{required: set.NewStringSet(search.HostNetwork.String()), printerFuncKey: printer.HostNetworkKey}},
 		fieldnames.HostPID:                        {{required: set.NewStringSet(search.HostPID.String()), printerFuncKey: printer.HostPIDKey}},
+		fieldnames.ContainerAge:                   {{required: set.NewStringSet(search.ContainerStartTime.String()), printerFuncKey: printer.ContainerAgeKey}},
 		fieldnames.ImageAge:                       {{required: set.NewStringSet(search.ImageCreatedTime.String()), printerFuncKey: printer.ImageAgeKey}},
 		fieldnames.ImageComponent:                 {{required: set.NewStringSet(augmentedobjs.ComponentAndVersionCustomTag), printerFuncKey: printer.ComponentKey}},
 		fieldnames.ImageOS:                        {{required: set.NewStringSet(search.ImageOS.String()), printerFuncKey: printer.ImageOSKey}},

--- a/pkg/booleanpolicy/violationmessages/printer/container.go
+++ b/pkg/booleanpolicy/violationmessages/printer/container.go
@@ -34,6 +34,28 @@ func readOnlyRootFSPrinter(fieldMap map[string][]string) ([]string, error) {
 }
 
 const (
+	// SPIKE: containerAgeTemplate displays the container instance start time from oldest_container_started.
+	// oldest_container_started is populated transiently at detection time — it is not persisted to the
+	// deployments table. The enrichment step (sensor-side or central-side, TBD) must set this before
+	// DetectDeployment is called, otherwise the field is zero and the criterion never fires.
+	containerAgeTemplate = `Container{{if .ContainerName}} '{{.ContainerName}}'{{end}} has been running since {{.ContainerStartTime}} (UTC)`
+)
+
+func containerAgePrinter(fieldMap map[string][]string) ([]string, error) {
+	type resultFields struct {
+		ContainerName      string
+		ContainerStartTime string
+	}
+	r := resultFields{}
+	r.ContainerName = maybeGetSingleValueFromFieldMap(augmentedobjs.ContainerNameCustomTag, fieldMap)
+	var err error
+	if r.ContainerStartTime, err = getSingleValueFromFieldMap(search.ContainerStartTime.String(), fieldMap); err != nil {
+		return nil, err
+	}
+	return executeTemplate(containerAgeTemplate, r)
+}
+
+const (
 	imageAgeTemplate = `{{if .ContainerName}}Container '{{.ContainerName}}' has image{{else}}Image was{{end}} created at {{.ImageCreationTime}} (UTC)`
 )
 

--- a/pkg/booleanpolicy/violationmessages/printer/gen-registrations.go
+++ b/pkg/booleanpolicy/violationmessages/printer/gen-registrations.go
@@ -8,6 +8,7 @@ const (
 	AppArmorProfileKey              = "appArmorProfile"
 	AutomountServiceAccountTokenKey = "automountServiceAccountToken"
 	ComponentKey                    = "component"
+	ContainerAgeKey                 = "containerAge"
 	ContainerNameKey                = "containerName"
 	CveKey                          = "cve"
 	DisallowedAnnotationKey         = "disallowedAnnotation"
@@ -54,6 +55,7 @@ func init() {
 	registerFunc(AppArmorProfileKey, appArmorProfilePrinter)
 	registerFunc(AutomountServiceAccountTokenKey, automountServiceAccountTokenPrinter)
 	registerFunc(ComponentKey, componentPrinter)
+	registerFunc(ContainerAgeKey, containerAgePrinter)
 	registerFunc(ContainerNameKey, containerNamePrinter)
 	registerFunc(CveKey, cvePrinter)
 	registerFunc(DisallowedAnnotationKey, disallowedAnnotationPrinter)

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -90,6 +90,7 @@ var (
 	HostIPC                        = newFieldLabel("Host IPC")
 	HostNetwork                    = newFieldLabel("Host Network")
 	HostPID                        = newFieldLabel("Host PID")
+	ContainerStartTime             = newFieldLabel("Container Start Time")
 	ImageCreatedTime               = newFieldLabel("Image Created Time")
 	ImageName                      = newFieldLabel("Image")
 	ImageSHA                       = newFieldLabel("Image Sha")

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -90,6 +90,21 @@ message Container {
   ReadinessProbe readiness_probe = 12;
 
   ContainerType type = 13; // @gotags: search:"Container Type" hash:"ignore" sensorhash:"ignore"
+
+  // oldest_container_started is the earliest start time of any live pod instance
+  // running this container. Populated at policy evaluation time from pod store data;
+  // not persisted. Used by the "Container Age" policy criterion.
+  //
+  // SPIKE NOTE: This field is set transiently by the detection enrichment step and
+  // intentionally not stored. The open question is WHERE enrichment happens:
+  //   (a) Central-side, in reprocessing/pipeline.go before forwarding to lifecycle
+  //       manager — requires pod datastore access in central.
+  //   (b) Sensor-side, in detector.go before calling DetectDeployment — requires
+  //       the sensor pod cache to be queryable by deployment ID at detection time.
+  // Option (b) is preferred to avoid a round-trip but needs investigation into
+  // whether sensor's podsByUID/podsByDeploymentID cache supports this lookup.
+  // @gotags: search:"Container Start Time,hidden" hash:"ignore" sensorhash:"ignore"
+  google.protobuf.Timestamp oldest_container_started = 14;
 }
 
 message Resources {

--- a/sensor/common/detector/container_age_enrichment.go
+++ b/sensor/common/detector/container_age_enrichment.go
@@ -1,0 +1,94 @@
+package detector
+
+// SPIKE: Container Age policy criterion — sensor-side enrichment stub
+//
+// This file documents the enrichment design for the ContainerAge policy criterion
+// (fieldnames.ContainerAge) and should be replaced with a real implementation
+// once the design questions below are resolved.
+//
+// # What this needs to do
+//
+// Before calling DetectDeployment, each container's oldest_container_started timestamp
+// must be populated on storage.Deployment.Containers[i].OldestContainerStarted.
+// This field is transient: it must be set at detection time from live pod data and
+// must NOT be persisted to the deployments table.
+//
+// # Sensor-side approach (preferred)
+//
+// The detector builds the EnhancedDeployment immediately before calling DetectDeployment.
+// Enrichment should happen in detectDeploymentFromScanResult, just before that call,
+// using a per-deployment lookup into the sensor pod cache.
+//
+// ## What the pod cache needs
+//
+// The concrete PodStore (sensor/kubernetes/listener/resources.PodStore) already stores
+// pods indexed by (namespace, deploymentID) and exposes a forEach method, but the
+// store.PodStore INTERFACE only exports:
+//
+//   GetAll() []*storage.Pod
+//   GetByName(podName, namespace string) *storage.Pod
+//
+// To support sensor-side enrichment without iterating all pods, the interface needs
+// a new method, e.g.:
+//
+//   ForDeployment(ns, deploymentID string, fn func(*storage.Pod))
+//
+// The concrete implementation already has forEach — this would just expose it.
+// The mock in sensor/common/store/mocks/types.go would need to be regenerated.
+//
+// ## Wire-up
+//
+// The detectorImpl struct would need a new field:
+//
+//   podStore store.PodStore
+//
+// ... and it would be passed in from the sensor main wiring (sensor.go),
+// analogous to how admissioncontroller.SettingsManager already receives a PodStore.
+//
+// # Central-side alternative
+//
+// Enrichment could happen in central/sensor/service/pipeline/reprocessing/pipeline.go
+// before ReprocessDeploymentRisk is called, using central's pod datastore. This avoids
+// touching the sensor interface but requires an extra datastore dependency in central.
+// Central's pod datastore is queryable by deployment ID via search options.
+// Recommendation: prefer sensor-side to keep enrichment collocated with detection.
+//
+// # Enrichment algorithm
+//
+//   func enrichContainerAge(deployment *storage.Deployment, podStore store.PodStore) {
+//       byContainerName := map[string]*timestamppb.Timestamp{}
+//       podStore.ForDeployment(deployment.GetNamespace(), deployment.GetId(), func(pod *storage.Pod) {
+//           for _, inst := range pod.GetLiveInstances() {
+//               t := inst.GetStarted()
+//               if t == nil {
+//                   continue
+//               }
+//               name := inst.GetContainerName()
+//               if prev := byContainerName[name]; prev == nil || t.AsTime().Before(prev.AsTime()) {
+//                   byContainerName[name] = t
+//               }
+//           }
+//       })
+//       for _, c := range deployment.GetContainers() {
+//           c.OldestContainerStarted = byContainerName[c.GetName()]
+//       }
+//   }
+//
+// For deployments with no live pods (Deployment with zero replicas, or not yet scheduled),
+// oldest_container_started will remain nil, and the criterion will not fire — correct.
+//
+// # Clearing violations
+//
+// When a container restarts, the sensor receives a new ContainerInstance event. The
+// next reprocessing cycle re-evaluates, byContainerName gets the fresh start time,
+// and the violation clears automatically.
+//
+// # Open questions for acceptance criteria
+//
+// 1. DaemonSet containers: one pod per node, potentially hundreds of containers per
+//    deployment. Is oldest_container_started across all DaemonSet pods the right value,
+//    or should the user have a way to scope by node?
+// 2. InitContainers: currently ContainerInstance records init containers. Should the
+//    criterion apply to init containers? (probably not — filter by container type)
+// 3. Violation granularity: per-deployment or per-pod? The current Deployment model
+//    aggregates across all pods; per-pod would require restructuring violations.

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -492,6 +492,21 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
+        // SPIKE: 'Container Age' maps to the oldest_container_started field on Deployment.Container,
+        // populated transiently at policy evaluation time from pod store data.
+        // Unlike 'Image Age' (when the image was built), this measures how long the running
+        // container instance has been alive. DEPLOY+RUNTIME lifecycles apply; BUILD is excluded.
+        label: 'Days since container started',
+        name: 'Container Age',
+        shortName: 'Container age',
+        longName: 'Minimum days since container instance started running',
+        category: policyCriteriaCategories.CONTAINER_CONFIGURATION,
+        type: 'number',
+        placeholder: '1',
+        canBooleanLogic: false,
+        lifecycleStages: ['DEPLOY', 'RUNTIME'],
+    },
+    {
         label: 'Days since image was created',
         name: 'Image Age',
         shortName: 'Image age',


### PR DESCRIPTION
## Description

Spike for RFE-8623 / ROX-36755 — a new **Container Age > N days** policy criterion that fires when a running container has been alive longer than a configured threshold (e.g., 30 days). Distinct from *Image Age* (which measures when the image was built).

**Goal of this PR:** establish the data flow, identify the open design questions, and validate that the criterion pattern fits the existing boolean policy engine — before committing to a full implementation.

### What is here

- `proto/storage/deployment.proto`: New transient field `oldest_container_started` on `Container`. Set at eval time from pod store data; never persisted.
- `pkg/search/options.go`: `ContainerStartTime` field label.
- `pkg/booleanpolicy/fieldnames/list.go`: `ContainerAge` field name.
- `pkg/booleanpolicy/field_metadata.go`: Criterion registration with `ForDays` query builder (same pattern as `ImageAge`). Spike notes inline.
- `pkg/booleanpolicy/violationmessages/`: Context fields, printer entry, `containerAgePrinter` function.
- `pkg/booleanpolicy/query_to_field_value_mappers.go`: `ContainerStartTime -> numberOfDaysSinceMap`.
- `ui/.../policyCriteriaDescriptors.tsx`: UI descriptor for policy builder wizard.
- `sensor/common/detector/container_age_enrichment.go`: Design doc covering enrichment algorithm, sensor vs central trade-offs, interface changes needed.
- `pkg/booleanpolicy/container_age_criteria_test.go`: Unit tests (blocked on proto codegen).

### What is NOT here (intentionally)

- Proto codegen (`make proto-generated-srcs` needs Docker; skipped for spike)
- Sensor wiring: `store.PodStore` interface extension + `detectorImpl.podStore` field
- E2E tests

### Key design finding: enrichment location

The policy engine evaluates `Deployment.Containers[i].OldestContainerStarted` at detection time. This field must be populated transiently before `DetectDeployment` is called. Two options:

**Option A (preferred) — sensor-side:** In `detectDeploymentFromScanResult`, look up live pods by `(namespace, deploymentID)` from the sensor pod cache. Requires extending `store.PodStore` interface with `ForDeployment(ns, deploymentID string, fn func(*storage.Pod))` and wiring `podStore` into `detectorImpl`.

**Option B — central-side:** In the reprocessing pipeline, query central's pod datastore before forwarding to the lifecycle manager. Simpler wiring but adds a pod datastore dependency in central's reprocessing path.

See `sensor/common/detector/container_age_enrichment.go` for the full algorithm and open questions (DaemonSets, init containers, per-pod vs per-deployment violation granularity).

### Re-evaluation without a Kubernetes event

The existing 4-hour reprocessing loop in `central/reprocessor/reprocessor.go` already sends `ReprocessDeployments` to all sensors. Containers aging past the threshold between events are caught within 4 hours with no new infrastructure.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Unit tests in `pkg/booleanpolicy/container_age_criteria_test.go`: fires when older than threshold, no-op when younger, no-op when field is nil (unenriched deployment), violation message includes container name. Tests blocked on proto codegen — will pass once `make proto-generated-srcs` is run.

- [x] added unit tests
- [ ] added e2e tests

### How I validated my change

- `go build ./pkg/booleanpolicy/... ./pkg/search/... ./sensor/common/detector/...` all pass.
- `go generate ./pkg/booleanpolicy/violationmessages/printer/` regenerated `gen-registrations.go` with `ContainerAgeKey`.
- Test file does not compile yet (expected) — `OldestContainerStarted` requires proto codegen.

AI-assisted spike.
