### PR TITLE
ROX-36887: Scan standalone VMIs first seen before Running

### DIFF
--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances.go
@@ -80,10 +80,16 @@ func (d *VirtualMachineInstanceDispatcher) ProcessEvent(
 		BootOrder:   extractBootOrder(disks),
 		CDRomDisks:  extractCDRomDisks(disks),
 	}
-	// If the instance is NOT handled by a VirtualMachine
-	// Process the instance as a VirtualMachine
+	// Ownerless VMIs are the authoritative instance: UpdateStateOrCreate writes
+	// Running so a later boot is visible to ListRunning.
 	if !handled {
-		return processVirtualMachine(vm, action, d.clusterID, d.store)
+		if action == central.ResourceAction_REMOVE_RESOURCE {
+			d.store.Remove(vm.ID)
+		} else {
+			d.store.UpdateStateOrCreate(vm)
+		}
+		attachStoredAgentFacts(d.store, vm)
+		return component.NewEvent(createEvent(action, d.clusterID, vm))
 	}
 
 	// This is an instance that is handled by a VirtualMachine

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances_test.go
@@ -13,6 +13,7 @@ import (
 	vmInfo "github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/mocks"
+	vmstore "github.com/stackrox/rox/sensor/kubernetes/listener/resources/virtualmachine/store"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
@@ -235,7 +236,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 			action: central.ResourceAction_CREATE_RESOURCE,
 			obj:    toUnstructured(newVirtualMachineInstanceWithOwnerKind(vmiUID, vmiName, vmiNamespace, ownerUID, "Not-VirtualMachine", nil, v1.Scheduled)),
 			expectFn: func() {
-				s.store.EXPECT().AddOrUpdate(gomock.Eq(
+				s.store.EXPECT().UpdateStateOrCreate(gomock.Eq(
 					&vmInfo.Info{
 						ID:        vmiUID,
 						Name:      vmiName,
@@ -243,14 +244,8 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						VSOCKCID:  nil,
 						Running:   false,
 					}),
-				).Times(1).Return(
-					&vmInfo.Info{
-						ID:        vmiUID,
-						Name:      vmiName,
-						Namespace: vmiNamespace,
-						VSOCKCID:  nil,
-						Running:   false,
-					})
+				).Times(1)
+				s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(vmiUID))).Times(1).Return(nil)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
 				Id:     vmiUID,
@@ -271,7 +266,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 			action: central.ResourceAction_UPDATE_RESOURCE,
 			obj:    toUnstructured(newVirtualMachineInstanceWithOwnerKind(vmiUID, vmiName, vmiNamespace, ownerUID, "Not-VirtualMachine", nil, v1.Scheduled)),
 			expectFn: func() {
-				s.store.EXPECT().AddOrUpdate(gomock.Eq(
+				s.store.EXPECT().UpdateStateOrCreate(gomock.Eq(
 					&vmInfo.Info{
 						ID:        vmiUID,
 						Name:      vmiName,
@@ -279,14 +274,8 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						VSOCKCID:  nil,
 						Running:   false,
 					}),
-				).Times(1).Return(
-					&vmInfo.Info{
-						ID:        vmiUID,
-						Name:      vmiName,
-						Namespace: vmiNamespace,
-						VSOCKCID:  nil,
-						Running:   false,
-					})
+				).Times(1)
+				s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(vmiUID))).Times(1).Return(nil)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
 				Id:     vmiUID,
@@ -308,6 +297,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 			obj:    toUnstructured(newVirtualMachineInstanceWithOwnerKind(vmiUID, vmiName, vmiNamespace, ownerUID, "Not-VirtualMachine", nil, v1.Scheduled)),
 			expectFn: func() {
 				s.store.EXPECT().Remove(gomock.Eq(vmInfo.VMID(vmiUID))).Times(1)
+				s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(vmiUID))).Times(1).Return(nil)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
 				Id:     vmiUID,
