### PR TITLE
fix(tests): apply old-roxctl scanner/; wait Central V2

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -576,6 +576,15 @@ function launch_central {
       fi
 
       if [[ "$SCANNER_SUPPORT" == "true" ]]; then
+          # scanner/ is applied only when the bundle contains it, so mixed-version
+          # kubectl installs (earlier roxctl) get V2 while HEAD bundles stay V2-free.
+          if [[ -d "${unzip_dir}/scanner" ]]; then
+            echo "Deploying Scanner..."
+            if [[ -x "${unzip_dir}/scanner/scripts/setup.sh" ]]; then
+              "${unzip_dir}/scanner/scripts/setup.sh"
+            fi
+            launch_service "${unzip_dir}" scanner
+          fi
           if [[ "${ROX_SCANNER_V4:-}" != "false" ]]; then
             if [[ -d "${unzip_dir}/scanner-v4" ]]; then
               echo "Deploying ScannerV4..."

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -844,9 +844,11 @@ EOT
 
     _begin "verify"
 
+    # Previous operator still creates Central V2. HEAD's SecuredCluster CR
+    # does not request slim V2, so the sensor namespace has none to wait for.
+    verify_scannerV2_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
     verify_scannerV4_deployed "${CUSTOM_CENTRAL_NAMESPACE}"
     verify_deployment_scannerV4_env_var_set "${CUSTOM_CENTRAL_NAMESPACE}" "central"
-    # Scanner V2 in sensor is disabled via operator deployment path.
     verify_scannerV4_indexer_deployed "${CUSTOM_SENSOR_NAMESPACE}"
     verify_deployment_scannerV4_env_var_set "${CUSTOM_SENSOR_NAMESPACE}" "sensor"
 
@@ -1061,6 +1063,16 @@ verify_no_scannerV4_matcher_deployed() {
     echo "Verifying that scanner V4 matcher is not deployed"
     run "${ORCH_CMD}" </dev/null -n "$namespace" get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
     refute_output --regexp "scanner-v4-matcher"
+}
+
+# verify_scannerV2_deployed waits for Scanner V2 on old-chart / previous-operator /
+# earlier-roxctl installs. HEAD steps use verify_no_scannerV2_deployed.
+verify_scannerV2_deployed() {
+    local namespace=${1:-stackrox}
+    info "Waiting for Scanner V2 deployment to appear in namespace ${namespace}..."
+    wait_for_object_to_appear "$namespace" deploy/scanner-db 600
+    wait_for_object_to_appear "$namespace" deploy/scanner 300
+    info "** Scanner V2 is deployed in namespace ${namespace}"
 }
 
 verify_no_scannerV2_deployed() {


### PR DESCRIPTION
## Description

Sibling of [PR 22645](https://github.com/stackrox/stackrox/pull/22645). Prow `*-scanner-v4-install-tests` still fail on mixed-version kubectl and operator cases after that parent.

4.11.3 `roxctl` still writes `scanner/` into the bundle. HEAD `deploy/common/k8sbased.sh` only launched `scanner-v4/` when `ROX_SCANNER_V4 != false`. The kubectl upgrade sets `ROX_SCANNER_V4=false` for the pre-upgrade deploy, so V2 YAML was never applied. This PR launches `scanner/` when that directory exists. HEAD `roxctl` does not emit `scanner/`, so 5.0 installs stay V2-free.

The parent already dropped the sensor-namespace V2 wait and turned the kubectl old-roxctl case into a V4-only check. This PR does not put `verify_scannerV2_deployed` back on that kubectl path. Manifest-bundle upgrades still do not prune leftover V2.

The previous operator still creates V2 on Central. The parent stopped waiting for it. This PR restores `verify_scannerV2_deployed` and uses it for that Central wait. HEAD's SecuredCluster CR does not request slim V2, so there is still no sensor-namespace wait. After upgrade, `verify_no_scannerV2_deployed` stays on both namespaces.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Coverage is the existing kubectl and operator mixed-version cases in `tests/e2e/run-scanner-v4-install.bats`. No new V4 asserts.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

No manual validation. I did not run the bats suite against a cluster.