### PR TITLE
ROX-36925: Fix VM search by Guest OS

### DIFF
--- a/central/convert/internaltostorage/virtual_machine_v2.go
+++ b/central/convert/internaltostorage/virtual_machine_v2.go
@@ -12,9 +12,9 @@ func VirtualMachineV2(vm *virtualMachineV1.VirtualMachine) *storage.VirtualMachi
 		return nil
 	}
 
-	guestOS := vm.GetFacts()[pkgVM.GuestOSKey]
-	if guestOS == "" {
-		guestOS = pkgVM.UnknownGuestOS
+	informerOS := vm.GetFacts()[pkgVM.GuestOSKey]
+	if informerOS == "" {
+		informerOS = pkgVM.UnknownGuestOS
 	}
 
 	return &storage.VirtualMachineV2{
@@ -23,7 +23,7 @@ func VirtualMachineV2(vm *virtualMachineV1.VirtualMachine) *storage.VirtualMachi
 		Namespace: vm.GetNamespace(),
 		ClusterId: vm.GetClusterId(),
 		Facts:     vm.GetFacts(),
-		GuestOs:   guestOS,
+		GuestOs:   pkgVM.DisplayGuestOS(vm.GetFacts(), informerOS),
 		State:     convertVirtualMachineV2State(vm.GetState()),
 		VsockCid:  vm.GetVsockCid(),
 	}

--- a/central/convert/internaltostorage/virtual_machine_v2_test.go
+++ b/central/convert/internaltostorage/virtual_machine_v2_test.go
@@ -49,7 +49,7 @@ func TestVirtualMachineV2(t *testing.T) {
 			},
 		},
 		{
-			name: "copies agent facts and keeps informer GuestOs column",
+			name: "writes detected guest OS into GuestOs column",
 			input: &virtualMachineV1.VirtualMachine{
 				Id:        "VM-ID-3",
 				Namespace: "ns",
@@ -72,7 +72,7 @@ func TestVirtualMachineV2(t *testing.T) {
 					pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
 					pkgVM.AgentVersionKey:    "4.10.0",
 				},
-				GuestOs: "Red Hat Enterprise Linux",
+				GuestOs: "Red Hat Enterprise Linux 9.2",
 				State:   storage.VirtualMachineV2_RUNNING,
 			},
 		},

--- a/central/convert/storagetov2/virtual_machine_v2.go
+++ b/central/convert/storagetov2/virtual_machine_v2.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stackrox/rox/central/views/common"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
-	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -22,7 +21,7 @@ func VirtualMachineV2ToListItem(vm *storage.VirtualMachineV2) *v2.VMListItem {
 		Namespace:   vm.GetNamespace(),
 		ClusterId:   vm.GetClusterId(),
 		ClusterName: vm.GetClusterName(),
-		GuestOs:     pkgVM.DisplayGuestOS(vm.GetFacts(), vm.GetGuestOs()),
+		GuestOs:     vm.GetGuestOs(),
 		State:       convertVirtualMachineV2State(vm.GetState()),
 		LastUpdated: vm.GetLastUpdated(),
 	}
