### PR TITLE
ROX-36890: Stop VM index pulls after a feature-disabled ACK

### DIFF
--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -121,7 +121,10 @@ type VMScraper struct {
 	// loggedSkip is set after the first skip log for a missing-capability stretch
 	// so a 10s ticker does not repeat it until the capability returns.
 	loggedSkip atomic.Bool
-	now        func() time.Time
+	// indexReportsDisabled is set from a feature-disabled ACK and cleared on
+	// CentralReachable so a later connection can scrape again.
+	indexReportsDisabled atomic.Bool
+	now                  func() time.Time
 	// randFloat64 returns a unit sample in [0, 1] for schedule offsets; tests inject a fixed source.
 	randFloat64          func() float64
 	lastSpreadWarnNumVMs int
@@ -198,6 +201,8 @@ func (s *VMScraper) Notify(e common.SensorComponentEvent) {
 	switch e {
 	case common.SensorComponentEventCentralReachable:
 		s.centralReady.Signal()
+		s.indexReportsDisabled.Store(false)
+		s.loggedSkip.Store(false)
 	case common.SensorComponentEventOfflineMode:
 		s.centralReady.Reset()
 	}
@@ -222,6 +227,10 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 
 	switch sensorAck.GetAction() {
 	case central.SensorACK_ACK:
+		if sensorAck.GetReason() == centralsensor.SensorACKReasonFeatureDisabled {
+			s.handleFeatureDisabled()
+			break
+		}
 		log.Debugf("VMScraper: received acknowledgement for resource_id=%q", sensorAck.GetResourceId())
 	case central.SensorACK_NACK:
 		s.handleNACK(sensorAck.GetResourceId())
@@ -229,6 +238,18 @@ func (s *VMScraper) ProcessMessage(_ context.Context, msg *central.MsgToSensor) 
 		log.Debugf("VMScraper: received unknown SensorACK action %v for resource_id=%q", sensorAck.GetAction(), sensorAck.GetResourceId())
 	}
 	return nil
+}
+
+// handleFeatureDisabled stops index pulls for this connection. CentralReachable
+// clears the flag so a later Central can be tried without a Sensor restart.
+func (s *VMScraper) handleFeatureDisabled() {
+	if s.indexReportsDisabled.Swap(true) {
+		return
+	}
+	log.Infof(
+		"VMScraper: Central ACKed a VM index report with reason %q; stopping index pulls for this connection to save resources",
+		centralsensor.SensorACKReasonFeatureDisabled,
+	)
 }
 
 // handleNACK clears lastToken and applies retry backoff so the next tick
@@ -306,9 +327,14 @@ func (s *VMScraper) run() {
 }
 
 func (s *VMScraper) tick(ctx context.Context, forceReconcile bool) {
-	if !centralcaps.Has(centralsensor.VirtualMachinesSupported) {
+	disabled := s.indexReportsDisabled.Load()
+	if disabled || !centralcaps.Has(centralsensor.VirtualMachinesSupported) {
 		if s.loggedSkip.CompareAndSwap(false, true) {
-			log.Infof("VMScraper: skipping pulling index reports from VMs; Central does not advertise VirtualMachinesSupported")
+			if disabled {
+				log.Infof("VMScraper: skipping pulling index reports from VMs; Central ACKed feature disabled")
+			} else {
+				log.Infof("VMScraper: skipping pulling index reports from VMs; Central does not advertise VirtualMachinesSupported")
+			}
 		}
 		return
 	}

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
@@ -846,6 +847,116 @@ func TestVMScraper_NACK(t *testing.T) {
 			assert.Equal(t, tc.wantTotalSent-1, forwardedCount(s), "additional reports forwarded after the ACK/NACK poll")
 		})
 	}
+}
+
+// TestVMScraper_ACKFeatureDisabledStopsScraping covers a 4.11 Central that
+// advertises VirtualMachinesSupported then ACKs index reports as feature-disabled.
+func TestVMScraper_ACKFeatureDisabledStopsScraping(t *testing.T) {
+	cases := map[string]struct {
+		reason      string
+		wantScrapes bool
+	}{
+		"stops scraping after a feature-disabled ACK": {
+			reason:      centralsensor.SensorACKReasonFeatureDisabled,
+			wantScrapes: false,
+		},
+		"keeps scraping after an ACK with an empty reason": {
+			reason:      "",
+			wantScrapes: true,
+		},
+		"keeps scraping after an ACK with an unrelated reason": {
+			reason:      centralsensor.SensorACKReasonRateLimited,
+			wantScrapes: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			vmA := makeVM("ns1", "vm-a", 100)
+			vmA.ID = "vm-a-id"
+			store := &mockStore{vms: []*virtualmachine.Info{vmA}}
+			dialer := &mockDialer{}
+			client := &mockProtocolClient{
+				resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+			}
+
+			s, clock := newTestScraper(t, store, dialer, client)
+			s.pollOnce(t.Context())
+			require.Equal(t, 1, forwardedCount(s))
+			require.True(t, centralcaps.Has(centralsensor.VirtualMachinesSupported))
+			reconcilesAfterFirst := store.listRunningCalls
+			dialsAfterFirst := dialer.callIdx.Load()
+
+			require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
+				Msg: &central.MsgToSensor_SensorAck{
+					SensorAck: &central.SensorACK{
+						MessageType: central.SensorACK_VM_INDEX_REPORT,
+						Action:      central.SensorACK_ACK,
+						ResourceId:  "vm-a-id:100",
+						Reason:      tc.reason,
+					},
+				},
+			}))
+			require.True(t, centralcaps.Has(centralsensor.VirtualMachinesSupported),
+				"hello capabilities are left unchanged")
+			assert.Equal(t, !tc.wantScrapes, s.indexReportsDisabled.Load())
+
+			client.reset()
+			client.resultQueue = []*vsockclient.GetReportResult{unchangedResult()}
+			clock.Advance(5 * time.Minute)
+			s.pollOnce(t.Context())
+
+			if tc.wantScrapes {
+				require.Len(t, client.calls, 1)
+				assert.Equal(t, reconcilesAfterFirst+1, store.listRunningCalls)
+				assert.Equal(t, dialsAfterFirst+1, dialer.callIdx.Load())
+			} else {
+				assert.Empty(t, client.calls)
+				assert.Equal(t, reconcilesAfterFirst, store.listRunningCalls)
+				assert.Equal(t, dialsAfterFirst, dialer.callIdx.Load())
+			}
+		})
+	}
+}
+
+// TestVMScraper_ACKFeatureDisabledResumesOnCentralReachable covers reconnect
+// after a feature-disabled ACK: the next Central is tried without a Sensor restart.
+func TestVMScraper_ACKFeatureDisabledResumesOnCentralReachable(t *testing.T) {
+	vmA := makeVM("ns1", "vm-a", 100)
+	vmA.ID = "vm-a-id"
+	store := &mockStore{vms: []*virtualmachine.Info{vmA}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(t.Context())
+	require.Equal(t, 1, forwardedCount(s))
+
+	require.NoError(t, s.ProcessMessage(t.Context(), &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{
+			SensorAck: &central.SensorACK{
+				MessageType: central.SensorACK_VM_INDEX_REPORT,
+				Action:      central.SensorACK_ACK,
+				ResourceId:  "vm-a-id:100",
+				Reason:      centralsensor.SensorACKReasonFeatureDisabled,
+			},
+		},
+	}))
+	require.True(t, s.indexReportsDisabled.Load())
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{unchangedResult()}
+	clock.Advance(5 * time.Minute)
+	s.pollOnce(t.Context())
+	assert.Empty(t, client.calls)
+
+	s.Notify(common.SensorComponentEventCentralReachable)
+	require.False(t, s.indexReportsDisabled.Load())
+
+	s.pollOnce(t.Context())
+	require.Len(t, client.calls, 1)
 }
 
 // TestVMScraper_InFlightSendDoesNotOverwriteNACKReset covers NACK while


### PR DESCRIPTION
## Description

A 5.0 Sensor with virtual machine scanning enabled will send index reports to a 4.11 Central that still advertises `VirtualMachinesSupported` even when `ROX_VIRTUAL_MACHINES` is off. That Central ACKs each report with reason `feature disabled on central` and does not store it. Sensor treated any ACK as success, kept the report token, and scraped again on the ordinary interval.

This PR stops index pulls for that connection when that ACK reason arrives. A scraper-local flag gates the scrape loop. Hello capabilities stay as advertised, so VM metadata dispatchers do not change behavior. `Notify(CentralReachable)` clears the flag so a later Central can be scraped without restarting Sensor.

Reconnect to the same 4.11 Central: one scrape, ACK, stop again. Connect to a 5.0 Central with the feature on: scraping continues.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] CI

AI-Assisted: cursor, generated the scraper flag and tests; user chose the local-flag approach over mutating Central capabilities and reviewed log wording.