### PR TITLE
ROX-36930: raise scanner e2e chart statement_timeout to 6m

### DIFF
--- a/scanner/e2etests/helmchart/templates/scanner-config.yaml
+++ b/scanner/e2etests/helmchart/templates/scanner-config.yaml
@@ -10,11 +10,11 @@ data:
     grpc_listen_addr: :8443
     indexer:
       database:
-        conn_string: host={{ .Values.app.db.name }}.{{ .Release.Namespace }} port=5432 user=postgres sslmode=verify-ca statement_timeout=60000 sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
+        conn_string: host={{ .Values.app.db.name }}.{{ .Release.Namespace }} port=5432 user=postgres sslmode=verify-ca statement_timeout=360000 sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
         password_file: /run/secrets/stackrox.io/postgresql/password
     matcher:
       database:
-        conn_string: host={{ .Values.app.db.name }}.{{ .Release.Namespace }} port=5432 user=postgres sslmode=verify-ca statement_timeout=60000 sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
+        conn_string: host={{ .Values.app.db.name }}.{{ .Release.Namespace }} port=5432 user=postgres sslmode=verify-ca statement_timeout=360000 sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
         password_file: /run/secrets/stackrox.io/postgresql/password
       vulnerabilities_url: https://definitions.stackrox.io/v4/vulnerability-bundles/ROX_VULNERABILITY_VERSION/vulnerabilities.zip
       readiness: vulnerability


### PR DESCRIPTION
## Description

The scanner functional-test Helm chart (`scanner/e2etests/helmchart/templates/scanner-config.yaml`) caps the indexer and matcher DB connections at `statement_timeout=60000` (60s). After the claircore mainline bump (ROX-36628, PR #22585 on master), the matcher's initial vulnerability load runs a new "bulk link vulnerability aliases" bulk `INSERT` over the RHEL VEX bundle (~3.4M rows). Measured on an OpenShift cluster, that single statement runs ~2 min, so it is cancelled at 60s (`SQLSTATE 57014`, `canceling statement due to statement timeout`) and the matcher never becomes ready — the functional suite (workflow "Scanner functional tests", label `scanner-functional-tests`) cannot run.

This raises the cap to `360000` (6 min): ~3x the observed ~2 min, leaving headroom for CI hardware variance and RHEL VEX growth without masking a genuinely stuck statement. Production scanner-v4 is unaffected: `scannerV4.db.source.statementTimeoutMs` defaults to `null`, so no `statement_timeout` is applied to real deployments; only the e2e chart imposes the cap.

Tracked in ROX-36930.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed (test-harness-only change)
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md) (test-only change; not shipped in product images)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests (raises the `statement_timeout` used by the scanner functional/e2e test harness)

### How I validated my change

Deployed scanner-v4 + scanner-v4-db from post-claircore-bump images via this e2e chart on an OpenShift cluster:

- With `statement_timeout=60000`: the matcher fails RHEL VEX import with `failed to bulk link vulnerability aliases: ERROR: canceling statement due to statement timeout (SQLSTATE 57014)` and never becomes ready.
- With a raised cap: RHEL VEX import completes (the `INSERT INTO vulnerability_alias ... unnest(...)` statement runs ~2 min over 3.4M rows), the matcher becomes ready, and `make -C scanner e2e-run` executes. `360000` (6 min) gives ~3x headroom over the observed ~2 min.
- A pre-bump baseline reaches ready under the default 60s cap (no alias-linking step), confirming the timeout is introduced by the claircore bump and not environmental.

To exercise this in CI, add the `scanner-functional-tests` label to run the "Scanner functional tests" workflow.
