### PR TITLE
fix(central-worker): recover reporting across worker handoffs

### DIFF
--- a/central/reports/scheduler/v2/README.md
+++ b/central/reports/scheduler/v2/README.md
@@ -1,0 +1,23 @@
+# Report scheduler ownership
+
+Central runs report scheduling when Central Worker is disabled. Otherwise the Worker
+owns it. Each scheduler acquires the PostgreSQL report advisory lock before recovering
+pending reports and schedules. Lock contention, connection errors, and failed initial
+discovery queries are retried every five seconds until shutdown.
+
+`Start` starts one background lifecycle. `Stop` cancels acquisition and running reports,
+waits for report execution to finish, stops cron, and releases ownership. Reports
+interrupted by scheduler shutdown remain pending for the successor to recover; explicit
+user cancellations still become failures. A stopped scheduler cannot be restarted.
+
+Worker `/readyz` requires initialized scheduler ownership; `/healthz` remains independent.
+The `rox_report_scheduler_ready` metric is 1 on the active, initialized scheduler and 0
+on an inactive, waiting, or stopping process. When reports are delegated, Central's
+metric is 0 and the Worker's metric should be 1. Central's API readiness remains
+independent so a replacement Central can become ready during a rolling update before
+the old Central releases scheduling ownership.
+
+The Central DB NetworkPolicy retains the same-namespace Worker selector even when the
+Worker is disabled. Removing that access during deletion can prevent a terminating
+Worker from releasing its session-level locks. Worker shutdown stops reporting and
+pruning concurrently, within the pod's 120-second termination grace period.

