### PR TITLE
fix(ci): gate scanner-v4-matcher readiness on vuln load in roxie deploys

### DIFF
--- a/tests/e2e/lib-compat.sh
+++ b/tests/e2e/lib-compat.sh
@@ -179,6 +179,7 @@ roxie_config_from_environment_compat() {
     info "Configuring scanner V4..."
     handle_scanner_v4_setting "$config_file" ".central.spec.scannerV4.scannerComponent" "Enabled"
     handle_scanner_v4_setting "$config_file" ".securedCluster.spec.scannerV4.scannerComponent" "AutoSense"
+    handle_scanner_v4_vuln_readiness "$config_file"
 
     info "Configuring declarative configuration..."
     handle_declarative_configuration "$config_file"
@@ -242,6 +243,36 @@ handle_scanner_v4_setting() {
             die "Unsupported value for ROX_SCANNER_V4: $rox_scanner_v4"
             ;;
     esac
+}
+
+# handle_scanner_v4_vuln_readiness gates the scanner-v4-matcher pod's readiness
+# probe on the vulnerability bundle being fully loaded. The matcher's default
+# readiness is "database" (ready as soon as Postgres is reachable), so without
+# this the deployment reports ready while vulns are still importing and tests
+# would scan before any vuln data exists. Setting
+# SCANNER_V4_MATCHER_READINESS=vulnerability keeps the matcher unready until the
+# initial load completes, so the deploy step waits for it. The env vars go into
+# the Central CR's customize.envVars, which the operator propagates to
+# scanner-v4-matcher.
+handle_scanner_v4_vuln_readiness() {
+    local config_file="$1"
+
+    # Only meaningful when Scanner V4 is enabled.
+    if [[ "${ROX_SCANNER_V4:-true}" == "false" ]]; then
+        return
+    fi
+
+    # export_test_environment establishes the default (true); jobs that don't
+    # need gating (e.g. install-only) set SCANNER_V4_VULN_READINESS=false.
+    if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" ]]; then
+        info "  gating scanner-v4-matcher readiness on vulnerability load"
+        set_custom_env "$config_file" "central" "SCANNER_V4_MATCHER_READINESS" "vulnerability"
+    fi
+
+    if [[ -n "${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST:-}" ]]; then
+        info "  restricting vuln bundle sources to ${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST}"
+        set_custom_env "$config_file" "central" "SCANNER_V4_MATCHER_VULN_BUNDLE_ALLOWLIST" "${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST}"
+    fi
 }
 
 handle_trusted_ca_file() {


### PR DESCRIPTION
## Description

Various CI jobs executed in GitHub Actions were not waiting for Scanner V4 vulns to load before attempting scans. 

Some jobs were working, others were failing, that ones that were failing appear to be the ones using `roxie` to install (per agent):

```
┌─────────────────────────────────┬────────────────────────┬─────────────────────────┬────────────────────────────────┐
│          GHA workflow           │      Deploy path       │ Gates matcher on vulns? │              Via               │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-qa-tests-gke                │ roxie compat           │ ✅ now                  │ this fix (lib-compat.sh)         │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-qa-tests-gke-konflux        │ roxie compat           │ ✅ now                  │ this fix                         │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-qa-tests-ocp-4-22           │ roxie compat           │ ✅ now                  │ this fix                         │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-byodb-tests                 │ helm (deploy_stackrox) │ ✅ already              │ k8sbased.sh:450/608            │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-nongroovy-tests             │ helm                   │ ✅ already              │ k8sbased.sh:450/608            │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-gke-upgrade-tests (×3 jobs) │ upgrade lib            │ ✅ already              │ tests/upgrade/lib.sh:246,249   │
├─────────────────────────────────┼────────────────────────┼─────────────────────────┼────────────────────────────────┤
│ e2e-db-backup-restore-tests     │ helm, V4 disabled      │ ➖ N/A                  │ ROX_SCANNER_V4=false, no scans │
└─────────────────────────────────┴────────────────────────┴─────────────────────────┴────────────────────────────────┘
```




The roxie compat deploy path (used by the e2e-qa-tests-gke and other roxie-based e2e jobs) reported scanner-v4-matcher ready as soon as its DB was reachable, because the matcher's default readiness mode is "database". With roxie deploy --early-readiness=false, the deploy step therefore returned before the vulnerability bundle finished loading, so scan tests ran against an empty vuln DB and failed. This surfaced once Scanner V2 was removed and V4 became the default scanner for these jobs.

Add handle_scanner_v4_vuln_readiness() to the compat layer, injecting SCANNER_V4_MATCHER_READINESS=vulnerability (and the vuln bundle allowlist) into the Central CR customize.envVars when Scanner V4 is enabled and SCANNER_V4_VULN_READINESS is on (the default). It keys off the same env vars the operator/helm deploy paths and Prow jobs already use, so install-only jobs can still opt out via SCANNER_V4_VULN_READINESS=false.

customize.envVars is used rather than a typed CR field because no CRD field exists for matcher readiness; the env var is the only lever, matching the operator and helm deploy paths.

This change was partially generated by an AI agent.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
