### PR TITLE
fix(ui): replace scanner deploy names in UI tests

### DIFF
--- a/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
+++ b/ui/apps/platform/cypress/integration/collections/deploymentMatching.test.js
@@ -36,7 +36,15 @@ describe('Collection deployment matching', () => {
         cy.get('input[aria-label="Select value 1 of 1 for the namespace name"]').type('stackrox');
 
         // Test that Stackrox deployments are matched
-        assertDeploymentsAreMatched(['central', 'central-db', 'collector', 'scanner', 'sensor']);
+        assertDeploymentsAreMatched([
+            'central',
+            'central-db',
+            'collector',
+            'scanner-v4-indexer',
+            'scanner-v4-matcher',
+            'scanner-v4-db',
+            'sensor',
+        ]);
 
         // Restrict collection to two specific deployments
         cy.get('button:contains("No deployments specified")').click();

--- a/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkDeploymentSidebar.test.js
@@ -33,7 +33,7 @@ describe('Network Graph deployment sidebar', () => {
         //  `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("central")`
         // ).should('not.exist');
         cy.get(
-            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("scanner")`
+            `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("scanner-v4-indexer")`
         ).should('not.exist');
         cy.get(
             `${networkGraphSelectors.nodes} > [data-type="node"] .pf-topology__node__label:contains("admission-controller")`

--- a/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
+++ b/ui/apps/platform/cypress/integration/networkGraph/networkGraph.test.js
@@ -105,28 +105,37 @@ describe('Network Graph smoke tests', () => {
         // Verify that 'stackrox' namespace is present
         cy.get(networkGraphSelectors.filteredNamespaceGroupNode('stackrox'));
 
-        // Verify that central, central-db, scanner, scanner-db, sensor are present
-        ['central', 'central-db', 'scanner', 'scanner-v4-db', 'sensor'].forEach((deployment) => {
+        // Verify that central, central-db, scanner-v4-indexer, scanner-v4-matcher, scanner-v4-db, sensor are present
+        [
+            'central',
+            'central-db',
+            'scanner-v4-indexer',
+            'scanner-v4-matcher',
+            'scanner-v4-db',
+            'sensor',
+        ].forEach((deployment) => {
             cy.get(networkGraphSelectors.deploymentNode(deployment));
         });
 
         // Apply a deployment filter for 'central-db'
         selectDeployment('central-db');
 
-        // Verify that central, central-db are present and that scanner, scanner-db, sensor are not present
+        // Verify that central, central-db are present and that scanner-v4-indexer, scanner-v4-matcher, scanner-v4-db, sensor are not present
         ['central', 'central-db'].forEach((deployment) => {
             cy.get(networkGraphSelectors.deploymentNode(deployment));
         });
-        ['scanner', 'scanner-v4-db', 'sensor'].forEach((deployment) => {
-            cy.get(networkGraphSelectors.deploymentNode(deployment)).should('not.exist');
-        });
+        ['scanner-v4-indexer', 'scanner-v4-matcher', 'scanner-v4-db', 'sensor'].forEach(
+            (deployment) => {
+                cy.get(networkGraphSelectors.deploymentNode(deployment)).should('not.exist');
+            }
+        );
 
         // Remove the central-db selection from the scope filter
         selectDeployment('central-db');
-        // Apply a general filter of "Deployment Label" for 'app=scanner-db'
+        // Apply a general filter of "Deployment Label" for 'app=scanner-v4-db'
         selectFilter('Deployment Label', 'app=scanner-v4-db');
 
-        ['scanner', 'scanner-v4-db'].forEach((deployment) => {
+        ['scanner-v4-indexer', 'scanner-v4-matcher', 'scanner-v4-db'].forEach((deployment) => {
             cy.get(networkGraphSelectors.deploymentNode(deployment));
         });
         ['central', 'central-db', 'sensor'].forEach((deployment) => {

--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -126,7 +126,7 @@ describe('Risk', () => {
             const nsOption = 'Namespace';
             const nsValue = 'stackrox';
             const deployOption = 'Deployment';
-            const deployValue = 'scanner';
+            const deployValue = 'scanner-v4-indexer';
 
             visitRiskDeploymentsWithSearchQuery(
                 'Platform view',


### PR DESCRIPTION
## Description

Updates e2e tests to replace `scanner` with `scanner-v4-*` deployments to match the removal of scanner v2 component.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Local Cypress run.

Tested CI against `master` merge.
