### PR TITLE
ROX-36762: SBOM button disabled for images with unidentifiable base os

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -39,9 +39,8 @@ import { runImageViewBasedReport } from 'services/ReportsService';
 import { vulnerabilityImageViewBasedJobsPath } from 'routePaths';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';
-import GenerateSbomModal, {
-    getSbomGenerationStatusMessage,
-} from '../../components/GenerateSbomModal';
+import GenerateSbomModal from '../../components/GenerateSbomModal';
+import { getSbomGenerationStatusMessage } from '../../utils/getSbomGenerationStatusMessage';
 import useInvalidateVulnerabilityQueries from '../../hooks/useInvalidateVulnerabilityQueries';
 import ImagePageVulnerabilities from './ImagePageVulnerabilities';
 import ImagePageResources from './ImagePageResources';
@@ -184,8 +183,17 @@ function ImagePage({
         imageData && imageName
             ? `${imageName.registry}/${getImageBaseNameDisplay(imageData.id, imageName)}`
             : 'NAME UNKNOWN';
-    const scanMessage = getImageScanMessage(imageData?.notes ?? [], imageData?.scanNotes ?? []);
+    const imageNotes = imageData?.notes ?? [];
+    const scanNotes = imageData?.scanNotes ?? [];
+    const scanMessage = getImageScanMessage(imageNotes, scanNotes);
     const hasScanMessage = !isEmpty(scanMessage);
+    // SBOM generation is only blocked when the image has no scan data at all;
+    // CVE-accuracy caveats (e.g. no base OS) must not disable it (ROX-36762).
+    const sbomGenerationStatusMessage = getSbomGenerationStatusMessage({
+        isScannerV4Enabled,
+        imageNotes,
+        scanNotes,
+    });
 
     const workloadCveOverviewImagePath = urlBuilder.imageList('OBSERVED');
 
@@ -235,10 +243,7 @@ function ImagePage({
                                 {hasWriteAccessForImage && (
                                     <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
                                         <OptionalSbomButtonTooltip
-                                            message={getSbomGenerationStatusMessage({
-                                                isScannerV4Enabled,
-                                                hasScanMessage,
-                                            })}
+                                            message={sbomGenerationStatusMessage}
                                         >
                                             <Button
                                                 variant="secondary"
@@ -249,8 +254,7 @@ function ImagePage({
                                                     });
                                                 }}
                                                 isAriaDisabled={
-                                                    !isScannerV4Enabled ||
-                                                    hasScanMessage ||
+                                                    sbomGenerationStatusMessage !== undefined ||
                                                     !imageData.name?.fullName
                                                 }
                                             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -192,7 +192,6 @@ function ImagePage({
     const sbomGenerationStatusMessage = getSbomGenerationStatusMessage({
         isScannerV4Enabled,
         imageNotes,
-        scanNotes,
     });
 
     const workloadCveOverviewImagePath = urlBuilder.imageList('OBSERVED');

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -20,9 +20,8 @@ import type { ManagedColumns } from 'hooks/useManagedColumns';
 import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import usePermissions from 'hooks/usePermissions';
 import type { GenerateSbomImageParams } from 'services/ImageSbomService';
-import GenerateSbomModal, {
-    getSbomGenerationStatusMessage,
-} from '../../components/GenerateSbomModal';
+import GenerateSbomModal from '../../components/GenerateSbomModal';
+import { getSbomGenerationStatusMessage } from '../../utils/getSbomGenerationStatusMessage';
 import ImageNameLink from '../components/ImageNameLink';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import type {
@@ -330,12 +329,12 @@ function ImageOverviewTable({
                         }
 
                         if (hasWriteAccessForImage) {
-                            const isAriaDisabled =
-                                !isScannerV4Enabled || hasScanMessage || !name?.fullName;
                             const description = getSbomGenerationStatusMessage({
                                 isScannerV4Enabled,
-                                hasScanMessage,
+                                imageNotes: notes,
+                                scanNotes,
                             });
+                            const isAriaDisabled = description !== undefined || !name?.fullName;
 
                             rowActions.push({
                                 title: 'Generate SBOM',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -332,7 +332,6 @@ function ImageOverviewTable({
                             const description = getSbomGenerationStatusMessage({
                                 isScannerV4Enabled,
                                 imageNotes: notes,
-                                scanNotes,
                             });
                             const isAriaDisabled = description !== undefined || !name?.fullName;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/GenerateSbomModal.tsx
@@ -18,24 +18,6 @@ import useRestMutation from 'hooks/useRestMutation';
 import { generateAndSaveSbom } from 'services/ImageSbomService';
 import type { GenerateSbomImageParams } from 'services/ImageSbomService';
 
-export function getSbomGenerationStatusMessage({
-    isScannerV4Enabled,
-    hasScanMessage,
-}: {
-    isScannerV4Enabled: boolean;
-    hasScanMessage: boolean;
-}): string | undefined {
-    if (!isScannerV4Enabled) {
-        return 'SBOM generation requires Scanner V4';
-    }
-
-    if (hasScanMessage) {
-        return 'SBOM generation is unavailable due to incomplete scan data';
-    }
-
-    return undefined;
-}
-
 export type GenerateSbomModalProps = {
     onClose: () => void;
     image: GenerateSbomImageParams;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.test.ts
@@ -6,7 +6,6 @@ describe('getSbomGenerationStatusMessage', () => {
             getSbomGenerationStatusMessage({
                 isScannerV4Enabled: true,
                 imageNotes: [],
-                scanNotes: [],
             })
         ).toBeUndefined();
     });
@@ -16,7 +15,6 @@ describe('getSbomGenerationStatusMessage', () => {
             getSbomGenerationStatusMessage({
                 isScannerV4Enabled: false,
                 imageNotes: [],
-                scanNotes: [],
             })
         ).toBe('SBOM generation requires Scanner V4');
     });
@@ -26,7 +24,6 @@ describe('getSbomGenerationStatusMessage', () => {
             getSbomGenerationStatusMessage({
                 isScannerV4Enabled: false,
                 imageNotes: ['MISSING_SCAN_DATA'],
-                scanNotes: [],
             })
         ).toBe('SBOM generation requires Scanner V4');
     });
@@ -36,7 +33,6 @@ describe('getSbomGenerationStatusMessage', () => {
             getSbomGenerationStatusMessage({
                 isScannerV4Enabled: true,
                 imageNotes: ['MISSING_SCAN_DATA'],
-                scanNotes: [],
             })
         ).toBe('SBOM generation is unavailable due to incomplete scan data');
     });
@@ -46,35 +42,19 @@ describe('getSbomGenerationStatusMessage', () => {
             getSbomGenerationStatusMessage({
                 isScannerV4Enabled: true,
                 imageNotes: ['MISSING_METADATA'],
-                scanNotes: [],
             })
         ).toBe('SBOM generation is unavailable due to incomplete scan data');
     });
 
     // The core of ROX-36762: an image with no detectable base OS (e.g. FROM scratch)
-    // still has scan data, so SBOM generation must remain enabled even though the
-    // "CVE data may be inaccurate" banner is shown.
-    it('should NOT block generation when scan notes contain OS_UNAVAILABLE', () => {
+    // has scan data but only scan-level notes (OS_UNAVAILABLE etc.), never the
+    // image-level MISSING_* notes. Those scan-level notes must not block generation,
+    // so with empty imageNotes the function keeps SBOM generation enabled.
+    it('should NOT block generation when the image has no missing-data notes', () => {
         expect(
             getSbomGenerationStatusMessage({
                 isScannerV4Enabled: true,
                 imageNotes: [],
-                scanNotes: ['OS_UNAVAILABLE'],
-            })
-        ).toBeUndefined();
-    });
-
-    it.each([
-        ['PARTIAL_SCAN_DATA', 'OS_CVES_UNAVAILABLE'],
-        ['PARTIAL_SCAN_DATA', 'LANGUAGE_CVES_UNAVAILABLE'],
-        ['PARTIAL_SCAN_DATA', 'CERTIFIED_RHEL_SCAN_UNAVAILABLE'],
-        ['OS_CVES_STALE'],
-    ])('should NOT block generation for CVE-accuracy scan notes %j', (...scanNotes) => {
-        expect(
-            getSbomGenerationStatusMessage({
-                isScannerV4Enabled: true,
-                imageNotes: [],
-                scanNotes,
             })
         ).toBeUndefined();
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.test.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.test.ts
@@ -1,0 +1,81 @@
+import { getSbomGenerationStatusMessage } from './getSbomGenerationStatusMessage';
+
+describe('getSbomGenerationStatusMessage', () => {
+    it('should return undefined (enabled) when Scanner V4 is enabled and there are no notes', () => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: true,
+                imageNotes: [],
+                scanNotes: [],
+            })
+        ).toBeUndefined();
+    });
+
+    it('should return the Scanner V4 message when Scanner V4 is not enabled', () => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: false,
+                imageNotes: [],
+                scanNotes: [],
+            })
+        ).toBe('SBOM generation requires Scanner V4');
+    });
+
+    it('should prefer the Scanner V4 message even when scan data is missing', () => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: false,
+                imageNotes: ['MISSING_SCAN_DATA'],
+                scanNotes: [],
+            })
+        ).toBe('SBOM generation requires Scanner V4');
+    });
+
+    it('should block generation when image notes contain MISSING_SCAN_DATA', () => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: true,
+                imageNotes: ['MISSING_SCAN_DATA'],
+                scanNotes: [],
+            })
+        ).toBe('SBOM generation is unavailable due to incomplete scan data');
+    });
+
+    it('should block generation when image notes contain MISSING_METADATA', () => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: true,
+                imageNotes: ['MISSING_METADATA'],
+                scanNotes: [],
+            })
+        ).toBe('SBOM generation is unavailable due to incomplete scan data');
+    });
+
+    // The core of ROX-36762: an image with no detectable base OS (e.g. FROM scratch)
+    // still has scan data, so SBOM generation must remain enabled even though the
+    // "CVE data may be inaccurate" banner is shown.
+    it('should NOT block generation when scan notes contain OS_UNAVAILABLE', () => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: true,
+                imageNotes: [],
+                scanNotes: ['OS_UNAVAILABLE'],
+            })
+        ).toBeUndefined();
+    });
+
+    it.each([
+        ['PARTIAL_SCAN_DATA', 'OS_CVES_UNAVAILABLE'],
+        ['PARTIAL_SCAN_DATA', 'LANGUAGE_CVES_UNAVAILABLE'],
+        ['PARTIAL_SCAN_DATA', 'CERTIFIED_RHEL_SCAN_UNAVAILABLE'],
+        ['OS_CVES_STALE'],
+    ])('should NOT block generation for CVE-accuracy scan notes %j', (...scanNotes) => {
+        expect(
+            getSbomGenerationStatusMessage({
+                isScannerV4Enabled: true,
+                imageNotes: [],
+                scanNotes,
+            })
+        ).toBeUndefined();
+    });
+});

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.ts
@@ -15,9 +15,6 @@ export function getSbomGenerationStatusMessage({
 }: {
     isScannerV4Enabled: boolean;
     imageNotes: string[];
-    // scanNotes intentionally does not affect the result; kept for a stable call-site
-    // contract where all of an image's notes are passed through.
-    scanNotes?: string[];
 }): string | undefined {
     if (!isScannerV4Enabled) {
         return 'SBOM generation requires Scanner V4';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/getSbomGenerationStatusMessage.ts
@@ -1,0 +1,31 @@
+// Image-level notes that indicate the image has no usable scan data at all.
+// These genuinely prevent SBOM generation. Scan-level notes such as
+// OS_UNAVAILABLE / OS_CVES_UNAVAILABLE / OS_CVES_STALE only affect CVE accuracy
+// (the image was still scanned), so they must NOT block SBOM generation — the
+// backend endpoint and roxctl produce an SBOM for those images (ROX-36762).
+const noScanDataImageNotes = ['MISSING_METADATA', 'MISSING_SCAN_DATA'];
+
+export function hasNoScanData(imageNotes: string[]): boolean {
+    return imageNotes?.some((note) => noScanDataImageNotes.includes(note)) ?? false;
+}
+
+export function getSbomGenerationStatusMessage({
+    isScannerV4Enabled,
+    imageNotes,
+}: {
+    isScannerV4Enabled: boolean;
+    imageNotes: string[];
+    // scanNotes intentionally does not affect the result; kept for a stable call-site
+    // contract where all of an image's notes are passed through.
+    scanNotes?: string[];
+}): string | undefined {
+    if (!isScannerV4Enabled) {
+        return 'SBOM generation requires Scanner V4';
+    }
+
+    if (hasNoScanData(imageNotes)) {
+        return 'SBOM generation is unavailable due to incomplete scan data';
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Currently if the OS unknown the UI will not allow downloading of the SBOM, even if roxctl allows for it. This PR fixes that situation.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)
There was one CI failure it appears to be an infra issue

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

A GKE infra cluster was created.

The following Dockerfile was created

```
 cat Dockerfile 
FROM docker.io/library/golang:1.21 AS builder
WORKDIR /build
COPY go.mod main.go go.sum ./
USER 0
RUN CGO_ENABLED=0 GOOS=linux go build -o app main.go
FROM scratch
COPY --from=builder /build/app /app
ENTRYPOINT ["/app"]
```

The following command was run

```
docker build -t quay.io/jvirtane/qa:ui_sbom-3 .
```

The image was also pushed.

A deployment that uses the image was created

```
$ cat deployment.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: scratch-repro
  labels:
    app: scratch-repro
spec:
  replicas: 1
  selector:
    matchLabels:
      app: scratch-repro
  template:
    metadata:
      labels:
        app: scratch-repro
    spec:
      containers:
        - name: scratch-repro
          image: quay.io/jvirtane/qa:ui_sbom-3
          imagePullPolicy: Always
          resources:
            requests:
              cpu: 10m
              memory: 16Mi
            limits:
              cpu: 50m
              memory: 32Mi
```

ACS was deployed using the master branch.

The UI was checked and it was confirmed that the SBOM could not be downloaded.

<img width="1910" height="1011" alt="Screenshot From 2026-09-10 16-16-16" src="https://github.com/user-attachments/assets/734fa304-d1e7-4168-b1a4-d322b963ec69" />

ACS was then torn down, this branch was checked out, and ACS was deployed again.

On this branch it was possible to generate and download the SBOM

<img width="1909" height="972" alt="image" src="https://github.com/user-attachments/assets/3719aaf8-58ec-45b1-85e8-24f626dd328c" />

<img width="1909" height="972" alt="image" src="https://github.com/user-attachments/assets/dfce44b9-92c5-41a4-932b-74e29cdce9d2" />

<img width="1909" height="972" alt="image" src="https://github.com/user-attachments/assets/f7ebb5b2-d18f-4e19-9357-aa51b9e3393f" />

