### PR TITLE
ROX-28254: stamp inactive on runtime alerts after delete

### DIFF
--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -374,6 +374,12 @@ func mergeAlerts(old, newAlert *storage.Alert) *storage.Alert {
 	}
 
 	newAlert.FirstOccurred = old.GetFirstOccurred()
+	// Sensor's payload does not set Inactive; keep the stored flag on the merged alert.
+	if oldDep := old.GetDeployment(); oldDep != nil && oldDep.GetInactive() {
+		if newDep := newAlert.GetDeployment(); newDep != nil {
+			newDep.Inactive = true
+		}
+	}
 	return newAlert
 }
 
@@ -427,7 +433,7 @@ func (d *alertManagerImpl) mergeManyAlerts(
 	}
 
 	// Phase 2: fetch full alerts for matched keys and merge.
-	mergedAlertIDs, mergedNew, mergedUpdated, mergeErr := d.fetchAndMergeCandidates(ctx, mergeCandidates)
+	_, mergedNew, mergedUpdated, mergeErr := d.fetchAndMergeCandidates(ctx, mergeCandidates)
 	if mergeErr != nil {
 		err = mergeErr
 		return
@@ -435,12 +441,18 @@ func (d *alertManagerImpl) mergeManyAlerts(
 	newAlerts = append(newAlerts, mergedNew...)
 	updatedAlerts = append(updatedAlerts, mergedUpdated...)
 
-	// Find old alerts no longer being produced, and identify inactive deployments.
 	deploymentsBeingRemoved := set.NewStringSet()
 	for _, f := range oldAlertFilters {
 		if depID := f.removedDeploymentID(); depID != "" {
 			deploymentsBeingRemoved.Add(depID)
 		}
+	}
+
+	for _, a := range newAlerts {
+		d.stampInactiveIfDeploymentGone(a, deploymentsBeingRemoved)
+	}
+	for _, a := range updatedAlerts {
+		d.stampInactiveIfDeploymentGone(a, deploymentsBeingRemoved)
 	}
 
 	var needInactiveIDs []string
@@ -454,9 +466,6 @@ func (d *alertManagerImpl) mergeManyAlerts(
 
 		if key.GetLifecycleStage() == storage.LifecycleStage_RUNTIME ||
 			key.GetState() == storage.ViolationState_ATTEMPTED {
-			if mergedAlertIDs.Contains(key.GetId()) {
-				continue
-			}
 			if key.HasDeployment() && !key.IsDeploymentInactive() {
 				depID := key.GetDeploymentId()
 				if deploymentsBeingRemoved.Contains(depID) || d.runtimeDetector.DeploymentInactive(depID) {
@@ -466,7 +475,7 @@ func (d *alertManagerImpl) mergeManyAlerts(
 		}
 	}
 
-	// Mark deployments inactive for alerts not already handled by the merge phase.
+	// Stored runtime alerts with no incoming write still need an inactive stamp.
 	inactiveUpdates, inactiveErr := d.markDeploymentsInactive(ctx, needInactiveIDs)
 	if inactiveErr != nil {
 		err = inactiveErr
@@ -479,9 +488,8 @@ func (d *alertManagerImpl) mergeManyAlerts(
 }
 
 // fetchAndMergeCandidates fetches full alerts for merge candidates and merges
-// them with incoming alerts. Returns the set of merged alert IDs (to skip in
-// inactive marking), any alerts treated as new (deleted between phases), and
-// any updated alerts from merging.
+// them with incoming alerts. Returns merged IDs, alerts treated as new
+// (deleted between phases), and updated alerts from merging.
 func (d *alertManagerImpl) fetchAndMergeCandidates(ctx context.Context, candidates []mergeCandidate) (mergedIDs set.StringSet, newAlerts, updatedAlerts []*storage.Alert, err error) {
 	mergedIDs = set.NewStringSet()
 	if len(candidates) == 0 {
@@ -544,6 +552,22 @@ func (d *alertManagerImpl) markDeploymentsInactive(ctx context.Context, alertIDs
 		}
 	}
 	return updated, nil
+}
+
+// stampInactiveIfDeploymentGone sets deployment.Inactive when the deployment is
+// being removed or is already gone. Sensor can still send runtime alerts after that.
+func (d *alertManagerImpl) stampInactiveIfDeploymentGone(alert *storage.Alert, deploymentsBeingRemoved set.StringSet) {
+	if alert.GetLifecycleStage() != storage.LifecycleStage_RUNTIME &&
+		alert.GetState() != storage.ViolationState_ATTEMPTED {
+		return
+	}
+	dep := alert.GetDeployment()
+	if dep == nil || dep.GetInactive() {
+		return
+	}
+	if deploymentsBeingRemoved.Contains(dep.GetId()) || d.runtimeDetector.DeploymentInactive(dep.GetId()) {
+		dep.Inactive = true
+	}
 }
 
 func (d *alertManagerImpl) shouldMarkAlertResolved(old alertviews.AlertMatcher, incomingAlerts []*storage.Alert, oldAlertFilters ...AlertFilterOption) bool {

--- a/central/detection/alertmanager/alert_manager_impl.go
+++ b/central/detection/alertmanager/alert_manager_impl.go
@@ -455,6 +455,13 @@ func (d *alertManagerImpl) mergeManyAlerts(
 		d.stampInactiveIfDeploymentGone(a, deploymentsBeingRemoved)
 	}
 
+	// IDs already in updatedAlerts were stamped in memory. Re-fetching them
+	// would upsert the stored blob and drop merged processes.
+	alreadyUpdated := set.NewStringSet()
+	for _, a := range updatedAlerts {
+		alreadyUpdated.Add(a.GetId())
+	}
+
 	var needInactiveIDs []string
 	for _, key := range previousKeys {
 		if d.shouldMarkAlertResolved(key, incomingAlerts, oldAlertFilters...) {
@@ -467,6 +474,9 @@ func (d *alertManagerImpl) mergeManyAlerts(
 		if key.GetLifecycleStage() == storage.LifecycleStage_RUNTIME ||
 			key.GetState() == storage.ViolationState_ATTEMPTED {
 			if key.HasDeployment() && !key.IsDeploymentInactive() {
+				if alreadyUpdated.Contains(key.GetId()) {
+					continue
+				}
 				depID := key.GetDeploymentId()
 				if deploymentsBeingRemoved.Contains(depID) || d.runtimeDetector.DeploymentInactive(depID) {
 					needInactiveIDs = append(needInactiveIDs, key.GetId())

--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -171,6 +171,26 @@ func getFakeRuntimeAlert(indicators ...*storage.ProcessIndicator) *storage.Alert
 	}
 }
 
+func runtimeDeploymentAlert(id, depID string, inactive bool, process *storage.ProcessIndicator) *storage.Alert {
+	v := &storage.Alert_ProcessViolation{Processes: []*storage.ProcessIndicator{process}}
+	printer.UpdateProcessAlertViolationMessage(v)
+	return &storage.Alert{
+		Id:     id,
+		Policy: getPolicies()[0],
+		Entity: &storage.Alert_Deployment_{
+			Deployment: &storage.Alert_Deployment{
+				Id:       depID,
+				Name:     depID,
+				Inactive: inactive,
+			},
+		},
+		LifecycleStage:   storage.LifecycleStage_RUNTIME,
+		State:            storage.ViolationState_ACTIVE,
+		Time:             protocompat.GetProtoTimestampFromSeconds(100),
+		ProcessViolation: v,
+	}
+}
+
 func getFakeResourceRuntimeAlert(resourceType storage.Alert_Resource_ResourceType, resourceName, clusterID, namespaceID, namespace string) *storage.Alert {
 	return &storage.Alert{
 		LifecycleStage: storage.LifecycleStage_RUNTIME,
@@ -710,6 +730,48 @@ func (suite *AlertManagerTestSuite) TestDeploymentMarkedInactiveOnRemoval() {
 	suite.True(modified.Contains("dep-to-remove"), "removed deployment should appear in modified set")
 }
 
+// TestNewRuntimeAlertMarkedInactiveWhenDeploymentGone covers a first runtime
+// alert arriving after the deployment is already gone.
+func (suite *AlertManagerTestSuite) TestNewRuntimeAlertMarkedInactiveWhenDeploymentGone() {
+	incoming := runtimeDeploymentAlert("runtime-alert-new", "dep-gone", false, nowProcess)
+
+	suite.runtimeDetectorMock.EXPECT().DeploymentInactive("dep-gone").Return(true).AnyTimes()
+	suite.alertsMock.EXPECT().SearchAlertMatchKeys(suite.ctx, gomock.Any(), true).Return(nil, nil)
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, gomock.Any()).DoAndReturn(func(_ context.Context, a *storage.Alert) error {
+		suite.True(a.GetDeployment().GetInactive(), "new runtime alert should be marked inactive")
+		return nil
+	})
+	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).Return()
+
+	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, []*storage.Alert{incoming})
+	suite.NoError(err)
+	suite.True(modified.Contains("dep-gone"))
+}
+
+// TestMergedRuntimeAlertMarkedInactiveWhenDeploymentGone covers a later runtime
+// alert merging into a stored one after the deployment is already gone.
+func (suite *AlertManagerTestSuite) TestMergedRuntimeAlertMarkedInactiveWhenDeploymentGone() {
+	previous := runtimeDeploymentAlert("runtime-alert-1", "dep-gone", false, yesterdayProcess)
+	incoming := runtimeDeploymentAlert("runtime-alert-incoming", "dep-gone", false, nowProcess)
+
+	suite.runtimeDetectorMock.EXPECT().DeploymentInactive("dep-gone").Return(true).AnyTimes()
+	suite.runtimeDetectorMock.EXPECT().PolicySet().Return(suite.policySet).AnyTimes()
+
+	suite.alertsMock.EXPECT().SearchAlertMatchKeys(suite.ctx, gomock.Any(), true).
+		Return(alertsToMatchKeys([]*storage.Alert{previous}), nil)
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), false).Return([]*storage.Alert{previous.CloneVT()}, nil).AnyTimes()
+
+	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, gomock.Any()).DoAndReturn(func(_ context.Context, a *storage.Alert) error {
+		suite.True(a.GetDeployment().GetInactive(), "merged runtime alert should be marked inactive")
+		return nil
+	}).AnyTimes()
+	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).Return().AnyTimes()
+
+	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, []*storage.Alert{incoming})
+	suite.NoError(err)
+	suite.True(modified.Contains("dep-gone"))
+}
+
 func (suite *AlertManagerTestSuite) TestResolvedDeploymentAlertReturnsDeploymentID() {
 	alerts := getAlerts()
 
@@ -729,6 +791,33 @@ func (suite *AlertManagerTestSuite) TestResolvedDeploymentAlertReturnsDeployment
 	suite.NoError(err)
 	suite.True(modified.Contains(alerts[0].GetDeployment().GetId()),
 		"resolved deployment alert's deployment ID should appear in modified set")
+}
+
+func TestMergeAlertsPreservesDeploymentInactive(t *testing.T) {
+	cases := map[string]struct {
+		oldInactive bool
+		newInactive bool
+		want        bool
+	}{
+		"stored inactive is kept when Sensor sends a new process": {
+			oldInactive: true,
+			newInactive: false,
+			want:        true,
+		},
+		"active stays active when both sides are active": {
+			oldInactive: false,
+			newInactive: false,
+			want:        false,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			old := runtimeDeploymentAlert("alert-1", "dep", c.oldInactive, yesterdayProcess)
+			newAlert := runtimeDeploymentAlert("alert-incoming", "dep", c.newInactive, nowProcess)
+			merged := mergeAlerts(old, newAlert)
+			assert.Equal(t, c.want, merged.GetDeployment().GetInactive())
+		})
+	}
 }
 
 func TestMergeProcessesFromOldIntoNew(t *testing.T) {

--- a/central/detection/alertmanager/alert_manager_impl_test.go
+++ b/central/detection/alertmanager/alert_manager_impl_test.go
@@ -759,13 +759,14 @@ func (suite *AlertManagerTestSuite) TestMergedRuntimeAlertMarkedInactiveWhenDepl
 
 	suite.alertsMock.EXPECT().SearchAlertMatchKeys(suite.ctx, gomock.Any(), true).
 		Return(alertsToMatchKeys([]*storage.Alert{previous}), nil)
-	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), false).Return([]*storage.Alert{previous.CloneVT()}, nil).AnyTimes()
+	suite.alertsMock.EXPECT().SearchRawAlerts(suite.ctx, gomock.Any(), false).Return([]*storage.Alert{previous.CloneVT()}, nil)
 
 	suite.alertsMock.EXPECT().UpsertAlert(suite.ctx, gomock.Any()).DoAndReturn(func(_ context.Context, a *storage.Alert) error {
 		suite.True(a.GetDeployment().GetInactive(), "merged runtime alert should be marked inactive")
+		suite.Len(a.GetProcessViolation().GetProcesses(), 2, "inactive stamp must not replace the merged processes")
 		return nil
-	}).AnyTimes()
-	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).Return().AnyTimes()
+	})
+	suite.notifierMock.EXPECT().ProcessAlert(gomock.Any(), gomock.Any()).Return()
 
 	modified, err := suite.alertManager.AlertAndNotify(suite.ctx, []*storage.Alert{incoming})
 	suite.NoError(err)