@@ -328,7 +318,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 			action: central.ResourceAction_SYNC_RESOURCE,
 			obj:    toUnstructured(newVirtualMachineInstanceWithOwnerKind(vmiUID, vmiName, vmiNamespace, ownerUID, "Not-VirtualMachine", nil, v1.Scheduled)),
 			expectFn: func() {
-				s.store.EXPECT().AddOrUpdate(gomock.Eq(
+				s.store.EXPECT().UpdateStateOrCreate(gomock.Eq(
 					&vmInfo.Info{
 						ID:        vmiUID,
 						Name:      vmiName,
@@ -336,14 +326,8 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						VSOCKCID:  nil,
 						Running:   false,
 					}),
-				).Times(1).Return(
-					&vmInfo.Info{
-						ID:        vmiUID,
-						Name:      vmiName,
-						Namespace: vmiNamespace,
-						VSOCKCID:  nil,
-						Running:   false,
-					})
+				).Times(1)
+				s.store.EXPECT().Get(gomock.Eq(vmInfo.VMID(vmiUID))).Times(1).Return(nil)
 			},
 			expectedMsg: component.NewEvent(&central.SensorEvent{
 				Id:     vmiUID,
@@ -448,6 +432,54 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 			} else {
 				s.Assert().Nil(actual)
 			}
+		})
+	}
+}
+
+// Test_OwnerlessVMIScheduledThenRunningIsScrapable covers an ownerless VMI first
+// seen before Running: later Running must reach the store and ListRunning.
+func (s *virtualMachineInstanceSuite) Test_OwnerlessVMIScheduledThenRunningIsScrapable() {
+	cases := map[string]struct {
+		buildVMI func(phase v1.VirtualMachineInstancePhase) *v1.VirtualMachineInstance
+	}{
+		"should mark ownerless VMI running after Scheduled then Running": {
+			buildVMI: func(phase v1.VirtualMachineInstancePhase) *v1.VirtualMachineInstance {
+				vmi := newVirtualMachineInstanceWithOwnerKind(vmiUID, vmiName, vmiNamespace, "", "", nil, phase)
+				vmi.OwnerReferences = nil
+				return vmi
+			},
+		},
+		"should mark ReplicaSet-owned VMI running after Scheduled then Running": {
+			buildVMI: func(phase v1.VirtualMachineInstancePhase) *v1.VirtualMachineInstance {
+				return newVirtualMachineInstanceWithOwnerKind(vmiUID, vmiName, vmiNamespace, ownerUID, "VirtualMachineInstanceReplicaSet", nil, phase)
+			},
+		},
+	}
+	for name, tc := range cases {
+		s.Run(name, func() {
+			realStore := vmstore.NewVirtualMachineStore()
+			d := NewVirtualMachineInstanceDispatcher(clusterID, realStore)
+
+			scheduled := d.ProcessEvent(toUnstructured(tc.buildVMI(v1.Scheduled)), nil, central.ResourceAction_CREATE_RESOURCE)
+			s.Require().NotNil(scheduled)
+			stored := realStore.Get(vmInfo.VMID(vmiUID))
+			s.Require().NotNil(stored)
+			s.False(stored.Running)
+			s.Empty(realStore.ListRunning())
+
+			running := d.ProcessEvent(toUnstructured(tc.buildVMI(v1.Running)), nil, central.ResourceAction_UPDATE_RESOURCE)
+			s.Require().NotNil(running)
+			s.Require().Len(running.ForwardMessages, 1)
+			vmEvent := running.ForwardMessages[0].GetVirtualMachine()
+			s.Require().NotNil(vmEvent)
+			s.Equal(virtualMachineV1.VirtualMachine_RUNNING, vmEvent.GetState())
+
+			stored = realStore.Get(vmInfo.VMID(vmiUID))
+			s.Require().NotNil(stored)
+			s.True(stored.Running)
+			runningList := realStore.ListRunning()
+			s.Require().Len(runningList, 1)
+			s.Equal(vmInfo.VMID(vmiUID), runningList[0].ID)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Sensor never scraped a standalone KubeVirt `VirtualMachineInstance` if it first observed that VMI in a pre-running phase. The store kept `Running=false` through later updates, so the VM never appeared in `ListRunning` and was never scraped, even with roxagent installed. Restarting Sensor after the VMI was already `Running` recovered it. Typical OpenShift Virtualization VMs (a `VirtualMachine` CR owning the VMI) already used a different store path and were not affected.

This is a documented KubeVirt and OpenShift Virtualization shape, not a synthetic edge. A `VirtualMachineInstance` is the running instance; a parent `VirtualMachine` controller is optional. Users create one by applying a VMI YAML (`kubectl`/`oc`/`virtctl`) or from a script. OpenShift Virtualization calls that a [standalone VMI](https://docs.okd.io/latest/virt/managing_vms/virt-manage-vmis.html) and has console support for listing, labeling, and deleting them.

[KubeVirt's architecture](https://kubevirt.io/user-guide/architecture/) also lists `VirtualMachineInstanceReplicaSet`, which owns a pool of identical ephemeral VMIs the way a ReplicaSet owns Pods. Those instances have an owner, but it is not `Kind=VirtualMachine`, so Sensor takes the same branch. The common console "create VM" path still creates a `VirtualMachine` CR and was never on this code path.

The bug was routing that branch through `AddOrUpdate`. That method is for parent `VirtualMachine` metadata events: it copies instance fields (`Running`, VSOCK CID, guest OS, IPs) from the existing store entry onto the incoming object so a VM spec update cannot clobber live instance state. `false` cannot become `true` through it. Parent-owned VMIs already call `UpdateStateOrCreate`, which does write the incoming `Running` flag. The ownerless branch now does the same, and `Remove` on delete. `AddOrUpdate`'s preserve-runtime contract is unchanged; parent VM updates still depend on it.

Before: create a standalone VMI in `Scheduled`, then update the same UID to `Running`. Store and outgoing event stay stopped; `ListRunning` is empty. After: store is running, the event is `RUNNING`, and the VM is in `ListRunning`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI only
- [ ] Need to check how to create a parentless VMI on a cluster to test that manually ⚠️ haven't done that yet - can't promise I make it Today.

AI-Assisted: cursor, generated the ownerless store path and regression test; user reviewed the logic.