### PR TITLE
ROX-36833: fix TestCancelNodeReport race on cancel status check

### DIFF
--- a/tests/node_report_test.go
+++ b/tests/node_report_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/tests/node_report_test.go
+++ b/tests/node_report_test.go
@@ -516,8 +516,12 @@ func (s *NodeReportSuite) TestCancelNodeReport() {
 		defer cancel()
 		statusResp, err := s.service.GetNodeReportStatus(ctx, &apiV2.ResourceByID{Id: runResp.GetReportId()})
 		if err != nil {
-			s.T().Logf("Report not found after cancel: %v", err)
-			return true // treat not-found as done
+			if status.Code(err) == codes.NotFound {
+				s.T().Logf("Report not found after cancel: %v", err)
+				return true
+			}
+			s.T().Logf("Error checking report status after cancel: %v", err)
+			return false
 		}
 		finalStatus = statusResp.GetStatus()
 		state := finalStatus.GetRunState()

--- a/tests/node_report_test.go
+++ b/tests/node_report_test.go
@@ -509,24 +509,32 @@ func (s *NodeReportSuite) TestCancelNodeReport() {
 		s.T().Logf("Cancel returned error (job may have already finished): %v", err)
 	}
 
-	statusCtx, statusCancel := context.WithTimeout(s.ctx, 30*time.Second)
-	defer statusCancel()
+	// Cancellation is processed asynchronously; poll until the report reaches a terminal state.
+	var finalStatus *apiV2.ReportStatus
+	s.Require().Eventually(func() bool {
+		ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+		defer cancel()
+		statusResp, err := s.service.GetNodeReportStatus(ctx, &apiV2.ResourceByID{Id: runResp.GetReportId()})
+		if err != nil {
+			s.T().Logf("Report not found after cancel: %v", err)
+			return true // treat not-found as done
+		}
+		finalStatus = statusResp.GetStatus()
+		state := finalStatus.GetRunState()
+		s.T().Logf("Report state after cancel: %s", state)
+		return state == apiV2.ReportStatus_FAILURE ||
+			state == apiV2.ReportStatus_GENERATED ||
+			state == apiV2.ReportStatus_DELIVERED
+	}, 2*time.Minute, 5*time.Second, "report did not reach terminal state after cancel")
 
-	statusResp, err := s.service.GetNodeReportStatus(statusCtx, &apiV2.ResourceByID{Id: runResp.GetReportId()})
-	if err != nil {
-		s.T().Logf("Report not found after cancel: %v", err)
-		return
+	if finalStatus == nil {
+		return // not-found case handled above
 	}
-
-	reportStatus := statusResp.GetStatus()
-	s.T().Logf("Report state after cancel: %s", reportStatus.GetRunState())
-	switch reportStatus.GetRunState() {
+	switch finalStatus.GetRunState() {
 	case apiV2.ReportStatus_FAILURE:
-		s.Equal("report cancelled by user", reportStatus.GetErrorMsg(), "cancelled report should have cancellation message")
+		s.Equal("report cancelled by user", finalStatus.GetErrorMsg(), "cancelled report should have cancellation message")
 	case apiV2.ReportStatus_GENERATED, apiV2.ReportStatus_DELIVERED:
 		s.T().Log("report completed before cancel took effect")
-	default:
-		s.Failf("unexpected report state after cancel", "got %s: %s", reportStatus.GetRunState(), reportStatus.GetErrorMsg())
 	}
 }
 


### PR DESCRIPTION
## Description

`TestNodeReport/TestCancelNodeReport` was flaky because `CancelNodeReport` is processed **asynchronously** when `CentralWorkerEnabled` is true: the API fires a `pgNotify.ReportRequestCancelled` event and returns immediately, while a listener goroutine later calls `scheduler.CancelReportRequest` to transition the snapshot state to `FAILURE`. The original test called `GetNodeReportStatus` in a single immediate check right after the cancel call, before that async transition had propagated, and failed with state `PREPARING`.

**Root cause (from CI triage):**
> TestCancelNodeReport race condition: CancelNodeReport API call succeeds but report state remains PREPARING because cancellation has not propagated by the time GetNodeReportStatus is called.

**Fix:** Replace the single immediate `GetNodeReportStatus` call with a `Require().Eventually` poll (2-minute timeout, 5-second interval) that waits for the report to reach a terminal state (FAILURE / GENERATED / DELIVERED). This is the same pattern used by `waitForReportCompletion` elsewhere in the same test suite.

Ticket: https://issues.redhat.com/browse/ROX-36833
CI failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-nightlies-ocp-4-22-nongroovy-e2e-tests/2097123947240755200

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

**Compile check:**
```
$ go vet -tags test_e2e ./tests/
# exits 0, no errors
```

**Before fix:** test fails immediately with `unexpected report state after cancel: got PREPARING`.

**After fix:** test polls every 5s up to 2 minutes; cancellation state propagates asynchronously within that window, so the test reaches the FAILURE branch and asserts `errorMsg == "report cancelled by user"`.

Local cluster E2E verification was not possible because the available cluster images predate the `NodeReportService` gRPC endpoint (introduced in #22388). CI (`/test all`) provides the authoritative E2E verification.