--- a/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RuntimeViolationLifecycleTest.groovy
@@ -51,6 +51,21 @@ class RuntimeViolationLifecycleTest extends BaseSpecification  {
         return disappearedFromStackRox
     }
 
+    // waitForAlertsInactive polls because Central deletes the deployment before
+    // the alerts pipeline stamps Inactive on remaining runtime alerts.
+    def waitForAlertsInactive(violations) {
+        Timer t = new Timer(60, 1)
+        while (t.IsValid()) {
+            if (violations.every { violation ->
+                def alert = AlertService.getViolation(violation.getId())
+                alert.getDeployment()?.getInactive()
+            }) {
+                return true
+            }
+        }
+        return false
+    }
+
     def assertAlertExistsForDeploymentUidAndGetViolations(String policyName, String deploymentUid) {
         checkPolicyExists(APTGETPOLICY)
         def violations = Services.getViolationsByDeploymentID(deploymentUid, policyName, false, 66)
@@ -215,10 +230,7 @@ class RuntimeViolationLifecycleTest extends BaseSpecification  {
         def newViolations =
                 assertAlertExistsForDeploymentUidAndGetViolations(APTGETPOLICY, DEPLOYMENT.getDeploymentUid())
         assert (newViolations*.id).toSet().containsAll(violations*.id)
-        for (def violation: newViolations) {
-            def alert = AlertService.getViolation(violation.getId())
-            assert alert.getDeployment() != null && alert.getDeployment().getInactive()
-        }
+        assert waitForAlertsInactive(newViolations)
 
         cleanup:
         if (!deploymentDeleted) {


### PR DESCRIPTION
## Description

TL;DR: Goal: Fix flake `RuntimeViolationLifecycleTest` - turned out not to be a flake, but a bug.

After you delete a deployment, its runtime alert (for example "apt-get ran") should stay. It should be marked as belonging to a deployment that no longer exists. That flag is `inactive`. On OpenShift it often stayed false, so `RuntimeViolationLifecycleTest` failed.

We first treated this as a slow race and added a 60s wait in the QA test. CI still failed. The Postgres dump from that run is the proof: alert `53e40f22` was written once at 10:03:35 UTC with `inactive=false`, and it was still false at 10:17. Deploy-time alerts for the same deployment were resolved. Central never wrote the flag. Waiting longer cannot fix that.

The job also had two pods for the same test label at delete time. That makes it easy for Sensor to send a late "apt-get ran" after Central already deleted the deployment.

**The bug:** Central only stamped `inactive` on leftover stored alerts. A runtime alert that arrives after the deployment is gone is a new write, or a merge into the stored one. Those paths skipped the stamp. Merge also copied Sensor's payload, which has `inactive=false`, so a later update could wipe the flag.

**Why this should fix it:** When Central writes a runtime alert and the deployment is already gone, it now sets `inactive` on that write. Merge keeps the stored flag instead of replacing it with Sensor's `false`. The QA wait stays so the test can poll until that write lands.

Related PR: https://github.com/stackrox/stackrox/pull/20557

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

QA `RuntimeViolationLifecycleTest` already waits up to 60s for `inactive` after delete. That wait is not the fix; it only observes the product write. No new e2e: the existing BAT test is the regression.

### How I validated my change

- CI ocp-4-22-qa-e2e:
    1. ✅ [e2e-dispatch / e2e-qa-tests-ocp-4-22 / run / qa-e2e-tests (pull_request)](https://github.com/stackrox/stackrox/actions/runs/34476733954/job/102871736684?pr=22775) 
- CI ocp-4-12-qa-e2e:
    - 1st run: for commit https://github.com/stackrox/stackrox/pull/22775/commits/d3e6ef7ee49672249b7365b105a990a1f3509756 - [failure](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22775/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2097946578982539264), discovered that this issue is not a test problem! the commit didn't fix it. 
    - 2nd run: for commit https://github.com/stackrox/stackrox/pull/22775/commits/2b1fc59cb0b5d87295cee7918852a46a8e4fd48a - [infra/installation issue](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22775/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2098118432510709760) - same as for all other prow jobs.
    - 3rd run: for commit https://github.com/stackrox/stackrox/pull/22775/commits/2b1fc59cb0b5d87295cee7918852a46a8e4fd48a - ✅  [prow link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22775/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2098402323813371904) (OCM failure) 
- GKE QA:
    -  for commit https://github.com/stackrox/stackrox/pull/22775/commits/2b1fc59cb0b5d87295cee7918852a46a8e4fd48a : ✅  [prow link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22775/pull-ci-stackrox-stackrox-master-gke-qa-e2e-tests/2098402527383916544)
