### PR TITLE
ROX-36888: WIP: Surface guest index failures as administration events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-35079: installation of the `app.k8s.io/v1beta1/Application` resource when central is installed is deprecated. It will be removed in a future release.
 
 ### Technical Changes
+- ROX-36888: Virtual machine scan time is the last vulnerability rematch of cached guest inventory. Guest indexing failures are reported as administration events.
 - ROX-36824: Diagnostic bundles now redact the value of the `openshift.io/token-secret.value` annotation on secrets. Previously this OpenShift-managed annotation, which contains a plaintext service account token on generated dockercfg secrets, was included unredacted in the bundle.
 - ROX-36660: The **Fixable → CVE is not yet fixable** policy criterion now matches Scanner V4 CVEs that have no fix version. Scanner V4 leaves `Fixed By` unset instead of empty (Scanner V2 always set an empty string), so the matcher previously skipped those CVEs.
 - ROX-36490: The virtual machine enhanced data model (`ROX_VIRTUAL_MACHINES_ENHANCED_DATA_MODEL`) is now enabled by default.

--- a/central/sensor/service/pipeline/virtualmachines/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/pkg/errors"
+	administrationEvents "github.com/stackrox/rox/central/administration/events"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/convert/internaltostorage"
 	countMetrics "github.com/stackrox/rox/central/metrics"
@@ -17,15 +18,19 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	virtualMachineV1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 )
 
 var (
-	_ pipeline.Fragment = (*pipelineImpl)(nil)
+	_   pipeline.Fragment = (*pipelineImpl)(nil)
+	log                   = logging.LoggerForModule(administrationEvents.EnableAdministrationEvents())
 )
 
 func GetPipeline() pipeline.Fragment {
@@ -162,6 +167,14 @@ func (p *pipelineImpl) runUpsertPipelineV1(
 		virtualMachineToStore.ClusterName = clusterName
 	}
 
+	p.maybeEmitGuestIndexError(virtualMachineToStore.GetId(), virtualMachineToStore.GetName(), virtualMachineToStore.GetFacts(), func() map[string]string {
+		existing, found, err := p.virtualMachineStore.GetVirtualMachine(ctx, virtualMachineToStore.GetId())
+		if err != nil || !found {
+			return nil
+		}
+		return existing.GetFacts()
+	})
+
 	return p.virtualMachineStore.UpsertVirtualMachine(ctx, virtualMachineToStore)
 }
 
@@ -177,5 +190,40 @@ func (p *pipelineImpl) runUpsertPipelineV2(
 		vmToStore.ClusterName = clusterName
 	}
 
+	p.maybeEmitGuestIndexError(vmToStore.GetId(), vmToStore.GetName(), vmToStore.GetFacts(), func() map[string]string {
+		existing, found, err := p.virtualMachineV2Store.GetVirtualMachine(ctx, vmToStore.GetId())
+		if err != nil || !found {
+			return nil
+		}
+		return existing.GetFacts()
+	})
+
 	return p.virtualMachineV2Store.UpsertVirtualMachine(ctx, vmToStore)
+}
+
+// guestIndexErrorChanged reports a new or changed guestIndexError on incoming
+// facts. Unchanged errors are skipped so KubeVirt informer UPDATEs do not
+// flood administration events.
+func guestIndexErrorChanged(incoming, existing map[string]string) (msg string, changed bool) {
+	msg = incoming[pkgVM.GuestIndexErrorKey]
+	if msg == "" || msg == existing[pkgVM.GuestIndexErrorKey] {
+		return msg, false
+	}
+	return msg, true
+}
+
+func (p *pipelineImpl) maybeEmitGuestIndexError(id, name string, incoming map[string]string, existingFacts func() map[string]string) {
+	if incoming[pkgVM.GuestIndexErrorKey] == "" {
+		return
+	}
+	msg, changed := guestIndexErrorChanged(incoming, existingFacts())
+	if !changed {
+		return
+	}
+	log.Errorw("Guest indexing failed",
+		logging.VirtualMachineName(name),
+		logging.VirtualMachineID(id),
+		logging.Err(errors.New(msg)),
+		logging.ErrCode(codes.VMGuestIndexFailed),
+	)
 }

--- a/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachines/pipeline_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/protomock"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/uuid"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
@@ -172,6 +173,38 @@ func TestPipelineRun(t *testing.T) {
 					Return(nil)
 			},
 			message: getVirtualMachineAdditionMessage(upsertTestVM),
