### PR TITLE
ROX-36890: Gate VirtualMachinesSupported on the VM flag

### DIFF
--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -64,7 +64,12 @@ type pipelineImpl struct {
 
 func (p *pipelineImpl) OnFinish(string) {}
 
+// Capabilities omits VirtualMachinesSupported when ROX_VIRTUAL_MACHINES is
+// off so Sensor treats this Central like a pre-VM build.
 func (p *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
+	if !features.VirtualMachines.Enabled() {
+		return nil
+	}
 	return []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported}
 }
 

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -2,6 +2,7 @@ package virtualmachineindex
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -158,8 +159,25 @@ func (suite *PipelineTestSuite) TestRun_UpdateScanError() {
 }
 
 func (suite *PipelineTestSuite) TestCapabilities() {
-	capabilities := suite.pipeline.Capabilities()
-	suite.Contains(capabilities, centralsensor.CentralCapability(centralsensor.VirtualMachinesSupported))
+	cases := map[string]struct {
+		enabled bool
+		want    []centralsensor.CentralCapability
+	}{
+		"flag on advertises VirtualMachinesSupported": {
+			enabled: true,
+			want:    []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported},
+		},
+		"flag off advertises nothing": {
+			enabled: false,
+			want:    nil,
+		},
+	}
+	for name, tc := range cases {
+		suite.Run(name, func() {
+			suite.T().Setenv(features.VirtualMachines.EnvVar(), strconv.FormatBool(tc.enabled))
+			suite.Equal(tc.want, suite.pipeline.Capabilities())
+		})
+	}
 }
 
 func (suite *PipelineTestSuite) TestOnFinish() {

--- a/central/sensor/service/pipeline/virtualmachines/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline.go
@@ -52,7 +52,12 @@ type pipelineImpl struct {
 
 func (p *pipelineImpl) OnFinish(_ string) {}
 
+// Capabilities omits VirtualMachinesSupported when ROX_VIRTUAL_MACHINES is
+// off so Sensor treats this Central like a pre-VM build.
 func (p *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
+	if !features.VirtualMachines.Enabled() {
+		return nil
+	}
 	return []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported}
 }
 

--- a/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
@@ -1,6 +1,7 @@
 package virtualmachines
 
 import (
+	"strconv"
 	"testing"
 
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
@@ -24,11 +25,25 @@ import (
 
 func TestCapabilities(t *testing.T) {
 	pipeline := &pipelineImpl{}
-	assert.ElementsMatch(
-		t,
-		[]centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported},
-		pipeline.Capabilities(),
-	)
+	cases := map[string]struct {
+		enabled bool
+		want    []centralsensor.CentralCapability
+	}{
+		"flag on advertises VirtualMachinesSupported": {
+			enabled: true,
+			want:    []centralsensor.CentralCapability{centralsensor.VirtualMachinesSupported},
+		},
+		"flag off advertises nothing": {
+			enabled: false,
+			want:    nil,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.VirtualMachines.EnvVar(), strconv.FormatBool(tc.enabled))
+			assert.Equal(t, tc.want, pipeline.Capabilities())
+		})
+	}
 }
 
 func TestMatch(t *testing.T) {


### PR DESCRIPTION
Master counterpart: https://github.com/stackrox/stackrox/pull/22743

## Description

4.11 Central advertises `VirtualMachinesSupported` from the virtual machine metadata and index pipelines even when `ROX_VIRTUAL_MACHINES` is off (the 4.11 default). A Sensor that starts VM collection from that capability then sends metadata events and index reports. Index reports are ACKed with reason `feature disabled on central` and are not stored.

This PR omits the capability when the flag is off, so Sensor treats this Central like a build that does not support VMs. The index pipeline still ACKs `feature disabled` if a report arrives while the flag is off. Metadata write/reconcile behavior is unchanged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [ ] CI

AI-Assisted: cursor, generated the capability gate and tests; user scoped this to the 4.11 capability advertisement only.