--- a/central/reports/scheduler/v2/lifecycle_test.go
+++ b/central/reports/scheduler/v2/lifecycle_test.go
@@ -1,0 +1,253 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	configMocks "github.com/stackrox/rox/central/reports/config/datastore/mocks"
+	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
+	generatorMocks "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator/mocks"
+	snapshotMocks "github.com/stackrox/rox/central/reports/snapshot/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/dblock"
+	"github.com/stackrox/rox/pkg/postgres"
+	pgMocks "github.com/stackrox/rox/pkg/postgres/mocks"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"gopkg.in/robfig/cron.v2"
+)
+
+type lockResult bool
+
+func (r lockResult) Scan(dest ...interface{}) error {
+	*dest[0].(*bool) = bool(r)
+	return nil
+}
+
+func TestSchedulerRetriesAndRecoversPendingReports(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		initialError       error
+		failSnapshotUpdate bool
+	}{
+		"lock contention":          {},
+		"transient database error": {initialError: errors.New("database unavailable")},
+		"snapshot update":          {failSnapshotUpdate: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			db := pgMocks.NewMockDB(ctrl)
+			conn := pgMocks.NewMockPgxPoolConn(ctrl)
+			snapshots := snapshotMocks.NewMockDataStore(ctrl)
+			configs := configMocks.NewMockDataStore(ctrl)
+			generator := generatorMocks.NewMockReportGenerator(ctrl)
+			var attempts atomic.Int32
+			db.EXPECT().Acquire(gomock.Any()).DoAndReturn(func(context.Context) (*postgres.Conn, error) {
+				if attempts.Add(1) == 1 && testCase.initialError != nil {
+					return nil, testCase.initialError
+				}
+				return &postgres.Conn{PgxPoolConn: conn}, nil
+			}).AnyTimes()
+			conn.EXPECT().QueryRow(gomock.Any(), "SELECT pg_try_advisory_lock($1)", dblock.ReportSchedulerLockID).
+				DoAndReturn(func(context.Context, string, ...interface{}) pgx.Row {
+					return lockResult(attempts.Load() > 1 || testCase.failSnapshotUpdate)
+				}).AnyTimes()
+			conn.EXPECT().Release().AnyTimes()
+			conn.EXPECT().Exec(gomock.Any(), "SELECT pg_advisory_unlock($1)", dblock.ReportSchedulerLockID).
+				Return(pgconn.NewCommandTag("SELECT 1"), nil).AnyTimes()
+			pending := &storage.ReportSnapshot{ReportId: "pending", Type: storage.ReportSnapshot_VULNERABILITY,
+				ReportStatus: &storage.ReportStatus{ReportRequestType: storage.ReportStatus_VIEW_BASED, RunState: storage.ReportStatus_WAITING}}
+			snapshots.EXPECT().SearchReportSnapshots(gomock.Any(), gomock.Any()).Return([]*storage.ReportSnapshot{pending}, nil)
+			if testCase.failSnapshotUpdate {
+				first := snapshots.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, snap *storage.ReportSnapshot) error {
+					assert.Equal(t, "pending", snap.GetReportId())
+					return errors.New("temporary update failure")
+				})
+				snapshots.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).After(first).DoAndReturn(func(_ context.Context, snap *storage.ReportSnapshot) error {
+					assert.Equal(t, "pending", snap.GetReportId())
+					return nil
+				})
+			} else {
+				snapshots.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).Return(nil)
+			}
+			configs.EXPECT().GetReportConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			processed := make(chan struct{})
+			generator.EXPECT().ProcessReportRequest(gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, *reportGen.ReportRequest) { close(processed) })
+			s := newSchedulerImpl(configs, snapshots, nil, nil, generator, nil, nil, runningCron())
+			t.Cleanup(s.Stop)
+			s.Start(db)
+			select {
+			case <-processed:
+			case <-time.After(7 * time.Second):
+				t.Fatal("scheduler did not retry and process the pending report")
+			}
+			if !testCase.failSnapshotUpdate {
+				assert.GreaterOrEqual(t, attempts.Load(), int32(2))
+			}
+		})
+	}
+}
+
+func TestSchedulerStopCancelsLockAcquisition(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := pgMocks.NewMockDB(ctrl)
+	acquiring := make(chan struct{})
+	db.EXPECT().Acquire(gomock.Any()).DoAndReturn(func(ctx context.Context) (*postgres.Conn, error) {
+		close(acquiring)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, nil, runningCron())
+	started := make(chan struct{})
+	go func() { s.Start(db); close(started) }()
+	<-acquiring
+	s.Stop()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel database lock acquisition")
+	}
+	require.False(t, s.isStarted.Load())
+}
+
+func TestSchedulerStopBeforeStart(t *testing.T) {
+	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, nil, runningCron())
+	s.Stop()
+	// A stopped scheduler must never touch the database, even on repeated starts.
+	s.Start(nil)
+	s.Start(nil)
+	assert.False(t, s.Ready())
+}
+
+func TestSchedulerShutdownWaitsForReportsBeforeUnlock(t *testing.T) {
+	t.Setenv("ROX_REPORT_EXECUTION_MAX_CONCURRENCY", "1")
+	ctrl := gomock.NewController(t)
+	db := pgMocks.NewMockDB(ctrl)
+	conn := pgMocks.NewMockPgxPoolConn(ctrl)
+	snapshots := snapshotMocks.NewMockDataStore(ctrl)
+	configs := configMocks.NewMockDataStore(ctrl)
+	generator := generatorMocks.NewMockReportGenerator(ctrl)
+	db.EXPECT().Acquire(gomock.Any()).Return(&postgres.Conn{PgxPoolConn: conn}, nil).Times(1)
+	conn.EXPECT().QueryRow(gomock.Any(), "SELECT pg_try_advisory_lock($1)", dblock.ReportSchedulerLockID).Return(lockResult(true))
+	conn.EXPECT().Release().Times(1)
+	var unlocked atomic.Bool
+	conn.EXPECT().Exec(gomock.Any(), "SELECT pg_advisory_unlock($1)", dblock.ReportSchedulerLockID).DoAndReturn(
+		func(context.Context, string, ...interface{}) (pgconn.CommandTag, error) {
+			unlocked.Store(true)
+			return pgconn.NewCommandTag("SELECT 1"), nil
+		})
+	initializing := make(chan struct{})
+	initialize := make(chan struct{})
+	snapshots.EXPECT().SearchReportSnapshots(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, interface{}) ([]*storage.ReportSnapshot, error) {
+			close(initializing)
+			<-initialize
+			return nil, nil
+		})
+	configs.EXPECT().GetReportConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	s := newSchedulerImpl(configs, snapshots, nil, nil, generator, nil, nil, runningCron())
+	s.Start(db)
+	<-initializing
+	assert.False(t, s.Ready(), "ownership alone is not readiness before recovery finishes")
+	// Start is idempotent even while initialization is running.
+	var starts sync.WaitGroup
+	for range 10 {
+		starts.Go(func() { s.Start(db) })
+	}
+	starts.Wait()
+	close(initialize)
+	require.Eventually(t, s.Ready, time.Second, time.Millisecond)
+	running := make(chan struct{})
+	cancelled := make(chan struct{})
+	finish := make(chan struct{})
+	generator.EXPECT().ProcessReportRequest(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ *reportGen.ReportRequest) {
+			close(running)
+			<-ctx.Done()
+			close(cancelled)
+			<-finish
+		})
+	q := s.queueByType[storage.ReportSnapshot_VULNERABILITY]
+	for _, id := range []string{"first", "second"} {
+		q.Enqueue(&reportGen.ReportRequest{ReportSnapshot: &storage.ReportSnapshot{ReportId: id, ReportConfigurationId: id}})
+	}
+	s.readyForReports.Signal()
+	<-running
+	stopped := make(chan struct{})
+	go func() { s.Stop(); close(stopped) }()
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("running report was not cancelled")
+	}
+	assert.False(t, s.Ready())
+	assert.False(t, unlocked.Load(), "ownership must remain until in-flight work exits")
+	close(finish)
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop blocked behind the report semaphore")
+	}
+	assert.True(t, unlocked.Load())
+	s.Stop()
+	s.Start(db)
+	assert.False(t, s.Ready())
+}
+
+func TestSchedulerStopDuringSuccessfulAcquisition(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := pgMocks.NewMockDB(ctrl)
+	conn := pgMocks.NewMockPgxPoolConn(ctrl)
+	db.EXPECT().Acquire(gomock.Any()).Return(&postgres.Conn{PgxPoolConn: conn}, nil)
+	acquiring := make(chan struct{})
+	conn.EXPECT().QueryRow(gomock.Any(), "SELECT pg_try_advisory_lock($1)", dblock.ReportSchedulerLockID).DoAndReturn(
+		func(ctx context.Context, _ string, _ ...interface{}) pgx.Row {
+			close(acquiring)
+			<-ctx.Done()
+			return lockResult(true)
+		})
+	conn.EXPECT().Exec(gomock.Any(), "SELECT pg_advisory_unlock($1)", dblock.ReportSchedulerLockID).Return(pgconn.NewCommandTag("SELECT 1"), nil)
+	conn.EXPECT().Release()
+	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, nil, runningCron())
+	s.Start(db)
+	<-acquiring
+	s.Stop()
+	assert.False(t, s.Ready())
+}
+
+func runningCron() *cron.Cron {
+	c := cron.New()
+	c.Start()
+	return c
+}
+
+func TestSchedulerRetriesFailedRecoveryBeforeReadiness(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	db := pgMocks.NewMockDB(ctrl)
+	conn := pgMocks.NewMockPgxPoolConn(ctrl)
+	snapshots := snapshotMocks.NewMockDataStore(ctrl)
+	configs := configMocks.NewMockDataStore(ctrl)
+	db.EXPECT().Acquire(gomock.Any()).Return(&postgres.Conn{PgxPoolConn: conn}, nil)
+	conn.EXPECT().QueryRow(gomock.Any(), "SELECT pg_try_advisory_lock($1)", dblock.ReportSchedulerLockID).Return(lockResult(true))
+	conn.EXPECT().Exec(gomock.Any(), "SELECT pg_advisory_unlock($1)", dblock.ReportSchedulerLockID).Return(pgconn.NewCommandTag("SELECT 1"), nil)
+	conn.EXPECT().Release()
+	var recovered atomic.Bool
+	first := snapshots.EXPECT().SearchReportSnapshots(gomock.Any(), gomock.Any()).Return(nil, errors.New("temporary read failure"))
+	snapshots.EXPECT().SearchReportSnapshots(gomock.Any(), gomock.Any()).After(first).DoAndReturn(
+		func(context.Context, interface{}) ([]*storage.ReportSnapshot, error) {
+			recovered.Store(true)
+			return nil, nil
+		})
+	configs.EXPECT().GetReportConfigurations(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	s := newSchedulerImpl(configs, snapshots, nil, nil, nil, nil, nil, runningCron())
+	t.Cleanup(s.Stop)
+	s.Start(db)
+	require.Eventually(t, s.Ready, 7*time.Second, time.Millisecond)
+	assert.True(t, recovered.Load(), "scheduler became ready without retrying failed recovery")
+}

--- a/central/reports/scheduler/v2/mocks/scheduler.go
+++ b/central/reports/scheduler/v2/mocks/scheduler.go
@@ -87,6 +87,20 @@ func (mr *MockSchedulerMockRecorder) GetScheduledConfigIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScheduledConfigIDs", reflect.TypeOf((*MockScheduler)(nil).GetScheduledConfigIDs))
 }
 
