### PR TITLE
ROX-36889: Delete VM inventory when removing a secured cluster

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -23,6 +23,8 @@ import (
 	secretDataStore "github.com/stackrox/rox/central/secret/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
+	virtualMachineDataStore "github.com/stackrox/rox/central/virtualmachine/datastore"
+	virtualMachineV2DataStore "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -101,6 +103,8 @@ func New(
 	networkBaselineMgr networkBaselineManager.Manager,
 	compliancePruner compliancePruning.Pruner,
 	clusterInitStore clusterInitStore.Store,
+	virtualMachines virtualMachineDataStore.DataStore,
+	virtualMachinesV2 virtualMachineV2DataStore.DataStore,
 ) (DataStore, error) {
 	ds := &datastoreImpl{
 		clusterStorage:            clusterStorage,
@@ -127,6 +131,8 @@ func New(
 		nameToIDCache:             simplecache.New(),
 		compliancePruner:          compliancePruner,
 		clusterInitStore:          clusterInitStore,
+		virtualMachineDataStore:   virtualMachines,
+		virtualMachineV2DataStore: virtualMachinesV2,
 	}
 
 	if err := ds.buildCache(sac.WithAllAccess(context.Background())); err != nil {

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"regexp"
 	"slices"
 	"strings"
@@ -34,6 +35,8 @@ import (
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
+	virtualMachineDataStore "github.com/stackrox/rox/central/virtualmachine/datastore"
+	virtualMachineV2DataStore "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -96,6 +99,9 @@ type datastoreImpl struct {
 	compliancePruner          compliancePruning.Pruner
 	cm                        connection.Manager
 	networkBaselineMgr        networkBaselineManager.Manager
+	virtualMachineDataStore   virtualMachineDataStore.DataStore
+	// virtualMachineV2DataStore is nil when VirtualMachinesEnhancedDataModel is off.
+	virtualMachineV2DataStore virtualMachineV2DataStore.DataStore
 
 	notifier      notifierProcessor.Processor
 	clusterRanker *ranking.Ranker
@@ -691,6 +697,8 @@ func (ds *datastoreImpl) postRemoveCluster(ctx context.Context, cluster *storage
 		log.Errorf("failed to remove nodes for cluster %s: %v", cluster.GetId(), err)
 	}
 
+	ds.removeClusterVirtualMachines(ctx, cluster)
+
 	if err := ds.netEntityDataStore.DeleteExternalNetworkEntitiesForCluster(ctx, cluster.GetId()); err != nil {
 		log.Errorf("failed to delete external network graph entities for removed cluster %s: %v", cluster.GetId(), err)
 	}
@@ -766,6 +774,43 @@ func (ds *datastoreImpl) removeClusterPods(ctx context.Context, cluster *storage
 			log.Errorf("Failed to remove pod with id %s as part of removal of cluster %s: %v", pod.ID, cluster.GetId(), err)
 		}
 	}
+}
+
+// removeClusterVirtualMachines deletes V1 and V2 VM inventory for the cluster.
+// Child scan/component/CVE rows cascade from the VM; ClusterID has no FK to clusters.
+func (ds *datastoreImpl) removeClusterVirtualMachines(ctx context.Context, cluster *storage.Cluster) {
+	q := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ClusterID, cluster.GetId()).ProtoQuery()
+	q.Pagination = &v1.QueryPagination{Limit: math.MaxInt32}
+
+	if ds.virtualMachineDataStore != nil {
+		vms, err := ds.virtualMachineDataStore.SearchRawVirtualMachines(ctx, q)
+		if err != nil {
+			log.Errorf("Failed to get virtual machines for removed cluster %s: %v", cluster.GetId(), err)
+		} else if ids := virtualMachineIDs(vms); len(ids) > 0 {
+			if err := ds.virtualMachineDataStore.DeleteVirtualMachines(ctx, ids...); err != nil {
+				log.Errorf("Failed to remove virtual machines as part of removal of cluster %s: %v", cluster.GetId(), err)
+			}
+		}
+	}
+
+	if ds.virtualMachineV2DataStore != nil {
+		results, err := ds.virtualMachineV2DataStore.Search(ctx, q)
+		if err != nil {
+			log.Errorf("Failed to get v2 virtual machines for removed cluster %s: %v", cluster.GetId(), err)
+		} else if ids := pkgSearch.ResultsToIDs(results); len(ids) > 0 {
+			if err := ds.virtualMachineV2DataStore.DeleteVirtualMachines(ctx, ids...); err != nil {
+				log.Errorf("Failed to remove v2 virtual machines as part of removal of cluster %s: %v", cluster.GetId(), err)
+			}
+		}
+	}
+}
+
+func virtualMachineIDs(vms []*storage.VirtualMachine) []string {
+	ids := make([]string, 0, len(vms))
+	for _, vm := range vms {
+		ids = append(ids, vm.GetId())
+	}
+	return ids
 }
 
 func (ds *datastoreImpl) removeClusterDeployments(ctx context.Context, cluster *storage.Cluster) []string {

--- a/central/cluster/datastore/datastore_impl_postgres_test.go
+++ b/central/cluster/datastore/datastore_impl_postgres_test.go
@@ -30,6 +30,10 @@ import (
 	secretDataStore "github.com/stackrox/rox/central/secret/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
+	vmCVEDatastore "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore"
+	vmDatastore "github.com/stackrox/rox/central/virtualmachine/datastore"
+	vmV2Datastore "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
+	"github.com/stackrox/rox/central/virtualmachine/v2/datastore/store/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -78,6 +82,9 @@ type ClusterPostgresDataStoreTestSuite struct {
 	imageIntegrationDatastore imageIntegrationDataStore.DataStore
 	clusterDatastore          DataStore
 	clusterInitStore          clusterInitStore.Store
+	vmDatastore               vmDatastore.DataStore
+	vmV2Datastore             vmV2Datastore.DataStore
+	vmCVEDatastore            vmCVEDatastore.DataStore
 
 	clusterHealthDBStore clusterHealthPostgresStore.Store
 }
@@ -112,11 +119,15 @@ func (s *ClusterPostgresDataStoreTestSuite) SetupTest() {
 	s.roleBindingDatastore = k8sRoleBindingDataStore.GetTestPostgresDataStore(s.T(), s.db.DB)
 	s.imageIntegrationDatastore = imageIntegrationDataStore.GetTestPostgresDataStore(s.T(), s.db.DB)
 	s.clusterInitStore = clusterInitStore.GetTestPostgresDataStore(s.T(), s.db.DB)
+	s.vmDatastore = vmDatastore.GetTestPostgresDataStore(s.T(), s.db)
+	s.vmV2Datastore = vmV2Datastore.GetTestPostgresDataStore(s.T(), s.db)
+	s.vmCVEDatastore = vmCVEDatastore.GetTestPostgresDataStore(s.T(), s.db)
 	s.clusterDatastore, err = New(clusterDBStore, s.clusterHealthDBStore, clusterCVEStore,
 		s.alertDatastore, s.imageIntegrationDatastore, s.nsDatastore, s.deploymentDatastore,
 		nodeStore, s.podDatastore, s.secretDatastore, netFlowStore, netEntityStore,
 		s.serviceAccountDatastore, s.roleDatastore, s.roleBindingDatastore, sensorCnxMgr, nil,
-		clusterRanker, networkBaselineM, compliancePruner, s.clusterInitStore)
+		clusterRanker, networkBaselineM, compliancePruner, s.clusterInitStore,
+		s.vmDatastore, s.vmV2Datastore)
 	s.NoError(err)
 }
 
@@ -170,6 +181,43 @@ func (s *ClusterPostgresDataStoreTestSuite) TestRemoveCluster() {
 	s.NotEmpty(imageIntegrationId)
 	s.NoError(imageIntegrationAddErr)
 
+	testV1VM := &storage.VirtualMachine{
+		Id:        fixtureconsts.VirtualMachine1,
+		Name:      "retired-vm-v1",
+		Namespace: "default",
+		ClusterId: clusterId,
+		Scan: &storage.VirtualMachineScan{
+			Components: []*storage.EmbeddedVirtualMachineScanComponent{
+				{Name: "openssl", Version: "1.1.1"},
+			},
+		},
+	}
+	s.NoError(s.vmDatastore.UpsertVirtualMachine(ctx, testV1VM))
+
+	testV2VM := &storage.VirtualMachineV2{
+		Id:          fixtureconsts.VirtualMachine2,
+		Name:        "retired-vm-v2",
+		Namespace:   "default",
+		ClusterId:   clusterId,
+		ClusterName: testCluster.GetName(),
+		GuestOs:     "rhel9",
+		State:       storage.VirtualMachineV2_RUNNING,
+	}
+	s.NoError(s.vmV2Datastore.UpsertVirtualMachine(ctx, testV2VM))
+	s.NoError(s.vmV2Datastore.UpsertScan(ctx, testV2VM.GetId(), clusterRemovalTestScanParts(testV2VM.GetId())))
+
+	keptCluster := &storage.Cluster{Name: fixtureconsts.ClusterName2, MainImage: mainImage, CentralApiEndpoint: centralEndpoint}
+	keptClusterID, keptClusterAddErr := s.clusterDatastore.AddCluster(ctx, keptCluster)
+	s.NotEmpty(keptClusterID)
+	s.NoError(keptClusterAddErr)
+	keptV1VM := &storage.VirtualMachine{
+		Id:        fixtureconsts.VirtualMachineFake,
+		Name:      "kept-vm-v1",
+		Namespace: "default",
+		ClusterId: keptClusterID,
+	}
+	s.NoError(s.vmDatastore.UpsertVirtualMachine(ctx, keptV1VM))
+
 	// Remove cluster and verify that the removal has been cascaded to all related components
 	doneSignal := concurrency.NewSignal()
 	clusterRemoveErr := s.clusterDatastore.RemoveCluster(ctx, clusterId, &doneSignal)
@@ -213,6 +261,66 @@ func (s *ClusterPostgresDataStoreTestSuite) TestRemoveCluster() {
 	_, imageIntegrationFound, imageIntegrationGetErr := s.imageIntegrationDatastore.GetImageIntegration(ctx, testImageIntegration.GetId())
 	s.NoError(imageIntegrationGetErr)
 	s.False(imageIntegrationFound)
+
+	v1Count, v1CountErr := s.vmDatastore.CountVirtualMachines(ctx, pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ClusterID, clusterId).ProtoQuery())
+	s.NoError(v1CountErr)
+	s.Zero(v1Count)
+	_, v1Found, v1GetErr := s.vmDatastore.GetVirtualMachine(ctx, testV1VM.GetId())
+	s.NoError(v1GetErr)
+	s.False(v1Found)
+
+	v2Count, v2CountErr := s.vmV2Datastore.CountVirtualMachines(ctx, pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ClusterID, clusterId).ProtoQuery())
+	s.NoError(v2CountErr)
+	s.Zero(v2Count)
+	_, v2Found, v2GetErr := s.vmV2Datastore.GetVirtualMachine(ctx, testV2VM.GetId())
+	s.NoError(v2GetErr)
+	s.False(v2Found)
+
+	cves, cveSearchErr := s.vmCVEDatastore.SearchRawVMCVEs(ctx, pkgSearch.EmptyQuery())
+	s.NoError(cveSearchErr)
+	s.Empty(cves)
+
+	_, keptFound, keptGetErr := s.vmDatastore.GetVirtualMachine(ctx, keptV1VM.GetId())
+	s.NoError(keptGetErr)
+	s.True(keptFound)
+}
+
+func clusterRemovalTestScanParts(vmID string) common.VMScanParts {
+	scanID := uuid.NewV4().String()
+	compID := uuid.NewV4().String()
+	cveID := uuid.NewV4().String()
+	return common.VMScanParts{
+		Scan: &storage.VirtualMachineScanV2{
+			Id:     scanID,
+			VmV2Id: vmID,
+			ScanOs: "rhel9",
+		},
+		Components: []*storage.VirtualMachineComponentV2{
+			{
+				Id:              compID,
+				VmScanId:        scanID,
+				Name:            "openssl",
+				Version:         "1.1.1",
+				Source:          storage.SourceType_OS,
+				OperatingSystem: "rhel:9",
+			},
+		},
+		CVEs: []*storage.VirtualMachineCVEV2{
+			{
+				Id:            cveID,
+				VmV2Id:        vmID,
+				VmComponentId: compID,
+				CveBaseInfo: &storage.CVEInfo{
+					Cve:     "CVE-2024-0001",
+					Summary: "test vulnerability",
+				},
+				PreferredCvss: 7.5,
+				Severity:      storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+				IsFixable:     true,
+				HasFixedBy:    &storage.VirtualMachineCVEV2_FixedBy{FixedBy: "1.1.2"},
+			},
+		},
+	}
 }
 
 func (s *ClusterPostgresDataStoreTestSuite) TestPopulateClusterHealthInfo() {

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"errors"
+	"math"
 	"regexp"
 	"testing"
 	"time"
@@ -27,6 +28,9 @@ import (
 	secretDataStoreMocks "github.com/stackrox/rox/central/secret/datastore/mocks"
 	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	serviceAccountDataStoreMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
+	virtualMachineDSMocks "github.com/stackrox/rox/central/virtualmachine/datastore/mocks"
+	virtualMachineV2DSMocks "github.com/stackrox/rox/central/virtualmachine/v2/datastore/mocks"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	clusterPkg "github.com/stackrox/rox/pkg/cluster"
@@ -80,6 +84,8 @@ type clusterDataStoreTestSuite struct {
 	k8sRoleBindingDS     *roleBindingDataStoreMocks.MockDataStore
 	secretDS             *secretDataStoreMocks.MockDataStore
 	serviceAccountDS     *serviceAccountDataStoreMocks.MockDataStore
+	vmDS                 *virtualMachineDSMocks.MockDataStore
+	vmV2DS               *virtualMachineV2DSMocks.MockDataStore
 
 	networkBaselineMgr *networkBaselineManagerMocks.MockManager
 
@@ -112,6 +118,8 @@ func (s *clusterDataStoreTestSuite) SetupTest() {
 	s.k8sRoleBindingDS = roleBindingDataStoreMocks.NewMockDataStore(s.mockCtrl)
 	s.secretDS = secretDataStoreMocks.NewMockDataStore(s.mockCtrl)
 	s.serviceAccountDS = serviceAccountDataStoreMocks.NewMockDataStore(s.mockCtrl)
+	s.vmDS = virtualMachineDSMocks.NewMockDataStore(s.mockCtrl)
+	s.vmV2DS = virtualMachineV2DSMocks.NewMockDataStore(s.mockCtrl)
 
 	s.networkBaselineMgr = networkBaselineManagerMocks.NewMockManager(s.mockCtrl)
 
@@ -138,6 +146,8 @@ func (s *clusterDataStoreTestSuite) SetupTest() {
 		serviceAccountDataStore:   s.serviceAccountDS,
 		roleDataStore:             s.k8sRoleDS,
 		roleBindingDataStore:      s.k8sRoleBindingDS,
+		virtualMachineDataStore:   s.vmDS,
+		virtualMachineV2DataStore: s.vmV2DS,
 		cm:                        s.sensorConnectionMgr,
 		notifier:                  s.notifierProcessor,
 		clusterRanker:             ranking.NewRanker(),
@@ -177,6 +187,9 @@ func (s *clusterDataStoreTestSuite) TestPostRemoveCluster() {
 
 	clusterIDSearchQuery := pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.ClusterID, clusterID).ProtoQuery()
 	matchClusterIDSearchQuery := protomock.GoMockMatcherEqualMessage(clusterIDSearchQuery)
+	vmClusterIDSearchQuery := clusterIDSearchQuery.CloneVT()
+	vmClusterIDSearchQuery.Pagination = &v1.QueryPagination{Limit: math.MaxInt32}
+	matchVMClusterIDSearchQuery := protomock.GoMockMatcherEqualMessage(vmClusterIDSearchQuery)
 
 	testError := errors.New("test error")
 
@@ -299,6 +312,31 @@ func (s *clusterDataStoreTestSuite) TestPostRemoveCluster() {
 				DeleteAllNodesForCluster(gomock.Any(), clusterID).
 				Times(1).
 				Return(tc.status)
+
+			// Remove virtual machines (v1 and v2)
+			v1VMs := make([]*storage.VirtualMachine, 0, len(tc.results))
+			for _, result := range tc.results {
+				v1VMs = append(v1VMs, &storage.VirtualMachine{Id: result.ID})
+			}
+			s.vmDS.EXPECT().
+				SearchRawVirtualMachines(gomock.Any(), matchVMClusterIDSearchQuery).
+				Times(1).
+				Return(v1VMs, tc.status)
+			s.vmV2DS.EXPECT().
+				Search(gomock.Any(), matchVMClusterIDSearchQuery).
+				Times(1).
+				Return(searchResults, tc.status)
+			if tc.status == nil && len(resultIDs) > 0 {
+				var deleteErr error
+				for _, result := range tc.results {
+					if result.status != nil {
+						deleteErr = result.status
+						break
+					}
+				}
+				s.vmDS.EXPECT().DeleteVirtualMachines(gomock.Any(), resultIDs[0], resultIDs[1]).Times(1).Return(deleteErr)
+				s.vmV2DS.EXPECT().DeleteVirtualMachines(gomock.Any(), resultIDs[0], resultIDs[1]).Times(1).Return(deleteErr)
+			}
 
 			// 9. Delete external network entities for cluster
 			s.networkEntityDS.EXPECT().

--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -25,6 +25,8 @@ import (
 	secretDataStore "github.com/stackrox/rox/central/secret/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
+	virtualMachineDataStore "github.com/stackrox/rox/central/virtualmachine/datastore"
+	virtualMachineV2DataStore "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
 	"github.com/stackrox/rox/pkg/postgres"
 )
 
@@ -75,5 +77,7 @@ func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error)
 		alertStore, iiStore, namespaceStore, deploymentStore,
 		nodeStore, podStore, secretStore, netFlowStore, netEntityStore,
 		serviceAccountStore, k8sRoleStore, k8sRoleBindingStore, sensorCnxMgr, nil,
-		clusterRanker, networkBaselineManager, compliancePruner, clusterInitStore)
+		clusterRanker, networkBaselineManager, compliancePruner, clusterInitStore,
+		virtualMachineDataStore.GetTestPostgresDataStore(t, pool),
+		virtualMachineV2DataStore.GetTestPostgresDataStore(t, pool))
 }

--- a/central/cluster/datastore/singleton.go
+++ b/central/cluster/datastore/singleton.go
@@ -23,6 +23,8 @@ import (
 	secretDataStore "github.com/stackrox/rox/central/secret/datastore"
 	"github.com/stackrox/rox/central/sensor/service/connection"
 	serviceAccountDataStore "github.com/stackrox/rox/central/serviceaccount/datastore"
+	virtualMachineDataStore "github.com/stackrox/rox/central/virtualmachine/datastore"
+	virtualMachineV2DataStore "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -60,7 +62,9 @@ func initialize() {
 		ranking.ClusterRanker(),
 		networkBaselineManager.Singleton(),
 		compliancePruning.Singleton(),
-		clusterInitStoreSingleton.Singleton())
+		clusterInitStoreSingleton.Singleton(),
+		virtualMachineDataStore.Singleton(),
+		virtualMachineV2DataStore.Singleton())
 
 	utils.CrashOnError(err)
 }

