### PR TITLE
fix(roxctl): default image flavor to opensource

### DIFF
--- a/roxctl/common/flags/imageFlavor.go
+++ b/roxctl/common/flags/imageFlavor.go
@@ -27,17 +27,12 @@ const (
 )
 
 var (
-	imageFlavorDefault = defaults.ImageFlavorNameRHACSRelease
+	// imageFlavorDefault is used when roxctl's --image-defaults flag is omitted.
+	imageFlavorDefault = defaults.ImageFlavorNameOpenSource
 )
 
 // ImageDefaultsFlagName is a shared constant for --image-defaults command line flag.
 const ImageDefaultsFlagName = "image-defaults"
-
-func init() {
-	if !buildinfo.ReleaseBuild {
-		imageFlavorDefault = defaults.ImageFlavorNameDevelopmentBuild
-	}
-}
 
 // AddImageDefaults adds the image-defaults flag to the command.
 func AddImageDefaults(pf *pflag.FlagSet, destination *string) {

--- a/roxctl/common/flags/imageFlavor_test.go
+++ b/roxctl/common/flags/imageFlavor_test.go
@@ -1,0 +1,21 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stackrox/rox/pkg/images/defaults"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddImageDefaultsUsesOpenSourceByDefault(t *testing.T) {
+	flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	var imageFlavor string
+
+	AddImageDefaults(flagSet, &imageFlavor)
+
+	flag := flagSet.Lookup(ImageDefaultsFlagName)
+	require.NotNil(t, flag)
+	require.Equal(t, defaults.ImageFlavorNameOpenSource, flag.DefValue)
+	require.Equal(t, defaults.ImageFlavorNameOpenSource, imageFlavor)
+}


### PR DESCRIPTION
## Description

Change roxctl's default `--image-defaults` value to `opensource` for both release and development builds. This avoids selecting build-dependent RHACS or development image repositories when the flag is omitted.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Ran the focused regression test for `AddImageDefaults`.
- Ran `gofmt` and the complete `roxctl/common/flags` package test suite.

Have you created automated tests for your change? Explain here which validation activities you did manually and why so.

The regression test verifies both the flag's displayed default and the destination value are `opensource`; the package test suite provides additional coverage for the affected flags package.

Validation observed for this change:
- `go test ./roxctl/common/flags -run TestAddImageDefaultsUsesOpenSourceByDefault -count=1`
- `gofmt -w roxctl/common/flags/imageFlavor.go roxctl/common/flags/imageFlavor_test.go && go test ./roxctl/common/flags -count=1`

Fixes #3029

<!-- repo-agent-case:89ec6e4c-d2cc-488d-8c0e-92426d40c597 -->