### PR TITLE
fix: add openshift-kni-infra exclusions to iptables Execution default policy

### DIFF
--- a/pkg/defaults/policies/files/exec-iptables.json
+++ b/pkg/defaults/policies/files/exec-iptables.json
@@ -13,6 +13,33 @@
   "eventSource": "DEPLOYMENT_EVENT",
   "exclusions": [
     {
+      "name": "Don't alert on haproxy-control-plane-* deployment in openshift-kni-infra namespace",
+      "deployment": {
+        "name": "haproxy-control-plane-.*",
+        "scope": {
+          "namespace": "openshift-kni-infra"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on keepalived-control-plane-* deployment in openshift-kni-infra namespace",
+      "deployment": {
+        "name": "keepalived-control-plane-.*",
+        "scope": {
+          "namespace": "openshift-kni-infra"
+        }
+      }
+    },
+    {
+      "name": "Don't alert on keepalived-worker-* deployment in openshift-kni-infra namespace",
+      "deployment": {
+        "name": "keepalived-worker-.*",
+        "scope": {
+          "namespace": "openshift-kni-infra"
+        }
+      }
+    },
+    {
       "name": "Don't alert on haproxy-* deployment in openshift-vsphere-infra namespace",
       "deployment": {
         "name": "haproxy-.*",


### PR DESCRIPTION
The "iptables Execution" policy (HIGH, exec-iptables.json) fires on keepalived-* and haproxy-* pods in openshift-kni-infra on bare-metal/KNI OCP deployments. These are static pods owned by the Node object, managing API and Ingress VIPs via iptables NAT rules — required OCP infrastructure, not user workloads.

The sister policy "Iptables or nftables Executed in Privileged Container" (exec-iptables-root.json, CRITICAL) already correctly excludes openshift-kni-infra for these exact workloads. The HIGH severity policy only excludes openshift-vsphere-infra, missing the bare-metal equivalent — a clear oversight.

This PR adds the three missing exclusions to exec-iptables.json, mirroring what exec-iptables-root.json already defines.

Made with [Cursor](https://cursor.com)