### PR TITLE
ROX-36654: Use legacy Scanner term vs. Scanner V2

### DIFF
--- a/central/certgen/central_scanner.go
+++ b/central/certgen/central_scanner.go
@@ -79,7 +79,7 @@ func (s *serviceImpl) scannerHandler(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Query().Get("v") != "4" {
 		httputil.WriteErrorf(w, http.StatusBadRequest,
-			"scanner v2 certificate generation is not supported; pass v=4 for Scanner V4")
+			"legacy Scanner certificate generation is not supported; pass v=4 for Scanner V4")
 		return
 	}
 

--- a/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-central/templates/_init.tpl.htpl
@@ -290,9 +290,9 @@
 
 {{- if and $._rox.scanner (not (kindIs "invalid" $._rox.scanner.disable)) (not $._rox.scanner.disable) -}}
   {{- if $.Release.IsUpgrade -}}
-    {{- include "srox.note" (list $ "Scanner V2 (StackRox Scanner) has been removed in this release. Scanner V4 is the sole vulnerability scanner. Existing scanner/scanner-db resources will be removed.") -}}
+    {{- include "srox.note" (list $ "The legacy Scanner has been removed in this release. Scanner V4 is the sole vulnerability scanner. Existing scanner/scanner-db resources will be removed.") -}}
   {{- else -}}
-    {{- include "srox.warn" (list $ "Scanner V2 has been removed. The `scanner.disable` setting is ignored. Scanner V4 is the replacement.") -}}
+    {{- include "srox.warn" (list $ "The legacy Scanner has been removed. The `scanner.disable` setting is ignored. Scanner V4 is the replacement.") -}}
   {{- end -}}
 {{- end -}}
 

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -149,7 +149,7 @@
 
 {{/* Scanner V2 has been removed. Warn if a user still tries to enable it. */}}
 {{- if and $._rox.scanner (not (kindIs "invalid" $._rox.scanner.disable)) (not $._rox.scanner.disable) -}}
-  {{- include "srox.warn" (list $ "Scanner V2 has been removed. The `scanner.disable` setting is ignored. Scanner V4 is the replacement.") -}}
+  {{- include "srox.warn" (list $ "The legacy Scanner has been removed. The `scanner.disable` setting is ignored. Scanner V4 is the replacement.") -}}
 {{- end -}}
 [<- end >]
 

