### PR TITLE
chore(CI): Fix CRD apply wait method

### DIFF
--- a/tests/complianceoperator/create.sh
+++ b/tests/complianceoperator/create.sh
@@ -15,5 +15,22 @@ if ! kubectl get crd compliancecheckresults.compliance.openshift.io; then
     while IFS='' read -r single_crd; do all_crds+=("$single_crd"); done < <(grep -rh '^  name:.*\.compliance\.openshift\.io' "${DIR}/crds/" | awk '{print "crd/" $2}')
     kubectl wait --for condition=established --timeout=60s "${all_crds[@]}"
 
+    # `kubectl wait --for condition=established` can fail immediately
+    # (not time out) when a just-applied CRD has not had its
+    # .status.conditions populated by the API server yet.
+    established=false
+    for _ in $(seq 1 5); do
+        if kubectl wait --for condition=established --timeout=60s "${all_crds[@]}"; then
+            established=true
+            break
+        fi
+        echo "kubectl wait for established compliance CRDs failed (status may not be populated yet); retrying in 5s..."
+        sleep 5
+    done
+    if [ "${established}" != "true" ]; then
+        echo "ERROR: compliance CRDs did not become established in time" >&2
+        exit 1
+    fi
+
     kubectl apply -R -f "${DIR}/resources"
 fi


### PR DESCRIPTION
## Description

We have an issue with compliance CRD apply.

PR: https://github.com/stackrox/stackrox/pull/20405 - has improved the situation, but still there are some edge cases where this functionality fails.

This PR addresses the following problme. When`kubectl wait --for condition=established` is called on freshly-applied CRDs, but if the API server hadn't populated a CRD's `.status.conditions` yet, kubectl wait fails immediately with the `.status.conditions` accessor error (not a timeout).

Log example:
```
2026-08-31T17:37:08.1864808Z customresourcedefinition.apiextensions.k8s.io/compliancecheckresults.compliance.openshift.io condition met
2026-08-31T17:37:08.3018551Z customresourcedefinition.apiextensions.k8s.io/tailoredprofiles.compliance.openshift.io condition met
2026-08-31T17:37:08.4177239Z customresourcedefinition.apiextensions.k8s.io/compliancesuites.compliance.openshift.io condition met
2026-08-31T17:37:08.5339398Z error: .status.conditions accessor error: <nil> is of the type <nil>, expected []interface***
2026-08-31T17:37:08.5341615Z customresourcedefinition.apiextensions.k8s.io/profiles.compliance.openshift.io condition met
2026-08-31T17:37:08.5376384Z ##[error]Process completed with exit code 1.
2026-08-31T17:37:08.5414602Z ##[group]Run source tests/e2e/lib.sh
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing test setup

### How I validated my change

- [x] let CI run changed script
