### PR TITLE
fix(scanner): tolerate empty CPE in request validators

### DIFF
--- a/scanner/services/validators/validators.go
+++ b/scanner/services/validators/validators.go
@@ -154,6 +154,20 @@ func validateContents(contents *v4.Contents) error {
 	return nil
 }
 
+// validateCPE reports an error if s is a non-empty string that isn't a valid
+// bound CPE WFN. An empty string is treated as "no CPE" and is not an error,
+// matching the same convention mappers.toClairCoreCPE uses for the wire
+// format: ClairCore's own zero-value WFN and this package's empty string are
+// both accepted as "unset", even though StackRox's own mappers now always
+// serialize "unset" as the bound wildcard CPE rather than "".
+func validateCPE(s string) error {
+	if s == "" {
+		return nil
+	}
+	_, err := cpe.Unbind(s)
+	return err
+}
+
 func validateMap[T hasIDAndCPE](m map[string]T, fieldName string, validateF func(T) error) error {
 	for k, v := range m {
 		if reflect.ValueOf(v).IsZero() {
@@ -162,8 +176,7 @@ func validateMap[T hasIDAndCPE](m map[string]T, fieldName string, validateF func
 		if v.GetId() == "" {
 			return fmt.Errorf("%s element %q: ID is empty", fieldName, k)
 		}
-		_, err := cpe.Unbind(v.GetCpe())
-		if err != nil {
+		if err := validateCPE(v.GetCpe()); err != nil {
 			return fmt.Errorf("%s element %q: invalid CPE: %w", fieldName, k, err)
 		}
 		if err := validateF(v); err != nil {
@@ -182,8 +195,7 @@ func validateList[T hasIDAndCPE](l []T, fieldName string, validateF func(T) erro
 		if o.GetId() == "" {
 			return fmt.Errorf("%s element #%d: Id is empty", fieldName, n)
 		}
-		_, err := cpe.Unbind(o.GetCpe())
-		if err != nil {
+		if err := validateCPE(o.GetCpe()); err != nil {
 			return fmt.Errorf("%s element #%d (id: %q): invalid CPE: %w", fieldName, n, o.GetId(), err)
 		}
 		if err := validateF(o); err != nil {

--- a/scanner/services/validators/validators_test.go
+++ b/scanner/services/validators/validators_test.go
@@ -131,6 +131,14 @@ func Test_validateGetVulnerabilitiesRequest(t *testing.T) {
 				addPackageDEPRECATED(&v4.Package{Id: "foobar", Cpe: "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"}),
 			},
 		},
+		"when a package has an empty CPE": {
+			// An empty CPE is treated the same as an unset one (e.g. the bound
+			// wildcard), not an invalid CPE. See mappers.toClairCoreCPE.
+			argOpts: []opts{
+				addPackage(&v4.Package{Id: "foobar", Cpe: ""}),
+				addPackageDEPRECATED(&v4.Package{Id: "foobar", Cpe: ""}),
+			},
+		},
 		"when a package has a source package with another source package": {
 			wantErr: `Contents.Packages element "foo": package ID="foo" has a source with a source`,
 			argOpts: []opts{


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

On top of https://github.com/stackrox/stackrox/pull/22752

Just to show an idea, do not merge. 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

unittest