--- a/operator/api/v1alpha1/central_types.go
+++ b/operator/api/v1alpha1/central_types.go
@@ -34,12 +34,12 @@ type CentralSpec struct {
 	Central *CentralComponentSpec `json:"central,omitempty"`
 
 	// Obsolete field. This field will be removed in a future release.
-	// Scanner V2 has been removed. This field is ignored.
+	// The legacy Scanner has been removed. This field is ignored.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Scanner *ScannerComponentSpec `json:"scanner,omitempty"`
 
 	// Settings for the Scanner V4 component, which can run in addition to the previously existing Scanner components
-	// TODO(ROX-36705): renumber order annotations after Scanner V2 field removal
+	// TODO(ROX-36705): renumber order annotations after legacy Scanner field removal
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=3,displayName="Scanner V4 Component Settings"
 	ScannerV4 *ScannerV4Spec `json:"scannerV4,omitempty"`
 

--- a/operator/api/v1alpha1/securedcluster_types.go
+++ b/operator/api/v1alpha1/securedcluster_types.go
@@ -70,12 +70,12 @@ type SecuredClusterSpec struct {
 	ProcessBaselines *ProcessBaselinesSpec `json:"processBaselines,omitempty"`
 
 	// Obsolete field. This field will be removed in a future release.
-	// Scanner V2 has been removed. This field is ignored.
+	// The legacy Scanner has been removed. This field is ignored.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Scanner *LocalScannerComponentSpec `json:"scanner,omitempty"`
 
 	// Settings for the Scanner V4 components, which can run in addition to the previously existing Scanner components
-	// TODO(ROX-36705): renumber order annotations after Scanner V2 field removal
+	// TODO(ROX-36705): renumber order annotations after legacy Scanner field removal
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=9,displayName="Scanner V4 Component Settings"
 	ScannerV4 *LocalScannerV4ComponentSpec `json:"scannerV4,omitempty"`
 	// Above default is necessary to make the nested default work see: https://github.com/kubernetes-sigs/controller-tools/issues/622
@@ -428,7 +428,7 @@ const (
 
 // LocalScannerComponentSpec defines settings for the "scanner" component.
 type LocalScannerComponentSpec struct {
-	// Obsolete: Scanner v2 has been removed. This field is ignored.
+	// Obsolete: The legacy Scanner has been removed. This field is ignored.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Scanner Component",order=1
 	ScannerComponent *LocalScannerComponentPolicy `json:"scannerComponent,omitempty"`
 

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -2270,7 +2270,7 @@ spec:
               scanner:
                 description: |-
                   Obsolete field. This field will be removed in a future release.
-                  Scanner V2 has been removed. This field is ignored.
+                  The legacy Scanner has been removed. This field is ignored.
                 properties:
                   analyzer:
                     description: Settings pertaining to the analyzer deployment, such

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -1033,7 +1033,7 @@ spec:
               scanner:
                 description: |-
                   Obsolete field. This field will be removed in a future release.
-                  Scanner V2 has been removed. This field is ignored.
+                  The legacy Scanner has been removed. This field is ignored.
                 properties:
                   analyzer:
                     description: Settings pertaining to the analyzer deployment, such
@@ -1339,8 +1339,8 @@ spec:
                         type: array
                     type: object
                   scannerComponent:
-                    description: 'Obsolete: Scanner v2 has been removed. This field
-                      is ignored.'
+                    description: 'Obsolete: The legacy Scanner has been removed. This
+                      field is ignored.'
                     enum:
                     - AutoSense
                     - Disabled

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -139,7 +139,7 @@ spec:
               - urn:alm:descriptor:com.tectonic.ui:hidden
           - description: |-
               Obsolete field. This field will be removed in a future release.
-              Scanner V2 has been removed. This field is ignored.
+              The legacy Scanner has been removed. This field is ignored.
             displayName: Scanner
             path: scanner
             x-descriptors:
@@ -1087,7 +1087,7 @@ spec:
               - urn:alm:descriptor:com.tectonic.ui:hidden
           - description: |-
               Obsolete field. This field will be removed in a future release.
-              Scanner V2 has been removed. This field is ignored.
+              The legacy Scanner has been removed. This field is ignored.
             displayName: Scanner
             path: scanner
             x-descriptors:
@@ -1374,7 +1374,7 @@ spec:
           - description: A regex specifying namespaces whose process indicators should not be persisted.
             displayName: Exclude Namespace Regex
             path: processIndicators.excludeNamespaceRegex
-          - description: 'Obsolete: Scanner v2 has been removed. This field is ignored.'
+          - description: 'Obsolete: The legacy Scanner has been removed. This field is ignored.'
             displayName: Scanner Component
             path: scanner.scannerComponent
           - description: Settings pertaining to the analyzer deployment, such as for autoscaling.

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -2269,7 +2269,7 @@ spec:
               scanner:
                 description: |-
                   Obsolete field. This field will be removed in a future release.
-                  Scanner V2 has been removed. This field is ignored.
+                  The legacy Scanner has been removed. This field is ignored.
                 properties:
                   analyzer:
                     description: Settings pertaining to the analyzer deployment, such

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -1032,7 +1032,7 @@ spec:
               scanner:
                 description: |-
                   Obsolete field. This field will be removed in a future release.
-                  Scanner V2 has been removed. This field is ignored.
+                  The legacy Scanner has been removed. This field is ignored.
                 properties:
                   analyzer:
                     description: Settings pertaining to the analyzer deployment, such
@@ -1338,8 +1338,8 @@ spec:
                         type: array
                     type: object
                   scannerComponent:
-                    description: 'Obsolete: Scanner v2 has been removed. This field
-                      is ignored.'
+                    description: 'Obsolete: The legacy Scanner has been removed. This
+                      field is ignored.'
                     enum:
                     - AutoSense
                     - Disabled

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -946,7 +946,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: |-
           Obsolete field. This field will be removed in a future release.
-          Scanner V2 has been removed. This field is ignored.
+          The legacy Scanner has been removed. This field is ignored.
         displayName: Scanner
         path: scanner
         x-descriptors:
@@ -1100,7 +1100,8 @@ spec:
           The default is: Enabled.
         displayName: Autoscaling
         path: scanner.analyzer.scaling.autoScaling
-      - description: 'Obsolete: Scanner v2 has been removed. This field is ignored.'
+      - description: 'Obsolete: The legacy Scanner has been removed. This field is
+          ignored.'
         displayName: Scanner Component
         path: scanner.scannerComponent
       - description: |-
@@ -1637,7 +1638,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: |-
           Obsolete field. This field will be removed in a future release.
-          Scanner V2 has been removed. This field is ignored.
+          The legacy Scanner has been removed. This field is ignored.
         displayName: Scanner
         path: scanner
         x-descriptors:

--- a/operator/internal/central/defaults/scanner_v4.go
+++ b/operator/internal/central/defaults/scanner_v4.go
@@ -13,7 +13,7 @@ var (
 )
 
 // Only returns Enabled or Disabled.
-// Scanner V4 is now always on (scanner v2 has been removed), so we default to
+// Scanner V4 is now always on (the legacy Scanner has been removed), so we default to
 // Enabled unless the user explicitly set Disabled in the CR spec.
 //
 // Second return value is `true`, if defaulting has been applied due to lack of explicit setting.

--- a/operator/internal/securedcluster/defaults/scanner_v4.go
+++ b/operator/internal/securedcluster/defaults/scanner_v4.go
@@ -13,7 +13,7 @@ var (
 )
 
 // Only returns AutoSense or Disabled.
-// Scanner V4 is now always on (scanner v2 has been removed), so we default to
+// Scanner V4 is now always on (the legacy Scanner has been removed), so we default to
 // AutoSense unless the user explicitly set Disabled in the CR spec.
 //
 // Second return value is `true`, if defaulting has been applied due to lack of explicit setting.

--- a/operator/internal/securedcluster/scanner/auto_sense.go
+++ b/operator/internal/securedcluster/scanner/auto_sense.go
@@ -18,8 +18,8 @@ type AutoSenseResult struct {
 	EnableLocalImageScanning bool
 }
 
-// AutoSenseLocalScannerConfig returns a disabled scanner v2 result.
-// Scanner v2 has been removed; this function is kept for callers that
+// AutoSenseLocalScannerConfig returns a disabled legacy Scanner result.
+// The legacy Scanner has been removed; this function is kept for callers that
 // gate scanner-db-password secret cleanup on the auto-sense result.
 func AutoSenseLocalScannerConfig(_ context.Context, _ ctrlClient.Client, _ platform.SecuredCluster) (AutoSenseResult, error) {
 	return AutoSenseResult{}, nil


### PR DESCRIPTION
## Description

Scanner V2 is more of an internal term - this replaces instances of that with legacy Scanner (also considered StackRox Scanner to match the former integration - happy to use that if is a strong opinion, legacy Scanner read better to me)

To avoid conflicts / re-runs, can be merged after the more critical #22645 is merged.

Stack:

- https://github.com/stackrox/stackrox/pull/22763 <-- This PR
- https://github.com/stackrox/stackrox/pull/22645

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No tests modified

### How I validated my change

CI / Manual testing