### PR TITLE
fix(qa): loosen quay-auto image metadata dataSource regex

### DIFF
--- a/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageScanningTest.groovy
@@ -667,7 +667,7 @@ class ImageScanningTest extends BaseSpecification {
                 { -> AzureRegistryIntegration.createDefaultIntegration() }
         "acr-config-only"     | "acr"       | true               | /^acr$/                    |
                 { -> AzureRegistryIntegration.createDefaultIntegration() }
-        "quay-auto"           | "quay"      | false              | source(".*.quay.io")       | null
+        "quay-auto"           | "quay"      | false              | source(".*quay\\.io.*")    | null
         // ROX-29720 - disable gcr.io until tests are fixed for metadata failures after migration to artifacts registry
         //"gcr-auto"            | "gcr"       | false              | source(".*.gcr.io")        | null
     }


### PR DESCRIPTION
## Description

Loosens the regex used when matching datasource to image integration name by ImageScanningTest.

In scenarios where multiple valid autogenerated integrations exist, the one chosen is non-deterministic.

Example failure: https://github.com/stackrox/stackrox/actions/runs/34539909331/job/103082379017

### The regex change

**Old name** (path stripped, no suffix):
```
Autogenerated https://quay.io for cluster remote
```

**New name** (path `/rhacs-eng` retained + `from …` suffix):
```
Autogenerated https://quay.io/rhacs-eng for cluster remote from openshift-config/pull-secret
```

| pattern | old name | new name |
|---|:---:|:---:|
| **old** `Autogenerated .*.quay.io for cluster remote` | ✅ | ❌ |
| **new** `Autogenerated .*quay\.io.* for cluster remote` | ✅ | ✅ |


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI