### PR TITLE
tests(unit): retry `go list`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,7 +568,7 @@ test-prep:
 go-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 25m -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git ls-files -- '*_test.go' | scripts/go-files-to-packages.sh | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
 	@echo "Run log tests"
@@ -590,19 +590,19 @@ sensor-pipeline-benchmark: build-prep test-prep
 go-postgres-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -timeout 15m  -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git grep -rl "//go:build sql_integration" central pkg tools | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git grep -rl "//go:build sql_integration" central pkg tools | scripts/go-files-to-packages.sh -tags sql_integration | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/migrator-coverage.out -v \
-		$(shell git grep -rl "//go:build sql_integration" migrator | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git grep -rl "//go:build sql_integration" migrator | scripts/go-files-to-packages.sh -tags sql_integration | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee -a $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: go-postgres-bench-tests
 go-postgres-bench-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -run=nonthing -bench=. -benchtime=$(BENCHTIME) -benchmem -timeout $(BENCHTIMEOUT) -count $(BENCHCOUNT) -v \
-  $(shell git grep -rl "testing.B" central pkg migrator tools | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git grep -rl "testing.B" central pkg migrator tools | scripts/go-files-to-packages.sh -tags sql_integration | grep -Ev $(UNIT_TEST_IGNORE)) \
 		| tee $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: shell-unit-tests

--- a/scripts/go-files-to-packages.sh
+++ b/scripts/go-files-to-packages.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Reads a list of files (one per line) from stdin and prints on stdout a list of go packages.
+# The arguments are passed to `go list` that is used to perform the transformation.
+# That go list command is retried, to help with go proxy unavailability.
+
+num_retries=4
+
+dir_list=$(mktemp)
+sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq > "${dir_list}"
+output=$(mktemp)
+for attempt in $(seq 0 $num_retries)
+do
+    sleep_sec=$((attempt * 5))
+    if [[ $sleep_sec -gt 0 ]]; then
+        echo >&2 "Sleeping ${sleep_sec} before retrying..."
+        sleep "${sleep_sec}"
+    fi
+    if xargs go list "$@" < "${dir_list}" > "${output}"; then
+        grep -v '^github.com/stackrox/rox/tests$' "${output}"
+        exit 0
+    fi
+done
+echo >&2 "Running 'go list $*' failed despite $num_retries retries."
+exit 1


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Turns out the multiple-valued `$GOPROXY` [trick](https://github.com/stackrox/stackrox/blob/master/make/goproxy.mk) does not help for [some classes of errors](https://redhat-internal.slack.com/archives/CLUNQEEMA/p1788789687364869?thread_ts=1788786564.068979&cid=CLUNQEEMA).
Let's retry explicitly.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Introduced a bogus dependency to force a `go list` error and tested the retries work as intended:
```
[stackrox]$ git grep -rl "//go:build sql_integration" central pkg tools | ./scripts/go-files-to-packages.sh  -tags sql_integration
central/auth/datastore/datastore_impl.go:10:2: no required module provides package github.com/bla/umpa; to add it:
	go get github.com/bla/umpa
Sleeping 5 before retrying...
central/auth/datastore/datastore_impl.go:10:2: no required module provides package github.com/bla/umpa; to add it:
	go get github.com/bla/umpa
Sleeping 10 before retrying...
central/auth/datastore/datastore_impl.go:10:2: no required module provides package github.com/bla/umpa; to add it:
	go get github.com/bla/umpa
Sleeping 15 before retrying...
central/auth/datastore/datastore_impl.go:10:2: no required module provides package github.com/bla/umpa; to add it:
	go get github.com/bla/umpa
Sleeping 20 before retrying...
central/auth/datastore/datastore_impl.go:10:2: no required module provides package github.com/bla/umpa; to add it:
	go get github.com/bla/umpa
Running 'go list -tags sql_integration' failed despite 4 retries.
[stackrox]$ echo $?
1
[stackrox]$ 
```

Also made sure the output is the same for a successful old and new command line.
