### PR TITLE
ROX-36838: fix flaky NetworkSimulator delete-policies test

### DIFF
--- a/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
+++ b/qa-tests-backend/src/main/groovy/util/NetworkGraphUtil.groovy
@@ -64,11 +64,24 @@ class NetworkGraphUtil {
         }
     }
 
-    static List<Edge> findEdges(NetworkGraphServiceOuterClass.NetworkGraph graph, String sourceId, String targetId) {
+    static List<Edge> findEdges(NetworkGraphServiceOuterClass.NetworkGraph graph, String sourceId, String targetId,
+                                 boolean deploymentsOnly = false) {
         log.debug "Checking for edge between deployments: sourceId ${sourceId}, targetId ${targetId}"
+
+        // NetworkPolicy simulation is purely policy-derived and never models traffic touching
+        // EXTERNAL_SOURCE/INTERNET nodes unless a rule has an explicit ipBlock peer, whereas the real/baseline
+        // graph reflects actually observed flows (which can include e.g. node/kubelet-probe traffic classified
+        // as an EXTERNAL_SOURCE). Callers comparing simulated vs. baseline edge counts should pass
+        // deploymentsOnly=true to avoid flaking on such environmental, policy-independent edges.
+        def isDeployment = { node ->
+            node.entity.type == NetworkFlowOuterClass.NetworkEntityInfo.Type.DEPLOYMENT
+        }
 
         def sourceNodes = sourceId == null ? graph.nodesList : graph.nodesList.findAll {
             it.deploymentId == sourceId
+        }
+        if (deploymentsOnly) {
+            sourceNodes = sourceNodes.findAll(isDeployment)
         }
         def targetNodeIndex = graph.nodesList.findIndexOf {
             it.deploymentId == targetId
@@ -92,8 +105,11 @@ class NetworkGraphUtil {
                 if (targetNodeIndex != -1 && it.key != targetNodeIndex) {
                     return []
                 }
-                log.debug "Source Id ${currentSourceId} -> edge target key: ${it.key}"
                 def targetNode = graph.nodesList.get(it.key)
+                if (deploymentsOnly && !isDeployment(targetNode)) {
+                    return []
+                }
+                log.debug "Source Id ${currentSourceId} -> edge target key: ${it.key}"
                 log.debug "  -> targetId: ${targetNode.deploymentId}"
 
                 def props = it.value.propertiesList

--- a/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkSimulator.groovy
@@ -426,12 +426,17 @@ class NetworkSimulator extends BaseSpecification {
                 allDeps.orchestratorDeployments, true, orchestratorDepsShouldExist)
 
         assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, null, clientAppId).size() > 0
-        assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, null, webAppId).size() ==
-                NetworkGraphUtil.findEdges(baseline, null, webAppId).size()
-        assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, webAppId, null).size() ==
-                NetworkGraphUtil.findEdges(baseline, webAppId, null).size()
-        assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, clientAppId, null).size() ==
-                NetworkGraphUtil.findEdges(baseline, clientAppId, null).size()
+        // NetworkPolicy simulation is purely policy-derived and cannot model traffic to/from
+        // EXTERNAL_SOURCE/INTERNET nodes (e.g. node/kubelet-probe traffic that Collector attributes to a
+        // cloud-provider CIDR), whereas the baseline graph reflects actually observed flows and can include
+        // such edges. Restrict the comparison to deployment-to-deployment edges to avoid flaking on this
+        // environmental, policy-independent traffic (see ROX-36838).
+        assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, null, webAppId, true).size() ==
+                NetworkGraphUtil.findEdges(baseline, null, webAppId, true).size()
+        assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, webAppId, null, true).size() ==
+                NetworkGraphUtil.findEdges(baseline, webAppId, null, true).size()
+        assert NetworkGraphUtil.findEdges(simulation.simulatedGraph, clientAppId, null, true).size() ==
+                NetworkGraphUtil.findEdges(baseline, clientAppId, null, true).size()
 
         assert simulation.policiesList.find { it.policy.name == "deny-all-traffic" }?.status ==
                 NetworkPolicyServiceOuterClass.NetworkPolicyInSimulation.Status.UNCHANGED


