### PR TITLE
chore: bump kubevirt.io/client-go to v1.10.0-alpha.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	k8s.io/kubelet v0.32.13
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	kubevirt.io/api v1.9.0
-	kubevirt.io/client-go v1.9.0-beta.0.0.20260825101120-f38626e05426
+	kubevirt.io/client-go v1.10.0-alpha.0
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
 	sigs.k8s.io/e2e-framework v0.7.0
@@ -540,10 +540,6 @@ replace (
 	gopkg.in/yaml.v2 => github.com/stackrox/yaml/v2 v2.4.1
 	gopkg.in/yaml.v3 => github.com/stackrox/yaml/v3 v3.0.0
 )
-
-// No tagged kubevirt.io/client-go includes kubevirt#18315, required for
-// kubevirt client-go against k8s.io/client-go v0.36. Pinned to
-// kubevirt/client-go@f38626e.
 
 // kubevirt.io/client-go requires the nonexistent k8s.io/kube-openapi@v0.31.0 tag.
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20260427204847-8949caaa1199

--- a/go.sum
+++ b/go.sum
@@ -2184,8 +2184,8 @@ k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbe
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 kubevirt.io/api v1.9.0 h1:FWqx9yGk/GHUP5o4IthGXZ8FeAlgVNv2It48wD86UUo=
 kubevirt.io/api v1.9.0/go.mod h1:tFKAVaJMm7bXCMLxOoUdAqBprKAXoCa0sp0gBmnfBgY=
-kubevirt.io/client-go v1.9.0-beta.0.0.20260825101120-f38626e05426 h1:W7o8PnS4K+fLbaDSB8QhK2J18pcnRDs4QlfrxNspMng=
-kubevirt.io/client-go v1.9.0-beta.0.0.20260825101120-f38626e05426/go.mod h1:bXmbwFVCJsUnFGg1lgVSB2Jc180N7IzlQRHXJxlrG6U=
+kubevirt.io/client-go v1.10.0-alpha.0 h1:4fEp/8Aa6OUDRo5RZT5Uehw3K6Bp/tQPA2hIJhFCQfw=
+kubevirt.io/client-go v1.10.0-alpha.0/go.mod h1:bXmbwFVCJsUnFGg1lgVSB2Jc180N7IzlQRHXJxlrG6U=
 kubevirt.io/containerized-data-importer-api v1.64.0 h1:yBLY6qEogUp8F+XSJvabIkx9uEEDeToYDfRr0mbUxJc=
 kubevirt.io/containerized-data-importer-api v1.64.0/go.mod h1:VGp35wxpLXU18b7cnEpmcThI3AjcZUSfg/Zfql44U4o=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 h1:fZYvD3/Vnitfkx6IJxjLAk8ugnZQ7CXVYcRfkSKmuZY=


### PR DESCRIPTION
## Description

ACS currently pins `kubevirt.io/client-go` to a pseudo-version (`v1.9.0-beta.0.0.20260825101120-f38626e05426`) because no tagged client-go included [kubevirt#18315](https://github.com/kubevirt/kubevirt/pull/18315), which is required to build against `k8s.io/client-go` v0.36.

Tagged `v1.9.0` exists, but it is older than that pin (2026-07-30 vs 2026-08-25) and does not include #18315. `v1.10.0-alpha.0` is the first tag that does. This PR moves the require to that tag and drops the obsolete pin comment.

`kubevirt.io/api` stays at tagged `v1.9.0`. The `k8s.io/kube-openapi` replace is unchanged: kubevirt client-go still requires the nonexistent `v0.31.0` tag, and that replace is not inherited from kubevirt's own `go.mod`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Dependency version bump only. Existing compile and unit tests cover the kubevirt client.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] CI

AI-Assisted: cursor, generated the module bump and this description; user chose the target version and reviewed `go.mod`.