@@ -43,7 +42,7 @@ func VirtualMachineV2ToDetail(vm *storage.VirtualMachineV2) *v2.VMDetail {
 		Namespace:   vm.GetNamespace(),
 		ClusterId:   vm.GetClusterId(),
 		ClusterName: vm.GetClusterName(),
-		GuestOs:     pkgVM.DisplayGuestOS(vm.GetFacts(), vm.GetGuestOs()),
+		GuestOs:     vm.GetGuestOs(),
 		State:       convertVirtualMachineV2State(vm.GetState()),
 		LastUpdated: vm.GetLastUpdated(),
 		Facts:       vm.GetFacts(),

--- a/central/convert/storagetov2/virtual_machine_v2_test.go
+++ b/central/convert/storagetov2/virtual_machine_v2_test.go
@@ -98,16 +98,24 @@ func TestVirtualMachineV2GuestOsDisplay(t *testing.T) {
 		storedOS string
 		want     string
 	}{
-		"prefers detected guest OS": {
+		"returns stored guest OS": {
 			facts: map[string]string{
 				pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
 				pkgVM.GuestOSKey:         "Red Hat Enterprise Linux",
 			},
-			storedOS: "Red Hat Enterprise Linux",
+			storedOS: "Red Hat Enterprise Linux 9.2",
 			want:     "Red Hat Enterprise Linux 9.2",
 		},
-		"falls back to stored guest OS": {
+		"returns stored guest OS when detected is absent": {
 			facts:    map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux"},
+			storedOS: "Red Hat Enterprise Linux",
+			want:     "Red Hat Enterprise Linux",
+		},
+		"does not overlay detected onto the stored column": {
+			facts: map[string]string{
+				pkgVM.DetectedGuestOSKey: "Red Hat Enterprise Linux 9.2",
+				pkgVM.GuestOSKey:         "Red Hat Enterprise Linux",
+			},
 			storedOS: "Red Hat Enterprise Linux",
 			want:     "Red Hat Enterprise Linux",
 		},

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -210,6 +210,8 @@ func (p *pipelineImpl) storeV2Scan(ctx context.Context, clusterID string, vm *st
 	return nil
 }
 
+// lookupGuestOS returns facts["guestOS"] so scan identity stays on the KubeVirt
+// family name rather than the versioned display string in guest_os.
 func (p *pipelineImpl) lookupGuestOS(ctx context.Context, vmID string) string {
 	if features.VirtualMachinesEnhancedDataModel.Enabled() {
 		vm, found, err := p.virtualMachineV2Store.GetVirtualMachine(ctx, vmID)
@@ -220,7 +222,7 @@ func (p *pipelineImpl) lookupGuestOS(ctx context.Context, vmID string) string {
 		if !found {
 			return ""
 		}
-		return vm.GetGuestOs()
+		return vm.GetFacts()[pkgVM.GuestOSKey]
 	}
 	vm, found, err := p.virtualMachineStore.GetVirtualMachine(ctx, vmID)
 	if err != nil {

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -891,9 +891,21 @@ func TestLookupGuestOS(t *testing.T) {
 		},
 		"v2 guest OS populates scan": {
 			v2Enabled: true,
-			v2VM:      &storage.VirtualMachineV2{GuestOs: "Red Hat Enterprise Linux 9"},
-			v2Found:   true,
-			wantOS:    "Red Hat Enterprise Linux 9",
+			v2VM: &storage.VirtualMachineV2{
+				GuestOs: "Red Hat Enterprise Linux 9",
+				Facts:   map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux 9"},
+			},
+			v2Found: true,
+			wantOS:  "Red Hat Enterprise Linux 9",
+		},
+		"v2 stamps scan from informer fact not display column": {
+			v2Enabled: true,
+			v2VM: &storage.VirtualMachineV2{
+				GuestOs: "Red Hat Enterprise Linux 9.2",
+				Facts:   map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux"},
+			},
+			v2Found: true,
+			wantOS:  "Red Hat Enterprise Linux",
 		},
 		"v1 VM not found leaves scan OS empty": {
 			v1Found: false,

--- a/pkg/virtualmachine/facts.go
+++ b/pkg/virtualmachine/facts.go
@@ -32,8 +32,8 @@ const (
 	DNFMetadataStatusUnavailable = "unavailable"
 )
 
-// DisplayGuestOS prefers the agent-detected OS so callers can show a versioned
-// string while storage.GuestOs remains the informer value used for scan stamping.
+// DisplayGuestOS is the guest OS written to storage.guest_os: agent-detected
+// when present, otherwise fallback (the KubeVirt informer value).
 func DisplayGuestOS(facts map[string]string, fallback string) string {
 	return cmp.Or(facts[DetectedGuestOSKey], fallback)
 }

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -125,6 +125,25 @@ func (s *VMScanningSuite) TestScanPipeline() {
 					"GetVM.guest_os should prefer facts.detectedGuestOS")
 			})
 
+			t.Run("VirtualMachineV2GuestOSSearch", func(t *testing.T) {
+				s.skipUnlessV2VMAPI(t)
+				detail := s.mustGetVMV2(snapshot.ID)
+				guestOS := detail.GetGuestOs()
+				require.Regexp(t, `^Red Hat Enterprise Linux \d`, guestOS,
+					"guest_os must be versioned so quoted informer search can miss")
+
+				found, err := vmhelpers.ListV2VMByNamespaceNameGuestOS(s.ctx, s.vmV2Client, vm.Namespace, vm.Name, guestOS)
+				require.NoError(t, err)
+				require.NotNil(t, found, "ListVMs Guest OS:%q should find this VM", guestOS)
+				require.Equal(t, snapshot.ID, found.GetId())
+
+				const informerGuestOS = "Red Hat Enterprise Linux"
+				miss, err := vmhelpers.ListV2VMByNamespaceNameGuestOS(s.ctx, s.vmV2Client, vm.Namespace, vm.Name, informerGuestOS)
+				require.NoError(t, err)
+				require.Nil(t, miss,
+					"quoted informer Guest OS must not match a versioned guest_os column")
+			})
+
 			t.Run("VirtualMachineV2ListVMs", func(t *testing.T) {
 				s.skipUnlessV2VMAPI(t)
 				listed := s.mustListV2VMByNamespaceAndName(vm.Namespace, vm.Name)

--- a/tests/vmhelpers/central.go
+++ b/tests/vmhelpers/central.go
@@ -145,6 +145,12 @@ func rawListQueryNamespaceAndName(namespace, name string) string {
 	return fmt.Sprintf("%s:%q+%s:%q", search.Namespace, namespace, search.VirtualMachineName, name)
 }
 
+// rawListQueryNamespaceNameGuestOS adds an exact Guest OS match so search
+// hits the same string List/GetVM return.
+func rawListQueryNamespaceNameGuestOS(namespace, name, guestOS string) string {
+	return fmt.Sprintf("%s+%s:%q", rawListQueryNamespaceAndName(namespace, name), search.GuestOS, guestOS)
+}
+
 // ListVMByNamespaceName returns the first VirtualMachine in Central whose namespace and name
 // match the given values. Returns (nil, nil) when no match is found.
 func ListVMByNamespaceName(ctx context.Context, client v2.VirtualMachineServiceClient, namespace, name string) (*v2.VirtualMachine, error) {

--- a/tests/vmhelpers/central_test.go
+++ b/tests/vmhelpers/central_test.go
@@ -24,6 +24,13 @@ func TestRawListQueryNamespaceAndName(t *testing.T) {
 	require.Contains(t, q, `Virtual Machine Name:"vm:special+name"`)
 }
 
+func TestRawListQueryNamespaceNameGuestOS(t *testing.T) {
+	q := rawListQueryNamespaceNameGuestOS("ns", "vm-rhel", "Red Hat Enterprise Linux 8.10")
+	require.Contains(t, q, `Namespace:"ns"`)
+	require.Contains(t, q, `Virtual Machine Name:"vm-rhel"`)
+	require.Contains(t, q, `Guest OS:"Red Hat Enterprise Linux 8.10"`)
+}
+
 type stubVirtualMachineClient struct {
 	listFn func(ctx context.Context, req *v2.ListVirtualMachinesRequest) (*v2.ListVirtualMachinesResponse, error)
 	getFn  func(ctx context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error)

--- a/tests/vmhelpers/central_v2.go
+++ b/tests/vmhelpers/central_v2.go
@@ -21,10 +21,17 @@ const (
 // ListV2VMByNamespaceName returns the first VM matching namespace and name.
 // Returns (nil, nil) when no match is found.
 func ListV2VMByNamespaceName(ctx context.Context, client v2.VirtualMachineV2ServiceClient, namespace, name string) (*v2.VMListItem, error) {
+	return listV2VM(ctx, client, rawListQueryNamespaceAndName(namespace, name))
+}
+
+// ListV2VMByNamespaceNameGuestOS is ListV2VMByNamespaceName plus an exact Guest OS match.
+func ListV2VMByNamespaceNameGuestOS(ctx context.Context, client v2.VirtualMachineV2ServiceClient, namespace, name, guestOS string) (*v2.VMListItem, error) {
+	return listV2VM(ctx, client, rawListQueryNamespaceNameGuestOS(namespace, name, guestOS))
+}
+
+func listV2VM(ctx context.Context, client v2.VirtualMachineV2ServiceClient, query string) (*v2.VMListItem, error) {
 	resp, err := client.ListVMs(ctx, &v2.ListVMsRequest{
-		Query: &v2.RawQuery{
-			Query: rawListQueryNamespaceAndName(namespace, name),
-		},
+		Query: &v2.RawQuery{Query: query},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list vms: %w", err)

--- a/tests/vmhelpers/central_v2_test.go
+++ b/tests/vmhelpers/central_v2_test.go
@@ -104,6 +104,27 @@ func TestWaitForV2VMPresentInCentral_UsesListVMs(t *testing.T) {
 	require.Contains(t, sawQuery, `Virtual Machine Name:"vm1"`)
 }
 
+func TestListV2VMByNamespaceNameGuestOS_Query(t *testing.T) {
+	ctx := t.Context()
+	var sawQuery string
+	client := &stubV2Client{
+		listVMsFn: func(_ context.Context, req *v2.ListVMsRequest) (*v2.ListVMsResponse, error) {
+			sawQuery = req.GetQuery().GetQuery()
+			return &v2.ListVMsResponse{
+				Vms: []*v2.VMListItem{
+					{Id: "id-1", Namespace: "ns1", Name: "vm1", GuestOs: "Red Hat Enterprise Linux 8.10"},
+				},
+			}, nil
+		},
+	}
+	vm, err := ListV2VMByNamespaceNameGuestOS(ctx, client, "ns1", "vm1", "Red Hat Enterprise Linux 8.10")
+	require.NoError(t, err)
+	require.Equal(t, "id-1", vm.GetId())
+	require.Contains(t, sawQuery, `Guest OS:"Red Hat Enterprise Linux 8.10"`)
+	require.Contains(t, sawQuery, `Namespace:"ns1"`)
+	require.Contains(t, sawQuery, `Virtual Machine Name:"vm1"`)
+}
+
 func TestWaitForV2VMLatestScan(t *testing.T) {
 	ctx := t.Context()
 	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}


### PR DESCRIPTION
## Description

VM list/detail and `GET /v2/virtualmachines` showed the agent-detected guest OS when it was present (for example `Red Hat Enterprise Linux 8.10`). Search, sort, CVE “Guest OS affected”, and the affected-VMs table used `storage.VirtualMachineV2.guest_os`, which was the KubeVirt informer string (`Red Hat Enterprise Linux`).

Quoted search is exact, so filtering on the header string returned nothing, while `Guest OS:"Red Hat Enterprise Linux"` returned every RHEL VM. The CVE counter then reported one distinct OS.

This writes the displayed string into `guest_os` on every Sensor upsert: agent-detected when that fact is non-empty, otherwise the informer value, otherwise `unknown`. The API copies that column with no overlay. Search and CVE counts follow the same field.

Scan stamping still uses `facts["guestOS"]` (the informer family name). Agent `os_version` can move; a `ScanOs` change replaces the whole scan, so the versioned display string must not become scan identity.

Existing rows keep the old informer string until the next Sensor upsert. Central upgrade does not rewrite VM rows by itself.

Quoted `Guest OS:"Red Hat Enterprise Linux"` no longer matches versioned guests. Unquoted prefix search still matches all of them.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
    - [x] [e2e 4.14](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22806/pull-ci-stackrox-stackrox-master-ocp-4-14-vm-scanning-e2e-tests/2098531731534516224) - ❄️  failing for 1 of 3 VMs (flake) - `VirtualMachineV2GuestOSSearch` pass on all 3.
    - [x] [e2e 4.18](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22806/pull-ci-stackrox-stackrox-master-ocp-4-18-vm-scanning-e2e-tests/2098531731563876352) - ✅ passing (this is sufficient)
    - [x] [e2e 4.22](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/22806/pull-ci-stackrox-stackrox-master-ocp-4-22-vm-scanning-e2e-tests/2098664217337925632) - ❌  infra issues
- [x] Manually in UI  

state without search:
<img width="726" height="311" alt="Screenshot 2026-09-14 at 11 51 09" src="https://github.com/user-attachments/assets/bc6acfcb-f386-48ba-80f4-15d4bf179e13" />

searching for OS version of one VM:
<img width="544" height="295" alt="Screenshot 2026-09-14 at 11 51 21" src="https://github.com/user-attachments/assets/cd595bde-aaa8-4d0f-81fd-7be432451823" />

searching for OS version of another VM:
<img width="709" height="321" alt="Screenshot 2026-09-14 at 11 51 32" src="https://github.com/user-attachments/assets/75968171-ca2e-492e-a2b4-fc032cacbb96" />

searching string common to both VMs:
<img width="509" height="323" alt="Screenshot 2026-09-14 at 11 51 51" src="https://github.com/user-attachments/assets/ea390678-c3d3-4696-be3c-1f05a3e72903" />

searching something unrelated:
<img width="730" height="507" alt="Screenshot 2026-09-14 at 11 52 08" src="https://github.com/user-attachments/assets/2ea9c5ca-fd18-44ce-8208-80c8f0431a85" />

searching `   ` (three spaces):
<img width="766" height="435" alt="Screenshot 2026-09-14 at 11 52 23" src="https://github.com/user-attachments/assets/ae92e4ae-b643-4379-8469-14a46cd1c6a8" />