+		},
+		{
+			name: "Addition looks up existing VM when guestIndexError is set",
+			setupMocks: func(testMock *mocks) {
+				vmWithErr := &virtualMachineV1.VirtualMachine{
+					Id:        uuid.NewTestUUID(1).String(),
+					Namespace: "test-namespace",
+					Name:      "test-virtual-machine",
+					ClusterId: testClusterID,
+					State:     virtualMachineV1.VirtualMachine_STOPPED,
+					Facts:     map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+				}
+				storedVM := internaltostorage.VirtualMachine(vmWithErr)
+				storedVM.ClusterName = "test-cluster"
+				testMock.clusters.EXPECT().
+					GetClusterName(gomock.Any(), testClusterID).
+					Return("test-cluster", true, nil)
+				testMock.virtualMachines.EXPECT().
+					GetVirtualMachine(gomock.Any(), vmWithErr.GetId()).
+					Return(nil, false, nil)
+				testMock.virtualMachines.EXPECT().
+					UpsertVirtualMachine(gomock.Any(), protomock.GoMockMatcherEqualMessage(storedVM)).
+					Return(nil)
+			},
+			message: getVirtualMachineAdditionMessage(&virtualMachineV1.VirtualMachine{
+				Id:        uuid.NewTestUUID(1).String(),
+				Namespace: "test-namespace",
+				Name:      "test-virtual-machine",
+				ClusterId: testClusterID,
+				State:     virtualMachineV1.VirtualMachine_STOPPED,
+				Facts:     map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+			}),
 		},
 	}
 
@@ -420,6 +453,38 @@ func TestPipelineRunV2(t *testing.T) {
 			},
 			message: getVirtualMachineAdditionMessage(upsertTestVM),
 		},