### PR DESCRIPTION
## Description

Fixes [ROX-36838](https://issues.redhat.com/browse/ROX-36838) (and its sibling [ROX-36839](https://issues.redhat.com/browse/ROX-36839), same test/root cause, different `scope` parameterization) — an intermittently failing e2e assertion in `NetworkSimulator.groovy`'s "Verify NetworkPolicy Simulator with delete policies" test.

**Triage** (`ci-triage.py` against the linked [GitHub Actions run](https://github.com/stackrox/stackrox/actions/runs/34191077754)): a real test assertion failure (not infra), `SpockComparisonFailure` in `NetworkGraphUtil.findEdges(...).size()` comparison, both ROX-36838/ROX-36839 are the same underlying issue (auto-triage already noted the correlation).

**Root cause**: the test compares edge counts into/out of the `web`/`client` deployments between two structurally different graphs:
- `baseline` = `NetworkGraphService.getNetworkGraph()` — built purely from **observed** `storage.NetworkFlow` rows (`central/networkgraph/service/service_impl.go`), independent of currently-applied policies.
- `simulation.simulatedGraph` = `NetworkPolicyService.SimulateNetworkGraph()` — a **pure policy-semantics** graph (`central/networkpolicies/graph/graph_builder.go`) with no flow data at all; it only introduces an `INTERNET` pseudo-node for rules with an explicit empty `ipBlock` peer.

The observed failure: `baseline` shows 1 incoming edge to `web` from a resolved `EXTERNAL_SOURCE` node (`Amazon/us-east-1`, e.g. node/kubelet-probe traffic that Collector attributes to a cloud CIDR range) that was actually observed in the last 5 minutes. `simulatedGraph` never models such external/node traffic (the test's `allow-ingress-application-web` policy only ever used `namespaceSelector: {}`, which the policy engine resolves to in-cluster deployments, never external sources) — so a raw edge-count equality between the two graphs is fundamentally flaky whenever this kind of environmental traffic is present in the observation window. This is a test-design flaw, not a product bug — no relevant code in `central/networkpolicies/graph/*` or `central/networkgraph/service/*` changed in the last 60 days.

**Fix**: added an opt-in `deploymentsOnly` flag to `NetworkGraphUtil.findEdges` (default `false`, fully backwards compatible with the other 30+ call sites) that restricts edge counting to deployment-to-deployment edges. Used it for the 3 baseline-vs-simulation equality assertions in the "with delete policies" test so they only compare what the policy simulator can actually model.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

This is a qa-tests-backend e2e test-only change (no production code touched), so verification is via the modified e2e test itself rather than new unit tests.

### How I validated my change

- Deployed a fresh StackRox (Central + Sensor, image `5.0.x-248-g418043feec`, unmodified — no product code was changed) via `roxie deploy both` on an OpenShift cluster (ga09).
- Ran the full `NetworkSimulator` Spock test class (`./gradlew test --tests "NetworkSimulator" -Dgroups=NetworkPolicySimulation`) against it: 24/24 tests passed except one pre-existing, unrelated local-env failure (`Verify invalid clusterId passed to notification API` — missing `SLACK_MAIN_WEBHOOK` env var in my local run, unrelated to this change).
- Specifically confirmed both parameterizations of "Verify NetworkPolicy Simulator with delete policies" (`scope: Orchestrator Component:false` / `scope: ""`) passed with no `<failure>` in the JUnit XML.
- Re-ran just that test (`--tests "NetworkSimulator.Verify NetworkPolicy Simulator with delete policies"`) a second time to confirm consistency — both parameterizations passed again.
- `./gradlew compileTestGroovy`, `codenarcMain`, `codenarcTest` all pass.


[ROX-36838]: https://redhat.atlassian.net/browse/ROX-36838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROX-36839]: https://redhat.atlassian.net/browse/ROX-36839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