--- a/central/graphql/resolvers/test_setup_utils.go
+++ b/central/graphql/resolvers/test_setup_utils.go
@@ -256,7 +256,8 @@ func CreateTestClusterDatastore(t testing.TB, testDB *pgtest.TestPostgres, ctrl 
 	connMgr.EXPECT().GetConnection(gomock.Any()).AnyTimes()
 	datastore, err := clusterDataStore.New(storage, healthStorage,
 		clusterCVEDS, nil, nil, namespaceDS, nil, nodeDataStore, nil, nil,
-		netFlows, netEntities, nil, nil, nil, connMgr, nil, ranking.ClusterRanker(), nil, nil, nil)
+		netFlows, netEntities, nil, nil, nil, connMgr, nil, ranking.ClusterRanker(), nil, nil, nil,
+		nil, nil)
 	assert.NoError(t, err, "failed to create cluster datastore")
 	return datastore
 }

--- a/central/pruning/pruning_test.go
+++ b/central/pruning/pruning_test.go
@@ -421,7 +421,9 @@ func (s *PruningTestSuite) generateClusterDataStructures() (configDatastore.Data
 		ranking.NewRanker(),
 		networkBaselineMgr,
 		compliancePruner,
-		clusterInitStore)
+		clusterInitStore,
+		nil,
+		nil)
 	require.NoError(s.T(), err)
 
 	return mockConfigDatastore, deployments, clusterDataStore

