### PR TITLE
ROX-36859: fix Cleanup/updateConfigNow race in registrymirror

### DIFF
--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -70,6 +70,14 @@ type FileStore struct {
 	itmsRules   map[types.UID]*configV1.ImageTagMirrorSet
 	ruleRWMutex sync.RWMutex
 
+	// configIOMutex serializes updateConfigNow's disk write against Cleanup's file
+	// removal, so a write that already read the (possibly stale) rules cannot land
+	// on disk after Cleanup has removed the file. It is a separate lock from
+	// ruleRWMutex (rather than widening Cleanup's hold on that lock) to avoid
+	// nesting Lock/RLock on the same mutex, since updateConfigNow reads the rules
+	// via getAllMirrorSets while holding this lock.
+	configIOMutex sync.Mutex
+
 	systemContext *ciTypes.SystemContext
 
 	updateDelay  time.Duration
@@ -112,13 +120,20 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 // Cleanup resets the store which includes in-memory and disk resources.
 func (s *FileStore) Cleanup() {
 	s.ruleRWMutex.Lock()
-	defer s.ruleRWMutex.Unlock()
-
 	s.icspRules = make(map[types.UID]*operatorV1Alpha1.ImageContentSourcePolicy)
 	s.idmsRules = make(map[types.UID]*configV1.ImageDigestMirrorSet)
 	s.itmsRules = make(map[types.UID]*configV1.ImageTagMirrorSet)
+	s.ruleRWMutex.Unlock()
 
 	s.cancelUpdate.Signal()
+
+	// Take configIOMutex before removing the file so that a concurrent
+	// updateConfigNow call that already started (and therefore already read the
+	// rules cleared above) is guaranteed to either finish before this removal, or
+	// start only after it -- never race with it and recreate the file right after
+	// cleanup. See configIOMutex's doc comment.
+	s.configIOMutex.Lock()
+	defer s.configIOMutex.Unlock()
 	if err := os.Remove(s.configPath); err != nil && !os.IsNotExist(err) {
 		log.Warnf("Failed to cleanup registries config at %q: %v", s.configPath, err)
 	}
@@ -147,6 +162,9 @@ func (s *FileStore) updateConfigDelayed() error {
 }
 
 func (s *FileStore) updateConfigNow() error {
+	s.configIOMutex.Lock()
+	defer s.configIOMutex.Unlock()
+
 	icspRules, idmsRules, itmsRules := s.getAllMirrorSets()
 
 	// Populate config.

--- a/pkg/registrymirror/store.go
+++ b/pkg/registrymirror/store.go
@@ -119,11 +119,11 @@ func NewFileStore(opts ...fileStoreOption) *FileStore {
 
 // Cleanup resets the store which includes in-memory and disk resources.
 func (s *FileStore) Cleanup() {
-	s.ruleRWMutex.Lock()
-	s.icspRules = make(map[types.UID]*operatorV1Alpha1.ImageContentSourcePolicy)
-	s.idmsRules = make(map[types.UID]*configV1.ImageDigestMirrorSet)
-	s.itmsRules = make(map[types.UID]*configV1.ImageTagMirrorSet)
-	s.ruleRWMutex.Unlock()
+	concurrency.WithLock(&s.ruleRWMutex, func() {
+		s.icspRules = make(map[types.UID]*operatorV1Alpha1.ImageContentSourcePolicy)
+		s.idmsRules = make(map[types.UID]*configV1.ImageDigestMirrorSet)
+		s.itmsRules = make(map[types.UID]*configV1.ImageTagMirrorSet)
+	})
 
 	s.cancelUpdate.Signal()
 


### PR DESCRIPTION
## Description

Fixes [ROX-36859](https://issues.redhat.com/browse/ROX-36859): `TestDataRaceAtCleanup` in `pkg/registrymirror` flaked in CI with `testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...: directory not empty`.

`ci-triage.py` classification: PRODUCT (unit test failure on master, not infra). No linked PR/build to re-triage against; this is a master-branch CI failure ticket with the failing test's stack trace attached.

### Root cause

`FileStore.Cleanup()` cleared the in-memory rules and called `os.Remove(s.configPath)` without any synchronization against a concurrently in-flight `updateConfigNow()` write. `TestDataRaceAtCleanup` runs two goroutines continuously calling `Upsert*`/`Delete*` while the main goroutine calls `Cleanup()`. If an `updateConfigNow()` call had already read the (soon to be cleared) rules via `getAllMirrorSets()` before `Cleanup()` ran, its `os.Create`/`Write` could complete *after* `Cleanup()`'s `os.Remove()`, recreating the config file right after cleanup returned. This raced with the test's own `t.TempDir()` cleanup (`os.RemoveAll`), which can fail with `ENOTEMPTY` if a file appears while it's walking the directory.

### Fix

Added a dedicated `configIOMutex` that serializes `updateConfigNow`'s disk write against `Cleanup`'s file removal — whichever gets there first now runs its entire operation to completion before the other starts, so a write can never land on disk after `Cleanup()` has already removed the file. It's a separate mutex from the existing `ruleRWMutex` (rather than widening `Cleanup`'s hold on that lock) to avoid nesting `Lock`/`RLock` on the same `sync.RWMutex`, since `updateConfigNow` reads the rules via `getAllMirrorSets` (which takes `ruleRWMutex.RLock()`) while holding `configIOMutex`.

Considered alternatives:
- A generation/epoch counter to invalidate stale scheduled writes — correct but adds real complexity (new field, check-and-act pattern) for a rare race in an infrequently-invoked path (registry mirror config only changes on ICSP/IDMS/ITMS resource events). The mutex fix closes the concrete, reproduced race with a 2-line change.
- Reordering the test to stop the writer goroutines before calling `Cleanup()` — would reduce but not eliminate the race (a legitimately new write could still fire after `Cleanup()` and before the test returns). Fixing the actual store bug is the root-cause fix; the test is unchanged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

No new permanent test added: the existing `TestDataRaceAtCleanup` already covers this scenario; it just wasn't reliably red without the fix (it's a narrow timing race). A throwaway deterministic reproduction (not included in this PR) was used to prove RED/GREEN — see below.

### How I validated my change

**RED (bug reproduced, without the fix):** wrote a throwaway test that injects a controllable stall inside `updateConfigNow`, right after it reads the mirror rules and before it writes to disk. Sequence: goroutine A calls `Upsert` (delay=0, synchronous path) and stalls after reading the rules; a second goroutine releases the stall 20ms after `Cleanup()` starts running concurrently. Without the fix, this reliably (10/10 runs) reproduced:
```
BUG REPRODUCED: config file ".../registries.conf" exists after Cleanup() returned, due to a write racing the removal
```
This is the exact underlying mechanism causing `t.TempDir()`'s `RemoveAll` to intermittently see a non-empty directory in `TestDataRaceAtCleanup`.

**GREEN (with the fix):** same throwaway repro, 20/20 runs — file correctly absent after `Cleanup()` returns. Also ran the real `TestDataRaceAtCleanup` under `-race` with `-count=500` (all green) and the full `pkg/registrymirror` suite under `-race` with `-count=100` (all green).

**Live cluster verification** (cluster `ga09`, deployed from this worktree's source — Sensor binary built with `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./sensor/kubernetes` and crane-appended onto a master-based image, so the running Sensor is my patched binary, not a stale prebuilt one):
- Created an `ImageDigestMirrorSet`; confirmed Sensor wrote the mirror into `/var/cache/stackrox/mirrors/registries.conf` inside the pod.
- Deleted it; confirmed the entry was correctly removed.
- Stress scenario matching the actual race: created 5 `ImageDigestMirrorSet` resources, immediately force-deleted the Sensor pod (triggering `listenerImpl.Stop()` → `StoreProvider.CleanupStores()` → `FileStore.Cleanup()`) while concurrently deleting all 5 IDMS resources (their informer-driven `Upsert`/`Delete` calls racing the restart's `Cleanup()` — the same class of race as `TestDataRaceAtCleanup`, exercised via the real Sensor→K8s-informer code path instead of the unit test's synthetic goroutines).
- Result: Sensor came back up healthy, 0 restarts, no panics/deadlocks in logs, and the final `registries.conf` state correctly reflected no mirrors configured (file absent, matching the "all deleted" state).


[ROX-36859]: https://redhat.atlassian.net/browse/ROX-36859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