### PR TITLE
ROX-36941: wait for namespace deletion in AdmissionControllerTest

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2678,8 +2678,11 @@ class Kubernetes {
         withRetry(2, 3) {
             client.namespaces().withName(ns).delete()
         }
-        if (waitForDeletion) {
-            waitForNamespaceDeletion(ns)
+        if (waitForDeletion && !waitForNamespaceDeletion(ns)) {
+            // Fail loudly: a namespace stuck Terminating leaks into later tests
+            // (e.g. NamespaceTest's ACS/orchestrator comparison) instead of being
+            // silently ignored.
+            throw new OrchestratorManagerException("Timed out waiting for namespace ${ns} to be deleted")
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -316,7 +316,9 @@ class AdmissionControllerTest extends BaseSpecification {
         if (created) {
             deleteDeploymentWithCaution(deployment)
         }
-        orchestrator.deleteNamespace(testNs, false)
+        // Wait for full namespace deletion; a namespace left in Terminating state
+        // leaks into NamespaceTest and breaks its ACS/orchestrator count check (ROX-36941).
+        orchestrator.deleteNamespace(testNs)
         if (policyId) {
             PolicyService.deletePolicy(policyId)
         }
@@ -413,7 +415,9 @@ class AdmissionControllerTest extends BaseSpecification {
         if (created2) {
             deleteDeploymentWithCaution(deployment2)
         }
-        orchestrator.deleteNamespace(testNs, false)
+        // Wait for full namespace deletion; a namespace left in Terminating state
+        // leaks into NamespaceTest and breaks its ACS/orchestrator count check (ROX-36941).
+        orchestrator.deleteNamespace(testNs)
         if (policyId) {
             PolicyService.deletePolicy(policyId)
         }


### PR DESCRIPTION
## Description

`NamespaceTest` intermittently failed its exact ACS↔orchestrator namespace set
comparison on a leftover `qa-label-scope-namespace-mismatch` namespace created by
`AdmissionControllerTest`. Two compounding causes, fixed here:

1. **`AdmissionControllerTest` cleanup** used `deleteNamespace(testNs, false)`
   (fire-and-forget). K8s deletion is async, so the namespace lingered in
   `Terminating` and `getNamespaces()` still returned it. Now waits for full
   deletion (the default `deleteNamespace` behavior).

2. **`deleteNamespace` swallowed timeouts**: `waitForNamespaceDeletion` returns
   `false` after ~60s, but the result was ignored, so cleanup continued with the
   namespace still terminating. Now throws `OrchestratorManagerException` when
   deletion is not confirmed, mirroring the existing pod-deletion timeout
   handling — surfacing the leak at its source.

Considered alternative: making `NamespaceTest` tolerant of `qa-*` namespaces.
Rejected — it weakens a legitimate sync assertion and hides future leaks.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Changes are scoped to E2E test cleanup and an orchestrator test helper; no product code affected.
- These are E2E Groovy/Spock tests that require a live cluster, so validation happens in CI: the fix removes the source of the stale `qa-label-scope-*` namespace that broke `NamespaceTest`.
- `deleteNamespace` default (`waitForDeletion = true`) polls up to ~60s until the namespace is fully gone, and now fails loudly instead of silently continuing when that window is exceeded.
- Note: `deleteNamespace(ns)` callers (with the default wait) will now throw on a confirmed-timeout instead of silently continuing — intended, since an undeleted namespace is a real failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