+		{
+			name: "V2 addition looks up existing VM when guestIndexError is set",
+			setupMocks: func(testMock *mocks) {
+				vmWithErr := &virtualMachineV1.VirtualMachine{
+					Id:        uuid.NewTestUUID(1).String(),
+					Namespace: "test-namespace",
+					Name:      "test-virtual-machine",
+					ClusterId: testClusterID,
+					State:     virtualMachineV1.VirtualMachine_STOPPED,
+					Facts:     map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+				}
+				storedVM := internaltostorage.VirtualMachineV2(vmWithErr)
+				storedVM.ClusterName = "test-cluster"
+				testMock.clusters.EXPECT().
+					GetClusterName(gomock.Any(), testClusterID).
+					Return("test-cluster", true, nil)
+				testMock.virtualMachinesV2.EXPECT().
+					GetVirtualMachine(gomock.Any(), vmWithErr.GetId()).
+					Return(nil, false, nil)
+				testMock.virtualMachinesV2.EXPECT().
+					UpsertVirtualMachine(gomock.Any(), protomock.GoMockMatcherEqualMessage(storedVM)).
+					Return(nil)
+			},
+			message: getVirtualMachineAdditionMessage(&virtualMachineV1.VirtualMachine{
+				Id:        uuid.NewTestUUID(1).String(),
+				Namespace: "test-namespace",
+				Name:      "test-virtual-machine",
+				ClusterId: testClusterID,
+				State:     virtualMachineV1.VirtualMachine_STOPPED,
+				Facts:     map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -542,6 +607,46 @@ func getNodeMessage() *central.MsgFromSensor {
 				Resource: &central.SensorEvent_Node{},
 			},
 		},
+	}
+}
+
+func TestGuestIndexErrorChanged(t *testing.T) {
+	cases := map[string]struct {
+		incoming map[string]string
+		existing map[string]string
+		wantMsg  string
+		want     bool
+	}{
+		"empty incoming is not a change": {
+			incoming: map[string]string{pkgVM.GuestOSKey: "rhel"},
+		},
+		"new error with no existing VM": {
+			incoming: map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+			wantMsg:  "rpm: indexer failed",
+			want:     true,
+		},
+		"same error as stored is not a change": {
+			incoming: map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+			existing: map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+			wantMsg:  "rpm: indexer failed",
+		},
+		"changed error is a change": {
+			incoming: map[string]string{pkgVM.GuestIndexErrorKey: "dnf metadata missing"},
+			existing: map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+			wantMsg:  "dnf metadata missing",
+			want:     true,
+		},
+		"cleared error is not emitted": {
+			incoming: map[string]string{},
+			existing: map[string]string{pkgVM.GuestIndexErrorKey: "rpm: indexer failed"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			msg, changed := guestIndexErrorChanged(tc.incoming, tc.existing)
+			assert.Equal(t, tc.wantMsg, msg)
+			assert.Equal(t, tc.want, changed)
+		})
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/cmd/rescanner.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner.go
@@ -95,6 +95,7 @@ func (r *rescanner) Run(ctx context.Context) {
 			// overwritten by the post-scan Reset.
 			t.Reset(r.interval)
 			if err := r.scanOnce(ctx); err != nil {
+				r.cache.RecordIndexError(err)
 				retryIn := min(backoff, r.interval)
 				log.Errorf("Rescan failed: %v; trying again in %v", err, retryIn)
 				backoff = min(backoff*2, rescanRetryMaxBackoff)

--- a/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
+++ b/compliance/virtualmachines/roxagent/cmd/rescanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -292,6 +293,52 @@ func TestRescanner_Run(t *testing.T) {
 	})
 }
 
+func TestRescanner_RecordsIndexErrorOnFailedScan(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		provider := &fakeGatedProvider{fakeProvider: fakeProvider{ready: true}}
+		r := testRescanner(provider)
+		r.interval = time.Hour
+		var failScan atomic.Bool
+		r.scanFn = func(context.Context, string, string) (*v4.IndexReport, error) {
+			if failScan.Load() {
+				return nil, errors.New("rpm: indexer failed")
+			}
+			return &v4.IndexReport{HashId: "ok"}, nil
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		stopped := r.runAsync(ctx)
+		defer func() {
+			cancel()
+			<-stopped
+		}()
+		synctest.Wait()
+
+		time.Sleep(r.interval)
+		synctest.Wait()
+
+		first := getReportResponse(t, r.cache, provider)
+		token := first.GetMeta().GetReportToken()
+		require.NotEmpty(t, token)
+		assert.Empty(t, first.GetMeta().GetFacts()["last_index_error"])
+
+		failScan.Store(true)
+		time.Sleep(r.interval)
+		synctest.Wait()
+
+		failed := getReportResponse(t, r.cache, provider)
+		assert.Equal(t, token, failed.GetMeta().GetReportToken())
+		assert.Equal(t, "rpm: indexer failed", failed.GetMeta().GetFacts()["last_index_error"])
+
+		failScan.Store(false)
+		time.Sleep(rescanRetryBaseBackoff)
+		synctest.Wait()
+
+		cleared := getReportResponse(t, r.cache, provider)
+		assert.Empty(t, cleared.GetMeta().GetFacts()["last_index_error"])
+	})
+}
+
 // TestScanOnce_StoresHashFromBeforeTheScan covers a URL refresh that
 // replaces the live mapping while scanFn runs: SetReport must keep the
 // hash from before the scan.
@@ -311,6 +358,11 @@ func TestScanOnce_StoresHashFromBeforeTheScan(t *testing.T) {
 
 func mappingHashFromCache(t *testing.T, cache *vsockserver.ReportCache, provider vsockserver.MappingProvider) string {
 	t.Helper()
+	return getReportResponse(t, cache, provider).GetMeta().GetRepoCpeMappingHash()
+}
+
+func getReportResponse(t *testing.T, cache *vsockserver.ReportCache, provider vsockserver.MappingProvider) *pb.VMServiceResponse {
+	t.Helper()
 	handler := vsockserver.NewHandler(cache, "test", provider, nil)
 	clientConn, serverConn := net.Pipe()
 	go handler.HandleConn(serverConn)
@@ -328,5 +380,5 @@ func mappingHashFromCache(t *testing.T, cache *vsockserver.ReportCache, provider
 	var resp pb.VMServiceResponse
 	require.NoError(t, proto.Unmarshal(respData, &resp))
 	require.NotNil(t, resp.GetGetReport())
-	return resp.GetMeta().GetRepoCpeMappingHash()
+	return &resp
 }

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol.go
@@ -25,6 +25,9 @@ const (
 
 	methodGetReport          = "get_report"
 	methodSyncRepoCPEMapping = "sync_repo_cpe_mapping"
+
+	factLastIndexError   = "last_index_error"
+	factLastIndexErrorAt = "last_index_error_at"
 )
 
 // reportSnapshot is an immutable point-in-time view of the cached report state.
@@ -36,12 +39,21 @@ type reportSnapshot struct {
 	mappingHash string
 }
 
+// indexErrorHealth is the last failed guest index, stored off the snapshot
+// so overlaying it on GetReport facts does not change the content-hash token.
+type indexErrorHealth struct {
+	err string
+	at  time.Time
+}
+
 // ReportCache holds the cached scan report with its content-hash token.
-// Invariant: exactly one goroutine (the rescan loop) calls SetReport; multiple
-// HandleConn goroutines read via snap.Load(). This single-writer/multi-reader
-// pattern is safe with atomic.Pointer without CAS.
+// Invariant: exactly one goroutine (the rescan loop) calls SetReport and
+// RecordIndexError; multiple HandleConn goroutines read via snap.Load()
+// and health.Load(). This single-writer/multi-reader pattern is safe with
+// atomic.Pointer without CAS.
 type ReportCache struct {
-	snap atomic.Pointer[reportSnapshot]
+	snap   atomic.Pointer[reportSnapshot]
+	health atomic.Pointer[indexErrorHealth]
 }
 
 // Token returns the published content-hash, or empty before the first scan.
@@ -56,8 +68,9 @@ func (c *ReportCache) Token() string {
 	return snap.token
 }
 
-// SetReport atomically publishes a new report and facts. The token is an
-// XXH64 of that content, so identical rescans stay unchanged for Sensor.
+// SetReport atomically publishes a new report and facts and clears any
+// last index error. The token is an XXH64 of that content, so identical
+// rescans stay unchanged for Sensor.
 //
 // mappingHash is the repo-to-CPE mapping the scan used, so GetReport can send
 // it after a later Sync has already replaced the live mapping.
@@ -76,6 +89,16 @@ func (c *ReportCache) SetReport(r *v4.IndexReport, facts map[string]string, mapp
 		facts:       clonedFacts,
 		mappingHash: mappingHash,
 	})
+	c.health.Store(nil)
+}
+
+// RecordIndexError publishes a failed guest index so GetReport can overlay
+// it onto facts without changing the content-hash token.
+func (c *ReportCache) RecordIndexError(err error) {
+	if c == nil || err == nil {
+		return
+	}
+	c.health.Store(&indexErrorHealth{err: err.Error(), at: time.Now()})
 }
 
 // reportToken is XXH64 of the IndexReport and facts, as 16 lowercase hex
@@ -221,6 +244,7 @@ func (h *Handler) newResponseFromSnap(snap *reportSnapshot) *pb.VMServiceRespons
 		token = snap.token
 		mappingHash = snap.mappingHash
 	}
