### PR TITLE
fix(tests): revert #22669 helmtest to unblock #22645

### DIFF
--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-compliance.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/collector-compliance.test.yaml
@@ -17,20 +17,6 @@ tests:
       - openshift-4.12
       availableSchemas:
       - openshift-4.12
-- name: "does not set node index host path on kubernetes"
-  expect: |
-    envVars(.daemonsets.collector; "compliance") | assertThat(has("ROX_NODE_INDEX_HOST_PATH") == false)
-    [container(.daemonsets.collector; "compliance") | .volumeMounts[] | select(.mountPath | startswith("/hostindex"))] | length | assertThat(. == 0)
-- name: "OpenShift 4 indexes /hostindex with usr/share and usr/lib RPM paths"
-  server:
-    visibleSchemas:
-    - openshift-4.12
-    availableSchemas:
-    - openshift-4.12
-  expect: |
-    envVars(.daemonsets.collector; "compliance")["ROX_NODE_INDEX_HOST_PATH"] | assertThat(. == "/hostindex")
-    [container(.daemonsets.collector; "compliance") | .volumeMounts[] | select(.mountPath == "/hostindex/usr/share")] | length | assertThat(. == 1)
-    [container(.daemonsets.collector; "compliance") | .volumeMounts[] | select(.mountPath == "/hostindex/usr/lib")] | length | assertThat(. == 1)
 - name: "customize.envVars can re-enable Scanner V2 node inventory calls"
   values:
     customize:


### PR DESCRIPTION
## Description

#22645 (Scanner V2 install removal) cannot merge into master because of a content conflict in `collector-compliance.test.yaml`. Master picked up two new helmtest cases from #22669 (V4 `/hostindex` mount and env assertions) in the same block where #22645 deletes the obsolete "re-enable Scanner V2 node inventory" test.

This PR removes only those two #22669 test cases from the helmtest file. It does not revert the #22669 chart or indexer changes on master. Remaining cases in the file (V2 env default-off, V2 re-enable via `customize.envVars`, securityContext) are unchanged and still match current master behavior.

Merge this before #22645 so the larger removal PR can land cleanly. After #22645 merges, re-add the V4 `/hostindex` helmtest assertions in post-Scanner V2-removal form (without the V2 re-enable case).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [ ] CI