--- a/central/virtualmachine/datastore/datastore_test_constructors.go
+++ b/central/virtualmachine/datastore/datastore_test_constructors.go
@@ -1,0 +1,13 @@
+package datastore
+
+import (
+	"testing"
+
+	pgStore "github.com/stackrox/rox/central/virtualmachine/datastore/internal/store/postgres"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
+	return newDatastoreImpl(pgStore.New(pool))
+}

--- a/central/virtualmachine/v2/datastore/datastore_test_constructors.go
+++ b/central/virtualmachine/v2/datastore/datastore_test_constructors.go
@@ -1,0 +1,14 @@
+package datastore
+
+import (
+	"testing"
+
+	pgStore "github.com/stackrox/rox/central/virtualmachine/v2/datastore/store/postgres"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// GetTestPostgresDataStore provides a datastore connected to postgres for testing purposes.
+func GetTestPostgresDataStore(_ testing.TB, pool postgres.DB) DataStore {
+	return newDatastoreImpl(pgStore.New(pool, concurrency.NewKeyFence()))
+}


### PR DESCRIPTION
## Description

Removing a secured cluster left that cluster's virtual machines and VM vulnerabilities in Postgres. Users with global VM read access still saw inventory and CVEs for a cluster that no longer exists. Sensor reconcile cannot clean this up: cluster removal closes the connection first, and `ClusterID` on the VM tables has no foreign key to clusters.

`postRemoveCluster` already deletes namespaces, deployments, pods, nodes, and other cluster-scoped inventory. This change searches both VM stores by cluster ID and deletes the matching VMs. V2 child scan, component, and CVE rows cascade from the VM.

The V1 store is always called so leftover rows from the enhanced-model flag flip are removed too. The V2 store is skipped when that flag is off.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [ ] CI

AI-Assisted: Cursor, ~70% generated, user reviewed logic