+	facts = h.overlayIndexErrorFacts(facts)
 	updatePath := h.provider.UpdatePath()
 	methods := []string{methodGetReport}
 	if h.updater != nil {
@@ -238,6 +262,24 @@ func (h *Handler) newResponseFromSnap(snap *reportSnapshot) *pb.VMServiceRespons
 		meta.ReportGeneratedAt = timestamppb.New(snap.generatedAt)
 	}
 	return &pb.VMServiceResponse{Meta: meta}
+}
+
+// overlayIndexErrorFacts copies last_index_error onto facts without putting
+// it on the snapshot, so the report token stays a content hash of inventory.
+func (h *Handler) overlayIndexErrorFacts(facts map[string]string) map[string]string {
+	if h == nil || h.cache == nil {
+		return facts
+	}
+	health := h.cache.health.Load()
+	if health == nil {
+		return facts
+	}
+	if facts == nil {
+		facts = make(map[string]string, 2)
+	}
+	facts[factLastIndexError] = health.err
+	facts[factLastIndexErrorAt] = health.at.UTC().Format(time.RFC3339)
+	return facts
 }
 
 // handleSyncRepoCPEMapping applies a Sensor-pushed mapping. URL-managed

--- a/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
+++ b/compliance/virtualmachines/roxagent/vsockserver/protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	pb "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
@@ -172,6 +173,34 @@ func TestHandleRequest_GetReport_IdenticalRescanUnchanged(t *testing.T) {
 	assert.True(t, resp.GetGetReport().GetUnchanged())
 	assert.Nil(t, resp.GetGetReport().GetIndexReport())
 	assert.Equal(t, token, resp.GetMeta().GetReportToken())
+}
+
+// TestHandleRequest_GetReport_IndexErrorOverlay covers a failed guest index
+// after a successful cache: Sensor still gets Unchanged, plus last_index_error
+// in facts. SetReport clears the overlay.
+func TestHandleRequest_GetReport_IndexErrorOverlay(t *testing.T) {
+	cache := &ReportCache{}
+	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil, "")
+
+	handler := NewHandler(cache, "test-1.0.0", readyProvider(), nil)
+	first := sendAndReceive(t, handler, getReportRequest("req-first", ""))
+	token := first.GetMeta().GetReportToken()
+	require.NotEmpty(t, token)
+	assert.Empty(t, first.GetMeta().GetFacts()[factLastIndexError])
+
+	cache.RecordIndexError(errors.New("rpm: indexer failed"))
+	resp := sendAndReceive(t, handler, getReportRequest("req-overlay", token))
+
+	assert.True(t, resp.GetGetReport().GetUnchanged())
+	assert.Equal(t, token, resp.GetMeta().GetReportToken(), "overlay must not change the content-hash token")
+	assert.Equal(t, "rpm: indexer failed", resp.GetMeta().GetFacts()[factLastIndexError])
+	_, err := time.Parse(time.RFC3339, resp.GetMeta().GetFacts()[factLastIndexErrorAt])
+	require.NoError(t, err)
+
+	cache.SetReport(&v4.IndexReport{HashId: "test-hash"}, nil, "")
+	cleared := sendAndReceive(t, handler, getReportRequest("req-cleared", token))
+	assert.True(t, cleared.GetGetReport().GetUnchanged())
+	assert.Empty(t, cleared.GetMeta().GetFacts()[factLastIndexError])
 }
 
 // TestHandleRequest_GetReport_ContentChangeServesReport covers a rescan