+// Ready mocks base method.
+func (m *MockScheduler) Ready() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ready")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Ready indicates an expected call of Ready.
+func (mr *MockSchedulerMockRecorder) Ready() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockScheduler)(nil).Ready))
+}
+
 // RemoveReportSchedule mocks base method.
 func (m *MockScheduler) RemoveReportSchedule(reportConfigID string) {
 	m.ctrl.T.Helper()

--- a/central/reports/scheduler/v2/reportgenerator/common_helpers.go
+++ b/central/reports/scheduler/v2/reportgenerator/common_helpers.go
@@ -52,11 +52,26 @@ func UpdateReportStatus(ctx context.Context, snapshotStore reportSnapshotDS.Data
 }
 
 // LogAndUpsertError logs the error and updates the report snapshot status to FAILURE.
-// requestCtx is used to check for user cancellation; statusCtx is used for the DB update
+// Reports interrupted by scheduler shutdown remain recoverable.
+// requestCtx is used to check for cancellation; statusCtx is used for the DB update
 // (should be an all-access context since requestCtx may be cancelled).
 func LogAndUpsertError(requestCtx, statusCtx context.Context, snapshotStore reportSnapshotDS.DataStore, reportErr error, req *ReportRequest) {
 	if req.ReportSnapshot == nil || req.ReportSnapshot.GetReportStatus() == nil {
 		utils.Should(errors.New("Request does not have non-nil report snapshot with a non-nil report status"))
+		return
+	}
+	if errors.Is(context.Cause(requestCtx), ErrSchedulerStopped) {
+		status := req.ReportSnapshot.GetReportStatus()
+		// GENERATED is final for downloads, but an email can still be awaiting
+		// delivery. Put an interrupted email back into the recovery query.
+		if status.GetRunState() == storage.ReportStatus_GENERATED && status.GetReportNotificationMethod() == storage.ReportStatus_EMAIL {
+			status.CompletedAt = nil
+			status.ErrorMsg = ""
+			if err := UpdateReportStatus(statusCtx, snapshotStore, req.ReportSnapshot, storage.ReportStatus_WAITING); err != nil {
+				log.Errorf("Error returning interrupted email report %s to WAITING: %v", req.ReportSnapshot.GetReportId(), err)
+			}
+		}
+		log.Infof("Report %s interrupted by scheduler shutdown", req.ReportSnapshot.GetReportId())
 		return
 	}
 	if errors.Is(context.Cause(requestCtx), ErrUserCancelled) {

--- a/central/reports/scheduler/v2/reportgenerator/common_helpers_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/common_helpers_test.go
@@ -1,0 +1,55 @@
+package reportgenerator
+
+import (
+	"context"
+	"testing"
+
+	snapshotMocks "github.com/stackrox/rox/central/reports/snapshot/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestReportCancellationStatus(t *testing.T) {
+	for name, cause := range map[string]error{"shutdown": ErrSchedulerStopped, "user cancellation": ErrUserCancelled} {
+		t.Run(name, func(t *testing.T) {
+			store := snapshotMocks.NewMockDataStore(gomock.NewController(t))
+			snap := &storage.ReportSnapshot{ReportId: "interrupted", ReportStatus: &storage.ReportStatus{RunState: storage.ReportStatus_PREPARING}}
+			if cause == ErrUserCancelled {
+				store.EXPECT().UpdateReportSnapshot(gomock.Any(), snap).Return(nil)
+			}
+			ctx, cancel := context.WithCancelCause(context.Background())
+			cancel(cause)
+			LogAndUpsertError(ctx, context.Background(), store, ctx.Err(), &ReportRequest{ReportSnapshot: snap})
+			if cause == ErrSchedulerStopped {
+				assert.Equal(t, storage.ReportStatus_PREPARING, snap.GetReportStatus().GetRunState())
+				assert.Nil(t, snap.GetReportStatus().GetCompletedAt())
+			} else {
+				assert.Equal(t, storage.ReportStatus_FAILURE, snap.GetReportStatus().GetRunState())
+				assert.Equal(t, ErrUserCancelled.Error(), snap.GetReportStatus().GetErrorMsg())
+			}
+		})
+	}
+}
+
+func TestShutdownAfterGeneration(t *testing.T) {
+	for name, method := range map[string]storage.ReportStatus_NotificationMethod{"email": storage.ReportStatus_EMAIL, "download": storage.ReportStatus_DOWNLOAD} {
+		t.Run(name, func(t *testing.T) {
+			store := snapshotMocks.NewMockDataStore(gomock.NewController(t))
+			snap := &storage.ReportSnapshot{ReportStatus: &storage.ReportStatus{RunState: storage.ReportStatus_GENERATED, ReportNotificationMethod: method, CompletedAt: protocompat.TimestampNow()}}
+			if method == storage.ReportStatus_EMAIL {
+				store.EXPECT().UpdateReportSnapshot(gomock.Any(), snap).Return(nil)
+			}
+			ctx, cancel := context.WithCancelCause(context.Background())
+			cancel(ErrSchedulerStopped)
+			LogAndUpsertError(ctx, context.Background(), store, ctx.Err(), &ReportRequest{ReportSnapshot: snap})
+			if method == storage.ReportStatus_EMAIL {
+				assert.Equal(t, storage.ReportStatus_WAITING, snap.GetReportStatus().GetRunState())
+				assert.Nil(t, snap.GetReportStatus().GetCompletedAt())
+			} else {
+				assert.Equal(t, storage.ReportStatus_GENERATED, snap.GetReportStatus().GetRunState())
+			}
+		})
+	}
+}

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -12,6 +12,9 @@ import (
 // ErrUserCancelled is the cause attached to a context when a user cancels a running report.
 var ErrUserCancelled = errors.New("report cancelled by user")
 
+// ErrSchedulerStopped marks interrupted work that the next scheduler must recover.
+var ErrSchedulerStopped = errors.New("report scheduler stopped")
+
 // ReportRequest contains information needed to generate and notify a report
 type ReportRequest struct {
 	ReportSnapshot *storage.ReportSnapshot

--- a/central/reports/scheduler/v2/scheduler.go
+++ b/central/reports/scheduler/v2/scheduler.go
@@ -31,10 +31,11 @@ type Scheduler interface {
 	// If the report is already being prepared or has completed execution, it cannot be cancelled.
 	CancelReportRequest(ctx context.Context, reportID string) (bool, error)
 
-	// Start acquires a PostgreSQL advisory lock and starts the scheduler.
-	// If the lock is already held by another process, the scheduler is not started.
-	// A scheduler instance can only be started once and cannot be re-started once stopped.
+	// Start asynchronously acquires ownership, retrying until successful or stopped.
+	// A scheduler instance can only be started once and cannot be restarted once stopped.
 	Start(db postgres.DB)
+	// Ready reports ownership and completed queue initialization.
+	Ready() bool
 	// Stop scheduler
 	Stop()
 }

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -31,11 +31,7 @@ import (
 	"gopkg.in/robfig/cron.v2"
 )
 
-var (
-	log = logging.LoggerForModule()
-
-	scheduledCtx = sac.WithAllAccess(context.Background())
-)
+var log = logging.LoggerForModule()
 
 // queueGeneratorBinding pairs a report job queue with the generator that processes
 // jobs from that queue. E.g., image CVE report job queue <-> image CVE report
@@ -68,12 +64,19 @@ type scheduler struct {
 	readyForReports concurrency.Signal
 
 	/* Concurrency and synchronization related fields */
-	// isStarted will make sure only one scheduling routine runs for an instance of scheduler
+	// isStarted permits submissions to enter the local queues after lock acquisition.
 	isStarted atomic.Bool
 	// isStopped will prevent scheduler from being re-started once it is stopped
 	isStopped atomic.Bool
 
-	stopper concurrency.Stopper
+	// lifecycleLock serializes Start and Stop, including Stop before Start.
+	lifecycleLock  sync.Mutex
+	cronStop       sync.Once
+	startRequested bool
+	ctx            context.Context
+	cancel         context.CancelCauseFunc
+	done           chan struct{}
+	ready          atomic.Bool
 
 	// Use to synchronize access to reportConfigToEntryIDs map
 	cronJobsLock sync.Mutex
@@ -82,9 +85,8 @@ type scheduler struct {
 	// NOTE: Lock only one mutex at a time. Do not lock another mutex when one is already held.
 	//      If you need to lock another mutex, you must free the locked one first.
 
-	cron                *cron.Cron
-	concurrencySema     *semaphore.Weighted
-	advisoryLockRelease func()
+	cron            *cron.Cron
+	concurrencySema *semaphore.Weighted
 }
 
 // New instantiates a new cron scheduler and supports adding and removing report requests
@@ -118,6 +120,7 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		queueByType[storage.ReportSnapshot_NODE_VULNERABILITY] = nodeQueue
 	}
 
+	ctx, cancel := context.WithCancelCause(context.Background())
 	s := &scheduler{
 		reportConfigToEntryIDs: make(map[string]cron.EntryID),
 		reportConfigDatastore:  reportConfigDatastore,
@@ -129,7 +132,9 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		nextQueueIdx:           0,
 		queueByType:            queueByType,
 		readyForReports:        concurrency.NewSignal(),
-		stopper:                concurrency.NewStopper(),
+		ctx:                    ctx,
+		cancel:                 cancel,
+		done:                   make(chan struct{}),
 		cron:                   cronScheduler,
 		concurrencySema:        semaphore.NewWeighted(int64(env.ReportExecutionMaxConcurrency.IntegerSetting())),
 	}
@@ -138,63 +143,89 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 
 /* Concurrency and scheduling functions */
 
-// Start acquires a PostgreSQL advisory lock and starts the scheduler.
-// If the lock is already held by another process, the scheduler is not started.
-// A scheduler instance can only be started once and cannot be re-started once stopped.
+// Start begins acquiring ownership in the background. Contention and transient
+// database errors are retried until acquisition succeeds or Stop is called.
 func (s *scheduler) Start(db postgres.DB) {
-	acquired, release, err := dblock.TryAcquireAdvisoryLock(scheduledCtx, db, dblock.ReportSchedulerLockID)
-	if err != nil {
-		log.Errorf("Report scheduler: failed to acquire advisory lock: %v", err)
+	s.lifecycleLock.Lock()
+	defer s.lifecycleLock.Unlock()
+	if s.startRequested || s.isStopped.Load() {
 		return
 	}
-	if !acquired {
-		log.Info("Report scheduler: advisory lock held by another process, not starting")
-		return
-	}
-	if s.isStopped.Load() {
-		release()
-		log.Error("Scheduler already stopped. It cannot be re-started once stopped.")
-		return
-	}
-	swapped := s.isStarted.CompareAndSwap(false, true)
-	if !swapped {
-		release()
-		log.Error("Scheduler already running")
-		return
-	}
-	s.advisoryLockRelease = release
-	s.queuePendingReports()
-	s.recoverMissedSchedules()
-	s.queueScheduledReports()
-	go s.runReports()
+	s.startRequested = true
+	go s.run(db)
 }
 
-// Stop scheduler
+// Ready reports whether this scheduler owns the lock and has initialized its queues.
+func (s *scheduler) Ready() bool {
+	return s.ready.Load() && !s.isStopped.Load()
+}
+
+func (s *scheduler) run(db postgres.DB) {
+	defer close(s.done)
+	defer s.isStarted.Store(false)
+	defer s.ready.Store(false)
+
+	for s.ctx.Err() == nil {
+		acquired, release, err := dblock.TryAcquireAdvisoryLock(s.ctx, db, dblock.ReportSchedulerLockID)
+		if acquired {
+			// Release only after execution and all in-flight reports have stopped.
+			defer release()
+			if s.ctx.Err() != nil {
+				return
+			}
+			s.isStarted.Store(true)
+			// Retry each initialization phase separately, so later query failures do
+			// not enqueue previously recovered reports a second time.
+			for _, initialize := range []func() error{s.queuePendingReports, s.recoverMissedSchedules, s.queueScheduledReports} {
+				if err := s.retryInitialization(initialize); err != nil {
+					return
+				}
+			}
+			if s.ctx.Err() != nil {
+				return
+			}
+			s.ready.Store(true)
+			log.Info("Report scheduler acquired ownership and is ready")
+			s.runReports()
+			return
+		}
+		if err != nil {
+			log.Errorf("Report scheduler: failed to acquire advisory lock, retrying: %v", err)
+		} else {
+			log.Info("Report scheduler: advisory lock held by another process, retrying")
+		}
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
+}
+
+// Stop cancels acquisition and execution, waits for reports to stop, and releases ownership.
+// It is safe to call concurrently or before Start, and a stopped scheduler cannot restart.
 func (s *scheduler) Stop() {
-	if !s.isStarted.Load() {
-		log.Error("Scheduler not started")
-		return
+	started := concurrency.WithLock1(&s.lifecycleLock, func() bool {
+		s.isStopped.Store(true)
+		s.cancel(reportGen.ErrSchedulerStopped)
+		return s.startRequested
+	})
+	if started {
+		<-s.done
 	}
-	swapped := s.isStopped.CompareAndSwap(false, true)
-	if !swapped {
-		log.Error("Scheduler already stopped")
-		return
-	}
-	s.stopper.Client().Stop()
-	err := s.stopper.Client().Stopped().Wait()
-	if err != nil {
-		log.Errorf("Error stopping vulnerability report scheduler : %v", err)
-	}
-	if s.advisoryLockRelease != nil {
-		s.advisoryLockRelease()
-	}
+	s.cronStop.Do(func() {
+		s.cronJobsLock.Lock()
+		defer s.cronJobsLock.Unlock()
+		s.cron.Stop()
+	})
 }
 
 func (s *scheduler) runReports() {
-	defer s.stopper.Flow().ReportStopped()
+	var running sync.WaitGroup
+	defer running.Wait()
 	for {
 		select {
-		case <-s.stopper.Flow().StopRequested():
+		case <-s.ctx.Done():
 			return
 		case <-s.readyForReports.Done():
 			req, q, gen := s.selectNextJobRoundRobin()
@@ -202,12 +233,17 @@ func (s *scheduler) runReports() {
 				s.readyForReports.Reset()
 				continue
 			}
-			if err := s.concurrencySema.Acquire(scheduledCtx, 1); err != nil {
-				log.Errorf("Error acquiring semaphore to run new report: %v", err)
-				continue
+			if err := s.concurrencySema.Acquire(s.ctx, 1); err != nil {
+				return
+			}
+			if s.ctx.Err() != nil {
+				s.concurrencySema.Release(1)
+				return
 			}
 			log.Infof("Executing report '%s' at %v", req.ReportSnapshot.GetName(), time.Now().Format(time.RFC822))
-			go s.runSingleReport(q, gen, req)
+			running.Go(func() {
+				s.runSingleReport(q, gen, req)
+			})
 		}
 	}
 }
@@ -231,7 +267,7 @@ func (s *scheduler) runSingleReport(q *reportqueue.ReportQueue, gen reportGen.Re
 	defer q.MarkReportDoneForConfig(req.ReportSnapshot.GetReportConfigurationId())
 
 	reportID := req.ReportSnapshot.GetReportId()
-	ctx, cancel := context.WithCancelCause(context.Background())
+	ctx, cancel := context.WithCancelCause(s.ctx)
 	q.AddCancelFunc(reportID, cancel)
 	defer cancel(nil)
 	defer q.RemoveCancelFunc(reportID)
@@ -243,6 +279,10 @@ func (s *scheduler) runSingleReport(q *reportqueue.ReportQueue, gen reportGen.Re
 func (s *scheduler) UpsertReportSchedule(reportConfig *storage.ReportConfiguration) error {
 	s.cronJobsLock.Lock()
 	defer s.cronJobsLock.Unlock()
+
+	if s.isStopped.Load() {
+		return nil
+	}
 
 	// Remove the old entry if this is an update
 	if oldEntryID, ok := s.reportConfigToEntryIDs[reportConfig.GetId()]; ok {
@@ -333,12 +373,14 @@ func (s *scheduler) SubmitReportRequest(ctx context.Context, request *reportGen.
 
 	request.ReportSnapshot.ReportStatus.RunState = storage.ReportStatus_WAITING
 	request.ReportSnapshot.ReportStatus.QueuedAt = protocompat.TimestampNow()
-	request.ReportSnapshot.ReportId, err = s.validateAndPersistSnapshot(ctx, request.ReportSnapshot, reSubmission)
+	reportID, err := s.validateAndPersistSnapshot(ctx, request.ReportSnapshot, reSubmission)
 	if err != nil {
 		return "", err
 	}
 
-	if s.isStarted.Load() {
+	request.ReportSnapshot.ReportId = reportID
+
+	if s.isStarted.Load() && !s.isStopped.Load() {
 		q.Enqueue(request)
 		s.readyForReports.Signal()
 	}
@@ -358,79 +400,89 @@ func (s *scheduler) reportClosure(reportConfig *storage.ReportConfiguration) fun
 		if err != nil {
 			log.Errorf("Error submitting scheduled report request for '%s': %s", reportConfig.GetName(), err)
 		}
-		_, err = s.SubmitReportRequest(scheduledCtx, reportReq, false)
+		_, err = s.SubmitReportRequest(sac.WithAllAccess(s.ctx), reportReq, false)
 		if err != nil {
 			log.Errorf("Error submitting scheduled report request for '%s': %s", reportConfig.GetName(), err)
 		}
 	}
 }
 
-func (s *scheduler) queuePendingReports() {
+// retryInitialization retries a single discovery query or record without repeating
+// successfully queued records. Cancellation also interrupts the retry delay.
+func (s *scheduler) retryInitialization(initialize func() error) error {
+	for s.ctx.Err() == nil {
+		if err := initialize(); err == nil {
+			return nil
+		} else {
+			log.Errorf("Report scheduler initialization failed, retrying: %v", err)
+		}
+		select {
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return s.ctx.Err()
+}
+
+func (s *scheduler) queuePendingReports() error {
 	pendingReportsQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String(), storage.ReportStatus_PREPARING.String()).
 		WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.ReportQueuedTime))).
 		ProtoQuery()
-	pendingReports, err := s.reportSnapshotStore.SearchReportSnapshots(scheduledCtx, pendingReportsQuery)
+	pendingReports, err := s.reportSnapshotStore.SearchReportSnapshots(sac.WithAllAccess(s.ctx), pendingReportsQuery)
 	if err != nil {
-		log.Errorf("Error finding pending reports: %s", err)
-		return
+		return errors.Wrap(err, "finding pending reports")
 	}
-
 	for _, snap := range pendingReports {
-		// View-based reports have no associated report configuration, resource scope, or collection.
-		if snap.GetReportStatus().GetReportRequestType() == storage.ReportStatus_VIEW_BASED {
-			repRequest := &reportGen.ReportRequest{
-				ReportSnapshot: snap,
-			}
-			_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
-			if err != nil {
-				log.Errorf("Error rescheduling pending view-based report job '%s': %s", snap.GetReportId(), err)
-			}
-			continue
-		}
-
-		_, found, err := s.reportConfigDatastore.GetReportConfiguration(scheduledCtx, snap.GetReportConfigurationId())
-		if err != nil {
-			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
-			continue
-		}
-		if !found {
-			log.Errorf("Report configuration with ID %s had pending reports but the configuration no longer exists",
-				snap.GetReportConfigurationId())
-			continue
-		}
-
-		if !common.HasValidResourceScope(snap.GetResourceScope()) {
-			log.Errorf("Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", snap.GetReportConfigurationId())
-			continue
-		}
-
-		repRequest := &reportGen.ReportRequest{
-			ReportSnapshot: snap,
-		}
-
-		if snap.GetCollection() != nil {
-			collection, found, err := s.collectionDatastore.Get(scheduledCtx, snap.GetCollection().GetId())
-			if err != nil {
-				log.Errorf("Error finding collection ID '%s': %s", snap.GetCollection().GetId(), err)
-				continue
-			}
-			if !found {
-				log.Errorf("Collection ID '%s' not found", snap.GetCollection().GetId())
-			}
-
-			repRequest.Collection = collection
-
-		}
-
-		_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
-		if err != nil {
-			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
+		if err := s.retryInitialization(func() error { return s.queuePendingReport(snap) }); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
-func (s *scheduler) queueScheduledReports() {
+func (s *scheduler) queuePendingReport(snap *storage.ReportSnapshot) error {
+	req := &reportGen.ReportRequest{ReportSnapshot: snap}
+	// View-based reports have no configuration or collection to reload.
+	if snap.GetReportStatus().GetReportRequestType() != storage.ReportStatus_VIEW_BASED {
+		_, found, err := s.reportConfigDatastore.GetReportConfiguration(sac.WithAllAccess(s.ctx), snap.GetReportConfigurationId())
+		if err != nil {
+			return errors.Wrapf(err, "loading report configuration %s", snap.GetReportConfigurationId())
+		}
+		if !found {
+			log.Errorf("Report configuration %s no longer exists; skipping pending report %s", snap.GetReportConfigurationId(), snap.GetReportId())
+			return nil
+		}
+		if !common.HasValidResourceScope(snap.GetResourceScope()) {
+			log.Errorf("Report configuration %s has an empty resource scope; skipping pending report %s", snap.GetReportConfigurationId(), snap.GetReportId())
+			return nil
+		}
+		if snap.GetCollection() != nil {
+			collection, found, err := s.collectionDatastore.Get(sac.WithAllAccess(s.ctx), snap.GetCollection().GetId())
+			if err != nil {
+				return errors.Wrapf(err, "loading collection %s", snap.GetCollection().GetId())
+			}
+			if !found {
+				log.Errorf("Collection %s no longer exists; skipping pending report %s", snap.GetCollection().GetId(), snap.GetReportId())
+				return nil
+			}
+			req.Collection = collection
+		}
+	}
+	// Invalid/disabled report types cannot be fixed by retrying a database operation.
+	if err := reportGen.ValidateReportRequest(req); err != nil {
+		log.Errorf("Skipping invalid pending report %s: %v", snap.GetReportId(), err)
+		return nil
+	}
+	if s.queueForSnapshot(snap) == nil {
+		return nil
+	}
+	_, err := s.SubmitReportRequest(sac.WithAllAccess(s.ctx), req, true)
+	return err
+}
+
+func (s *scheduler) queueScheduledReports() error {
 	reportTypes := []string{storage.ReportConfiguration_VULNERABILITY.String()}
 	if features.NodeVulnerabilityReports.Enabled() {
 		reportTypes = append(reportTypes, storage.ReportConfiguration_NODE_VULNERABILITY.String())
@@ -438,10 +490,9 @@ func (s *scheduler) queueScheduledReports() {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportType, reportTypes...).
 		ProtoQuery()
-	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
+	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(sac.WithAllAccess(s.ctx), query)
 	if err != nil {
-		log.Errorf("Error finding scheduled reports: %s", err)
-		return
+		return errors.Wrap(err, "finding scheduled reports")
 	}
 	for _, rc := range reportConfigs {
 		if !common.HasValidResourceScope(rc.GetResourceScope()) {
@@ -455,11 +506,12 @@ func (s *scheduler) queueScheduledReports() {
 			}
 		}
 	}
+	return nil
 }
 
-func (s *scheduler) recoverMissedSchedules() {
+func (s *scheduler) recoverMissedSchedules() error {
 	if !env.ReportMissedScheduleRecovery.BooleanSetting() {
-		return
+		return nil
 	}
 
 	reportTypes := []string{storage.ReportConfiguration_VULNERABILITY.String()}
@@ -469,10 +521,9 @@ func (s *scheduler) recoverMissedSchedules() {
 	query := search.NewQueryBuilder().
 		AddExactMatches(search.ReportType, reportTypes...).
 		ProtoQuery()
-	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(scheduledCtx, query)
+	reportConfigs, err := s.reportConfigDatastore.GetReportConfigurations(sac.WithAllAccess(s.ctx), query)
 	if err != nil {
-		log.Errorf("Error finding report configs for missed schedule recovery: %s", err)
-		return
+		return errors.Wrap(err, "finding report configs for missed schedule recovery")
 	}
 
 	for _, rc := range reportConfigs {
@@ -508,7 +559,7 @@ func (s *scheduler) recoverMissedSchedules() {
 				AddSortOption(search.NewSortOption(search.ReportQueuedTime).Reversed(true)).
 				Limit(1)).
 			ProtoQuery()
-		snapshots, err := s.reportSnapshotStore.SearchReportSnapshots(scheduledCtx, snapshotQuery)
+		snapshots, err := s.reportSnapshotStore.SearchReportSnapshots(sac.WithAllAccess(s.ctx), snapshotQuery)
 		if err != nil {
 			log.Errorf("Error querying snapshots for missed schedule recovery, config '%s': %v", rc.GetId(), err)
 			continue
@@ -548,12 +599,13 @@ func (s *scheduler) recoverMissedSchedules() {
 				log.Errorf("Error generating report request for missed schedule recovery, config '%s': %v", rc.GetId(), err)
 				continue
 			}
-			_, err = s.SubmitReportRequest(scheduledCtx, reportReq, false)
+			_, err = s.SubmitReportRequest(sac.WithAllAccess(s.ctx), reportReq, false)
 			if err != nil {
 				log.Errorf("Error submitting missed scheduled report for config '%s': %v", rc.GetId(), err)
 			}
 		}
 	}
+	return nil
 }
 
 // findPreviousFireTime finds the most recent time before `now` that the cron schedule would have fired.
@@ -630,7 +682,7 @@ func (s *scheduler) doesUserHaveViewBasedPendingReport(userID string, reportType
 		AddExactMatches(search.UserID, userID).
 		AddExactMatches(search.ReportType, reportType.String()).
 		ProtoQuery()
-	runningReports, err := s.reportSnapshotStore.Count(scheduledCtx, query)
+	runningReports, err := s.reportSnapshotStore.Count(sac.WithAllAccess(s.ctx), query)
 	if err != nil {
 		return false, err
 	}
@@ -644,7 +696,7 @@ func (s *scheduler) doesUserHavePendingReport(configID string, userID string, re
 		AddExactMatches(search.ReportRequestType, storage.ReportStatus_ON_DEMAND.String()).
 		AddExactMatches(search.ReportType, reportType.String()).
 		ProtoQuery()
-	runningReports, err := s.reportSnapshotStore.SearchReportSnapshots(scheduledCtx, query)
+	runningReports, err := s.reportSnapshotStore.SearchReportSnapshots(sac.WithAllAccess(s.ctx), query)
 	if err != nil {
 		return false, err
 	}

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -155,7 +155,7 @@ func TestQueueScheduledReportsSkipsEmptyResourceScope(t *testing.T) {
 	defer cronScheduler.Stop()
 
 	s := newSchedulerImpl(mockReportConfigDS, nil, nil, nil, nil, nil, nil, cronScheduler)
-	s.queueScheduledReports()
+	assert.NoError(t, s.queueScheduledReports())
 
 	// Only the two valid configs should have been scheduled
 	assert.Len(t, s.reportConfigToEntryIDs, 2)
@@ -293,7 +293,7 @@ func TestQueuePendingReports(t *testing.T) {
 
 	s := newSchedulerImpl(mockReportConfigDS, mockSnapshotStore, mockCollectionDS, nil, nil, nil, nil, cronScheduler)
 	s.isStarted.Store(true)
-	s.queuePendingReports()
+	assert.NoError(t, s.queuePendingReports())
 
 	assert.Equal(t, 2, s.queues[0].queue.Len())
 }

--- a/central/reports/scheduler/v2/singleton.go
+++ b/central/reports/scheduler/v2/singleton.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	reportConfigDS "github.com/stackrox/rox/central/reports/config/datastore"
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
@@ -8,6 +9,7 @@ import (
 	reportSnapshotDS "github.com/stackrox/rox/central/reports/snapshot/datastore"
 	"github.com/stackrox/rox/central/reports/validation"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
+	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -28,6 +30,16 @@ func initialize() {
 		nodeReportGen.Singleton(),
 		validation.Singleton(),
 	)
+	prometheus.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Name:      "report_scheduler_ready",
+		Help:      "Whether this process owns report scheduling and has initialized recovery (1 ready, 0 inactive or waiting).",
+	}, func() float64 {
+		if sched.Ready() {
+			return 1
+		}
+		return 0
+	}))
 }
 
 // Singleton will return a singleton instance of the v2 report scheduler

--- a/central/reports/service/v2/singleton.go
+++ b/central/reports/service/v2/singleton.go
@@ -21,7 +21,7 @@ var (
 func initialize() {
 	scheduler := schedulerV2.Singleton()
 	if !env.CentralWorkerEnabled.BooleanSetting() {
-		go scheduler.Start(globaldb.GetPostgres())
+		scheduler.Start(globaldb.GetPostgres())
 	} else {
 		log.Info("Report scheduling is managed by central-worker, skipping start in Central")
 	}

--- a/central/worker/main.go
+++ b/central/worker/main.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"math"
 	"net/http"
-	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -27,6 +27,7 @@ import (
 	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/premain"
 	"github.com/stackrox/rox/pkg/retry"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 const (
@@ -44,7 +45,7 @@ func main() {
 
 	log.Infof("Starting central-worker")
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	poolVal := workerPoolSize.IntegerSetting()
@@ -52,21 +53,41 @@ func main() {
 		log.Fatalf("ROX_WORKER_DB_POOL_MAX_CONNS must be between 1 and %d, got %d", math.MaxInt32, poolVal)
 	}
 	globaldb.InitializePostgresWithPoolSize(ctx, int32(poolVal))
+	defer globaldb.Close()
 	log.Infof("DB pool initialized with max_conns=%d", poolVal)
 
 	waitForMigrations(ctx)
 	ensureDBCurrent()
 
-	startHealthServer()
+	scheduler := vulnReportV2Scheduler.Singleton()
+	var listenerStarted atomic.Bool
+	startHealthServer(func() bool {
+		return ctx.Err() == nil && listenerStarted.Load() && scheduler.Ready()
+	})
 
 	go startMetricsServer()
 
 	pruning.Singleton().Start()
 	log.Infof("Pruning GC started")
 
-	scheduler := vulnReportV2Scheduler.Singleton()
 	scheduler.Start(globaldb.GetPostgres())
-	log.Infof("Vulnerability report scheduler started")
+	var stopListener func()
+	defer func() {
+		stopBackgroundTasks(scheduler.Stop, pruning.Singleton().Stop, func() {
+			if stopListener != nil {
+				stopListener()
+			}
+		})
+	}()
+
+	// Do not register cron jobs from notifications before this process owns reporting.
+	for !scheduler.Ready() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
 
 	collectionDatastore, _ := collectionDS.Singleton()
 	rl := newReportListener(
@@ -78,19 +99,15 @@ func main() {
 		notifierDS.Singleton(),
 		notifierProcessor.Singleton(),
 	)
-	rl.start(ctx)
+	stopListener = rl.start(ctx)
+	listenerStarted.Store(true)
 	log.Infof("Report LISTEN/NOTIFY listener started")
 
 	log.Infof("central-worker is ready")
 
-	waitForTerminationSignal()
+	<-ctx.Done()
 
 	log.Infof("central-worker shutting down")
-
-	pruning.Singleton().Stop()
-	scheduler.Stop()
-
-	globaldb.Close()
 }
 
 func waitForMigrations(ctx context.Context) {
@@ -128,14 +145,8 @@ func ensureDBCurrent() {
 	log.Infof("DB version verified")
 }
 
-func startHealthServer() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+func startHealthServer(ready func() bool) {
+	mux := healthHandler(ready)
 
 	srv := &http.Server{
 		Addr:    healthAddr,
@@ -167,9 +178,28 @@ func startMetricsServer() {
 	pkgMetrics.GatherThrottleMetricsForever(pkgMetrics.CentralWorkerSubsystem.String())
 }
 
-func waitForTerminationSignal() {
-	signalsC := make(chan os.Signal, 1)
-	signal.Notify(signalsC, syscall.SIGINT, syscall.SIGTERM)
-	sig := <-signalsC
-	log.Infof("Caught %s signal", sig)
+// Stop report scheduling independently of pruning so a long GC cycle does not
+// consume the scheduler's time to cancel reports and release its advisory lock.
+func stopBackgroundTasks(tasks ...func()) {
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Go(task)
+	}
+	wg.Wait()
+}
+
+func healthHandler(ready func() bool) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !ready() {
+			http.Error(w, "report scheduler is not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return mux
 }

--- a/central/worker/main_test.go
+++ b/central/worker/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealthHandler(t *testing.T) {
+	for name, ready := range map[string]bool{"waiting for ownership": false, "owns scheduler": true} {
+		t.Run(name, func(t *testing.T) {
+			handler := healthHandler(func() bool { return ready })
+			live := httptest.NewRecorder()
+			handler.ServeHTTP(live, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+			assert.Equal(t, http.StatusOK, live.Code)
+			probe := httptest.NewRecorder()
+			handler.ServeHTTP(probe, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+			expected := http.StatusServiceUnavailable
+			if ready {
+				expected = http.StatusOK
+			}
+			assert.Equal(t, expected, probe.Code)
+		})
+	}
+}
+
+func TestStopBackgroundTasks(t *testing.T) {
+	schedulerStopped := make(chan struct{})
+	pruningStopped := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		stopBackgroundTasks(
+			func() { <-schedulerStopped; close(pruningStopped) },
+			func() { close(schedulerStopped) },
+		)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("pruning blocked scheduler shutdown")
+	}
+	select {
+	case <-pruningStopped:
+	default:
+		t.Fatal("shutdown did not wait for pruning")
+	}
+}

--- a/central/worker/report_listener.go
+++ b/central/worker/report_listener.go
@@ -23,9 +23,8 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-var listenerCtx = sac.WithAllAccess(context.Background())
-
 type reportListener struct {
+	ctx                 context.Context
 	db                  postgres.DB
 	scheduler           schedulerV2.Scheduler
 	reportConfigStore   reportConfigDS.DataStore
@@ -47,6 +46,7 @@ func newReportListener(
 	notifierProcessor notifier.Processor,
 ) *reportListener {
 	return &reportListener{
+		ctx:                 sac.WithAllAccess(context.Background()),
 		db:                  db,
 		scheduler:           scheduler,
 		reportConfigStore:   reportConfigStore,
@@ -58,15 +58,19 @@ func newReportListener(
 	}
 }
 
-func (r *reportListener) start(ctx context.Context) {
+func (r *reportListener) start(ctx context.Context) func() {
+	ctx, cancel := context.WithCancel(ctx)
+	r.ctx = sac.WithAllAccess(ctx)
 	listener := pgNotify.NewListener(r.db, r.handleNotification,
 		pgNotify.NotifierChanged,
 		pgNotify.ReportConfigChanged,
 		pgNotify.ReportRequestSubmitted,
 		pgNotify.ReportRequestCancelled,
 	)
-	go listener.Listen(ctx)
-	go r.periodicResync(ctx)
+	var wg sync.WaitGroup
+	wg.Go(func() { listener.Listen(ctx) })
+	wg.Go(func() { r.periodicResync(ctx) })
+	return func() { cancel(); wg.Wait() }
 }
 
 func (r *reportListener) handleNotification(channel, payload string) {
@@ -83,13 +87,13 @@ func (r *reportListener) handleNotification(channel, payload string) {
 }
 
 func (r *reportListener) handleNotifierChanged(notifierID string) {
-	protoNotifier, exists, err := r.notifierStore.GetNotifier(listenerCtx, notifierID)
+	protoNotifier, exists, err := r.notifierStore.GetNotifier(r.ctx, notifierID)
 	if err != nil {
 		log.Errorf("Failed to load notifier %s: %v", notifierID, err)
 		return
 	}
 	if !exists {
-		r.notifierProcessor.RemoveNotifier(listenerCtx, notifierID)
+		r.notifierProcessor.RemoveNotifier(r.ctx, notifierID)
 		return
 	}
 	n, err := pkgNotifiers.CreateNotifier(protoNotifier)
@@ -97,11 +101,11 @@ func (r *reportListener) handleNotifierChanged(notifierID string) {
 		log.Errorf("Failed to create notifier %s: %v", notifierID, err)
 		return
 	}
-	r.notifierProcessor.UpdateNotifier(listenerCtx, n)
+	r.notifierProcessor.UpdateNotifier(r.ctx, n)
 }
 
 func (r *reportListener) handleConfigChanged(configID string) {
-	config, exists, err := r.reportConfigStore.GetReportConfiguration(listenerCtx, configID)
+	config, exists, err := r.reportConfigStore.GetReportConfiguration(r.ctx, configID)
 	if err != nil {
 		log.Errorf("Failed to load report config %s: %v", configID, err)
 		return
@@ -120,7 +124,7 @@ func (r *reportListener) handleConfigChanged(configID string) {
 }
 
 func (r *reportListener) handleRequestSubmitted(snapshotID string) {
-	snap, exists, err := r.snapshotStore.Get(listenerCtx, snapshotID)
+	snap, exists, err := r.snapshotStore.Get(r.ctx, snapshotID)
 	if err != nil || !exists {
 		log.Errorf("Failed to load report snapshot %s: exists=%v err=%v", snapshotID, exists, err)
 		return
@@ -131,7 +135,7 @@ func (r *reportListener) handleRequestSubmitted(snapshotID string) {
 
 	var collection *storage.ResourceCollection
 	if snap.GetCollection().GetId() != "" {
-		collection, exists, err = r.collectionDatastore.Get(listenerCtx, snap.GetCollection().GetId())
+		collection, exists, err = r.collectionDatastore.Get(r.ctx, snap.GetCollection().GetId())
 		if err != nil || !exists {
 			log.Errorf("Failed to load collection for snapshot %s: %v", snapshotID, err)
 			return
@@ -146,7 +150,7 @@ func (r *reportListener) handleRequestSubmitted(snapshotID string) {
 }
 
 func (r *reportListener) handleRequestCancelled(snapshotID string) {
-	if _, err := r.scheduler.CancelReportRequest(listenerCtx, snapshotID); err != nil {
+	if _, err := r.scheduler.CancelReportRequest(r.ctx, snapshotID); err != nil {
 		log.Errorf("Failed to cancel report request %s: %v", snapshotID, err)
 	}
 }
@@ -172,7 +176,7 @@ func (r *reportListener) resyncConfigs() {
 			storage.ReportConfiguration_NODE_VULNERABILITY.String(),
 		).
 		ProtoQuery()
-	configs, err := r.reportConfigStore.GetReportConfigurations(listenerCtx, query)
+	configs, err := r.reportConfigStore.GetReportConfigurations(r.ctx, query)
 	if err != nil {
 		log.Errorf("Error resyncing report configs: %v", err)
 		return
@@ -200,7 +204,7 @@ func (r *reportListener) resyncPendingRequests() {
 		AddExactMatches(search.ReportState, storage.ReportStatus_WAITING.String()).
 		WithPagination(search.NewPagination().AddSortOption(search.NewSortOption(search.ReportQueuedTime))).
 		ProtoQuery()
-	snapshots, err := r.snapshotStore.SearchReportSnapshots(listenerCtx, query)
+	snapshots, err := r.snapshotStore.SearchReportSnapshots(r.ctx, query)
 	if err != nil {
 		log.Errorf("Error resyncing pending report requests: %v", err)
 		return
@@ -210,7 +214,7 @@ func (r *reportListener) resyncPendingRequests() {
 		var collection *storage.ResourceCollection
 		if collID := snap.GetCollection().GetId(); collID != "" {
 			var exists bool
-			collection, exists, err = r.collectionDatastore.Get(listenerCtx, collID)
+			collection, exists, err = r.collectionDatastore.Get(r.ctx, collID)
 			if err != nil || !exists {
 				log.Errorf("Error loading collection for pending snapshot %s: %v", snap.GetReportId(), err)
 				continue
@@ -232,7 +236,7 @@ func (r *reportListener) submitIfNew(reportID string, req *reportGen.ReportReque
 	if r.knownReportIDs.Contains(reportID) {
 		return
 	}
-	if _, err := r.scheduler.SubmitReportRequest(listenerCtx, req, true); err != nil {
+	if _, err := r.scheduler.SubmitReportRequest(r.ctx, req, true); err != nil {
 		log.Errorf("Failed to submit report request %s: %v", reportID, err)
 		return
 	}

--- a/image/templates/helm/stackrox-central/templates/01-central-10-db-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-10-db-networkpolicy.yaml
@@ -19,11 +19,10 @@ spec:
     - podSelector:
         matchLabels:
           app: central
-    {{- if ._rox.centralWorker.enabled }}
+    # Keep access during disable/upgrade so terminating workers can release DB locks.
     - podSelector:
         matchLabels:
           app: central-worker
-    {{- end }}
     ports:
     - port: 5432
       protocol: TCP

--- a/image/templates/helm/stackrox-central/templates/03-central-worker-01-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/03-central-worker-01-deployment.yaml.htpl
@@ -106,7 +106,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "srox.injectedCABundleVolumeMount" . | nindent 8 }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 120
       volumes:
       - name: central-certs-volume
         secret:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central-worker.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central-worker.test.yaml
@@ -1,0 +1,18 @@
+values:
+  imagePullSecrets:
+    allowNone: true
+tests:
+- name: "disabled worker retains database access while terminating"
+  set:
+    centralWorker.enabled: false
+  expect: |
+    .deployments["central-worker"] | assertThat(. == null)
+    .networkpolicys["central-db"].spec.ingress[0] | assertThat(.from == [{"podSelector":{"matchLabels":{"app":"central"}}},{"podSelector":{"matchLabels":{"app":"central-worker"}}}])
+    .networkpolicys["central-db"].spec.ingress[0].ports | assertThat(. == [{"port":5432,"protocol":"TCP"}])
+
+- name: "enabled worker can release database locks during graceful shutdown"
+  set:
+    centralWorker.enabled: true
+  expect: |
+    .deployments["central-worker"].spec.template.spec.terminationGracePeriodSeconds | assertThat(. >= 120)
+    .networkpolicys["central-db"].spec.ingress[0] | assertThat(.from == [{"podSelector":{"matchLabels":{"app":"central"}}},{"podSelector":{"matchLabels":{"app":"central-worker"}}}])


### PR DESCRIPTION
## Description

Disabling Central Worker could strand reports: the outgoing Worker lost database access during shutdown, and the replacement scheduler gave up after one lock attempt.

Retry ownership and pending-report recovery, preserve interrupted work, and cancel/join background tasks before releasing locks. Keep Worker DB ingress during removal and allow 120 seconds for shutdown. Worker readiness now reflects scheduler ownership; Central exposes `rox_report_scheduler_ready` to support rolling updates.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Uncached race tests for scheduler lifecycle, report cancellation/recovery, and Worker readiness; related report service, queue, node-report, and Operator translation tests.
- Full Central Helm chart suite, including enabled/disabled DB ingress and shutdown grace regressions.
- Live Helm install and disable/re-enable upgrades; targeted Operator reconciliation using patched test CSV images. All eight report ZIPs downloaded; PVC identities, volumes, and credential hashes stayed intact.
- A 90-second injected lock held Worker readiness at HTTP 503 while liveness stayed 200; the queued report completed automatically after release.
- Changed-code lint, custom vet, and normal repository-wide Go lint passed. Full local `make style` is incomplete: QA requires an unavailable Java runtime; the remaining broad release/UI scans were stopped. CI is running.
