### PR TITLE
fix(be): Add operating system column to Node CVE reports

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen.go
@@ -16,6 +16,7 @@ import (
 var csvHeader = []string{
 	"Cluster",
 	"Node",
+	"Operating System",
 	"Component",
 	"Component Version",
 	"CVE",
@@ -34,6 +35,7 @@ func generateCSV(cveResponses []*NodeCVEQueryResponse, configName string) (*byte
 		row := csv.Value{
 			r.GetCluster(),
 			r.GetNode(),
+			r.GetOperatingSystem(),
 			r.GetComponent(),
 			r.GetComponentVersion(),
 			r.GetCVE(),

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
@@ -137,7 +137,7 @@ func TestGenerateCSV_NilFieldsProduceDefaults(t *testing.T) {
 	row := records[1]
 	assert.Equal(t, "", row[0])               // Cluster
 	assert.Equal(t, "", row[1])               // Node
-	assert.Equal(t, "", row[2])               // Operating System
+	assert.Equal(t, "Not Available", row[2])  // Operating System
 	assert.Equal(t, "", row[3])               // Component
 	assert.Equal(t, "", row[4])               // ComponentVersion
 	assert.Equal(t, "", row[5])               // CVE

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
@@ -27,6 +27,7 @@ func TestGenerateCSV_EmptyResponses(t *testing.T) {
 func TestGenerateCSV_WithResponses(t *testing.T) {
 	cluster := "prod-us"
 	node := "node-1"
+	operatingSystem := "rhcos:4.14"
 	component := "openssl"
 	componentVersion := "1.1.1"
 	cve := "CVE-2021-1234"
@@ -41,6 +42,7 @@ func TestGenerateCSV_WithResponses(t *testing.T) {
 		{
 			Cluster:          &cluster,
 			Node:             &node,
+			OperatingSystem:  &operatingSystem,
 			Component:        &component,
 			ComponentVersion: &componentVersion,
 			CVE:              &cve,
@@ -73,15 +75,16 @@ func TestGenerateCSV_WithResponses(t *testing.T) {
 	assert.Equal(t, csvHeader, records[0])
 	assert.Equal(t, "prod-us", records[1][0])
 	assert.Equal(t, "node-1", records[1][1])
-	assert.Equal(t, "openssl", records[1][2])
-	assert.Equal(t, "1.1.1", records[1][3])
-	assert.Equal(t, "CVE-2021-1234", records[1][4])
-	assert.Equal(t, "true", records[1][5])
-	assert.Equal(t, "1.1.2", records[1][6])
-	assert.Equal(t, "CRITICAL", records[1][7])
-	assert.Equal(t, "9.80", records[1][8])
-	assert.Equal(t, "June 15, 2021", records[1][9])
-	assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2021-1234", records[1][10])
+	assert.Equal(t, "rhcos:4.14", records[1][2])
+	assert.Equal(t, "openssl", records[1][3])
+	assert.Equal(t, "1.1.1", records[1][4])
+	assert.Equal(t, "CVE-2021-1234", records[1][5])
+	assert.Equal(t, "true", records[1][6])
+	assert.Equal(t, "1.1.2", records[1][7])
+	assert.Equal(t, "CRITICAL", records[1][8])
+	assert.Equal(t, "9.80", records[1][9])
+	assert.Equal(t, "June 15, 2021", records[1][10])
+	assert.Equal(t, "https://nvd.nist.gov/vuln/detail/CVE-2021-1234", records[1][11])
 }
 
 func TestGenerateCSV_LongConfigNameIsTruncated(t *testing.T) {
@@ -132,15 +135,16 @@ func TestGenerateCSV_NilFieldsProduceDefaults(t *testing.T) {
 	require.Len(t, records, 2)
 
 	row := records[1]
-	assert.Equal(t, "", row[0])              // Cluster
-	assert.Equal(t, "", row[1])              // Node
-	assert.Equal(t, "", row[2])              // Component
-	assert.Equal(t, "", row[3])              // ComponentVersion
-	assert.Equal(t, "", row[4])              // CVE
-	assert.Equal(t, "false", row[5])         // Fixable
-	assert.Equal(t, "", row[6])              // FixedBy
-	assert.Equal(t, "UNKNOWN", row[7])       // Severity
-	assert.Equal(t, "0.00", row[8])          // CVSS
-	assert.Equal(t, "Not Available", row[9]) // First System Occurrence
-	assert.Equal(t, "", row[10])             // Link
+	assert.Equal(t, "", row[0])               // Cluster
+	assert.Equal(t, "", row[1])               // Node
+	assert.Equal(t, "", row[2])               // Operating System
+	assert.Equal(t, "", row[3])               // Component
+	assert.Equal(t, "", row[4])               // ComponentVersion
+	assert.Equal(t, "", row[5])               // CVE
+	assert.Equal(t, "false", row[6])          // Fixable
+	assert.Equal(t, "", row[7])               // FixedBy
+	assert.Equal(t, "UNKNOWN", row[8])        // Severity
+	assert.Equal(t, "0.00", row[9])           // CVSS
+	assert.Equal(t, "Not Available", row[10]) // First System Occurrence
+	assert.Equal(t, "", row[11])              // Link
 }

--- a/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/csv_gen_test.go
@@ -148,3 +148,27 @@ func TestGenerateCSV_NilFieldsProduceDefaults(t *testing.T) {
 	assert.Equal(t, "Not Available", row[10]) // First System Occurrence
 	assert.Equal(t, "", row[11])              // Link
 }
+
+func TestGenerateCSV_EmptyOperatingSystemProducesDefault(t *testing.T) {
+	emptyOS := ""
+	responses := []*NodeCVEQueryResponse{
+		{OperatingSystem: &emptyOS},
+	}
+
+	buf, err := generateCSV(responses, "empty-os-test")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	rc, err := reader.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	csvReader := csv.NewReader(rc)
+	records, err := csvReader.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+
+	assert.Equal(t, "Not Available", records[1][2])
+}

--- a/central/reports/scheduler/v2/reportgenerator/node/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/report_gen_impl.go
@@ -37,6 +37,7 @@ var (
 		Selects: []*v1.QuerySelect{
 			search.NewQuerySelect(search.Cluster).Proto(),
 			search.NewQuerySelect(search.Node).Proto(),
+			search.NewQuerySelect(search.OperatingSystem).Proto(),
 			search.NewQuerySelect(search.Component).Proto(),
 			search.NewQuerySelect(search.ComponentVersion).Proto(),
 			search.NewQuerySelect(search.CVEID).Proto(),

--- a/central/reports/scheduler/v2/reportgenerator/node/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/types.go
@@ -39,7 +39,9 @@ func (r *NodeCVEQueryResponse) GetNode() string {
 }
 
 func (r *NodeCVEQueryResponse) GetOperatingSystem() string {
-	if r.OperatingSystem == nil {
+	// Nodes scanned without OS metadata come back as an empty string rather than
+	// NULL, so both cases need the placeholder.
+	if r.OperatingSystem == nil || *r.OperatingSystem == "" {
 		return "Not Available"
 	}
 	return *r.OperatingSystem

--- a/central/reports/scheduler/v2/reportgenerator/node/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/types.go
@@ -40,7 +40,7 @@ func (r *NodeCVEQueryResponse) GetNode() string {
 
 func (r *NodeCVEQueryResponse) GetOperatingSystem() string {
 	if r.OperatingSystem == nil {
-		return ""
+		return "Not Available"
 	}
 	return *r.OperatingSystem
 }

--- a/central/reports/scheduler/v2/reportgenerator/node/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/node/types.go
@@ -10,6 +10,7 @@ import (
 type NodeCVEQueryResponse struct {
 	Cluster          *string                        `db:"cluster"`
 	Node             *string                        `db:"node"`
+	OperatingSystem  *string                        `db:"operating_system"`
 	Component        *string                        `db:"component"`
 	ComponentVersion *string                        `db:"component_version"`
 	CVEID            *string                        `db:"cve_id"`
@@ -35,6 +36,13 @@ func (r *NodeCVEQueryResponse) GetNode() string {
 		return ""
 	}
 	return *r.Node
+}
+
+func (r *NodeCVEQueryResponse) GetOperatingSystem() string {
+	if r.OperatingSystem == nil {
+		return ""
+	}
+	return *r.OperatingSystem
 }
 
 func (r *NodeCVEQueryResponse) GetComponent() string {


### PR DESCRIPTION
## Description

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests and manual tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