--- a/pkg/administration/events/codes/codes.go
+++ b/pkg/administration/events/codes/codes.go
@@ -39,4 +39,7 @@ const (
 	SyslogGeneric            = "syslog-generic"
 	TeamsGeneric             = "teams-generic"
 	WebhookGeneric           = "webhook-generic"
+
+	// Virtual machine scanning codes.
+	VMGuestIndexFailed = "vm-guest-index-failed"
 )

--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -3,10 +3,11 @@ package events
 import "regexp"
 
 const (
-	AuthenticationDomain = "Authentication"
-	DefaultDomain        = "General"
-	ImageScanningDomain  = "Image Scanning"
-	IntegrationDomain    = "Integrations"
+	AuthenticationDomain         = "Authentication"
+	DefaultDomain                = "General"
+	ImageScanningDomain          = "Image Scanning"
+	IntegrationDomain            = "Integrations"
+	VirtualMachineScanningDomain = "Virtual Machine Scanning"
 )
 
 var moduleToDomain = map[*regexp.Regexp]string{
@@ -17,6 +18,7 @@ var moduleToDomain = map[*regexp.Regexp]string{
 	regexp.MustCompile(`(^|/)cloudsources(/|$)`):                                  IntegrationDomain,
 	regexp.MustCompile(`(^|/)notifiers(/|$)`):                                     IntegrationDomain,
 	regexp.MustCompile(`^reprocessor|image/service|detection/service|enrichment`): ImageScanningDomain,
+	regexp.MustCompile(`pipeline/virtualmachines`):                                VirtualMachineScanningDomain,
 }
 
 // GetDomainFromModule retrieves a domain based on a specific module which will be

--- a/pkg/administration/events/hints.go
+++ b/pkg/administration/events/hints.go
@@ -145,6 +145,16 @@ In case a timeout error occurred, adjust the timeout for sending alerts by setti
 environment variable.`,
 			},
 		},
+		VirtualMachineScanningDomain: {
+			adminResources.VirtualMachine: {
+				codes.VMGuestIndexFailed: `Guest indexing failed. The virtual machine scan time is the last vulnerability rematch of cached inventory, not a fresh guest index.
+
+Ensure that:
+- roxagent is running in the guest.
+- RPM and DNF metadata are available.
+- The repository-to-CPE mapping is present and current.`,
+			},
+		},
 	}
 )
 

--- a/pkg/administration/events/resources/resources.go
+++ b/pkg/administration/events/resources/resources.go
@@ -13,7 +13,8 @@ const (
 
 // Resources used in administration events.
 var (
-	Cluster = resources.Cluster.String()
-	Image   = resources.Image.String()
-	Node    = resources.Node.String()
+	Cluster        = resources.Cluster.String()
+	Image          = resources.Image.String()
+	Node           = resources.Node.String()
+	VirtualMachine = resources.VirtualMachine.String()
 )

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -12,32 +12,36 @@ import (
 const (
 	ClusterIDContextValue = "stackrox.cluster.id"
 
-	alertIDField      = "alert_id"
-	apiTokenIDField   = "api_token_id"
-	authProviderField = "auth_provider"
-	apiTokenNameField = "api_token_name"
-	backupField       = "backup"
-	cloudSourceField  = "cloud_source"
-	clusterIDField    = "cluster_id"
-	clusterNameField  = "cluster_name"
-	errCodeField      = "err_code"
-	imageField        = "image"
-	imageIDField      = "image_id"
-	nodeIDField       = "node_id"
-	notifierField     = "notifier"
+	alertIDField          = "alert_id"
+	apiTokenIDField       = "api_token_id"
+	authProviderField     = "auth_provider"
+	apiTokenNameField     = "api_token_name"
+	backupField           = "backup"
+	cloudSourceField      = "cloud_source"
+	clusterIDField        = "cluster_id"
+	clusterNameField      = "cluster_name"
+	errCodeField          = "err_code"
+	imageField            = "image"
+	imageIDField          = "image_id"
+	nodeIDField           = "node_id"
+	notifierField         = "notifier"
+	virtualMachineField   = "virtual_machine"
+	virtualMachineIDField = "virtual_machine_id"
 )
 
 var resourceTypeFields = map[string]string{
-	apiTokenIDField:   administrationResources.APIToken,
-	apiTokenNameField: administrationResources.APIToken,
-	authProviderField: administrationResources.AuthProvider,
-	backupField:       administrationResources.Backup,
-	cloudSourceField:  administrationResources.CloudSource,
-	clusterIDField:    administrationResources.Cluster,
-	imageField:        administrationResources.Image,
-	imageIDField:      administrationResources.Image,
-	nodeIDField:       administrationResources.Node,
-	notifierField:     administrationResources.Notifier,
+	apiTokenIDField:       administrationResources.APIToken,
+	apiTokenNameField:     administrationResources.APIToken,
+	authProviderField:     administrationResources.AuthProvider,
+	backupField:           administrationResources.Backup,
+	cloudSourceField:      administrationResources.CloudSource,
+	clusterIDField:        administrationResources.Cluster,
+	imageField:            administrationResources.Image,
+	imageIDField:          administrationResources.Image,
+	nodeIDField:           administrationResources.Node,
+	notifierField:         administrationResources.Notifier,
+	virtualMachineField:   administrationResources.VirtualMachine,
+	virtualMachineIDField: administrationResources.VirtualMachine,
 }
 
 type ContextField struct {
@@ -136,6 +140,16 @@ func ClusterName(name string) zap.Field {
 	return String(clusterNameField, name)
 }
 
+// VirtualMachineName provides the virtual machine name as a structured log field.
+func VirtualMachineName(name string) zap.Field {
+	return String(virtualMachineField, name)
+}
+
+// VirtualMachineID provides the virtual machine ID as a structured log field.
+func VirtualMachineID(id string) zap.Field {
+	return String(virtualMachineIDField, id)
+}
+
 // Wrapper functions for zap.Field functions.
 
 // String provides a wrapper around zap.String and adds the key-value pair as structured log field.
@@ -194,5 +208,6 @@ func isIDField(fieldName string) bool {
 		fieldName != backupField &&
 		fieldName != cloudSourceField &&
 		fieldName != imageField &&
-		fieldName != notifierField
+		fieldName != notifierField &&
+		fieldName != virtualMachineField
 }

--- a/pkg/logging/log_converter_impl_test.go
+++ b/pkg/logging/log_converter_impl_test.go
@@ -80,6 +80,25 @@ func TestConvert(t *testing.T) {
 				String("response", "some api response"),
 			},
 		},
+		{
+			event: &events.AdministrationEvent{
+				Domain:       "Virtual Machine Scanning",
+				Hint:         events.GetHint("Virtual Machine Scanning", "VirtualMachine", "vm-guest-index-failed"),
+				Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_ERROR,
+				Message:      `Error: this is an events test {"virtual_machine": "rhel9", "virtual_machine_id": "vm-id-1", "err_code": "vm-guest-index-failed"}`,
+				ResourceType: "VirtualMachine",
+				ResourceName: "rhel9",
+				ResourceID:   "vm-id-1",
+				Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_LOG_MESSAGE,
+			},
+			msg:    "Error: this is an events test",
+			level:  "error",
+			module: "sensor/service/pipeline/virtualmachines",
+			fields: []interface{}{
+				VirtualMachineName("rhel9"), VirtualMachineID("vm-id-1"),
+				ErrCode("vm-guest-index-failed"),
+			},
+		},
 	}
 
 	for i, tc := range cases {

--- a/pkg/virtualmachine/facts.go
+++ b/pkg/virtualmachine/facts.go
@@ -21,6 +21,12 @@ const (
 	ActivationStatusKey = "activationStatus"
 	// DNFMetadataStatusKey is whether DNF metadata is available on the guest.
 	DNFMetadataStatusKey = "dnfMetadataStatus"
+	// GuestIndexErrorKey is the last failed guest index from roxagent.
+	GuestIndexErrorKey = "guestIndexError"
+	// GuestIndexErrorAtKey is when that last guest index failed, RFC3339 UTC.
+	GuestIndexErrorAtKey = "guestIndexErrorAt"
+	// InventoryGeneratedAtKey is ResponseMeta.report_generated_at as RFC3339 UTC.
+	InventoryGeneratedAtKey = "inventoryGeneratedAt"
 	// UnknownGuestOS is the user-facing default value for GuestOSKey when the
 	// guest OS has not been reported by the virtual machine instance.
 	UnknownGuestOS = "unknown"

--- a/sensor/common/virtualmachine/facts.go
+++ b/sensor/common/virtualmachine/facts.go
@@ -16,6 +16,8 @@ const (
 	responseOSVersionKey         = "os_version"
 	responseActivationStatusKey  = "activation_status"
 	responseDNFMetadataStatusKey = "dnf_metadata_status"
+	responseLastIndexErrorKey    = "last_index_error"
+	responseLastIndexErrorAtKey  = "last_index_error_at"
 )
 
 // Facts builds the VM facts map sent to Central.
@@ -86,6 +88,12 @@ func AgentFactsFromResponseFacts(facts map[string]string) map[string]string {
 		out[pkgVM.DNFMetadataStatusKey] = pkgVM.DNFMetadataStatusAvailable
 	case v1.DnfMetadataStatus_UNAVAILABLE.String():
 		out[pkgVM.DNFMetadataStatusKey] = pkgVM.DNFMetadataStatusUnavailable
+	}
+	if v := facts[responseLastIndexErrorKey]; v != "" {
+		out[pkgVM.GuestIndexErrorKey] = v
+	}
+	if v := facts[responseLastIndexErrorAtKey]; v != "" {
+		out[pkgVM.GuestIndexErrorAtKey] = v
 	}
 	if len(out) == 0 {
 		return nil

--- a/sensor/common/virtualmachine/facts_test.go
+++ b/sensor/common/virtualmachine/facts_test.go
@@ -113,6 +113,23 @@ func TestAgentFactsFromResponseFacts(t *testing.T) {
 			},
 			expected: nil,
 		},
+		"copies last index error without enum facts": {
+			input: map[string]string{
+				"last_index_error":    "rpm: indexer failed",
+				"last_index_error_at": "2026-01-02T03:04:05Z",
+			},
+			expected: map[string]string{
+				pkgVM.GuestIndexErrorKey:   "rpm: indexer failed",
+				pkgVM.GuestIndexErrorAtKey: "2026-01-02T03:04:05Z",
+			},
+		},
+		"omits empty last index error": {
+			input: map[string]string{
+				"last_index_error":    "",
+				"last_index_error_at": "",
+			},
+			expected: nil,
+		},
 	}
 
 	for name, tc := range cases {

--- a/sensor/common/virtualmachine/vmscraper/scraper.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/message"
@@ -1005,6 +1006,12 @@ func snapshotAgentFacts(meta *pb.ResponseMeta) (mapped map[string]string, ok boo
 		return nil, false
 	}
 	mapped = virtualmachine.AgentFactsFromResponse(meta.GetFacts(), meta.GetAgentVersion())
+	if ts := meta.GetReportGeneratedAt(); ts != nil && ts.IsValid() {
+		if mapped == nil {
+			mapped = make(map[string]string, 1)
+		}
+		mapped[pkgVM.InventoryGeneratedAtKey] = ts.AsTime().UTC().Format(time.RFC3339)
+	}
 	return mapped, len(mapped) > 0
 }
 

--- a/sensor/common/virtualmachine/vmscraper/scraper_test.go
+++ b/sensor/common/virtualmachine/vmscraper/scraper_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // --- Mocks ---
@@ -524,6 +525,85 @@ func TestVMScraper_ForwardsChangedAgentFactsOnUnchangedReport(t *testing.T) {
 	clock.Advance(s.interval)
 	s.pollOnce(context.Background())
 	assert.Empty(t, drainToCentral(s), "should not emit a VM update when agent facts are unchanged")
+}
+
+func TestSnapshotAgentFacts(t *testing.T) {
+	generatedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	cases := map[string]struct {
+		meta *pb.ResponseMeta
+		want map[string]string
+		ok   bool
+	}{
+		"nil meta": {},
+		"report generated at is copied as inventoryGeneratedAt": {
+			meta: &pb.ResponseMeta{
+				AgentVersion:      "roxagent-test",
+				ReportGeneratedAt: timestamppb.New(generatedAt),
+			},
+			want: map[string]string{
+				pkgVM.AgentVersionKey:         "roxagent-test",
+				pkgVM.InventoryGeneratedAtKey: "2026-01-02T03:04:05Z",
+			},
+			ok: true,
+		},
+		"last index error is copied": {
+			meta: &pb.ResponseMeta{
+				Facts: map[string]string{
+					"last_index_error":    "rpm: indexer failed",
+					"last_index_error_at": "2026-01-02T03:04:05Z",
+				},
+			},
+			want: map[string]string{
+				pkgVM.GuestIndexErrorKey:   "rpm: indexer failed",
+				pkgVM.GuestIndexErrorAtKey: "2026-01-02T03:04:05Z",
+			},
+			ok: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, ok := snapshotAgentFacts(tc.meta)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestVMScraper_ForwardsGuestIndexErrorOnUnchangedReport(t *testing.T) {
+	store := &mockStore{vms: []*virtualmachine.Info{
+		makeVM("ns1", "vm-a", 100),
+	}}
+	dialer := &mockDialer{}
+	client := &mockProtocolClient{
+		resultQueue: []*vsockclient.GetReportResult{makeReport("1")},
+	}
+
+	s, clock := newTestScraper(t, store, dialer, client)
+	s.pollOnce(context.Background())
+	require.Equal(t, 1, forwardedCount(s))
+
+	client.reset()
+	client.resultQueue = []*vsockclient.GetReportResult{{
+		Unchanged: true,
+		Meta: &pb.ResponseMeta{
+			ReportToken:  "1",
+			AgentVersion: "roxagent-test",
+			Facts: map[string]string{
+				"detected_os":         "RHEL",
+				"activation_status":   "ACTIVE",
+				"dnf_metadata_status": "AVAILABLE",
+				"last_index_error":    "rpm: indexer failed",
+				"last_index_error_at": "2026-01-02T03:04:05Z",
+			},
+		},
+	}}
+	clock.Advance(s.interval)
+	s.pollOnce(context.Background())
+
+	updates := drainVMUpdates(s)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "rpm: indexer failed", updates[0].GetFacts()[pkgVM.GuestIndexErrorKey])
+	assert.Equal(t, "2026-01-02T03:04:05Z", updates[0].GetFacts()[pkgVM.GuestIndexErrorAtKey])
 }
 
 func TestVMScraper_ForwardsAgentVersionChangeOnUnchangedReport(t *testing.T) {


### PR DESCRIPTION
## Description

After a successful guest index, later indexer failures leave the last good inventory in the agent cache. Sensor's periodic mandatory refresh still pulls that cache. Central rematches it and stamps scan time and last agent contact as now. The VM page looks recently scanned and the agent looks Active while packages can be stale.

This keeps rematch of cached inventory. The agent overlays `last_index_error` onto GetReport facts without putting it on the snapshot, so the content-hash token stays a hash of inventory and Sensor still gets Unchanged. Sensor copies that onto the existing VM UPDATE path as `guestIndexError`, and copies `report_generated_at` as `inventoryGeneratedAt`. Central emits an administration event when the error is new or different from the stored VM, so KubeVirt informer updates do not flood the log.

The VM CVE page is unchanged. Scan time remains the last vulnerability rematch of cached inventory; that is stated in the changelog. Splitting last guest index from last vuln match in the API, storage, and UI is the complete fix and is out of scope. Dropping cached inventory on indexer failure would stop rematch.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI

AI-Assisted: cursor, generated the overlay, fact forwarding, and administration-event path; user chose this approach over a proto/API/UI split of scan time.