### PR TITLE
ROX-36951: Node config reports all jobs tab

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeReportJobs.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useMemo } from 'react';
+import {
+    Pagination,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+    useInterval,
+} from '@patternfly/react-core';
+
+import MyJobsFilter from 'Components/ReportJob/MyJobsFilter';
+import ReportJobStatusFilter, {
+    isReportJobStatus,
+} from 'Components/ReportJob/ReportJobStatusFilter';
+import type { ReportJobStatus } from 'Components/ReportJob/types';
+import useRestQuery from 'hooks/useRestQuery';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
+import useURLStringUnion from 'hooks/useURLStringUnion';
+import { fetchMyNodeReportHistory, fetchNodeReportHistory } from 'services/NodeReportsService';
+import { toggleItemInArray } from 'utils/arrayUtils';
+import { ensureBoolean, ensureStringArray } from 'utils/ensure';
+import { getTableUIState } from 'utils/getTableUIState';
+
+import NodeReportJobsTable from './NodeReportJobsTable';
+import { getRequestQueryString } from '../../../../VulnerablityReporting/api/apiUtils';
+
+export type NodeReportJobsProps = {
+    reportId: string;
+};
+
+const sortOptions = {
+    sortFields: ['Report Completion Time'],
+    defaultSortOption: { field: 'Report Completion Time', direction: 'desc' } as const,
+};
+
+const reportStateByJobStatus: Partial<Record<ReportJobStatus, string>> = {
+    WAITING: 'WAITING',
+    PREPARING: 'PREPARING',
+    ERROR: 'FAILURE',
+    DOWNLOAD_GENERATED: 'GENERATED',
+    EMAIL_DELIVERED: 'DELIVERED',
+};
+
+function NodeReportJobs({ reportId }: NodeReportJobsProps) {
+    const { page, perPage, setPage, setPerPage } = useURLPagination(10);
+    const { sortOption, getSortParams } = useURLSort(sortOptions);
+    const { searchFilter, setSearchFilter } = useURLSearch();
+    const [isViewingOnlyMyJobs, setIsViewingOnlyMyJobs] = useURLStringUnion('viewOnlyMyJobs', [
+        'false',
+        'true',
+    ]);
+
+    const reportJobStatusFilters = useMemo(() => {
+        return ensureStringArray(searchFilter['Report Job Status']).filter(isReportJobStatus);
+    }, [searchFilter]);
+
+    const fetchNodeReportsHistoryCallback = useCallback(() => {
+        const fetchHistory =
+            isViewingOnlyMyJobs === 'true' ? fetchMyNodeReportHistory : fetchNodeReportHistory;
+
+        const query = getRequestQueryString({
+            'Report state': reportJobStatusFilters.flatMap(
+                (status) => reportStateByJobStatus[status] ?? []
+            ),
+        });
+
+        return fetchHistory({
+            id: reportId,
+            query,
+            page,
+            perPage,
+            sortOption,
+        });
+    }, [reportId, reportJobStatusFilters, page, perPage, sortOption, isViewingOnlyMyJobs]);
+
+    const { data, isLoading, error, refetch } = useRestQuery(fetchNodeReportsHistoryCallback, {
+        clearErrorBeforeRequest: false,
+    });
+
+    const tableState = getTableUIState({
+        isLoading,
+        data,
+        error,
+        searchFilter,
+        isPolling: true,
+    });
+
+    const onReportJobStatusFilterChange = (_checked: boolean, selectedStatus: ReportJobStatus) => {
+        const newFilters = toggleItemInArray(reportJobStatusFilters, selectedStatus);
+        setSearchFilter({
+            ...searchFilter,
+            'Report Job Status': newFilters,
+        });
+        setPage(1);
+    };
+
+    const onMyJobsFilterChange = (checked: boolean) => {
+        setIsViewingOnlyMyJobs(String(checked));
+        setPage(1);
+    };
+
+    useInterval(refetch, 10000);
+
+    return (
+        <>
+            <Toolbar>
+                <ToolbarContent>
+                    <ToolbarItem alignItems="center">
+                        <ReportJobStatusFilter
+                            availableStatuses={[
+                                'WAITING',
+                                'PREPARING',
+                                'DOWNLOAD_GENERATED',
+                                'EMAIL_DELIVERED',
+                                'ERROR',
+                            ]}
+                            selectedStatuses={reportJobStatusFilters}
+                            onChange={onReportJobStatusFilterChange}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem alignSelf="center">
+                        <MyJobsFilter
+                            isViewingOnlyMyJobs={ensureBoolean(isViewingOnlyMyJobs)}
+                            onMyJobsFilterChange={onMyJobsFilterChange}
+                        />
+                    </ToolbarItem>
+                    <ToolbarItem variant="pagination" align={{ default: 'alignEnd' }}>
+                        <Pagination
+                            toggleTemplate={({ firstIndex, lastIndex }) => (
+                                <span>
+                                    <b>
+                                        {firstIndex} - {lastIndex}
+                                    </b>{' '}
+                                    of <b>many</b>
+                                </span>
+                            )}
+                            page={page}
+                            perPage={perPage}
+                            onSetPage={(_, newPage) => setPage(newPage)}
+                            onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
+                            isCompact
+                        />
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+            <NodeReportJobsTable
+                tableState={tableState}
+                getSortParams={getSortParams}
+                onClearFilters={() => {
+                    setSearchFilter({});
+                    setPage(1);
+                }}
+            />
+        </>
+    );
+}
+
+export default NodeReportJobs;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeReportJobsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeReportJobsTable.tsx
@@ -1,0 +1,140 @@
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+import ReportJobStatus from 'Components/ReportJob/ReportJobStatus';
+import { onDownloadReport } from 'Components/ReportJob/utils';
+import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import useAuthStatus from 'hooks/useAuthStatus';
+import useSet from 'hooks/useSet';
+import type { GetSortParams } from 'hooks/useURLSort';
+import { nodeReportDownloadURL } from 'services/NodeReportsService';
+import type {
+    ConfiguredReportSnapshot,
+    NodeVulnerabilityReportConfiguration,
+} from 'services/ReportsService.types';
+import { getDateTime } from 'utils/dateUtils';
+import type { TableUIState } from 'utils/getTableUIState';
+
+import NodeVulnerabilityReportView from './NodeVulnerabilityReportView';
+import {
+    attributesSeparateFromConfigForNodeVulnerabilityReport,
+    searchFilterConfigForNodeVulnerabilityReport,
+} from '../../../../searchFilterConfig';
+import JobDetails from '../../../../VulnerablityReporting/ViewVulnReport/JobDetails';
+
+export type NodeReportJobsTableProps = {
+    tableState: TableUIState<ConfiguredReportSnapshot>;
+    getSortParams: GetSortParams;
+    onClearFilters: () => void;
+};
+
+function NodeReportJobsTable({
+    tableState,
+    getSortParams,
+    onClearFilters,
+}: NodeReportJobsTableProps) {
+    const { currentUser } = useAuthStatus();
+    const expandedRowSet = useSet<string>();
+
+    return (
+        <Table aria-label="Node report jobs table">
+            <Thead>
+                <Tr>
+                    <Th screenReaderText="Row expansion" />
+                    <Th>Job status</Th>
+                    <Th sort={getSortParams('Report Completion Time')}>Completed</Th>
+                    <Th>Requester</Th>
+                </Tr>
+            </Thead>
+            <TbodyUnified
+                tableState={tableState}
+                colSpan={4}
+                emptyProps={{
+                    title: 'No report jobs found',
+                    message:
+                        'Send or generate a report from the Actions menu to create a report job.',
+                }}
+                filteredEmptyProps={{ onClearFilters }}
+                renderer={({ data }) =>
+                    data.map((snapshot, rowIndex) => {
+                        const { user, reportStatus, isDownloadAvailable, reportJobId, name } =
+                            snapshot;
+                        const areDownloadActionsDisabled = currentUser.userId !== user.id;
+                        const isExpanded = expandedRowSet.has(reportJobId);
+
+                        return (
+                            <Tbody key={reportJobId} isExpanded={isExpanded}>
+                                <Tr>
+                                    <Td
+                                        expand={{
+                                            rowIndex,
+                                            isExpanded,
+                                            onToggle: () => expandedRowSet.toggle(reportJobId),
+                                        }}
+                                    />
+                                    <Td dataLabel="Job status">
+                                        <ReportJobStatus
+                                            reportStatus={reportStatus}
+                                            isDownloadAvailable={isDownloadAvailable}
+                                            areDownloadActionsDisabled={areDownloadActionsDisabled}
+                                            onDownload={() =>
+                                                onDownloadReport({
+                                                    reportJobId,
+                                                    name,
+                                                    completedAt: reportStatus.completedAt,
+                                                    baseDownloadURL: nodeReportDownloadURL,
+                                                })
+                                            }
+                                        />
+                                    </Td>
+                                    <Td dataLabel="Completed">
+                                        {reportStatus.completedAt
+                                            ? getDateTime(reportStatus.completedAt)
+                                            : '-'}
+                                    </Td>
+                                    <Td dataLabel="Requester">{user.name}</Td>
+                                </Tr>
+                                <Tr isExpanded={isExpanded}>
+                                    <Td colSpan={4}>
+                                        <ExpandableRowContent>
+                                            <Flex
+                                                direction={{ default: 'column' }}
+                                                spaceItems={{ default: 'spaceItemsLg' }}
+                                            >
+                                                <FlexItem>
+                                                    <JobDetails
+                                                        reportStatus={reportStatus}
+                                                        isDownloadAvailable={isDownloadAvailable}
+                                                    />
+                                                </FlexItem>
+                                                <FlexItem>
+                                                    <NodeVulnerabilityReportView
+                                                        attributesSeparateFromConfig={
+                                                            attributesSeparateFromConfigForNodeVulnerabilityReport
+                                                        }
+                                                        headingLevel="h2"
+                                                        horizontalTermWidthModifier={{
+                                                            default: '24ch',
+                                                        }}
+                                                        searchFilterConfig={
+                                                            searchFilterConfigForNodeVulnerabilityReport
+                                                        }
+                                                        values={
+                                                            snapshot as unknown as NodeVulnerabilityReportConfiguration
+                                                        }
+                                                    />
+                                                </FlexItem>
+                                            </Flex>
+                                        </ExpandableRowContent>
+                                    </Td>
+                                </Tr>
+                            </Tbody>
+                        );
+                    })
+                }
+            />
+        </Table>
+    );
+}
+
+export default NodeReportJobsTable;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityReportViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/Reports/NodeVulnerabilityReports/Configurations/View/NodeVulnerabilityReportViewPage.tsx
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
 import { generatePath, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import {
+    Alert,
+    AlertActionCloseButton,
+    AlertGroup,
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
@@ -10,6 +13,9 @@ import {
     FlexItem,
     PageSection,
     Spinner,
+    Tab,
+    TabTitleText,
+    Tabs,
     Title,
 } from '@patternfly/react-core';
 
@@ -17,8 +23,13 @@ import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import PageTitle from 'Components/PageTitle';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
+import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
+import { jobContextTabs } from 'Components/ReportJob/types';
+import useToasts from 'hooks/patternfly/useToasts';
+import type { Toast } from 'hooks/patternfly/useToasts';
 import usePermissions from 'hooks/usePermissions';
 import useRestQuery from 'hooks/useRestQuery';
+import useURLStringUnion from 'hooks/useURLStringUnion';
 import {
     vulnerabilityNodeConfigurationsReportsDetailsPath,
     vulnerabilityNodeConfigurationsReportsPath,
@@ -26,21 +37,30 @@ import {
 } from 'routePaths';
 import {
     deleteNodeReportConfiguration,
+    fetchMyNodeReportHistory,
     fetchNodeReportConfiguration,
+    runNodeReport,
 } from 'services/NodeReportsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import DeleteReportsModal from '../../../components/DeleteReportsModal';
+import NodeReportJobs from './NodeReportJobs';
 import NodeVulnerabilityReportView from './NodeVulnerabilityReportView';
 import {
     attributesSeparateFromConfigForNodeVulnerabilityReport,
     searchFilterConfigForNodeVulnerabilityReport,
 } from '../../../../searchFilterConfig';
+import useRunReport from '../../../../VulnerablityReporting/api/useRunReport';
+import { useWatchLastSnapshotForReports } from '../../../../VulnerablityReporting/api/useWatchLastSnapshotForReports';
 import useDeleteModal from '../../../../VulnerablityReporting/hooks/useDeleteModal';
+
+const configDetailsTabId = 'NodeVulnReportsConfigDetails';
+const allReportJobsTabId = 'NodeVulnReportsConfigReportJobs';
 
 function NodeVulnerabilityReportViewPage() {
     const navigate = useNavigate();
     const { reportId } = useParams() as { reportId: string };
+    const [selectedTab, setSelectedTab] = useURLStringUnion('reportJobsTab', jobContextTabs);
 
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
     const hasDeleteAccessForReport = hasReadWriteAccess('WorkflowAdministration');
@@ -56,6 +76,28 @@ function NodeVulnerabilityReportViewPage() {
         isLoading,
         error: fetchError,
     } = useRestQuery(fetchReportConfigurationCallback);
+
+    const { reportSnapshots } = useWatchLastSnapshotForReports(
+        reportConfiguration ?? null,
+        fetchMyNodeReportHistory
+    );
+    const reportSnapshot = reportSnapshots[reportId];
+
+    const { toasts, addToast, removeToast } = useToasts();
+
+    const { isRunning, runError, runReport } = useRunReport({
+        runReportRequest: runNodeReport,
+        onCompleted: ({ reportNotificationMethod }) => {
+            if (reportNotificationMethod === 'EMAIL') {
+                addToast('The report has been sent to the configured email notifier', 'success');
+            } else if (reportNotificationMethod === 'DOWNLOAD') {
+                addToast(
+                    'The report generation has started and will be available for download once complete',
+                    'success'
+                );
+            }
+        },
+    });
 
     const {
         openDeleteModal,
@@ -76,8 +118,34 @@ function NodeVulnerabilityReportViewPage() {
         reportId,
     });
 
+    const isReportStatusPending =
+        reportSnapshot?.reportStatus.runState === 'PREPARING' ||
+        reportSnapshot?.reportStatus.runState === 'WAITING';
+
     return (
         <>
+            <AlertGroup isToast isLiveRegion>
+                {toasts.map(({ key, variant, title, children }: Toast) => (
+                    <Alert
+                        key={key}
+                        variant={variant}
+                        title={title}
+                        component="p"
+                        timeout
+                        onTimeout={() => removeToast(key)}
+                        actionClose={
+                            <AlertActionCloseButton
+                                title={title}
+                                variantLabel={variant}
+                                onClose={() => removeToast(key)}
+                            />
+                        }
+                    >
+                        {children}
+                    </Alert>
+                ))}
+            </AlertGroup>
+            {runError && <Alert variant="danger" isInline title={runError} component="p" />}
             <PageTitle title="View node vulnerability report" />
             {isLoading ? (
                 <Bullseye>
@@ -119,8 +187,35 @@ function NodeVulnerabilityReportViewPage() {
                                                 onClick={() =>
                                                     navigate(`${reportPageURL}?action=edit`)
                                                 }
+                                                isDisabled={isReportStatusPending || isRunning}
                                             >
                                                 Edit report
+                                            </DropdownItem>
+                                        )}
+                                        {hasWriteAccessForReport && <Divider component="li" />}
+                                        {hasWriteAccessForReport && (
+                                            <DropdownItem
+                                                onClick={() => runReport(reportId, 'EMAIL')}
+                                                isDisabled={
+                                                    isReportStatusPending ||
+                                                    isRunning ||
+                                                    reportConfiguration.notifiers.length === 0
+                                                }
+                                                description={
+                                                    reportConfiguration.notifiers.length === 0
+                                                        ? 'No delivery destinations set'
+                                                        : ''
+                                                }
+                                            >
+                                                Send report
+                                            </DropdownItem>
+                                        )}
+                                        {hasWriteAccessForReport && (
+                                            <DropdownItem
+                                                onClick={() => runReport(reportId, 'DOWNLOAD')}
+                                                isDisabled={isReportStatusPending || isRunning}
+                                            >
+                                                Generate download
                                             </DropdownItem>
                                         )}
                                         {hasWriteAccessForReport && (
@@ -152,17 +247,46 @@ function NodeVulnerabilityReportViewPage() {
                             )}
                         </Flex>
                     </PageSection>
-                    <PageSection isFilled hasOverflowScroll>
-                        <NodeVulnerabilityReportView
-                            attributesSeparateFromConfig={
-                                attributesSeparateFromConfigForNodeVulnerabilityReport
-                            }
-                            headingLevel="h2"
-                            horizontalTermWidthModifier={{ default: '24ch' }}
-                            values={reportConfiguration}
-                            searchFilterConfig={searchFilterConfigForNodeVulnerabilityReport}
-                        />
+                    <PageSection type="tabs">
+                        <Tabs
+                            activeKey={selectedTab}
+                            onSelect={(_e, tab) => {
+                                setSelectedTab(tab);
+                            }}
+                            aria-label="Node report details tabs"
+                            usePageInsets
+                        >
+                            <Tab
+                                tabContentId={configDetailsTabId}
+                                eventKey="CONFIGURATION_DETAILS"
+                                title={<TabTitleText>Configuration details</TabTitleText>}
+                            />
+                            <Tab
+                                tabContentId={allReportJobsTabId}
+                                eventKey="ALL_REPORT_JOBS"
+                                title={<TabTitleText>All report jobs</TabTitleText>}
+                                actions={<ReportJobsHelpAction reportType="Vulnerability" />}
+                            />
+                        </Tabs>
                     </PageSection>
+                    {selectedTab === 'CONFIGURATION_DETAILS' && (
+                        <PageSection isFilled hasOverflowScroll id={configDetailsTabId}>
+                            <NodeVulnerabilityReportView
+                                attributesSeparateFromConfig={
+                                    attributesSeparateFromConfigForNodeVulnerabilityReport
+                                }
+                                headingLevel="h2"
+                                horizontalTermWidthModifier={{ default: '24ch' }}
+                                values={reportConfiguration}
+                                searchFilterConfig={searchFilterConfigForNodeVulnerabilityReport}
+                            />
+                        </PageSection>
+                    )}
+                    {selectedTab === 'ALL_REPORT_JOBS' && (
+                        <PageSection id={allReportJobsTabId}>
+                            <NodeReportJobs reportId={reportId} />
+                        </PageSection>
+                    )}
                     <DeleteReportsModal
                         isOpen={isDeleteModalOpen}
                         onClose={closeDeleteModal}


### PR DESCRIPTION
## Description

Adds tabbed navigation to the node vulnerability report configuration detail page (`NodeVulnerabilityReportViewPage`)
- Configuration details tab: the existing config view.
- All report jobs tab: a new table of report job runs for the config.

Also adds "Send report" (EMAIL) and "Generate download" (DOWNLOAD) actions to the page's Actions dropdown

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="2199" height="1107" alt="Screenshot 2026-09-10 at 4 04 20 PM" src="https://github.com/user-attachments/assets/361417dd-c4dc-4fb9-a692-fd2f49dec4ef" />


<img width="2196" height="1191" alt="Screenshot 2026-09-10 at 4 04 28 PM" src="https://github.com/user-attachments/assets/3c84622b-4fab-47ce-b729-0f50152502d6" />

