### PR TITLE
ROX-36967: remove ocm token test

### DIFF
--- a/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CloudSourcesTest.groovy
@@ -49,7 +49,6 @@ class CloudSourcesTest extends BaseSpecification {
 
         where:
         authMethod            | token                        | clientId                 | clientSecret
-        "OCM offline token"   | Env.mustGetOcmOfflineToken() | ""                       | ""
         "OCM service account" | ""                           | Env.mustGetOcmClientId() | Env.mustGetOcmClientSecret()
     }
 }


### PR DESCRIPTION
ocm offline token use is deprecated. Our token for testing has randomly expired/broken multiple times this year!? So, just stop testing it. (https://redhat.atlassian.net/browse/ROX-36290?focusedCommentId=17968940)

we are testing with the replaced standard method: service accounts